### PR TITLE
EditorCell split slice 5+7: move Maxima-code-only state onto CodeEditorCell

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -158,6 +158,7 @@ stability fixes.
 - Windows: wxMaxima now repairs its own .wxmx/.wxm/.mac file association on startup, so updating to a new install location no longer makes Windows "forget" which program opens .wxmx files.
 - Windows: a new Help menu item registers wxMaxima as the tool TortoiseSVN and TortoiseGit use to compare .wxmx files.
 - Added a regression test guarding the worksheet's line-wrapping (line-breaking) layout pass.
+- Internal: the Maxima-code-only editor state (tokenizer output, autocomplete word list and matching-parenthesis highlight) now lives on the CodeEditorCell subclass instead of on every EditorCell, so text and heading cells no longer carry it. Behaviour is unchanged.
 
 # 26.07.0
 

--- a/src/cells/EditorCell.cpp
+++ b/src/cells/EditorCell.cpp
@@ -127,6 +127,33 @@ public:
   //! Code serializes to RTF snippet-by-snippet, keeping the syntax
   //! highlighting; prose maps its heading/text style in the base.
   wxString ToRTF() const override;
+
+  // --- code-only state + behavior (moved off the base in slice 5) ---
+  const std::vector<wxString> &GetWordList() const override { return m_wordList; }
+  const MaximaTokenizer::TokenList &GetAllTokens() const override;
+  void FindMatchingParens() override;
+  void ClearParenMatch() override { m_paren1 = m_paren2 = -1; }
+  void DrawParenHighlight(wxDC *dc) override;
+
+private:
+  //! The code-vs-prose styler for code (populates m_tokens/m_wordList). Only
+  //! ever runs on a CodeEditorCell (via StyleTypedText()).
+  void StyleTextCode() const;
+  //! Helper of FindMatchingParens() for the "cursor on a quote" case.
+  bool FindMatchingQuotes();
+
+  //! A list of all potential autoComplete targets within this cell
+  mutable std::vector<wxString> m_wordList;
+  //! The individual commands, parenthesis, strings and whitespaces a code cell consists of
+  mutable MaximaTokenizer::TokenList m_tokens;
+  //! The individual commands, parenthesis, strings and whitespaces including hidden lines
+  mutable MaximaTokenizer::TokenList m_tokens_including_hidden;
+  //! Does the list of displayed tokens need to be recalculated?
+  mutable bool m_tokens_valid = false;
+  //! Does the list of tokens including hidden items need to be recalculated?
+  mutable bool m_tokens_including_hidden_valid = false;
+  //! The offsets of the pair of matching parens/quotes to highlight, or -1.
+  long m_paren1 = -1, m_paren2 = -1;
 };
 
 class TextEditorCell final : public EditorCell {
@@ -946,39 +973,11 @@ void EditorCell::Draw(wxDC *dc, wxDC *antialiassingDC) {
                         SelectionRight(), TS_SELECTION);
 
         //
-        // Matching parens - draw only if we don't have selection
+        // Matching parens - draw only if we don't have selection. Prose cells
+        // have no parens; CodeEditorCell draws its m_paren1/m_paren2 highlight.
         //
-        else if ((m_paren1 != -1 && m_paren2 != -1) &&
-                 (m_configuration->ShowMatchingParens())) {
-          {
-
-#if defined(__WXOSX__)
-            dc->SetPen(wxNullPen); // no border on rectangles
-#else
-            dc->SetPen(*(wxThePenList->FindOrCreatePen(m_configuration->GetColor(TS_SELECTION), 1,
-                                                       wxPENSTYLE_SOLID))); // window linux, set a pen
-#endif
-            dc->SetBrush(*(wxTheBrushList->FindOrCreateBrush(m_configuration->GetColor(TS_SELECTION)))); // highlight c.
-          }
-          if (m_paren1 >= 0 && static_cast<size_t>(m_paren1) < m_text.Length() &&
-              m_paren2 >= 0 && static_cast<size_t>(m_paren2) < m_text.Length()) {
-            wxPoint matchPoint = PositionToPoint(m_paren1);
-            wxCoord width, height;
-            dc->GetTextExtent(m_text.at(m_paren1), &width, &height);
-            wxRect matchRect(matchPoint.x + 1,
-                             matchPoint.y + Scale_Px(2) - m_center + 1,
-                             width - 1, height - 1);
-            if (m_configuration->InUpdateRegion(matchRect))
-              dc->DrawRectangle(CropToUpdateRegion(matchRect));
-            matchPoint = PositionToPoint(m_paren2);
-            dc->GetTextExtent(m_text.at(m_paren2), &width, &height);
-            matchRect = wxRect(matchPoint.x + 1,
-                               matchPoint.y + Scale_Px(2) - m_center + 1,
-                               width - 1, height - 1);
-            if (m_configuration->InUpdateRegion(matchRect))
-              dc->DrawRectangle(CropToUpdateRegion(matchRect));
-          }
-        } // else if (m_paren1 != -1 && m_paren2 != -1)
+        else
+          DrawParenHighlight(dc);
       }   // if (IsActive())
 
     //
@@ -1296,8 +1295,7 @@ void EditorCell::ProcessEvent(wxKeyEvent &event) {
   if ((!done) && (wxIsprint(event.GetUnicodeKey())))
     HandleOrdinaryKey(event);
 
-  if (m_type == MC_TYPE_INPUT)
-    FindMatchingParens();
+  FindMatchingParens();
 
   if (m_isDirty) {
     if (GetGroup())
@@ -2208,7 +2206,7 @@ bool EditorCell::HandleOrdinaryKey(wxKeyEvent &event) {
  *
  * @return true if matching quotation marks were found; false otherwise
  */
-bool EditorCell::FindMatchingQuotes() {
+bool CodeEditorCell::FindMatchingQuotes() {
   size_t pos = 0;
   for (auto const &tok : m_tokens) {
     if ((tok.GetText().StartsWith(wxS("\""))) &&
@@ -2228,7 +2226,7 @@ bool EditorCell::FindMatchingQuotes() {
   return false;
 }
 
-void EditorCell::FindMatchingParens() {
+void CodeEditorCell::FindMatchingParens() {
   m_paren1 = m_paren2 = -1;
   if (CursorPosition() >= m_text.Length())
     return;
@@ -2339,7 +2337,7 @@ bool EditorCell::ActivateCursor() {
   m_documentCellPointers->SetActiveCell(this);
 
   ClearSelection();
-  m_paren1 = m_paren2 = -1;
+  ClearParenMatch();
 
   // upon activation unhide the parent groupcell
   if (FirstLineOnlyEditor()) {
@@ -2349,8 +2347,7 @@ bool EditorCell::ActivateCursor() {
       retval = true;
     }
   }
-  if (GetType() == MC_TYPE_INPUT)
-    FindMatchingParens();
+  FindMatchingParens();
   return retval;
 }
 
@@ -2395,7 +2392,7 @@ bool EditorCell::AddEnding() {
 
   if (endingNeeded) {
     m_text += wxS(";");
-      m_paren1 = m_paren2 = -1;
+      ClearParenMatch();
       m_width.Invalidate();
     StyleText();
     return true;
@@ -2611,7 +2608,7 @@ void EditorCell::SelectRectText(const wxPoint one, const wxPoint two) {
   SelectPointText(one);
   size_t start = CursorPosition();
   SelectPointText(two);
-  m_paren2 = m_paren1 = -1;
+  ClearParenMatch();
   SelectionStart(start);
 }
 
@@ -2857,7 +2854,7 @@ bool EditorCell::CutToClipboard() {
   StyleText();
 
   ClearSelection();
-  m_paren1 = m_paren2 = -1;
+  ClearParenMatch();
   m_width.Invalidate();
   m_height.Invalidate();
   m_center.Invalidate();
@@ -2874,8 +2871,7 @@ void EditorCell::InsertText(wxString text) {
 
   ReplaceSelection(GetSelectionString(), text);
 
-  if (GetType() == MC_TYPE_INPUT)
-    FindMatchingParens();
+  FindMatchingParens();
 
   m_text.Replace(wxS("\u2028"), "\n");
   m_text.Replace(wxS("\u2029"), "\n");
@@ -3055,7 +3051,7 @@ void EditorCell::History::ClearUndoBuffer() {
 void EditorCell::SetState(const EditorCell::History::HistoryEntry &state) {
   m_text = state.GetText();
   StyleText();
-  m_paren1 = m_paren2 = -1;
+  ClearParenMatch();
   m_isDirty = true;
   m_width.Invalidate();
   m_height.Invalidate();
@@ -3178,8 +3174,11 @@ void EditorCell::HandleSoftLineBreaks_Code(SoftBreakCandidate &candidate,
   candidate.valid = false;
 }
 
-void EditorCell::StyleTextCode() const {
-  // We have to style code
+void CodeEditorCell::StyleTextCode() const {
+  // We have to style code. m_wordList is cleared here because the base
+  // StyleText() no longer knows about it (it moved to this subclass);
+  // m_tokens_valid is set at the very end for the same reason.
+  m_wordList.clear();
   SoftBreakCandidate candidate;
   // If a space is part of the initial spaces that do the indentation of a cell
   // it is not eligible for soft line breaks: It would add a soft line break
@@ -3298,6 +3297,7 @@ void EditorCell::StyleTextCode() const {
   std::sort(m_wordList.begin(), m_wordList.end());
   if(!suppressedLinesInfo.IsEmpty())
     m_styledText.push_back(StyledText(TS_CODE_COMMENT, suppressedLinesInfo));
+  m_tokens_valid = true;
 }
 
 void EditorCell::StyleTextTexts() const {
@@ -3569,7 +3569,7 @@ lineProcessed:
   }
 } // Style text, not code?
 
-const MaximaTokenizer::TokenList &EditorCell::GetAllTokens() const {
+const MaximaTokenizer::TokenList &CodeEditorCell::GetAllTokens() const {
   if(FirstLineOnlyEditor())
     {
       if(!m_tokens_including_hidden_valid)
@@ -3599,7 +3599,6 @@ void EditorCell::StyleText() const {
   // the font type and size.
   SetFont(m_configuration->GetRecalcDC());
 
-  m_wordList.clear();
   m_styledText.clear();
   // Soft breaks are derived layout data; re-derive them from scratch on every
   // restyle. They live in a side table (m_softBreaks), never inside m_text.
@@ -3610,15 +3609,63 @@ void EditorCell::StyleText() const {
     // (legacy files, paste). Real soft breaks are never stored in the content
     // any more, so this touches nothing in normal operation.
     m_text.Replace(wxS("\r"), wxS(" "));
-    // Style as code or prose, dispatched by the concrete subclass.
+    // Style as code or prose, dispatched by the concrete subclass. The code
+    // path (CodeEditorCell::StyleTextCode) also fills its own m_wordList and
+    // marks its tokens valid; prose has neither.
     StyleTypedText();
   }
-  m_tokens_valid = true;
 }
 
 // Base = prose; CodeEditorCell overrides this to style Maxima code. This is the
 // virtual seam that replaced StyleText()'s old `if (m_type == MC_TYPE_INPUT)`.
 void EditorCell::StyleTypedText() const { StyleTextTexts(); }
+
+// --- Base (prose) defaults for the code-only virtuals. CodeEditorCell overrides
+// each; prose cells have no tokens, no word list and no paren highlight. ---
+void EditorCell::FindMatchingParens() {}
+
+const std::vector<wxString> &EditorCell::GetWordList() const {
+  static const std::vector<wxString> empty;
+  return empty;
+}
+
+const MaximaTokenizer::TokenList &EditorCell::GetAllTokens() const {
+  static const MaximaTokenizer::TokenList empty;
+  return empty;
+}
+
+void CodeEditorCell::DrawParenHighlight(wxDC *dc) {
+  if (!((m_paren1 != -1 && m_paren2 != -1) &&
+        m_configuration->ShowMatchingParens()))
+    return;
+
+#if defined(__WXOSX__)
+  dc->SetPen(wxNullPen); // no border on rectangles
+#else
+  dc->SetPen(*(wxThePenList->FindOrCreatePen(m_configuration->GetColor(TS_SELECTION), 1,
+                                             wxPENSTYLE_SOLID))); // window linux, set a pen
+#endif
+  dc->SetBrush(*(wxTheBrushList->FindOrCreateBrush(m_configuration->GetColor(TS_SELECTION)))); // highlight c.
+
+  if (m_paren1 >= 0 && static_cast<size_t>(m_paren1) < m_text.Length() &&
+      m_paren2 >= 0 && static_cast<size_t>(m_paren2) < m_text.Length()) {
+    wxPoint matchPoint = PositionToPoint(m_paren1);
+    wxCoord width, height;
+    dc->GetTextExtent(m_text.at(m_paren1), &width, &height);
+    wxRect matchRect(matchPoint.x + 1,
+                     matchPoint.y + Scale_Px(2) - m_center + 1,
+                     width - 1, height - 1);
+    if (m_configuration->InUpdateRegion(matchRect))
+      dc->DrawRectangle(CropToUpdateRegion(matchRect));
+    matchPoint = PositionToPoint(m_paren2);
+    dc->GetTextExtent(m_text.at(m_paren2), &width, &height);
+    matchRect = wxRect(matchPoint.x + 1,
+                       matchPoint.y + Scale_Px(2) - m_center + 1,
+                       width - 1, height - 1);
+    if (m_configuration->InUpdateRegion(matchRect))
+      dc->DrawRectangle(CropToUpdateRegion(matchRect));
+  }
+}
 
 wxString EditorCell::PreprocessNewValue(const wxString &text,
                                         std::size_t &cursorPos) const {
@@ -3948,8 +3995,7 @@ bool EditorCell::ReplaceSelection(const wxString &oldStr,
   else
     ClearSelection();
 
-  if (GetType() == MC_TYPE_INPUT)
-    FindMatchingParens();
+  FindMatchingParens();
 
   StyleText();
   return true;
@@ -3977,8 +4023,7 @@ bool EditorCell::ReplaceSelection_RegEx(const wxString &oldStr,
   m_text = text;
   CursorPosition(match.GetEnd());
 
-  if (GetType() == MC_TYPE_INPUT)
-    FindMatchingParens();
+  FindMatchingParens();
 
   StyleText();
   return true;
@@ -4077,20 +4122,17 @@ bool EditorCell::FindNextTemplate(bool left) {
 
 void EditorCell::CaretToEnd() {
   CursorPosition(m_text.Length());
-  if (GetType() == MC_TYPE_INPUT)
-    FindMatchingParens();
+  FindMatchingParens();
 }
 
 void EditorCell::CaretToStart() {
   CursorPosition(0);
-  if (GetType() == MC_TYPE_INPUT)
-    FindMatchingParens();
+  FindMatchingParens();
 }
 
 void EditorCell::CaretToPosition(size_t pos) {
   CursorPosition(pos);
-  if (GetType() == MC_TYPE_INPUT)
-    FindMatchingParens();
+  FindMatchingParens();
 }
 
 #if wxUSE_ACCESSIBILITY

--- a/src/cells/EditorCell.h
+++ b/src/cells/EditorCell.h
@@ -157,7 +157,8 @@ public:
   void KeyboardSelectionStartedHere() const;
 
   //! A list of words that might be applicable to the autocomplete function.
-  const auto &GetWordList() const { return m_wordList; }
+  //! Only code cells carry one; the base (prose) returns an empty list.
+  virtual const std::vector<wxString> &GetWordList() const;
 
   /*! Expand all tabulators.
 
@@ -258,8 +259,8 @@ public:
     that this line is to be broken here until the window's width changes.
   */
   void StyleText() const;
-  /*! Is Called by StyleText() if this is a code cell */
-  void StyleTextCode() const;
+  //! Style prose (text/heading cells). Code styling (StyleTextCode) lives on
+  //! CodeEditorCell, which owns the tokenizer/word-list state it produces.
   void StyleTextTexts() const;
 
 protected:
@@ -287,6 +288,22 @@ protected:
     switch inside ToXML().
   */
   virtual wxString XMLTypeAttribute() const;
+
+  /*! Forget any matching-parenthesis highlight.
+
+    The base (prose) has no paren highlight and does nothing; CodeEditorCell
+    resets its m_paren1/m_paren2. Called from shared editing operations that
+    invalidate the cursor context (activation, cut, selection, undo, ...).
+  */
+  virtual void ClearParenMatch() {}
+
+  /*! Draw the matching-parenthesis highlight boxes, if any.
+
+    The base (prose) draws nothing; CodeEditorCell draws the boxes for
+    m_paren1/m_paren2. Called from Draw() when this cell is active and no
+    selection is shown.
+  */
+  virtual void DrawParenHighlight(wxDC *dc) { (void)dc; }
 
 public:
   void Reset();
@@ -376,9 +393,12 @@ public:
       return SelectionActive();
     }
 
-  bool FindMatchingQuotes();
+  /*! Recompute the matching-parenthesis highlight for the current cursor.
 
-  void FindMatchingParens();
+    The base (prose) has no parens to match and does nothing; CodeEditorCell
+    scans its token list. Called from the shared editing/cursor operations.
+  */
+  virtual void FindMatchingParens();
 
   wxCoord GetLineWidth(size_t line, size_t pos);
 
@@ -599,8 +619,9 @@ public:
 
   //! Get the list of commands, parenthesis, strings and whitespaces in a code cell
 //  const MaximaTokenizer::TokenList &GetDisplayedTokens() const;
-  //! Get the list of commands, parenthesis, strings and whitespaces including hidden ones
-  const MaximaTokenizer::TokenList &GetAllTokens() const;
+  //! Get the list of commands, parenthesis, strings and whitespaces including
+  //! hidden ones. Only code cells have tokens; the base returns an empty list.
+  virtual const MaximaTokenizer::TokenList &GetAllTokens() const;
 
 private:
   //! Clamps a (possibly negative or past-the-end) position to a valid index into
@@ -705,6 +726,9 @@ private:
     \c textPos is the content offset where the continuation line begins (the
     value pushed to \ref m_softBreaks).
   */
+protected:
+  // The code-styling helpers below are protected because StyleTextCode() (which
+  // uses them) lives on the CodeEditorCell subclass.
   struct SoftBreakCandidate {
     std::size_t snippetIdx = 0;
     std::size_t textPos = 0;
@@ -756,8 +780,9 @@ private:
   //! Determines the size of a text snippet
   wxSize GetTextSize(const wxString &text) const;
 
+private:
   //! The memory for the undo history
-  History m_history;  
+  History m_history;
   //! Set the editor's state from a history entry
   void SetState(const History::HistoryEntry &state);
   //! Get the styled text
@@ -769,18 +794,10 @@ private:
   //! Cached widths of text snippets, one width per style
   mutable StringHash m_widths;
 
-  //! A list of all potential autoComplete targets within this cell
-  mutable std::vector<wxString> m_wordList;
-
-  //! The individual commands, parenthesis, strings and whitespaces a code cell consists of
-  mutable MaximaTokenizer::TokenList m_tokens;
-  //! The individual commands, parenthesis, strings and whitespaces including hidden lines
-  mutable MaximaTokenizer::TokenList m_tokens_including_hidden;
-
+protected:
   /*! The text this Editor contains
    */
   mutable wxString m_text;
-protected:
   //! The styled-run rendering representation of m_text; see StyledText.
   mutable std::vector<StyledText> m_styledText;
 private:
@@ -819,7 +836,6 @@ private:
   size_t m_errorIndex = 1;
   mutable size_t m_numberOfLines = 1;
   mutable wxCoord m_charHeight = 12;
-  long m_paren1 = -1, m_paren2 = -1;
 
 //** 2 bytes
 //**
@@ -827,10 +843,6 @@ private:
   AFontWeight m_fontWeight;
 
 
-  //! Does the list of tokens including hidden items need to be recalculated?
-  mutable bool m_tokens_including_hidden_valid = false;
-  //! Does the list of displayed tokens need to be recalculated?
-  mutable bool m_tokens_valid = false;
 
 
 //** Bitfield objects (2 bytes)


### PR DESCRIPTION
## What

Completes the long-running **EditorCell split** arc (slices 1–4, 6 already landed). The tokenizer output, autocomplete word list and matching-parenthesis highlight are only meaningful for Maxima **input** cells, yet every `EditorCell` — text and every heading level included — carried that state. This moves the state *and its behaviour* onto the `CodeEditorCell` subclass, so prose/heading cells no longer carry it.

**Behaviour is unchanged** — this is a pure relocation behind virtual dispatch.

## The move

The code-only cluster is inseparable (`FindMatchingParens`/`FindMatchingQuotes` iterate the token list; `StyleTextCode` populates both the tokens and the word list), so it moves as a unit onto `CodeEditorCell`:

- **State:** `m_tokens`, `m_tokens_including_hidden`, `m_wordList`, `m_paren1`/`m_paren2`, and their validity flags.
- **Methods:** `StyleTextCode()`, `FindMatchingParens()`, `FindMatchingQuotes()`, `GetAllTokens()`, and the paren-highlight drawing.

Shared editing/drawing code in the base reaches the moved behaviour through **five virtual seams**, each a no-op / empty default on prose:

| Seam | Called from |
|---|---|
| `FindMatchingParens()` | shared cursor/edit operations |
| `GetAllTokens()` | tokeniser consumers (empty for prose) |
| `GetWordList()` | autocomplete gathering (empty for prose) |
| `ClearParenMatch()` | the shared paren-reset sites |
| `DrawParenHighlight()` | `Draw()` |

Because `StyleTextCode()` moved onto the subclass, the base layout helpers it uses (`m_text`, `GetTextSize`, `HandleSoftLineBreaks_Code`, `BreakAfterOperator`, the `SoftBreakCandidate` struct) are now `protected`.

## Slice 7 (dead-branch cleanup)

`FindMatchingParens()` is now a no-op on prose, so the eight `if (GetType() == MC_TYPE_INPUT) FindMatchingParens();` guards became dead. All ten call sites now call it unconditionally, matching the two that already did. (The build compiling proves no base branch touched the moved state; the remaining `m_type == MC_TYPE_INPUT` conditionals are live behaviour and are intentionally left alone.)

## Verification

Builds clean (first try), and the EditorCell unit tests pass:

- `test_EditorCellInvariants` — **96,435 assertions** (the fuzz driver: thousands of real key events exercising paren-matching and styling across **both** code and text cells)
- `test_GroupCellLayout` — 55 assertions (covers the code-vs-prose virtual dispatch)
- `test_TreeUndo`, `test_WXMRoundtrip`, `test_WXMXRoundtrip` — all green

CI will run the full suite + the ASan/UBSan sanitizer build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DU23YMfQHdrkGCNJxn7dJs