### PR TITLE
provide a relevant OSDescription

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -158,6 +158,7 @@ set(SOURCE_FILES
     wxMaximaFrame.cpp
     wxMaximaIcon.cpp
     wxMaximaArtProvider.cpp
+    wxMaximaOSDescription.cpp
 )
 
 if(NOT CYGWIN)

--- a/src/dialogs/AboutDialog.cpp
+++ b/src/dialogs/AboutDialog.cpp
@@ -27,6 +27,7 @@
 
 #include "AboutDialog.h"
 #include "../wxMaximaIcon.h"
+#include "../wxMaximaOSDescription.h"
 #include <wx/wx.h>
 #include <wx/button.h>
 #include <wx/dialog.h>
@@ -55,6 +56,9 @@ AboutDialog::AboutDialog(wxWindow *WXUNUSED(parent), Configuration *config) {
         }
       else
         description += _("\nNot connected to Maxima.");
+
+      description += wxString::Format(_("\n\nOperating System: %s\n"),
+        wxMaximaOperatingSystemLongDescription());
 
       info.SetIcon(wxMaximaIcon());
       info.SetDescription(description);

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -81,6 +81,7 @@
 #include "wizards/SumWiz.h"
 #include "wizards/SystemWiz.h"
 #include "dialogs/TipOfTheDay.h"
+#include "wxMaximaOSDescription.h"
 #include "Version.h"
 #include "WXMformat.h"
 #include "WXMXformat.h"
@@ -11004,6 +11005,11 @@ void wxMaxima::InsertMenu(wxCommandEvent &event) {
 }
 
 void wxMaxima::ResetTitle(bool saved, bool force) {
+#ifndef __WXOSX__
+  static wxString TitlePreambleSep = wxString::Format(
+                    _("wxMaxima %s (%s) "), WXMAXIMA_VERSION,
+                    wxMaximaOperatingSystemDescription());
+#endif
   SetRepresentedFilename(GetWorksheet()->m_currentFile);
   OSXSetModified((saved != m_fileSaved) || (force));
 
@@ -11012,15 +11018,9 @@ void wxMaxima::ResetTitle(bool saved, bool force) {
     if (GetWorksheet()->m_currentFile.Length() == 0) {
 #ifndef __WXOSX__
       if (saved)
-        SetTitle(wxString::Format(
-                                  _("wxMaxima %s (%s) "), WXMAXIMA_VERSION,
-                                  wxPlatformInfo::Get().GetOperatingSystemDescription()) +
-                 _("[ unsaved ]"));
+        SetTitle(TitlePreambleSep + _("[ unsaved ]"));
       else
-        SetTitle(wxString::Format(
-                                  _("wxMaxima %s (%s) "), WXMAXIMA_VERSION,
-                                  wxPlatformInfo::Get().GetOperatingSystemDescription()) +
-                 _("[ unsaved* ]"));
+        SetTitle(TitlePreambleSep + _("[ unsaved* ]"));
 #endif
     } else {
       wxString name, ext;
@@ -11028,14 +11028,10 @@ void wxMaxima::ResetTitle(bool saved, bool force) {
                             &ext);
 #ifndef __WXOSX__
       if (m_fileSaved)
-        SetTitle(wxString::Format(
-                                  _("wxMaxima %s (%s) "), WXMAXIMA_VERSION,
-                                  wxPlatformInfo::Get().GetOperatingSystemDescription()) +
+        SetTitle(TitlePreambleSep +
                  wxS(" [ ") + name + wxS(".") + ext + wxS(" ]"));
       else
-        SetTitle(wxString::Format(
-                                  _("wxMaxima %s (%s) "), WXMAXIMA_VERSION,
-                                  wxPlatformInfo::Get().GetOperatingSystemDescription()) +
+        SetTitle(TitlePreambleSep +
                  wxS(" [ ") + name + wxS(".") + ext + wxS("* ]"));
 #else
       SetTitle(name + wxS(".") + ext);

--- a/src/wxMaximaFrame.cpp
+++ b/src/wxMaximaFrame.cpp
@@ -42,6 +42,7 @@
 #include "wizards/Gen1Wiz.h"
 #include "sidebars/GreekSidebar.h"
 #include "sidebars/UnicodeSidebar.h"
+#include "wxMaximaOSDescription.h"
 #include "wxMaximaIcon.h"
 #include <wx/artprov.h>
 #include <wx/config.h>
@@ -187,7 +188,7 @@ wxMaximaFrame::wxMaximaFrame(wxWindow *parent, int id,
 #ifndef __WXOSX__
   SetTitle(
            wxString::Format(_("wxMaxima %s (%s) "), wxS(WXMAXIMA_VERSION),
-                            wxPlatformInfo::Get().GetOperatingSystemDescription()) +
+                            wxMaximaOperatingSystemDescription()) +
            _("[ unsaved ]"));
 #else
   SetTitle(_("untitled"));

--- a/src/wxMaximaOSDescription.cpp
+++ b/src/wxMaximaOSDescription.cpp
@@ -1,0 +1,60 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode:
+// nil -*-
+//
+//  Copyright (C) 2026 Jerome Benoit <jgmbenoit@rezozer.net>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+/*! \file
+  This file defines the function wxMaximaOperatingSystemDescription.
+*/
+
+#include "wxMaximaOSDescription.h"
+#include <wx/utils.h>
+
+wxString wxMaximaOperatingSystemDescription() {
+  static wxString OSDescription;
+  if (OSDescription.IsEmpty()) {
+#if __LINUX__
+    wxLinuxDistributionInfo ldi = wxGetLinuxDistributionInfo();
+    OSDescription = !ldi.Id.IsEmpty()?
+          wxString::Format("%s %s",ldi.Id,
+             !ldi.Release.IsEmpty()?ldi.Release:
+             !ldi.CodeName.IsEmpty()?ldi.CodeName.Capitalize():"no-codename-given")
+          :wxGetOsDescription();
+#else
+    OSDescription = wxGetOsDescription();
+#endif
+    }
+  return OSDescription;
+}
+
+wxString wxMaximaOperatingSystemLongDescription() {
+  static wxString OSLongDescription;
+  if (OSLongDescription.IsEmpty()) {
+#if __LINUX__
+    wxLinuxDistributionInfo ldi = wxGetLinuxDistributionInfo();
+    OSLongDescription = !ldi.Description.IsEmpty()?
+          ldi.Description
+          :wxGetOsDescription();
+#else
+    OSLongDescription = wxGetOsDescription();
+#endif
+    }
+  return OSLongDescription;
+}

--- a/src/wxMaximaOSDescription.h
+++ b/src/wxMaximaOSDescription.h
@@ -1,0 +1,36 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+//
+//  Copyright (C) 2026 Jerome Benoit <jgmbenoit@rezozer.net>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+/*! \file
+  This file declares a function that returns a relevant description of the
+  Operating System
+*/
+
+#ifndef WXMAXIMAOSDESCRIPTION_H
+#define WXMAXIMAOSDESCRIPTION_H
+
+#include <wx/string.h>
+
+//! The wxMaxima way to describe the Operating System.
+wxString wxMaximaOperatingSystemDescription();
+wxString wxMaximaOperatingSystemLongDescription();
+
+#endif // WXMAXIMAOSDESCRIPTION_H


### PR DESCRIPTION
This patch introduces material to provide the pre-title in the top bar with a relevant Operating-System description. It focuses on Linux distributions, but other OS famillies can be easily introduced. Let me illustrate the move. In an updated Debian Trixie environment, the former description would be 'Linux 6.18.15+deb13-amd64 x86_64': first, this is long and rather technical; second, it eats space that can be given to the worksheet name instead. This patch gives as description 'Debian 13' ('Debian Forky' in the current Forky/Sid environment): this is shorter and more user-friendly; second, it offers more space to the worksheet name. However, as a full description of the OS might be helpful otherwise, this patch introduces a `Operating System' entry in the `About Window'.