### PR TITLE
snap: fix the broken core24 build; add snap+appdata CI; refresh release checklist

### DIFF
--- a/.github/workflows/build_snap.yml
+++ b/.github/workflows/build_snap.yml
@@ -1,0 +1,36 @@
+name: build_snap
+
+# Builds the Snap package from snap/snapcraft.yaml so that breakage is caught
+# in CI instead of only when the Snap Store (or a maintainer) tries to build a
+# release. The snap silently rotted once already: base was bumped to core24
+# (Ubuntu 24.04) in 2024 while the build/stage packages stayed at wxWidgets 3.0,
+# which no longer exists on noble -- nothing in CI noticed because the snap was
+# never built here. This job closes that gap and uploads the built .snap as an
+# artifact for inspection / manual test-install.
+
+on: [push]
+
+permissions:
+  contents: read
+
+jobs:
+  build_snap:
+    name: Build the snap
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout wxMaxima
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 15
+
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: build
+
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wxmaxima-snap
+          path: ${{ steps.build.outputs.snap }}
+          if-no-files-found: error

--- a/.github/workflows/compile_ubuntu.yml
+++ b/.github/workflows/compile_ubuntu.yml
@@ -25,7 +25,13 @@ jobs:
       - name: install_packages
         run: |
              sudo apt-get update
-             sudo apt-get install appstream cmake desktop-file-utils doxygen gettext gnuplot gnuplot-x11 graphviz libwxgtk3.2-dev libwxgtk-webview3.2-dev maxima maxima-share maxima-doc netcat-openbsd ninja-build pandoc xvfb at-spi2-core dbus dpkg-dev po4a rpmlint lintian weston rpm
+             sudo apt-get install appstream appstream-util cmake desktop-file-utils doxygen gettext gnuplot gnuplot-x11 graphviz libwxgtk3.2-dev libwxgtk-webview3.2-dev maxima maxima-share maxima-doc netcat-openbsd ninja-build pandoc xvfb at-spi2-core dbus dpkg-dev po4a rpmlint lintian weston rpm
+      - name: validate_appdata
+        # Release-blocker gate, previously a manual checklist step: a malformed
+        # appdata file breaks the flatpak/appImage/appstream builders. Catch it
+        # in CI on every push instead of discovering it at release time.
+        run: |
+             appstream-util validate data/io.github.wxmaxima_developers.wxMaxima.appdata.xml
       - name: configure
         run: |
              export CXXFLAGS="-Wall -Wextra -ansi -Werror -Wpedantic"

--- a/ReleaseChecklist.md
+++ b/ReleaseChecklist.md
@@ -4,39 +4,61 @@
 
 <https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository>
 
-## wxMaxima (additional) steps:
+## What CI now does automatically
 
-- Does the current git version compile? Do the checks on GitHub work?
-- Enter the new version number into CMakeLists.txt
-- Update the version numbers in the 'docker-wxmaxima' repository (update_versions.sh)
-- Update NEWS.md in order to announce the new version on <https://freshcode.club/>
-- Update data/io.github.wxmaxima_developers.wxMaxima.appdata.xml with the information
-  about the new release. Most html tags are forbidden by flatpack or appImage
-  builders.
-- Validate the appdata file with:
-  appstream-util validate data/io.github.wxmaxima_developers.wxMaxima.appdata.xml
-- Update snap/snapcraft.yaml
-- Run "make test"
-- Does test/testbench_simple.wxmx work?
+Pushing an **annotated tag whose name starts with `Version`** triggers the
+release automation. You no longer need to build or upload the platform
+binaries, create the release, or un-draft it by hand:
+
+- All platforms are built as **Release** builds and attached to the GitHub
+  release for that tag:
+  - Windows: the NSIS installer (`.exe`) — `compile_windows.yml`
+  - macOS: the `.dmg` — `compile_mac.yml`
+  - Linux: the `.deb` — `compile_ubuntu.yml`
+  - Windows on Arm (ARM64): the self-contained portable `.zip`
+    — `compile_windows_arm.yml`
+- The release is created (or updated) and un-drafted automatically, with its
+  body taken from the `# Current development version` section of `NEWS.md`.
+
+Other checks that now run on every push (so they can't surprise you at release
+time):
+
+- Full build + unit/integration tests on all platforms.
+- `appstream-util validate` of the appdata file (`compile_ubuntu.yml`).
+- The snap package builds from `snap/snapcraft.yaml` (`build_snap.yml`).
+
+## Manual steps (still required)
+
+- Make sure the current git version compiles and **all GitHub checks are
+  green** — the release jobs only publish after their build+tests pass.
+- Enter the new version number into `CMakeLists.txt`.
+- Update `NEWS.md` (this also becomes the release notes / the announcement on
+  <https://freshcode.club/>).
+- Update `data/io.github.wxmaxima_developers.wxMaxima.appdata.xml` with the new
+  `<release>` entry. Most HTML tags are forbidden by the flatpak/appImage
+  builders. (CI now validates the file, but you still write the entry.)
+- Update `snap/snapcraft.yaml` (at least the `version:`). CI now *builds* the
+  snap, but does not bump its version for you.
+- Update the version numbers in the `docker-wxmaxima` repository
+  (`update_versions.sh`).
 - Update the included HTML manuals.
-- Create an (annotated: using "git tag -a") git tag for the release
-- Push the tag to GitHub, using: git push origin --tags
-- When building binaries (RPM, DEB, binary tar.gz, ...) do a RELEASE build:
-  configure wxMaxima with `cmake -DCMAKE_BUILD_TYPE=Release ..`
-  This will not append the Suffix "-dev" to the file names of
-  the generated packages. (This is done, when building (default) "Debug" builds,
-  so that Development versions can be clearly recognized.
-- Go to the releases page GitHub and convert the tag into a release.
-  If possible add an Windows installer too.
-  Be sure, to remove the 'draft' status. Log out from GitHub and check,
-  if you see the release as an anonymous user too.
-- Update the release info in the files download.html and in version.txt
-  in the gh_pages branch.
-- Download the tarball (.tar.gz and .zip version) and run the following command on them:
-  gpg --armor --detach-sign <filename>
-- On the release page on github modify the release to contain the two .asc files
-  the command produced.
-- In Maxima's source tree in crosscompile-windows/wxmaxima/CMakeLists.txt: Change the
-  version number and the MD5 sum of the release tarball to the newest value.
-- Create a Windows installer using the 'Crosscompiled-Windows-installer' repository
-  and add it to the release.
+- Confirm `test/testbench_simple.wxmx` still works.
+- Create an **annotated** tag: `git tag -a Version-<x.y.z>` and push it:
+  `git push origin --tags`. **This push is what triggers the automated build +
+  release above.**
+- After the release is published, verify it as an anonymous user (log out of
+  GitHub and check the release page).
+- Update the release info in `download.html` and `version.txt` in the
+  `gh_pages` branch.
+- Download the source tarball (`.tar.gz` and `.zip`) and sign each:
+  `gpg --armor --detach-sign <filename>`, then add the two `.asc` files to the
+  release page. (Signing needs your private key and is therefore still manual.)
+- In Maxima's source tree, `crosscompile-windows/wxmaxima/CMakeLists.txt`:
+  update the version number and the MD5 sum of the release tarball.
+
+### Superseded
+
+- The old "create a Windows installer using the *Crosscompiled-Windows-installer*
+  repository and add it to the release" step is superseded by the Windows
+  installer that `compile_windows.yml` now builds and attaches automatically.
+  Keep it only as a fallback if the CI installer is ever unavailable.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,12 +6,12 @@ confinement: strict
 grade: stable
 base: core24
 license: GPL-2.0+
-architectures:
-   - build-on: arm64
-   - build-on: armhf
-   - build-on: amd64
-   - build-on: ppc64el
-   - build-on: s390x
+platforms:
+  amd64:
+  arm64:
+  armhf:
+  ppc64el:
+  s390x:
 
 apps:
   wxmaxima:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,23 +34,24 @@ parts:
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
     source: https://github.com/wxMaxima-developers/wxmaxima.git
+    # core24 == Ubuntu 24.04 (noble), which ships wxWidgets 3.2 (not 3.0) and
+    # applied the 64-bit time_t transition, so the runtime libraries carry the
+    # "t64" suffix. These names mirror the wxWidgets 3.2 packages the Ubuntu CI
+    # job builds against. (The old 3.0 names silently broke the snap when the
+    # base was bumped to core24.)
     build-packages:
-     - libwxbase3.0-dev
-     - libwxgtk3.0-gtk3-dev
-     - libwxgtk-webview3.0-gtk3-dev
+     - libwxgtk3.2-dev
+     - libwxgtk-webview3.2-dev
      - gettext
     stage-snaps:
      - maxima
     stage-packages:
-     - libwxbase3.0-0v5
+     - libwxbase3.2-1t64
+     - libwxgtk3.2-1t64
+     - libwxgtk-webview3.2-1t64
      - libglu1-mesa
-     - freeglut3
      - wx-common
-     - libwxgtk-webview3.0-gtk3-0v5
      - gettext
-     - libwxbase3.0-dev
-     - libwxgtk3.0-gtk3-dev
-     - libwxgtk-webview3.0-gtk3-dev
      - locales-all
     stage:
      - -usr/share/texmf/ls-R


### PR DESCRIPTION
The snap has been broken since the `base` was bumped to `core24` (Ubuntu 24.04) in 2024 — the rest of the file was never migrated to match, and nothing in CI built the snap, so it went unnoticed.

## Fixes to `snap/snapcraft.yaml`
- **`architectures:` → `platforms:`** — core24 rejects `architectures:` (fails snapcraft.yaml validation before apt even runs).
- **wxWidgets 3.0 → 3.2 + t64 names** — noble ships wx 3.2 and applied the 64-bit `time_t` transition, so the runtime libs are `libwxbase3.2-1t64`, `libwxgtk3.2-1t64`, `libwxgtk-webview3.2-1t64`. The old `libwx*3.0*` / `0v5` packages don't exist on noble. Also dropped the stale `freeglut3` and the `-dev` packages that were wrongly in `stage-packages`. These mirror the wx 3.2 packages the Ubuntu CI already builds against.

## New CI coverage
- **`build_snap.yml`** — builds the snap on every push (uploads the `.snap` artifact), so it can't silently rot again. **Verified green** on this branch.
- **`appstream-util validate`** added to the Ubuntu job — turns the manual "validate the appdata" release-checklist gate into an automatic one. **Verified passing** on this branch.

## Docs
- **`ReleaseChecklist.md`** refreshed to mark the steps CI now handles automatically (Release builds, release creation + un-draft, per-platform artifact attach for Win/mac/Linux/ARM, appdata validation, snap build) and keep only the genuinely manual steps.

## Follow-up (not in this PR)
"Always ship the newest Maxima": the snap bundles Maxima via `stage-snaps: [maxima]` (pulled at build time), so it goes stale between wxMaxima releases. A truly-fresh guarantee needs a scheduled rebuild+publish (store credentials as a secret) — tracked as separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)