### PR TITLE
For a one-way selection

### DIFF
--- a/src/cells/EditorCell.cpp
+++ b/src/cells/EditorCell.cpp
@@ -2472,8 +2472,8 @@ bool EditorCell::IsPointInSelection(wxPoint point) {
     positionOfCaret++;
   }
   positionOfCaret = std::min(positionOfCaret, text.Length());
-  return ((SelectionStart() <= positionOfCaret) &&
-           (positionOfCaret < SelectionEnd()));
+  return ((SelectionLeft() <= positionOfCaret) &&
+           (positionOfCaret < SelectionRight()));
 }
 
 wxString EditorCell::DivideAtCaret() {


### PR DESCRIPTION
When selecting from right to left, the variables are reversed.