### PR TITLE
Cache wxFont instances, reducing the number of wxFont instance churn by a factor of 5000+

### DIFF
--- a/src/FontCache.cpp
+++ b/src/FontCache.cpp
@@ -1,0 +1,210 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+//
+//  Copyright (C) 2020 Kuba Ober <kuba@bertec.com>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+#include "FontCache.h"
+#include <wx/log.h>
+
+FontCache::~FontCache()
+{
+  wxLogDebug("~FontCache: hits=%d misses=%d h:m ratio=%.2f",
+             m_hits, m_misses, double(m_hits)/m_misses);
+}
+
+wxFont FontCache::GetFont(const wxFontInfo &request)
+{
+  if (!m_enabled)
+  {
+    m_misses ++;
+    return {request};
+  }
+  auto font = m_cache.try_emplace(request, request);
+  assert(font.first != m_cache.end());
+  m_misses += font.second ? 1 : 0;
+  m_hits += font.second ? 0 : 1;
+  return font.first->second;
+}
+
+wxFontInfo FontCache::AddFont(const wxFontInfo &info, const wxFont &font)
+{
+  auto &request = info;
+  m_cache.insert_or_assign(request, font);
+  return request;
+}
+
+wxFontInfo FontCache::AddFont(const wxFont &font)
+{
+  return AddFont(FontInfo::GetFor(font), font);
+}
+
+bool FontCache::IsOk(const wxFontInfo &request)
+{
+  return GetFont(request).IsOk();
+}
+
+void FontCache::Clear()
+{
+  m_cache.clear();
+  m_hits = 0;
+  m_misses = 0;
+}
+
+template <typename T>
+static wxFontInfo &SetSize(wxFontInfo &info, T size)
+{
+  wxFontInfo newInfo{size};
+  FontInfo::CopyWithoutSize(info, newInfo);
+  return (info = newInfo);
+}
+
+namespace FontInfo
+{
+
+void CopyWithoutSize(const wxFontInfo &src, wxFontInfo &dst)
+{
+  dst
+    .Family(src.GetFamily())
+    .FaceName(src.GetFaceName())
+    .Underlined(src.IsUnderlined())
+    .Strikethrough(src.IsStrikethrough())
+    .Encoding(src.GetEncoding())
+#if wxCHECK_VERSION(3, 1, 2)
+    .Style(src.GetStyle())
+    .Weight(src.GetNumericWeight())
+#else
+    .Slant(src.GetStyle() == wxFONTSTYLE_SLANT)
+    .Italic(src.GetStyle() == wxFONTSTYLE_ITALIC)
+    .Bold(src.GetWeight() == wxFONTWEIGHT_BOLD)
+    .Light(src.GetWeight() == wxFONTWEIGHT_LIGHT)
+#endif
+    ;
+}
+
+void CopyWithoutSize(const wxFont *font, wxFontInfo &dst)
+{
+  auto req = GetFor(*font);
+  FontCache::AddAFont(req, *font);
+  CopyWithoutSize(req, dst);
+}
+
+wxFontInfo GetFor(const wxFont &font)
+{
+  wxFontInfo request;
+  if (font.IsUsingSizeInPixels())
+    request = wxFontInfo(font.GetPixelSize());
+  else
+    request = wxFontInfo(font.GetFractionalPointSize());
+  return request
+#if wxCHECK_VERSION(3, 1, 2)
+    .Style(font.GetStyle())
+    .Weight(font.GetNumericWeight())
+#else
+    .Slant(font.GetStyle() == wxFONTSTYLE_SLANT)
+    .Italic(font.GetStyle() == wxFONTSTYLE_ITALIC)
+    .Bold(font.GetWeight() == wxFONTWEIGHT_BOLD)
+    .Light(font.GetWeight() == wxFONTWEIGHT_LIGHT)
+#endif
+    .Family(font.GetFamily())
+    .Encoding(font.GetEncoding())
+    .FaceName(font.GetFaceName())
+    .Underlined(font.GetUnderlined())
+    .Strikethrough(font.GetStrikethrough());
+}
+
+void SetPointSize(wxFontInfo &info, int p)
+{
+  if (info.GetPointSize() != p) SetSize(info, p);
+}
+
+void SetPointSize(wxFontInfo &info, float p)
+{
+#if wxCHECK_VERSION(3, 1, 2)
+  if (info.GetFractionalPointSize() != p) SetSize(info, p);
+#else
+  p = roundf(p);
+  if (info.GetPointSize() != p) SetSize(info, p);
+#endif // wx version > 3.1.2
+}
+
+void SetPointSize(wxFontInfo &info, double p)
+{
+#if wxCHECK_VERSION(3, 1, 2)
+  if (info.GetFractionalPointSize() != p) SetSize(info, p);
+#else
+  p = round(p);
+  if (info.GetPointSize() != p) SetSize(info, p);
+#endif // wx version > 3.1.2
+}
+
+void SetPixelSize(wxFontInfo &info, wxSize size)
+{
+  if (!info.IsUsingSizeInPixels() || info.GetPixelSize() != size)
+    SetSize(info, size);
+}
+
+} // namespace FontInfo
+
+template <typename T>
+static std::size_t mixHash(std::size_t seed, const T &value)
+{
+  seed ^= std::hash<T>{}(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  return seed;
+}
+
+namespace std {
+
+std::size_t hash<wxSize>::operator()(wxSize size) const
+{
+  return mixHash(mixHash(0, size.x), size.y);
+}
+
+std::size_t hash<wxFontInfo>::operator()(const wxFontInfo &fi) const
+{
+  std::size_t h = 0;
+  h = mixHash(h, fi.GetEncoding());
+  h = mixHash(h, fi.GetFamily());
+  h = mixHash(h, fi.GetFaceName());
+  h = mixHash(h, fi.GetStyle());
+  h = mixHash(h, fi.GetNumericWeight());
+  h = mixHash(h, fi.IsUnderlined() ? wxFONTFLAG_UNDERLINED : 0);
+  h = mixHash(h, fi.IsStrikethrough() ? wxFONTFLAG_STRIKETHROUGH : 0);
+  if (fi.IsUsingSizeInPixels())
+    h = mixHash(h, fi.GetPixelSize());
+  else
+    h = mixHash(h, fi.GetFractionalPointSize());
+  return h;
+}
+
+bool equal_to<wxFontInfo>::operator()(const wxFontInfo &l, const wxFontInfo &r) const
+{
+  return
+    l.IsUsingSizeInPixels() == r.IsUsingSizeInPixels() &&
+    ((l.IsUsingSizeInPixels() && l.GetPixelSize() == r.GetPixelSize()) ||
+     (!l.IsUsingSizeInPixels() && l.GetFractionalPointSize() == r.GetFractionalPointSize())) &&
+    l.GetFamily() == r.GetFamily() &&
+    l.GetFaceName() == r.GetFaceName() &&
+    l.GetNumericWeight() == r.GetNumericWeight() &&
+    l.IsUnderlined() == r.IsUnderlined() &&
+    l.IsStrikethrough() == r.IsStrikethrough() &&
+    l.GetEncoding() == r.GetEncoding();
+}
+
+} // namespace std
+

--- a/src/FontCache.h
+++ b/src/FontCache.h
@@ -1,0 +1,116 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+//
+//  Copyright (C) 2020 Kuba Ober <kuba@bertec.com>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+#ifndef FONTCACHE_H
+#define FONTCACHE_H
+
+#include <wx/font.h>
+#include <functional>
+#include <unordered_map>
+
+/*! \file
+ * This file implements the wxFont cache system.
+ */
+
+namespace std {
+
+template <>
+struct hash<wxSize> {
+  std::size_t operator()(wxSize size) const;
+};
+
+template <>
+struct hash<wxFontInfo> {
+  std::size_t operator()(const wxFontInfo &fi) const;
+};
+
+template <>
+struct equal_to<wxFontInfo> {
+  bool operator()(const wxFontInfo &l, const wxFontInfo &r) const;
+};
+
+} // namespace std
+
+/*! \namespace
+ * Provides extension methods for the wxFontInfo class.
+ */
+namespace FontInfo
+{
+  wxFontInfo GetFor(const wxFont &font);
+  void CopyWithoutSize(const wxFontInfo &src, wxFontInfo &dst);
+  void CopyWithoutSize(const wxFont *font, wxFontInfo &dst);
+
+  void SetPointSize(wxFontInfo &info, int p);
+  void SetPointSize(wxFontInfo &info, float p);
+  void SetPointSize(wxFontInfo &info, double p);
+  void SetPixelSize(wxFontInfo &info, wxSize size);
+}
+
+class FontCache final
+{
+  FontCache(const FontCache &) = delete;
+  FontCache &operator=(const FontCache &) = delete;
+  std::unordered_map<wxFontInfo, wxFont> m_cache;
+  bool m_enabled = true;
+  int m_hits = 0;
+  int m_misses = 0;
+public:
+  FontCache() = default;
+  ~FontCache();
+  wxFont GetFont(const wxFontInfo &request);
+  wxFontInfo AddFont(const wxFontInfo &info, const wxFont &font);
+  wxFontInfo AddFont(const wxFont &font);
+  bool IsOk(const wxFontInfo &request);
+  int GetHits() const { return m_hits; }
+  int GetMisses() const { return m_misses; }
+  void SetEnabled(bool enabled = true) { m_enabled = enabled; }
+  void Clear();
+  static FontCache &Get()
+  {
+#ifdef _WIN32
+    static thread_local FontCache globalCache;
+    // Windows allows font access from multiple threads, as long as each font
+    // is built separately.
+#else
+    static FontCache globalCache;
+#endif // _WIN32
+    return globalCache;
+  }
+  static wxFont GetAFont(const wxFontInfo &request)
+  {
+    return Get().GetFont(request);
+  }
+  static wxFont GetAFont(const wxFont &font)
+  {
+    Get().AddFont(font);
+    return font;
+  }
+  static wxFontInfo AddAFont(const wxFont &font)
+  {
+    return Get().AddFont(font);
+  }
+  static wxFontInfo AddAFont(const wxFontInfo &info, const wxFont &font)
+  {
+    return Get().AddFont(info, font);
+  }
+};
+
+#endif  // FONTCACHE_H

--- a/src/IntCell.cpp
+++ b/src/IntCell.cpp
@@ -27,6 +27,7 @@
 */
 
 #include "IntCell.h"
+#include "FontCache.h"
 #include "TextCell.h"
 
 #if defined __WXMSW__
@@ -141,17 +142,22 @@ void IntCell::RecalculateWidths(int fontsize)
   {
     wxDC *dc = configuration->GetDC();
     double fontsize1 = Scale_Px(fontsize * 1.5);
-    wxFont font(fontsize1, wxFONTFAMILY_MODERN,
-                wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false,
-                configuration->GetTeXCMEX());
-    if (!font.IsOk())
-      font = *wxNORMAL_FONT;
-#if wxCHECK_VERSION(3, 1, 2)
-    font.SetFractionalPointSize(fontsize1);
-#else
-    font.SetPointSize(fontsize1);
-#endif
     wxASSERT(fontsize1 > 0);
+
+    wxFont font =
+      FontCache::GetAFont(wxFontInfo(fontsize1)
+                            .Family(wxFONTFAMILY_MODERN)
+                            .Style(wxFONTSTYLE_NORMAL)
+                            .Weight(wxFONTWEIGHT_NORMAL)
+                            .Underlined(false)
+                            .FaceName(configuration->GetTeXCMEX()));
+    if (!font.IsOk())
+    {
+      auto req = wxFontInfo(fontsize1);
+      FontInfo::CopyWithoutSize(wxNORMAL_FONT, req);
+      font = FontCache::GetAFont(req);
+    }
+
     dc->SetFont(font);
     dc->GetTextExtent(wxT("\u005A"), &m_signWidth, &m_signHeight);
 
@@ -172,18 +178,23 @@ void IntCell::RecalculateWidths(int fontsize)
 #if defined __WXMSW__
     wxDC *dc = configuration->GetDC();
     double fontsize1 = Scale_Px(INTEGRAL_FONT_SIZE);
-    wxFont font(fontsize1, wxFONTFAMILY_MODERN,
-                wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL,
-                false,
-                configuration->GetSymbolFontName());
-    if(!font.IsOk())
-      font = *wxNORMAL_FONT;
-#if wxCHECK_VERSION(3, 1, 2)
-    font.SetFractionalPointSize(fontsize1);
-#else
-    font.SetPointSize(fontsize1);
-#endif
     wxASSERT(fontsize1 > 0);
+
+    wxFont font =
+      FontCache::GetAFont(wxFontInfo(fontsize1)
+                            .Family(wxFONTFAMILY_MODERN)
+                            .Style(wxFONTSTYLE_NORMAL)
+                            .Weight(wxFONTWEIGHT_NORMAL)
+                            .Underlined(false)
+                            .FaceName(configuration->GetSymbolFontName()));
+
+    if(!font.IsOk())
+    {
+      auto req = wxFontInfo(fontsize1);
+      FontInfo::CopyWithoutSize(wxNORMAL_FONT, req);
+      font = FontCache::GetAFont(req);
+    }
+
     dc->SetFont(font);
     dc->GetTextExtent(INTEGRAL_TOP, &m_charWidth, &m_charHeight);
 
@@ -249,17 +260,19 @@ void IntCell::Draw(wxPoint point)
     {
       SetForeground();
       double fontsize1 = Scale_Px(m_fontSize * 1.5);
-      wxFont font(fontsize1, wxFONTFAMILY_MODERN,
-                  wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false,
-                  configuration->GetTeXCMEX());
+      wxASSERT(fontsize1 > 0);
+
+      wxFont font =
+        FontCache::GetAFont(wxFontInfo(fontsize1)
+                              .Family(wxFONTFAMILY_MODERN)
+                              .Style(wxFONTSTYLE_NORMAL)
+                              .Weight(wxFONTWEIGHT_NORMAL)
+                              .Underlined(false)
+                              .FaceName(configuration->GetTeXCMEX()));
+
       if (!font.IsOk())
         configuration->CheckTeXFonts(false);
-      wxASSERT(fontsize1 > 0);
-#if wxCHECK_VERSION(3, 1, 2)
-      font.SetFractionalPointSize(fontsize1);
-#else
-      font.SetPointSize(fontsize1);
-#endif
+
       dc->SetFont(font);
       dc->DrawText(wxT("\u005A"),
                   sign.x,
@@ -271,18 +284,16 @@ void IntCell::Draw(wxPoint point)
       SetForeground();
       double fontsize1 = Scale_Px(INTEGRAL_FONT_SIZE);
       int m_signWCenter = m_signWidth / 2;
-
       wxASSERT(fontsize1 > 0);
-      wxFont font (fontsize1, wxFONTFAMILY_MODERN,
-      wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL,
-      false,
-                   configuration->GetSymbolFontName());
 
-#if wxCHECK_VERSION(3, 1, 2)
-      font.SetFractionalPointSize(fontsize1);
-#else
-      font.SetPointSize(fontsize1);
-#endif
+      wxFont font =
+        FontCache::GetAFont(wxFontInfo(fontsize1)
+                              .Family(wxFONTFAMILY_MODERN)
+                              .Style(wxFONTSTYLE_NORMAL)
+                              .Weight(wxFONTWEIGHT_NORMAL)
+                              .Underlined(false)
+                              .FaceName(configuration->GetSymbolFontName()));
+
       dc->SetFont(font);
       dc->DrawText(INTEGRAL_TOP,
                   sign.x + m_signWCenter - m_charWidth / 2,

--- a/src/ParenCell.cpp
+++ b/src/ParenCell.cpp
@@ -28,6 +28,7 @@
  */
 
 #include "ParenCell.h"
+#include "FontCache.h"
 
 ParenCell::ParenCell(Cell *parent, Configuration **config, CellPointers *cellPointers) :
   Cell(parent, config, cellPointers),
@@ -134,13 +135,14 @@ void ParenCell::SetFont(int fontsize)
   Configuration *configuration = (*m_configuration);
   wxDC *dc = configuration->GetDC();
 
+  wxFontInfo req;
   wxFont font;
   if(m_bigParenType == Configuration::ascii)
-    font = configuration->GetFont(TS_FUNCTION, fontsize);
+    req = FontInfo::GetFor(configuration->GetFont(TS_FUNCTION, fontsize));
   else
-    font = configuration->GetFont(TS_FUNCTION, configuration->GetMathFontSize());
+    req = FontInfo::GetFor(configuration->GetFont(TS_FUNCTION, configuration->GetMathFontSize()));
 
-  wxASSERT(font.GetPointSize() > 0);
+  wxASSERT(req.GetPointSize() > 0);
 
   switch(m_bigParenType)
   {
@@ -149,29 +151,30 @@ void ParenCell::SetFont(int fontsize)
     break;
 
   case Configuration::assembled_unicode_fallbackfont:
-    font.SetFaceName(wxT("Linux Libertine"));
+    req.FaceName(wxT("Linux Libertine"));
     break;
 
   case Configuration::assembled_unicode_fallbackfont2:
-    font.SetFaceName(wxT("Linux Libertine O"));
+    req.FaceName(wxT("Linux Libertine O"));
     break;
 
   default:
     break;
   }
 
-  font.SetStyle(wxFONTSTYLE_NORMAL);
-  font.SetUnderlined(false);
+  req.Style(wxFONTSTYLE_NORMAL).Underlined(false);
+  font = FontCache::GetAFont(req);
   if (!font.IsOk())
   {
-    font.SetFamily(wxFONTFAMILY_MODERN);
-    font.SetStyle(wxFONTSTYLE_NORMAL);
-    font.SetFaceName(wxEmptyString);
-    font.SetUnderlined(false);
+    req.Family(wxFONTFAMILY_MODERN)
+      .Style(wxFONTSTYLE_NORMAL)
+      .FaceName(wxEmptyString)
+      .Underlined(false);
+    font = FontCache::GetAFont(req);
   }
 
   if (!font.IsOk())
-    font = *wxNORMAL_FONT;
+    font = FontCache::GetAFont(*wxNORMAL_FONT);
 
   // A fallback if we have been completely unable to set a working font
   if (!dc->GetFont().IsOk())

--- a/src/SqrtCell.cpp
+++ b/src/SqrtCell.cpp
@@ -27,6 +27,7 @@
  */
 
 #include "SqrtCell.h"
+#include "FontCache.h"
 
 #define SIGN_FONT_SCALE 2.0
 
@@ -109,13 +110,15 @@ void SqrtCell::RecalculateWidths(int fontsize)
     m_signFontScale = 1.0;
     double fontsize1 = Scale_Px(SIGN_FONT_SCALE * fontsize * m_signFontScale);
     wxASSERT(fontsize1 > 0);
-    wxFont font(fontsize1, wxFONTFAMILY_MODERN, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false,
-                configuration->GetTeXCMEX());
-#if wxCHECK_VERSION(3, 1, 2)
-    font.SetFractionalPointSize(fontsize1);
-#else
-    font.SetPointSize(fontsize1);
-#endif
+
+    wxFont font =
+      FontCache::GetAFont(wxFontInfo(fontsize1)
+                            .Family(wxFONTFAMILY_MODERN)
+                            .Style(wxFONTSTYLE_NORMAL)
+                            .Weight(wxFONTWEIGHT_NORMAL)
+                            .Underlined(false)
+                            .FaceName(configuration->GetTeXCMEX()));
+
     dc->SetFont(font);
     dc->GetTextExtent(wxT("s"), &m_signWidth, &m_signSize);
     m_signTop = m_signSize / 5;
@@ -150,14 +153,16 @@ void SqrtCell::RecalculateWidths(int fontsize)
     }
 
     fontsize1 = Scale_Px(SIGN_FONT_SCALE * fontsize * m_signFontScale);
-    font = wxFont(fontsize1, wxFONTFAMILY_MODERN, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false,
-                  configuration->GetTeXCMEX());
     wxASSERT(fontsize1 > 0);
-#if wxCHECK_VERSION(3, 1, 2)
-    font.SetFractionalPointSize(fontsize1);
-#else
-    font.SetPointSize(fontsize1);
-#endif
+
+    font =
+      FontCache::GetAFont(wxFontInfo(fontsize1)
+                            .Family(wxFONTFAMILY_MODERN)
+                            .Style(wxFONTSTYLE_NORMAL)
+                            .Weight(wxFONTWEIGHT_NORMAL)
+                            .Underlined(false)
+                            .FaceName(configuration->GetTeXCMEX()));
+
     dc->SetFont(font);
     dc->GetTextExtent(wxT("s"), &m_signWidth, &m_signSize);
     m_signTop = m_signSize / 5;
@@ -205,15 +210,16 @@ void SqrtCell::Draw(wxPoint point)
       in.x += m_signWidth;
 
       double fontsize1 = Scale_Px(SIGN_FONT_SCALE * m_fontSize * m_signFontScale);
-
-      wxFont font(fontsize1, wxFONTFAMILY_MODERN, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false,
-                  configuration->GetTeXCMEX());
       wxASSERT(fontsize1 > 0);
-#if wxCHECK_VERSION(3, 1, 2)
-      font.SetFractionalPointSize(fontsize1);
-#else
-      font.SetPointSize(fontsize1);
-#endif
+
+      wxFont font =
+        FontCache::GetAFont(wxFontInfo(fontsize1)
+                              .Family(wxFONTFAMILY_MODERN)
+                              .Style(wxFONTSTYLE_NORMAL)
+                              .Weight(wxFONTWEIGHT_NORMAL)
+                              .Underlined(false)
+                              .FaceName(configuration->GetTeXCMEX()));
+
       dc->SetFont(font);
       SetForeground();
       if (m_signType < 4)

--- a/src/SumCell.cpp
+++ b/src/SumCell.cpp
@@ -30,6 +30,7 @@
 
 #include "SumCell.h"
 #include "TextCell.h"
+#include "FontCache.h"
 
 SumCell::SumCell(Cell *parent, Configuration **config, CellPointers *cellPointers) :
   Cell(parent, config, cellPointers),
@@ -119,27 +120,35 @@ void SumCell::RecalculateWidths(int fontsize)
     m_over = std::shared_ptr<TextCell>(new TextCell(m_group, m_configuration, m_cellPointers));
   m_over->RecalculateWidthsList(wxMax(MC_MIN_SIZE, fontsize - SUM_DEC));
 
-//   if (configuration->CheckTeXFonts())
-//   {
-//     wxDC *dc = configuration->GetDC();
-//     double fontsize1 = Scale_Px(configuration->GetMathFontSize());
-//     wxFont font(fontsize1, wxFONTFAMILY_MODERN,
-//                 wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false,
-//                 configuration->GetTeXCMEX());
-//     if (!font.IsOk())
-//       configuration->CheckTeXFonts(false);
-  
-// #if wxCHECK_VERSION(3, 1, 2)
-//     font.SetFractionalPointSize(fontsize1);
-// #else
-//     font.SetPointSize(fontsize1);
-// #endif
-//     dc->SetFont(font);
-//     dc->GetTextExtent(m_sumStyle == SM_SUM ? wxT(SUM_SIGN) : wxT(PROD_SIGN), &m_signWidth, &m_signHeight);
-//     m_signWCenter = m_signWidth / 2;
-//     m_signTop = (2 * m_signHeight) / 5;
-//     m_signHeight = (2 * m_signHeight) / 5;
-//   }
+  if (false)
+  {
+    Configuration *configuration = *m_configuration;
+    if (configuration->CheckTeXFonts())
+    {
+      wxDC *dc = configuration->GetDC();
+      double fontsize1 = Scale_Px(configuration->GetMathFontSize());
+
+      wxFont font =
+        FontCache::GetAFont(wxFontInfo(fontsize1)
+                              .Family(wxFONTFAMILY_MODERN)
+                              .Style(wxFONTSTYLE_NORMAL)
+                              .Weight(wxFONTWEIGHT_NORMAL)
+                              .Underlined(false)
+                              .FaceName(configuration->GetTeXCMEX()));
+
+      if (!font.IsOk())
+        configuration->CheckTeXFonts(false);
+
+      dc->SetFont(font);
+#if 0
+      dc->GetTextExtent(m_sumStyle == SM_SUM ? wxT(SUM_SIGN) : wxT(PROD_SIGN), &m_signWidth, &m_signHeight);
+      m_signWCenter = m_signWidth / 2;
+      m_signTop = (2 * m_signHeight) / 5;
+      m_signHeight = (2 * m_signHeight) / 5;
+#endif
+    }
+  } // if (false)
+
   m_signWCenter = wxMax(m_signWCenter, m_under->GetFullWidth() / 2);
   m_signWCenter = wxMax(m_signWCenter, m_over->GetFullWidth() / 2);
   m_width = 2 * m_signWCenter + m_displayedBase->GetFullWidth() + Scale_Px(4);
@@ -184,27 +193,35 @@ void SumCell::Draw(wxPoint point)
     over.y = point.y - m_signHeight / 2 - m_over->GetMaxDrop() - Scale_Px(2);
     m_over->DrawList(over);
 
-// //     if (configuration->CheckTeXFonts())
-// //     {
-// //       SetForeground();
-// //       double fontsize1 = Scale_Px(configuration->GetMathFontSize());
-// //       wxFont font(fontsize1, wxFONTFAMILY_MODERN,
-// //                   wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false,
-// //                   configuration->GetTeXCMEX());
-// //       if (!font.IsOk())
-// //         font = *wxNORMAL_FONT;
-// //       wxASSERT(fontsize1 > 0);
-// // #if wxCHECK_VERSION(3, 1, 2)
-// //       font.SetFractionalPointSize(fontsize1);
-// // #else
-// //       font.SetPointSize(fontsize1);
-// // #endif
-// //       dc->SetFont(font);
-// //       dc->DrawText(m_sumStyle == SM_SUM ? wxT(SUM_SIGN) : wxT(PROD_SIGN),
-// //                   sign.x + m_signWCenter - m_signWidth / 2,
-// //                   sign.y - m_signTop);
-// //     }
-// //     else
+    if (false /*this code is disabled*/ && configuration->CheckTeXFonts())
+    {
+      /*this code is disabled*/
+      SetForeground();
+      double fontsize1 = Scale_Px(configuration->GetMathFontSize());
+      wxASSERT(fontsize1 > 0);
+
+      auto req = wxFontInfo(fontsize1)
+                   .Family(wxFONTFAMILY_MODERN)
+                   .Style(wxFONTSTYLE_NORMAL)
+                   .Weight(wxFONTWEIGHT_NORMAL)
+                   .Underlined(false)
+                   .FaceName(configuration->GetTeXCMEX());
+
+      wxFont font = FontCache::GetAFont(req);
+
+      if (!font.IsOk()) {
+        FontInfo::CopyWithoutSize(wxNORMAL_FONT, req);
+        font = FontCache::GetAFont(req);
+      }
+
+      dc->SetFont(font);
+#if 0
+      dc->DrawText(m_sumStyle == SM_SUM ? wxT(SUM_SIGN) : wxT(PROD_SIGN),
+                   sign.x + m_signWCenter - m_signWidth / 2,
+                   sign.y - m_signTop);
+#endif
+    }
+    else
     {
       SetPen(1.5);
       if (m_sumStyle == SM_SUM)

--- a/src/TextStyle.cpp
+++ b/src/TextStyle.cpp
@@ -27,6 +27,7 @@
 */
 
 #include "TextStyle.h"
+#include "FontCache.h"
 #include <wx/colour.h>
 
 void Style::Read(wxConfigBase *config, wxString where)
@@ -49,14 +50,16 @@ void Style::Read(wxConfigBase *config, wxString where)
 #ifdef __WXOSX_MAC__
   if(m_fontName == wxEmptyString) m_fontName = "Monaco";
 #endif
-  wxFont font;
-  font.SetFamily(wxFONTFAMILY_MODERN);
-  font.SetFaceName(m_fontName);
+  auto req = wxFontInfo()
+               .Family(wxFONTFAMILY_MODERN)
+               .FaceName(m_fontName);
+  wxFont font = FontCache::GetAFont(req);
   if (!font.IsOk())
-    {
-      font = wxFontInfo(10);
-      m_fontName = font.GetFaceName();
-    }
+  {
+    req = wxFontInfo(10);
+    font = FontCache::GetAFont(req);
+    m_fontName = font.GetFaceName();
+  }
 }
 
 void Style::Write(wxConfigBase *config, wxString where)


### PR DESCRIPTION
wxMaxima wastes lots of time copying, destroying and reinstantiating objects. For a long document (~80 printed pages), this causes tens of millions of unnecessary allocations, copies and destructions across a wide range of objects (this problem is pervasive). 

This is a small step towards resolving #1185 - not nearly done yet of course.

On a test document, just the wxFont was reinstantiated hundreds of thousands of times. All that works was done just to utilize about 50 unique fonts. wxFont creation is extremely slow: it had to create and destruct native font handles. Fixing that alone cuts down document load times between 15-50% for me.

Sample debug session;

```
06:03:42: Debugging starts
~FontCache: hits=215904 misses=59 h:m ratio=3659.39
06:04:26: Debugging has finished
```

There's lots more to improve in this area: the wxFontInfo comparisons compare strings that are continuously reallocated. There's possibly a need for string interning or a better font identification mechanism. The hashing is likely unnecessary since the cache mostly hits, so the comparisons will be executed anyway and hashing is wasteful. But so far so good - it helps. Long term there may be a better solution that obviates the need for this design.

Note: I fixed build under wxWidgets <= 3.1.1