### PR TITLE
Regression tests: folding across undo/redo and with output/images

### DIFF
--- a/test/unit_tests/test_TreeUndo.cpp
+++ b/test/unit_tests/test_TreeUndo.cpp
@@ -88,6 +88,13 @@ void BuildTree(const std::vector<wxString> &texts) {
       std::make_unique<GroupCell>(g_cfg, GC_TYPE_CODE, t), where);
   g_ws->TreeUndo_ClearBuffers();
 }
+
+//! Append a fresh GroupCell of the given type/text after the last cell, without
+//! recording an undo action (buffers are cleared afterwards by the caller).
+GroupCell *AppendCell(GroupType type, const wxString &text) {
+  return g_ws->InsertGroupCells(std::make_unique<GroupCell>(g_cfg, type, text),
+                                NthCell(CellCount() - 1));
+}
 } // namespace
 
 SCENARIO("Adding a cell is undoable and redoable") {
@@ -207,6 +214,110 @@ SCENARIO("SetCellStyle refuses to convert an image cell") {
       THEN("the cell is left untouched as an image cell") {
         REQUIRE(CellCount() == countBefore);
         REQUIRE(NthCell(CellCount() - 1)->GetGroupType() == GC_TYPE_IMAGE);
+      }
+    }
+  }
+}
+
+SCENARIO("Folding survives an unrelated deletion and its undo") {
+  GIVEN("a worksheet [code, section, code] with the section folded") {
+    g_ws->ClearDocument();
+    GroupCell *top = AppendCell(GC_TYPE_CODE, wxS("top:1$"));
+    GroupCell *section = AppendCell(GC_TYPE_SECTION, wxS("A section"));
+    AppendCell(GC_TYPE_CODE, wxS("child:2$")); // becomes the section's child
+    g_ws->TreeUndo_ClearBuffers();
+
+    // Fold the section: its following code child moves into the hidden tree.
+    REQUIRE(g_ws->ToggleFold(section) == section);
+    REQUIRE(section->GetHiddenTree() != nullptr);
+    REQUIRE(section->GetHiddenTree()->GetEditable()->GetValue() == wxS("child:2$"));
+    REQUIRE(CellCount() == 2); // only [code, section] are visible now
+    g_ws->TreeUndo_ClearBuffers(); // folding itself is not an undoable action
+
+    WHEN("an unrelated cell above the fold is deleted and the delete is undone") {
+      g_ws->DeleteRegion(top, top);
+      REQUIRE(CellCount() == 1); // just the section is left visible
+
+      REQUIRE(g_ws->TreeUndo());
+
+      THEN("the deleted cell returns and the section is still folded") {
+        REQUIRE(CellCount() == 2);
+        GroupCell *restoredSection = NthCell(1);
+        REQUIRE(restoredSection->GetGroupType() == GC_TYPE_SECTION);
+        REQUIRE(restoredSection->GetHiddenTree() != nullptr);
+        CHECK(restoredSection->GetHiddenTree()->GetEditable()->GetValue() ==
+              wxS("child:2$"));
+      }
+    }
+  }
+}
+
+SCENARIO("Deleting a folded section and undoing it restores the fold") {
+  GIVEN("a worksheet [code, section, code] with the section folded") {
+    g_ws->ClearDocument();
+    AppendCell(GC_TYPE_CODE, wxS("top:1$"));
+    GroupCell *section = AppendCell(GC_TYPE_SECTION, wxS("A section"));
+    AppendCell(GC_TYPE_CODE, wxS("child:2$"));
+    g_ws->TreeUndo_ClearBuffers();
+
+    REQUIRE(g_ws->ToggleFold(section) == section);
+    REQUIRE(section->GetHiddenTree() != nullptr);
+    REQUIRE(CellCount() == 2);
+    g_ws->TreeUndo_ClearBuffers();
+
+    WHEN("the folded section itself is deleted") {
+      g_ws->DeleteRegion(section, section);
+      REQUIRE(CellCount() == 1); // the hidden child goes with the section
+
+      THEN("undo brings the section back still folded; redo removes it again") {
+        REQUIRE(g_ws->TreeUndo());
+        REQUIRE(CellCount() == 2);
+        GroupCell *restored = NthCell(1);
+        REQUIRE(restored->GetGroupType() == GC_TYPE_SECTION);
+        REQUIRE(restored->GetHiddenTree() != nullptr);
+        CHECK(restored->GetHiddenTree()->GetGroupType() == GC_TYPE_CODE);
+        CHECK(restored->GetHiddenTree()->GetEditable()->GetValue() ==
+              wxS("child:2$"));
+        // The hidden child must not have leaked into the visible list.
+        CHECK(restored->GetNext() == nullptr);
+
+        REQUIRE(g_ws->TreeRedo());
+        CHECK(CellCount() == 1);
+      }
+    }
+  }
+}
+
+SCENARIO("Undoing an insertion whose cell was folded away reveals and removes it") {
+  // This drives TreeUndoCellAddition's RevealHidden() branch: the undo range
+  // (the inserted cell) has since been folded into a section's hidden tree, so
+  // the undo must first unfold it back into the visible list before deleting it.
+  GIVEN("a section, a code cell inserted after it, then folded into the section") {
+    g_ws->ClearDocument();
+    GroupCell *section = AppendCell(GC_TYPE_SECTION, wxS("A section"));
+    g_ws->TreeUndo_ClearBuffers();
+
+    // The insertion we will undo: a code cell right after the section.
+    GroupCell *child = g_ws->InsertGroupCells(
+      std::make_unique<GroupCell>(g_cfg, GC_TYPE_CODE, wxS("child:2$")), section);
+    REQUIRE(CellCount() == 2);
+    REQUIRE(g_ws->CanUndo());
+
+    // Fold the section: the freshly-inserted child moves into the hidden tree,
+    // so the pending undo action now points at a hidden cell.
+    REQUIRE(g_ws->ToggleFold(section) == section);
+    REQUIRE(section->GetHiddenTree() == child);
+    REQUIRE(CellCount() == 1);
+
+    WHEN("the insertion is undone") {
+      REQUIRE(g_ws->TreeUndo());
+
+      THEN("the child is gone and the section is left unfolded and empty") {
+        REQUIRE(CellCount() == 1);
+        GroupCell *only = NthCell(0);
+        REQUIRE(only->GetGroupType() == GC_TYPE_SECTION);
+        CHECK(only->GetHiddenTree() == nullptr); // unfolded during the undo
+        CHECK(only->GetNext() == nullptr);        // the inserted cell was removed
       }
     }
   }

--- a/test/unit_tests/test_WXMRoundtrip.cpp
+++ b/test/unit_tests/test_WXMRoundtrip.cpp
@@ -393,6 +393,48 @@ SCENARIO("Nested folds survive the .wxm round-trip") {
   }
 }
 
+SCENARIO("An image folded into a section survives the .wxm round-trip byte-for-byte") {
+  // The basic fold round-trip used input-only cells; here the hidden tree holds
+  // an image cell (bytes stored inline as base64) plus a following code cell, so
+  // the fold wrapper must not disturb the embedded image data.
+  const wxMemoryBuffer png = EncodeImage(wxBITMAP_TYPE_PNG);
+  REQUIRE(png.GetDataLen() > 0);
+
+  auto imgGroup = std::make_unique<GroupCell>(g_cfg, GC_TYPE_IMAGE);
+  imgGroup->SetOutput(std::make_unique<ImgCell>(nullptr, g_cfg, png, wxS("png")));
+  auto codeGroup = std::make_unique<GroupCell>(g_cfg, GC_TYPE_CODE, wxS("2+2;"));
+
+  auto section = std::make_unique<GroupCell>(g_cfg, GC_TYPE_SECTION, wxS("With an image"));
+  CellListBuilder<GroupCell> children;
+  children.DynamicAppend(imgGroup.release());
+  children.DynamicAppend(codeGroup.release());
+  REQUIRE(section->HideTree(std::move(children)));
+
+  auto reloaded = SerializeAndReload({section.get()});
+  REQUIRE(reloaded != nullptr);
+
+  THEN("only the section is visible and its hidden image keeps its bytes intact") {
+    std::vector<GroupCell *> got;
+    for (auto &g : OnList(reloaded.get()))
+      got.push_back(&g);
+    REQUIRE(got.size() == 1);
+    REQUIRE(got[0]->GetGroupType() == GC_TYPE_SECTION);
+
+    GroupCell *hidden = got[0]->GetHiddenTree();
+    REQUIRE(hidden != nullptr);
+    REQUIRE(hidden->GetGroupType() == GC_TYPE_IMAGE);
+    auto *img = dynamic_cast<ImgCell *>(hidden->GetLabel());
+    REQUIRE(img != nullptr);
+    const wxMemoryBuffer reloadedBytes = img->GetCompressedImage();
+    REQUIRE(reloadedBytes.GetDataLen() > 0);     // not the "zero length" bug
+    REQUIRE(SameBytes(reloadedBytes, png));       // stored verbatim inside the fold
+
+    REQUIRE(hidden->GetNext() != nullptr);
+    REQUIRE(hidden->GetNext()->GetGroupType() == GC_TYPE_CODE);
+    REQUIRE(hidden->GetNext()->GetEditable()->GetValue() == wxS("2+2;"));
+  }
+}
+
 class TestApp : public wxApp {
 public:
   bool OnInit() override { return true; }

--- a/test/unit_tests/test_WXMXRoundtrip.cpp
+++ b/test/unit_tests/test_WXMXRoundtrip.cpp
@@ -176,6 +176,54 @@ SCENARIO("A folded section's hidden children survive the content.xml round-trip"
   }
 }
 
+SCENARIO("A folded code cell keeps its computed output across the content.xml round-trip") {
+  // .wxm stores input only, so evaluation output inside a hidden tree is a
+  // .wxmx-only concern. This folds a code cell that has an <output> block and
+  // checks the output survives both the idempotency check and a structural
+  // reparse of the hidden tree.
+  const wxString folded =
+    wxS("<cell type=\"section\" sectioning_level=\"2\">\n")
+    wxS("<editor type=\"section\" sectioning_level=\"2\">\n")
+    wxS("<line>A section</line>\n")
+    wxS("</editor>\n")
+    wxS("<fold>\n")
+    wxS("<cell type=\"code\">\n")
+    wxS("<input>\n")
+    wxS("<editor type=\"input\">\n")
+    wxS("<line>1+1;</line>\n")
+    wxS("</editor>\n")
+    wxS("</input>\n")
+    wxS("<output>\n")
+    wxS("<mth><lbl altCopy=\"(%o1)&#009;\">(%o1) </lbl><n>2</n>\n")
+    wxS("</mth></output>\n")
+    wxS("</cell>\n")
+    wxS("</fold>\n")
+    wxS("</cell>");
+
+  THEN("the folded cell with output round-trips to a stable serialization") {
+    RequireIdempotent(WrapDocument(folded));
+  }
+  THEN("re-parsing recovers the hidden code cell together with its output") {
+    const wxString wrapped = WrapDocument(folded);
+    const wxScopedCharBuffer utf8 = wrapped.utf8_str();
+    wxMemoryInputStream in(utf8.data(), utf8.length());
+    wxXmlDocument doc;
+    REQUIRE(doc.Load(in));
+    MathParser mp(g_cfg);
+    std::unique_ptr<GroupCell> tree = mp.CreateTreeFromXMLNode(doc.GetRoot());
+    REQUIRE(tree != nullptr);
+    REQUIRE(tree->GetGroupType() == GC_TYPE_SECTION);
+    REQUIRE(tree->GetNext() == nullptr); // the code cell is hidden, not visible
+
+    GroupCell *hidden = tree->GetHiddenTree();
+    REQUIRE(hidden != nullptr);
+    REQUIRE(hidden->GetGroupType() == GC_TYPE_CODE);
+    REQUIRE(hidden->GetEditable()->GetValue() == wxS("1+1;"));
+    // The computed result must have travelled into the hidden tree too.
+    REQUIRE(hidden->GetOutput() != nullptr);
+  }
+}
+
 class TestApp : public wxApp {
 public:
   bool OnInit() override { return true; }


### PR DESCRIPTION
## What

Adds automated regression coverage for cell **folding** in three previously-untested situations. These are **test-only changes** — all scenarios pass on current code, so no behaviour change and no bug fix; this locks in existing guarantees.

Folding stores a section's children in its `m_hiddenTree` (a `unique_ptr` member of the section `GroupCell`) rather than in the visible cell list. Visible-list operations — delete, insert, undo/redo — walk `GetNext()` and therefore never touch hidden cells, and a folded section's hidden tree travels with the `GroupCell` automatically. That was reasoned to be sound but had no tests for the interaction with tree undo/redo, nor for hidden trees carrying evaluation output or embedded images.

## Tests added

**`test_TreeUndo.cpp`** (+3 scenarios)
- A folded section survives an *unrelated* cell's delete + undo with its hidden tree intact.
- Deleting the *folded section itself* and undoing restores it **still folded** (hidden tree carried through the undo buffer); redo re-deletes.
- Undoing an *insertion* whose cell was subsequently folded away drives `TreeUndoCellAddition`'s `RevealHidden()` branch — the cell is unfolded back into the visible list, then removed.

**`test_WXMXRoundtrip.cpp`** (+1 scenario)
- A folded code cell keeps its computed `<output>` across the `content.xml` round-trip (output is a `.wxmx`-only concern; `.wxm` stores input alone).

**`test_WXMRoundtrip.cpp`** (+1 scenario)
- An image folded into a section survives the `.wxm` round-trip **byte-for-byte**, and a following code cell in the hidden tree is not swallowed.

## Verification

All three test binaries built and run green:
- `test_TreeUndo` — 8 cases / 68 assertions
- `test_WXMRoundtrip` — 10 cases / 128 assertions
- `test_WXMXRoundtrip` — 3 cases / 61 assertions

## Context

Follow-up to the earlier fold-hardening work (basic + nested round-trips, and the diff-viewer folded-content fix). This closes the two items that investigation left explicitly unchecked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DU23YMfQHdrkGCNJxn7dJs