### PR TITLE
Fix iterator use when wxWidgets is built with STL.

### DIFF
--- a/src/ButtonWrapSizer.cpp
+++ b/src/ButtonWrapSizer.cpp
@@ -41,7 +41,7 @@ void Buttonwrapsizer::RecalcSizes()
   wxSizerItemList children = GetChildren();
   long width = -1;
   long height = 20;
-  for (wxSizerItemList::Node *node = children.GetFirst(); node; node = node->GetNext())
+  for (auto node = children.GetFirst(); node; node = node->GetNext())
   {
     wxSizerItem* current =  node->GetData();
     wxWindow *item = current->GetWindow();
@@ -57,7 +57,7 @@ void Buttonwrapsizer::RecalcSizes()
 //    width = m_availSize / (m_availSize / width);
      
   wxSize bestSize(width, height);
-  for (wxSizerItemList::Node *node = children.GetFirst(); node; node = node->GetNext())
+  for (auto node = children.GetFirst(); node; node = node->GetNext())
   {
     wxSizerItem* current =  node->GetData();
     wxWindow *item = current->GetWindow();


### PR DESCRIPTION
When wxWidgets is built with STL containers, `wxSizerItemList::compatibility_iterator` must be used instead of `wxSizerItemList::Node *`. Just use `auto` to avoid explicitly determining which kind of iterator to use.

Fixes #1463 