### PR TITLE
Another attempt to fix #1113

### DIFF
--- a/src/Worksheet.cpp
+++ b/src/Worksheet.cpp
@@ -405,6 +405,10 @@ void Worksheet::OnPaint(wxPaintEvent &WXUNUSED(event))
 #ifdef __WXGTK__
 #ifndef __WXGTK3__
   PrepareDC(dc);
+#else
+#if wxCHECK_VERSION(3, 1, 0)
+  PrepareDC(dc);
+#endif
 #endif
 #else
   PrepareDC(dc);


### PR DESCRIPTION
Unfortunately, the last update (_19.05.0_) has broken the program under wxWidgets 3.1.

It doesn't now correctly display the area when scrolling.

Example input:
```
for i thru 100 do display(i!);
```

Result:
![wxMaxima_19.05.0_wxWidgets-3.1.png](https://i.imgur.com/F6cuhS4.png
 "wxMaxima_19.05.0_wxWidgets-3.1.png")

The error does **not** occur in wxWidgets 3.0 (versions 3.0.2 and 3.0.4 were tested, the second one with both toolkits: gtk+2 and gtk+3).

I can also confirm that this error did **not** occur in the previous version (_19.04.3_).

---

This patch fixes the bug on GNOME 3.32 runtime in Flatpak when using wxGTK3 3.1.2.

It applies only to wxGTK3 in wxWidgets 3.1, so it shouldn't break anything else.
Please keep in mind that all major Linux distribution use wxWidgets 3.0 by default. This includes EL, Fedora, SLE, openSUSE, Ubuntu LTS and Debian stable. Moreover, there is no wxGTK31 in the official Fedora repos.
However, this wxWidgets version may be used by some bleeding edge distributions, such as Arch or Gentoo. And to be honest, I don't have time to test it on every single distro.

See also:
https://github.com/wxMaxima-developers/wxmaxima/issues/1113#issuecomment-489347885
https://github.com/wxMaxima-developers/wxmaxima/issues/1113#issuecomment-489353364

Hope this is the final solution for #1113