### PR TITLE
Call wxAutoBufferedPaintDC::SetPen() correctly

### DIFF
--- a/src/Worksheet.cpp
+++ b/src/Worksheet.cpp
@@ -430,7 +430,7 @@ void Worksheet::OnPaint(wxPaintEvent &WXUNUSED(event))
   dc.Clear();
 #else
 #ifdef __WXGTK3__
-  dc.SetPen(wxTRANSPARENT_PEN);
+  dc.SetPen(*wxTRANSPARENT_PEN);
   dc.DrawRectangle(updateRegion);
 #else
   dc.Clear();


### PR DESCRIPTION
`Worksheet.cpp`: Call `wxAutoBufferedPaintDC::SetPen(const wxPen&)` correctly

Closes #1121