### PR TITLE
Fix an uninitialized member.

### DIFF
--- a/src/EditorCell.h
+++ b/src/EditorCell.h
@@ -577,7 +577,7 @@ protected:
       m_widths.clear();
     }
 private:
-  Cell *m_nextToDraw;
+  Cell *m_nextToDraw = {};
   //! Determines the size of a text snippet
   wxSize GetTextSize(wxString const &text);
   //! Mark this cell as "Automatically answer questions".


### PR DESCRIPTION
This pointer was not initialized and could be potentially used uninitialized.