### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,8 +7,15 @@ name: "CodeQL"
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/analyze to upload SARIF results
     name: Analyze
     runs-on: ubuntu-latest
 

--- a/.github/workflows/compile_mac.yml
+++ b/.github/workflows/compile_mac.yml
@@ -5,6 +5,9 @@ on: [push]
 env:
   BUILD_TYPE: Release
 
+permissions:
+  contents: read
+
 jobs:
   compile_Ninja:
     runs-on: macos-latest

--- a/.github/workflows/compile_ubuntu.yml
+++ b/.github/workflows/compile_ubuntu.yml
@@ -5,6 +5,9 @@ on: [push]
 env:
   BUILD_TYPE: Release
 
+permissions:
+  contents: read
+
 jobs:
   compile_2004:
     runs-on: ubuntu-20.04

--- a/.github/workflows/compile_windows.yml
+++ b/.github/workflows/compile_windows.yml
@@ -6,8 +6,13 @@ env:
   BUILD_TYPE: Release
   WXVERSION: 3.1.4
 
+permissions:
+  contents: read
+
 jobs:
   compile_windows:
+    permissions:
+      contents: write  # for actions/create-release to create a release
     runs-on: windows-latest
     steps:
       - name: create_release

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -5,6 +5,9 @@ on: [push]
 env:
   BUILD_TYPE: Release
 
+permissions:
+  contents: read
+
 jobs:
   run_cppcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
