### PR TITLE
Make GetDiffPart work with different cell types

### DIFF
--- a/src/cells/Cell.cpp
+++ b/src/cells/Cell.cpp
@@ -942,7 +942,7 @@ wxString Cell::ListToXML() const
 }
 
 /***
- * Get the part for diff tag support - only ExpTag overvrides this.
+ * Get the part for diff tag support - only ExptCell and SubSupCell override this.
  */
 wxString Cell::GetDiffPart() const
 {

--- a/src/cells/Cell.cpp
+++ b/src/cells/Cell.cpp
@@ -946,7 +946,11 @@ wxString Cell::ListToXML() const
  */
 wxString Cell::GetDiffPart() const
 {
-  return {};
+  wxString s = ToString();
+  if (s == wxEmptyString)
+    return s;
+
+  return wxT(",") + s + wxT(",1");
 }
 
 Cell::Range Cell::GetCellsInRect(const wxRect &rect) const

--- a/src/cells/SubSupCell.cpp
+++ b/src/cells/SubSupCell.cpp
@@ -435,3 +435,26 @@ wxString SubSupCell::ToXML() const
   }
   return retval;
 }
+
+wxString SubSupCell::GetDiffPart() const
+{
+  wxString s(wxT(","));
+  if (m_baseCell->IsCompound())
+    s += "(" + m_baseCell->ListToString() + ")";
+  else
+    s += m_baseCell->ListToString();
+
+  if (m_scriptCells.empty())
+  {
+    s += "[" + m_postSubCell->ListToString() + "]";
+    s += ",";
+    s += m_postSupCell->ListToString();
+  }
+  else
+  {
+    for (auto &cell : m_scriptCells)
+      s += "[" + cell->ListToString() + "]";
+    s += ",1";
+  }
+  return s;
+}

--- a/src/cells/SubSupCell.h
+++ b/src/cells/SubSupCell.h
@@ -56,6 +56,8 @@ public:
   wxString ToTeX() const override;
   wxString ToXML() const override;
 
+  wxString GetDiffPart() const override;
+  
   void SetAltCopyText(const wxString &text) override { m_altCopyText = text; }
   const wxString &GetAltCopyText() const override { return m_altCopyText; }
 

--- a/src/cells/TextCell.cpp
+++ b/src/cells/TextCell.cpp
@@ -1264,11 +1264,6 @@ wxString TextCell::ToXML() const
   return wxT("<") + tag + GetXMLFlags() + wxT(">") + xmlstring + wxT("</") + tag + wxT(">");
 }
 
-wxString TextCell::GetDiffPart() const
-{
-  return wxT(",") + m_text + wxT(",1");
-}
-
 bool TextCell::IsShortNum() const
 {
   return (!GetNext()) && (m_text.Length() < 4);

--- a/src/cells/TextCell.h
+++ b/src/cells/TextCell.h
@@ -68,8 +68,6 @@ public:
   wxString ToTeX() const override;
   wxString ToXML() const override;
 
-  wxString GetDiffPart() const override;
-
   bool IsOperator() const override;
 
   const wxString &GetValue() const override { return m_text; }


### PR DESCRIPTION
This PR closes #1575.

First commit fixes the `ToString` (copy) for the inputs below, by adding a default `GetDiffPart` function that should work with many cell types:

```
diff(f(x[1]), x[1], 1);
```
```
'diff(f(x), g(x));
```
```
'diff(f(x),g(x),2);
```

Second commit fixes it for this input, where the variable of differentiation has a subscript and the order of differentiation is higher than one (therefore `SubSupCell` is used):

```
'diff(f(x[1]),x[1],3);
```

---

One problem that remains is that `'diff(f(x), x^2, 1)` results in the operator `d/(dx^2)`, and wxMaxima takes the exponent 2 in the denominator as the order of differentiation. But I think this should be a separate issue.