### PR TITLE
Match the group type correctly in ChangeCellStyle

### DIFF
--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -8730,7 +8730,7 @@ void wxMaxima::ChangeCellStyle(wxCommandEvent& WXUNUSED(event))
   if(m_worksheet->GetActiveCell())
   {
     GroupCell *group = dynamic_cast<GroupCell *>(m_worksheet->GetActiveCell()->GetGroup());
-    switch(group->GetStyle())
+    switch(group->GetGroupType())
     {
     case GC_TYPE_CODE:
     case GC_TYPE_TEXT:


### PR DESCRIPTION
Found by a compiler warning:

```
  /usr/pkg/pobj/wxMaxima-19.08.1/wxmaxima-Version-19.08.1/src/wxMaxima.cpp:8742:10: warning: comparison of two values with different enumeration types in switch statement ('TextStyle' and 'GroupType') [-Wenum-compare-switch]
      case GC_TYPE_HEADING6:
           ^~~~~~~~~~~~~~~~
```

The intent of this code appears to be to restrict changing the cell's style to text cells only, but the wrong method call was used to get the cell's type.

This created a bug whereby changing the cell style appeared to work correctly for text cells, but non-text cells were broken. To reproduce:

  1. Go to Cell -> Insert image...
  1. Insert an image cell (with any image)
  1. Click on the text at the top of the image cell to activate it.
  1. Use the drop-down menu to change its type from Maths to any other type.
  1. The image cell will be replaced with a non-image cell, and the image will vanish from view.

Video capture of the bug: http://v.pha.lt/wxmaxima-image.mp4