### PR TITLE
Now .wxm files are saved in a .wxm~ file first to prevent data loss.

### DIFF
--- a/src/MathCtrl.cpp
+++ b/src/MathCtrl.cpp
@@ -2767,14 +2767,25 @@ wxString ConvertToUnicode(wxString str)
 #endif
 }
 
+/*
+  Save the data as wxmx file
+
+  First saves the data to a backup file ending in .wxmx~ so if anything goes 
+  horribly wrong in this stepp all that is lost is the data that was input 
+  since the last save. Then the original .wxmx file is replaced in a 
+  (hopefully) atomic operation.
+ */
 bool MathCtrl::ExportToWXMX(wxString file)
 {
-  // delete file if it already exists
-  if(wxFileExists(file))
-    if(!wxRemoveFile(file))
-      return false;
-
-  wxFFileOutputStream out(file);
+  // delete temp file if it already exists
+  wxString backupfile=file+wxT("~");
+  if(wxFileExists(backupfile))
+    {
+      if(!wxRemoveFile(backupfile))
+	return false;
+    }
+  
+  wxFFileOutputStream out(backupfile);
   if (!out.IsOk())
     return false;
   wxZipOutputStream zip(out);
@@ -2830,6 +2841,10 @@ bool MathCtrl::ExportToWXMX(wxString file)
   }
 
   delete fsystem;
+  // Now that all data is save we can overwrite the actual save file.
+  if(!wxRenameFile(backupfile,file,true))
+    return false;
+
   m_saved = true;
   return true;
 }


### PR DESCRIPTION
There currently are three ways I know of to loose the whole contents of the current session on save:
- Saving a .wxmx file containing a ridiculously large .png image
- Running out of disk space while saving and
- (only for wxmx, as I know): pressing the save button after the input from maxima has been read but while wxMaxima is formatting an output cell.

In my case they all won't do this much harm since I never walk very far without using a version control system. But I know how to at least work around a complete data loss in most cases: Saving things in a temp file first and then place a (hopefully) atomic replace command.

This patch makes the .wxmx output logic use such a temp file and adds a few additional lines of documentation.
