### PR TITLE
Custom dynamic memory limit

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -801,6 +801,8 @@ void Configuration::ReadConfig() {
   config->Read("greekSidebar_Show_mu", &m_greekSidebar_Show_mu);
   config->Read("symbolPaneAdditionalChars", &m_symbolPaneAdditionalChars);
   config->Read("parameters", &m_maximaParameters);
+  config->Read("enableCustomDynamicMemory", &m_maximaEnableCustomDynamicMemory);
+  config->Read("customDynamicMemory", &m_maximaCustomDynamicMemory);
   config->Read("autodetectHelpBrowser", &m_autodetectHelpBrowser);
   config->Read(wxS("useInternalHelpBrowser"), &m_useInternalHelpBrowser);
   config->Read(wxS("singlePageManual"), &m_singlePageManual);
@@ -1617,6 +1619,8 @@ void Configuration::WriteStyles(wxConfigBase *config) {
   config->Write(wxS("printBrackets"), m_printBrackets);
   config->Write(wxS("autodetectMaxima"), m_autodetectMaxima);
   config->Write(wxS("parameters"), m_maximaParameters);
+  config->Write(wxS("enableCustomDynamicMemory"), m_maximaEnableCustomDynamicMemory);
+  config->Write(wxS("customDynamicMemory"), m_maximaCustomDynamicMemory);
   config->Write(wxS("maxima"), m_maximaUserLocation);
   config->Write(wxS("autodetectHelpBrowser"), m_autodetectHelpBrowser);
   if (OfferInternalHelpBrowser())

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -760,6 +760,15 @@ public:
   //! The parameters we pass to the maxima binary
   void MaximaParameters(wxString parameters){m_maximaParameters = std::move(parameters);}
 
+  //! Dynamic memory parameter to maxima binary
+  bool MaximaEnableCustomDynamicMemory() const {return m_maximaEnableCustomDynamicMemory;}
+  //! The dynamic memory parameter for the maxima binary
+  void MaximaEnableCustomDynamicMemory(bool enable) {m_maximaEnableCustomDynamicMemory = enable;}
+  //! Dynamic memory parameter to maxima binary if MaximaEnableCustomDynamicMemory() is true. Otherwise this parameter is ignored
+  int MaximaCustomDynamicMemory() const {return m_maximaCustomDynamicMemory;}
+  //! The dynamic memory parameter for the maxima binary if MaximaEnableCustomDynamicMemory() is true. Otherwise this parameter is ignored
+  void MaximaCustomDynamicMemory(int memory) {m_maximaCustomDynamicMemory = memory;}
+
   //! The auto-detected maxima location
   static wxString MaximaDefaultLocation();
 
@@ -1200,6 +1209,8 @@ private:
   bool m_clipToDrawRegion = true;
   bool m_outdated;
   wxString m_maximaParameters;
+  bool m_maximaEnableCustomDynamicMemory{false};
+  int m_maximaCustomDynamicMemory{1000};
   bool m_keepPercent;
   bool m_restartOnReEvaluation;
   wxString m_fontCMRI, m_fontCMSY, m_fontCMEX, m_fontCMMI, m_fontCMTI;

--- a/src/dialogs/ConfigDialogue.cpp
+++ b/src/dialogs/ConfigDialogue.cpp
@@ -329,6 +329,11 @@ void ConfigDialogue::SetCheckboxValues() {
                                    _("Enter the path to the Maxima executable."));
   m_additionalParameters->SetToolTip(_("Additional parameters for Maxima"
                                        " (e.g. -l clisp)."));
+
+  m_enableDynamicMemorySpace->SetToolTip(_("If enabled the value in the spinbox is used new memory limit for maxima "
+                                           "equal to: -X \"--dynamic-space-size <value>\""));
+  m_dynamicMemorySpace->SetToolTip(_("The new memory limit for maxima in MB"));
+
   m_mathJaxURL->SetToolTip(
                            _("The URL MathJaX.js should be downloaded from by our HTML export."));
   m_texPreamble->SetToolTip(_("Additional commands to be added to the preamble "
@@ -484,6 +489,9 @@ void ConfigDialogue::SetCheckboxValues() {
   m_maximaUserLocation->SetValue(configuration->MaximaUserLocation());
 
   m_additionalParameters->SetValue(configuration->MaximaParameters());
+  m_enableDynamicMemorySpace->SetValue(configuration->MaximaEnableCustomDynamicMemory());
+  m_dynamicMemorySpace->SetValue(configuration->MaximaCustomDynamicMemory());
+
   m_usesvg->SetValue(configuration->UseSVG());
 
   m_TeXExponentsAfterSubscript->SetValue(
@@ -1333,6 +1341,7 @@ wxWindow *ConfigDialogue::CreateMaximaPanel() {
 
   wxFlexGridSizer *sizer = new wxFlexGridSizer(5, 2, 0, 0);
   wxFlexGridSizer *sizer2 = new wxFlexGridSizer(6, 2, 0, 0);
+  wxFlexGridSizer *dynamicMemory = new wxFlexGridSizer(1, 3, 0, 0);
   wxBoxSizer *vsizer = new wxBoxSizer(wxVERTICAL);
   panel->SetSizer(vsizer);
   wxStaticBoxSizer *invocationSizer =
@@ -1496,6 +1505,27 @@ wxWindow *ConfigDialogue::CreateMaximaPanel() {
   configSizer->Add(
                    m_additionalParameters,
                    wxSizerFlags().Border(wxRIGHT, 10 * GetContentScaleFactor()).Expand());
+
+  configSizer->Add(10 * GetContentScaleFactor(), 10 * GetContentScaleFactor());
+
+  dynamicMemory->Add(new wxStaticText(
+      configSizer->GetStaticBox(), wxID_ANY,
+      _("Overwrite Maxima Default Memory [MB]: ")), wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT | wxALL, 20);
+
+  m_enableDynamicMemorySpace = new wxCheckBox(
+      configSizer->GetStaticBox(), wxID_ANY, _(""), wxDefaultPosition);
+  dynamicMemory->Add(
+      m_enableDynamicMemorySpace,
+      wxSizerFlags().Border(wxRIGHT, 10 * GetContentScaleFactor()).Expand());
+
+  m_dynamicMemorySpace = new wxSpinCtrl(configSizer->GetStaticBox(), wxID_ANY, _(""), wxDefaultPosition);
+  m_dynamicMemorySpace->SetRange(1000, std::numeric_limits<int>::max());
+  m_dynamicMemorySpace->SetValue(1000);
+  dynamicMemory->Add(
+      m_dynamicMemorySpace,
+      wxSizerFlags().Border(wxRIGHT, 10 * GetContentScaleFactor()).Expand());
+
+  configSizer->Add(dynamicMemory);
 
   configSizer->Add(10 * GetContentScaleFactor(), 10 * GetContentScaleFactor());
   m_maximaEnvVariables = new wxGrid(configSizer->GetStaticBox(), wxID_ANY);
@@ -2129,6 +2159,8 @@ void ConfigDialogue::WriteSettings() {
     configuration->AutodetectHelpBrowser(m_autodetectHelpBrowser->GetValue());
   }
   configuration->MaximaParameters(m_additionalParameters->GetValue());
+  configuration->MaximaEnableCustomDynamicMemory(m_enableDynamicMemorySpace->GetValue());
+  configuration->MaximaCustomDynamicMemory(m_dynamicMemorySpace->GetValue());
   configuration->SetMatchParens(m_matchParens->GetValue());
   configuration->ShowMatchingParens(m_showMatchingParens->GetValue());
   configuration->ShowLength(m_showLength->GetSelection());

--- a/src/dialogs/ConfigDialogue.cpp
+++ b/src/dialogs/ConfigDialogue.cpp
@@ -1510,7 +1510,7 @@ wxWindow *ConfigDialogue::CreateMaximaPanel() {
 
   dynamicMemory->Add(new wxStaticText(
       configSizer->GetStaticBox(), wxID_ANY,
-      _("Overwrite Maxima Default Memory [MB]: ")), wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT | wxALL, 20);
+      _("Overwrite Maxima Default Memory Limit [MB]: ")), wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT | wxALL, 20);
 
   m_enableDynamicMemorySpace = new wxCheckBox(
       configSizer->GetStaticBox(), wxID_ANY, _(""), wxDefaultPosition);

--- a/src/dialogs/ConfigDialogue.h
+++ b/src/dialogs/ConfigDialogue.h
@@ -271,6 +271,8 @@ protected:
   wxCheckBox *m_autoSave;
   wxButton *m_wxMathMLBrowse;
   wxTextCtrl *m_additionalParameters;
+  wxCheckBox *m_enableDynamicMemorySpace;
+  wxSpinCtrl *m_dynamicMemorySpace;
   wxTextCtrl *m_mathJaxURL;
   wxChoice *m_language;
   wxTextCtrl *m_symbolPaneAdditionalChars;

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -4850,6 +4850,9 @@ wxString wxMaxima::GetCommand(bool params) {
   } else {
     command = wxS("\"") + command + wxS("\"");
   }
+  if (m_configuration.MaximaEnableCustomDynamicMemory()) {
+      command = command + wxS(" -X \"--dynamic-space-size ") + wxString::Format(wxT("%i"), m_configuration.MaximaCustomDynamicMemory()) + wxS("\"");
+  }
   wxString extraMaximaArgs = ExtraMaximaArgs();
   if (!extraMaximaArgs.IsEmpty())
     {


### PR DESCRIPTION
Add possibility to easily overwrite the maxima dynamic memory limit in the gui

![grafik](https://github.com/user-attachments/assets/885da17b-aaf4-4ab5-a8d6-8b985f655d8e)

Currently the label is not vertically aligned. How can I achive this?