### PR TITLE
Suppress the false at the end

### DIFF
--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -9275,7 +9275,7 @@ void wxMaxima::HelpMenu(wxCommandEvent &event) {
   }
 
   else if(event.GetId() == EventIDs::menu_bug_report){
-    MenuCommand(wxT("wxbug_report();"));
+    MenuCommand(wxT("wxbug_report()$"));
   }
 
   else if(event.GetId() == EventIDs::menu_help_tutorials){


### PR DESCRIPTION
By putting a $ at the end of the command, we suppress the false output of the command end.
The wxbug_report now works without the false output at the end.