### PR TITLE
Fix bug #1624: Can paste text from other apps in macOS

### DIFF
--- a/src/Worksheet.cpp
+++ b/src/Worksheet.cpp
@@ -7468,7 +7468,10 @@ void Worksheet::PasteFromClipboard()
     return;
 
   // Check if the clipboard contains text.
-  if ((wxTheClipboard->IsSupported(wxDF_TEXT)) || (wxTheClipboard->IsSupported(m_wxmFormat)))
+  wxClipboard *clip = wxClipboard::Get();
+  if ((wxTheClipboard->IsSupported(wxDF_TEXT))
+    || (wxTheClipboard->IsSupported(wxDF_UNICODETEXT))
+    || (wxTheClipboard->IsSupported(m_wxmFormat)))
   {
     wxString inputs;
 
@@ -7572,7 +7575,8 @@ void Worksheet::PasteFromClipboard()
     }
     else
     {
-      if (m_hCaretActive && wxTheClipboard->IsSupported(wxDF_TEXT))
+      if (m_hCaretActive && (wxTheClipboard->IsSupported(wxDF_TEXT)
+        || wxTheClipboard->IsSupported(wxDF_UNICODETEXT)))
       {
         wxTextDataObject obj;
         wxTheClipboard->GetData(obj);

--- a/src/cells/EditorCell.cpp
+++ b/src/cells/EditorCell.cpp
@@ -3190,7 +3190,8 @@ void EditorCell::PasteFromClipboard(const bool primary)
 {
   wxTheClipboard->UsePrimarySelection(primary);
   wxASSERT_MSG(wxTheClipboard->IsOpened(),_("Bug: The clipboard isn't open on pasting into an editor cell"));
-  if (wxTheClipboard->IsSupported(wxDF_TEXT))
+  if (wxTheClipboard->IsSupported(wxDF_TEXT)
+    || wxTheClipboard->IsSupported(wxDF_UNICODETEXT))
   {
     wxTextDataObject obj;
     wxTheClipboard->GetData(obj);


### PR DESCRIPTION
Fixes the bug #1624.

The type of clipboard texts from other Apps is usually `kUTTypeUTF8PlainText = "public.utf8-plain-text"` corresponding to `wxDF_UNICODETEXT`, while current implementation only accepts type of `kUTTypeTraditionalMacText = "com.apple.traditional-mac-plain-text"` corresponding to `wxDF_TEXT`. Therefore accepting `wxDF_UNICODETEXT` solves this problem.