### PR TITLE
Feature/refactor clipboard and export

### DIFF
--- a/src/BitmapOut.h
+++ b/src/BitmapOut.h
@@ -20,18 +20,17 @@
 //
 //  SPDX-License-Identifier: GPL-2.0+
 
-#ifndef BITMAP_H
-#define BITMAP_H
+#ifndef BITMAPOUT_H
+#define BITMAPOUT_H
 
-#include "Cell.h"
-#include "GroupCell.h"
+#include "OutCommon.h"
 
 /*! Renders portions of the work sheet (including 2D maths) as bitmap.
 
    This is used for exporting HTML with embedded maths as bitmap
    and for putting bitmaps for the clipboard
  */
-class BitmapOut
+class BitmapOut final
 {
 public:
   /*! The constructor.
@@ -42,11 +41,6 @@ public:
            storage
   */
   explicit BitmapOut(Configuration **configuration, int scale = 1);
-
-  //! This class doesn't have a copy constructor
-  BitmapOut(const BitmapOut&) = delete;
-  //! This class doesn't have a = operator
-  BitmapOut& operator=(const BitmapOut&) = delete;
   ~BitmapOut();
 
   /*! Renders tree as bitmap
@@ -66,56 +60,19 @@ public:
   wxSize ToFile(wxString file);
 
   //! Returns the bitmap representation of the list of cells that was passed to SetData()
-  wxBitmap GetBitmap() const
-  { return m_bmp; }
+  wxBitmap GetBitmap() const { return m_bmp; }
 
   //! Copies the bitmap representation of the list of cells that was passed to SetData()
   bool ToClipboard();
 
-protected:
-  void DestroyTree();
-
-  // cppcheck-suppress functionStatic
-  // cppcheck-suppress functionConst
-  void RecalculateWidths();
-
-  // cppcheck-suppress functionStatic
-  // cppcheck-suppress functionConst
-  void BreakLines();
-
-  // cppcheck-suppress functionStatic
-  // cppcheck-suppress functionConst
-  void RecalculateHeight();
-
-  void GetMaxPoint(int *width, int *height) const;
-
-  // cppcheck-suppress functionStatic
-  // cppcheck-suppress functionConst
-  void BreakUpCells();
+private:
+  std::unique_ptr<Cell> m_tree;
+  OutCommon m_cmn;
+  wxBitmap m_bmp;
+  wxMemoryDC m_dc;
 
   bool Layout(long int maxSize = -1);
-
   void Draw();
-
-  std::unique_ptr<Cell> m_tree;
-
-  double GetRealHeight() const;
-
-  double GetRealWidth() const;
-
-private:
-  std::unique_ptr<wxMemoryDC> m_dc;
-  Configuration **m_configuration, *m_oldconfig;
-  //! How many times the natural resolution do we want this bitmap to be?
-  int m_scale;
-  wxBitmap m_bmp;
-  //! The width of the current bitmap;
-  int m_width;
-  //! The height of the current bitmap;
-  int m_height;
-  //! The resolution of the bitmap.
-  wxSize m_ppi;
-
 };
 
-#endif // BITMAP_H
+#endif // BITMAPOUT_H

--- a/src/CompositeDataObject.cpp
+++ b/src/CompositeDataObject.cpp
@@ -1,0 +1,154 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+//
+//  Copyright (C) 2020 Kuba Ober <kuba@bertec.com>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+#include "CompositeDataObject.h"
+
+CompositeDataObject::CompositeDataObject()
+{}
+
+CompositeDataObject::~CompositeDataObject()
+{}
+
+void CompositeDataObject::Add(wxDataObject *object, bool preferred)
+{
+  if (!object)
+    return;
+
+  // Check if the object already exists
+  for (auto &entry : m_entries)
+    if (entry.object.get() == object)
+      return;
+
+  std::shared_ptr<wxDataObject> objPtr{object};
+
+  std::vector<wxDataFormat> addedFormats(object->GetFormatCount());
+  object->GetAllFormats(addedFormats.data());
+
+  if (preferred && !addedFormats.empty())
+    SetPreferredFormat(addedFormats.front());
+
+  // Check if any prior entries have some of the added formats, and replace their
+  // objects if necessary.
+  for (auto &priorEntry : m_entries)
+    for (auto addedFormat = addedFormats.begin(); addedFormat != addedFormats.end(); )
+    {
+      if (priorEntry.format == *addedFormat)
+      {
+        priorEntry.format = *addedFormat;
+        priorEntry.object = objPtr;
+        addedFormat = addedFormats.erase(addedFormat);
+        continue;
+      }
+      ++ addedFormat;
+    }
+
+  // Add all remaining formats
+  for (auto &addedFormat : addedFormats)
+    m_entries.emplace_back(addedFormat, objPtr);
+}
+
+wxDataObject *CompositeDataObject::GetObject(const wxDataFormat& format,
+                                             wxDataObjectBase::Direction dir) const
+{
+  if (!(dir & wxDataObject::Get))
+    return 0;
+
+  for (auto &entry : m_entries)
+    if (entry.format == format)
+      return entry.object.get();
+
+  return {};
+}
+
+wxDataFormat CompositeDataObject::GetPreferredFormat(Direction dir) const
+{
+  return (dir & wxDataObject::Get) ? m_preferredFormat : wxDataFormat();
+}
+
+void CompositeDataObject::SetPreferredFormat(const wxDataFormat &format)
+{
+  m_preferredFormat = format;
+}
+
+size_t CompositeDataObject::GetFormatCount(Direction dir) const
+{
+  return (dir & wxDataObject::Get) ? m_entries.size() : 0;
+}
+
+void CompositeDataObject::GetAllFormats(wxDataFormat *formats, Direction dir) const
+{
+  if (!(dir & wxDataObject::Get))
+    return;
+
+  for (auto &entry : m_entries)
+    *formats ++ = entry.format;
+}
+
+size_t CompositeDataObject::GetDataSize(const wxDataFormat &format) const
+{
+  for (auto &entry : m_entries)
+    if (entry.format == format)
+      return entry.object->GetDataSize(format);
+
+  return 0;
+}
+
+bool CompositeDataObject::GetDataHere(const wxDataFormat &format, void *buf) const
+{
+  for (auto &entry : m_entries)
+    if (entry.format == format)
+      return entry.object->GetDataHere(format, buf);
+
+  return false;
+}
+
+#ifdef __WXMSW__
+
+const void* CompositeDataObject::GetSizeFromBuffer(const void* buffer, size_t* size,
+                                                   const wxDataFormat& format)
+{
+  if (!size)
+    return {};
+
+  auto *object = GetObject(format);
+  if (!object)
+  {
+    *size = 0;
+    return {};
+  }
+
+  return object->GetSizeFromBuffer(buffer, size, format);
+}
+
+void* CompositeDataObject::SetSizeInBuffer(void* buffer, size_t size,
+                                           const wxDataFormat& format)
+{
+  auto *object = GetObject(format);
+  return object ? object->SetSizeInBuffer(buffer, size, format) : nullptr;
+}
+
+size_t CompositeDataObject::GetBufferOffset(const wxDataFormat& format)
+{
+  auto *object = GetObject(format);
+  return object ? object->GetBufferOffset(format) : 0;
+}
+
+#endif // __WXMSW__

--- a/src/CompositeDataObject.h
+++ b/src/CompositeDataObject.h
@@ -1,0 +1,72 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+//
+//  Copyright (C) 2020 Kuba Ober <kuba@bertec.com>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+#ifndef COMPOSITEDATAOBJECT_H
+#define COMPOSITEDATAOBJECT_H
+
+#include <wx/clipbrd.h>
+#include <memory>
+#include <vector>
+
+/*!
+ * \file The declaration of the CompositeDataObject class - a superset
+ * of the wxDataObjectComposite functionality.
+ */
+
+//! A composite data object like wxDataObjectComposite, but accepts also
+//! non-simple data objects. Only the Get direction is supported.
+class CompositeDataObject final : public wxDataObject
+{
+public:
+  CompositeDataObject();
+  ~CompositeDataObject() override;
+
+  void Add(wxDataObject *object, bool preferred = false);
+  wxDataObject *GetObject(const wxDataFormat& format,
+                                wxDataObjectBase::Direction dir = Get) const;
+  wxDataFormat GetPreferredFormat(Direction dir=Get) const override;
+  void SetPreferredFormat(const wxDataFormat &format);
+
+  size_t GetFormatCount(Direction dir=Get) const override;
+  void GetAllFormats(wxDataFormat *formats, Direction dir=Get) const override;
+  size_t GetDataSize(const wxDataFormat &format) const override;
+  bool GetDataHere(const wxDataFormat &format, void *buf) const override;
+
+#ifdef __WXMSW__
+  const void* GetSizeFromBuffer(const void* buffer, size_t* size,
+                                const wxDataFormat& format) override;
+  void* SetSizeInBuffer(void* buffer, size_t size, const wxDataFormat& format) override;
+  size_t GetBufferOffset(const wxDataFormat& format) override;
+#endif
+
+private:
+  struct Entry
+  {
+    wxDataFormat format;
+    std::shared_ptr<wxDataObject> object;
+    Entry(const wxDataFormat &format, std::shared_ptr<wxDataObject> object) :
+        format(format), object(object) {}
+  };
+  std::vector<Entry> m_entries;
+  wxDataFormat m_preferredFormat;
+};
+
+#endif // COMPOSITEDATAOBJECT_H

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -135,6 +135,7 @@ public:
     m_dc = &dc;
     m_antialiassingDC = NULL;
   }
+  void UnsetContext() {m_dc = NULL;}
 
   void SetBackgroundBrush(wxBrush brush);
   wxBrush GetBackgroundBrush() const {return m_BackgroundBrush;}

--- a/src/EMFout.cpp
+++ b/src/EMFout.cpp
@@ -64,26 +64,20 @@ bool Emfout::Layout()
 
   config.SetContext(dc);
   m_cmn.Draw(m_tree.get());
-  dc.Close(); // Closing the DC seems to trigger the actual output of the file.
+  m_metaFile.reset(dc.Close()); // Closing the DC triggers the output of the file.
   config.UnsetContext();
 
   return true;
 }
 
-static wxDataFormat &Format()
+wxEnhMetaFileDataObject *Emfout::GetDataObject()
 {
-  static wxDataFormat format(wxT("image/x-emf"));
-  return format;
-}
-
-wxCustomDataObject *Emfout::GetDataObject()
-{
-  return m_cmn.GetDataObject(Format()).release();
+  return m_metaFile ? new wxEnhMetaFileDataObject(*m_metaFile) : nullptr;
 }
 
 bool Emfout::ToClipboard()
 {
-  return m_cmn.ToClipboard(Format());
+  return m_metaFile && m_metaFile->SetClipboard();
 }
 
 #endif // wxUSE_ENH_METAFILE

--- a/src/EMFout.cpp
+++ b/src/EMFout.cpp
@@ -25,359 +25,65 @@
  */
 
 #include "EMFout.h"
-#include "ErrorRedirector.h"
-#include <wx/txtstrm.h>
-#include <wx/filename.h>
-#include <wx/wfstream.h>
-#include "Configuration.h"
-#include "GroupCell.h"
-#include <wx/config.h>
-#include <wx/log.h>
-#include <wx/clipbrd.h>
+#include "Cell.h"
 
 #if wxUSE_ENH_METAFILE
 
-Emfout::Emfout(Configuration **configuration, wxString filename)
+Emfout::Emfout(Configuration **configuration, const wxString &filename) :
+    m_cmn(configuration, filename, 500, 1.0),
+    m_recalculationDc(m_cmn.GetTempFilename(), 3000, 50000)
 {
-  m_width = m_height = -1;
-  m_scale = 1;
-  m_configuration = configuration;
-  m_oldconfig = *m_configuration;
-  m_tree = NULL;
-  m_emfFormat = wxDataFormat(wxT("image/x-emf"));
-
-  m_filename = filename;
-  if (m_filename == wxEmptyString)
-    m_filename = wxFileName::CreateTempFileName(wxT("wxmaxima_"));
-
-  m_dc = NULL;
-
-  wxString m_tempFileName = wxFileName::CreateTempFileName(wxT("wxmaxima_size_"));
-  m_recalculationDc = new wxEnhMetaFileDC(m_tempFileName,3000,50000);
-  *m_configuration = new Configuration(m_recalculationDc);
-  (*m_configuration)->ShowCodeCells(m_oldconfig->ShowCodeCells());
-  (*m_configuration)->SetClientWidth(3000);
-  (*m_configuration)->SetZoomFactor_temporarily(1);
-  // The last time I tried it the vertical positioning of the elements
-  // of a big unicode parenthesis wasn't accurate enough in emf to be
-  // usable. Also the probability was high that the right font wasn't
-  // available in inkscape.
-  (*m_configuration)->SetGrouphesisDrawMode(Configuration::handdrawn);
-  (*m_configuration)->ClipToDrawRegion(false);
-  (*m_configuration)->RecalculationForce(true);
+  m_cmn.SetRecalculationContext(m_recalculationDc);
+  auto &config = m_cmn.GetConfiguration();
+  config.SetContext(m_recalculationDc);
+  config.SetClientWidth(3000);
+  config.RecalculationForce(true);
 }
 
 Emfout::~Emfout()
-{
-  wxDELETE(m_tree);
-  m_tree = NULL;
-  wxDELETE(*m_configuration);
-  wxDELETE(m_dc);
-  m_dc = NULL;
-  wxDELETE(m_recalculationDc);
-  m_recalculationDc = NULL;
-  if(wxFileExists(m_tempFileName))
-  {
-    // We don't want a braindead virus scanner that disallows us to delete our temp
-    // files to trigger asserts.
-    SuppressErrorDialogs messageBlocker;
-    
-    if(!wxRemoveFile(m_tempFileName))
-      wxLogMessage(_("Cannot remove the file %s"),m_tempFileName.utf8_str());
-  }
-  *m_configuration = m_oldconfig;
-  (*m_configuration)->FontChanged(true);
-  (*m_configuration)->RecalculationForce(true);
-  m_configuration = NULL;
-}
+{}
 
 wxSize Emfout::SetData(Cell *tree)
 {
-  wxDELETE(m_tree);
-  m_tree = tree;
-  if(m_tree != NULL)
-  {
-    m_tree = tree;
-    m_tree->ResetSize();
-    if(Layout())
-      return wxSize(m_width, m_height);
-    else
-      return wxSize(-1,-1);
-  }
-  else
-    return wxSize(-1,-1);
+  m_tree.reset(tree);
+  if (m_tree && Layout())
+      return m_cmn.GetSize();
+
+  return wxDefaultSize;
 }
 
 bool Emfout::Layout()
 {
-  if(m_recalculationDc == NULL)
+  if (!m_cmn.PrepareLayout(m_tree.get()))
     return false;
-  
-  (*m_configuration)->SetContext(*m_recalculationDc);
 
-  if (m_tree->GetType() != MC_TYPE_GROUP)
-  {
-    RecalculateWidths();
-    BreakUpCells();
-    BreakLines();
-    RecalculateHeight();
-  }
-  else
-  {
-    GroupCell *tmp = dynamic_cast<GroupCell *>(m_tree);
-    while (tmp != NULL)
-    {
-      tmp->Recalculate();
-      tmp = tmp->GetNext();
-    }
-  }
-
-  if(!m_recalculationDc->IsOk())
-  {
-    return false;
-  }
-
-  GetMaxPoint(&m_width, &m_height);
-  if(m_dc != NULL)
-  {
-    m_dc->Close();
-    wxDELETE(m_dc);
-  }
   // Let's switch to a DC of the right size for our object.
-  m_dc = new wxEnhMetaFileDC(m_filename, m_width, m_height);
-  if(m_dc != NULL)
-  {
-    (*m_configuration)->SetContext(*m_dc);
-    
-    Draw();
-    // Closing the DC seems to trigger the actual output of the file.
-    m_dc->Close();
-    wxDELETE(m_dc);
-    m_dc = NULL;
-  }
+  auto size = m_cmn.GetSize();
+  auto &config = m_cmn.GetConfiguration();
+  wxEnhMetaFileDC dc(m_cmn.GetFilename(), size.x, size.y);
+
+  config.SetContext(dc);
+  m_cmn.Draw(m_tree.get());
+  dc.Close(); // Closing the DC seems to trigger the actual output of the file.
+  config.UnsetContext();
+
   return true;
 }
 
-double Emfout::GetRealWidth()
+static wxDataFormat &Format()
 {
-  return m_width;
+  static wxDataFormat format(wxT("image/x-emf"));
+  return format;
 }
 
-double Emfout::GetRealHeight()
+wxCustomDataObject *Emfout::GetDataObject()
 {
-  return m_height;
-}
-
-void Emfout::RecalculateHeight()
-{
-  int fontsize = 12;
-  wxConfig::Get()->Read(wxT("fontSize"), &fontsize);
-  int mfontsize = fontsize;
-  wxConfig::Get()->Read(wxT("mathfontsize"), &mfontsize);
-  Cell *tmp = m_tree;
-
-  while (tmp != NULL)
-  {
-    tmp->RecalculateHeight(tmp->IsMath() ? mfontsize : fontsize);
-    tmp = tmp->m_next;
-  }
-}
-
-void Emfout::RecalculateWidths()
-{
-  int fontsize = 12;
-  wxConfig::Get()->Read(wxT("fontSize"), &fontsize);
-  int mfontsize = fontsize;
-  wxConfig::Get()->Read(wxT("mathfontsize"), &mfontsize);
-  Cell *tmp = m_tree;
-
-  while (tmp != NULL)
-  {
-    tmp->RecalculateWidths(tmp->IsMath() ? mfontsize : fontsize);
-    tmp = tmp->m_next;
-  }
-}
-
-void Emfout::BreakLines()
-{
-  int fullWidth = 500;
-  int currentWidth = 0;
-
-  Cell *tmp = m_tree;
-
-  while (tmp != NULL)
-  {
-    if (!tmp->m_isBrokenIntoLines)
-    {
-      tmp->SoftLineBreak(false);
-      tmp->ResetData();
-      if (tmp->BreakLineHere() ||
-          (currentWidth + tmp->GetWidth() >= fullWidth))
-      {
-        currentWidth = tmp->GetWidth();
-        tmp->SoftLineBreak(true);
-      }
-      else
-        currentWidth += (tmp->GetWidth());
-    }
-    tmp = tmp->GetNextToDraw();
-  }
-}
-
-void Emfout::GetMaxPoint(int *width, int *height)
-{
-  Cell *tmp = m_tree;
-  int currentHeight = 0;
-  int currentWidth = 0;
-  *width = 0;
-  *height = 0;
-  bool bigSkip = false;
-  bool firstCell = true;
-  while (tmp != NULL)
-  {
-    if (!tmp->m_isBrokenIntoLines)
-    {
-      if (tmp->BreakLineHere() || firstCell)
-      {
-        firstCell = false;
-        currentHeight += tmp->GetHeightList();
-        if (bigSkip)
-          currentHeight += MC_LINE_SKIP;
-        *height = currentHeight;
-        currentWidth = tmp->GetWidth();
-        *width = wxMax(currentWidth, *width);
-      }
-      else
-      {
-        currentWidth += (tmp->GetWidth());
-        *width = wxMax(currentWidth, *width);
-      }
-      bigSkip = tmp->m_bigSkip;
-    }
-    tmp = tmp->GetNextToDraw();
-  }
-}
-
-void Emfout::Draw()
-{
-  Cell *tmp = m_tree;
-
-  if (tmp != NULL)
-  {
-    wxPoint point;
-    point.x = 0;
-    point.y = tmp->GetCenterList();
-    int fontsize = 12;
-    int drop = tmp->GetMaxDrop();
-
-    wxConfig::Get()->Read(wxT("fontSize"), &fontsize);
-    int mfontsize = fontsize;
-    wxConfig::Get()->Read(wxT("mathfontsize"), &mfontsize);
-
-    while (tmp != NULL)
-    {
-      if (!tmp->m_isBrokenIntoLines)
-      {
-        tmp->Draw(point);
-        if ((tmp->m_next != NULL) && (tmp->m_next->BreakLineHere()))
-        {
-          point.x = 0;
-          point.y += drop + tmp->m_next->GetCenterList();
-          if (tmp->m_bigSkip)
-            point.y += MC_LINE_SKIP;
-          drop = tmp->m_next->GetMaxDrop();
-        }
-        else
-          point.x += (tmp->GetWidth());
-      }
-      else
-      {
-        if ((tmp->m_next != NULL) && (tmp->m_next->BreakLineHere()))
-        {
-          point.x = 0;
-          point.y += drop + tmp->m_next->GetCenterList();
-          if (tmp->m_bigSkip)
-            point.y += MC_LINE_SKIP;
-          drop = tmp->m_next->GetMaxDrop();
-        }
-      }
-      tmp = tmp->GetNextToDraw();
-    }
-  }
-}
-
-Emfout::EMFDataObject::EMFDataObject() : wxCustomDataObject(m_emfFormat)
-{
-}
-
-Emfout::EMFDataObject::EMFDataObject(wxMemoryBuffer data) : wxCustomDataObject(m_emfFormat)
-{
-  SetData(data.GetBufSize(), data.GetData());
-}
-
-
-wxDataFormat Emfout::m_emfFormat;
-
-Emfout::EMFDataObject *Emfout::GetDataObject()
-{
-  wxMemoryBuffer emfContents;
-  {
-    char *data =(char *) malloc(8192);
-    wxFileInputStream str(m_filename);
-    if(str.IsOk())
-      while (!str.Eof())
-      {
-        str.Read(data,8192);
-        emfContents.AppendData(data,str.LastRead());
-      }
-    free(data);
-  }
-  if((m_filename != wxEmptyString) && (wxFileExists(m_filename)))
-  {
-    // Don't output error messages if the worst thing that can happen is that we
-    // cannot clean up a temp file
-
-    SuppressErrorDialogs messageBlocker;
-
-    wxRemoveFile(m_filename);
-  }
-  m_filename = wxEmptyString;
-
-  return new EMFDataObject(emfContents);
+  return m_cmn.GetDataObject(Format()).release();
 }
 
 bool Emfout::ToClipboard()
 {
-  wxASSERT_MSG(!wxTheClipboard->IsOpened(),_("Bug: The clipboard is already opened"));
-  if (wxTheClipboard->Open())
-  {
-    bool res = wxTheClipboard->SetData(GetDataObject());
-    wxTheClipboard->Close();
-    m_filename = wxEmptyString;
-    return res;
-  }
-  return false;
+  return m_cmn.ToClipboard(Format());
 }
 
-void Emfout::BreakUpCells()
-{
-  Cell *tmp = m_tree;
-  int fontsize = 12;
-  wxConfig::Get()->Read(wxT("fontSize"), &fontsize);
-  int mfontsize = fontsize;
-  wxConfig::Get()->Read(wxT("mathfontsize"), &mfontsize);
-
-  while (tmp != NULL)
-  {
-    if (tmp->GetWidth() > 500)
-    {
-      if (tmp->BreakUp())
-      {
-        tmp->RecalculateWidths(tmp->IsMath() ? mfontsize : fontsize);
-        tmp->RecalculateHeight(tmp->IsMath() ? mfontsize : fontsize);
-      }
-    }
-    tmp = tmp->GetNextToDraw();
-  }
-}
 #endif // wxUSE_ENH_METAFILE

--- a/src/EMFout.h
+++ b/src/EMFout.h
@@ -47,13 +47,15 @@ public:
   bool ToClipboard();
 
   //! Returns the emf representation in a format that can be placed on the clipBoard.
-  wxCustomDataObject *GetDataObject();
+  wxEnhMetaFileDataObject *GetDataObject();
 
 private:
   std::unique_ptr<Cell> m_tree;
   OutCommon m_cmn;
   //! The draw context we draw to during recalculation.
   wxEnhMetaFileDC m_recalculationDc;
+  //! The most recently rendered metafile - used to paste to clipboard.
+  std::unique_ptr<wxEnhMetaFile> m_metaFile;
 
   bool Layout();
 };

--- a/src/EMFout.h
+++ b/src/EMFout.h
@@ -20,29 +20,21 @@
 //
 //  SPDX-License-Identifier: GPL-2.0+
 
-#include "Cell.h"
 #ifndef EMFOUT_H
 #define EMFOUT_H
 
+#include "OutCommon.h"
+
 #if wxUSE_ENH_METAFILE
 #include <wx/msw/enhmeta.h>
-/* Renders portions of the work sheet (including 2D maths) as extended Metafile.
+#include <memory>
 
-   Let's hope it provides as useful.
- */
-class Emfout
+//! Renders portions of the work sheet (including 2D maths) as extended Metafile.
+class Emfout final
 {
 public:
-  /*! The constructor.
-  */
-  explicit Emfout(Configuration **configuration, wxString filename = wxEmptyString);
-  //! This class doesn't have a copy constructor
-  Emfout(const Emfout&) = delete;
-  //! This class doesn't have a = operator
-  Emfout& operator=(const Emfout&) = delete;
+  explicit Emfout(Configuration **configuration, const wxString &filename = {});
   ~Emfout();
-
-  int Scale_Px(double px){ return (*m_configuration)->Scale_Px(px);}
 
   /*! Renders tree as emf
 
@@ -54,78 +46,17 @@ public:
   //! Copies the emf representation of the list of cells that was passed to SetData()
   bool ToClipboard();
 
-protected:
-  void DestroyTree();
-
-  // cppcheck-suppress functionStatic
-  // cppcheck-suppress functionConst
-  void RecalculateWidths();
-
-  // cppcheck-suppress functionStatic
-  // cppcheck-suppress functionConst
-  void BreakLines();
-
-  // cppcheck-suppress functionStatic
-  // cppcheck-suppress functionConst
-  void RecalculateHeight();
-
-  void GetMaxPoint(int *width, int *height);
-
-  // cppcheck-suppress functionStatic
-  // cppcheck-suppress functionConst
-  void BreakUpCells();
-
-  bool Layout();
-
-  void Draw();
-
-  Cell *m_tree;
-
-  // cppcheck-suppress functionStatic
-  // cppcheck-suppress functionConst
-  double GetRealHeight();
-
-  // cppcheck-suppress functionStatic
-  // cppcheck-suppress functionConst
-  double GetRealWidth();
-
-
-  /*! An object that can be filled with EMF data for the clipboard
-   */
-  class EMFDataObject : public wxCustomDataObject
-  {
-  public:
-    explicit EMFDataObject(wxMemoryBuffer data);
-
-    EMFDataObject();
-
-  private:
-    //! A class that publishes MathML data to the clipboard
-    wxCharBuffer m_databuf;
-  };
+  //! Returns the emf representation in a format that can be placed on the clipBoard.
+  wxCustomDataObject *GetDataObject();
 
 private:
-  //! The name of a temp file we create while calculating the emf size.
-  wxString m_tempFileName;
+  std::unique_ptr<Cell> m_tree;
+  OutCommon m_cmn;
   //! The draw context we draw to during recalculation.
-  wxEnhMetaFileDC *m_recalculationDc;
-  //! The draw context we draw to.
-  wxEnhMetaFileDC *m_dc;
-  static wxDataFormat m_emfFormat;
-  wxString m_filename;
-  Configuration **m_configuration, *m_oldconfig;
-  //! How many times the natural resolution do we want this emfout to be?
-  double m_scale;
-  //! The width of the current emfout;
-  int m_width;
-  //! The height of the current emfout;
-  int m_height;
-  //! The resolution of the emfout.
-  wxSize m_ppi;
+  wxEnhMetaFileDC m_recalculationDc;
 
-public:
-  //! Returns the emf representation in a format that can be placed on the clipBoard.
-  EMFDataObject *GetDataObject();
+  bool Layout();
 };
+
 #endif // wxUSE_ENH_METAFILE
 #endif // EMFOUT_H

--- a/src/OutCommon.cpp
+++ b/src/OutCommon.cpp
@@ -1,0 +1,317 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+//
+//  Copyright (C) 2004-2015 Andrej Vodopivec <andrej.vodopivec@gmail.com>
+//  Copyright (C) 2015      Gunter Königsmann <wxMaxima@physikbuch.de>
+//  Copyright (C) 2020      Kuba Ober <kuba@bertec.com>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+#include "OutCommon.h"
+#include "ErrorRedirector.h"
+#include "GroupCell.h"
+#include <wx/clipbrd.h>
+#include <wx/filename.h>
+#include <wx/wfstream.h>
+#include <cmath>
+
+static wxString MakeTempFilename()
+{
+  return wxFileName::CreateTempFileName(wxT("wxmaxima_size_"));
+}
+
+OutCommon::OutCommon(Configuration **configuration, const wxString &filename, int fullWidth, double scale) :
+    m_tempFilename(MakeTempFilename()),
+    m_filename(filename.empty() ? wxFileName::CreateTempFileName(wxT("wxmaxima_")) : filename),
+    m_configuration(configuration),
+    m_scale(scale),
+    m_fullWidth(fullWidth)
+{
+  m_thisconfig.ShowCodeCells(m_oldconfig->ShowCodeCells());
+  *m_configuration = &m_thisconfig;
+  m_thisconfig.SetZoomFactor_temporarily(1);
+  // The last time I tried it the vertical positioning of the elements
+  // of a big unicode parenthesis wasn't accurate enough in emf to be
+  // usable. Also the probability was high that the right font wasn't
+  // available in inkscape.
+  m_thisconfig.SetGrouphesisDrawMode(Configuration::handdrawn);
+  m_thisconfig.ClipToDrawRegion(false);
+}
+
+OutCommon::OutCommon(Configuration **configuration, int fullWidth, double scale) :
+    OutCommon(configuration, {}, fullWidth, scale)
+{}
+
+OutCommon::~OutCommon()
+{
+  if (wxFileExists(m_tempFilename))
+  {
+    // We don't want a braindead virus scanner that disallows us to delete our temp
+    // files to trigger asserts.
+    SuppressErrorDialogs messageBlocker;
+
+    if (!wxRemoveFile(m_tempFilename))
+      wxLogMessage(_("Cannot remove the file %s"),m_tempFilename.utf8_str());
+  }
+  *m_configuration = m_oldconfig;
+  (*m_configuration)->FontChanged(true);
+  (*m_configuration)->RecalculationForce(true);
+}
+
+wxSize OutCommon::GetScaledSize() const
+{
+  int w = std::lround(m_size.x * m_scale);
+  int h = std::lround(m_size.y * m_scale);
+  return {w, h};
+}
+
+wxSize OutCommon::GetInvScaledSize() const
+{
+  int w = std::lround(m_size.x / m_scale);
+  int h = std::lround(m_size.y / m_scale);
+  return {w, h};
+}
+
+bool OutCommon::PrepareLayout(Cell *tree)
+{
+  wxASSERT(m_recalculationDc);
+
+  tree->ResetSize();
+  m_thisconfig.SetContext(*m_recalculationDc);
+
+  if (tree->GetType() != MC_TYPE_GROUP)
+  {
+    RecalculateWidths(tree);
+    BreakUpCells(tree);
+    BreakLines(tree);
+    RecalculateHeight(tree);
+  }
+  else
+  {
+    for (auto *tmp = dynamic_cast<GroupCell *>(tree); tmp; tmp = tmp->GetNext())
+      tmp->Recalculate();
+  }
+
+  if (!m_recalculationDc->IsOk())
+    return false;
+
+  GetMaxPoint(tree, &m_size.x, &m_size.y);
+  return true;
+}
+
+void OutCommon::RecalculateHeight(Cell *tree) const
+{
+  int fontsize = m_thisconfig.GetDefaultFontSize();
+  int mathFontsize = m_thisconfig.GetMathFontSize();
+
+  for (Cell *tmp = tree; tmp; tmp = tmp->m_next)
+    tmp->RecalculateHeight(tmp->IsMath() ? mathFontsize : fontsize);
+}
+
+void OutCommon::RecalculateWidths(Cell *tree) const
+{
+  int fontsize = m_thisconfig.GetDefaultFontSize();
+  int mathFontsize = m_thisconfig.GetMathFontSize();
+
+  for (Cell *tmp = tree; tmp; tmp = tmp->m_next)
+    tmp->RecalculateWidths(tmp->IsMath() ? mathFontsize : fontsize);
+}
+
+void OutCommon::BreakLines(Cell *tree) const
+{
+  int currentWidth = 0;
+  int fullWidth = m_fullWidth * m_scale;
+
+  for (Cell *tmp = tree; tmp; tmp = tmp->GetNextToDraw())
+  {
+    if (tmp->m_isBrokenIntoLines)
+      continue;
+
+    if (tmp->SoftLineBreak(false))
+      // Note: This ResetData() call was unconditional in EMFout and SVGout.
+      // The condition check was only performed in BitmapOut. That was likely
+      // an ommission. This note is here in case bugs were found in this area.
+      tmp->ResetData();
+
+    if (tmp->BreakLineHere() || (currentWidth + tmp->GetWidth() >= fullWidth))
+    {
+      currentWidth = tmp->GetWidth();
+      tmp->SoftLineBreak(true);
+    }
+    else
+      currentWidth += (tmp->GetWidth());
+  }
+}
+
+void OutCommon::GetMaxPoint(Cell *tree, int *width, int *height) const
+{
+  int currentHeight = 0;
+  int currentWidth = 0;
+  *width = 0;
+  *height = 0;
+  bool bigSkip = false;
+  bool firstCell = true;
+
+  for (Cell *tmp = tree; tmp; tmp = tmp->GetNextToDraw())
+  {
+    if (tmp->m_isBrokenIntoLines)
+      continue;
+
+    if (tmp->BreakLineHere() || firstCell)
+    {
+      firstCell = false;
+      currentHeight += tmp->GetHeightList();
+      if (bigSkip)
+        // Note: This skip was observerd in EMFout and SVGout, but not BitmapOut.
+        currentHeight += MC_LINE_SKIP;
+      *height = currentHeight;
+      currentWidth = tmp->GetWidth();
+      *width = wxMax(currentWidth, *width);
+    }
+    else
+    {
+      currentWidth += (tmp->GetWidth());
+      *width = wxMax(currentWidth, *width);
+    }
+    bigSkip = tmp->m_bigSkip;
+  }
+}
+
+void OutCommon::Draw(Cell *tree)
+{
+  Cell *tmp = tree;
+  wxPoint point;
+  point.x = 0;
+  point.y = tmp->GetCenterList();
+  int drop = tmp->GetMaxDrop();
+
+  for (; tmp; tmp = tmp->GetNextToDraw())
+  {
+    if (!tmp->m_isBrokenIntoLines)
+    {
+      tmp->Draw(point);
+      if (tmp->m_next && tmp->m_next->BreakLineHere())
+      {
+        point.x = 0;
+        point.y += drop + tmp->m_next->GetCenterList();
+        if (tmp->m_bigSkip)
+          // Note: This skip was observerd in EMFout and SVGout, but not BitmapOut.
+          point.y += MC_LINE_SKIP;
+        drop = tmp->m_next->GetMaxDrop();
+      }
+      else
+        point.x += (tmp->GetWidth());
+    }
+    else
+    {
+      if (tmp->m_next && tmp->m_next->BreakLineHere())
+      {
+        point.x = 0;
+        point.y += drop + tmp->m_next->GetCenterList();
+        if (tmp->m_bigSkip)
+          // Note: This skip was observerd in EMFout and SVGout, but not BitmapOut.
+          point.y += MC_LINE_SKIP;
+        drop = tmp->m_next->GetMaxDrop();
+      }
+    }
+  }
+
+  // Update the bitmap's size information.
+  m_ppi = m_thisconfig.GetDC()->GetPPI();
+  m_ppi.x *= m_scale;
+  m_ppi.y *= m_scale;
+}
+
+void OutCommon::BreakUpCells(Cell *tree)
+{
+  int fullWidth = m_fullWidth * m_scale;
+  int fontsize = m_thisconfig.GetDefaultFontSize();
+  int mathFontsize = m_thisconfig.GetMathFontSize();
+
+  for (Cell *tmp = tree; tmp; tmp = tmp->GetNextToDraw())
+  {
+    if (tmp->GetWidth() > fullWidth && tmp->BreakUp())
+    {
+      tmp->RecalculateWidths(tmp->IsMath() ? mathFontsize : fontsize);
+      tmp->RecalculateHeight(tmp->IsMath() ? mathFontsize : fontsize);
+    }
+  }
+}
+
+bool OutCommon::ToClipboard(const wxDataFormat &format)
+{
+  wxASSERT_MSG(!wxTheClipboard->IsOpened(),_("Bug: The clipboard is already opened"));
+  if (wxTheClipboard->Open())
+  {
+    bool res = wxTheClipboard->SetData(GetDataObject(format).release());
+    wxTheClipboard->Close();
+    m_filename.clear();
+    return res;
+  }
+  return false;
+}
+
+std::unique_ptr<OutCommon::DataObject> OutCommon::GetDataObject(const wxDataFormat &format)
+{
+  constexpr auto chunkSize = 8192;
+  wxMemoryBuffer contents;
+  {
+    wxFileInputStream str(m_filename);
+    if (str.IsOk())
+      while (!str.Eof())
+      {
+        auto *buf = contents.GetAppendBuf(chunkSize);
+        str.Read(buf, chunkSize);
+        contents.UngetAppendBuf(str.LastRead());
+      }
+  }
+
+  if ((!m_filename.empty()) && wxFileExists(m_filename))
+  {
+    // Don't output error messages if the worst thing that can happen is that we
+    // cannot clean up a temp file
+    SuppressErrorDialogs messageBlocker;
+    wxRemoveFile(m_filename);
+  }
+  m_filename.clear();
+
+  return std::unique_ptr<DataObject>(new DataObject(format, contents));
+}
+
+OutCommon::DataObject::DataObject(const wxDataFormat &format, const wxMemoryBuffer &data) :
+    wxCustomDataObject(format),
+    m_databuf(0)
+    // We can't point m_databuf to data here, since TakeData calls Free() and will ruin it!
+{
+  m_databuf = data;
+}
+
+bool OutCommon::DataObject::GetDataHere(void *buf) const
+{
+  memcpy(buf, m_databuf.GetData(), m_databuf.GetDataLen());
+  return true;
+}
+
+size_t OutCommon::DataObject::GetDataSize() const
+{
+  return m_databuf.GetDataLen();
+}
+
+void OutCommon::DataObject::Free()
+{
+  m_databuf.Clear();
+}

--- a/src/OutCommon.h
+++ b/src/OutCommon.h
@@ -1,0 +1,131 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+//
+//  Copyright (C) 2004-2015 Andrej Vodopivec <andrej.vodopivec@gmail.com>
+//  Copyright (C) 2015      Gunter Königsmann <wxMaxima@physikbuch.de>
+//  Copyright (C) 2020      Kuba Ober <kuba@bertec.com>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+#ifndef OUTCOMMON_H
+#define OUTCOMMON_H
+
+#include "Configuration.h"
+#include <wx/dataobj.h>
+#include <memory>
+
+/*! \file
+ * This is the header for common code used by various file output modules that render
+ * cells to files.
+ */
+
+class Cell;
+class wxDC;
+
+//! A collection of common code used in rendering the cells to a non-default output,
+//! e.g. a graphics file.
+class OutCommon
+{
+public:
+  //! An object that can be filled with output data in given format for the clipboard
+  class DataObject final : public wxCustomDataObject
+  {
+    wxMemoryBuffer m_databuf;
+
+  public:
+    explicit DataObject(const wxDataFormat &format, const wxMemoryBuffer &data);
+    bool GetDataHere(void *buf) const override;
+    size_t GetDataSize() const override;
+    void Free() override;
+  };
+
+  //! Returns the representation that can be placed on the clipboard. Removes the
+  //! file the data was saved in.
+  std::unique_ptr<DataObject> GetDataObject(const wxDataFormat &format);
+
+  /*! Constructs the instance of the helper, temporarily overriding the
+   * configuration.
+   *
+   * \param fullWidth multiplied by scale is only used as maximum width during line
+   *        breaking.
+   */
+  explicit OutCommon(Configuration **configuration, const wxString &filename,
+                     int fullWidth, double scale);
+  explicit OutCommon(Configuration **configuration, int fullWidth, double scale);
+  ~OutCommon();
+
+  OutCommon(const OutCommon&) = delete;
+  void operator=(const OutCommon&) = delete;
+
+  int Scale_Px(double px) const { return m_thisconfig.Scale_Px(px); }
+  double GetScale() const { return m_scale; }
+  const wxString &GetFilename() const { return m_filename; }
+  const wxString &GetTempFilename() const { return m_tempFilename; }
+  Configuration &GetConfiguration() { return m_thisconfig; }
+  wxSize getPPI() const { return m_ppi; }
+
+  //! Sets the context for the configuration used in recalculating the cell dimensions.
+  void SetRecalculationContext(wxDC &context) { m_recalculationDc = &context; }
+
+  //! Prepares to render the tree to the output DC, and computes the size of the output.
+  bool PrepareLayout(Cell *tree);
+
+  //! Returns the size of the prepared output layout
+  wxSize GetSize() const { return m_size; }
+  //! Sets the "default" size of the prepared layout
+  void SetSize(wxSize size) { m_size = size; }
+
+  //! Returns the size of the prepared output layout multiplied by the scale factor
+  wxSize GetScaledSize() const;
+  //! Returns the size of the prepared output layout divided by the scale factor
+  wxSize GetInvScaledSize() const;
+
+  //! Copies the representation of the list of cells that was passed to SetData()
+  //! to the clipboard.
+  bool ToClipboard(const wxDataFormat &format);
+
+  //! Recursively draws the cells.
+  void Draw(Cell *tree);
+
+private:
+  void GetMaxPoint(Cell *tree, int *width, int *height) const;
+  void RecalculateWidths(Cell *tree) const;
+  void RecalculateHeight(Cell *tree) const;
+
+  void BreakLines(Cell *tree) const;
+  void BreakUpCells(Cell *tree);
+
+  //! The name of a temp file we create while calculating the output size.
+  wxString m_tempFilename;
+  //! The draw context we draw to during recalculation.
+  wxDC *m_recalculationDc = {};
+
+  wxString m_filename;
+  Configuration **m_configuration;
+  Configuration *m_oldconfig = *m_configuration;
+  Configuration m_thisconfig;
+  //! How many times the natural resolution do we want this output to be?
+  double m_scale = 1.0;
+  //! The size of the current output
+  wxSize m_size = wxDefaultSize;
+  //! The maximum width of the rendered output
+  int m_fullWidth;
+  //! The resolution of the output (useful for bitmaps only)
+  wxSize m_ppi;
+};
+
+#endif  // OUTCOMMON_H

--- a/src/SVGout.cpp
+++ b/src/SVGout.cpp
@@ -35,346 +35,72 @@
 #include <wx/config.h>
 #include <wx/clipbrd.h>
 
-Svgout::Svgout(Configuration **configuration, wxString filename, double scale) :
-  m_CWD(wxGetCwd())
+Svgout::Svgout(Configuration **configuration, const wxString &filename, double scale) :
+    m_cmn(configuration, filename, 500, scale), // Note: old SVGout code had this also at 500
+    m_recalculationDc(m_cmn.GetTempFilename(), 700*scale, 50000*scale, 20*scale),
+    m_CWD(wxGetCwd())
 {
-  m_width = m_height = -1;
-  m_configuration = configuration;
-  m_oldconfig = *m_configuration;
-  m_tree = NULL;
-  m_scale = scale;
-  m_svgFormat = wxDataFormat(wxT("image/svg+xml"));
 
-  m_filename = filename;
-  if (m_filename == wxEmptyString)
-    m_filename = wxFileName::CreateTempFileName(wxStandardPaths::Get().GetTempDir ()+wxT("/wxmaxima_"));
-  {
-    wxFileName name(m_filename);
-    name.MakeAbsolute();
-    m_filename = name.GetFullPath();
-  }
-  {
-    wxString path = wxFileName(m_filename).GetPath();
-    if(path.Length() > 1)
-      wxSetWorkingDirectory(path);
-  }
+  wxString path = wxFileName(filename).GetPath();
+  if (path.Length() > 1)
+    wxSetWorkingDirectory(path);
+  m_cmn.SetRecalculationContext(m_recalculationDc);
   
-  m_dc = NULL;
-  
-  wxString m_tempFileName = wxFileName::CreateTempFileName(wxT("wxmaxima_size_"));
-  m_recalculationDc = new wxSVGFileDC(m_tempFileName,700*m_scale,50000*m_scale,20*m_scale);
 #if wxCHECK_VERSION(3, 1, 0)
-  m_recalculationDc->SetBitmapHandler(new wxSVGBitmapEmbedHandler());
+  m_recalculationDc.SetBitmapHandler(new wxSVGBitmapEmbedHandler());
 #endif
-  *m_configuration = new Configuration(m_recalculationDc);
-  (*m_configuration)->ShowCodeCells(m_oldconfig->ShowCodeCells());
-  (*m_configuration)->SetClientWidth(700*m_scale);
-  (*m_configuration)->SetZoomFactor_temporarily(1);
-  // The last time I tried it the vertical positioning of the elements
-  // of a big unicode parenthesis wasn't accurate enough in svg to be
-  // usable. Also the probability was high that the right font wasn't
-  // available in inkscape.
-  (*m_configuration)->SetGrouphesisDrawMode(Configuration::handdrawn);
-  (*m_configuration)->ClipToDrawRegion(false);
+  auto &config = m_cmn.GetConfiguration();
+  config.SetContext(m_recalculationDc);
+  config.SetClientWidth(700*scale);
+  config.RecalculationForce(true);
 }
 
 Svgout::~Svgout()
 {
-  wxDELETE(m_tree);
-  wxDELETE(*m_configuration);
-  wxDELETE(m_dc);
-  wxDELETE(m_recalculationDc);
-  if(wxFileExists(m_tempFileName))
-  {
-    // We don't want a braindead virus scanner that disallows us to delete our temp
-    // files to trigger asserts.
-    SuppressErrorDialogs messageBlocker;
-    wxRemoveFile(m_tempFileName);
-  }
-  *m_configuration = m_oldconfig;
-  (*m_configuration)->FontChanged(true);
-  (*m_configuration)->RecalculationForce(true);
   wxSetWorkingDirectory(m_CWD);
 }
 
 wxSize Svgout::SetData(Cell *tree)
 {
-  wxDELETE(m_tree);
-  m_tree = tree;
-  if(m_tree != NULL)
-  {
-    m_tree = tree;
-    m_tree->ResetSize();
-    if(Layout())
-      return wxSize(m_width / m_scale, m_height / m_scale);  
-    else
-      return wxSize(-1,-1);
-  }
-  else
-    return wxSize(-1,-1);
+  m_tree.reset(tree);
+  if (m_tree && Layout())
+    return m_cmn.GetScaledSize();
+
+  return wxDefaultSize;
 }
 
 bool Svgout::Layout()
 {
-  (*m_configuration)->SetContext(*m_recalculationDc);
-  
-  if (m_tree->GetType() != MC_TYPE_GROUP)
-  {
-    RecalculateWidths();
-    BreakUpCells();
-    BreakLines();
-    RecalculateHeight();
-  }
-  else
-  {
-    GroupCell *tmp = dynamic_cast<GroupCell *>(m_tree);
-    while (tmp != NULL)
-    {
-      tmp->Recalculate();
-      tmp = tmp->GetNext();
-    }
-  }
-
-  if(!m_recalculationDc->IsOk())
-  {
+  if (!m_cmn.PrepareLayout(m_tree.get()))
     return false;
-  }
 
-  GetMaxPoint(&m_width, &m_height);
-
-  wxDELETE(m_dc);
   // Let's switch to a DC of the right size for our object.
-  m_dc = new wxSVGFileDC(m_filename, m_width, m_height, 20*m_scale);
+  auto size = m_cmn.GetSize();
+  auto &config = m_cmn.GetConfiguration();
+  wxSVGFileDC dc(m_cmn.GetFilename(), size.x, size.y, 20*m_cmn.GetScale());
 #if wxCHECK_VERSION(3, 1, 0)
-  m_dc->SetBitmapHandler(new wxSVGBitmapEmbedHandler());
+  dc.SetBitmapHandler(new wxSVGBitmapEmbedHandler());
 #endif
-  (*m_configuration)->SetContext(*m_dc);
-  
-  Draw();
-  wxDELETE(m_dc);
-  m_dc = NULL;
+
+  config.SetContext(dc);
+  m_cmn.Draw(m_tree.get());
+  config.UnsetContext();
+
   return true;
 }
 
-double Svgout::GetRealWidth() const
+static wxDataFormat &Format()
 {
-  return m_width / m_scale;
+  static wxDataFormat format(wxT("image/svg+xml"));
+  return format;
 }
 
-double Svgout::GetRealHeight() const
+wxCustomDataObject *Svgout::GetDataObject()
 {
-  return m_height / m_scale;
-}
-
-void Svgout::RecalculateHeight()
-{
-  int fontsize = 12;
-  wxConfig::Get()->Read(wxT("fontSize"), &fontsize);
-  int mfontsize = fontsize;
-  wxConfig::Get()->Read(wxT("mathfontsize"), &mfontsize);
-  Cell *tmp = m_tree;
-
-  while (tmp != NULL)
-  {
-    tmp->RecalculateHeight(tmp->IsMath() ? mfontsize : fontsize);
-    tmp = tmp->m_next;
-  }
-}
-
-void Svgout::RecalculateWidths()
-{
-  int fontsize = 12;
-  wxConfig::Get()->Read(wxT("fontSize"), &fontsize);
-  int mfontsize = fontsize;
-  wxConfig::Get()->Read(wxT("mathfontsize"), &mfontsize);
-
-  Cell *tmp = m_tree;
-
-  while (tmp != NULL)
-  {
-    tmp->RecalculateWidths(tmp->IsMath() ? mfontsize : fontsize);
-    tmp = tmp->m_next;
-  }
-}
-
-void Svgout::BreakLines()
-{
-  int fullWidth = 500*m_scale;
-  int currentWidth = 0;
-
-  Cell *tmp = m_tree;
-
-  while (tmp != NULL)
-  {
-    if (!tmp->m_isBrokenIntoLines)
-    {
-      tmp->SoftLineBreak(false);
-      tmp->ResetData();
-      if (tmp->BreakLineHere() ||
-          (currentWidth + tmp->GetWidth() >= fullWidth))
-      {
-        currentWidth = tmp->GetWidth();
-        tmp->SoftLineBreak(true);
-      }
-      else
-        currentWidth += (tmp->GetWidth());
-    }
-    tmp = tmp->GetNextToDraw();
-  }
-}
-
-void Svgout::GetMaxPoint(int *width, int *height)
-{
-  Cell *tmp = m_tree;
-  int currentHeight = 0;
-  int currentWidth = 0;
-  *width = 0;
-  *height = 0;
-  bool bigSkip = false;
-  bool firstCell = true;
-  while (tmp != NULL)
-  {
-    if (!tmp->m_isBrokenIntoLines)
-    {
-      if (tmp->BreakLineHere() || firstCell)
-      {
-        firstCell = false;
-        currentHeight += tmp->GetHeightList();
-        if (bigSkip)
-          currentHeight += MC_LINE_SKIP;
-        *height = currentHeight;
-        currentWidth = tmp->GetWidth();
-        *width = wxMax(currentWidth, *width);
-      }
-      else
-      {
-        currentWidth += (tmp->GetWidth());
-        *width = wxMax(currentWidth, *width);
-      }
-      bigSkip = tmp->m_bigSkip;
-    }
-    tmp = tmp->GetNextToDraw();
-  }
-}
-
-void Svgout::Draw()
-{
-  Cell *tmp = m_tree;
-
-  if (tmp != NULL)
-  {
-    wxPoint point;
-    point.x = 0;
-    point.y = tmp->GetCenterList();
-    int fontsize = 12;
-    int drop = tmp->GetMaxDrop();
-
-    wxConfig::Get()->Read(wxT("fontSize"), &fontsize);
-    int mfontsize = fontsize;
-    wxConfig::Get()->Read(wxT("mathfontsize"), &mfontsize);
-
-    while (tmp != NULL)
-    {
-      if (!tmp->m_isBrokenIntoLines)
-      {
-        tmp->Draw(point);
-        if ((tmp->m_next != NULL) && (tmp->m_next->BreakLineHere()))
-        {
-          point.x = 0;
-          point.y += drop + tmp->m_next->GetCenterList();
-          if (tmp->m_bigSkip)
-            point.y += MC_LINE_SKIP;
-          drop = tmp->m_next->GetMaxDrop();
-        }
-        else
-          point.x += (tmp->GetWidth());
-      }
-      else
-      {
-        if ((tmp->m_next != NULL) && (tmp->m_next->BreakLineHere()))
-        {
-          point.x = 0;
-          point.y += drop + tmp->m_next->GetCenterList();
-          if (tmp->m_bigSkip)
-            point.y += MC_LINE_SKIP;
-          drop = tmp->m_next->GetMaxDrop();
-        }
-      }
-      tmp = tmp->GetNextToDraw();
-    }
-  }
-}
-
-Svgout::SVGDataObject::SVGDataObject() : wxCustomDataObject(m_svgFormat)
-{
-}
-
-Svgout::SVGDataObject::SVGDataObject(wxMemoryBuffer data) : wxCustomDataObject(m_svgFormat)
-{
-  SetData(data.GetBufSize(), data.GetData());
-}
-
-
-wxDataFormat Svgout::m_svgFormat;
-
-Svgout::SVGDataObject *Svgout::GetDataObject()
-{
-  wxMemoryBuffer svgContents;
-  {
-    char *data =(char *) malloc(8192);
-    wxFileInputStream str(m_filename);
-    if(str.IsOk())
-      while (!str.Eof())
-      {
-        str.Read(data,8192);
-        svgContents.AppendData(data,str.LastRead());
-      }
-    free(data);
-  }
-  if((m_filename != wxEmptyString) && (wxFileExists(m_filename)))
-  {
-    // Don't output error messages if the worst thing that can happen is that we
-    // cannot clean up a temp file
-    SuppressErrorDialogs messageBlocker;
-
-    wxRemoveFile(m_filename);
-  }
-  m_filename = wxEmptyString;
-  
-  return new SVGDataObject(svgContents);
+  return m_cmn.GetDataObject(Format()).release();
 }
 
 bool Svgout::ToClipboard()
 {
-  wxASSERT_MSG(!wxTheClipboard->IsOpened(),_("Bug: The clipboard is already opened"));
-  if (wxTheClipboard->Open())
-  {
-    bool res = wxTheClipboard->SetData(GetDataObject());
-    wxTheClipboard->Close();
-    m_filename = wxEmptyString;
-    return res;
-  }
-  return false;
-}
-
-void Svgout::BreakUpCells()
-{
-  Cell *tmp = m_tree;
-  int fontsize = 12;
-  wxConfig::Get()->Read(wxT("fontSize"), &fontsize);
-  int mfontsize = fontsize;
-  wxConfig::Get()->Read(wxT("mathfontsize"), &mfontsize);
-
-  while (tmp != NULL)
-  {
-    if (tmp->GetWidth() > 500*m_scale)
-    {
-      if (tmp->BreakUp())
-      {
-        tmp->RecalculateWidths(tmp->IsMath() ? mfontsize : fontsize);
-        tmp->RecalculateHeight(tmp->IsMath() ? mfontsize : fontsize);
-      }
-    }
-    tmp = tmp->GetNextToDraw();
-  }
+  return m_cmn.ToClipboard(Format());
 }

--- a/src/SVGout.h
+++ b/src/SVGout.h
@@ -23,21 +23,21 @@
 #ifndef SVGOUT_H
 #define SVGOUT_H
 
-#include "Cell.h"
-
+#include "OutCommon.h"
 #include <wx/dcsvg.h>
+#include <memory>
+
 /* Renders portions of the work sheet (including 2D maths) as svg.
 
    This is used for exporting HTML with embedded maths as a scalable vector
    graphics and for them on the clipboard
  */
-class Svgout
+class Svgout final
 {
 public:
   /*! The constructor.
   */
-  explicit Svgout(Configuration **configuration, wxString filename = wxEmptyString, double scale = 1.0);
-
+  explicit Svgout(Configuration **configuration, const wxString &filename = {}, double scale = 1.0);
   ~Svgout();
   
   /*! Renders tree as svg
@@ -50,72 +50,13 @@ public:
   //! Copies the svg representation of the list of cells that was passed to SetData()
   bool ToClipboard();
 
-protected:
-  void DestroyTree();
-
-  // cppcheck-suppress functionConst
-  void RecalculateWidths();
-
-  // cppcheck-suppress functionConst
-  void BreakLines();
-
-  // cppcheck-suppress functionConst
-  void RecalculateHeight();
-
-  void GetMaxPoint(int *width, int *height);
-
-  // cppcheck-suppress functionConst
-  void BreakUpCells();
-
-  bool Layout();
-
-  void Draw();
-
-  Cell *m_tree;
-
-  double GetRealHeight() const;
-
-  double GetRealWidth() const;
-
-  
-  /*! An object that can be filled with SVG data for the clipboard
-   */
-  class SVGDataObject : public wxCustomDataObject
-  {
-  public:
-    explicit SVGDataObject(wxMemoryBuffer data);
-
-    SVGDataObject();
-
-  private:
-    //! A class that publishes MathML data to the clipboard
-    wxCharBuffer m_databuf;
-  };
+  //! Returns the svg representation in a format that can be placed on the clipBoard.
+  wxCustomDataObject *GetDataObject();
 
 private:
-  //! This class doesn't have a copy constructor
-  Svgout(const Svgout&) = delete;
-  //! This class doesn't have a = operator
-  Svgout& operator=(const Svgout&) = delete;
-
-  int Scale_Px(double px){ return (*m_configuration)->Scale_Px(px);}
-  //! The name of a temp file we create while calculating the svg size.
-  wxString m_tempFileName;
-  //! The draw context we draw to during recalculation.
-  wxSVGFileDC *m_recalculationDc;
-  //! The draw context we draw to.
-  wxSVGFileDC *m_dc;
-  static wxDataFormat m_svgFormat;
-  wxString m_filename;
-  Configuration **m_configuration, *m_oldconfig;
-  //! How many times the natural resolution do we want this svgout to be?
-  double m_scale;
-  //! The width of the current svgout;
-  int m_width;
-  //! The height of the current svgout;
-  int m_height;
-  //! The resolution of the svgout.
-  wxSize m_ppi;
+  std::unique_ptr<Cell> m_tree;
+  OutCommon m_cmn;
+  wxSVGFileDC m_recalculationDc;
 
   /*! The current working directory we were in when we started creating a svg file
 
@@ -124,9 +65,8 @@ private:
     directory.
    */
   wxString m_CWD;
-public:
-  //! Returns the svg representation in a format that can be placed on the clipBoard.
-  SVGDataObject *GetDataObject();
+
+  bool Layout();
 };
 
 #endif // SVGOUT_H

--- a/src/Worksheet.cpp
+++ b/src/Worksheet.cpp
@@ -30,6 +30,7 @@
 
 
 #include "wxMaxima.h"
+#include "CompositeDataObject.h"
 #include "ErrorRedirector.h"
 #include "MaxSizeChooser.h"
 #include "SVGout.h"
@@ -2697,7 +2698,11 @@ bool Worksheet::CopyCells()
 
   if (wxTheClipboard->Open())
   {
+#if wxUSE_ENH_METAFILE
+    auto *data = new CompositeDataObject;
+#else
     wxDataObjectComposite *data = new wxDataObjectComposite;
+#endif
     wxString wxm;
     wxString str;
     wxString rtf = RTFStart();


### PR DESCRIPTION
1. Factor out duplicate code in the SVGout, EMFout and BitmapOut classes.
2. Implement `CompositeDataObject` to replace the silly `wxDataObjectComposite`, allowing compositing complex data objects (those that have more than one format), such as EMF files.
3. Fix EMF format not making it to the clipboard on Windows. Fixes #1274.

Note that the `CompositeDataObject` class can be used as a superior replacement to `wxDataObjectComposite` on all platforms, but thus far I've only substituted it when the EMF output is enabled on Windows builds. I'm sure we'll run into a similar problem on other platforms sooner or later, and can switch to it on all platforms. But so far I wanted to minimize the changes to only those that were necessary - i.e. on builds where EMF output is enabled.