### PR TITLE
Support all line styles from the upcoming version of maxima.

### DIFF
--- a/data/wxmathml.lisp
+++ b/data/wxmathml.lisp
@@ -1249,7 +1249,7 @@
   (let ((frmt 
          (cond
            ($wxplot_old_gnuplot "set terminal png picsize ~d ~d; set zeroaxis;")
-           ($wxplot_pngcairo "set terminal pngcairo background \"white\" enhanced font \"arial,10\" fontscale 1.0 size ~d,~d; set zeroaxis;")
+           ($wxplot_pngcairo "set terminal pngcairo dashed background \"white\" enhanced font \"arial,10\" fontscale 1.0 size ~d,~d; set zeroaxis;")
            (t "set terminal png size ~d,~d; set zeroaxis;"))))
     (format nil frmt
 	    ($first $wxplot_size)


### PR DESCRIPTION
Closes #321.

The next maxima version will officially introduce the line styles "dashed" and "dash_dots". Besides that it will add new line styles. To make them work the "dashed" terminal option for pngcairo has to be set. If it isn't these line styles will be drawn as solid lines instead.

Technical background: Gnuplot allows the user to select the style a line will be drawn in. Maxima will explicitely select a linestyle for every line (and has done so since at least 2011). If the current terminal doesn't support the line style that has been selected gnuplot will fall back to "solid", so the thing is pretty fail-save. And gnuplot provides an terminal option ("solid") that overrides all line styles. Unfortunately this terminal option defaults to "on" on every terminal save postscript so we'll have to explicitely disable it to make the linestyles actually be displayed.

Compatibility: Using a new maxima version with an old wxMaxima version will result in all line styles except of "dots" to be drawn as "solid". But maxima's manual will tell that all other line styles will work with gnuplot terminals that support them. Using a new wxMaxima version with an old Maxima will result in higher graphics quality than using an old version of wxMaxima. But there aren't any other changes. 

Test case:

```
 wxdraw2d(
        key="test",
        line_type=dashes,
        grid=true,
        explicit(sin(x),x,0,4)
    );
```

This piece of maxima code will draw a solid line on the current wxMaxima version. Since the user explicitely has requested a dashed line this clearly is a bug. After all of my three pull requests are applied a dashed line will be output instead.

Did create a branch named "allfeatures" on  git@github.com:gunterkoenigsmann/wxmaxima.git
that incorporates my three patches.
