### PR TITLE
Fix AppData file: Make only one default screenshot

### DIFF
--- a/data/io.github.wxmaxima_developers.wxMaxima.appdata.xml
+++ b/data/io.github.wxmaxima_developers.wxMaxima.appdata.xml
@@ -30,11 +30,11 @@
       <image>https://wxMaxima-developers.github.io/wxmaxima/images/linux_1.jpg</image>
       <caption>An example of a plot embedded in a work sheet</caption>
     </screenshot>
-    <screenshot type="default">
+    <screenshot>
       <image>https://wxMaxima-developers.github.io/wxmaxima/images/linux_2.jpg</image>
       <caption>Another example of a plot embedded in a work sheet</caption>
     </screenshot>
-    <screenshot type="default">
+    <screenshot>
       <image>https://wxMaxima-developers.github.io/wxmaxima/images/linux_3.jpg</image>
       <caption>wxMaxima provides wizards for the most important functions of Maxima</caption>
     </screenshot>


### PR DESCRIPTION
There should be only one default screenshot.

Property `type="default"` is intended to indicate the application's primary screenshot.

This patch has already been applied to the flatpak package.
https://github.com/flathub/flathub/pull/801#issuecomment-457083756