### PR TITLE
Enable reloading and changing images inserted via "Cell" -> "Insert Image..."

### DIFF
--- a/src/ConfigDialogue.cpp
+++ b/src/ConfigDialogue.cpp
@@ -459,6 +459,7 @@ void ConfigDialogue::SetCheckboxValues()
   else
     m_ctrlEnterEvaluates->SetValue(true);
   m_numpadEnterEvaluates->SetValue(configuration->NumpadEnterEvaluates());
+  m_saveImgFileName->SetValue(configuration->SaveImgFileName());
   m_saveUntitled->SetValue(configuration->SaveUntitled());
   m_openHCaret->SetValue(configuration->GetOpenHCaret());
   m_insertAns->SetValue(configuration->GetInsertAns());
@@ -718,6 +719,18 @@ wxWindow *ConfigDialogue::CreateWorksheetPanel()
   m_numpadEnterEvaluates = new wxCheckBox(evalSizer->GetStaticBox(), -1, _("\"Numpad Enter\" always evaluates cells"));
   evalSizer->Add(m_numpadEnterEvaluates, wxSizerFlags());
   vsizer->Add(evalSizer, wxSizerFlags().Expand().Border(wxALL, 5*GetContentScaleFactor()));
+
+  wxStaticBoxSizer *evalPrivacy = new wxStaticBoxSizer(wxVERTICAL, panel, _("Privacy settings"));
+  m_saveImgFileName = new wxCheckBox(evalPrivacy->GetStaticBox(), -1, _("Store filenames in image cells to enable image reloading after re-opening the worksheet"));
+  m_saveImgFileName->SetToolTip(_("If this option is enabled, the filename and path of images inserted with \"Cell\" -> \"Insert Image...\" "
+                                  "is stored in the worksheet file on save. This enables reloading of the image file via the "
+                                  "context menu after re-opening the worksheet, but storing the filenames and paths may be an "
+                                  "undesired data leak. If this option is disabled, reloading still works as long as the worksheet "
+                                  "is not closed."
+                                  "\n\nNote: Storing the filenames for the reload functionality is independent of the automatically "
+                                  "generated image captions."));
+  evalPrivacy->Add(m_saveImgFileName, wxSizerFlags());
+  vsizer->Add(evalPrivacy, wxSizerFlags().Expand().Border(wxALL, 5*GetContentScaleFactor()));
 
   panel->SetSizer(vsizer);
   panel->FitInside();
@@ -1741,6 +1754,7 @@ void ConfigDialogue::WriteSettings()
   configuration->Latin2Greek(m_latin2Greek->GetValue());
   configuration->EnterEvaluates(m_enterEvaluates->GetValue());
   configuration->NumpadEnterEvaluates(m_numpadEnterEvaluates->GetValue());
+  configuration->SaveImgFileName(m_saveImgFileName->GetValue());
   configuration->SaveUntitled(m_saveUntitled->GetValue());
   configuration->SetOpenHCaret(m_openHCaret->GetValue());
   configuration->SetInsertAns(m_insertAns->GetValue());

--- a/src/ConfigDialogue.h
+++ b/src/ConfigDialogue.h
@@ -321,6 +321,7 @@ protected:
   wxRadioButton *m_enterEvaluates;
   wxRadioButton *m_ctrlEnterEvaluates;
   wxCheckBox *m_numpadEnterEvaluates;
+  wxCheckBox *m_saveImgFileName;
   wxCheckBox *m_saveUntitled;
   wxCheckBox *m_openHCaret;
   wxCheckBox *m_insertAns;

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -100,6 +100,7 @@ void Configuration::ResetAllToDefaults(InitOpt options)
   m_lineBreaksInLongNums = false;
   m_autoSaveMinutes = 3;
   m_numpadEnterEvaluates = true;
+  m_saveImgFileName = false;
   m_maximaEnvVars.clear();
   // Tell gnuplot not to wait for <enter> every few lines
   #ifndef __WXMSW__
@@ -612,6 +613,7 @@ void Configuration::ReadConfig()
   if(m_maxClipbrd_BitmapMegabytes<0)
     m_maxClipbrd_BitmapMegabytes = 1;
   config->Read(wxT("numpadEnterEvaluates"), &m_numpadEnterEvaluates);
+  config->Read(wxT("saveImgFileName"), &m_saveImgFileName);
   config->Read(wxT("usePartialForDiff"), &m_usePartialForDiff);
   config->Read(wxT("TeXExponentsAfterSubscript"), &m_TeXExponentsAfterSubscript);
   config->Read(wxT("defaultPlotWidth"), &m_defaultPlotWidth);
@@ -1308,6 +1310,7 @@ void Configuration::WriteStyles(wxConfigBase *config)
   config->Write(wxT("exportContainsWXMX"), m_exportContainsWXMX);
   config->Write(wxT("texPreamble"), m_texPreamble);
   config->Write(wxT("numpadEnterEvaluates"), m_numpadEnterEvaluates);
+  config->Write(wxT("saveImgFileName"), m_saveImgFileName);
   config->Write(wxT("usePartialForDiff"), m_usePartialForDiff);
   config->Write(wxT("TeXExponentsAfterSubscript"), m_TeXExponentsAfterSubscript);
   config->Write(wxT("defaultPlotWidth"), m_defaultPlotWidth);

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -413,6 +413,9 @@ public:
   bool NumpadEnterEvaluates(){ return m_numpadEnterEvaluates;}
   void NumpadEnterEvaluates(bool eval){m_numpadEnterEvaluates = eval;}
 
+  bool SaveImgFileName() { return m_saveImgFileName;}
+  void SaveImgFileName(bool save) { m_saveImgFileName = save;}
+
   //! Do we want to have automatic line breaks for text cells?
   bool GetAutoWrap() const
   { return m_autoWrap > 0; }
@@ -991,6 +994,7 @@ private:
   bool m_saveUntitled;
   bool m_cursorJump;
   bool m_numpadEnterEvaluates;
+  bool m_saveImgFileName;
   std::unique_ptr<CellRedrawTrace> m_cellRedrawTrace;
   wxString m_documentclass;
   wxString m_documentclassOptions;

--- a/src/MathParser.cpp
+++ b/src/MathParser.cpp
@@ -325,7 +325,16 @@ std::unique_ptr<Cell> MathParser::ParseImageTag(wxXmlNode *node)
   wxString filename(node->GetChildren()->GetContent());
 
   if (m_fileSystem) // loading from zip
+  {
     imageCell = std::make_unique<ImgCell>(m_group, m_configuration, filename, m_fileSystem, false);
+
+    wxString origImageFile = node->GetAttribute(wxT("origImageFile"), wxEmptyString);
+  
+    if(!origImageFile.empty())
+    {
+      imageCell->SetOrigImageFile(origImageFile);
+    }
+  }
   else
   {
     std::shared_ptr<wxFileSystem> system_fs = {};
@@ -372,6 +381,7 @@ std::unique_ptr<Cell> MathParser::ParseImageTag(wxXmlNode *node)
     if (sizeString.ToDouble(&height))
       imageCell->SetMaxHeight(height);
   }
+  
   return imageCell;
 }
 

--- a/src/Worksheet.cpp
+++ b/src/Worksheet.cpp
@@ -1329,6 +1329,7 @@ void Worksheet::OnMouseRightDown(wxMouseEvent &event)
         {
           popupMenu.AppendSeparator();
           popupMenu.Append(popid_maxsizechooser, _("Restrict Maximum size"), wxEmptyString, wxITEM_NORMAL);
+          popupMenu.Append(popid_reloadimage, _("Reload Image"), wxEmptyString, wxITEM_NORMAL);
         }
       }
       if (m_cellPointers.m_selectionStart && m_cellPointers.m_selectionStart->CanPopOut())

--- a/src/Worksheet.cpp
+++ b/src/Worksheet.cpp
@@ -1330,12 +1330,21 @@ void Worksheet::OnMouseRightDown(wxMouseEvent &event)
           popupMenu.AppendSeparator();
           popupMenu.Append(popid_maxsizechooser, _("Restrict Maximum size"), wxEmptyString, wxITEM_NORMAL);
           
-          wxMenuItem* reloadItem = popupMenu.Append(popid_reloadimage, _("Reload Image"), wxEmptyString, wxITEM_NORMAL);              
+          Cell *cell = m_cellPointers.m_selectionStart->GetGroup()->GetGroup()->GetLabel();
+          wxString imgFile = dynamic_cast<ImgCell *>(cell)->GetOrigImageFile();
+          
           
           // Disable the reload menu item if the original file name is unknown.
-          Cell *cell = m_cellPointers.m_selectionStart->GetGroup()->GetGroup()->GetLabel();
-          if(dynamic_cast<ImgCell *>(cell)->GetOrigImageFile().Length() == 0) {
+          if(imgFile.Length() == 0)
+          {
+              wxMenuItem* reloadItem = popupMenu.Append(popid_reloadimage, _("Reload Image"), wxEmptyString, wxITEM_NORMAL);              
               reloadItem->Enable(false);
+          }
+          else
+          {
+            popupMenu.Append(popid_reloadimage,
+              wxString::Format(_("Reload Image \"%s\""), imgFile),
+              wxEmptyString, wxITEM_NORMAL);              
           }
           
           popupMenu.Append(popid_change_image, _("Change Image..."), wxEmptyString, wxITEM_NORMAL);

--- a/src/Worksheet.cpp
+++ b/src/Worksheet.cpp
@@ -1330,6 +1330,7 @@ void Worksheet::OnMouseRightDown(wxMouseEvent &event)
           popupMenu.AppendSeparator();
           popupMenu.Append(popid_maxsizechooser, _("Restrict Maximum size"), wxEmptyString, wxITEM_NORMAL);
           popupMenu.Append(popid_reloadimage, _("Reload Image"), wxEmptyString, wxITEM_NORMAL);
+          popupMenu.Append(popid_change_image, _("Change Image..."), wxEmptyString, wxITEM_NORMAL);
         }
       }
       if (m_cellPointers.m_selectionStart && m_cellPointers.m_selectionStart->CanPopOut())

--- a/src/Worksheet.cpp
+++ b/src/Worksheet.cpp
@@ -1329,7 +1329,15 @@ void Worksheet::OnMouseRightDown(wxMouseEvent &event)
         {
           popupMenu.AppendSeparator();
           popupMenu.Append(popid_maxsizechooser, _("Restrict Maximum size"), wxEmptyString, wxITEM_NORMAL);
-          popupMenu.Append(popid_reloadimage, _("Reload Image"), wxEmptyString, wxITEM_NORMAL);
+          
+          wxMenuItem* reloadItem = popupMenu.Append(popid_reloadimage, _("Reload Image"), wxEmptyString, wxITEM_NORMAL);              
+          
+          // Disable the reload menu item if the original file name is unknown.
+          Cell *cell = m_cellPointers.m_selectionStart->GetGroup()->GetGroup()->GetLabel();
+          if(dynamic_cast<ImgCell *>(cell)->GetOrigImageFile().Length() == 0) {
+              reloadItem->Enable(false);
+          }
+          
           popupMenu.Append(popid_change_image, _("Change Image..."), wxEmptyString, wxITEM_NORMAL);
         }
       }

--- a/src/Worksheet.h
+++ b/src/Worksheet.h
@@ -895,6 +895,7 @@ public:
     popid_fold,
     popid_unfold,
     popid_maxsizechooser,
+    popid_reloadimage,
     popid_suggestion1,
     popid_suggestion2,
     popid_suggestion3,

--- a/src/Worksheet.h
+++ b/src/Worksheet.h
@@ -875,6 +875,7 @@ public:
     popid_digits_all,
     popid_digits_all_linebreak,
     popid_image,
+    popid_change_image,
     popid_svg,
     popid_emf,
     popid_animation_save,

--- a/src/cells/GroupCell.cpp
+++ b/src/cells/GroupCell.cpp
@@ -190,8 +190,14 @@ GroupCell::GroupCell(Configuration **config, GroupType groupType, const wxString
   if ((groupType == GC_TYPE_IMAGE) && (initString.Length() > 0))
   {
     std::unique_ptr<Cell> ic;
-    if (wxImage::GetImageCount(initString) < 2)
+    if (wxImage::GetImageCount(initString) < 2) {
       ic = std::make_unique<ImgCell>(this, m_configuration, initString, std::shared_ptr<wxFileSystem>{} /* system fs */, false);
+
+      // Since this is the (only?) place where an ImgCell is constructed when the user manually
+      // inserts an image file (not loaded from zip or gnuplot tempfile), set the filename such that reloading the
+      // file later is possible.
+      static_cast<ImgCell &>(*ic).SetOrigImageFile(initString);
+    }
     else
       ic = std::make_unique<SlideShow>(this, m_configuration, initString, false);
     AppendOutput(std::move(ic));

--- a/src/cells/ImgCell.cpp
+++ b/src/cells/ImgCell.cpp
@@ -343,8 +343,12 @@ wxString ImgCell::ToXML() const
   if(m_image->GetHeightList() > 0)
     flags += wxString::Format(wxT(" maxHeight=\"%f\""), m_image->GetHeightList());
 
-  if(m_origImageFile != wxEmptyString) {
-    flags += wxString::Format(wxT(" origImageFile=\"%s\""), XMLescape(m_origImageFile));
+  if(m_origImageFile != wxEmptyString)
+  {
+    if((*m_configuration)->SaveImgFileName())
+    {
+      flags += wxString::Format(wxT(" origImageFile=\"%s\""), XMLescape(m_origImageFile));
+    }
   }
 
   if (m_image)

--- a/src/cells/ImgCell.cpp
+++ b/src/cells/ImgCell.cpp
@@ -78,7 +78,9 @@ ImgCell::ImgCell(GroupCell *group, Configuration **config, const wxString &image
   InitBitFields();
   m_type = MC_TYPE_IMAGE;
   if (image != wxEmptyString)
+  {
     m_image = std::make_shared<Image>(m_configuration, image, filesystem, remove);
+  }
   else
     m_image = std::make_shared<Image>(m_configuration);
   m_drawBoundingBox = false;
@@ -340,6 +342,10 @@ wxString ImgCell::ToXML() const
 
   if(m_image->GetHeightList() > 0)
     flags += wxString::Format(wxT(" maxHeight=\"%f\""), m_image->GetHeightList());
+
+  if(m_origImageFile != wxEmptyString) {
+    flags += wxString::Format(wxT(" origImageFile=\"%s\""), XMLescape(m_origImageFile));
+  }
 
   if (m_image)
   {

--- a/src/cells/ImgCell.cpp
+++ b/src/cells/ImgCell.cpp
@@ -96,6 +96,19 @@ ImgCell::ImgCell(GroupCell *group, const ImgCell &cell) :
 
 DEFINE_CELL(ImgCell)
 
+void ImgCell::ReloadImage(const wxString &image, std::shared_ptr<wxFileSystem> filesystem) {
+    // Store old size limits
+    double width = m_image->GetMaxWidth();
+    double height = m_image->GetHeightList();
+    
+    // Load new image
+    m_image = std::make_shared<Image>(m_configuration, image, filesystem, false);
+    
+    // Restore size limits
+    m_image->SetMaxHeight(height);
+    m_image->SetMaxWidth(width);
+}
+
 void ImgCell::LoadImage(wxString image, bool remove)
 {
   m_image = std::make_shared<Image>(m_configuration, remove, image);

--- a/src/cells/ImgCell.h
+++ b/src/cells/ImgCell.h
@@ -56,6 +56,8 @@ public:
 
   void LoadImage(wxString image, bool remove = true);
 
+  void ReloadImage(const wxString &image, std::shared_ptr<wxFileSystem> filesystem);
+
   //! Can this image be exported in SVG format?
   bool CanExportSVG() const {return (m_image != NULL) && m_image->CanExportSVG();}
 

--- a/src/cells/ImgCell.h
+++ b/src/cells/ImgCell.h
@@ -94,6 +94,14 @@ public:
   wxString GetExtension() const
   { if (m_image)return m_image->GetExtension(); else return wxEmptyString; }
 
+  //! Returns the name of the file the image was originally created from
+  wxString GetOrigImageFile() const
+  { return m_origImageFile; }
+  
+  //! Sets the name of the file the image was originally created from
+  void SetOrigImageFile(wxString file)
+  { m_origImageFile = file; }
+
   //! Returns the original compressed version of the image
   wxMemoryBuffer GetCompressedImage() const { return m_image->m_compressedImage; }
 
@@ -136,6 +144,8 @@ private:
   bool m_drawBoundingBox : 1 /* InitBitFields */;
 
   static int s_counter;
+  
+  wxString m_origImageFile;
 };
 
 #endif // IMGCELL_H

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -915,6 +915,8 @@ wxMaxima::wxMaxima(wxWindow *parent, int id, wxLocale *locale, const wxString ti
           wxCommandEventHandler(wxMaxima::PopupMenu), NULL, this);
   Connect(Worksheet::popid_reloadimage, wxEVT_MENU,
           wxCommandEventHandler(wxMaxima::PopupMenu), NULL, this);
+  Connect(Worksheet::popid_change_image, wxEVT_MENU,
+          wxCommandEventHandler(wxMaxima::PopupMenu), NULL, this);
   Connect(TableOfContents::popid_Fold, wxEVT_MENU,
           wxCommandEventHandler(wxMaxima::PopupMenu), NULL, this);
   Connect(TableOfContents::popid_Unfold, wxEVT_MENU,
@@ -8880,7 +8882,7 @@ void wxMaxima::PopupMenu(wxCommandEvent &event)
         if(output->GetType() != MC_TYPE_IMAGE)
             return;
 
-        wxString imgFile = m_worksheet->GetSelectionStart()->GetGroup()->GetEditable()->GetValue();
+        wxString imgFile = dynamic_cast<ImgCell *>(output)->GetOrigImageFile();
 
         if(!wxFileExists(imgFile)) {
           LoggingMessageDialog dialog(this,
@@ -8894,6 +8896,9 @@ void wxMaxima::PopupMenu(wxCommandEvent &event)
           return;
         }
 
+        wxLogMessage(
+            wxString::Format(_("Reloading image file %s."),
+                imgFile));
         dynamic_cast<ImgCell *>(output)->ReloadImage(imgFile, std::shared_ptr<wxFileSystem>{} /* system fs */);
         
         m_worksheet->RecalculateForce();
@@ -9262,6 +9267,58 @@ void wxMaxima::PopupMenu(wxCommandEvent &event)
       m_worksheet->CopyToFile(file);
       m_lastPath = wxPathOnly(file);
     }
+  }
+  break;
+  case Worksheet::popid_change_image:
+  {
+    if(!m_worksheet->GetSelectionStart())
+        return;
+        
+    Cell *cell = m_worksheet->GetSelectionStart()->GetGroup()->GetLabel();
+    if(cell == NULL)
+        return;
+
+    if(cell->GetType() != MC_TYPE_IMAGE)
+        return;
+
+    wxString newImg = wxFileSelector(_("Change Image"), m_lastPath,
+                                     wxEmptyString, wxEmptyString,
+                                     _("Image files (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, *.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"),
+                                     wxFD_OPEN);
+
+    if(!newImg.Length()) {
+        return;
+    }
+
+    if(!wxFileExists(newImg)) {
+      LoggingMessageDialog dialog(this,
+                             wxString::Format(_("The image file \"%s\" cannot be found."),
+                                              newImg.utf8_str()),
+                             "wxMaxima", wxCENTER | wxOK);
+      dialog.SetOKLabel(_("OK"));
+      
+      dialog.ShowModal();
+      
+      return;
+    }
+
+    ImgCell* ic = dynamic_cast<ImgCell *>(cell);
+
+    wxLogMessage(
+        wxString::Format(_("Changing image originally loaded from file %s to %s."),
+            ic->GetOrigImageFile(),
+            newImg));
+    ic->ReloadImage(newImg, std::shared_ptr<wxFileSystem>{} /* system fs */);
+    ic->SetOrigImageFile(newImg);
+    
+    
+    m_worksheet->RecalculateForce();
+    m_worksheet->RequestRedraw();
+    m_worksheet->SetSaved(false);
+    m_lastPath = wxPathOnly(newImg);
+    
+    UpdateMenus();
+    UpdateToolBar();
   }
   break;
   case Worksheet::popid_animation_save:


### PR DESCRIPTION
This branch adds "Reload" and "Change Image" items to the image cell context menu:
![reloading_enabled](https://user-images.githubusercontent.com/6277053/137621752-dcc3fb9e-95ad-4cbe-bc02-340f64e31268.png)

- "Reload" reloads the file from disk using the original image filename and path. This is useful if the image was edited externally and it needs to be updated in the worksheet.
- "Change Image" opens a file dialog where an alternative file for replacing the current image can be selected.

The original image filenames and paths are stored in the worksheet file to keep the reload capability after re-opening the worksheet. Since users may not want to leak filenames and paths in their worksheets, a configuration checkbox for disabling storing the filenames has also been implemented.
![cfg_dialog](https://user-images.githubusercontent.com/6277053/137622068-39aacf19-e553-470d-9724-a6111e7cbbac.png)
The option defaults to off (not storing in the worksheet file) which prevents `ImgCell::ToXML` from outputting the filenames.

If a filenames is not found, the reload function is disabled
![reloading_disabled](https://user-images.githubusercontent.com/6277053/137622182-efc74fe7-c864-446f-86db-d9e7e9ecd6c9.png)
Changing the image is, of course, still possible.
