### PR TITLE
The pngcairo terminal was broken for wxdraw2d. Made it work again.

### DIFF
--- a/data/wxmathml.lisp
+++ b/data/wxmathml.lisp
@@ -1360,7 +1360,7 @@
                 ($apply '$draw
                         (append
                          `((mlist simp)
-                           ((mequal simp) $terminal $png)
+                           ((mequal simp) $terminal ,(if $wxplot_pngcairo '$pngcairo '$png))
                            ((mequal simp) $file_name ,filename))
                          (get-pic-size-opt)
                          (list args)))))
@@ -1436,7 +1436,7 @@
     (setq res ($apply '$draw
                       (append
                        `((mlist simp)
-                         ((mequal simp) $terminal $png)
+                         ((mequal simp) $terminal ,(if $wxplot_pngcairo '$pngcairo '$png))
                          ((mequal simp) $file_name ,filename))
                        (cond
                          ((eq ($get '$draw '$version) 1)


### PR DESCRIPTION
Closes #323

The variable wxplot_pngcairo that allows to tell wxplot and wxdraw to use the newer pngcairo terminal instead of the old basic png one was introduced in 2011: https://www.ma.utexas.edu/pipermail/maxima/2011/023696.html

Unfortunately it hase ceased to work for wxdraw2d, since.

This patch re-enables this feature.
