### PR TITLE
Fix type conversion from wxChar * to wxString

### DIFF
--- a/src/WXMformat.cpp
+++ b/src/WXMformat.cpp
@@ -221,7 +221,7 @@ GroupCell *TreeFromWXM(const wxArrayString &wxmLines, Configuration **config)
 
   //! Consumes and concatenates lines until a closing tag is reached,
   //! consumes the tag and returns the line.
-  const auto getLinesUntil = [&wxmLine, end](const wxChar *tag) -> wxString
+  const auto getLinesUntil = [&wxmLine, end](const wxString &tag) -> wxString
   {
     wxString line;
     while (wxmLine != end)


### PR DESCRIPTION
Change the input arg for `getLinesUntil` to accept `wxString` instead of `wxChar *`. Fixes #1324.