### PR TITLE
Don't allow zero for autoSaveMinutes.

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -662,6 +662,8 @@ void Configuration::ReadConfig() {
     config->Read(wxS("showAllDigits"), &m_showAllDigits);
     config->Read(wxS("lineBreaksInLongNums"), &m_lineBreaksInLongNums);
     config->Read(wxS("autoSaveMinutes"), &m_autoSaveMinutes);
+    if (m_autoSaveMinutes <= 0)
+      m_autoSaveMinutes = 3;
     config->Read(wxS("wrapLatexMath"), &m_wrapLatexMath);
     config->Read(wxS("allowNetworkHelp"), &m_allowNetworkHelp);
     config->Read(wxS("exportContainsWXMX"), &m_exportContainsWXMX);


### PR DESCRIPTION
Somehow I ended up with `autoSaveMinutes=0` in my wxMaxima.conf. And because `m_autoSaveTimer` had an interval of 0, wxMaxima would barely run because it was spending all its time in that timer's handler.

On Linux.

```
$ wx-config --selected-config
gtk3-unicode-3.2
```