### PR TITLE
Clean up include guards and a bug.

### DIFF
--- a/src/AbsCell.h
+++ b/src/AbsCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _ABSCELL_H_
-#define _ABSCELL_H_
+#ifndef ABSCELL_H
+#define ABSCELL_H
 
 #include "MathCell.h"
 
@@ -46,4 +46,4 @@ protected:
   wxString ToXML(bool all);	//new!!!
 };
 
-#endif //_ABSCELL_H_
+#endif // ABSCELL_H

--- a/src/AtCell.h
+++ b/src/AtCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _ATCELL_H_
-#define _ATTCELL_H_
+#ifndef ATCELL_H
+#define ATCELL_H
 
 #include "MathCell.h"
 
@@ -44,4 +44,4 @@ protected:
   MathCell *m_indexCell;
 };
 
-#endif //_ATCELL_H_
+#endif // ATCELL_H

--- a/src/Autocomplete.h
+++ b/src/Autocomplete.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _AUTOCOMPL_H_
-#define _AUTOCOMPL_H_
+#ifndef AUTOCOMPLETE_H
+#define AUTOCOMPLETE_H
 
 #include <wx/wx.h>
 #include <wx/arrstr.h>
@@ -38,4 +38,4 @@ private:
   wxRegEx m_args;
 };
 
-#endif
+#endif // AUTOCOMPLETE_H

--- a/src/BTextCtrl.h
+++ b/src/BTextCtrl.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _BTEXTCTRL_H_
-#define _BTEXTCTRL_H_
+#ifndef BTEXTCTRL_H
+#define BTEXTCTRL_H
 
 #include <wx/wx.h>
 
@@ -49,4 +49,4 @@ private:
   DECLARE_EVENT_TABLE()
 };
 
-#endif //_TEXTCTRL_H_
+#endif // BTEXTCTRL_H

--- a/src/Bitmap.h
+++ b/src/Bitmap.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _BITMAP_H_
-#define _BITMAP_H_
+#ifndef BITMAP_H
+#define BITMAP_H
 
 #include "MathCell.h"
 
@@ -43,4 +43,4 @@ protected:
   wxBitmap m_bmp;
 };
 
-#endif
+#endif // BITMAP_H

--- a/src/CellParser.h
+++ b/src/CellParser.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _CELLPARSER_H
-#define _CELLPARSER_H
+#ifndef CELLPARSER_H
+#define CELLPARSER_H
 
 #include <wx/wx.h>
 #include <wx/fontenum.h>
@@ -116,4 +116,4 @@ private:
   style m_styles[STYLE_NUM];
 };
 
-#endif
+#endif // CELLPARSER_H

--- a/src/DiffCell.h
+++ b/src/DiffCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _DIFFCELL_H_
-#define _DIFFCELL_H_
+#ifndef DIFFCELL_H
+#define DIFFCELL_H
 
 #include "MathCell.h"
 
@@ -44,4 +44,4 @@ protected:
   MathCell *m_diffCell;
 };
 
-#endif	//_EXPTCELL_H_
+#endif // DIFFCELL_H

--- a/src/EditorCell.h
+++ b/src/EditorCell.h
@@ -18,8 +18,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _EDITOR_CELL_H
-#define _EDITOR_CELL_H
+#ifndef EDITORCELL_H
+#define EDITORCELL_H
 
 #include "MathCell.h"
 
@@ -136,7 +136,7 @@ private:
   std::vector<int> m_positionHistory;
   std::vector<int> m_startHistory;
   std::vector<int> m_endHistory;
-  int m_historyPosition;
+  ptrdiff_t m_historyPosition;
 //  int m_oldPosition;
   int m_positionOfCaret;
   int m_caretColumn;
@@ -165,4 +165,4 @@ private:
   bool m_firstLineOnly;
 };
 
-#endif
+#endif // EDITORCELL_H

--- a/src/EvaluationQueue.h
+++ b/src/EvaluationQueue.h
@@ -19,8 +19,8 @@
 ///
 
 
-#ifndef EVALUATIONQUEUE_H_
-#define EVALUATIONQUEUE_H_
+#ifndef EVALUATIONQUEUE_H
+#define EVALUATIONQUEUE_H
 
 #include "GroupCell.h"
 
@@ -53,4 +53,4 @@ class EvaluationQueue
 };
 
 
-#endif /* EVALUATIONQUEUE_H_ */
+#endif /* EVALUATIONQUEUE_H */

--- a/src/ExptCell.h
+++ b/src/ExptCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _EXPTCELL_H_
-#define _EXPTCELL_H_
+#ifndef EXPTCELL_H
+#define EXPTCELL_H
 
 #include "MathCell.h"
 
@@ -53,4 +53,4 @@ protected:
 };
 
 
-#endif //_EXPTCELL_H_
+#endif // EXPTCELL_H

--- a/src/FracCell.h
+++ b/src/FracCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _FRACCELL_H_
-#define _FRACCELL_H_
+#ifndef FRACCELL_H
+#define FRACCELL_H
 
 #include "MathCell.h"
 
@@ -67,4 +67,4 @@ protected:
   int m_expDivideWidth;
 };
 
-#endif //_FRACCELL_H_
+#endif // FRACCELL_H

--- a/src/FunCell.h
+++ b/src/FunCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _FUNCELL_H_
-#define _FUNCELL_H_
+#ifndef FUNCELL_H
+#define FUNCELL_H
 
 #include "MathCell.h"
 
@@ -47,4 +47,4 @@ protected:
 };
 
 
-#endif //_FUNCELL_H_
+#endif // FUNCELL_H

--- a/src/Gen1Wiz.h
+++ b/src/Gen1Wiz.h
@@ -54,4 +54,4 @@ private:
 wxString GetTextFromUser(wxString label, wxString title, wxString value,
                          wxWindow* parent);
 
-#endif // GEN2WIZ_H
+#endif // GEN1WIZ_H

--- a/src/Gen3Wiz.h
+++ b/src/Gen3Wiz.h
@@ -67,4 +67,4 @@ protected:
   wxButton* button_2;
 };
 
-#endif // DIFFWIZ_H
+#endif // GEN3WIZ_H

--- a/src/Gen4Wiz.h
+++ b/src/Gen4Wiz.h
@@ -73,4 +73,4 @@ protected:
   wxButton* button_2;
 };
 
-#endif // DIFFWIZ_H
+#endif // GEN4WIZ_H

--- a/src/GroupCell.h
+++ b/src/GroupCell.h
@@ -18,8 +18,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef GROUPCELL_H_
-#define GROUPCELL_H_
+#ifndef GROUPCELL_H
+#define GROUPCELL_H
 
 #include "MathCell.h"
 #include "EditorCell.h"
@@ -123,4 +123,4 @@ protected:
   wxString ToString(bool all);
 };
 
-#endif /* GROUPCELL_H_ */
+#endif /* GROUPCELL_H */

--- a/src/History.h
+++ b/src/History.h
@@ -44,4 +44,4 @@ private:
   DECLARE_EVENT_TABLE()
 };
 
-#endif
+#endif // HISTORY_H

--- a/src/ImgCell.h
+++ b/src/ImgCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _IMGCELL_H_
-#define _IMGCELL_H_
+#ifndef IMGCELL_H
+#define IMGCELL_H
 
 #include "MathCell.h"
 #include <wx/image.h>
@@ -62,4 +62,4 @@ protected:
 	bool m_drawRectangle;
 };
 
-#endif //_ABSCELL_H_
+#endif // IMGCELL_H

--- a/src/IntCell.h
+++ b/src/IntCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _INTCELL_H_
-#define _INTCELL_H_
+#ifndef INTCELL_H
+#define INTCELL_H
 
 #include "MathCell.h"
 #include "Setup.h"
@@ -65,4 +65,4 @@ protected:
 #endif
 };
 
-#endif  //_UNDERCELL_H_
+#endif  // INTCELL_H

--- a/src/LimitCell.h
+++ b/src/LimitCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _LIMITCELL_H_
-#define _LIMITCELL_H_
+#ifndef LIMITCELL_H
+#define LIMITCELL_H
 
 #include "MathCell.h"
 
@@ -46,4 +46,4 @@ protected:
   MathCell *m_name;
 };
 
-#endif //_UNDERCELL_H_
+#endif // LIMITCELL_H

--- a/src/MathCell.h
+++ b/src/MathCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _MATHCELL_H_
-#define _MATHCELL_H_
+#ifndef MATHCELL_H
+#define MATHCELL_H
 
 #define MAX(a,b) ((a)>(b) ? (a) : (b))
 #define MIN(a,b) ((a)>(b) ? (b) : (a))
@@ -196,4 +196,4 @@ protected:
   wxString m_altCopyText; // m_altCopyText is not check in all cells!
 };
 
-#endif //_MATHCELL_H_
+#endif // MATHCELL_H

--- a/src/MathCtrl.h
+++ b/src/MathCtrl.h
@@ -18,8 +18,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _MATHCTRL_H_
-#define _MATHCTRL_H_
+#ifndef MATHCTRL_H
+#define MATHCTRL_H
 
 #include <wx/wx.h>
 #include <wx/textfile.h>
@@ -268,4 +268,4 @@ protected:
   DECLARE_EVENT_TABLE()
 };
 
-#endif //_MATHCTRL_H_
+#endif // MATHCTRL_H

--- a/src/MathParser.h
+++ b/src/MathParser.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _MATHPARSER_H_
-#define _MATHPARSER_H_
+#ifndef MATHPARSER_H
+#define MATHPARSER_H
 
 #include <wx/xml/xml.h>
 
@@ -61,4 +61,4 @@ private:
   wxFileSystem *m_fileSystem; // used for loading pictures in <img> and <slide>
 };
 
-#endif //_MATHPARSER_H_
+#endif // MATHPARSER_H

--- a/src/MathPrintout.h
+++ b/src/MathPrintout.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _MATHPRINTOUT_H
-#define _MATHPRINTOUT_H
+#ifndef MATHPRINTOUT_H
+#define MATHPRINTOUT_H
 
 #include "Setup.h"
 
@@ -61,6 +61,6 @@ private:
   vector<MathCell*> m_pages;
 };
 
-#endif
+#endif // WXM_PRINT
 
-#endif
+#endif // MATHPRINTOUT_H

--- a/src/MatrCell.h
+++ b/src/MatrCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _MATRCELL_H_
-#define _MATRCELL_H_
+#ifndef MATRCELL_H
+#define MATRCELL_H
 
 #include "MathCell.h"
 
@@ -68,4 +68,4 @@ protected:
   vector<int> m_centers;
 };
 
-#endif //_MATRCELL_H_
+#endif // MATRCELL_H

--- a/src/MyTipProvider.h
+++ b/src/MyTipProvider.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _MYTIPPROVIDER_H_
-#define _MYTIPPROVIDER_H_
+#ifndef MYTIPPROVIDER_H
+#define MYTIPPROVIDER_H
 
 #include <wx/wx.h>
 #include <wx/tipdlg.h>
@@ -38,4 +38,4 @@ private:
   wxTextFile m_file;
 };
 
-#endif
+#endif // MYTIPPROVIDER_H

--- a/src/ParenCell.h
+++ b/src/ParenCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _PARENCELL_H_
-#define _PARENCELL_H_
+#ifndef PARENCELL_H
+#define PARENCELL_H
 
 #include "MathCell.h"
 #include "Setup.h"
@@ -57,4 +57,4 @@ protected:
   int m_bigParenType;
 };
 
-#endif //_PARENCELL_H_
+#endif // PARENCELL_H

--- a/src/SlideShowCell.h
+++ b/src/SlideShowCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _SLIDESHOW_H_
-#define _SLIDESHOW_H_
+#ifndef SLIDESHOWCELL_H
+#define SLIDESHOWCELL_H
 
 #include "MathCell.h"
 #include <wx/image.h>
@@ -61,4 +61,4 @@ protected:
 	wxString ToXML(bool all);	//new!
 };
 
-#endif //_ABSCELL_H_
+#endif // SLIDESHOWCELL_H

--- a/src/SqrtCell.h
+++ b/src/SqrtCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _SQRTCELL_H_
-#define _SQRTCELL_H_
+#ifndef SQRTCELL_H
+#define SQRTCELL_H
 
 #include "MathCell.h"
 
@@ -48,4 +48,4 @@ protected:
   double m_signFontScale;
 };
 
-#endif //_SQRTCELL_H_
+#endif // SQRTCELL_H

--- a/src/SubCell.h
+++ b/src/SubCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _SUBCELL_H_
-#define _SUBCELL_H_
+#ifndef SUBCELL_H
+#define SUBCELL_H
 
 #include "MathCell.h"
 
@@ -44,4 +44,4 @@ protected:
   MathCell *m_indexCell;
 };
 
-#endif //_SUBCELL_H_
+#endif // SUBCELL_H

--- a/src/SubSupCell.h
+++ b/src/SubSupCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _SUBSUPCELL_H_
-#define _SUBSUPCELL_H_
+#ifndef SUBSUPCELL_H
+#define SUBSUPCELL_H
 
 #include "MathCell.h"
 
@@ -46,4 +46,4 @@ protected:
   MathCell *m_indexCell;
 };
 
-#endif //_SUBSUPCELL_H_
+#endif // SUBSUPCELL_H

--- a/src/SubstituteWiz.h
+++ b/src/SubstituteWiz.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _SUBSTITUTEWIZ_H_
-#define _SUBSTITUTEWIZ_H_
+#ifndef SUBSTITUTEWIZ_H
+#define SUBSTITUTEWIZ_H
 
 #include <wx/wx.h>
 #include <wx/statline.h>

--- a/src/SumCell.h
+++ b/src/SumCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _SUMCELL_H_
-#define _SUMCELL_H_
+#ifndef SUMCELL_H
+#define SUMCELL_H
 
 #include "MathCell.h"
 
@@ -60,4 +60,4 @@ protected:
   int m_signTop;
 };
 
-#endif //_UNDERCELL_H_
+#endif // SUMCELL_H

--- a/src/SystemWiz.h
+++ b/src/SystemWiz.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef SYSWIZ_H
-#define SYSWIZ_H
+#ifndef SYSTEMWIZ_H
+#define SYSTEMWIZ_H
 
 #include <wx/wx.h>
 #include <wx/statline.h>
@@ -46,4 +46,4 @@ private:
   wxButton* button_2;
 };
 
-#endif // SYSWIZ_H
+#endif // SYSTEMWIZ_H

--- a/src/TextCell.h
+++ b/src/TextCell.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _TEXTCELL_H_
-#define _TEXTCELL_H_
+#ifndef TEXTCELL_H
+#define TEXTCELL_H
 
 #include "MathCell.h"
 
@@ -64,4 +64,4 @@ protected:
   int m_labelWidth, m_labelHeight;
 };
 
-#endif //_TEXTCELL_H_
+#endif // TEXTCELL_H

--- a/src/TextStyle.h
+++ b/src/TextStyle.h
@@ -17,8 +17,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _TEXTSTYLE_H
-#define _TEXTSTYLE_H
+#ifndef TEXTSTYLE_H
+#define TEXTSTYLE_H
 
 struct style
 {
@@ -62,4 +62,4 @@ enum
 
 #define STYLE_NUM 23
 
-#endif
+#endif // TEXTSTYLE_H

--- a/src/wxMaxima.h
+++ b/src/wxMaxima.h
@@ -18,8 +18,8 @@
 ///  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ///
 
-#ifndef _WXMAXIMA_H_
-#define _WXMAXIMA_H_
+#ifndef WXMAXIMA_H
+#define WXMAXIMA_H
 
 #include "wxMaximaFrame.h"
 #include "MathParser.h"
@@ -235,4 +235,4 @@ private:
 
 #endif
 
-#endif //_WXMAXIM_H_
+#endif // WXMAXIMA_H


### PR DESCRIPTION
Use ptrdiff_t instead of size_t/int for EditorCell.h:m_historyPosition, which is the signed opposite of size_t.

Please don't define macros beginning with an underscore, those are reserved as per C++ standard.
