### PR TITLE
Use the existing Mac icon by setting the icon filename.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,6 +68,7 @@ if(WIN32)
 elseif(APPLE)
     set(MACOSX_BUNDLE TRUE)
     SET(MACOSX_BUNDLE_NAME wxmaxima)
+    SET(MACOSX_BUNDLE_ICON_FILE wxmac.icns)
     list(APPEND SOURCE_FILES ${RESOURCE_FILES})
     add_executable(wxmaxima ${SOURCE_FILES})
     set_target_properties(wxmaxima PROPERTIES


### PR DESCRIPTION
Until now, the app was run with Apple's placeholder app icon
because the wxmac.icns was not mentioned in the Info.plist
file, despite being in the bundle.