### PR TITLE
In EditorCell::HandleOrdinaryKey, do not convert Shift+Space to nonbreaking space

### DIFF
--- a/src/EditorCell.cpp
+++ b/src/EditorCell.cpp
@@ -2326,9 +2326,6 @@ bool EditorCell::HandleOrdinaryKey(wxKeyEvent &event)
 
     chr = event.GetUnicodeKey();
 
-    if (event.ShiftDown())
-      chr.Replace(wxT(" "), wxT("\xa0"));
-
     m_text = m_text.SubString(0, m_positionOfCaret - 1) +
              chr +
              m_text.SubString(m_positionOfCaret, m_text.Length());


### PR DESCRIPTION
This PR contains 1 commit which reverts the behavior which was introduced in commit 20e7e19. It appears that users encountered problems with Shift+Space --> nbsp, as discussed in issue #1031 (https://github.com/wxMaxima-developers/wxmaxima/issues/1031).

I believe that EditorCell::HandleOrdinaryKey is the only place in the code in which Shift+Space is converted to nbsp.

This PR only changes the behavior of EditorCell::HandleOrdinaryKey, it does not change any other code related to nonbreaking spaces (e.g. to convert nonbreaking space to tilde for TeX output) and it does not change any of the locales strings which mention Shift+Space --> nbsp, and it does not change the Tip Of The Day which mentions it.