### PR TITLE
Fix for update to wx2.9 that broke pre-wx2.9 builds on Windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,11 @@
 #endif
 
 
+#if wxCHECK_VERSION(2, 9, 0)
 wxIMPLEMENT_APP(MyApp);
+#else
+IMPLEMENT_APP(MyApp);
+#endif
 
 bool MyApp::OnInit()
 {


### PR DESCRIPTION
Due to build issues on Windows when using wx2.9, I've been building with wx2.8.12.

I think until stability issues are resolved and cross-platform is verified, wxMaxima should still support builds using wx2.8.

This fix restores the ability to build with 2.8.12 on Windows.
