### PR TITLE
Now maxima is doing its file I/O relatively to the path of the file we opened, as it did a few months ago.

### DIFF
--- a/data/wxmathml.lisp
+++ b/data/wxmathml.lisp
@@ -31,6 +31,11 @@
 (defun tofiledir (file)
   (let ((path (pathname file)))
     (namestring (make-pathname :device (pathname-device path) :directory (pathname-directory path)))))
+(defun $cd (dir)
+ (let ((dir (cond ((pathnamep dir) dir)
+                  ((stringp dir) (make-pathname :directory #+gcl (list dir) #-gcl dir))
+                  (t (error "cd(dir): dir must be a string or pathname.")))))
+       (and (xchdir dir) (setf *default-pathname-defaults* dir) (namestring dir))))
 
 #+ccl (setf *print-circle* nil)
 

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -1005,7 +1005,7 @@ void wxMaxima::SetCWD(wxString file)
   if (filename.GetPath() == wxEmptyString)
     filename.AssignDir(wxGetCwd());
 
-  SendMaxima(wxT(":lisp-quiet (xchdir (tofiledir \"") + filename.GetFullPath() + wxT("\"))"));
+  SendMaxima(wxT(":lisp-quiet ($cd (tofiledir \"") + filename.GetFullPath() + wxT("\"))"));
 }
 
 // OpenWXM(X)File


### PR DESCRIPTION
Seems like the xchdir lisp command does st the pwd for child processes but not necessarily the dir file I/O of the current process is relative to. Did test this patch using the current maxima release with gcl and sbcl as lisp. Without it with the current maxima and wxmaxima the following .wxm file:

```
load(numericalio);
read_matrix("Test.csv");
```

will read the file "Test.csv" in the directory the maxima process was started in, which (especially on windows) might not be the directory the .wxm file was read from.
