### PR TITLE
Fix strings for list rest options (in menu)

### DIFF
--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -7537,7 +7537,7 @@ void wxMaxima::ListMenu(wxCommandEvent &event)
       Gen2Wiz *wiz = new Gen2Wiz(_("List"), _("n"),
                                  expr, wxEmptyString,
                                  m_worksheet->m_configuration,
-                                 this, -1, _("Return the list without its last n elements"),
+                                 this, -1, _("Return the list without its first n elements"),
                                  true);
       //wiz->Centre(wxBOTH);
       if (wiz->ShowModal() == wxID_OK)
@@ -7561,7 +7561,7 @@ void wxMaxima::ListMenu(wxCommandEvent &event)
       Gen2Wiz *wiz = new Gen2Wiz(_("List"), _("n"),
                                  expr, wxEmptyString,
                                  m_worksheet->m_configuration,
-                                 this, -1, _("Return the list without its first n elements"),
+                                 this, -1, _("Return the list without its last n elements"),
                                  true);
       //wiz->Centre(wxBOTH);
       if (wiz->ShowModal() == wxID_OK)


### PR DESCRIPTION
In latest wxMaxima the titles of the windows for selecting list elements (extract all but 1st/last n elements) are exchanged. This commit shoud fix it.