### PR TITLE
Correctly set the document saved state when the size of an image is changed.

### DIFF
--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -8855,9 +8855,9 @@ void wxMaxima::PopupMenu(wxCommandEvent &event)
       if (chooser->ShowModal() == wxID_OK)
       {
         if(dynamic_cast<ImgCell *>(output)->GetMaxWidth() != chooser->GetMaxWidth())
-          m_fileSaved = false;
+          m_worksheet->SetSaved(false);
         if(dynamic_cast<ImgCell *>(output)->GetHeightList() != chooser->GetHeightList())
-          m_fileSaved = false;
+          m_worksheet->SetSaved(false);
 
         dynamic_cast<ImgCell *>(output)->SetMaxWidth(chooser->GetMaxWidth());
         dynamic_cast<ImgCell *>(output)->SetMaxHeight(chooser->GetHeightList());


### PR DESCRIPTION
Just setting m_fileSaved to false does not work, because it gets overwritten at
other locations.