### PR TITLE
Enhance mechanism to find gnuplot

### DIFF
--- a/src/Dirstructure.cpp
+++ b/src/Dirstructure.cpp
@@ -29,11 +29,14 @@
   DirStructure informs about what directory is to be found where on the current system.
 */
 
-
 #include "Dirstructure.h"
 #include <wx/filename.h>
 #include <wx/dir.h>
 #include "Version.h"
+
+// This macro is used to mark the macports prefix, so that it can be easily patched
+// The MacPorts port file for wxMaxima uses this, so don't remove this!
+#define OSX_MACPORTS_PREFIX "/opt/local"
 
 Dirstructure::Dirstructure()
 {
@@ -214,7 +217,7 @@ wxString Dirstructure::MaximaDefaultLocation()
     return maximaLocation;
 
   wxLogMessage(wxString::Format(notFound,maximaLocation.utf8_str()));
-  maximaLocation = "/opt/local/bin/maxima";
+  maximaLocation = OSX_MACPORTS_PREFIX "/bin/maxima";
   if (wxFileExists(maximaLocation))
     return maximaLocation;
 
@@ -237,6 +240,65 @@ wxString Dirstructure::MaximaDefaultLocation()
   wxLogMessage(wxString::Format(notFound,maximaLocation.utf8_str()));
 #endif
   return wxT("maxima");
+}
+
+wxString Dirstructure::GnuplotDefaultLocation(wxString pathguess)
+{
+  wxString gnuplot_binary;
+
+  if(wxFileName(pathguess).IsAbsolute())
+    gnuplot_binary = pathguess;
+  else
+  {
+    wxPathList pathlist;
+
+    // Add paths relative to the path of the wxMaxima executable
+    pathlist.Add(wxFileName(wxStandardPaths::Get().GetExecutablePath()).GetPath());
+    pathlist.Add(wxFileName(wxStandardPaths::Get().GetExecutablePath()).GetPath()+"/../");
+    pathlist.Add(wxFileName(wxStandardPaths::Get().GetExecutablePath()).GetPath()+"/../gnuplot");
+    pathlist.Add(wxFileName(wxStandardPaths::Get().GetExecutablePath()).GetPath()+"/../gnuplot/bin");
+
+    // Add paths from the PATH environment variable
+    pathlist.AddEnvList(wxT("PATH"));
+
+    // Add OSX specific paths
+#ifdef __WXOSX__
+    // MacPorts:
+    // The MacPorts default binary path /opt/local/bin/ is not in the PATH for applications.
+    // It is added to .profile, but this is only used by shells.
+    // => Add the default MacPorts binary path /opt/local/bin/ to our search path list.
+    //
+    // Homebrew:
+    // Homebrew installs binaries in /usr/local/bin, which is in the PATH by default.
+    //
+    // Application packages including gnuplot:
+    // The above wxMaxima executable relative logic should work
+    //
+    // If gnuplot is somewhere else (e.g. non default MacPort or Homebrew path), the command
+    //   gnuplot_command:"/opt/local/bin/gnuplot"$
+    // must be added manually to ~/.maxima/wxmaxima-init.mac
+    // This should be documented for the installer packages, e.g. as MacPorts "notes" field.
+    pathlist.Add(OSX_MACPORTS_PREFIX "/bin");
+#endif
+
+    // Find executable "gnuplot" in our list of paths
+    gnuplot_binary = pathlist.FindAbsoluteValidPath(pathguess);
+    // If not successfull, Find executable "gnuplot.exe" in our list of paths
+    if(gnuplot_binary == wxEmptyString)
+      gnuplot_binary = pathlist.FindAbsoluteValidPath(pathguess + wxT(".exe"));
+    // If not successfull, use the original command (better than empty for error messaqges)
+    if(gnuplot_binary == wxEmptyString)
+    {
+      wxLogMessage(_("Gnuplot not found, using the default: ") + pathguess);
+      gnuplot_binary = pathguess;
+    }
+    else
+    {
+      wxLogMessage(_("Gnuplot found at: ") + gnuplot_binary);
+    }    
+  }
+
+  return gnuplot_binary;
 }
 
 wxString Dirstructure::UserAutocompleteFile()

--- a/src/Dirstructure.h
+++ b/src/Dirstructure.h
@@ -89,8 +89,11 @@ public:
   wxString LocaleDir() const
   { return ResourcesDir() + wxT("/locale"); }
 
-  //! The path we pass to the operating system if we want it to locate maxima instead
+  //! The executable file path to the maxima executable (or .bat on Windows)
   static wxString MaximaDefaultLocation();
+
+  //! The executable file path to the gnuplot executable
+  static wxString GnuplotDefaultLocation(wxString pathguess);
 
   static Dirstructure *Get()
     {

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -182,7 +182,7 @@ wxMaxima::wxMaxima(wxWindow *parent, int id, wxLocale *locale, const wxString ti
   wxMaximaFrame(parent, id, title, pos, size, wxDEFAULT_FRAME_STYLE,
                 MyApp::m_topLevelWindows.empty()),
   m_openFile(filename),
-  m_gnuplotcommand(Dirstructure::GnuplotDefaultLocation("gnuplot")),
+  m_gnuplotcommand("gnuplot"),
   m_parser(&m_worksheet->m_configuration, &m_worksheet->m_cellPointers)
 {
   #ifdef HAVE_OMP_HEADER
@@ -2640,7 +2640,7 @@ void wxMaxima::ReadVariables(wxString &data)
             }
             if(name == "gnuplot_command")
             {
-              m_gnuplotcommand = Dirstructure::GnuplotDefaultLocation(value);
+              m_gnuplotcommand = value;
               wxLogMessage(wxString::Format(_("Gnuplot can be found at %s"),m_gnuplotcommand.utf8_str()));
             }
             if(name == "*maxima-sharedir*")
@@ -3708,8 +3708,9 @@ void wxMaxima::SetupVariables()
   wxString cmd;
 
 #if defined (__WXOSX__)
-  if (wxFileExists(m_gnuplotcommand))
-    cmd += wxT("\n:lisp-quiet (setf $gnuplot_command \"") + m_gnuplotcommand + wxT("\")\n");
+  wxString gunplot_binary = Dirstructure::GnuplotDefaultLocation(m_gnuplotcommand);
+  if (wxFileExists(gunplot_binary))
+    cmd += wxT("\n:lisp-quiet (setf $gnuplot_command \"") + gunplot_binary + wxT("\")\n");
 #endif
   cmd.Replace(wxT("\\"), wxT("/"));
   SendMaxima(cmd);
@@ -5786,7 +5787,7 @@ void wxMaxima::EditMenu(wxCommandEvent &event)
     }
       
     // Execute gnuplot
-    wxString cmdline = m_gnuplotcommand + wxT(" " + gnuplotSource + wxT(".popout"));
+    wxString cmdline = Dirstructure::GnuplotDefaultLocation(m_gnuplotcommand) + wxT(" " + gnuplotSource + wxT(".popout"));
     wxLogMessage(_("Running gnuplot as: " + cmdline));
     
     m_gnuplotProcess = new wxProcess(this, gnuplot_process_id);


### PR DESCRIPTION
This PR enhances the mechanism to find gnuplot:

- Centralised two different places in the code searching for gnuplot into Directorystructure.cpp
- Added a Macports specific search path for OSX
- Added a mechanism to easily patch the MacPorts root folder to the actual prefix chosen on each system
- Always set m_gnuplotcommand to a path of gnuplot in case gnuplot can be found and do this only once, in the constructor of wxMaxima and when settings are read in.