### PR TITLE
PWDs containing backslashes still fail to be set on windows.

### DIFF
--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -1005,16 +1005,13 @@ void wxMaxima::SetCWD(wxString file)
   if (filename.GetPath() == wxEmptyString)
     filename.AssignDir(wxGetCwd());
 
-  // Escape all backslashes in the filename.
- wxString FilenameEscaped= filename.GetFullPath();
-  size_t backslash_pos=0;
-  while((backslash_pos=FilenameEscaped.find('\\',backslash_pos))!=string::npos)
-    {
-      FilenameEscaped[backslash_pos]='/';
-      backslash_pos++;
-    }
+  // Escape all backslashes in the filename if needed by the OS.
+  wxString Filenamestring= filename.GetFullPath();
+  #if defined __WXMSW__
+  Filenamestring.Replace(wxT("\\"),wxT("/"));
+  #endif
   
-  SendMaxima(wxT(":lisp-quiet ($cd (tofiledir \"") + FilenameEscaped + wxT("\"))"));
+  SendMaxima(wxT(":lisp-quiet ($cd (tofiledir \"") + Filenamestring + wxT("\"))"));
 }
 
 // OpenWXM(X)File


### PR DESCRIPTION
Pull Request #360 works fine on linux. Using new gcl versions on windows changing the directory still failed, though:
- windows paths generally contain backslashes
- the path is passed to lisp as string and lisp requires backslashes to be escaped by a backslash. Seems like old gcl versions accepted backslashes that didn't escape a " or a \ But current versions ignore them as does sbcl and glisp => the backslashes get dropped by the lisp invalidating the path name.

The most natural way of fixing this would be to insert a backslash in front of every backslash in the path name. But this additional backslash causes tofiledir to fail, at least on my system. Escaping the escaped backslash and escaping even this sequence (in case that the function just needs escaped backslashes, too) didn't help.

The best alternative I found was to replace all backslashes by slashes: Windows allows to use a slash as a path delimiter in all but a few well-documented cases (something with loading .dll's, if I remember it well) and we use none of them. The downside would be that when using a unix that allows file and directory names to contain backslashes wxMaxima no more support it. But I never had a reason to use such a path and since wxwidgets seems not allow to open a file from a path that contains a directory name that contains a backslash I would say that this isn't a big limitation.

Kind regards,

```
 Gunter.
```
