### PR TITLE
Make various dialogs window-modal

### DIFF
--- a/src/wizards/Gen1Wiz.cpp
+++ b/src/wizards/Gen1Wiz.cpp
@@ -23,6 +23,7 @@
 
 #include "Gen1Wiz.h"
 #include <wx/persist/toplevel.h>
+#include <wx/windowptr.h>
 
 Gen1Wiz::Gen1Wiz(wxWindow *parent, int id, Configuration *cfg,
                  const wxString &title, const wxString &label,
@@ -88,17 +89,17 @@ void Gen1Wiz::do_layout() {
   Layout();
 }
 
-wxString GetTextFromUser(wxString label, wxString title, Configuration *cfg,
-                         wxString value, wxWindow *parent) {
-  Gen1Wiz *wiz = new Gen1Wiz(parent, -1, cfg, title, label);
+void GetTextFromUser(wxString label, wxString title, Configuration *cfg,
+                     wxString value, wxWindow *parent, std::function<void (wxString)> callback) {
+  wxWindowPtr<Gen1Wiz> wiz(new Gen1Wiz(parent, -1, cfg, title, label));
   wiz->SetValue(value);
-  wxString val;
   wiz->Centre(wxBOTH);
-  if (wiz->ShowModal() == wxID_OK) {
-    val = wiz->GetValue();
-    val.Trim();
-    val.Trim(false);
-  }
-  wiz->Destroy();
-  return val;
+  wiz->ShowWindowModalThenDo([wiz,callback](int retcode) {
+    if (retcode == wxID_OK) {
+      wxString val = wiz->GetValue();
+      val.Trim();
+      val.Trim(false);
+      callback(val);
+    }
+  });
 }

--- a/src/wizards/Gen1Wiz.h
+++ b/src/wizards/Gen1Wiz.h
@@ -26,6 +26,7 @@
 #include "precomp.h"
 #include <wx/wx.h>
 #include <wx/statline.h>
+#include <functional>
 
 #include "BTextCtrl.h"
 
@@ -69,7 +70,7 @@ private:
   wxString m_warningText;
 };
 
-wxString GetTextFromUser(wxString label, wxString title, Configuration *cfg, wxString value,
-                         wxWindow *parent);
+void GetTextFromUser(wxString label, wxString title, Configuration *cfg, wxString value,
+                     wxWindow *parent, std::function<void (wxString)> callback);
 
 #endif // GEN1WIZ_H

--- a/src/wizards/Plot2dWiz.cpp
+++ b/src/wizards/Plot2dWiz.cpp
@@ -24,6 +24,7 @@
 
 #include <wx/artprov.h>
 #include <wx/config.h>
+#include <wx/windowptr.h>
 
 Plot2DWiz::Plot2DWiz(wxWindow *parent, int id, Configuration *cfg,
                      const wxString &title, const wxPoint &pos,
@@ -403,28 +404,31 @@ void Plot2DWiz::OnButton(wxCommandEvent &WXUNUSED(event)) {
 void Plot2DWiz::OnPopupMenu(wxCommandEvent &event) {
   switch (event.GetId()) {
   case parametric_plot: {
-    Plot2DPar *wiz = new Plot2DPar(this, -1, m_configuration, _("Plot 2D"));
+    wxWindowPtr<Plot2DPar> wiz(new Plot2DPar(this, -1, m_configuration, _("Plot 2D")));
     wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      if (text_ctrl_1->GetValue() == wxT("%"))
-        text_ctrl_1->SetValue(wxEmptyString);
-      if (((text_ctrl_1->GetValue()).Strip()).Length())
-        text_ctrl_1->AppendText(wxT(", "));
-      text_ctrl_1->AppendText(wiz->GetValue());
-    }
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        if (text_ctrl_1->GetValue() == wxT("%"))
+          text_ctrl_1->SetValue(wxEmptyString);
+        if (((text_ctrl_1->GetValue()).Strip()).Length())
+          text_ctrl_1->AppendText(wxT(", "));
+        text_ctrl_1->AppendText(wiz->GetValue());
+      }
+    });
   } //-V773
     break;
   case discrete_plot: {
-    Plot2DDiscrete *wiz =
-      new Plot2DDiscrete(this, -1, m_configuration, _("Plot 2D"));
+    wxWindowPtr<Plot2DDiscrete> wiz(new Plot2DDiscrete(this, -1, m_configuration, _("Plot 2D")));
     wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      if (text_ctrl_1->GetValue() == wxT("%"))
-        text_ctrl_1->SetValue(wxEmptyString);
-      if (((text_ctrl_1->GetValue()).Strip()).Length())
-        text_ctrl_1->AppendText(wxT(", "));
-      text_ctrl_1->AppendText(wiz->GetValue());
-    }
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        if (text_ctrl_1->GetValue() == wxT("%"))
+          text_ctrl_1->SetValue(wxEmptyString);
+        if (((text_ctrl_1->GetValue()).Strip()).Length())
+          text_ctrl_1->AppendText(wxT(", "));
+        text_ctrl_1->AppendText(wiz->GetValue());
+      }
+    });
   } //-V773
     break;
   }

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -7445,49 +7445,49 @@ void wxMaxima::EquationsMenu(wxCommandEvent &event) {
                wxT("eliminate([#1#],[#2#]);"), _("Equation(s):"), expr,
                wxEmptyString, _("Variable(s):"), wxEmptyString, wxEmptyString);
     break;
-  case menu_solve_algsys: {
-    wxString sz =
-      GetTextFromUser(_("Number of equations:"), _("Solve algebraic system"),
-		      &m_configuration, wxT("3"), this);
-    if (sz.Length() == 0)
-      return;
-    long isz;
-    if (!sz.ToLong(&isz) || isz <= 0) {
-      LoggingMessageBox(_("Not a valid number of equations!"), _("Error!"),
-                        wxOK | wxICON_ERROR);
-      return;
-    }
-    wxWindowPtr<SysWiz> wiz(new SysWiz(this, -1, &m_configuration,
-                                       _("Solve algebraic system"), isz));
-    // wiz->Centre(wxBOTH);
-    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
-      if (retcode == wxID_OK) {
-        wxString cmd = wxT("algsys") + wiz->GetValue();
-        MenuCommand(cmd);
-      }
-    });
-  } break;
-  case menu_solve_lin: {
-    wxString sz =
-      GetTextFromUser(_("Number of equations:"), _("Solve linear system"),
-		      &m_configuration, wxT("3"), this);
-    if (sz.Length() == 0)
-      return;
-    long isz;
-    if (!sz.ToLong(&isz) || isz <= 0) {
-      LoggingMessageBox(_("Not a valid number of equations!"), _("Error!"),
-                        wxOK | wxICON_ERROR);
-      return;
-    }
-    wxWindowPtr<SysWiz> wiz(new SysWiz(this, -1, &m_configuration, _("Solve linear system"), isz));
-    // wiz->Centre(wxBOTH);
-    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
-      if (retcode == wxID_OK) {
-        wxString cmd = wxT("linsolve") + wiz->GetValue();
-        MenuCommand(cmd);
-      }
-    });
-  } break;
+  case menu_solve_algsys:
+    GetTextFromUser(_("Number of equations:"), _("Solve algebraic system"),
+                    &m_configuration, wxT("3"), this, [this](wxString sz) {
+                      if (sz.Length() == 0)
+                        return;
+                      long isz;
+                      if (!sz.ToLong(&isz) || isz <= 0) {
+                        LoggingMessageBox(_("Not a valid number of equations!"), _("Error!"),
+                                          wxOK | wxICON_ERROR);
+                        return;
+                      }
+                      wxWindowPtr<SysWiz> wiz(new SysWiz(this, -1, &m_configuration,
+                                                         _("Solve algebraic system"), isz));
+                      // wiz->Centre(wxBOTH);
+                      wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+                        if (retcode == wxID_OK) {
+                          wxString cmd = wxT("algsys") + wiz->GetValue();
+                          MenuCommand(cmd);
+                        }
+                      });
+                    });
+    break;
+  case menu_solve_lin:
+    GetTextFromUser(_("Number of equations:"), _("Solve linear system"),
+                    &m_configuration, wxT("3"), this, [this](wxString sz) {
+                      if (sz.Length() == 0)
+                        return;
+                      long isz;
+                      if (!sz.ToLong(&isz) || isz <= 0) {
+                        LoggingMessageBox(_("Not a valid number of equations!"), _("Error!"),
+                                          wxOK | wxICON_ERROR);
+                        return;
+                      }
+                      wxWindowPtr<SysWiz> wiz(new SysWiz(this, -1, &m_configuration, _("Solve linear system"), isz));
+                      // wiz->Centre(wxBOTH);
+                      wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+                        if (retcode == wxID_OK) {
+                          wxString cmd = wxT("linsolve") + wiz->GetValue();
+                          MenuCommand(cmd);
+                        }
+                      });
+                    });
+    break;
   case menu_solve_de:
     CommandWiz(_("Solve differential equations using laplace()"),
                _("The solution variable needs to be in the form\n"

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -103,6 +103,7 @@
 #include <wx/uri.h>
 #include <wx/utils.h>
 #include <wx/wupdlock.h>
+#include <wx/windowptr.h>
 
 #include <wx/fs_mem.h>
 #include <wx/persist/toplevel.h>
@@ -7285,15 +7286,15 @@ void wxMaxima::MaximaMenu(wxCommandEvent &event) {
                wxEmptyString);
     break;
   case button_subst: {
-    SubstituteWiz *wiz =
-      new SubstituteWiz(this, -1, &m_configuration, _("Substitute"));
+    wxWindowPtr<SubstituteWiz> wiz(new SubstituteWiz(this, -1, &m_configuration, _("Substitute")));
     wiz->SetValue(expr);
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString val = wiz->GetValue();
-      MenuCommand(val);
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString val = wiz->GetValue();
+        MenuCommand(val);
+      }
+    });
   } break;
   default:
     break;
@@ -7456,14 +7457,15 @@ void wxMaxima::EquationsMenu(wxCommandEvent &event) {
                         wxOK | wxICON_ERROR);
       return;
     }
-    SysWiz *wiz = new SysWiz(this, -1, &m_configuration,
-                             _("Solve algebraic system"), isz);
+    wxWindowPtr<SysWiz> wiz(new SysWiz(this, -1, &m_configuration,
+                                       _("Solve algebraic system"), isz));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString cmd = wxT("algsys") + wiz->GetValue();
-      MenuCommand(cmd);
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString cmd = wxT("algsys") + wiz->GetValue();
+        MenuCommand(cmd);
+      }
+    });
   } break;
   case menu_solve_lin: {
     wxString sz =
@@ -7477,14 +7479,14 @@ void wxMaxima::EquationsMenu(wxCommandEvent &event) {
                         wxOK | wxICON_ERROR);
       return;
     }
-    SysWiz *wiz =
-      new SysWiz(this, -1, &m_configuration, _("Solve linear system"), isz);
+    wxWindowPtr<SysWiz> wiz(new SysWiz(this, -1, &m_configuration, _("Solve linear system"), isz));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString cmd = wxT("linsolve") + wiz->GetValue();
-      MenuCommand(cmd);
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString cmd = wxT("linsolve") + wiz->GetValue();
+        MenuCommand(cmd);
+      }
+    });
   } break;
   case menu_solve_de:
     CommandWiz(_("Solve differential equations using laplace()"),
@@ -7530,23 +7532,25 @@ void wxMaxima::MatrixMenu(wxCommandEvent &event) {
   wxString expr = GetDefaultEntry();
   switch (event.GetId()) {
   case menu_csv2mat: {
-    CsvImportWiz *wiz = new CsvImportWiz(this, &m_configuration);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString cmd = wxT("read_matrix(\"") + wiz->GetFilename() + wxT("\", ") +
-	wiz->GetSeparator() + wxT(");");
-      MenuCommand(cmd);
-    }
-    wiz->Destroy();
+    wxWindowPtr<CsvImportWiz> wiz(new CsvImportWiz(this, &m_configuration));
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString cmd = wxT("read_matrix(\"") + wiz->GetFilename() + wxT("\", ") +
+          wiz->GetSeparator() + wxT(");");
+        MenuCommand(cmd);
+      }
+    });
     break;
   }
   case menu_mat2csv: {
-    CsvExportWiz *wiz = new CsvExportWiz(this, &m_configuration, _("Matrix"));
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString cmd = wxT("write_data(") + wiz->GetMatrix() + wxT(", \"") +
-	wiz->GetFilename() + wxT("\", ") + wiz->GetSeparator() + wxT(");");
-      MenuCommand(cmd);
-    }
-    wiz->Destroy();
+    wxWindowPtr<CsvExportWiz> wiz(new CsvExportWiz(this, &m_configuration, _("Matrix")));
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString cmd = wxT("write_data(") + wiz->GetMatrix() + wxT(", \"") +
+          wiz->GetFilename() + wxT("\", ") + wiz->GetSeparator() + wxT(");");
+        MenuCommand(cmd);
+      }
+    });
     break;
   }
   case menu_matrix_row:
@@ -7730,49 +7734,49 @@ void wxMaxima::MatrixMenu(wxCommandEvent &event) {
     MenuCommand(cmd);
   } break;
   case menu_map_mat: {
-    Gen3Wiz *wiz =
-      new Gen3Wiz(_("Resulting Matrix name (may be empty):"), _("Function:"),
-		  _("Matrix:"), wxEmptyString, wxEmptyString, expr,
-		  &m_configuration, this, -1, _("Matrix map"));
+    wxWindowPtr<Gen3Wiz> wiz(new Gen3Wiz(_("Resulting Matrix name (may be empty):"), _("Function:"),
+                                         _("Matrix:"), wxEmptyString, wxEmptyString, expr,
+                                         &m_configuration, this, -1, _("Matrix map")));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString cmd = wxEmptyString;
-      if (wiz->GetValue1().IsEmpty())
-        cmd = wiz->GetValue1() + wxT(":");
-      cmd += wxT("matrixmap(") + wiz->GetValue2() + wxT(", ") +
-	wiz->GetValue3() + wxT(");");
-      MenuCommand(cmd);
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString cmd = wxEmptyString;
+        if (wiz->GetValue1().IsEmpty())
+          cmd = wiz->GetValue1() + wxT(":");
+        cmd += wxT("matrixmap(") + wiz->GetValue2() + wxT(", ") +
+          wiz->GetValue3() + wxT(");");
+        MenuCommand(cmd);
+      }
+    });
   } break;
   case menu_enter_mat:
   case menu_stats_enterm: {
-    MatDim *wiz = new MatDim(this, -1, &m_configuration, _("Matrix"));
+    wxWindowPtr<MatDim> wiz(new MatDim(this, -1, &m_configuration, _("Matrix")));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString cmd;
-      if (wiz->GetValue0() != wxEmptyString)
-        cmd = wiz->GetValue0() + wxT(": ");
-      long w, h;
-      int type = wiz->GetMatrixType();
-      if (!(wiz->GetValue2()).ToLong(&h) || !(wiz->GetValue1()).ToLong(&w) ||
-          w <= 0 || h <= 0) {
-        LoggingMessageBox(_("Not a valid matrix dimension!"), _("Error!"),
-                          wxOK | wxICON_ERROR);
-        return; //-V773
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString cmd;
+        if (wiz->GetValue0() != wxEmptyString)
+          cmd = wiz->GetValue0() + wxT(": ");
+        long w, h;
+        int type = wiz->GetMatrixType();
+        if (!(wiz->GetValue2()).ToLong(&h) || !(wiz->GetValue1()).ToLong(&w) ||
+            w <= 0 || h <= 0) {
+          LoggingMessageBox(_("Not a valid matrix dimension!"), _("Error!"),
+                            wxOK | wxICON_ERROR);
+          return; //-V773
+        }
+        if (w != h)
+          type = MatWiz::MATRIX_GENERAL;
+        wxWindowPtr<MatWiz> mwiz(new MatWiz(this, -1, &m_configuration, _("Enter matrix"), type, w, h));
+        // wiz->Centre(wxBOTH);
+        wiz->ShowWindowModalThenDo([this,mwiz,cmd](int retcode) {
+          if (retcode == wxID_OK) {
+            MenuCommand(cmd + mwiz->GetValue());
+          }
+        });
       }
-      if (w != h)
-        type = MatWiz::MATRIX_GENERAL;
-      MatWiz *mwiz =
-	new MatWiz(this, -1, &m_configuration, _("Enter matrix"), type, w, h);
-      // wiz->Centre(wxBOTH);
-      if (mwiz->ShowModal() == wxID_OK) {
-        cmd += mwiz->GetValue();
-        MenuCommand(cmd);
-      }
-      mwiz->Destroy();
-    }
-    wiz->Destroy();
+    });
   } break;
   case menu_cpoly:
     CommandWiz(_("Characteristic polynom"), wxEmptyString, wxEmptyString,
@@ -7866,37 +7870,40 @@ void wxMaxima::DrawMenu(wxCommandEvent &event) {
 
   switch (event.GetId()) {
   case menu_draw_2d: {
-    DrawWiz *wiz = new DrawWiz(this, &m_configuration, 2);
+    wxWindowPtr<DrawWiz> wiz(new DrawWiz(this, &m_configuration, 2));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      m_worksheet->SetFocus();
-
-      m_worksheet->OpenHCaret(wiz->GetValue());
-      m_worksheet->GetActiveCell()->SetCaretPosition(
-						     m_worksheet->GetActiveCell()->GetCaretPosition() - 3);
-    }
-    wiz->Destroy();
-    break;
-  }
-  case menu_draw_3d:
-    if (dimensions < 2) {
-      DrawWiz *wiz = new DrawWiz(this, &m_configuration, 3);
-      // wiz->Centre(wxBOTH);
-      if (wiz->ShowModal() == wxID_OK) {
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
         m_worksheet->SetFocus();
 
         m_worksheet->OpenHCaret(wiz->GetValue());
         m_worksheet->GetActiveCell()->SetCaretPosition(
-						       m_worksheet->GetActiveCell()->GetCaretPosition() - 3);
+                                                       m_worksheet->GetActiveCell()->GetCaretPosition() - 3);
       }
-      wiz->Destroy();
+    });
+    break;
+  }
+  case menu_draw_3d:
+    if (dimensions < 2) {
+      wxWindowPtr<DrawWiz> wiz(new DrawWiz(this, &m_configuration, 3));
+      // wiz->Centre(wxBOTH);
+      wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+        if (retcode == wxID_OK) {
+          m_worksheet->SetFocus();
+
+          m_worksheet->OpenHCaret(wiz->GetValue());
+          m_worksheet->GetActiveCell()->SetCaretPosition(
+                                                         m_worksheet->GetActiveCell()->GetCaretPosition() - 3);
+        }
+      });
       break;
     } else {
-      Wiz3D *wiz = new Wiz3D(this, &m_configuration);
+      wxWindowPtr<Wiz3D> wiz(new Wiz3D(this, &m_configuration));
       // wiz->Centre(wxBOTH);
-      if (wiz->ShowModal() == wxID_OK)
-        AddDrawParameter(wiz->GetValue());
-      wiz->Destroy();
+      wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+        if (retcode == wxID_OK)
+          AddDrawParameter(wiz->GetValue());
+      });
       break;
     }
   case menu_draw_fgcolor: {
@@ -7914,109 +7921,116 @@ void wxMaxima::DrawMenu(wxCommandEvent &event) {
     break;
   }
   case menu_draw_title: {
-    Gen1Wiz *wiz = new Gen1Wiz(
-			       this, -1, &m_configuration, _("Set the diagram title"),
-			       _("Title (Sub- and superscripts as x_{10} or x^{10})"), expr);
+    wxWindowPtr<Gen1Wiz> wiz(new Gen1Wiz(
+                                         this, -1, &m_configuration, _("Set the diagram title"),
+                                         _("Title (Sub- and superscripts as x_{10} or x^{10})"), expr));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString cmd = wxT("title=\"") + wiz->GetValue() + wxT("\"");
-      AddDrawParameter(cmd);
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString cmd = wxT("title=\"") + wiz->GetValue() + wxT("\"");
+        AddDrawParameter(cmd);
+      }
+    });
     break;
   }
   case menu_draw_key: {
-    Gen1Wiz *wiz = new Gen1Wiz(
-			       this, -1, &m_configuration,
-			       _("Set the next plot's title. Empty = no title."),
-			       _("Title (Sub- and superscripts as x_{10} or x^{10})"), expr);
+    wxWindowPtr<Gen1Wiz> wiz(new Gen1Wiz(
+                                         this, -1, &m_configuration,
+                                         _("Set the next plot's title. Empty = no title."),
+                                         _("Title (Sub- and superscripts as x_{10} or x^{10})"), expr));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString cmd = wxT("key=\"") + wiz->GetValue() + wxT("\"");
-      AddDrawParameter(cmd);
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString cmd = wxT("key=\"") + wiz->GetValue() + wxT("\"");
+        AddDrawParameter(cmd);
+      }
+    });
     break;
   }
   case menu_draw_explicit: {
-    ExplicitWiz *wiz =
-      new ExplicitWiz(this, &m_configuration, expr, dimensions);
+    wxWindowPtr<ExplicitWiz> wiz(new ExplicitWiz(this, &m_configuration, expr, dimensions));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK)
-      AddDrawParameter(wiz->GetValue());
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK)
+        AddDrawParameter(wiz->GetValue());
+    });
     break;
   }
 
   case menu_draw_implicit: {
-    ImplicitWiz *wiz =
-      new ImplicitWiz(this, &m_configuration, expr, dimensions);
+    wxWindowPtr<ImplicitWiz> wiz(new ImplicitWiz(this, &m_configuration, expr, dimensions));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK)
-      AddDrawParameter(wiz->GetValue());
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK)
+        AddDrawParameter(wiz->GetValue());
+    });
     break;
   }
 
   case menu_draw_parametric: {
-    ParametricWiz *wiz = new ParametricWiz(this, &m_configuration, dimensions);
+    wxWindowPtr<ParametricWiz> wiz(new ParametricWiz(this, &m_configuration, dimensions));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK)
-      AddDrawParameter(wiz->GetValue());
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK)
+        AddDrawParameter(wiz->GetValue());
+    });
     break;
   }
 
   case menu_draw_points: {
-    WizPoints *wiz = new WizPoints(this, &m_configuration, dimensions, expr);
+    wxWindowPtr<WizPoints> wiz(new WizPoints(this, &m_configuration, dimensions, expr));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK)
-      AddDrawParameter(wiz->GetValue());
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK)
+        AddDrawParameter(wiz->GetValue());
+    });
     break;
   }
 
   case menu_draw_grid: {
-    Gen2Wiz *wiz = new Gen2Wiz(
-			       _("x direction [in multiples of the tick frequency]"),
-			       _("y direction [in multiples of the tick frequency]"), "1", "1",
-			       &m_configuration, this, -1, _("Set the grid density."));
+    wxWindowPtr<Gen2Wiz> wiz(new Gen2Wiz(
+                                         _("x direction [in multiples of the tick frequency]"),
+                                         _("y direction [in multiples of the tick frequency]"), "1", "1",
+                                         &m_configuration, this, -1, _("Set the grid density.")));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString cmd =
-	wxT("grid=[") + wiz->GetValue1() + "," + wiz->GetValue2() + wxT("]");
-      AddDrawParameter(cmd);
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString cmd =
+          wxT("grid=[") + wiz->GetValue1() + "," + wiz->GetValue2() + wxT("]");
+        AddDrawParameter(cmd);
+      }
+    });
     break;
   }
 
   case menu_draw_axis: {
-    AxisWiz *wiz = new AxisWiz(this, &m_configuration, dimensions);
+    wxWindowPtr<AxisWiz> wiz(new AxisWiz(this, &m_configuration, dimensions));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      AddDrawParameter(wiz->GetValue());
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        AddDrawParameter(wiz->GetValue());
+      }
+    });
     break;
   }
 
   case menu_draw_contour: {
-    WizContour *wiz = new WizContour(this, &m_configuration);
+    wxWindowPtr<WizContour> wiz(new WizContour(this, &m_configuration));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK)
-      AddDrawParameter(wiz->GetValue(), 3);
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK)
+        AddDrawParameter(wiz->GetValue(), 3);
+    });
     break;
   }
 
   case menu_draw_accuracy: {
-    WizDrawAccuracy *wiz =
-      new WizDrawAccuracy(this, &m_configuration, dimensions);
+    wxWindowPtr<WizDrawAccuracy> wiz(new WizDrawAccuracy(this, &m_configuration, dimensions));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK)
-      AddDrawParameter(wiz->GetValue(), dimensions);
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz,dimensions](int retcode) {
+      if (retcode == wxID_OK)
+        AddDrawParameter(wiz->GetValue(), dimensions);
+    });
     break;
   }
   }
@@ -8029,23 +8043,25 @@ void wxMaxima::ListMenu(wxCommandEvent &event) {
   wxString expr = GetDefaultEntry();
   switch (event.GetId()) {
   case menu_csv2list: {
-    CsvImportWiz *wiz = new CsvImportWiz(this, &m_configuration);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString cmd = wxT("read_nested_list(\"") + wiz->GetFilename() + wxT("\", ") +
-	wiz->GetSeparator() + wxT(");");
-      MenuCommand(cmd);
-    }
-    wiz->Destroy();
+    wxWindowPtr<CsvImportWiz> wiz(new CsvImportWiz(this, &m_configuration));
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString cmd = wxT("read_nested_list(\"") + wiz->GetFilename() + wxT("\", ") +
+          wiz->GetSeparator() + wxT(");");
+        MenuCommand(cmd);
+      }
+    });
     break;
   }
   case menu_list2csv: {
-    CsvExportWiz *wiz = new CsvExportWiz(this, &m_configuration, _("List"));
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString cmd = wxT("write_data(") + wiz->GetMatrix() + wxT(", \"") +
-	wiz->GetFilename() + wxT("\", ") + wiz->GetSeparator() + wxT(");");
-      MenuCommand(cmd);
-    }
-    wiz->Destroy();
+    wxWindowPtr<CsvExportWiz> wiz(new CsvExportWiz(this, &m_configuration, _("List")));
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString cmd = wxT("write_data(") + wiz->GetMatrix() + wxT(", \"") +
+          wiz->GetFilename() + wxT("\", ") + wiz->GetSeparator() + wxT(");");
+        MenuCommand(cmd);
+      }
+    });
     break;
   }
   case menu_list_create_from_args:
@@ -8089,23 +8105,24 @@ void wxMaxima::ListMenu(wxCommandEvent &event) {
 	       _("Source list:"), wxT("[1,8,32]"), wxEmptyString);
     break;
   case menu_list_actual_values_storage: {
-    ActualValuesStorageWiz *wiz = new ActualValuesStorageWiz(
-							     &m_configuration, this, -1,
-							     _("Create a list as a storage for the values of variables"));
+    wxWindowPtr<ActualValuesStorageWiz> wiz(new ActualValuesStorageWiz(
+                                                                       &m_configuration, this, -1,
+                                                                       _("Create a list as a storage for the values of variables")));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      MenuCommand(wiz->GetValue());
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        MenuCommand(wiz->GetValue());
+      }
+    });
   } break;
   case menu_list_sort: {
-    ListSortWiz *wiz =
-      new ListSortWiz(&m_configuration, this, -1, _("Sort a list"), expr);
+    wxWindowPtr<ListSortWiz> wiz(new ListSortWiz(&m_configuration, this, -1, _("Sort a list"), expr));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      MenuCommand(wiz->GetValue());
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        MenuCommand(wiz->GetValue());
+      }
+    });
   } break;
   case menu_list_length:
     MenuCommand(wxT("length(") + expr + wxT(")"));
@@ -8593,15 +8610,15 @@ void wxMaxima::CalculusMenu(wxCommandEvent &event) {
     break;
   case button_integrate:
   case menu_integrate: {
-    IntegrateWiz *wiz =
-      new IntegrateWiz(this, -1, &m_configuration, _("Integrate"));
+    wxWindowPtr<IntegrateWiz> wiz(new IntegrateWiz(this, -1, &m_configuration, _("Integrate")));
     wiz->SetValue(expr);
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString val = wiz->GetValue();
-      MenuCommand(val);
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString val = wiz->GetValue();
+        MenuCommand(val);
+      }
+    });
   } break;
   case menu_laplace:
     CommandWiz(_("Laplace"), wxEmptyString, wxEmptyString,
@@ -8623,25 +8640,27 @@ void wxMaxima::CalculusMenu(wxCommandEvent &event) {
                _("Times:"), wxT("1"), wxEmptyString);
     break;
   case button_taylor: {
-    SeriesWiz *wiz = new SeriesWiz(this, -1, &m_configuration, _("Series"));
+    wxWindowPtr<SeriesWiz> wiz(new SeriesWiz(this, -1, &m_configuration, _("Series")));
     wiz->SetValue(expr);
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString val = wiz->GetValue();
-      MenuCommand(val);
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString val = wiz->GetValue();
+        MenuCommand(val);
+      }
+    });
   } break;
   case button_limit:
   case menu_limit: {
-    LimitWiz *wiz = new LimitWiz(this, -1, &m_configuration, _("Limit"));
+    wxWindowPtr<LimitWiz> wiz(new LimitWiz(this, -1, &m_configuration, _("Limit")));
     wiz->SetValue(expr);
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString val = wiz->GetValue();
-      MenuCommand(val);
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString val = wiz->GetValue();
+        MenuCommand(val);
+      }
+    });
   } break;
   case menu_lbfgs:
     CommandWiz(_("Find minimum"),
@@ -8654,14 +8673,15 @@ void wxMaxima::CalculusMenu(wxCommandEvent &event) {
     break;
   case button_sum:
   case menu_sum: {
-    SumWiz *wiz = new SumWiz(this, -1, &m_configuration, _("Sum"));
+    wxWindowPtr<SumWiz> wiz(new SumWiz(this, -1, &m_configuration, _("Sum")));
     wiz->SetValue(expr);
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString val = wiz->GetValue();
-      MenuCommand(val);
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString val = wiz->GetValue();
+        MenuCommand(val);
+      }
+    });
   } break;
   case button_product:
   case menu_product:
@@ -8684,14 +8704,15 @@ void wxMaxima::PlotMenu(wxCommandEvent &event) {
   switch (event.GetId()) {
   case button_plot3:
   case gp_plot3: {
-    Plot3DWiz *wiz = new Plot3DWiz(this, -1, &m_configuration, _("Plot 3D"));
+    wxWindowPtr<Plot3DWiz> wiz(new Plot3DWiz(this, -1, &m_configuration, _("Plot 3D")));
     wiz->SetValue(expr);
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString val = wiz->GetValue();
-      MenuCommand(val);
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString val = wiz->GetValue();
+        MenuCommand(val);
+      }
+    });
   } break;
   case menu_animationautostart:
     if (event.IsChecked())
@@ -8707,23 +8728,24 @@ void wxMaxima::PlotMenu(wxCommandEvent &event) {
   } break;
   case button_plot2:
   case gp_plot2: {
-    Plot2DWiz *wiz = new Plot2DWiz(this, -1, &m_configuration, _("Plot 2D"));
+    wxWindowPtr<Plot2DWiz> wiz(new Plot2DWiz(this, -1, &m_configuration, _("Plot 2D")));
     wiz->SetValue(expr);
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString val = wiz->GetValue();
-      MenuCommand(val);
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString val = wiz->GetValue();
+        MenuCommand(val);
+      }
+    });
   } break;
   case menu_plot_format: {
-    PlotFormatWiz *wiz =
-      new PlotFormatWiz(this, -1, &m_configuration, _("Plot format"));
+    wxWindowPtr<PlotFormatWiz> wiz(new PlotFormatWiz(this, -1, &m_configuration, _("Plot format")));
     wiz->Center(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      MenuCommand(wiz->GetValue());
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        MenuCommand(wiz->GetValue());
+      }
+    });
     /*wxString format = GetTextFromUser(_("Enter new plot format:"),
       _("Plot format"),
       m_configuration,
@@ -9052,16 +9074,16 @@ void wxMaxima::HelpMenu(wxCommandEvent &event) {
 
   switch (event.GetId()) {
   case menu_goto_url: {
-    GenWiz *wiz =
-      new GenWiz(this, &m_configuration, m_worksheet->GetMaximaManual(),
-		 _("Go to URL"), wxEmptyString, wxEmptyString, wxEmptyString,
-		 _("URL"), wxEmptyString, wxEmptyString);
+    wxWindowPtr<GenWiz> wiz(new GenWiz(this, &m_configuration, m_worksheet->GetMaximaManual(),
+                                       _("Go to URL"), wxEmptyString, wxEmptyString, wxEmptyString,
+                                       _("URL"), wxEmptyString, wxEmptyString));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      m_helpPane->SetURL((*wiz)[0]);
-      wxMaximaFrame::ShowPane(menu_pane_help);
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        m_helpPane->SetURL((*wiz)[0]);
+        wxMaximaFrame::ShowPane(menu_pane_help);
+      }
+    });
   } break;
   case wxID_ABOUT: {
     wxAboutDialogInfo info;
@@ -9282,34 +9304,35 @@ void wxMaxima::StatsMenu(wxCommandEvent &event) {
     }
   } break;
   case menu_stats_subsample: {
-    Gen4Wiz *wiz = new Gen4Wiz(
-			       _("Data Matrix:"), _("Condition:"), _("Include columns:"),
-			       _("Matrix name:"), expr, wxT("col[1]#'NA"), wxEmptyString,
-			       wxEmptyString, &m_configuration, this, -1, _("Select Subsample"), true);
+    wxWindowPtr<Gen4Wiz> wiz(new Gen4Wiz(
+                                         _("Data Matrix:"), _("Condition:"), _("Include columns:"),
+                                         _("Matrix name:"), expr, wxT("col[1]#'NA"), wxEmptyString,
+                                         wxEmptyString, &m_configuration, this, -1, _("Select Subsample"), true));
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString name = wiz->GetValue4();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString name = wiz->GetValue4();
 
-      wxString cmd;
+        wxString cmd;
 
-      if (name != wxEmptyString)
-        cmd << name << wxT(": ");
+        if (name != wxEmptyString)
+          cmd << name << wxT(": ");
 
-      cmd += wxT("subsample(\n   ") + wiz->GetValue1() + wxT(",\n   ") +
-	wxT("lambda([col], is( ");
+        cmd += wxT("subsample(\n   ") + wiz->GetValue1() + wxT(",\n   ") +
+          wxT("lambda([col], is( ");
 
-      if (wiz->GetValue2() != wxEmptyString)
-        cmd += wiz->GetValue2() + wxT(" ))");
-      else
-        cmd += wxT("true ))");
+        if (wiz->GetValue2() != wxEmptyString)
+          cmd += wiz->GetValue2() + wxT(" ))");
+        else
+          cmd += wxT("true ))");
 
-      if (wiz->GetValue3() != wxEmptyString)
-        cmd += wxT(",\n   ") + wiz->GetValue3();
+        if (wiz->GetValue3() != wxEmptyString)
+          cmd += wxT(",\n   ") + wiz->GetValue3();
 
-      cmd += wxT(");");
-      MenuCommand(cmd);
-    }
-    wiz->Destroy();
+        cmd += wxT(");");
+        MenuCommand(cmd);
+      }
+    });
   } break;
   }
 }
@@ -9765,15 +9788,15 @@ void wxMaxima::PopupMenu(wxCommandEvent &event) {
                wxEmptyString, _("Upper bound:"), wxT("1"), wxEmptyString);
     break;
   case Worksheet::popid_integrate: {
-    IntegrateWiz *wiz =
-      new IntegrateWiz(this, -1, &m_configuration, _("Integrate"));
+    wxWindowPtr<IntegrateWiz> wiz(new IntegrateWiz(this, -1, &m_configuration, _("Integrate")));
     wiz->SetValue(selection);
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString val = wiz->GetValue();
-      MenuCommand(val);
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString val = wiz->GetValue();
+        MenuCommand(val);
+      }
+    });
   } break;
   case Worksheet::popid_diff:
     CommandWiz(_("Differentiate"), _("Differentiates the expression n times"),
@@ -9789,24 +9812,26 @@ void wxMaxima::PopupMenu(wxCommandEvent &event) {
                _("Expression"), selection, wxEmptyString);
     break;
   case Worksheet::popid_plot2d: {
-    Plot2DWiz *wiz = new Plot2DWiz(this, -1, &m_configuration, _("Plot 2D"));
+    wxWindowPtr<Plot2DWiz> wiz(new Plot2DWiz(this, -1, &m_configuration, _("Plot 2D")));
     wiz->SetValue(selection);
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString val = wiz->GetValue();
-      MenuCommand(val);
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString val = wiz->GetValue();
+        MenuCommand(val);
+      }
+    });
   } break;
   case Worksheet::popid_plot3d: {
-    Plot3DWiz *wiz = new Plot3DWiz(this, -1, &m_configuration, _("Plot 3D"));
+    wxWindowPtr<Plot3DWiz> wiz(new Plot3DWiz(this, -1, &m_configuration, _("Plot 3D")));
     wiz->SetValue(selection);
     // wiz->Centre(wxBOTH);
-    if (wiz->ShowModal() == wxID_OK) {
-      wxString val = wiz->GetValue();
-      MenuCommand(val);
-    }
-    wiz->Destroy();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK) {
+        wxString val = wiz->GetValue();
+        MenuCommand(val);
+      }
+    });
   } break;
   case Worksheet::popid_float:
     MenuCommand(wxT("float(") + selection + wxT("), numer;"));

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -5724,7 +5724,6 @@ void wxMaxima::FileMenu(wxCommandEvent &event) {
     m_worksheet->CloseAutoCompletePopup();
 
   wxString expr = GetDefaultEntry();
-  wxString cmd;
   bool forceSave = false;
 #if defined __WXMSW__
   wxString b = wxT("\\");
@@ -6501,7 +6500,6 @@ void wxMaxima::MaximaMenu(wxCommandEvent &event) {
     m_worksheet->CloseAutoCompletePopup();
 
   wxString expr = GetDefaultEntry();
-  wxString cmd;
   wxString b = wxT("\\");
   wxString f = wxT("/");
   switch (event.GetId()) {
@@ -6569,37 +6567,38 @@ void wxMaxima::MaximaMenu(wxCommandEvent &event) {
       wxGetSingleChoice(_("Select math display algorithm"),
 			_("Display algorithm"), 3, choices, this);
     if (choice.Length()) {
-      cmd = wxT("set_display('") + choice + wxT(")$");
+      wxString cmd = wxT("set_display('") + choice + wxT(")$");
       MenuCommand(cmd);
     }
   } break;
-  case menu_texform:
-    cmd = wxT("tex(") + expr + wxT(")$");
+  case menu_texform: {
+    wxString cmd = wxT("tex(") + expr + wxT(")$");
     MenuCommand(cmd);
-    break;
-  case menu_grind:
-    cmd = wxT("grind(") + expr + wxT(")$");
+  } break;
+  case menu_grind: {
+    wxString cmd = wxT("grind(") + expr + wxT(")$");
     MenuCommand(cmd);
-    break;
-  case menu_debugmode_lisp:
-    cmd = wxT("debugmode: lisp$");
+  } break;
+  case menu_debugmode_lisp: {
+    wxString cmd = wxT("debugmode: lisp$");
     MenuCommand(cmd);
-    break;
-  case menu_debugmode_all:
-    cmd = wxT("debugmode: true$");
+  } break;
+  case menu_debugmode_all: {
+    wxString cmd = wxT("debugmode: true$");
     MenuCommand(cmd);
-    break;
-  case menu_debugmode_off:
-    cmd = wxT("debugmode: false$");
+  } break;
+  case menu_debugmode_off: {
+    wxString cmd = wxT("debugmode: false$");
     MenuCommand(cmd);
-    break;
-  case menu_time:
+  } break;
+  case menu_time: {
+    wxString cmd;
     if (event.IsChecked())
       cmd = wxT("showtime:all$");
     else
       cmd = wxT("showtime:false$");
     MenuCommand(cmd);
-    break;
+  } break;
   case gentran_lang_c:
     MenuCommand(wxT("gentranlang:c;"));
     break;
@@ -7229,7 +7228,7 @@ void wxMaxima::MaximaMenu(wxCommandEvent &event) {
 #if defined(__WXMSW__)
       dir.Replace(wxT("\\"), wxT("/"));
 #endif
-      cmd = wxT("file_search_maxima : cons(sconcat(\"") + dir +
+      wxString cmd = wxT("file_search_maxima : cons(sconcat(\"") + dir +
 	wxT("/###.{lisp,mac,mc}\"), file_search_maxima)$");
       MenuCommand(cmd);
     }
@@ -7306,7 +7305,6 @@ void wxMaxima::EquationsMenu(wxCommandEvent &event) {
     m_worksheet->CloseAutoCompletePopup();
 
   wxString expr = GetDefaultEntry();
-  wxString cmd;
   switch (event.GetId()) {
   case menu_allroots:
     CommandWiz(
@@ -7462,7 +7460,7 @@ void wxMaxima::EquationsMenu(wxCommandEvent &event) {
                              _("Solve algebraic system"), isz);
     // wiz->Centre(wxBOTH);
     if (wiz->ShowModal() == wxID_OK) {
-      cmd = wxT("algsys") + wiz->GetValue();
+      wxString cmd = wxT("algsys") + wiz->GetValue();
       MenuCommand(cmd);
     }
     wiz->Destroy();
@@ -7483,7 +7481,7 @@ void wxMaxima::EquationsMenu(wxCommandEvent &event) {
       new SysWiz(this, -1, &m_configuration, _("Solve linear system"), isz);
     // wiz->Centre(wxBOTH);
     if (wiz->ShowModal() == wxID_OK) {
-      cmd = wxT("linsolve") + wiz->GetValue();
+      wxString cmd = wxT("linsolve") + wiz->GetValue();
       MenuCommand(cmd);
     }
     wiz->Destroy();
@@ -7506,14 +7504,14 @@ void wxMaxima::EquationsMenu(wxCommandEvent &event) {
                wxEmptyString, _("Point:"), wxT("x=0"), wxEmptyString,
                _("Value:"), wxT("0"), wxEmptyString);
     break;
-  case menu_lhs:
-    cmd = wxT("lhs(") + expr + wxT(");");
+  case menu_lhs: {
+    wxString cmd = wxT("lhs(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_rhs:
-    cmd = wxT("rhs(") + expr + wxT(");");
+  } break;
+  case menu_rhs: {
+    wxString cmd = wxT("rhs(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
+  } break;
   case menu_construct_fraction:
     CommandWiz(_("Construct a fraction"), wxEmptyString, wxEmptyString,
                wxT("(#1#)/(#2#)"), _("Enumerator:"), expr, wxEmptyString,
@@ -7530,12 +7528,11 @@ void wxMaxima::MatrixMenu(wxCommandEvent &event) {
     m_worksheet->CloseAutoCompletePopup();
 
   wxString expr = GetDefaultEntry();
-  wxString cmd;
   switch (event.GetId()) {
   case menu_csv2mat: {
     CsvImportWiz *wiz = new CsvImportWiz(this, &m_configuration);
     if (wiz->ShowModal() == wxID_OK) {
-      cmd = wxT("read_matrix(\"") + wiz->GetFilename() + wxT("\", ") +
+      wxString cmd = wxT("read_matrix(\"") + wiz->GetFilename() + wxT("\", ") +
 	wiz->GetSeparator() + wxT(");");
       MenuCommand(cmd);
     }
@@ -7545,7 +7542,7 @@ void wxMaxima::MatrixMenu(wxCommandEvent &event) {
   case menu_mat2csv: {
     CsvExportWiz *wiz = new CsvExportWiz(this, &m_configuration, _("Matrix"));
     if (wiz->ShowModal() == wxID_OK) {
-      cmd = wxT("write_data(") + wiz->GetMatrix() + wxT(", \"") +
+      wxString cmd = wxT("write_data(") + wiz->GetMatrix() + wxT(", \"") +
 	wiz->GetFilename() + wxT("\", ") + wiz->GetSeparator() + wxT(");");
       MenuCommand(cmd);
     }
@@ -7704,34 +7701,34 @@ void wxMaxima::MatrixMenu(wxCommandEvent &event) {
   case menu_matrix_zheev:
     break;
 
-  case menu_invert_mat:
-    cmd = wxT("invert(") + expr + wxT(");");
+  case menu_invert_mat: {
+    wxString cmd = wxT("invert(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_determinant:
-    cmd = wxT("determinant(") + expr + wxT(");");
+  } break;
+  case menu_determinant: {
+    wxString cmd = wxT("determinant(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_rank:
-    cmd = wxT("rank(") + expr + wxT(");");
+  } break;
+  case menu_rank: {
+    wxString cmd = wxT("rank(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_eigen:
-    cmd = wxT("eigenvalues(") + expr + wxT(");");
+  } break;
+  case menu_eigen: {
+    wxString cmd = wxT("eigenvalues(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_eigvect:
-    cmd = wxT("eigenvectors(") + expr + wxT(");");
+  } break;
+  case menu_eigvect: {
+    wxString cmd = wxT("eigenvectors(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_adjoint_mat:
-    cmd = wxT("adjoint(") + expr + wxT(");");
+  } break;
+  case menu_adjoint_mat: {
+    wxString cmd = wxT("adjoint(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_transpose:
-    cmd = wxT("transpose(") + expr + wxT(");");
+  } break;
+  case menu_transpose: {
+    wxString cmd = wxT("transpose(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
+  } break;
   case menu_map_mat: {
     Gen3Wiz *wiz =
       new Gen3Wiz(_("Resulting Matrix name (may be empty):"), _("Function:"),
@@ -7739,7 +7736,7 @@ void wxMaxima::MatrixMenu(wxCommandEvent &event) {
 		  &m_configuration, this, -1, _("Matrix map"));
     // wiz->Centre(wxBOTH);
     if (wiz->ShowModal() == wxID_OK) {
-      cmd = wxEmptyString;
+      wxString cmd = wxEmptyString;
       if (wiz->GetValue1().IsEmpty())
         cmd = wiz->GetValue1() + wxT(":");
       cmd += wxT("matrixmap(") + wiz->GetValue2() + wxT(", ") +
@@ -7753,6 +7750,7 @@ void wxMaxima::MatrixMenu(wxCommandEvent &event) {
     MatDim *wiz = new MatDim(this, -1, &m_configuration, _("Matrix"));
     // wiz->Centre(wxBOTH);
     if (wiz->ShowModal() == wxID_OK) {
+      wxString cmd;
       if (wiz->GetValue0() != wxEmptyString)
         cmd = wiz->GetValue0() + wxT(": ");
       long w, h;
@@ -7866,7 +7864,6 @@ void wxMaxima::DrawMenu(wxCommandEvent &event) {
   else
     expr = "%";
 
-  wxString cmd;
   switch (event.GetId()) {
   case menu_draw_2d: {
     DrawWiz *wiz = new DrawWiz(this, &m_configuration, 2);
@@ -7922,7 +7919,7 @@ void wxMaxima::DrawMenu(wxCommandEvent &event) {
 			       _("Title (Sub- and superscripts as x_{10} or x^{10})"), expr);
     // wiz->Centre(wxBOTH);
     if (wiz->ShowModal() == wxID_OK) {
-      cmd = wxT("title=\"") + wiz->GetValue() + wxT("\"");
+      wxString cmd = wxT("title=\"") + wiz->GetValue() + wxT("\"");
       AddDrawParameter(cmd);
     }
     wiz->Destroy();
@@ -7935,7 +7932,7 @@ void wxMaxima::DrawMenu(wxCommandEvent &event) {
 			       _("Title (Sub- and superscripts as x_{10} or x^{10})"), expr);
     // wiz->Centre(wxBOTH);
     if (wiz->ShowModal() == wxID_OK) {
-      cmd = wxT("key=\"") + wiz->GetValue() + wxT("\"");
+      wxString cmd = wxT("key=\"") + wiz->GetValue() + wxT("\"");
       AddDrawParameter(cmd);
     }
     wiz->Destroy();
@@ -7986,7 +7983,7 @@ void wxMaxima::DrawMenu(wxCommandEvent &event) {
 			       &m_configuration, this, -1, _("Set the grid density."));
     // wiz->Centre(wxBOTH);
     if (wiz->ShowModal() == wxID_OK) {
-      cmd =
+      wxString cmd =
 	wxT("grid=[") + wiz->GetValue1() + "," + wiz->GetValue2() + wxT("]");
       AddDrawParameter(cmd);
     }
@@ -8030,12 +8027,11 @@ void wxMaxima::ListMenu(wxCommandEvent &event) {
     m_worksheet->CloseAutoCompletePopup();
 
   wxString expr = GetDefaultEntry();
-  wxString cmd;
   switch (event.GetId()) {
   case menu_csv2list: {
     CsvImportWiz *wiz = new CsvImportWiz(this, &m_configuration);
     if (wiz->ShowModal() == wxID_OK) {
-      cmd = wxT("read_nested_list(\"") + wiz->GetFilename() + wxT("\", ") +
+      wxString cmd = wxT("read_nested_list(\"") + wiz->GetFilename() + wxT("\", ") +
 	wiz->GetSeparator() + wxT(");");
       MenuCommand(cmd);
     }
@@ -8045,7 +8041,7 @@ void wxMaxima::ListMenu(wxCommandEvent &event) {
   case menu_list2csv: {
     CsvExportWiz *wiz = new CsvExportWiz(this, &m_configuration, _("List"));
     if (wiz->ShowModal() == wxID_OK) {
-      cmd = wxT("write_data(") + wiz->GetMatrix() + wxT(", \"") +
+      wxString cmd = wxT("write_data(") + wiz->GetMatrix() + wxT(", \"") +
 	wiz->GetFilename() + wxT("\", ") + wiz->GetSeparator() + wxT(");");
       MenuCommand(cmd);
     }
@@ -8231,7 +8227,6 @@ void wxMaxima::SimplifyMenu(wxCommandEvent &event) {
     m_worksheet->CloseAutoCompletePopup();
 
   wxString expr = GetDefaultEntry();
-  wxString cmd;
   switch (event.GetId()) {
   case menu_nouns:
     CommandWiz(
@@ -8251,10 +8246,10 @@ void wxMaxima::SimplifyMenu(wxCommandEvent &event) {
                wxEmptyString);
     break;
   case button_ratsimp:
-  case menu_ratsimp:
-    cmd = wxT("ratsimp(") + expr + wxT(");");
+  case menu_ratsimp: {
+    wxString cmd = wxT("ratsimp(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
+  } break;
   case button_radcan:
   case menu_radsimp:
     CommandWiz(
@@ -8270,30 +8265,30 @@ void wxMaxima::SimplifyMenu(wxCommandEvent &event) {
 	       wxEmptyString, wxT("radcan(#1#);"), _("Expression"), expr,
 	       wxEmptyString);
     break;
-  case menu_to_fact:
-    cmd = wxT("makefact(") + expr + wxT(");");
+  case menu_to_fact: {
+    wxString cmd = wxT("makefact(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_to_gamma:
-    cmd = wxT("makegamma(") + expr + wxT(");");
+  } break;
+  case menu_to_gamma: {
+    wxString cmd = wxT("makegamma(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_factcomb:
-    cmd = wxT("factcomb(") + expr + wxT(");");
+  } break;
+  case menu_factcomb: {
+    wxString cmd = wxT("factcomb(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_factsimp:
-    cmd = wxT("minfactorial(") + expr + wxT(");");
+  } break;
+  case menu_factsimp: {
+    wxString cmd = wxT("minfactorial(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_logcontract:
-    cmd = wxT("logcontract(") + expr + wxT(");");
+  } break;
+  case menu_logcontract: {
+    wxString cmd = wxT("logcontract(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_logexpand:
-    cmd = expr + wxT(", logexpand=super;");
+  } break;
+  case menu_logexpand: {
+    wxString cmd = expr + wxT(", logexpand=super;");
     MenuCommand(cmd);
-    break;
+  } break;
   case menu_logexpand_false:
     MenuCommand(wxT("logexpand:false$"));
     break;
@@ -8307,23 +8302,23 @@ void wxMaxima::SimplifyMenu(wxCommandEvent &event) {
     MenuCommand(wxT("logexpand:super$"));
     break;
   case button_expand:
-  case menu_expand:
-    cmd = wxT("expand(") + expr + wxT(");");
+  case menu_expand: {
+    wxString cmd = wxT("expand(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_scsimp:
-    cmd = wxT("scsimp(") + expr + wxT(");");
+  } break;
+  case menu_scsimp: {
+    wxString cmd = wxT("scsimp(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_xthru:
-    cmd = wxT("xthru(") + expr + wxT(");");
+  } break;
+  case menu_xthru: {
+    wxString cmd = wxT("xthru(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
+  } break;
   case button_factor:
-  case menu_factor:
-    cmd = wxT("factor(") + expr + wxT(");");
+  case menu_factor: {
+    wxString cmd = wxT("factor(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
+  } break;
   case menu_expandwrt:
     CommandWiz(_("Expand for variable(s):"), wxEmptyString, wxEmptyString,
                wxT("expandwrt(#1#,#2#);"), wxT("Expression"), wxT("%"),
@@ -8381,13 +8376,14 @@ void wxMaxima::SimplifyMenu(wxCommandEvent &event) {
                wxT("Term numbers"), wxT("x^2=u,u=x^2"),
                _("Comma-separated numbers of the terms to substitute in"));
     break;
-  case menu_opsubst:
+  case menu_opsubst: {
+    wxString cmd;
     if (event.IsChecked())
       cmd = wxT("opsubst:true$");
     else
       cmd = wxT("opsubst:false$");
     MenuCommand(cmd);
-    break;
+  } break;
   case menu_expandwrt_denom:
     CommandWiz(_("Expand for variable(s) including denominator:"),
                wxEmptyString, wxEmptyString,
@@ -8395,83 +8391,84 @@ void wxMaxima::SimplifyMenu(wxCommandEvent &event) {
                wxT("Expression"), wxT("%"), wxEmptyString, wxT("Variable(s)"),
                wxT("x"), _("Comma-separated variables"));
     break;
-  case menu_horner:
-    cmd = wxT("horner(") + expr + wxT(");");
+  case menu_horner: {
+    wxString cmd = wxT("horner(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_collapse:
-    cmd = wxT("collapse(") + expr + wxT(");");
+  } break;
+  case menu_collapse: {
+    wxString cmd = wxT("collapse(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_optimize:
-    cmd = wxT("optimize(") + expr + wxT(");");
+  } break;
+  case menu_optimize: {
+    wxString cmd = wxT("optimize(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
+  } break;
   case menu_mainvar:
     CommandWiz(_("Declare main variable:"), wxEmptyString, wxEmptyString,
                wxT("declare(#1#,mainvar);"), wxT("Variable"), wxT("%"),
                wxEmptyString);
     break;
-  case menu_scanmapfactor:
-    cmd = wxT("scanmap('factor,") + expr + wxT(");");
+  case menu_scanmapfactor: {
+    wxString cmd = wxT("scanmap('factor,") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_gfactor:
-    cmd = wxT("gfactor(") + expr + wxT(");");
+  } break;
+  case menu_gfactor: {
+    wxString cmd = wxT("gfactor(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
+  } break;
   case button_trigreduce:
-  case menu_trigreduce:
-    cmd = wxT("trigreduce(") + expr + wxT(");");
+  case menu_trigreduce: {
+    wxString cmd = wxT("trigreduce(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
+  } break;
   case button_trigsimp:
-  case menu_trigsimp:
-    cmd = wxT("trigsimp(") + expr + wxT(");");
+  case menu_trigsimp: {
+    wxString cmd = wxT("trigsimp(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
+  } break;
   case button_trigexpand:
-  case menu_trigexpand:
-    cmd = wxT("trigexpand(") + expr + wxT(");");
+  case menu_trigexpand: {
+    wxString cmd = wxT("trigexpand(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
+  } break;
   case menu_trigrat:
-  case button_trigrat:
-    cmd = wxT("trigrat(") + expr + wxT(");");
+  case button_trigrat: {
+    wxString cmd = wxT("trigrat(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
+  } break;
   case button_rectform:
-  case menu_rectform:
-    cmd = wxT("rectform(") + expr + wxT(");");
+  case menu_rectform: {
+    wxString cmd = wxT("rectform(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_polarform:
-    cmd = wxT("polarform(") + expr + wxT(");");
+  } break;
+  case menu_polarform: {
+    wxString cmd = wxT("polarform(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_demoivre:
-    cmd = wxT("demoivre(") + expr + wxT(");");
+  } break;
+  case menu_demoivre: {
+    wxString cmd = wxT("demoivre(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_exponentialize:
-    cmd = wxT("exponentialize(") + expr + wxT(");");
+  } break;
+  case menu_exponentialize: {
+    wxString cmd = wxT("exponentialize(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_realpart:
-    cmd = wxT("realpart(") + expr + wxT(");");
+  } break;
+  case menu_realpart: {
+    wxString cmd = wxT("realpart(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_imagpart:
-    cmd = wxT("imagpart(") + expr + wxT(");");
+  } break;
+  case menu_imagpart: {
+    wxString cmd = wxT("imagpart(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_talg:
+  } break;
+  case menu_talg: {
+    wxString cmd;
     if (event.IsChecked())
       cmd = wxT("algebraic:true$");
     else
       cmd = wxT("algebraic:false$");
     MenuCommand(cmd);
-    break;
+  } break;
   case menu_tellrat:
     CommandWiz(_("Enter an equation for rational simplification:"),
                wxEmptyString, wxEmptyString, wxT("tellrat(#1#);"),
@@ -8491,7 +8488,6 @@ void wxMaxima::CalculusMenu(wxCommandEvent &event) {
     m_worksheet->CloseAutoCompletePopup();
 
   wxString expr = GetDefaultEntry();
-  wxString cmd;
   switch (event.GetId()) {
   case menu_change_var:
     CommandWiz(
@@ -8566,10 +8562,10 @@ void wxMaxima::CalculusMenu(wxCommandEvent &event) {
                wxEmptyString, _("Range radius:"), wxT("2"), wxEmptyString);
     break;
   }
-  case menu_continued_fraction:
-    cmd += wxT("cfdisrep(cf(") + expr + wxT("));");
+  case menu_continued_fraction: {
+    wxString cmd = wxT("cfdisrep(cf(") + expr + wxT("));");
     MenuCommand(cmd);
-    break;
+  } break;
   case menu_lcm:
     CommandWiz(_("LCM"), wxEmptyString, wxEmptyString, wxT("lcm(#1#,#2#);"),
                _("Polynomial 1:"), expr, wxEmptyString, _("Polynomial 2:"),
@@ -8685,7 +8681,6 @@ void wxMaxima::PlotMenu(wxCommandEvent &event) {
     m_worksheet->CloseAutoCompletePopup();
 
   wxString expr = GetDefaultEntry();
-  wxString cmd;
   switch (event.GetId()) {
   case button_plot3:
   case gp_plot3: {
@@ -8749,7 +8744,6 @@ void wxMaxima::NumericalMenu(wxCommandEvent &event) {
     m_worksheet->CloseAutoCompletePopup();
 
   wxString expr = GetDefaultEntry();
-  wxString cmd;
   wxString integralSign = wxT("∫");
   if (!m_configuration.FontRendersChar(wxT('∫'), *wxNORMAL_FONT))
     integralSign = wxT("integrate");
@@ -8772,51 +8766,54 @@ void wxMaxima::NumericalMenu(wxCommandEvent &event) {
     m_worksheet->RequestRedraw();
     break;
   }
-  case menu_num_domain:
+  case menu_num_domain: {
+    wxString cmd;
     if (event.IsChecked())
       cmd = wxT("domain:'complex$");
     else
       cmd = wxT("domain:'real$");
     MenuCommand(cmd);
-    break;
-  case menu_to_float:
-    cmd = wxT("float(") + expr + wxT("), numer;");
+  } break;
+  case menu_to_float: {
+    wxString cmd = wxT("float(") + expr + wxT("), numer;");
     MenuCommand(cmd);
-    break;
-  case menu_to_bfloat:
-    cmd = wxT("bfloat(") + expr + wxT(");");
+  } break;
+  case menu_to_bfloat: {
+    wxString cmd = wxT("bfloat(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_to_numer:
-    cmd = expr + wxT(",numer;");
+  } break;
+  case menu_to_numer: {
+    wxString cmd = expr + wxT(",numer;");
     MenuCommand(cmd);
-    break;
-  case menu_rat:
-    cmd = wxT("rat(") + expr + wxT(");");
+  } break;
+  case menu_rat: {
+    wxString cmd = wxT("rat(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_rationalize:
-    cmd = wxT("rationalize(") + expr + wxT(");");
+  } break;
+  case menu_rationalize: {
+    wxString cmd = wxT("rationalize(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_guess_exact_value:
-    cmd = wxT("guess_exact_value(") + expr + wxT(");");
+  } break;
+  case menu_guess_exact_value: {
+    wxString cmd = wxT("guess_exact_value(") + expr + wxT(");");
     MenuCommand(cmd);
-    break;
-  case menu_num_out:
+  } break;
+  case menu_num_out: {
+    wxString cmd;
     if (!event.IsChecked())
       cmd = wxT("numer:false$");
     else
       cmd = wxT("numer:true$");
     MenuCommand(cmd);
-    break;
-  case menu_stringdisp:
+  } break;
+  case menu_stringdisp: {
+    wxString cmd;
     if (!event.IsChecked())
       cmd = wxT("stringdisp:false$");
     else
       cmd = wxT("stringdisp:true$");
     MenuCommand(cmd);
-    break;
+  } break;
   case menu_set_precision:
     CommandWiz(_("Enter new precision for bigfloats:"), wxEmptyString,
                wxEmptyString, wxT("fpprec : #1#$"), _("Precision"), wxT("%"),
@@ -9052,7 +9049,6 @@ void wxMaxima::HelpMenu(wxCommandEvent &event) {
     m_worksheet->CloseAutoCompletePopup();
 
   wxString expr = GetDefaultEntry();
-  wxString cmd;
 
   switch (event.GetId()) {
   case menu_goto_url: {

--- a/src/wxMaximaFrame.cpp
+++ b/src/wxMaximaFrame.cpp
@@ -49,6 +49,7 @@
 #include <wx/stdpaths.h>
 #include <wx/sysopt.h>
 #include <wx/wupdlock.h>
+#include <wx/windowptr.h>
 
 wxMaximaFrame::wxMaximaFrame(wxWindow *parent, int id, wxLocale *locale,
                              const wxString &title, const wxPoint &pos,
@@ -2875,17 +2876,18 @@ wxMaximaFrame::SymbolsPane::SymbolsPane(wxWindow *parent,
 void wxMaximaFrame::SymbolsPane::OnMenu(wxCommandEvent &event) {
   switch (event.GetId()) {
   case menu_additionalSymbols:
-    Gen1Wiz *wiz = new Gen1Wiz(
-			       this, -1, m_configuration, _("Non-builtin symbols"),
-			       _("Unicode symbols:"), m_configuration->SymbolPaneAdditionalChars(),
-			       _("Allows to specify which not-builtin unicode symbols should be "
-				 "displayed in the symbols sidebar along with the built-in symbols."));
+    wxWindowPtr<Gen1Wiz> wiz(new Gen1Wiz(
+                                         this, -1, m_configuration, _("Non-builtin symbols"),
+                                         _("Unicode symbols:"), m_configuration->SymbolPaneAdditionalChars(),
+                                         _("Allows to specify which not-builtin unicode symbols should be "
+                                           "displayed in the symbols sidebar along with the built-in symbols.")));
     // wiz->Centre(wxBOTH);
     wiz->SetLabel1ToolTip(_("Drag-and-drop unicode symbols here"));
-    if (wiz->ShowModal() == wxID_OK)
-      m_configuration->SymbolPaneAdditionalChars(wiz->GetValue());
-    wiz->Destroy();
-    UpdateUserSymbols();
+    wiz->ShowWindowModalThenDo([this,wiz](int retcode) {
+      if (retcode == wxID_OK)
+        m_configuration->SymbolPaneAdditionalChars(wiz->GetValue());
+      UpdateUserSymbols();
+    });
     break;
   }
 }


### PR DESCRIPTION
On macOS, wxMaxima uses a single process to show all document windows.  A consequence is, use of `ShowModal` make background windows unusable.

This PR improves the situation by making various dialogs use `ShowWindowModalThenDo`, which allows other windows to interact with user.