### PR TITLE
Issue 213: Compensate for empty statements and comments in input

### DIFF
--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -137,6 +137,8 @@ wxMaxima::wxMaxima(wxWindow *parent, int id, const wxString title,
   m_funRegEx.Compile(wxT("^ *([[:alnum:]%_]+) *\\(([[:alnum:]%_,[[.].] ]*)\\) *:="));
   // RegEx for variable definitions
   m_varRegEx.Compile(wxT("^ *([[:alnum:]%_]+) *:"));
+  // RegEx for blank statement removal
+  m_blankStatementRegEx.Compile(wxT("(^;)|((^|;)(((\\/\\*.*\\*\\/)?([[:space:]]*))+;)+)"));
 }
 
 wxMaxima::~wxMaxima()
@@ -454,9 +456,7 @@ void wxMaxima::DoRawConsoleAppend(wxString s, int type)
  */
 void wxMaxima::StripComments(wxString& s)
 {
-  wxRegEx blankStatementRemoval;
-  blankStatementRemoval.Compile(wxT("(^;)|((^|;)(((\\/\\*.*\\*\\/)?([[:space:]]*))+;)+)"));
-  blankStatementRemoval.Replace(&s, wxT(";"));
+  m_blankStatementRegEx.Replace(&s, wxT(";"));
 }
 
 void wxMaxima::SendMaxima(wxString s, bool history)

--- a/src/wxMaxima.h
+++ b/src/wxMaxima.h
@@ -83,7 +83,7 @@ public:
   {
     m_openFile = file;
   }
-  static void StripComments(wxString& s);
+  void StripComments(wxString& s);
   void SendMaxima(wxString s, bool history = false);
   void OpenFile(wxString file,
                 wxString command = wxEmptyString); // Open a file
@@ -214,6 +214,7 @@ protected:
   wxFindReplaceData m_findData;
   wxRegEx m_funRegEx;
   wxRegEx m_varRegEx;
+  wxRegEx m_blankStatementRegEx;
 #if wxUSE_DRAG_AND_DROP
   friend class MyDropTarget;
 #endif


### PR DESCRIPTION
Closes #213

It is the case that users (such as @mantxu and myself, at least) often insert blank statements or unintentionally insert comments outside of their existing statements, resulting in empty statements being sent to Maxima.

Rather than ignoring empty statements, Maxima treats them as errors and displays an error `Incorrect syntax: Premature termination of input at ;.` as such. However, when an error of this kind occurs, and the offending statement is not the only statement in the line, wxMaxima locks up and the way to fix it seems to be to fiddle with the "Interrupt Current Computation" button and try to evaluate some syntactically correct statement until wxMaxima finally allows the user to continue with the normal workflow. (More details in #225)

Since this has an easy fix (removing any effectively blank statements from the input before sending it to Maxima), it makes sense to deal with it in wxMaxima to deliver a better experience.

Although, I still hold that this is a bug that Maxima needs to fix, that empty statements as such should simply be ignored. AFAIK there has been no response to my bug report to them on this issue.
