### PR TITLE
add copy to matlab

### DIFF
--- a/src/AbsCell.cpp
+++ b/src/AbsCell.cpp
@@ -160,6 +160,15 @@ wxString AbsCell::ToString()
   return s;
 }
 
+wxString AbsCell::ToMatlab()
+{
+  if (m_isBrokenIntoLines)
+	return wxEmptyString;
+  wxString s;
+  s = wxT("abs(") + m_innerCell->ListToMatlab() + wxT(")");
+  return s;
+}
+
 wxString AbsCell::ToTeX()
 {
   if (m_isBrokenIntoLines)

--- a/src/AbsCell.h
+++ b/src/AbsCell.h
@@ -89,6 +89,8 @@ protected:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToTeX();
 
   wxString ToMathML();

--- a/src/AtCell.cpp
+++ b/src/AtCell.cpp
@@ -143,6 +143,14 @@ wxString AtCell::ToString()
   return s;
 }
 
+wxString AtCell::ToMatlab()
+{
+  wxString s = wxT("at(");
+  s += m_baseCell->ListToMatlab();
+  s += wxT(",") + m_indexCell->ListToMatlab() + wxT(")");
+  return s;
+}
+
 wxString AtCell::ToTeX()
 {
   wxString s = wxT("\\left. ");

--- a/src/AtCell.h
+++ b/src/AtCell.h
@@ -46,6 +46,8 @@ public:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToTeX();
 
   wxString ToXML();

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -559,6 +559,47 @@ wxString Cell::ListToString()
   return retval;
 }
 
+wxString Cell::ToMatlab()
+{
+  return wxEmptyString;
+}
+
+wxString Cell::ListToMatlab()
+{
+	wxString retval;
+	Cell *tmp = this;
+	bool firstline = true;
+
+	while (tmp != NULL)
+	{
+	  if ((!firstline) && (tmp->m_forceBreakLine))
+	  {
+		if(!retval.EndsWith(wxT('\n')))
+		  retval += wxT("\n");
+		// if(
+		//    (tmp->GetStyle() != TS_LABEL) &&
+		//    (tmp->GetStyle() != TS_USERLABEL) &&
+		//    (tmp->GetStyle() != TS_MAIN_PROMPT) &&
+		//    (tmp->GetStyle() != TS_OTHER_PROMPT))
+		//   retval += wxT("\t");
+	  }
+	  // if(firstline)
+	  // {
+	  //   if((tmp->GetStyle() != TS_LABEL) &&
+	  //      (tmp->GetStyle() != TS_USERLABEL) &&
+	  //      (tmp->GetStyle() != TS_MAIN_PROMPT) &&
+	  //      (tmp->GetStyle() != TS_OTHER_PROMPT))
+	  //     retval += wxT("\t");
+	  // }
+	  retval += tmp->ToMatlab();
+
+	  firstline = false;
+	  tmp = tmp->m_nextToDraw;
+	}
+
+	return retval;
+}
+
 wxString Cell::ToTeX()
 {
   return wxEmptyString;

--- a/src/Cell.h
+++ b/src/Cell.h
@@ -517,6 +517,9 @@ class Cell
   virtual wxString ListToString();
 
   //! Convert this list to its LaTeX representation
+  virtual wxString ListToMatlab();
+
+  //! Convert this list to its LaTeX representation
   virtual wxString ListToTeX();
 
   //! Convert this list to an representation fit for saving in a .wxmx file
@@ -559,6 +562,9 @@ class Cell
    */
   virtual wxString ToOMML()
   { return wxEmptyString; }
+
+  //! Convert this cell to its Matlab representation
+  virtual wxString ToMatlab();
 
   //! Convert this cell to its LaTeX representation
   virtual wxString ToTeX();

--- a/src/ConjugateCell.cpp
+++ b/src/ConjugateCell.cpp
@@ -163,6 +163,14 @@ wxString ConjugateCell::ToString()
     return wxT("conjugate(") + m_innerCell->ListToString() + wxT(")");
 }
 
+wxString ConjugateCell::ToMatlab()
+{
+  if (m_isBrokenIntoLines)
+	return wxEmptyString;
+  else
+	return wxT("conjugate(") + m_innerCell->ListToMatlab() + wxT(")");
+}
+
 wxString ConjugateCell::ToTeX()
 {
   if (m_isBrokenIntoLines)

--- a/src/ConjugateCell.h
+++ b/src/ConjugateCell.h
@@ -77,6 +77,8 @@ protected:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToTeX();
 
   wxString ToMathML();

--- a/src/DiffCell.cpp
+++ b/src/DiffCell.cpp
@@ -140,6 +140,19 @@ wxString DiffCell::ToString()
   return s;
 }
 
+wxString DiffCell::ToMatlab()
+{
+  if (m_isBrokenIntoLines)
+	return wxEmptyString;
+  Cell *tmp = m_baseCell->m_next;
+  wxString s = wxT("'diff(");
+  if (tmp != NULL)
+	s += tmp->ListToMatlab();
+  s += m_diffCell->ListToMatlab();
+  s += wxT(")");
+  return s;
+}
+
 wxString DiffCell::ToTeX()
 {
   if (m_isBrokenIntoLines)

--- a/src/DiffCell.h
+++ b/src/DiffCell.h
@@ -48,6 +48,8 @@ public:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToTeX();
 
   wxString ToMathML();

--- a/src/EditorCell.cpp
+++ b/src/EditorCell.cpp
@@ -303,6 +303,30 @@ wxString EditorCell::ToString(bool dontLimitToSelection)
   return text;
 }
 
+wxString EditorCell::ToMatlab()
+{
+  return ToMatlab(false);
+}
+
+wxString EditorCell::ToMatlab(bool dontLimitToSelection)
+{
+  wxString text = m_text;
+  // Remove all soft line breaks
+  text.Replace(wxT('\r'), wxT(' '));
+  // Convert non-breakable spaces to breakable ones
+  text.Replace(wxT("\xa0"), wxT(" "));
+
+  if (SelectionActive() && (!dontLimitToSelection))
+  {
+	long start = MIN(m_selectionStart, m_selectionEnd);
+	long end = MAX(m_selectionStart, m_selectionEnd) - 1;
+	if (end >= (signed)m_text.Length()) end = m_text.Length() - 1;
+	if (start < 0) start = 0;
+	text = m_text.SubString(start, end);
+  }
+  return text;
+}
+
 wxString EditorCell::ToRTF()
 {
   wxString retval;

--- a/src/EditorCell.h
+++ b/src/EditorCell.h
@@ -227,6 +227,8 @@ public:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   /*! Convert the current cell to a string
   
     \param dontLimitToSelection
@@ -234,6 +236,9 @@ public:
     - true:  Always return all text in this text cell
   */
   wxString ToString(bool dontLimitToSelection);
+
+  //! Convert the current cell to Matlab code
+  wxString ToMatlab(bool dontLimitToSelection);
 
   //! Convert the current cell to LaTeX code
   wxString ToTeX();

--- a/src/ExptCell.cpp
+++ b/src/ExptCell.cpp
@@ -204,6 +204,22 @@ wxString ExptCell::ToString()
   return s;
 }
 
+wxString ExptCell::ToMatlab()
+{
+  if (m_altCopyText != wxEmptyString)
+	return m_altCopyText;
+  if (m_isBrokenIntoLines)
+	return wxEmptyString;
+  wxString s = m_baseCell->ListToMatlab() + wxT("^");
+  if (m_isMatrix)
+	s += wxT("^");
+  if (m_powCell->IsCompound())
+	s += wxT("(") + m_powCell->ListToMatlab() + wxT(")");
+  else
+	s += m_powCell->ListToMatlab();
+  return s;
+}
+
 wxString ExptCell::ToTeX()
 {
   if (m_isBrokenIntoLines)

--- a/src/ExptCell.h
+++ b/src/ExptCell.h
@@ -70,6 +70,8 @@ public:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToTeX();
 
   wxString ToXML();

--- a/src/FracCell.cpp
+++ b/src/FracCell.cpp
@@ -327,6 +327,49 @@ wxString FracCell::ToString()
   return s;
 }
 
+wxString FracCell::ToMatlab()
+{
+  wxString s;
+  if (!m_isBrokenIntoLines)
+  {
+	if (m_fracStyle == FC_NORMAL)
+	{
+	  if (m_num->IsCompound())
+		s += wxT("(") + m_num->ListToMatlab() + wxT(")/");
+	  else
+		s += m_num->ListToMatlab() + wxT("/");
+	  if (m_denom->IsCompound())
+		s += wxT("(") + m_denom->ListToMatlab() + wxT(")");
+	  else
+		s += m_denom->ListToMatlab();
+	}
+	else if (m_fracStyle == FC_CHOOSE)
+	{
+	  s = wxT("binomial(") + m_num->ListToMatlab() + wxT(",") +
+		  m_denom->ListToMatlab() + wxT(")");
+	}
+	else
+	{
+	  Cell *tmp = m_denom;
+	  while (tmp != NULL)
+	  {
+		tmp = tmp->m_next;   // Skip the d
+		if (tmp == NULL)
+		  break;
+		tmp = tmp->m_next;   // Skip the *
+		if (tmp == NULL)
+		  break;
+		s += tmp->GetDiffPart();
+		tmp = tmp->m_next;   // Skip the *
+		if (tmp == NULL)
+		  break;
+		tmp = tmp->m_next;
+	  }
+	}
+  }
+  return s;
+}
+
 wxString FracCell::ToTeX()
 {
   wxString s;

--- a/src/FracCell.h
+++ b/src/FracCell.h
@@ -83,6 +83,8 @@ public:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToTeX();
 
   wxString ToMathML();

--- a/src/FunCell.cpp
+++ b/src/FunCell.cpp
@@ -139,6 +139,16 @@ wxString FunCell::ToString()
   return s;
 }
 
+wxString FunCell::ToMatlab()
+{
+  if (m_isBrokenIntoLines)
+	return wxEmptyString;
+  if (m_altCopyText != wxEmptyString)
+	return m_altCopyText + Cell::ListToMatlab();
+  wxString s = m_nameCell->ListToMatlab() + m_argCell->ListToMatlab();
+  return s;
+}
+
 wxString FunCell::ToTeX()
 {
   if (m_isBrokenIntoLines)

--- a/src/FunCell.h
+++ b/src/FunCell.h
@@ -72,6 +72,8 @@ public:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToTeX();
 
   wxString ToMathML();

--- a/src/ImgCell.cpp
+++ b/src/ImgCell.cpp
@@ -237,6 +237,11 @@ wxString ImgCell::ToString()
   return _(" (Graphics) ");
 }
 
+wxString ImgCell::ToMatlab()
+{
+  return _(" (Graphics) ");
+}
+
 wxString ImgCell::ToTeX()
 {
   return _(" (Graphics) ");

--- a/src/ImgCell.h
+++ b/src/ImgCell.h
@@ -127,6 +127,8 @@ protected:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToRTF();
 
   wxString ToTeX();

--- a/src/IntCell.cpp
+++ b/src/IntCell.cpp
@@ -431,6 +431,31 @@ wxString IntCell::ToString()
   return s;
 }
 
+wxString IntCell::ToMatlab()
+{
+  wxString s = wxT("integrate(");
+
+  s += m_base->ListToMatlab();
+
+  Cell *tmp = m_var;
+  wxString var;
+  tmp = tmp->m_next;
+  if (tmp != NULL)
+  {
+	var = tmp->ListToMatlab();
+  }
+
+  wxString to = m_over->ListToMatlab();
+  wxString from = m_under->ListToMatlab();
+
+  s += wxT(",") + var;
+  if (m_intStyle == INT_DEF)
+	s += wxT(",") + from + wxT(",") + to;
+
+  s += wxT(")");
+  return s;
+}
+
 wxString IntCell::ToTeX()
 {
   wxString s = wxT("\\int");

--- a/src/IntCell.h
+++ b/src/IntCell.h
@@ -78,6 +78,8 @@ public:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToTeX();
 
   wxString ToMathML();

--- a/src/LimitCell.cpp
+++ b/src/LimitCell.cpp
@@ -216,6 +216,23 @@ wxString LimitCell::ToString()
   wxString base = m_base->ListToString();
   wxString var = under.SubString(0, under.Find(wxT("->")) - 1);
   wxString to = under.SubString(under.Find(wxT("->")) + 2,
+								under.Length() - 1);
+  if (to.Right(1) == wxT("+"))
+	to = to.Left(to.Length() - 1) + wxT(",plus");
+  if (to.Right(1) == wxT("-"))
+	to = to.Left(to.Length() - 1) + wxT(",minus");
+
+  s += wxT("(") + base + wxT(",") + var + wxT(",") + to + wxT(")");
+  return s;
+}
+
+wxString LimitCell::ToMatlab()
+{
+  wxString s(wxT("limit"));
+  wxString under = m_under->ListToMatlab();
+  wxString base = m_base->ListToMatlab();
+  wxString var = under.SubString(0, under.Find(wxT("->")) - 1);
+  wxString to = under.SubString(under.Find(wxT("->")) + 2,
                                 under.Length() - 1);
   if (to.Right(1) == wxT("+"))
     to = to.Left(to.Length() - 1) + wxT(",plus");

--- a/src/LimitCell.h
+++ b/src/LimitCell.h
@@ -57,6 +57,8 @@ public:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToTeX();
 
   wxString ToXML();

--- a/src/MatrCell.cpp
+++ b/src/MatrCell.cpp
@@ -280,7 +280,7 @@ wxString MatrCell::ToString()
     s += wxT("\t\t[");
     for (unsigned int j = 0; j < m_matWidth; j++)
     {
-      s += m_cells[i * m_matWidth + j]->ListToString();
+	  s += m_cells[i * m_matWidth + j]->ListToString();
       if (j < m_matWidth - 1)
         s += wxT(",\t");
     }
@@ -291,6 +291,29 @@ wxString MatrCell::ToString()
   }
   s += wxT("\t)");
   return s;
+}
+
+wxString MatrCell::ToMatlab()
+{
+	//ToDo: We ignore colNames and rowNames here. Are they currently in use?
+	wxString s;
+
+	s = wxT("[");
+	for (unsigned int i = 0; i < m_matHeight; i++)
+	{
+	  for (unsigned int j = 0; j < m_matWidth; j++)
+	  {
+		s += m_cells[i * m_matWidth + j]->ListToMatlab();
+		if (j < m_matWidth - 1)
+		  s += wxT(", ");
+	  }
+	  if (i < m_matHeight - 1)
+		s += wxT(";\n");
+	}
+
+	s += wxT("];");
+
+	return s;
 }
 
 wxString MatrCell::ToTeX()

--- a/src/MatrCell.h
+++ b/src/MatrCell.h
@@ -65,6 +65,8 @@ public:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToTeX();
 
   wxString ToMathML();

--- a/src/ParenCell.cpp
+++ b/src/ParenCell.cpp
@@ -410,6 +410,19 @@ wxString ParenCell::ToString()
   return s;
 }
 
+wxString ParenCell::ToMatlab()
+{
+  wxString s;
+  if (!m_isBrokenIntoLines)
+  {
+	if (m_print)
+	  s = wxT("(") + m_innerCell->ListToMatlab() + wxT(")");
+	else
+	  s = m_innerCell->ListToMatlab();
+  }
+  return s;
+}
+
 wxString ParenCell::ToTeX()
 {
   wxString s;

--- a/src/ParenCell.h
+++ b/src/ParenCell.h
@@ -76,6 +76,8 @@ public:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToTeX();
 
   wxString ToMathML();

--- a/src/SlideShowCell.cpp
+++ b/src/SlideShowCell.cpp
@@ -299,6 +299,11 @@ wxString SlideShow::ToString()
   return wxT(" << Animation >> ");
 }
 
+wxString SlideShow::ToMatlab()
+{
+  return wxT(" << Animation >> ");
+}
+
 wxString SlideShow::ToTeX()
 {
   return wxT(" << Graphics >> ");

--- a/src/SlideShowCell.h
+++ b/src/SlideShowCell.h
@@ -168,6 +168,8 @@ protected:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToTeX();
 
   wxString ToRTF();

--- a/src/SqrtCell.cpp
+++ b/src/SqrtCell.cpp
@@ -321,6 +321,14 @@ wxString SqrtCell::ToString()
     return wxT("sqrt(") + m_innerCell->ListToString() + wxT(")");
 }
 
+wxString SqrtCell::ToMatlab()
+{
+  if (m_isBrokenIntoLines)
+	return wxEmptyString;
+  else
+	return wxT("sqrt(") + m_innerCell->ListToMatlab() + wxT(")");
+}
+
 wxString SqrtCell::ToTeX()
 {
   if (m_isBrokenIntoLines)

--- a/src/SqrtCell.h
+++ b/src/SqrtCell.h
@@ -70,6 +70,8 @@ public:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToTeX();
 
   wxString ToMathML();

--- a/src/SubCell.cpp
+++ b/src/SubCell.cpp
@@ -147,6 +147,22 @@ wxString SubCell::ToString()
   return s;
 }
 
+wxString SubCell::ToMatlab()
+{
+  if (m_altCopyText != wxEmptyString)
+  {
+	return m_altCopyText;
+  }
+
+  wxString s;
+  if (m_baseCell->IsCompound())
+	s += wxT("(") + m_baseCell->ListToMatlab() + wxT(")");
+  else
+	s += m_baseCell->ListToMatlab();
+  s += wxT("[") + m_indexCell->ListToMatlab() + wxT("]");
+  return s;
+}
+
 wxString SubCell::ToTeX()
 {
   wxString s;

--- a/src/SubCell.h
+++ b/src/SubCell.h
@@ -48,6 +48,8 @@ public:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToTeX();
 
   wxString ToMathML();

--- a/src/SubSupCell.cpp
+++ b/src/SubSupCell.cpp
@@ -178,6 +178,23 @@ wxString SubSupCell::ToString()
   return s;
 }
 
+wxString SubSupCell::ToMatlab()
+{
+  wxString s;
+  if (m_baseCell->IsCompound())
+	s += wxT("(") + m_baseCell->ListToMatlab() + wxT(")");
+  else
+	s += m_baseCell->ListToMatlab();
+  s += wxT("[") + m_indexCell->ListToMatlab() + wxT("]");
+  s += wxT("^");
+  if (m_exptCell->IsCompound())
+	s += wxT("(");
+  s += m_exptCell->ListToMatlab();
+  if (m_exptCell->IsCompound())
+	s += wxT(")");
+  return s;
+}
+
 wxString SubSupCell::ToTeX()
 {
   wxConfigBase *config = wxConfig::Get();

--- a/src/SubSupCell.h
+++ b/src/SubSupCell.h
@@ -50,6 +50,8 @@ public:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToTeX();
 
   wxString ToXML();

--- a/src/SumCell.cpp
+++ b/src/SumCell.cpp
@@ -322,6 +322,34 @@ wxString SumCell::ToString()
   return s;
 }
 
+wxString SumCell::ToMatlab()
+{
+  wxString s;
+  if (m_sumStyle == SM_SUM)
+	s = wxT("sum(");
+  else
+	s = wxT("product(");
+  s += m_base->ListToMatlab();
+
+  Cell *tmp = m_under;
+  wxString var = tmp->ToMatlab();
+  wxString from;
+  tmp = tmp->m_next;
+  if (tmp != NULL)
+  {
+	tmp = tmp->m_next;
+	if (tmp != NULL)
+	  from = tmp->ListToMatlab();
+  }
+  wxString to = m_over->ListToMatlab();
+  s += wxT(",") + var + wxT(",") + from;
+  if (to != wxEmptyString)
+	s += wxT(",") + to + wxT(")");
+  else
+	s = wxT("l") + s + wxT(")");
+  return s;
+}
+
 wxString SumCell::ToTeX()
 {
   wxString s;

--- a/src/SumCell.h
+++ b/src/SumCell.h
@@ -69,6 +69,8 @@ public:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToTeX();
 
   wxString ToMathML();

--- a/src/TextCell.h
+++ b/src/TextCell.h
@@ -68,6 +68,8 @@ public:
 
   wxString ToString();
 
+  wxString ToMatlab();
+
   wxString ToTeX();
 
   wxString ToMathML();

--- a/src/Worksheet.cpp
+++ b/src/Worksheet.cpp
@@ -1297,7 +1297,8 @@ void Worksheet::OnMouseRightDown(wxMouseEvent &event)
         if (CanCopy())
         {
           popupMenu->Append(popid_copy, _("Copy"), wxEmptyString, wxITEM_NORMAL);
-          popupMenu->Append(popid_copy_tex, _("Copy as LaTeX"), wxEmptyString, wxITEM_NORMAL);
+		  popupMenu->Append(popid_copy_matlab, _("Copy as Matlab"), wxEmptyString, wxITEM_NORMAL);
+		  popupMenu->Append(popid_copy_tex, _("Copy as LaTeX"), wxEmptyString, wxITEM_NORMAL);
           popupMenu->Append(popid_copy_text, _("Copy as plain text"), wxEmptyString, wxITEM_NORMAL);
           if (m_cellPointers.m_selectionStart == m_cellPointers.m_selectionEnd)
             popupMenu->Append(popid_copy_mathml, _("Copy as MathML (e.g. to word processor)"), wxEmptyString,
@@ -1390,6 +1391,7 @@ void Worksheet::OnMouseRightDown(wxMouseEvent &event)
         if (CanCopy(true))
         {
           popupMenu->Append(popid_copy, _("Copy"), wxEmptyString, wxITEM_NORMAL);
+		  popupMenu->Append(popid_copy_matlab, _("Copy as Matlab"), wxEmptyString, wxITEM_NORMAL);
           popupMenu->Append(popid_copy_tex, _("Copy as LaTeX"), wxEmptyString, wxITEM_NORMAL);
           popupMenu->Append(popid_copy_text, _("Copy as plain text"), wxEmptyString, wxITEM_NORMAL);
           popupMenu->Append(popid_copy_mathml, _("Copy as MathML (e.g. to word processor)"), wxEmptyString,
@@ -2321,6 +2323,42 @@ bool Worksheet::CopyMathML()
     Recalculate();
     return true;
   }
+  return false;
+}
+
+bool Worksheet::CopyMatlab()
+{
+  if (GetActiveCell() != NULL)
+	return false;
+
+  if (m_cellPointers.m_selectionStart == NULL)
+	return false;
+
+  wxString result;
+  Cell *tmp = m_cellPointers.m_selectionStart;
+
+  bool firstcell = true;
+  while (tmp != NULL)
+  {
+	if ((tmp->HardLineBreak()) && (!firstcell))
+	  result += wxT("\n");
+	result += tmp->ToMatlab();
+	if (tmp == m_cellPointers.m_selectionEnd)
+	  break;
+	tmp = tmp->m_next;
+	firstcell = false;
+  }
+
+  wxASSERT_MSG(!wxTheClipboard->IsOpened(),_("Bug: The clipboard is already opened"));
+  if (wxTheClipboard->Open())
+  {
+	wxDataObjectComposite *data = new wxDataObjectComposite;
+	data->Add(new wxTextDataObject(result));
+	wxTheClipboard->SetData(data);
+	wxTheClipboard->Close();
+	return true;
+  }
+
   return false;
 }
 

--- a/src/Worksheet.h
+++ b/src/Worksheet.h
@@ -841,6 +841,7 @@ public:
     popid_edit,
     popid_add_comment,
     popid_insert_input,
+	popid_copy_matlab,
     popid_copy_tex,
     popid_copy_text,
     popid_copy_mathml,
@@ -1044,6 +1045,9 @@ public:
 
   //! Copy the selection to the clipboard as it would appear in a .wxm file
   bool CopyCells();
+
+  //! Copy a Matlab representation of the current selection to the clipboard
+  bool CopyMatlab();
 
   //! Copy a textual representation of the current selection to the clipboard
   bool CopyText();

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -4396,6 +4396,10 @@ void wxMaxima::EditMenu(wxCommandEvent &event)
     if (m_worksheet->CanRedo())
       m_worksheet->Redo();
     break;
+  case menu_copy_matlab_from_worksheet:
+	if (m_worksheet->CanCopy())
+	  m_worksheet->CopyMatlab();
+	break;
   case menu_copy_tex_from_worksheet:
     if (m_worksheet->CanCopy())
       m_worksheet->CopyTeX();
@@ -7257,6 +7261,10 @@ void wxMaxima::PopupMenu(wxCommandEvent &event)
       if (m_worksheet->CanCopy(true))
         m_worksheet->Copy();
       break;
+	case Worksheet::popid_copy_matlab:
+		if (m_worksheet->CanCopy(true))
+		  m_worksheet->CopyMatlab();
+	break;
     case Worksheet::popid_copy_tex:
       if (m_worksheet->CanCopy(true))
         m_worksheet->CopyTeX();
@@ -8650,6 +8658,7 @@ BEGIN_EVENT_TABLE(wxMaxima, wxFrame)
                 EVT_MENU(Worksheet::popid_diff, wxMaxima::PopupMenu)
                 EVT_MENU(Worksheet::popid_integrate, wxMaxima::PopupMenu)
                 EVT_MENU(Worksheet::popid_float, wxMaxima::PopupMenu)
+				EVT_MENU(Worksheet::popid_copy_matlab, wxMaxima::PopupMenu)
                 EVT_MENU(Worksheet::popid_copy_tex, wxMaxima::PopupMenu)
                 EVT_MENU(Worksheet::popid_copy_text, wxMaxima::PopupMenu)
                 EVT_MENU(Worksheet::popid_image, wxMaxima::PopupMenu)
@@ -8797,6 +8806,7 @@ BEGIN_EVENT_TABLE(wxMaxima, wxFrame)
                 EVT_MENU(menu_copy_from_worksheet, wxMaxima::EditMenu)
                 EVT_MENU(menu_copy_text_from_worksheet, wxMaxima::EditMenu)
                 EVT_MENU(menu_copy_tex_from_worksheet, wxMaxima::EditMenu)
+				EVT_MENU(menu_copy_matlab_from_worksheet, wxMaxima::EditMenu)
                 EVT_MENU(Worksheet::popid_copy_mathml, wxMaxima::EditMenu)
                 EVT_MENU(menu_undo, wxMaxima::EditMenu)
                 EVT_MENU(menu_redo, wxMaxima::EditMenu)

--- a/src/wxMaximaFrame.cpp
+++ b/src/wxMaximaFrame.cpp
@@ -567,6 +567,9 @@ void wxMaximaFrame::SetupMenu()
   m_EditMenu->Append(menu_copy_text_from_worksheet, _("Copy as Text\tCtrl+Shift+C"),
                      _("Copy selection from document as text"),
                      wxITEM_NORMAL);
+  m_EditMenu->Append(menu_copy_matlab_from_worksheet, _("Copy as Matlab"),
+					 _("Copy selection from document in Matlab format"),
+					 wxITEM_NORMAL);
   m_EditMenu->Append(menu_copy_tex_from_worksheet, _("Copy as LaTeX"),
                      _("Copy selection from document in LaTeX format"),
                      wxITEM_NORMAL);

--- a/src/wxMaximaFrame.h
+++ b/src/wxMaximaFrame.h
@@ -268,6 +268,7 @@ public:
     menu_evaluate_all,
     menu_show_tip,
     menu_copy_from_worksheet,
+	menu_copy_matlab_from_worksheet,
     menu_copy_tex_from_worksheet,
     menu_copy_text_from_worksheet,
     menu_undo,


### PR DESCRIPTION
I'm calculating my matrices in wxmaxima and use them in matlab for simulation. Everytime I copy the matrices, I have to do some changes, because the copied matrix has not the same format like in matlab. For this it's nice to copy directly matlab code and just paste it in matlab.
(Maybe an alignment can be made, then it looks like in matlab symbolic toolbox, but the matrices are then much bigger)