### PR TITLE
Feature/node refactor 1

### DIFF
--- a/src/AbsCell.cpp
+++ b/src/AbsCell.cpp
@@ -36,7 +36,7 @@ AbsCell::AbsCell(Cell *parent, Configuration **config, CellPointers *cellPointer
   m_close(new TextCell(parent, config, cellPointers, wxT(")"))),
   m_last(NULL)
 {
-  m_open->DontEscapeOpeningParenthesis();
+  static_cast<TextCell&>(*m_open).DontEscapeOpeningParenthesis();
   m_open->SetStyle(TS_FUNCTION);
 }
 
@@ -59,9 +59,9 @@ AbsCell::~AbsCell()
   MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> AbsCell::GetInnerCells()
+Cell::InnerCells AbsCell::GetInnerCells() const
 {
-  std::list<std::shared_ptr<Cell>> innerCells;
+  InnerCells innerCells;
   if(m_innerCell)
     innerCells.push_back(m_innerCell);
   if(m_open)

--- a/src/AbsCell.h
+++ b/src/AbsCell.h
@@ -63,7 +63,7 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   AbsCell &operator=(const AbsCell&) = delete;
 
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
+  InnerCells GetInnerCells() const override;
 
   void SetInner(Cell *inner);
 
@@ -91,9 +91,9 @@ protected:
   //! The contents of the abs() command
   std::shared_ptr<Cell> m_innerCell;
   //! The cell containing the eventual "abs" and the opening parenthesis
-  std::shared_ptr<TextCell> m_open;
+  std::shared_ptr<Cell> m_open;
   //! The cell containing the closing parenthesis
-  std::shared_ptr<TextCell> m_close;
+  std::shared_ptr<Cell> m_close;
   //! The last element of m_innerCell
   Cell *m_last;
 };

--- a/src/AtCell.cpp
+++ b/src/AtCell.cpp
@@ -31,8 +31,8 @@
 
 AtCell::AtCell(Cell *parent, Configuration **config, CellPointers *cellPointers) :
   Cell(parent, config, cellPointers),
-  m_baseCell (new TextCell(parent, config, cellPointers)),
-  m_indexCell(new TextCell(parent, config, cellPointers))
+  m_baseCell (std::make_shared<TextCell>(parent, config, cellPointers)),
+  m_indexCell(std::make_shared<TextCell>(parent, config, cellPointers))
 {
 }
 

--- a/src/AtCell.cpp
+++ b/src/AtCell.cpp
@@ -51,9 +51,9 @@ AtCell::~AtCell()
   MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> AtCell::GetInnerCells()
+Cell::InnerCells AtCell::GetInnerCells() const
 {
-  std::list<std::shared_ptr<Cell>> innerCells;
+  InnerCells innerCells;
   if(m_baseCell)
     innerCells.push_back(m_baseCell);
   if(m_indexCell)

--- a/src/AtCell.h
+++ b/src/AtCell.h
@@ -36,7 +36,7 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   AtCell &operator=(const AtCell&) = delete;
 
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
+  InnerCells GetInnerCells() const override;
   
   void SetBase(Cell *base);
   void SetIndex(Cell *index);

--- a/src/ConjugateCell.cpp
+++ b/src/ConjugateCell.cpp
@@ -34,7 +34,7 @@ ConjugateCell::ConjugateCell(Cell *parent, Configuration **config, CellPointers 
   m_open(new TextCell(parent, config, cellPointers, "conjugate(")),
   m_close(new TextCell(parent, config, cellPointers, ")"))
 {
-  m_open->DontEscapeOpeningParenthesis();
+  static_cast<TextCell&>(*m_open).DontEscapeOpeningParenthesis();
   m_last = NULL;
 }
 
@@ -58,9 +58,9 @@ ConjugateCell::~ConjugateCell()
   MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> ConjugateCell::GetInnerCells()
+Cell::InnerCells ConjugateCell::GetInnerCells() const
 {
-  std::list<std::shared_ptr<Cell>> innerCells;
+  InnerCells innerCells;
   if(m_innerCell)
     innerCells.push_back(m_innerCell);
   if(m_open)

--- a/src/ConjugateCell.cpp
+++ b/src/ConjugateCell.cpp
@@ -30,9 +30,9 @@
 
 ConjugateCell::ConjugateCell(Cell *parent, Configuration **config, CellPointers *cellPointers) :
   Cell(parent, config, cellPointers),
-  m_innerCell(new TextCell(parent, config, cellPointers, "")),
-  m_open(new TextCell(parent, config, cellPointers, "conjugate(")),
-  m_close(new TextCell(parent, config, cellPointers, ")"))
+  m_innerCell(std::make_shared<TextCell>(parent, config, cellPointers, "")),
+  m_open(std::make_shared<TextCell>(parent, config, cellPointers, "conjugate(")),
+  m_close(std::make_shared<TextCell>(parent, config, cellPointers, ")"))
 {
   static_cast<TextCell&>(*m_open).DontEscapeOpeningParenthesis();
   m_last = NULL;

--- a/src/ConjugateCell.h
+++ b/src/ConjugateCell.h
@@ -56,7 +56,7 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   ConjugateCell &operator=(const ConjugateCell&) = delete;
 
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
+  InnerCells GetInnerCells() const override;
 
   void SetInner(Cell *inner);
 
@@ -64,8 +64,8 @@ public:
 
 protected:
   std::shared_ptr<Cell> m_innerCell;
-  std::shared_ptr<TextCell> m_open;
-  std::shared_ptr<TextCell> m_close;
+  std::shared_ptr<Cell> m_open;
+  std::shared_ptr<Cell> m_close;
   Cell *m_last;
 
   void RecalculateHeight(int fontsize) override;

--- a/src/DiffCell.cpp
+++ b/src/DiffCell.cpp
@@ -32,8 +32,8 @@
 
 DiffCell::DiffCell(Cell *parent, Configuration **config, CellPointers *cellPointers) :
   Cell(parent, config, cellPointers),
-  m_baseCell(new TextCell(parent, config, cellPointers)),
-  m_diffCell(new TextCell(parent, config, cellPointers))
+  m_baseCell(std::make_shared<TextCell>(parent, config, cellPointers)),
+  m_diffCell(std::make_shared<TextCell>(parent, config, cellPointers))
 {
 }
 

--- a/src/DiffCell.cpp
+++ b/src/DiffCell.cpp
@@ -52,9 +52,9 @@ DiffCell::~DiffCell()
   MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> DiffCell::GetInnerCells()
+Cell::InnerCells DiffCell::GetInnerCells() const
 {
-  std::list<std::shared_ptr<Cell>> innerCells;
+  InnerCells innerCells;
   if(m_baseCell)
     innerCells.push_back(m_baseCell);
   if(m_diffCell)

--- a/src/DiffCell.h
+++ b/src/DiffCell.h
@@ -35,7 +35,7 @@ public:
   DiffCell &operator=(const DiffCell&) = delete;
   ~DiffCell();
   
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
+  InnerCells GetInnerCells() const override;
 
   void SetBase(Cell *base);
 

--- a/src/EditorCell.cpp
+++ b/src/EditorCell.cpp
@@ -408,12 +408,6 @@ void EditorCell::MarkAsDeleted()
   Cell::MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> EditorCell::GetInnerCells()
-{
-  std::list<std::shared_ptr<Cell>> innerCells;
-  return innerCells;
-}
-
 wxString EditorCell::ToTeX()
 {
   wxString text = m_text;

--- a/src/EditorCell.h
+++ b/src/EditorCell.h
@@ -200,7 +200,6 @@ public:
     no more displayed currently.
    */
   void MarkAsDeleted() override;
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
 
   /*! Expand all tabulators.
 

--- a/src/ExptCell.cpp
+++ b/src/ExptCell.cpp
@@ -45,7 +45,7 @@ ExptCell::ExptCell(Cell *parent, Configuration **config, CellPointers *cellPoint
   m_base_last = m_baseCell.get();
   m_expt_last = m_exptCell.get();
   m_isMatrix = false;
-  m_open->DontEscapeOpeningParenthesis();
+  static_cast<TextCell&>(*m_open).DontEscapeOpeningParenthesis();
 }
 
 ExptCell::ExptCell(const ExptCell &cell):
@@ -79,9 +79,9 @@ void ExptCell::Draw(wxPoint point)
   }
 }
 
-std::list<std::shared_ptr<Cell>> ExptCell::GetInnerCells()
+Cell::InnerCells ExptCell::GetInnerCells() const
 {
-  std::list<std::shared_ptr<Cell>> innerCells;
+  InnerCells innerCells;
   if(m_baseCell)
     innerCells.push_back(m_baseCell);
   if(m_exptCell)

--- a/src/ExptCell.cpp
+++ b/src/ExptCell.cpp
@@ -32,11 +32,11 @@
 
 ExptCell::ExptCell(Cell *parent, Configuration **config, CellPointers *cellPointers) :
   Cell(parent, config, cellPointers),
-  m_baseCell(new TextCell(parent, config, cellPointers)),
-  m_exptCell(new TextCell(parent, config, cellPointers)),
-  m_open(new TextCell(parent, config, cellPointers, "(")),
-  m_close(new TextCell(parent, config, cellPointers, ")")),
-  m_exp(new TextCell(parent, config, cellPointers, "^"))
+  m_baseCell(std::make_shared<TextCell>(parent, config, cellPointers)),
+  m_exptCell(std::make_shared<TextCell>(parent, config, cellPointers)),
+  m_open(std::make_shared<TextCell>(parent, config, cellPointers, "(")),
+  m_close(std::make_shared<TextCell>(parent, config, cellPointers, ")")),
+  m_exp(std::make_shared<TextCell>(parent, config, cellPointers, "^"))
 {
   m_open->SetStyle(TS_FUNCTION);
   m_close->SetStyle(TS_FUNCTION);

--- a/src/ExptCell.h
+++ b/src/ExptCell.h
@@ -56,7 +56,7 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   ExptCell &operator=(const ExptCell&) = delete;
 
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
+  InnerCells GetInnerCells() const override;
 
   //! Set the mantissa
   void SetBase(Cell *base);
@@ -97,9 +97,9 @@ public:
 protected:
   std::shared_ptr<Cell> m_baseCell;
   std::shared_ptr<Cell> m_exptCell;
-  std::shared_ptr<TextCell> m_open;
-  std::shared_ptr<TextCell> m_close;
-  std::shared_ptr<TextCell> m_exp;
+  std::shared_ptr<Cell> m_open;
+  std::shared_ptr<Cell> m_close;
+  std::shared_ptr<Cell> m_exp;
   Cell *m_expt_last;
   Cell *m_base_last;
   bool m_isMatrix;

--- a/src/FracCell.cpp
+++ b/src/FracCell.cpp
@@ -66,9 +66,9 @@ FracCell::~FracCell()
   MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> FracCell::GetInnerCells()
+Cell::InnerCells FracCell::GetInnerCells() const
 {
-  std::list<std::shared_ptr<Cell>> innerCells;
+  InnerCells innerCells;
   if(m_divide)
     innerCells.push_back(m_divide);
   // Contains m_num
@@ -85,7 +85,7 @@ void FracCell::SetNum(Cell *num)
   if (num == NULL)
     return;
   m_num = std::shared_ptr<Cell>(num);
-  m_numParenthesis->SetInner(m_num);
+  static_cast<ParenCell&>(*m_numParenthesis).SetInner(m_num);
   m_num_Last = num;
   SetupBreakUps();
 }
@@ -95,7 +95,7 @@ void FracCell::SetDenom(Cell *denom)
   if (denom == NULL)
     return;
   m_denom = std::shared_ptr<Cell>(denom);
-  m_denomParenthesis->SetInner(m_denom);
+  static_cast<ParenCell&>(*m_denomParenthesis).SetInner(m_denom);
   SetupBreakUps();
 }
 

--- a/src/FracCell.cpp
+++ b/src/FracCell.cpp
@@ -32,11 +32,11 @@
 
 FracCell::FracCell(Cell *parent, Configuration **config, CellPointers *cellPointers) :
   Cell(parent, config, cellPointers),
-  m_num(new TextCell(parent, config, cellPointers)),
-  m_denom(new TextCell(parent, config, cellPointers)),
-  m_numParenthesis(new ParenCell(m_group, m_configuration, m_cellPointers)),
-  m_denomParenthesis(new ParenCell(m_group, m_configuration, m_cellPointers)),
-  m_divide(new TextCell(parent, config, cellPointers, "/"))
+  m_num(std::make_shared<TextCell>(parent, config, cellPointers)),
+  m_denom(std::make_shared<TextCell>(parent, config, cellPointers)),
+  m_numParenthesis(std::make_shared<ParenCell>(m_group, m_configuration, m_cellPointers)),
+  m_denomParenthesis(std::make_shared<ParenCell>(m_group, m_configuration, m_cellPointers)),
+  m_divide(std::make_shared<TextCell>(parent, config, cellPointers, "/"))
 {
   m_divide->SetStyle(TS_VARIABLE);
   m_num_Last = NULL;

--- a/src/FracCell.h
+++ b/src/FracCell.h
@@ -51,8 +51,7 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   FracCell &operator=(const FracCell&) = delete;
 
-  
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
+  InnerCells GetInnerCells() const override;
 
   //! All types of fractions we support
   enum FracType
@@ -110,11 +109,11 @@ protected:
   //! The denominator
   std::shared_ptr<Cell> m_denom;
   //! A parenthesis around the numerator
-  std::shared_ptr<ParenCell> m_numParenthesis;
+  std::shared_ptr<Cell> m_numParenthesis;
   //! A parenthesis around the denominator
-  std::shared_ptr<ParenCell> m_denomParenthesis;
+  std::shared_ptr<Cell> m_denomParenthesis;
   //! The "/" sign
-  std::shared_ptr<TextCell> m_divide;
+  std::shared_ptr<Cell> m_divide;
   //! The last element of the numerator
   Cell *m_num_Last;
   //! The last element of the denominator

--- a/src/FunCell.cpp
+++ b/src/FunCell.cpp
@@ -60,9 +60,9 @@ FunCell::~FunCell()
   MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> FunCell::GetInnerCells()
+Cell::InnerCells FunCell::GetInnerCells() const
 {
-  std::list<std::shared_ptr<Cell>> innerCells;
+  InnerCells innerCells;
   if(m_nameCell)
     innerCells.push_back(m_nameCell);
   if(m_argCell)

--- a/src/FunCell.h
+++ b/src/FunCell.h
@@ -58,7 +58,7 @@ public:
   ~FunCell();
   FunCell &operator=(const FunCell&) = delete;
 
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
+  InnerCells GetInnerCells() const override;
 
   void SetName(Cell *name);
 

--- a/src/GroupCell.cpp
+++ b/src/GroupCell.cpp
@@ -447,16 +447,15 @@ void GroupCell::MarkAsDeleted()
   Cell::MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> GroupCell::GetInnerCells()
+Cell::InnerCells GroupCell::GetInnerCells() const
 {
-  std::list<std::shared_ptr<Cell>> innerCells;
-  if (m_groupType != GC_TYPE_PAGEBREAK)
-  {
-    if(GetInput())
-      innerCells.push_back(m_inputLabel);
-    if(GetOutput())
-      innerCells.push_back(m_output);
-  }
+  if (m_groupType == GC_TYPE_PAGEBREAK) return {};
+
+  InnerCells innerCells;
+  if(GetInput())
+    innerCells.push_back(m_inputLabel);
+  if(GetOutput())
+    innerCells.push_back(m_output);
   return innerCells;
 }
 

--- a/src/GroupCell.h
+++ b/src/GroupCell.h
@@ -114,7 +114,7 @@ public:
     no more displayed currently.
    */
   void MarkAsDeleted() override;
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
+  InnerCells GetInnerCells() const override;
 
   /*! Which GroupCell was the last maxima was working on?
 

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -109,7 +109,7 @@ Image::Image(Configuration **config, const wxBitmap &bitmap)
 }
 
 // constructor which loads an image
-Image::Image(Configuration **config, wxString image, const std::shared_ptr<wxFileSystem> &filesystem, bool remove):
+Image::Image(Configuration **config, wxString image, std::shared_ptr<wxFileSystem> filesystem, bool remove):
   m_fs_keepalive_imagedata(filesystem)
 {
   #ifdef HAVE_OMP_HEADER
@@ -243,10 +243,9 @@ bool Image::IsOk()
 }
 
 
-void Image::GnuplotSource(wxString gnuplotFilename, wxString dataFilename, const std::shared_ptr<wxFileSystem> &filesystem)
+void Image::GnuplotSource(wxString gnuplotFilename, wxString dataFilename, std::shared_ptr<wxFileSystem> filesystem)
 {
   m_fs_keepalive_gnuplotdata = filesystem;
-  std::shared_ptr<wxFileSystem> keepFilesystemAlive(filesystem);
   #ifdef HAVE_OPENMP_TASKS
   wxLogMessage(_("Starting background task that loads the gnuplot data for a plot."));
   #pragma omp task
@@ -254,7 +253,7 @@ void Image::GnuplotSource(wxString gnuplotFilename, wxString dataFilename, const
   LoadGnuplotSource_Backgroundtask(gnuplotFilename, dataFilename, filesystem);
 }
 
-void Image::LoadGnuplotSource_Backgroundtask(wxString gnuplotFilename, wxString dataFilename, const std::shared_ptr<wxFileSystem> &filesystem)
+void Image::LoadGnuplotSource_Backgroundtask(wxString gnuplotFilename, wxString dataFilename, std::shared_ptr<wxFileSystem> filesystem)
 {
   #ifdef HAVE_OMP_HEADER
   omp_set_lock(&m_gnuplotLock);
@@ -875,7 +874,7 @@ wxString Image::GetExtension()
   return m_extension;
 }
 
-void Image::LoadImage(wxString image, const std::shared_ptr<wxFileSystem> &filesystem, bool remove)
+void Image::LoadImage(wxString image, std::shared_ptr<wxFileSystem> filesystem, bool remove)
 {
   m_fs_keepalive_imagedata = filesystem;
   m_extension = wxFileName(image).GetExt();
@@ -893,7 +892,7 @@ void Image::LoadImage(wxString image, const std::shared_ptr<wxFileSystem> &files
   LoadImage_Backgroundtask(image, filesystem, remove);
 }
 
-void Image::LoadImage_Backgroundtask(wxString image, const std::shared_ptr<wxFileSystem> &filesystem, bool remove)
+void Image::LoadImage_Backgroundtask(wxString image, std::shared_ptr<wxFileSystem> filesystem, bool remove)
 {
   #ifdef HAVE_OMP_HEADER
   WaitForLoad waitforload(&m_imageLoadLock);

--- a/src/Image.h
+++ b/src/Image.h
@@ -89,7 +89,7 @@ public:
     \param filesystem The filesystem to load it from
     \param remove true = Delete the file after loading it
    */
-  Image(Configuration **config, wxString image, const std::shared_ptr<wxFileSystem> &filesystem, bool remove = true);
+  Image(Configuration **config, wxString image, std::shared_ptr<wxFileSystem> filesystem, bool remove = true);
 
   ~Image();
 
@@ -102,7 +102,7 @@ public:
     are text-only they profit from being compressed and are stored in the 
     memory in their compressed form.
    */
-  void GnuplotSource(wxString gnuplotFilename, wxString dataFilename, const std::shared_ptr<wxFileSystem> &filesystem);
+  void GnuplotSource(wxString gnuplotFilename, wxString dataFilename, std::shared_ptr<wxFileSystem> filesystem);
 
   //! Load the gnuplot source file from the system's filesystem
   void GnuplotSource(wxString gnuplotFilename, wxString dataFilename)
@@ -234,12 +234,12 @@ protected:
   wxString m_gnuplotSource;
   //! The gnuplot data file for this image, if any.
   wxString m_gnuplotData;
-  void LoadImage_Backgroundtask(wxString image, const std::shared_ptr<wxFileSystem> &filesystem, bool remove);
-  void LoadGnuplotSource_Backgroundtask(wxString gnuplotFilename, wxString dataFilename, const std::shared_ptr<wxFileSystem> &filesystem);
+  void LoadImage_Backgroundtask(wxString image, std::shared_ptr<wxFileSystem> filesystem, bool remove);
+  void LoadGnuplotSource_Backgroundtask(wxString gnuplotFilename, wxString dataFilename, std::shared_ptr<wxFileSystem> filesystem);
 
 private:
   //! Loads an image from a file
-  void LoadImage(wxString image, const std::shared_ptr<wxFileSystem> &filesystem, bool remove = true);
+  void LoadImage(wxString image, std::shared_ptr<wxFileSystem> filesystem, bool remove = true);
   //! Reads the compressed image into a memory buffer
   static wxMemoryBuffer ReadCompressedImage(wxInputStream *data);  
   Configuration **m_configuration;

--- a/src/ImgCell.cpp
+++ b/src/ImgCell.cpp
@@ -115,12 +115,6 @@ void ImgCell::MarkAsDeleted()
   Cell::MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> ImgCell::GetInnerCells()
-{
-  std::list<std::shared_ptr<Cell>> innerCells;
-  return innerCells;
-}
-
 wxString ImgCell::GetToolTip(const wxPoint &point)
 {
   if(ContainsPoint(point))

--- a/src/ImgCell.cpp
+++ b/src/ImgCell.cpp
@@ -72,7 +72,7 @@ ImgCell::ImgCell(Cell *parent, Configuration **config, CellPointers *cellPointer
 int ImgCell::s_counter = 0;
 
 // constructor which load image
-ImgCell::ImgCell(Cell *parent, Configuration **config, CellPointers *cellPointers, wxString image, const std::shared_ptr<wxFileSystem> &filesystem, bool remove)
+ImgCell::ImgCell(Cell *parent, Configuration **config, CellPointers *cellPointers, wxString image, std::shared_ptr<wxFileSystem> filesystem, bool remove)
   : Cell(parent, config, cellPointers)
 {
   m_type = MC_TYPE_IMAGE;

--- a/src/ImgCell.cpp
+++ b/src/ImgCell.cpp
@@ -78,21 +78,21 @@ ImgCell::ImgCell(Cell *parent, Configuration **config, CellPointers *cellPointer
   m_type = MC_TYPE_IMAGE;
   m_drawRectangle = true;
   if (image != wxEmptyString)
-    m_image = std::shared_ptr<Image>(new Image(m_configuration, image, filesystem, remove));
+    m_image = std::make_shared<Image>(m_configuration, image, filesystem, remove);
   else
-    m_image = std::shared_ptr<Image>(new Image(m_configuration));
+    m_image = std::make_shared<Image>(m_configuration);
   m_drawBoundingBox = false;
 }
 
 void ImgCell::LoadImage(wxString image, bool remove)
 {
-  m_image = std::shared_ptr<Image>(new Image(m_configuration, remove, image));
+  m_image = std::make_shared<Image>(m_configuration, remove, image);
 }
 
 void ImgCell::SetBitmap(const wxBitmap &bitmap)
 {
   m_width = m_height = -1;
-  m_image = std::shared_ptr<Image>(new Image(m_configuration, bitmap));
+  m_image = std::make_shared<Image>(m_configuration, bitmap);
 }
 
 ImgCell::ImgCell(const ImgCell &cell):
@@ -101,7 +101,7 @@ ImgCell::ImgCell(const ImgCell &cell):
   CopyCommonData(cell);
   m_drawRectangle = cell.m_drawRectangle;
   m_drawBoundingBox = false;
-  m_image = std::shared_ptr<Image>(new Image(*cell.m_image));
+  m_image = std::make_shared<Image>(*cell.m_image);
 }
 
 ImgCell::~ImgCell()

--- a/src/ImgCell.h
+++ b/src/ImgCell.h
@@ -35,7 +35,7 @@ class ImgCell : public Cell
 public:
   ImgCell(Cell *parent, Configuration **config, CellPointers *cellpointers);
   ImgCell(Cell *parent, Configuration **config, CellPointers *cellPointers, wxMemoryBuffer image, wxString type);
-  ImgCell(Cell *parent, Configuration **config, CellPointers *cellPointers, wxString image, const std::shared_ptr<wxFileSystem> &filesystem, bool remove = true);
+  ImgCell(Cell *parent, Configuration **config, CellPointers *cellPointers, wxString image, std::shared_ptr<wxFileSystem> filesystem, bool remove = true);
 
   ImgCell(Cell *parent, Configuration **config, CellPointers *cellPointers, const wxBitmap &bitmap);
   ImgCell(const ImgCell &cell);

--- a/src/ImgCell.h
+++ b/src/ImgCell.h
@@ -68,7 +68,6 @@ public:
         return m_image->GnuplotData();
     }
 
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
   void MarkAsDeleted() override;
 
   void LoadImage(wxString image, bool remove = true);

--- a/src/IntCell.cpp
+++ b/src/IntCell.cpp
@@ -78,9 +78,9 @@ IntCell::~IntCell()
   MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> IntCell::GetInnerCells()
+Cell::InnerCells IntCell::GetInnerCells() const
 {
-  std::list<std::shared_ptr<Cell>> innerCells;
+  InnerCells innerCells;
   if(m_base)
     innerCells.push_back(m_base);
   if(m_under)

--- a/src/IntCell.h
+++ b/src/IntCell.h
@@ -46,7 +46,7 @@ public:
   IntCell &operator=(const IntCell&) = delete;
   ~IntCell();
 
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
+  InnerCells GetInnerCells() const override;
 
   void RecalculateHeight(int fontsize) override;
 

--- a/src/LimitCell.cpp
+++ b/src/LimitCell.cpp
@@ -68,9 +68,9 @@ LimitCell::~LimitCell()
   MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> LimitCell::GetInnerCells()
+Cell::InnerCells LimitCell::GetInnerCells() const
 {
-  std::list<std::shared_ptr<Cell>> innerCells;
+  InnerCells innerCells;
   if(m_base)
     innerCells.push_back(m_base);
   if(m_under)

--- a/src/LimitCell.cpp
+++ b/src/LimitCell.cpp
@@ -33,12 +33,12 @@
 
 LimitCell::LimitCell(Cell *parent, Configuration **config, CellPointers *cellPointers) :
   Cell(parent, config, cellPointers),
-  m_name(new TextCell(parent, config, cellPointers)),
-  m_open(new TextCell(parent, config, cellPointers, "(")),
-  m_base(new TextCell(parent, config, cellPointers)),
-  m_comma(new TextCell(parent, config, cellPointers, ",")),
-  m_under(new TextCell(parent, config, cellPointers)),
-  m_close(new TextCell(parent, config, cellPointers, ")"))
+  m_name(std::make_shared<TextCell>(parent, config, cellPointers)),
+  m_open(std::make_shared<TextCell>(parent, config, cellPointers, "(")),
+  m_base(std::make_shared<TextCell>(parent, config, cellPointers)),
+  m_comma(std::make_shared<TextCell>(parent, config, cellPointers, ",")),
+  m_under(std::make_shared<TextCell>(parent, config, cellPointers)),
+  m_close(std::make_shared<TextCell>(parent, config, cellPointers, ")"))
 {
   m_open->SetStyle(TS_FUNCTION);
   m_close->SetStyle(TS_FUNCTION);

--- a/src/LimitCell.h
+++ b/src/LimitCell.h
@@ -44,7 +44,7 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   LimitCell &operator=(const LimitCell&) = delete;
 
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
+  InnerCells GetInnerCells() const override;
 
   void RecalculateHeight(int fontsize) override;
 
@@ -74,11 +74,11 @@ public:
 
 protected:
   std::shared_ptr<Cell> m_name;
-  std::shared_ptr<TextCell> m_open;
+  std::shared_ptr<Cell> m_open;
   std::shared_ptr<Cell> m_base;
-  std::shared_ptr<TextCell> m_comma;
+  std::shared_ptr<Cell> m_comma;
   std::shared_ptr<Cell> m_under;
-  std::shared_ptr<TextCell> m_close;
+  std::shared_ptr<Cell> m_close;
   Cell *m_name_last;
   Cell *m_base_last;
   Cell *m_under_last;

--- a/src/MatrCell.cpp
+++ b/src/MatrCell.cpp
@@ -64,12 +64,12 @@ MatrCell::~MatrCell()
   MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> MatrCell::GetInnerCells()
+Cell::InnerCells MatrCell::GetInnerCells() const
 {
-  std::list<std::shared_ptr<Cell>> innerCells;
-  for (unsigned int i = 0; i < m_cells.size(); i++)
-    if(m_cells[i])
-      innerCells.push_back(m_cells[i]);
+  InnerCells innerCells;
+  innerCells.reserve(m_cells.size());
+  std::copy_if(m_cells.begin(), m_cells.end(), std::back_inserter(innerCells),
+               [](const std::shared_ptr<Cell> &cell){ return bool(cell); });
   return innerCells;
 }
 

--- a/src/MatrCell.h
+++ b/src/MatrCell.h
@@ -39,7 +39,7 @@ public:
   MatrCell &operator=(const MatrCell&) = delete;
   ~MatrCell();
 
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
+  InnerCells GetInnerCells() const override;
 
   void RecalculateHeight(int fontsize) override;
 

--- a/src/ParenCell.cpp
+++ b/src/ParenCell.cpp
@@ -32,9 +32,9 @@
 
 ParenCell::ParenCell(Cell *parent, Configuration **config, CellPointers *cellPointers) :
   Cell(parent, config, cellPointers),
-  m_innerCell(new TextCell(parent, config, cellPointers)),
-  m_open(new TextCell(parent, config, cellPointers, wxT("("))),
-  m_close(new TextCell(parent, config, cellPointers, wxT(")")))
+  m_innerCell(std::make_shared<TextCell>(parent, config, cellPointers)),
+  m_open(std::make_shared<TextCell>(parent, config, cellPointers, wxT("("))),
+  m_close(std::make_shared<TextCell>(parent, config, cellPointers, wxT(")")))
 {
   m_open->SetStyle(TS_FUNCTION);
   m_close->SetStyle(TS_FUNCTION);

--- a/src/ParenCell.cpp
+++ b/src/ParenCell.cpp
@@ -82,9 +82,9 @@ ParenCell::~ParenCell()
   MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> ParenCell::GetInnerCells()
+Cell::InnerCells ParenCell::GetInnerCells() const
 {
-  std::list<std::shared_ptr<Cell>> innerCells;
+  InnerCells innerCells;
   if(m_innerCell)
     innerCells.push_back(m_innerCell);
   if(m_open)

--- a/src/ParenCell.h
+++ b/src/ParenCell.h
@@ -59,7 +59,7 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   ParenCell &operator=(const ParenCell&) = delete;
 
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
+  InnerCells GetInnerCells() const override;
 
   void SetInner(Cell *inner, CellType type = MC_TYPE_DEFAULT);
   void SetInner(std::shared_ptr<Cell> inner, CellType type = MC_TYPE_DEFAULT);
@@ -95,8 +95,8 @@ protected:
   Configuration::drawMode m_bigParenType;
   void SetFont(int fontsize);
   std::shared_ptr<Cell> m_innerCell;
-  std::shared_ptr<TextCell> m_open;
-  std::shared_ptr<TextCell> m_close;
+  std::shared_ptr<Cell> m_open;
+  std::shared_ptr<Cell> m_close;
   Cell *m_last1;
   bool m_print;
   int m_numberOfExtensions;

--- a/src/SlideShowCell.cpp
+++ b/src/SlideShowCell.cpp
@@ -176,8 +176,7 @@ void SlideShow::LoadImages(wxMemoryBuffer imageData)
     wxMemoryInputStream istream2(imageData.GetData(), imageData.GetDataLen());
     wxImage image;
     image.LoadFile(istream2, wxBITMAP_TYPE_ANY, i);
-    m_images.push_back(std::shared_ptr<Image>(
-                         new Image(m_configuration, wxBitmap(image))));
+    m_images.push_back(std::make_shared<Image>(m_configuration, wxBitmap(image)));
     m_size++;
   }
 }
@@ -192,8 +191,7 @@ void SlideShow::LoadImages(wxString imageFile)
   {
     wxImage image;
     image.LoadFile(imageFile, wxBITMAP_TYPE_ANY, i);
-    m_images.push_back(std::shared_ptr<Image>(
-                         new Image(m_configuration, wxBitmap(image))));
+    m_images.push_back(std::make_shared<Image>(m_configuration, wxBitmap(image)));
     m_size++;
   }
 }
@@ -218,8 +216,8 @@ void SlideShow::LoadImages(wxArrayString images, bool deleteRead)
           dataFilename = images[i];
         else
         {
-          m_images.push_back(std::shared_ptr<Image>(
-                               new Image(m_configuration, images[i], m_fileSystem, deleteRead)));
+          m_images.push_back(
+            std::make_shared<Image>(m_configuration, images[i], m_fileSystem, deleteRead));
           if(gnuplotFilename != wxEmptyString)
           {
             std::shared_ptr<wxFileSystem> filesystem;
@@ -241,7 +239,7 @@ SlideShow::SlideShow(const SlideShow &cell):
   AnimationRunning(false);
 
   for (size_t i = 0; i < cell.m_images.size(); i++)
-    m_images.push_back(std::shared_ptr<Image>(new Image(*cell.m_images[i])));
+    m_images.push_back(std::make_shared<Image>(*cell.m_images[i]));
 
   m_framerate = cell.m_framerate;
   m_displayed = true;

--- a/src/SlideShowCell.cpp
+++ b/src/SlideShowCell.cpp
@@ -116,7 +116,7 @@ void SlideShow::ReloadTimer()
   if(!m_timer)
   {
     // Tell MathCtrl about our timer.
-    m_timer = std::shared_ptr<wxTimer>(new wxTimer(m_cellPointers->GetMathCtrl(), wxNewId()));
+    m_timer = std::make_shared<wxTimer>(m_cellPointers->GetMathCtrl(), wxNewId());
     m_cellPointers->m_slideShowTimers[this] = m_timer->GetId();
   }
   

--- a/src/SlideShowCell.cpp
+++ b/src/SlideShowCell.cpp
@@ -263,12 +263,6 @@ void SlideShow::MarkAsDeleted()
   Cell::MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> SlideShow::GetInnerCells()
-{
-  std::list<std::shared_ptr<Cell>> innerCells;
-  return innerCells;
-}
-
 void SlideShow::SetDisplayedIndex(int ind)
 {
   if (ind >= 0 && ind < m_size)

--- a/src/SlideShowCell.cpp
+++ b/src/SlideShowCell.cpp
@@ -45,7 +45,7 @@
 #include <wx/wfstream.h>
 #include <wx/anidecod.h>
 
-SlideShow::SlideShow(Cell *parent, Configuration **config, CellPointers *cellPointers, const std::shared_ptr <wxFileSystem> &filesystem, int framerate) :
+SlideShow::SlideShow(Cell *parent, Configuration **config, CellPointers *cellPointers, std::shared_ptr <wxFileSystem> filesystem, int framerate) :
   Cell(parent, config, cellPointers),
   m_timer(NULL),
   m_fileSystem(filesystem)

--- a/src/SlideShowCell.cpp
+++ b/src/SlideShowCell.cpp
@@ -220,7 +220,6 @@ void SlideShow::LoadImages(wxArrayString images, bool deleteRead)
             std::make_shared<Image>(m_configuration, images[i], m_fileSystem, deleteRead));
           if(gnuplotFilename != wxEmptyString)
           {
-            std::shared_ptr<wxFileSystem> filesystem;
             if(m_images.back())
               m_images.back()->GnuplotSource(gnuplotFilename, dataFilename);
           }

--- a/src/SlideShowCell.h
+++ b/src/SlideShowCell.h
@@ -94,7 +94,6 @@ public:
   
   virtual wxString GetToolTip(const wxPoint &point) override;
 
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
   void MarkAsDeleted()  override;
 
   /*! Remove all cached scaled images from memory

--- a/src/SlideShowCell.h
+++ b/src/SlideShowCell.h
@@ -59,7 +59,7 @@ public:
     \param cellPointers All pointers that might point to this cell and that need to
                         be set to NULL if this cell is deleted.
    */
-  SlideShow(Cell *parent, Configuration **config, CellPointers *cellPointers, const std::shared_ptr<wxFileSystem> &filesystem, int framerate = -1);
+  SlideShow(Cell *parent, Configuration **config, CellPointers *cellPointers, std::shared_ptr<wxFileSystem> filesystem, int framerate = -1);
   SlideShow(Cell *parent, Configuration **config, CellPointers *cellPointers, int framerate = -1);
   SlideShow(const SlideShow &cell);
   //! A constructor that loads the compressed file from a wxMemoryBuffer
@@ -160,7 +160,7 @@ public:
       return (!m_images[m_displayed]->GnuplotSource().IsEmpty());
     }
 
-  void GnuplotSource(int image, wxString gnuplotFilename, wxString dataFilename, const std::shared_ptr<wxFileSystem> &filesystem)
+  void GnuplotSource(int image, wxString gnuplotFilename, wxString dataFilename, std::shared_ptr<wxFileSystem> filesystem)
     {
       m_images[image]->GnuplotSource(gnuplotFilename, dataFilename, filesystem);
     }

--- a/src/SqrtCell.cpp
+++ b/src/SqrtCell.cpp
@@ -44,7 +44,7 @@ SqrtCell::SqrtCell(Cell *parent, Configuration **config, CellPointers *cellPoint
   m_last = NULL;
   m_signType = 0;
   m_signFontScale = 0;
-  m_open->DontEscapeOpeningParenthesis();
+  static_cast<TextCell&>(*m_open).DontEscapeOpeningParenthesis();
 }
 
 // cppcheck-suppress uninitMemberVar symbolName=SqrtCell::m_open
@@ -68,9 +68,9 @@ SqrtCell::~SqrtCell()
   MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> SqrtCell::GetInnerCells()
+Cell::InnerCells SqrtCell::GetInnerCells() const
 {
-  std::list<std::shared_ptr<Cell>> innerCells;
+  InnerCells innerCells;
   if(m_innerCell)
     innerCells.push_back(m_innerCell);
   if(m_open)

--- a/src/SqrtCell.cpp
+++ b/src/SqrtCell.cpp
@@ -34,8 +34,8 @@
 SqrtCell::SqrtCell(Cell *parent, Configuration **config, CellPointers *cellPointers) :
   Cell(parent, config, cellPointers),
   m_innerCell(new TextCell(parent, config, cellPointers)),
-  m_open(new TextCell(parent, config, cellPointers, "sqrt(")),
-  m_close(new TextCell(parent, config, cellPointers, ")"))
+  m_open(std::make_shared<TextCell>(parent, config, cellPointers, "sqrt(")),
+  m_close(std::make_shared<TextCell>(parent, config, cellPointers, ")"))
 {
   m_open->SetStyle(TS_FUNCTION);
   m_signSize = 50;

--- a/src/SqrtCell.h
+++ b/src/SqrtCell.h
@@ -57,7 +57,7 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   SqrtCell &operator=(const SqrtCell&) = delete;
 
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
+  InnerCells GetInnerCells() const override;
 
   void SetInner(Cell *inner);
 
@@ -83,8 +83,8 @@ public:
 
 protected:
   std::shared_ptr<Cell> m_innerCell;
-  std::shared_ptr<TextCell> m_open;
-  std::shared_ptr<TextCell> m_close;
+  std::shared_ptr<Cell> m_open;
+  std::shared_ptr<Cell> m_close;
   Cell *m_last;
   int m_signWidth, m_signSize, m_signTop;
   int m_signType;

--- a/src/SubCell.cpp
+++ b/src/SubCell.cpp
@@ -50,9 +50,9 @@ SubCell::~SubCell()
   MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> SubCell::GetInnerCells()
+Cell::InnerCells SubCell::GetInnerCells() const
 {
-  std::list<std::shared_ptr<Cell>> innerCells;
+  InnerCells innerCells;
   if(m_baseCell)
     innerCells.push_back(m_baseCell);
   if(m_indexCell)

--- a/src/SubCell.h
+++ b/src/SubCell.h
@@ -36,7 +36,7 @@ public:
 
   SubCell operator=(const SubCell&) = delete;
 
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
+  InnerCells GetInnerCells() const override;
 
   void SetBase(Cell *base);
 

--- a/src/SubSupCell.cpp
+++ b/src/SubSupCell.cpp
@@ -59,9 +59,9 @@ SubSupCell::~SubSupCell()
   MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> SubSupCell::GetInnerCells()
+Cell::InnerCells SubSupCell::GetInnerCells() const
 {
-  std::list<std::shared_ptr<Cell>> innerCells;
+  InnerCells innerCells;
   if(m_baseCell)
     innerCells.push_back(m_baseCell);
   if(m_postSubCell)
@@ -287,12 +287,8 @@ wxString SubSupCell::ToString()
   }
   else
   {
-    std::list<std::shared_ptr<Cell>> innerCells = m_innerCellList;
-    while(!innerCells.empty())
-    {
-      s += "[" + innerCells.front()->ListToString() + "]";
-      innerCells.pop_front();
-    }
+    for (auto &cell : std::as_const(m_innerCellList))
+      s += "[" + cell->ListToString() + "]";
   }
   return s;
 }
@@ -316,18 +312,15 @@ wxString SubSupCell::ToMatlab()
   }
   else
   {
-    std::list<std::shared_ptr<Cell>> innerCells = m_innerCellList;
-
     s += "[";
     bool first = false;
     
-    while(!innerCells.empty())
+    for (auto &cell : std::as_const(m_innerCellList))
     {
       if(!first)
         s += ";";
       first = true;
-      s += innerCells.front()->ListToMatlab();
-      innerCells.pop_front();
+      s += cell->ListToMatlab();
     }
     s += "]";
   }

--- a/src/SubSupCell.h
+++ b/src/SubSupCell.h
@@ -38,7 +38,7 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   SubSupCell operator=(const SubSupCell&) = delete;
 
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
+  InnerCells GetInnerCells() const override;
   
   void SetBase(Cell *base);
 
@@ -78,7 +78,7 @@ protected:
   std::shared_ptr<Cell> m_postSubCell;
   std::shared_ptr<Cell> m_preSupCell;
   std::shared_ptr<Cell> m_preSubCell;
-  std::list<std::shared_ptr<Cell>> m_innerCellList;
+  InnerCells m_innerCellList;
 };
 
 #endif // SUBSUPCELL_H

--- a/src/SumCell.cpp
+++ b/src/SumCell.cpp
@@ -117,7 +117,7 @@ void SumCell::RecalculateWidths(int fontsize)
   m_signWCenter = m_signWidth / 2.0;
   m_under->RecalculateWidthsList(wxMax(MC_MIN_SIZE, fontsize - SUM_DEC));
   if (m_over == NULL)
-    m_over = std::shared_ptr<TextCell>(new TextCell(m_group, m_configuration, m_cellPointers));
+    m_over = std::make_shared<TextCell>(m_group, m_configuration, m_cellPointers);
   m_over->RecalculateWidthsList(wxMax(MC_MIN_SIZE, fontsize - SUM_DEC));
 
   if (false)

--- a/src/SumCell.cpp
+++ b/src/SumCell.cpp
@@ -67,9 +67,9 @@ SumCell::~SumCell()
   MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> SumCell::GetInnerCells()
+Cell::InnerCells SumCell::GetInnerCells() const
 {
-  std::list<std::shared_ptr<Cell>> innerCells;
+  InnerCells innerCells;
   if(m_under)
     innerCells.push_back(m_under);
   if(m_over)
@@ -92,7 +92,7 @@ void SumCell::SetBase(Cell *base)
   if (base == NULL)
     return;
   m_base = std::shared_ptr<Cell>(base);
-  m_paren->SetInner(m_base);
+  static_cast<ParenCell&>(*m_paren).SetInner(m_base);
   m_displayedBase = m_paren;
 }
 

--- a/src/SumCell.h
+++ b/src/SumCell.h
@@ -52,7 +52,7 @@ public:
     //! This class can be derived from wxAccessible which has no copy constructor
   SumCell operator=(const SumCell&) = delete;
 
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
+  InnerCells GetInnerCells() const override;
   
   void RecalculateHeight(int fontsize) override;
   void RecalculateWidths(int fontsize) override;
@@ -86,7 +86,7 @@ protected:
   std::shared_ptr<Cell> m_base;
   std::shared_ptr<Cell> m_under;
   std::shared_ptr<Cell> m_over;
-  std::shared_ptr<ParenCell> m_paren;
+  std::shared_ptr<Cell> m_paren;
   std::shared_ptr<Cell> m_displayedBase;
   int m_signHeight;
   double m_signWidth;

--- a/src/TextCell.cpp
+++ b/src/TextCell.cpp
@@ -81,12 +81,6 @@ TextCell::~TextCell()
   MarkAsDeleted();
 }
 
-std::list<std::shared_ptr<Cell>> TextCell::GetInnerCells()
-{
-  std::list<std::shared_ptr<Cell>> innerCells;
-  return innerCells;
-}
-
 void TextCell::SetStyle(TextStyle style)
 {
   m_widths.clear();

--- a/src/TextCell.h
+++ b/src/TextCell.h
@@ -43,8 +43,6 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   TextCell &operator=(const TextCell&) = delete;
   
-  std::list<std::shared_ptr<Cell>> GetInnerCells() override;
-  
   ~TextCell();  
 
   double GetScaledTextSize() const;

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -1713,7 +1713,7 @@ void wxMaxima::OnMaximaConnect()
   else
   {
     wxLogMessage(_("Connected."));
-    m_clientStream = std::shared_ptr<wxSocketInputStream>(new wxSocketInputStream(*m_client));
+    m_clientStream = std::make_shared<wxSocketInputStream>(*m_client);
     m_clientTextStream = std::unique_ptr<wxTextInputStream>(
       new wxTextInputStream(*m_clientStream, wxT('\t'),
                             wxConvUTF8));

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -1714,9 +1714,7 @@ void wxMaxima::OnMaximaConnect()
   {
     wxLogMessage(_("Connected."));
     m_clientStream = std::make_shared<wxSocketInputStream>(*m_client);
-    m_clientTextStream = std::unique_ptr<wxTextInputStream>(
-      new wxTextInputStream(*m_clientStream, wxT('\t'),
-                            wxConvUTF8));
+    m_clientTextStream.reset(new wxTextInputStream(*m_clientStream, wxT('\t'), wxConvUTF8));
     m_client->SetEventHandler(*GetEventHandler());
     m_client->SetNotify(wxSOCKET_INPUT_FLAG|wxSOCKET_OUTPUT_FLAG|wxSOCKET_LOST_FLAG|wxSOCKET_CONNECTION_FLAG);
     m_client->Notify(true);
@@ -3370,7 +3368,7 @@ bool wxMaxima::OpenWXMXFile(wxString file, Worksheet *document, bool clearDocume
   #ifdef HAVE_OPENMP_TASKS
   #pragma omp critical (OpenFSFile)
   #endif
-  fsfile = std::shared_ptr<wxFSFile>(fs.OpenFile(filename));
+  fsfile.reset(fs.OpenFile(filename));
   if (!fsfile)
   {
     if(m_worksheet)
@@ -3398,7 +3396,7 @@ bool wxMaxima::OpenWXMXFile(wxString file, Worksheet *document, bool clearDocume
       #ifdef HAVE_OPENMP_TASKS
       #pragma omp critical (OpenFSFile)
       #endif
-      fsfile2 = std::shared_ptr<wxFSFile>(fs.OpenFile(filename));
+      fsfile2.reset(fs.OpenFile(filename));
       if (fsfile2)
       {
         // Read the file into a string


### PR DESCRIPTION
This replaces inner node lists with vectors, and uses make_shared to create the instances.

There are many other uses of std::shared_ptr(new Class(...)) that can be replaced, but it looks like all of the shared pointers can be unique pointers anyway, so that's what the future PRs will be about.