### PR TITLE
Windows build issue using wxWidgets2.9.2: wxWIN95 macro not found

### DIFF
--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -676,7 +676,11 @@ bool wxMaxima::StartMaxima()
   if (command.Length() > 0)
   {
 #if defined(__WXMSW__)
+ #if wxCHECK_VERSION(2, 9, 0)
+    if (wxGetOsVersion() == wxOS_WINDOWS_9X)
+ #else
     if (wxGetOsVersion() == wxWIN95)
+ #endif
     {
       wxString maximaPrefix = command.SubString(1, command.Length() - 3);
       wxString sysPath;


### PR DESCRIPTION
Build error details:

```
$ make
Making all in src
make[1]: Entering directory `/c/Users/Doug/source/wxmaxima/src'
make  all-am
make[2]: Entering directory `/c/Users/Doug/source/wxmaxima/src'
g++ -DHAVE_CONFIG_H -I.   -I/c/Users/Doug/source/wxWidgets-2.9.2/build/lib/wx/include/msw-unicode-st
atic-2.9 -I/c/Users/Doug/source/wxWidgets-2.9.2/include -D_LARGEFILE_SOURCE=unknown -D__WXMSW__ -mth
reads -DPREFIX=\"/usr/local\" -g -O2 -MT Config.o -MD -MP -MF .deps/Config.Tpo -c -o Config.o Config
.cpp
mv -f .deps/Config.Tpo .deps/Config.Po
g++ -DHAVE_CONFIG_H -I.   -I/c/Users/Doug/source/wxWidgets-2.9.2/build/lib/wx/include/msw-unicode-st
atic-2.9 -I/c/Users/Doug/source/wxWidgets-2.9.2/include -D_LARGEFILE_SOURCE=unknown -D__WXMSW__ -mth
reads -DPREFIX=\"/usr/local\" -g -O2 -MT main.o -MD -MP -MF .deps/main.Tpo -c -o main.o main.cpp
mv -f .deps/main.Tpo .deps/main.Po
g++ -DHAVE_CONFIG_H -I.   -I/c/Users/Doug/source/wxWidgets-2.9.2/build/lib/wx/include/msw-unicode-st
atic-2.9 -I/c/Users/Doug/source/wxWidgets-2.9.2/include -D_LARGEFILE_SOURCE=unknown -D__WXMSW__ -mth
reads -DPREFIX=\"/usr/local\" -g -O2 -MT wxMaxima.o -MD -MP -MF .deps/wxMaxima.Tpo -c -o wxMaxima.o
wxMaxima.cpp
wxMaxima.cpp: In member function 'bool wxMaxima::StartMaxima()':
wxMaxima.cpp:679:29: error: 'wxWIN95' was not declared in this scope
make[2]: *** [wxMaxima.o] Error 1
make[2]: Leaving directory `/c/Users/Doug/source/wxmaxima/src'
make[1]: *** [all] Error 2
make[1]: Leaving directory `/c/Users/Doug/source/wxmaxima/src'
make: *** [all-recursive] Error 1
```

After some research, I tracked it down to the <wx/platinfo.h> file where the OS macros are defined, and it appears (based on a comment) that after wxWidgets 2.6, wxWIN95 (among other macros) has been deprecated, and the preferred macro is wxOS_WINDOWS_9X.

I'm not sure why the build broke with this version of wxWidgets (I looked into 2.8.12, the last stable release, and everything worked fine).

One of the things I tried was to make sure that the flag to enable compatibility support (WXWIN_COMPATIBILITY_2_6) was enabled, but apparently it was already defined...

```
$ make
Making all in src
make[1]: Entering directory `/c/Users/Doug/source/wxmaxima/src'
make  all-am
make[2]: Entering directory `/c/Users/Doug/source/wxmaxima/src'
g++ -DHAVE_CONFIG_H -I.   -I/c/Users/Doug/source/wxWidgets-2.9.2/build/lib/wx/include/msw-unicode-st
atic-2.9 -I/c/Users/Doug/source/wxWidgets-2.9.2/include -D_LARGEFILE_SOURCE=unknown -D__WXMSW__ -mth
reads -DPREFIX=\"/usr/local\" -g -O2 -MT wxMaxima.o -MD -MP -MF .deps/wxMaxima.Tpo -c -o wxMaxima.o
wxMaxima.cpp
wxMaxima.cpp:44:0: warning: "WXWIN_COMPATIBILITY_2_6" redefined [enabled by default]
c:/Users/Doug/source/wxWidgets-2.9.2/build/lib/wx/include/msw-unicode-static-2.9/wx/setup.h:156:0: n
ote: this is the location of the previous definition
In file included from wxMaxima.cpp:60:0:
c:/Users/Doug/source/wxWidgets-2.9.2/include/wx/zipstrm.h:366:29: error: operator '&&' has no left o
perand
c:/Users/Doug/source/wxWidgets-2.9.2/include/wx/zipstrm.h:387:28: error: #if with no expression
c:/Users/Doug/source/wxWidgets-2.9.2/include/wx/zipstrm.h:398:29: error: operator '&&' has no left o
perand
c:/Users/Doug/source/wxWidgets-2.9.2/include/wx/zipstrm.h:444:28: error: #if with no expression
In file included from wxMaxima.cpp:62:0:
c:/Users/Doug/source/wxWidgets-2.9.2/include/wx/txtstrm.h:79:28: error: #if with no expression
wxMaxima.cpp: In member function 'bool wxMaxima::StartMaxima()':
wxMaxima.cpp:681:29: error: 'wxWIN95' was not declared in this scope
make[2]: *** [wxMaxima.o] Error 1
make[2]: Leaving directory `/c/Users/Doug/source/wxmaxima/src'
make[1]: *** [all] Error 2
make[1]: Leaving directory `/c/Users/Doug/source/wxmaxima/src'
make: *** [all-recursive] Error 1
```

Anyway I added the `#if wxCHECK_VERSION(2, 9, 0)` because I didn't want to change the stable compilation while fixing the compilation for 2.9.2.

(I have not yet tested the change on another platform.)
