### PR TITLE
Windows dark mode: apply the appearance at startup so the native UI follows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Current development version
 
+- On Windows, switching to dark mode now also darkens the native user
+  interface (menus, toolbars, sidebars, dialogs), not just the worksheet.
+  wxWidgets can only enable this during application startup, so the saved
+  appearance is now applied before the main window is created. (Toggling the
+  appearance while wxMaxima is running may still need a restart to fully
+  re-theme the native controls -- a Windows limitation.)
 - Native Windows-on-Arm (ARM64) builds: each release now includes a
   self-contained portable ZIP for ARM64 Windows, built natively with the
   clang-aarch64 toolchain. Unzip it and run wxmaxima.exe -- no installer and

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -570,6 +570,22 @@ bool MyApp::OnInit() {
   } else
     wxConfig::Set(new wxConfig(wxS("wxMaxima")));
 
+  // Pull the light/dark appearance lever now -- before the first top-level
+  // window is created further down -- so the native chrome (menus, toolbars,
+  // sidebars, dialogs) follows it on Windows, where wxApp::SetAppearance() only
+  // affects the chrome when called during startup. The runtime call in
+  // wxMaxima::ConfigChanged() stays for macOS/GTK, which can switch live. Read
+  // the saved setting straight from the just-installed config (mirrors
+  // Configuration's own read: default followSystem, clamp to the valid range).
+  {
+    long appearance = static_cast<long>(Configuration::Appearance::followSystem);
+    wxConfig::Get()->Read(wxS("appearance"), &appearance);
+    if (appearance < 0 ||
+        appearance > static_cast<long>(Configuration::Appearance::followSystem))
+      appearance = static_cast<long>(Configuration::Appearance::followSystem);
+    ApplyAppearanceToApp(static_cast<Configuration::Appearance>(appearance));
+  }
+
   if (cmdLineParser.Found(wxS("logtostderr"))) {
 #ifdef __WXMSW__
     // Windows *GUI applications* do not have stderr (and stdout/stdin) assigned.

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -152,7 +152,14 @@ wxDECLARE_APP(MyApp);
 // worksheet's light/dark appearance. Only wxWidgets 3.3+ can drive the OS
 // appearance from inside the app; on older wx this is a no-op (the worksheet is
 // themed via its style set, the chrome stays whatever the OS gives us).
-static void ApplyAppearanceToApp(Configuration::Appearance appearance) {
+//
+// On Windows the native chrome only honours this when it runs during startup,
+// before the first top-level window exists: a later SetAppearance() returns
+// AppearanceResult::CannotChange and leaves the chrome untouched (which is why
+// only the worksheet used to switch). It is therefore also called early from
+// MyApp::OnInit(), not just from ConfigChanged() at runtime. Declared in
+// wxMaxima.h so OnInit() can reach it.
+void ApplyAppearanceToApp(Configuration::Appearance appearance) {
 #if wxCHECK_VERSION(3, 3, 0)
   if (!wxTheApp)
     return;

--- a/src/wxMaxima.h
+++ b/src/wxMaxima.h
@@ -691,6 +691,15 @@ private:
   MaximaOutputAppender m_outputAppender;
 };
 
+//! Apply the chosen light/dark appearance to the native application chrome
+//! (menus, toolbars, sidebars, dialogs) via wxApp::SetAppearance().
+//!
+//! No-op before wxWidgets 3.3. On Windows the native chrome only picks up the
+//! appearance when this is called during startup, before the first top-level
+//! window is created -- so it must run early in MyApp::OnInit() and not only
+//! from wxMaxima::ConfigChanged() at runtime.
+void ApplyAppearanceToApp(Configuration::Appearance appearance);
+
 #if wxUSE_DRAG_AND_DROP
 
 // cppcheck-suppress noConstructor


### PR DESCRIPTION
## Report
On Windows, switching to dark mode only darkened the **worksheet**; the native chrome (menus, toolbars, sidebars, dialogs) stayed light.

## Cause
The appearance lever `wxApp::SetAppearance()` (via `ApplyAppearanceToApp()`) was only called from `wxMaxima::ConfigChanged()` — at **runtime**, after the main frame already exists. On Windows, wxWidgets can only enable dark mode for the native chrome **during application startup**; a later `SetAppearance()` returns `AppearanceResult::CannotChange` and leaves the chrome untouched. The worksheet flipped anyway because it themes itself through its own style set, independent of the OS appearance. (macOS/GTK switch live, which is why the report was Windows-only.)

## Fix
Pull the lever early in `MyApp::OnInit()`, reading the saved `appearance` setting straight from the just-installed config, **before the first top-level window is created**. `ApplyAppearanceToApp()` is un-`static`'d and declared in `wxMaxima.h` so `OnInit()` can reach it. The runtime `ConfigChanged()` call is kept for macOS/GTK.

## Known limitation
Even with this fix, *toggling* the appearance while wxMaxima is running on Windows may not fully re-theme already-created native controls — a wxWidgets/Windows limitation likely needing a restart for a complete switch. Launching in the saved appearance now themes the whole UI correctly. NEWS.md notes this.

## Verification
- Builds and links cleanly (verified locally on Linux/wxGTK; the `#if wxCHECK_VERSION(3,3,0)` guard keeps it a no-op on older wx).
- The **Windows behaviour cannot be verified here** (no Windows box) — needs confirmation on a Windows build that the chrome now themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)