### PR TITLE
remove a compiler warning

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -365,7 +365,7 @@ bool MyApp::OnInit() {
     if (!freopen("CON", "w", stderr)) wxLogMessage(_("Re-opening STDERR failed."));
     if (!freopen("CON", "r", stdin)) wxLogMessage(_("Re-opening STDIN failed."));
 #endif
-    m_logChain = new wxLogChain(new wxLogStderr);
+    m_logChain = std::unique_ptr<wxLogChain>(new wxLogChain(new wxLogStderr));
   }
 
   if (cmdLineParser.Found(wxS("debug")))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -365,7 +365,7 @@ bool MyApp::OnInit() {
     if (!freopen("CON", "w", stderr)) wxLogMessage(_("Re-opening STDERR failed."));
     if (!freopen("CON", "r", stdin)) wxLogMessage(_("Re-opening STDIN failed."));
 #endif
-    wxLogChain *logChain = new wxLogChain(new wxLogStderr);
+    m_logChain = new wxLogChain(new wxLogStderr);
   }
 
   if (cmdLineParser.Found(wxS("debug")))

--- a/src/wxMaxima.h
+++ b/src/wxMaxima.h
@@ -874,6 +874,7 @@ public:
   virtual void MacOpenFile(const wxString &file);
 
 private:
+  std::unique_ptr<wxLogChain> m_logChain;
   static std::vector<wxProcess *> m_wxMaximaProcesses;
 #if wxUSE_ON_FATAL_EXCEPTION && wxUSE_CRASHREPORT
   void GenerateDebugReport(wxDebugReport::Context ctx);


### PR DESCRIPTION
Removed a compiler warning by switching to automatic pointers that issue a free() when appropriate.