### PR TITLE
Issue195: type over close parens in BTextCtrl rather than inserting a pair

### DIFF
--- a/src/BTextCtrl.cpp
+++ b/src/BTextCtrl.cpp
@@ -110,10 +110,23 @@ void BTextCtrl::CloseParenthesis(wxString open, wxString close, bool fromOpen)
   long from, to;
   GetSelection(&from, &to);
 
-  if (from == to)
+  if (from == to)  // nothing selected
   {
-    WriteText(open + close);
-    SetInsertionPoint(GetInsertionPoint() - 1);
+    wxString text = this->GetValue();
+    wxString charHere = text.GetChar((size_t)GetInsertionPoint());
+
+    if (!fromOpen)
+    {
+      if (charHere == close)
+        SetInsertionPoint(GetInsertionPoint() + 1);
+      else
+        WriteText(close);
+    }
+    else
+    {
+      WriteText(open + close);
+      SetInsertionPoint(GetInsertionPoint() - 1);
+    }
   }
   else
   {


### PR DESCRIPTION
As described in my first comment on #195
