### PR TITLE
Issue244: GetDefaultEntry returns first expression, without semicolon

### DIFF
--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -1794,31 +1794,32 @@ void wxMaxima::UpdateToolBar(wxUpdateUIEvent& event)
 
 #endif
 
+wxString ExtractFirstExpression(wxString entry)
+{
+  int semicolon = entry.Find(";");
+  int dollar = entry.Find("$");
+  bool semiFound = (semicolon != wxNOT_FOUND);
+  bool dollarFound = (dollar != wxNOT_FOUND);
+
+  int index;
+  if (semiFound && dollarFound)
+    index = MIN(semicolon, dollar);
+  else if (semiFound && !dollarFound)
+    index = semicolon;
+  else if (!semiFound && dollarFound)
+    index = dollar;
+  else // neither semicolon nor dollar found
+    index = entry.Length();
+
+  return entry.SubString(0, index - 1);
+}
+
 wxString wxMaxima::GetDefaultEntry()
 {
   if (m_console->CanCopy(true))
     return (m_console->GetString()).Trim().Trim(false);
   if (m_console->GetActiveCell() != NULL)
-  {
-    wxString entry = m_console->GetActiveCell()->ToString(false);
-
-    int semicolon = entry.Find(";");
-    int dollar = entry.Find("$");
-    bool semiFound = (semicolon != wxNOT_FOUND);
-    bool dollarFound = (dollar != wxNOT_FOUND);
-
-    int index;
-    if (semiFound && dollarFound)
-      index = MIN(semicolon, dollar);
-    else if (semiFound && !dollarFound)
-      index = semicolon;
-    else if (!semiFound && dollarFound)
-      index = dollar;
-    else // neither found
-      index = entry.Length();
-
-    return entry.SubString(0, index - 1);
-  }
+    return ExtractFirstExpression(m_console->GetActiveCell()->ToString(false));
   return wxT("%");
 }
 

--- a/src/wxMaxima.h
+++ b/src/wxMaxima.h
@@ -1,5 +1,6 @@
 ///
 ///  Copyright (C) 2004-2011 Andrej Vodopivec <andrej.vodopivec@gmail.com>
+///            (C) 2013 Doug Ilijev <doug.ilijev@gmail.com>
 ///
 ///  This program is free software; you can redistribute it and/or modify
 ///  it under the terms of the GNU General Public License as published by
@@ -139,6 +140,7 @@ protected:
   void PrintMenu(wxCommandEvent& event);
 #endif
 
+  wxString ExtractFirstExpression(wxString entry);
   wxString GetDefaultEntry();
   bool StartServer();                              // starts the server
   bool StartMaxima();                              // starts maxima (uses getCommand)


### PR DESCRIPTION
From #244

When GUI commands choose which expression to use (Plot2d..., Simplify...) etc, and a cell is active but no selection is made, GetDefaultEntry would copy the entire text of the active cell, but this always wrong because it includes the semicolon or dollar sign, which causes a syntax error.

This patch fixes this issue, as well as only allowing the first expression in a cell to be copied in, because these functions cannot deal with multiple expressions either.
