### PR TITLE
fix the wxbuild_info in wxbug_report

### DIFF
--- a/src/wxMathML.lisp
+++ b/src/wxMathML.lisp
@@ -206,7 +206,9 @@ Submit bug reports by following the 'New issue' link on that page."))
   (format t "Please include the following information with your bug report:~%")
   (format t "-------------------------------------------------------------~%")
   ($wxbuild_info)
-  (format t "-------------------------------------------------------------~%"))
+  ;;(format t "-------------------------------------------------------------~%")
+  ;; last line over writes wxbuild_info
+  )
 
 
 ;; The tag that is put around something that might be a variable or function name


### PR DESCRIPTION
the wxbuild_info was overwritten by the last line. I am not sure how to correct it. This is a temp fix.