### PR TITLE
Fix out-of-bounds string access in EditorCell::FindMatchingParens().

### DIFF
--- a/src/EditorCell.cpp
+++ b/src/EditorCell.cpp
@@ -2512,14 +2512,14 @@ void EditorCell::FindMatchingParens()
   }
 
   m_paren2 = m_positionOfCaret;
+  if(m_paren2 >= (long)m_text.Length())
+    m_paren2 = m_text.Length() - 1;
   if (m_paren2 < 0)
   {
     m_paren1 = m_paren2 = -1;
     return;
   }
 
-  if(m_paren2 >= (long)m_text.Length())
-    m_paren2 = m_text.Length() - 1;
   if ((m_paren2 >= (long) m_text.Length())||
       (wxString(wxT("([{}])")).Find(m_text.GetChar(m_paren2)) == -1))
   {


### PR DESCRIPTION
This fixes an out-of-bounds access crash when adding a character to a freshly created editor cell.

To reproduce:
1. Build wxWidgets 3.1.3 build using MSVC 2019 16.5.4, 64 bits debug build.
2. Build wxMaxima in the same way.
3. Start wxMaxima, press any printable key (e.g. simply a). A new EditorCell is created, parenthesis matching is attempted, and promptly crashes since the cell is empty and an a call is made to wxString::GetChar(-1).