### PR TITLE
Update cp_utfw.hpp

### DIFF
--- a/src/ww898/cp_utfw.hpp
+++ b/src/ww898/cp_utfw.hpp
@@ -33,7 +33,7 @@ namespace utf {
 using utfw = utf16;
 }}
 
-#elif defined(__linux__) || defined(__APPLE__)
+#elif defined(__linux__) || defined(__APPLE__) || defined (__NetBSD__)
 
 #include <ww898/cp_utf32.hpp>
 


### PR DESCRIPTION
This is the only patch one needs to build wxMaxima successfully under NetBSD-current using wxGTK31 and the pkgsrc framework.