### PR TITLE
Fix incorrect use of ^ operator

### DIFF
--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -4004,7 +4004,7 @@ long long wxMaxima::GetTotalCpuTime()
   FILETIME systemtime;
   GetSystemTimeAsFileTime(&systemtime);
   return (long long) systemtime.dwLowDateTime +
-        (2^32)*((long long) systemtime.dwHighDateTime);
+        ((long long) systemtime.dwHighDateTime << 32);
 #else
   int CpuJiffies = 0;
   if(wxFileExists("/proc/stat"))


### PR DESCRIPTION
`2^32` equals `34`, which does not do what this code wants.