### PR TITLE
CI: auto-update the website version strings on a Version tag

### DIFF
--- a/.github/workflows/update_website_version.yml
+++ b/.github/workflows/update_website_version.yml
@@ -1,0 +1,69 @@
+name: update_website_version
+
+# On a Version tag, update the version strings the download page shows so they
+# always match the release, instead of relying on a manual edit that is easy to
+# forget. The gh-pages branch hand-maintains two of them:
+#   * version.txt                -> "wxmaxima = <version>"
+#   * download.html "latest ..." -> "The latest version of wxMaxima is <version>."
+# (Only these root files are touched; the Doxygen docs subtree that the separate
+# doxygen-gh-pages workflow deploys is left alone.)
+
+on:
+  push:
+    tags:
+      - 'Version-*'
+
+permissions:
+  contents: write
+
+jobs:
+  update_website_version:
+    name: Update the website's version strings
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v7
+        with:
+          ref: gh-pages
+          # Full history so the rebase-retry below can re-sync cleanly if the
+          # Doxygen deploy pushed to gh-pages in the meantime.
+          fetch-depth: 0
+
+      - name: Update version.txt and download.html
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#Version-}"
+          echo "Release version: $version"
+          printf 'wxmaxima = %s\n' "$version" > version.txt
+          # Replace only the version number, keeping the surrounding sentence
+          # (and its trailing period) intact. Exactly one line matches.
+          sed -i -E "s/(The latest version of wxMaxima is )[0-9]+\.[0-9]+\.[0-9]+/\1${version}/" download.html
+          echo "--- version.txt ---"; cat version.txt
+          echo "--- download.html ---"; grep -nE "The latest version of wxMaxima is" download.html
+
+      - name: Commit and push if changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "version.txt / download.html already up to date; nothing to commit."
+            exit 0
+          fi
+          version="${GITHUB_REF_NAME#Version-}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add version.txt download.html
+          git commit -m "Update version.txt / download.html (${version} release)"
+          # gh-pages is also written by the Doxygen deploy (on pushes to main),
+          # so a concurrent write could reject this push. Retry with a rebase --
+          # the two touch different files, so the rebase applies cleanly.
+          for attempt in 1 2 3 4 5; do
+            if git push origin HEAD:gh-pages; then
+              echo "pushed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "push rejected (attempt ${attempt}); rebasing onto latest gh-pages"
+            git pull --rebase origin gh-pages
+          done
+          echo "::error::could not push the website version update after several attempts"
+          exit 1


### PR DESCRIPTION
Automates the "update `download.html` and `version.txt` in gh-pages" release-checklist step — the one that's easy to forget (the site had been stuck at 26.06.2, having missed 26.07.0 entirely).

## What it does
On a `Version-*` tag, a new workflow checks out `gh-pages` and updates the two hand-maintained version strings to match the tag:
- `version.txt` → `wxmaxima = <version>`
- `download.html` → `The latest version of wxMaxima is <version>.`

Then commits + pushes to `gh-pages` (only if something changed).

## Safety
- Touches **only** those two root files — the Doxygen docs subtree that `doxygen-gh-pages.yml` deploys is untouched.
- The `sed` matches **exactly one** line and replaces only the version number, keeping the sentence and its trailing period. Verified against the live `download.html`.
- Push **retries with a rebase** in case the Doxygen deploy wrote `gh-pages` concurrently (they touch different files, so it applies cleanly).
- `contents: write` via the default `GITHUB_TOKEN`; no secrets.

## Note
This fires on the *next* release; 26.07.1's gh-pages was already updated by hand this time. Once merged, the checklist's gh-pages step can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)