### PR TITLE
Issue232: m_console focus after loading WXMX file from command line

### DIFF
--- a/src/MathCtrl.cpp
+++ b/src/MathCtrl.cpp
@@ -1,7 +1,7 @@
 ///
 ///  Copyright (C) 2004-2011 Andrej Vodopivec <andrej.vodopivec@gmail.com>
 ///            (C) 2008-2009 Ziga Lenarcic <zigalenarcic@users.sourceforge.net>
-///            (C) 2012 Doug Ilijev <doug.ilijev@gmail.com>
+///            (C) 2012-2013 Doug Ilijev <doug.ilijev@gmail.com>
 ///
 ///  This program is free software; you can redistribute it and/or modify
 ///  it under the terms of the GNU General Public License as published by
@@ -3304,6 +3304,14 @@ GroupCell *MathCtrl::GetHCaret()
     return dynamic_cast<GroupCell*>(m_activeCell->GetParent());
 
   return m_last;
+}
+
+/**
+ * Set the HCaret to its default location, at the end of the document.
+ */
+void MathCtrl::SetDefaultHCaret()
+{
+  SetHCaret(m_last);
 }
 
 /**

--- a/src/MathCtrl.h
+++ b/src/MathCtrl.h
@@ -1,6 +1,6 @@
 ///
 ///  Copyright (C) 2004-2011 Andrej Vodopivec <andrej.vodopivec@gmail.com>
-///            (C) 2012 Doug Ilijev <doug.ilijev@gmail.com>
+///            (C) 2012-2013 Doug Ilijev <doug.ilijev@gmail.com>
 ///
 ///  This program is free software; you can redistribute it and/or modify
 ///  it under the terms of the GNU General Public License as published by
@@ -165,6 +165,7 @@ public:
   void SetWorkingGroup(GroupCell *group);
   bool IsSelectionInWorking();
   void SetActiveCell(EditorCell *cell, bool callRefresh = true);
+  void SetDefaultHCaret();
   void SetHCaret(MathCell *where, bool callRefresh = true); // call with false, when manually refreshing
   GroupCell *GetHCaret();
   void OpenHCaret(wxString txt = wxEmptyString, int type = GC_TYPE_CODE);

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -1023,7 +1023,7 @@ bool wxMaxima::OpenWXMFile(wxString file, MathCtrl *document, bool clearDocument
   document->Thaw();
   document->Refresh(); // redraw document outside Freeze-Thaw
 
-  m_console->SetHCaret(NULL);
+  m_console->SetDefaultHCaret();
   m_console->SetFocus();
   SetStatusText(_("Ready for user input"), 1);
   wxEndBusyCursor();
@@ -1127,7 +1127,7 @@ bool wxMaxima::OpenWXMXFile(wxString file, MathCtrl *document, bool clearDocumen
   document->Thaw();
   document->Refresh(); // redraw document outside Freeze-Thaw
 
-  m_console->SetHCaret(NULL);
+  m_console->SetDefaultHCaret();
   m_console->SetFocus();
   SetStatusText(_("Ready for user input"), 1);
   wxEndBusyCursor();


### PR DESCRIPTION
From #232.

In Linux (at least) when loading a WXMX file from the command line, the focus is not set on m_console, and a user is unable to type in the editor without first clicking it to give it focus, and is unable interact with any prompts which are issued by Maxima after doing Ctrl+R or Ctrl+Shift+R (this bug was found while testing the Ctrl+Shift+R functionality).

There did not seem to be a problem with loading WXM files, but the HCaret is not set as when a file is loaded from the File->Open... dialog, which is what I thought the original issue was. For consistency, I am correcting this so that loading both kinds of files from the command line results in the cursor being in the same place as if the files had been loaded from the dialog.

---

Test files:
https://dl.dropbox.com/u/11334386/wxmaxima/issue232.wxmx
https://dl.dropbox.com/u/11334386/wxmaxima/issue232.wxm
