### PR TITLE
 Fix double release of OMP locks in several places

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ deploy_rsa
 .ninja_log
 build.ninja
 rules.ninja
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ deploy_rsa
 build.ninja
 rules.ninja
 .DS_Store
+.vscode/
+wxmaxima.code-workspace

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -803,9 +803,6 @@ wxBitmap Image::GetBitmap(double scale)
   }
   else
     m_scaledBitmap = wxBitmap(1,1);
-  #ifdef HAVE_OMP_HEADER
-  omp_unset_lock(&m_gnuplotLock);
-  #endif
   return m_scaledBitmap;
 }
 
@@ -1029,9 +1026,6 @@ void Image::LoadImage_Backgroundtask(wxString image, std::shared_ptr<wxFileSyste
     }
   }
   m_fs_keepalive_imagedata.reset();
-  #ifdef HAVE_OMP_HEADER
-  omp_unset_lock(&m_imageLoadLock);
-  #endif
 }
 
 void Image::Recalculate(double scale)


### PR DESCRIPTION
This PR fixes a bug that OMP locks are released twice, once via a helper class and once explicitly. This leads to crashes on Mac if OMP is enabled.

This fixes #1474 