### PR TITLE
Fix AppData file: Remove ModernToolkit from kudos

### DIFF
--- a/data/io.github.wxmaxima_developers.wxMaxima.appdata.xml
+++ b/data/io.github.wxmaxima_developers.wxMaxima.appdata.xml
@@ -44,7 +44,6 @@
   <url type="help">https://wxmaxima-developers.github.io/wxmaxima/help.html</url>
   <developer_name>wxMaxima Team</developer_name>
   <kudos>
-    <kudo>ModernToolkit</kudo>
     <kudo>HiDpiIcon</kudo>
     <kudo>HighContrast</kudo>
     <kudo>UserDocs</kudo>
@@ -65,7 +64,7 @@
       <description>
         <ul>
           <li>Corrected the size of error messages</li>
-          <li>A &quot;Copy to Matlab/Octave&quot;-feature</li>
+          <li>A "Copy to Matlab/Octave"-feature</li>
           <li>wxMaxima now defers interpreting the data from Maxima until it encounters a newline or a timer expires</li>
           <li>EMF output no more causes crashes and strange behaviour</li>
           <li>RTF output should now work again</li>
@@ -104,7 +103,7 @@
           <li>HighDPI fixes for ArchLinux, Windows and SuSE</li>
           <li>Resolved crashes on RedHat and MS Windows</li>
           <li>SBCL's compilation messages now appear in the status bar, not in the worksheet</li>
-          <li>Removed an unneeded &quot;maxima has finished calculating&quot; on startup</li>
+          <li>Removed an unneeded "maxima has finished calculating" on startup</li>
           <li>wxWidgets &gt;= 3.1.0: Corrected the toolbar icon size</li>
           <li>Many small bug fixes</li>
         </ul>
@@ -380,7 +379,7 @@
     <release version="16.12" date="2016-12-11">
       <description>
         <ul>
-          <li>Not a change in wxMaxima, but useful: In Maxima >5.38 the load() command can load .wxm files like it would load .mac files</li>
+          <li>Not a change in wxMaxima, but useful: In Maxima &gt;5.38 the load() command can load .wxm files like it would load .mac files</li>
           <li>Better detection and diagnosis for Maxima process that terminate unexpectedly even if the OS fails to notify us that the network connection with Maxima has dropped</li>
           <li>Incremental search</li>
           <li>Automatic line wrap</li>
@@ -389,9 +388,9 @@
           <li>A button that temporarily hides all code cells</li>
           <li>Massive speedups in the drawing code</li>
           <li>Added a wxstatusbar() command that allows a long-ranging block() to send a string about its progress to the status bar</li>
-          <li>Support for cells that are >5000 pixels wide</li>
+          <li>Support for cells that are &gt;5000 pixels wide</li>
           <li>Better High-DPI support</li>
-          <li>A Kabyle Translation for users of wxWidgets >= 3.0.1</li>
+          <li>A Kabyle Translation for users of wxWidgets &gt;= 3.0.1</li>
           <li>Holding the "evaluate" key now evaluates all cells of the document one-by-one</li>
           <li>.wxm files now include image cells</li>
           <li>Drag-and-drop now handles image cells</li>


### PR DESCRIPTION
`ModernToolkit` in `kudos` means that the application uses a modern toolkit like Gtk+3 or Qt5. 
However, wxMaxima, just like almost every wxWidgets app, can use Gtk+2 as well.
This is why we should leave it to the automatic detection mechanism in `appstream-builder`.

See also:
https://github.com/flathub/flathub/wiki/AppData-Guidelines#kudos
https://gitlab.gnome.org/GNOME/gnome-software/blob/master/doc/kudos.md#kudos-used-in-software

---

To remove `ModernToolkit` from `kudos` I used the following command:
```
xmlstarlet ed --inplace -d '/component/kudos/kudo[text()="ModernToolkit"]' data/io.github.wxmaxima_developers.wxMaxima.appdata.xml
```
That's why it has fixed a few things related to XML as well.