### PR TITLE
A try to make the command line for the build commands shorter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,6 @@ if(Git_FOUND)
                         OUTPUT_VARIABLE WXMAXIMA_GIT_SHORT_HASH
                         OUTPUT_STRIP_TRAILING_WHITESPACE)
         message(STATUS "Building from git development tree, revision: ${WXMAXIMA_GIT_SHORT_HASH}")
-        add_definitions("-DWXMAXIMA_GIT_SHORT_HASH=\"${WXMAXIMA_GIT_SHORT_HASH}\"")
     endif()
 endif()
 

--- a/src/Version.h.cin
+++ b/src/Version.h.cin
@@ -11,3 +11,4 @@
 //#endif
 #endif
 #cmakedefine NANOSVG_CAUSES_NO_LINK_ERROR
+#cmakedefine WXMAXIMA_GIT_SHORT_HASH "@WXMAXIMA_GIT_SHORT_HASH@"


### PR DESCRIPTION
MS Windows is limited to ridiculously short command lines.