### PR TITLE
SystemWiz: fix invalid format specifier

### DIFF
--- a/src/wizards/SystemWiz.cpp
+++ b/src/wizards/SystemWiz.cpp
@@ -64,7 +64,7 @@ void SysWiz::do_layout() {
   wxBoxSizer *sizer_1 = new wxBoxSizer(wxHORIZONTAL);
   wxStaticText *text;
   for (long i = 1; i <= m_size; i++) {
-    text = new wxStaticText(this, -1, wxString::Format(_("Equation %d:"), i));
+    text = new wxStaticText(this, -1, wxString::Format(_("Equation %ld:"), i));
     grid_sizer_2->Add(text, 0, wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL | wxALL,
                       5);
     grid_sizer_2->Add(m_inputs[static_cast<size_t>(i) - 1], 0, wxALL, 5);


### PR DESCRIPTION
Otherwise, an assertion fails, when trying to solve a linear system (Equations > Solve symbolically > Solve Linear System...):

> /usr/include/wx-3.2/wx/strvararg.h(484): assert "(argtype & (wxFormatStringSpecifier<T>::value)) == argtype" failed in wxArgNormalizer(): format specifier doesn't match argument type