### PR TITLE
Added menu item for producing the numeric form of a result

### DIFF
--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -3310,6 +3310,10 @@ void wxMaxima::NumericalMenu(wxCommandEvent& event)
     cmd = wxT("bfloat(") + expr + wxT(");");
     MenuCommand(cmd);
     break;
+  case menu_to_numer:
+    cmd = expr + wxT(",numer;");
+    MenuCommand(cmd);
+    break;
   case menu_num_out:
     cmd = wxT("if numer#false then numer:false else numer:true;");
     MenuCommand(cmd);
@@ -4628,6 +4632,7 @@ BEGIN_EVENT_TABLE(wxMaxima, wxFrame)
   EVT_MENU(menu_num_out, wxMaxima::NumericalMenu)
   EVT_MENU(menu_to_float, wxMaxima::NumericalMenu)
   EVT_MENU(menu_to_bfloat, wxMaxima::NumericalMenu)
+  EVT_MENU(menu_to_numer, wxMaxima::NumericalMenu)
   EVT_MENU(menu_exponentialize, wxMaxima::SimplifyMenu)
   EVT_MENU(menu_invert_mat, wxMaxima::AlgebraMenu)
   EVT_MENU(menu_determinant, wxMaxima::AlgebraMenu)

--- a/src/wxMaximaFrame.cpp
+++ b/src/wxMaximaFrame.cpp
@@ -646,6 +646,9 @@ void wxMaximaFrame::SetupMenu()
   wxglade_tmp_menu_6->Append(menu_to_bfloat, _("To &Bigfloat"),
                              _("Calculate bigfloat value of the last result"),
                              wxITEM_NORMAL);
+  wxglade_tmp_menu_6->Append(menu_to_numer, _("To Numeri&c\tCTRL+SHIFT+N"),
+                             _("Calculate numeric value of the last result"),
+                             wxITEM_NORMAL);
   wxglade_tmp_menu_6->Append(menu_set_precision, _("Set &Precision..."),
                              _("Set bigfloat precision"),
                              wxITEM_NORMAL);

--- a/src/wxMaximaFrame.h
+++ b/src/wxMaximaFrame.h
@@ -91,6 +91,7 @@ enum {
   menu_num_out,
   menu_to_float,
   menu_to_bfloat,
+  menu_to_numer,
   menu_set_precision,
   menu_functions,
   menu_variables,


### PR DESCRIPTION
I like to work in the default mode where expressions are not computed automatically to numeric form, but then I have to manually type %,numer; when I want to display a numeric result. This menu item facilitates the use of this functionality.
