### PR TITLE
CI: native Windows-on-Arm (aarch64) build + unit tests

### DIFF
--- a/.github/workflows/compile_windows_arm.yml
+++ b/.github/workflows/compile_windows_arm.yml
@@ -1,0 +1,82 @@
+name: compile_windows_arm
+
+# Native Windows-on-Arm (aarch64) build -- PHASE 1: bring-up only.
+#
+# Purpose is twofold (see discussion): produce a Windows ARM64 binary AND
+# exercise wxMaxima's own code on a native aarch64 toolchain, which tends to
+# surface latent portability bugs (word-size/pointer assumptions, alignment,
+# endianness-free but ABI-sensitive code) that the x86 builds never hit.
+#
+# This is deliberately a SEPARATE workflow from compile_windows.yml so that a
+# broken ARM experiment can never block or corrupt the proven x86 MinGW release
+# job. It builds and runs the self-contained C++ unit tests only; it does NOT
+# package an installer and does NOT attach anything to a release yet. Once this
+# is reliably green we add packaging (bundling the clang/wx runtime DLLs) and,
+# after that, the release-attach on a Version tag -- mirroring the x86 job.
+#
+# Toolchain: GitHub's native "windows-11-arm" runner (GA + free for public
+# repos since 2025-08) + MSYS2's CLANGARM64 environment. wxWidgets is taken
+# from MSYS2's PREBUILT clang-aarch64 3.3 package rather than built from source,
+# so the very first run tests our code, not a from-scratch wx build. (A static
+# from-source wx build, matching the x86 installer, is a later, optional phase.)
+
+on: [push]
+
+permissions:
+  contents: read
+
+jobs:
+  compile_windows_arm:
+    name: Compile using CLANGARM64
+    runs-on: windows-11-arm
+    timeout-minutes: 60
+    # MSYS2 shells emit a normal (non-fatal) message on first login; make bash
+    # strict so a real error still fails the step.
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - name: Checkout wxMaxima
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 15
+
+      - name: Set up MSYS2 (CLANGARM64)
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: CLANGARM64
+          update: true
+          # Prebuilt clang-aarch64 toolchain + build tools + wxWidgets 3.3.
+          # The wxwidgets3.3-msw package pulls in its own runtime deps, and
+          # ships wx-config in the CLANGARM64 prefix so CMake's FindwxWidgets
+          # resolves it without hints.
+          install: >-
+            git
+            mingw-w64-clang-aarch64-clang
+            mingw-w64-clang-aarch64-cmake
+            mingw-w64-clang-aarch64-ninja
+            mingw-w64-clang-aarch64-pkgconf
+            mingw-w64-clang-aarch64-wxwidgets3.3-msw
+
+      - name: Configure wxMaxima
+        # No -DMAXIMA: there is no native aarch64 Windows Maxima, so we do not
+        # register the Maxima-driven integration tests (they would hang waiting
+        # for a CAS that never connects). WXM_UNIT_TESTS=YES still registers the
+        # self-contained C++ unit tests, which need neither Maxima nor a display.
+        run: |
+            mkdir -p build
+            cd build
+            export CXXFLAGS="-Wall -Wextra"
+            cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DWXM_UNIT_TESTS=YES ..
+
+      - name: Compile wxMaxima
+        run: cmake --build build
+
+      - name: Run unit tests
+        # "unittest" label = the self-contained C++ tests. MenuHelpString and
+        # ButtonWrapSizer are excluded on x86 MinGW because their standalone
+        # harnesses hang there; whether that reproduces under CLANGARM64 is
+        # unknown, so keep the exclusion for now and revisit once the rest is
+        # green (dropping it is a one-line follow-up if they pass here).
+        run: ctest --test-dir build -L unittest -E "MenuHelpString|ButtonWrapSizer" --output-on-failure

--- a/.github/workflows/compile_windows_arm.yml
+++ b/.github/workflows/compile_windows_arm.yml
@@ -68,7 +68,15 @@ jobs:
             mkdir -p build
             cd build
             export CXXFLAGS="-Wall -Wextra"
-            cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DWXM_UNIT_TESTS=YES ..
+            # -DwxWidgets_USE_STATIC=ON is REQUIRED: MSYS2's clang-aarch64 wx
+            # package ships static archives (libwx_*-3.3.a), but CMake's
+            # FindwxWidgets otherwise asks wx-config for a *shared* link, which
+            # defines WXUSINGDLL and marks every wx symbol __declspec(dllimport).
+            # Linking those dllimport references against the static archives
+            # fails ("... is not an import library"). Forcing static makes
+            # wx-config drop WXUSINGDLL so both sides agree -- same as the x86
+            # MinGW job (-DwxWidgets_USE_STATIC=true).
+            cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DWXM_UNIT_TESTS=YES -DwxWidgets_USE_STATIC=ON ..
 
       - name: Compile wxMaxima
         run: cmake --build build


### PR DESCRIPTION
Adds a native Windows-on-Arm (aarch64) CI job — **phase 1: build + unit tests only**.

## What
New workflow `.github/workflows/compile_windows_arm.yml` running on GitHub's native `windows-11-arm` runner using MSYS2's `CLANGARM64` environment and the prebuilt clang-aarch64 wxWidgets 3.3 package. It builds wxMaxima and runs the self-contained C++ unit tests.

Kept as a **separate** workflow from `compile_windows.yml` so this can never block or corrupt the proven x86 MinGW release job.

## Why separate / why phase 1 only
The immediate value is twofold: produce an aarch64 build path, and exercise wxMaxima's own code on a native aarch64 toolchain (which tends to flush out latent portability bugs). This PR deliberately stops at build + unit tests — no packaging, no release attach — so the aarch64 CI guard can land now and packaging can be iterated separately.

## Results (CI-verified)
- Runner + MSYS2 CLANGARM64 setup + `FindwxWidgets` locating the prebuilt wx — all worked with no hints.
- **Every wxMaxima source compiled cleanly on aarch64** — no code portability bugs surfaced.
- **33/33 unit tests pass** on the `windows-11-arm` runner.

The only fix bring-up needed was `-DwxWidgets_USE_STATIC=ON`: MSYS2's clang-aarch64 wx ships static archives, but `FindwxWidgets` defaulted to a shared link (`WXUSINGDLL`/`dllimport`) that can't resolve against them. Forcing static makes headers and libs agree — the same as the x86 MinGW job.

## Not in scope (follow-ups)
- Phase 2: package an installer (bundle the remaining runtime DLLs) + attach an `-arm64` asset to the release on a `Version` tag + NEWS.md entry.
- Phase 3 (later): build wx from source statically to match the x86 self-contained installer.

No Maxima-driven integration tests: there is no native aarch64 Windows Maxima, so those are intentionally not registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)