### PR TITLE
Feature/internal cell iterators

### DIFF
--- a/src/AbsCell.cpp
+++ b/src/AbsCell.cpp
@@ -61,18 +61,6 @@ AbsCell::~AbsCell()
   MarkAsDeleted();
 }
 
-Cell::InnerCells AbsCell::GetInnerCells() const
-{
-  InnerCells innerCells;
-  if(m_innerCell)
-    innerCells.push_back(m_innerCell);
-  if(m_open)
-    innerCells.push_back(m_open);
-  if(m_close)
-    innerCells.push_back(m_close);
-  return innerCells;
-}
-
 void AbsCell::SetInner(Cell *inner)
 {
   if (inner == NULL)

--- a/src/AbsCell.h
+++ b/src/AbsCell.h
@@ -63,7 +63,8 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   AbsCell &operator=(const AbsCell&) = delete;
 
-  InnerCells GetInnerCells() const override;
+  InnerCellIterator InnerBegin() const override { return &m_innerCell; }
+  InnerCellIterator InnerEnd() const override { return &m_close+1; }
 
   void SetInner(Cell *inner);
 
@@ -94,6 +95,7 @@ public:
 private:
   Cell *m_nextToDraw;
 protected:
+  // The pointers below point to inner cells and must be kept contiguous.
   //! The contents of the abs() command
   std::shared_ptr<Cell> m_innerCell;
   //! The cell containing the eventual "abs" and the opening parenthesis

--- a/src/AtCell.cpp
+++ b/src/AtCell.cpp
@@ -53,16 +53,6 @@ AtCell::~AtCell()
   MarkAsDeleted();
 }
 
-Cell::InnerCells AtCell::GetInnerCells() const
-{
-  InnerCells innerCells;
-  if(m_baseCell)
-    innerCells.push_back(m_baseCell);
-  if(m_indexCell)
-    innerCells.push_back(m_indexCell);
-  return innerCells;
-}
-
 void AtCell::SetIndex(Cell *index)
 {
   if (index == NULL)

--- a/src/AtCell.h
+++ b/src/AtCell.h
@@ -36,7 +36,8 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   AtCell &operator=(const AtCell&) = delete;
 
-  InnerCells GetInnerCells() const override;
+  InnerCellIterator InnerBegin() const override { return &m_baseCell; }
+  InnerCellIterator InnerEnd() const override { return &m_indexCell+1; }
   
   void SetBase(Cell *base);
   void SetIndex(Cell *index);
@@ -66,6 +67,7 @@ public:
 private:
     Cell *m_nextToDraw;
 protected:
+  // The pointers below point to inner cells and must be kept contiguous.
   std::shared_ptr<Cell> m_baseCell;
   std::shared_ptr<Cell> m_indexCell;
 };

--- a/src/Cell.h
+++ b/src/Cell.h
@@ -1035,8 +1035,31 @@ protected:
   wxString m_altCopyText;
   Configuration **m_configuration;
 
-  using InnerCells = std::vector<std::shared_ptr<Cell>>;
-  virtual InnerCells GetInnerCells() const;
+  class InnerCellIterator
+  {
+    const std::shared_ptr<Cell> *ptr = {};
+  public:
+    InnerCellIterator() = default;
+    InnerCellIterator(const std::shared_ptr<Cell> *p) : ptr(p) {}
+    InnerCellIterator(const InnerCellIterator &o) = default;
+    InnerCellIterator &operator=(const InnerCellIterator &o) = default;
+    InnerCellIterator operator++(int) {
+      auto ret = *this;
+      ptr ++;
+      return ret;
+    }
+    InnerCellIterator &operator++() { ++ptr; return *this; }
+    bool operator==(const InnerCellIterator &o) const { return ptr == o.ptr; }
+    bool operator!=(const InnerCellIterator &o) const { return ptr != o.ptr; }
+    operator bool() const { return ptr && ptr->get(); }
+    operator Cell*() const { return ptr ? ptr->get() : nullptr; }
+    Cell *operator->() const { return ptr ? ptr->get() : nullptr; }
+  };
+
+  //! Iterator to the beginning of the inner cell range
+  virtual InnerCellIterator InnerBegin() const;
+  //! Iterator to the end of the inner cell range
+  virtual InnerCellIterator InnerEnd() const;
 
 protected:
   //! The height of this cell.

--- a/src/Cell.h
+++ b/src/Cell.h
@@ -281,22 +281,27 @@ class Cell
     Is used for displaying/printing/exporting of text/maths
    */
   int Scale_Px(double px) const {return (*m_configuration)->Scale_Px(px);}
+
 #if wxUSE_ACCESSIBILITY
+  // The methods marked final indicate that their implementation within Cell
+  // should be sufficient. If that's not the case, the final qualification can be
+  // removed with due caution.
+  //! Accessibility: Inform the Screen Reader which cell is the parent of this one
+  wxAccStatus GetParent (wxAccessible ** parent) override final;
+  //! Accessibility: How many childs of this cell GetChild() can retrieve?
+  wxAccStatus GetChildCount (int *childCount) override final;
+  //! Accessibility: Retrieve a child cell. childId=0 is the current cell
+  wxAccStatus GetChild (int childId, wxAccessible **child) override final;
+  //! Accessibility: Is pt inside this cell or a child cell?
+  wxAccStatus HitTest (const wxPoint &pt,
+                      int *childId, wxAccessible **childObject) override final;
+
   //! Accessibility: Describe the current cell to a Screen Reader
   wxAccStatus GetDescription(int childId, wxString *description) override;
-  //! Accessibility: Inform the Screen Reader which cell is the parent of this one
-  wxAccStatus GetParent (wxAccessible ** parent) override;
-  //! Accessibility: How many childs of this cell GetChild() can retrieve?
-  wxAccStatus GetChildCount (int *childCount) override;
-  //! Accessibility: Retrieve a child cell. childId=0 is the current cell
-  wxAccStatus GetChild (int childId, wxAccessible **child) override;
   //! Accessibility: Does this or a child cell currently own the focus?
   wxAccStatus GetFocus (int *childId, wxAccessible **child) override;
   //! Accessibility: Where is this cell to be found?
   wxAccStatus GetLocation (wxRect &rect, int elementId) override;
-  //! Is pt inside this cell or a child cell?
-  wxAccStatus HitTest (const wxPoint &pt,
-                      int *childId, wxAccessible **childObject) override;
   //! Accessibility: What is the contents of this cell?
   wxAccStatus GetValue (int childId, wxString *strValue) override;
   wxAccStatus GetRole (int childId, wxAccRole *role) override;

--- a/src/ConjugateCell.cpp
+++ b/src/ConjugateCell.cpp
@@ -60,18 +60,6 @@ ConjugateCell::~ConjugateCell()
   MarkAsDeleted();
 }
 
-Cell::InnerCells ConjugateCell::GetInnerCells() const
-{
-  InnerCells innerCells;
-  if(m_innerCell)
-    innerCells.push_back(m_innerCell);
-  if(m_open)
-    innerCells.push_back(m_open);
-  if(m_close)
-    innerCells.push_back(m_close);
-  return innerCells;
-}
-
 void ConjugateCell::SetInner(Cell *inner)
 {
   if (inner == NULL)

--- a/src/ConjugateCell.h
+++ b/src/ConjugateCell.h
@@ -56,7 +56,8 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   ConjugateCell &operator=(const ConjugateCell&) = delete;
 
-  InnerCells GetInnerCells() const override;
+  InnerCellIterator InnerBegin() const override { return &m_innerCell; }
+  InnerCellIterator InnerEnd() const override { return &m_close+1; }
 
   void SetInner(Cell *inner);
 
@@ -69,6 +70,7 @@ public:
 private:
   Cell *m_nextToDraw;
 protected:
+  // The pointers below point to inner cells and must be kept contiguous.
   std::shared_ptr<Cell> m_innerCell;
   std::shared_ptr<Cell> m_open;
   std::shared_ptr<Cell> m_close;

--- a/src/DiffCell.cpp
+++ b/src/DiffCell.cpp
@@ -54,17 +54,6 @@ DiffCell::~DiffCell()
   MarkAsDeleted();
 }
 
-Cell::InnerCells DiffCell::GetInnerCells() const
-{
-  InnerCells innerCells;
-  if(m_baseCell)
-    innerCells.push_back(m_baseCell);
-  if(m_diffCell)
-    innerCells.push_back(m_diffCell);
-  return innerCells;
-}
-
-
 void DiffCell::SetDiff(Cell *diff)
 {
   if (diff == NULL)

--- a/src/DiffCell.h
+++ b/src/DiffCell.h
@@ -35,7 +35,8 @@ public:
   DiffCell &operator=(const DiffCell&) = delete;
   ~DiffCell();
   
-  InnerCells GetInnerCells() const override;
+  InnerCellIterator InnerBegin() const override { return &m_baseCell; }
+  InnerCellIterator InnerEnd() const override { return &m_diffCell+1; }
 
   void SetBase(Cell *base);
 
@@ -66,6 +67,7 @@ public:
 private:
     Cell *m_nextToDraw;
 protected:
+  // The pointers below point to inner cells and must be kept contiguous.
   std::shared_ptr<Cell> m_baseCell;
   std::shared_ptr<Cell> m_diffCell;
 };

--- a/src/ExptCell.cpp
+++ b/src/ExptCell.cpp
@@ -81,23 +81,6 @@ void ExptCell::Draw(wxPoint point)
   }
 }
 
-Cell::InnerCells ExptCell::GetInnerCells() const
-{
-  InnerCells innerCells;
-  if(m_baseCell)
-    innerCells.push_back(m_baseCell);
-  if(m_exptCell)
-    innerCells.push_back(m_exptCell);
-  if(m_exp)
-    innerCells.push_back(m_exp);
-  if(m_open)
-    innerCells.push_back(m_open);
-  if(m_close)
-    innerCells.push_back(m_close);
-  return innerCells;
-}
-
-
 void ExptCell::SetPower(Cell *power)
 {
   if (power == NULL)

--- a/src/ExptCell.h
+++ b/src/ExptCell.h
@@ -56,7 +56,8 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   ExptCell &operator=(const ExptCell&) = delete;
 
-  InnerCells GetInnerCells() const override;
+  InnerCellIterator InnerBegin() const override { return &m_baseCell; }
+  InnerCellIterator InnerEnd() const override { return &m_close+1; }
 
   //! Set the mantissa
   void SetBase(Cell *base);
@@ -101,11 +102,12 @@ public:
 private:
     Cell *m_nextToDraw;
 protected:
+  // The pointers below point to inner cells and must be kept contiguous.
   std::shared_ptr<Cell> m_baseCell;
   std::shared_ptr<Cell> m_exptCell;
+  std::shared_ptr<Cell> m_exp;
   std::shared_ptr<Cell> m_open;
   std::shared_ptr<Cell> m_close;
-  std::shared_ptr<Cell> m_exp;
   Cell *m_expt_last;
   Cell *m_base_last;
   bool m_isMatrix;

--- a/src/FracCell.cpp
+++ b/src/FracCell.cpp
@@ -68,20 +68,6 @@ FracCell::~FracCell()
   MarkAsDeleted();
 }
 
-Cell::InnerCells FracCell::GetInnerCells() const
-{
-  InnerCells innerCells;
-  if(m_divide)
-    innerCells.push_back(m_divide);
-  // Contains m_num
-  if(m_displayedNum)
-    innerCells.push_back(m_displayedNum);
-  // Contains m_denom
-  if(m_displayedDenom)
-    innerCells.push_back(m_displayedDenom);
-  return innerCells;
-}
-
 void FracCell::SetNum(Cell *num)
 {
   if (num == NULL)

--- a/src/FracCell.h
+++ b/src/FracCell.h
@@ -51,7 +51,8 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   FracCell &operator=(const FracCell&) = delete;
 
-  InnerCells GetInnerCells() const override;
+  InnerCellIterator InnerBegin() const override { return &m_divide; }
+  InnerCellIterator InnerEnd() const override { return &m_displayedDenom+1; }
 
   //! All types of fractions we support
   enum FracType
@@ -118,14 +119,15 @@ protected:
   std::shared_ptr<Cell> m_numParenthesis;
   //! A parenthesis around the denominator
   std::shared_ptr<Cell> m_denomParenthesis;
-  //! The "/" sign
-  std::shared_ptr<Cell> m_divide;
   //! The last element of the numerator
   Cell *m_num_Last;
   //! The last element of the denominator
   Cell *m_denom_Last;
   //! Fractions in exponents are shown in their linear form.
   bool m_exponent;
+  // The pointers below point to inner cells and must be kept contiguous.
+  //! The "/" sign
+  std::shared_ptr<Cell> m_divide;
   //! The displayed version of the numerator, if needed with parenthesis
   std::shared_ptr<Cell> m_displayedNum;
   //! The displayed version of the denominator, if needed with parenthesis

--- a/src/FunCell.cpp
+++ b/src/FunCell.cpp
@@ -62,16 +62,6 @@ FunCell::~FunCell()
   MarkAsDeleted();
 }
 
-Cell::InnerCells FunCell::GetInnerCells() const
-{
-  InnerCells innerCells;
-  if(m_nameCell)
-    innerCells.push_back(m_nameCell);
-  if(m_argCell)
-    innerCells.push_back(m_argCell);
-  return innerCells;
-}
-
 void FunCell::SetName(Cell *name)
 {
   if (name == NULL)

--- a/src/FunCell.h
+++ b/src/FunCell.h
@@ -58,7 +58,8 @@ public:
   ~FunCell();
   FunCell &operator=(const FunCell&) = delete;
 
-  InnerCells GetInnerCells() const override;
+  InnerCellIterator InnerBegin() const override { return &m_nameCell; }
+  InnerCellIterator InnerEnd() const override { return &m_argCell+1; }
 
   void SetName(Cell *name);
 
@@ -91,6 +92,7 @@ public:
 private:
     Cell *m_nextToDraw;
 protected:
+  // The pointers below point to inner cells and must be kept contiguous.
   std::shared_ptr<Cell> m_nameCell;
   std::shared_ptr<Cell> m_argCell;
   Cell *m_nameCell_Last;

--- a/src/GroupCell.cpp
+++ b/src/GroupCell.cpp
@@ -448,18 +448,6 @@ void GroupCell::MarkAsDeleted()
   Cell::MarkAsDeleted();
 }
 
-Cell::InnerCells GroupCell::GetInnerCells() const
-{
-  if (m_groupType == GC_TYPE_PAGEBREAK) return {};
-
-  InnerCells innerCells;
-  if(GetInput())
-    innerCells.push_back(m_inputLabel);
-  if(GetOutput())
-    innerCells.push_back(m_output);
-  return innerCells;
-}
-
 wxString GroupCell::TexEscapeOutputCell(wxString Input)
 {
   wxString retval(Input);

--- a/src/GroupCell.h
+++ b/src/GroupCell.h
@@ -114,7 +114,10 @@ public:
     no more displayed currently.
    */
   void MarkAsDeleted() override;
-  InnerCells GetInnerCells() const override;
+
+  InnerCellIterator InnerBegin() const override { return &m_inputLabel; }
+  InnerCellIterator InnerEnd() const override
+  { return (m_groupType == GC_TYPE_PAGEBREAK) ? InnerBegin() : &m_output+1; }
 
   /*! Which GroupCell was the last maxima was working on?
 
@@ -518,6 +521,7 @@ protected:
   GroupCell *m_hiddenTreeParent; //!< store linkage to the parent of the fold
   //! Which type this cell is of?
   GroupType m_groupType;
+  // The pointers below point to inner cells and must be kept contiguous.
   //! The input label of this cell. Is followed by the input of the cell.
   std::shared_ptr<Cell> m_inputLabel;
   //! The maxima output this cell contains

--- a/src/GroupCell.h
+++ b/src/GroupCell.h
@@ -440,54 +440,44 @@ public:
   wxAccStatus GetDescription(int childId, wxString *description) override;
   wxAccStatus GetLocation (wxRect &rect, int elementId) override;
 
+  // TODO This class is not used anyhere.
   class HCaretCell: public wxAccessible
   {
   public:
-    explicit HCaretCell(GroupCell* group) : wxAccessible()
-      {
-        m_group = group;
-      }
+    explicit HCaretCell(GroupCell* group) : wxAccessible(), m_group(group) {}
+
     //! Describe the current cell to a Screen Reader
-    virtual wxAccStatus GetDescription(int childId, wxString *description)
-      {
-        if (description != NULL)
-        {
-          *description = _("A space between GroupCells");
-          return wxACC_OK;
-        }
-        return wxACC_FAIL;
-      }
+    wxAccStatus GetDescription(int WXUNUSED(childId), wxString *description) override
+    {
+      if (description)
+        return (*description = _("A space between GroupCells")), wxACC_OK;
+
+      return wxACC_FAIL;
+    }
     //! Inform the Screen Reader which cell is the parent of this one
-    wxAccStatus GetParent (wxAccessible ** parent)
-      {
-        if (parent != NULL)
-        {
-          *parent = m_group;
-          return wxACC_OK;
-        }
-        return wxACC_FAIL;
-      }
-  //! How many childs of this cell GetChild() can retrieve?
-    wxAccStatus GetChildCount (int *childCount)
-      {
-        if (childCount != NULL)
-        {
-          *childCount = 0;
-          return wxACC_OK;
-        }
-        return wxACC_FAIL;
-      }
+    wxAccStatus GetParent (wxAccessible ** parent) override
+    {
+      if (parent)
+        return (*parent = m_group), wxACC_OK;
+
+      return wxACC_FAIL;
+    }
+    //! How many childs of this cell GetChild() can retrieve?
+    wxAccStatus GetChildCount (int *childCount) override
+    {
+      if (childCount)
+        return (*childCount = 0), wxACC_OK;
+
+      return wxACC_FAIL;
+    }
     //! Retrieve a child cell. childId=0 is the current cell
-    wxAccStatus GetChild (int childId, wxAccessible **child)
-      {
-        if((childId != 0) || (child == NULL))
-          return wxACC_FAIL;
-        else
-        {
-          *child = this;
-          return wxACC_OK;
-        }
-      }
+    wxAccStatus GetChild (int childId, wxAccessible **child) override
+    {
+      if (childId == 0 && child)
+        return (*child = this), wxACC_OK;
+
+      return wxACC_FAIL;
+    }
     // //! Does this or a child cell currently own the focus?
     // wxAccStatus GetFocus (int *childId, wxAccessible **child)
     //   {
@@ -499,7 +489,7 @@ public:
     // //! Is pt inside this cell or a child cell?
     // wxAccStatus HitTest (const wxPoint &pt,
     //                      int *childId, wxAccessible **childObject);
-    wxAccStatus GetRole (int childId, wxAccRole *role);
+    wxAccStatus GetRole (int childId, wxAccRole *role) override;
 
   private:
 	GroupCell *m_group;

--- a/src/GroupCell.h
+++ b/src/GroupCell.h
@@ -221,7 +221,7 @@ public:
   void AppendInput(Cell *cell);
 
   // Get the next cell in the list.
-  virtual GroupCell *GetNext() const override {if (m_next != NULL) return dynamic_cast<GroupCell *>(m_next); else return NULL;}
+  virtual GroupCell *GetNext() const override {return dynamic_cast<GroupCell *>(m_next);}
 
   static wxString TexEscapeOutputCell(wxString Input);
 

--- a/src/IntCell.cpp
+++ b/src/IntCell.cpp
@@ -80,20 +80,6 @@ IntCell::~IntCell()
   MarkAsDeleted();
 }
 
-Cell::InnerCells IntCell::GetInnerCells() const
-{
-  InnerCells innerCells;
-  if(m_base)
-    innerCells.push_back(m_base);
-  if(m_under)
-    innerCells.push_back(m_under);
-  if(m_over)
-    innerCells.push_back(m_over);
-  if(m_var)
-    innerCells.push_back(m_var);
-  return innerCells;
-}
-
 void IntCell::SetOver(Cell *name)
 {
   if (name == NULL)

--- a/src/IntCell.h
+++ b/src/IntCell.h
@@ -46,7 +46,8 @@ public:
   IntCell &operator=(const IntCell&) = delete;
   ~IntCell();
 
-  InnerCells GetInnerCells() const override;
+  InnerCellIterator InnerBegin() const override { return &m_base; }
+  InnerCellIterator InnerEnd() const override { return &m_var+1; }
 
   void RecalculateHeight(int fontsize) override;
 
@@ -96,6 +97,7 @@ public:
 private:
     Cell *m_nextToDraw;
 protected:
+  // The pointers below point to inner cells and must be kept contiguous.
   //! The part of the formula that is to be integrated.
   std::shared_ptr<Cell> m_base;
   //! The lower limit of the integral

--- a/src/LimitCell.cpp
+++ b/src/LimitCell.cpp
@@ -70,24 +70,6 @@ LimitCell::~LimitCell()
   MarkAsDeleted();
 }
 
-Cell::InnerCells LimitCell::GetInnerCells() const
-{
-  InnerCells innerCells;
-  if(m_base)
-    innerCells.push_back(m_base);
-  if(m_under)
-    innerCells.push_back(m_under);
-  if(m_name)
-    innerCells.push_back(m_name);
-  if(m_open)
-    innerCells.push_back(m_open);
-  if(m_comma)
-    innerCells.push_back(m_comma);
-  if(m_close)
-    innerCells.push_back(m_close);
-  return innerCells;
-}
-
 void LimitCell::SetName(Cell *name)
 {
   if (name == NULL)

--- a/src/LimitCell.h
+++ b/src/LimitCell.h
@@ -44,7 +44,8 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   LimitCell &operator=(const LimitCell&) = delete;
 
-  InnerCells GetInnerCells() const override;
+  InnerCellIterator InnerBegin() const override { return &m_base; }
+  InnerCellIterator InnerEnd() const override { return &m_close+1; }
 
   void RecalculateHeight(int fontsize) override;
 
@@ -79,11 +80,12 @@ public:
 private:
     Cell *m_nextToDraw;
 protected:
+  // The pointers below point to inner cells and must be kept contiguous.
+  std::shared_ptr<Cell> m_base;
+  std::shared_ptr<Cell> m_under;
   std::shared_ptr<Cell> m_name;
   std::shared_ptr<Cell> m_open;
-  std::shared_ptr<Cell> m_base;
   std::shared_ptr<Cell> m_comma;
-  std::shared_ptr<Cell> m_under;
   std::shared_ptr<Cell> m_close;
   Cell *m_name_last;
   Cell *m_base_last;

--- a/src/MatrCell.cpp
+++ b/src/MatrCell.cpp
@@ -66,17 +66,6 @@ MatrCell::~MatrCell()
   MarkAsDeleted();
 }
 
-Cell::InnerCells MatrCell::GetInnerCells() const
-{
-  InnerCells innerCells;
-  innerCells.reserve(m_cells.size());
-  std::copy_if(m_cells.begin(), m_cells.end(), std::back_inserter(innerCells),
-               [](const std::shared_ptr<Cell> &cell){ return bool(cell); });
-  return innerCells;
-}
-
-
-
 void MatrCell::RecalculateWidths(int fontsize)
 {
   if(!NeedsRecalculation(fontsize))

--- a/src/MatrCell.h
+++ b/src/MatrCell.h
@@ -39,7 +39,10 @@ public:
   MatrCell &operator=(const MatrCell&) = delete;
   ~MatrCell();
 
-  InnerCells GetInnerCells() const override;
+  InnerCellIterator InnerBegin() const override
+  { return m_cells.empty() ? InnerCellIterator{} : &m_cells.front(); }
+  InnerCellIterator InnerEnd() const override
+  { return m_cells.empty() ? InnerCellIterator{} : &m_cells.back() + 1; }
 
   void RecalculateHeight(int fontsize) override;
 
@@ -102,6 +105,7 @@ protected:
   bool m_roundedParens;
   unsigned int m_matHeight;
   bool m_specialMatrix, m_inferenceMatrix, m_rowNames, m_colNames;
+  //! Collections of pointers to inner cells.
   vector<std::shared_ptr<Cell>> m_cells;
   vector<int> m_widths;
   vector<int> m_drops;

--- a/src/ParenCell.cpp
+++ b/src/ParenCell.cpp
@@ -84,18 +84,6 @@ ParenCell::~ParenCell()
   MarkAsDeleted();
 }
 
-Cell::InnerCells ParenCell::GetInnerCells() const
-{
-  InnerCells innerCells;
-  if(m_innerCell)
-    innerCells.push_back(m_innerCell);
-  if(m_open)
-    innerCells.push_back(m_open);
-  if(m_close)
-    innerCells.push_back(m_close);
-  return innerCells;
-}
-
 void ParenCell::SetInner(Cell *inner, CellType type)
 {
   if (inner != NULL)

--- a/src/ParenCell.h
+++ b/src/ParenCell.h
@@ -59,7 +59,8 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   ParenCell &operator=(const ParenCell&) = delete;
 
-  InnerCells GetInnerCells() const override;
+  InnerCellIterator InnerBegin() const override { return &m_innerCell; }
+  InnerCellIterator InnerEnd() const override { return &m_close+1; }
 
   void SetInner(Cell *inner, CellType type = MC_TYPE_DEFAULT);
   void SetInner(std::shared_ptr<Cell> inner, CellType type = MC_TYPE_DEFAULT);
@@ -100,6 +101,7 @@ protected:
    */
   Configuration::drawMode m_bigParenType;
   void SetFont(int fontsize);
+  // The pointers below point to inner cells and must be kept contiguous.
   std::shared_ptr<Cell> m_innerCell;
   std::shared_ptr<Cell> m_open;
   std::shared_ptr<Cell> m_close;

--- a/src/SqrtCell.cpp
+++ b/src/SqrtCell.cpp
@@ -70,18 +70,6 @@ SqrtCell::~SqrtCell()
   MarkAsDeleted();
 }
 
-Cell::InnerCells SqrtCell::GetInnerCells() const
-{
-  InnerCells innerCells;
-  if(m_innerCell)
-    innerCells.push_back(m_innerCell);
-  if(m_open)
-    innerCells.push_back(m_open);
-  if(m_close)
-    innerCells.push_back(m_close);
-  return innerCells;
-}
-
 void SqrtCell::SetInner(Cell *inner)
 {
   if (inner == NULL)

--- a/src/SqrtCell.h
+++ b/src/SqrtCell.h
@@ -57,7 +57,8 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   SqrtCell &operator=(const SqrtCell&) = delete;
 
-  InnerCells GetInnerCells() const override;
+  InnerCellIterator InnerBegin() const override { return &m_innerCell; }
+  InnerCellIterator InnerEnd() const override { return &m_close+1; }
 
   void SetInner(Cell *inner);
 
@@ -88,6 +89,7 @@ public:
 private:
     Cell *m_nextToDraw;
 protected:
+  // The pointers below point to inner cells and must be kept contiguous.
   std::shared_ptr<Cell> m_innerCell;
   std::shared_ptr<Cell> m_open;
   std::shared_ptr<Cell> m_close;

--- a/src/SubCell.cpp
+++ b/src/SubCell.cpp
@@ -52,17 +52,6 @@ SubCell::~SubCell()
   MarkAsDeleted();
 }
 
-Cell::InnerCells SubCell::GetInnerCells() const
-{
-  InnerCells innerCells;
-  if(m_baseCell)
-    innerCells.push_back(m_baseCell);
-  if(m_indexCell)
-    innerCells.push_back(m_indexCell);
-  return innerCells;
-}
-
-
 void SubCell::SetIndex(Cell *index)
 {
   if (index == NULL)

--- a/src/SubCell.h
+++ b/src/SubCell.h
@@ -36,7 +36,8 @@ public:
 
   SubCell operator=(const SubCell&) = delete;
 
-  InnerCells GetInnerCells() const override;
+  InnerCellIterator InnerBegin() const override { return &m_baseCell; }
+  InnerCellIterator InnerEnd() const override { return &m_indexCell+1; }
 
   void SetBase(Cell *base);
 
@@ -67,6 +68,7 @@ public:
 private:
     Cell *m_nextToDraw;
 protected:
+  // The pointers below point to inner cells and must be kept contiguous.
   std::shared_ptr<Cell> m_baseCell;
   std::shared_ptr<Cell> m_indexCell;
 };

--- a/src/SubSupCell.cpp
+++ b/src/SubSupCell.cpp
@@ -61,52 +61,40 @@ SubSupCell::~SubSupCell()
   MarkAsDeleted();
 }
 
-Cell::InnerCells SubSupCell::GetInnerCells() const
-{
-  InnerCells innerCells;
-  if(m_baseCell)
-    innerCells.push_back(m_baseCell);
-  if(m_postSubCell)
-    innerCells.push_back(m_postSubCell);
-  if(m_postSupCell)
-    innerCells.push_back(m_postSupCell);
-  if(m_preSubCell)
-    innerCells.push_back(m_preSubCell);
-  if(m_preSupCell)
-    innerCells.push_back(m_preSupCell);
-  return innerCells;
-}
-
 void SubSupCell::SetPreSup(Cell *index)
 {
-  if (index == NULL)
+  if (!index)
     return;
+  wxASSERT(!m_preSupCell);
   m_preSupCell = std::shared_ptr<Cell>(index);
-  m_innerCellList.push_back(m_preSupCell);
+  m_scriptCells.push_back(m_preSupCell);
 }
 
 void SubSupCell::SetPreSub(Cell *index)
 {
-  if (index == NULL)
+  if (!index)
     return;
+  wxASSERT(!m_preSubCell);
   m_preSubCell = std::shared_ptr<Cell>(index);
-  m_innerCellList.push_back(m_preSubCell);
+  m_scriptCells.push_back(m_preSubCell);
 }
 
 void SubSupCell::SetPostSup(Cell *index)
 {
-  if (index == NULL)
+  if (!index)
     return;
+  wxASSERT(!m_postSupCell);
   m_postSupCell = std::shared_ptr<Cell>(index);
-  m_innerCellList.push_back(m_postSupCell);
+  m_scriptCells.push_back(m_postSupCell);
 }
 
 void SubSupCell::SetPostSub(Cell *index)
 {
-  if (index == NULL)
+  if (!index)
     return;
+  wxASSERT(!m_postSubCell);
   m_postSubCell = std::shared_ptr<Cell>(index);
-  m_innerCellList.push_back(m_postSubCell);
+  m_scriptCells.push_back(m_postSubCell);
 }
 
 void SubSupCell::SetIndex(Cell *index)
@@ -275,7 +263,7 @@ wxString SubSupCell::ToString()
     s += "(" + m_baseCell->ListToString() + ")";
   else
     s += m_baseCell->ListToString();
-  if(m_innerCellList.empty())
+  if (m_scriptCells.empty())
   {
     s += "[" + m_postSubCell->ListToString() + "]";
     s += "^";
@@ -287,7 +275,7 @@ wxString SubSupCell::ToString()
   }
   else
   {
-    for (auto &cell : m_innerCellList)
+    for (auto &cell : m_scriptCells)
       s += "[" + cell->ListToString() + "]";
   }
   return s;
@@ -300,7 +288,7 @@ wxString SubSupCell::ToMatlab()
 	s += "(" + m_baseCell->ListToMatlab() + ")";
   else
 	s += m_baseCell->ListToMatlab();
-  if(m_innerCellList.empty())
+  if (m_scriptCells.empty())
   {
     s += "[" + m_postSubCell->ListToMatlab() + "]";
     s += "^";
@@ -315,7 +303,7 @@ wxString SubSupCell::ToMatlab()
     s += "[";
     bool first = false;
     
-    for (auto &cell : m_innerCellList)
+    for (auto &cell : m_scriptCells)
     {
       if(!first)
         s += ";";
@@ -337,7 +325,7 @@ wxString SubSupCell::ToTeX()
 
   wxString s;
 
-  if(m_innerCellList.empty())
+  if (m_scriptCells.empty())
   {
     if (TeXExponentsAfterSubscript)
     {
@@ -381,7 +369,7 @@ wxString SubSupCell::ToTeX()
 wxString SubSupCell::ToMathML()
 {
   wxString retval;
-  if(m_innerCellList.empty())
+  if (m_scriptCells.empty())
   {
     retval = "<msubsup>" +
       m_baseCell->ListToMathML();
@@ -466,7 +454,7 @@ wxString SubSupCell::ToXML()
     flags += " altCopy=\"" + XMLescape(m_altCopyText) + "\"";
 
   wxString retval;
-  if(m_innerCellList.empty())
+  if (m_scriptCells.empty())
   {
     retval = "<ie" + flags + "><r>" + m_baseCell->ListToXML()
       + "</r><r>";

--- a/src/SubSupCell.h
+++ b/src/SubSupCell.h
@@ -38,8 +38,9 @@ public:
   //! This class can be derived from wxAccessible which has no copy constructor
   SubSupCell operator=(const SubSupCell&) = delete;
 
-  InnerCells GetInnerCells() const override;
-  
+  InnerCellIterator InnerBegin() const override { return &m_baseCell; }
+  InnerCellIterator InnerEnd() const override { return &m_preSupCell+1; }
+
   void SetBase(Cell *base);
 
   void SetIndex(Cell *index);
@@ -79,12 +80,15 @@ public:
 private:
   Cell *m_nextToDraw;
 protected:
+  // The pointers below point to inner cells and must be kept contiguous.
   std::shared_ptr<Cell> m_baseCell;
-  std::shared_ptr<Cell> m_postSupCell;
   std::shared_ptr<Cell> m_postSubCell;
-  std::shared_ptr<Cell> m_preSupCell;
+  std::shared_ptr<Cell> m_postSupCell;
   std::shared_ptr<Cell> m_preSubCell;
-  InnerCells m_innerCellList;
+  std::shared_ptr<Cell> m_preSupCell;
+  //! The inner cells set via SetPre* or SetPost*, but not SetBase nor SetIndex
+  //! nor SetExponent.
+  std::vector<std::shared_ptr<Cell>> m_scriptCells;
 };
 
 #endif // SUBSUPCELL_H

--- a/src/SumCell.cpp
+++ b/src/SumCell.cpp
@@ -69,19 +69,6 @@ SumCell::~SumCell()
   MarkAsDeleted();
 }
 
-Cell::InnerCells SumCell::GetInnerCells() const
-{
-  InnerCells innerCells;
-  if(m_under)
-    innerCells.push_back(m_under);
-  if(m_over)
-    innerCells.push_back(m_over);
-  // Contains m_base
-  if(m_paren)
-    innerCells.push_back(m_paren);
-  return innerCells;
-}
-
 void SumCell::SetOver(Cell *over)
 {
   if (over == NULL)

--- a/src/SumCell.h
+++ b/src/SumCell.h
@@ -52,7 +52,8 @@ public:
     //! This class can be derived from wxAccessible which has no copy constructor
   SumCell operator=(const SumCell&) = delete;
 
-  InnerCells GetInnerCells() const override;
+  InnerCellIterator InnerBegin() const override { return &m_under; }
+  InnerCellIterator InnerEnd() const override { return &m_paren+1; }
   
   void RecalculateHeight(int fontsize) override;
   void RecalculateWidths(int fontsize) override;
@@ -91,9 +92,11 @@ private:
   
 protected:
   std::shared_ptr<Cell> m_base;
+  // The pointers below point to inner cells and must be kept contiguous.
   std::shared_ptr<Cell> m_under;
   std::shared_ptr<Cell> m_over;
   std::shared_ptr<Cell> m_paren;
+  // The pointers above point to inner cells and must be kept contiguous.
   std::shared_ptr<Cell> m_displayedBase;
   int m_signHeight;
   double m_signWidth;


### PR DESCRIPTION
This gets rid of GetInternalCells and the associated allocations. Instead, `Cell::InternalBegin()` and `Cell::InternalEnd()` provide iterators over the internal cells. Iterating over internal cells is a hot path and does not allocate.

The accessibility code is reworked to use these iterators, getting rid of repeated cell counting. The accessible cell ids are generated on the fly while the cells are iterated, and there's no need to count cells ahead of time.