### PR TITLE
Snap: open the system browser via the XDG portal + weekly Snap Store publish

### DIFF
--- a/.github/workflows/build_snap.yml
+++ b/.github/workflows/build_snap.yml
@@ -5,10 +5,27 @@ name: build_snap
 # release. The snap silently rotted once already: base was bumped to core24
 # (Ubuntu 24.04) in 2024 while the build/stage packages stayed at wxWidgets 3.0,
 # which no longer exists on noble -- nothing in CI noticed because the snap was
-# never built here. This job closes that gap and uploads the built .snap as an
-# artifact for inspection / manual test-install.
+# never built here. This job closes that gap.
+#
+# On every push the snap is only built and uploaded as a workflow artifact (a
+# CI check). Once a week -- and on a manual "Run workflow" -- the freshly built
+# snap is additionally published to the Snap Store's "edge" channel. Because the
+# snapcraft.yaml pulls Maxima in via `stage-snaps: [maxima]`, the weekly rebuild
+# also picks up the newest Maxima snap (rebuilt on its own schedule) together
+# with the latest security fixes from the core24 runtime.
+#
+# Publishing needs the SNAPCRAFT_STORE_CREDENTIALS repository secret, generated
+# with:
+#   snapcraft export-login --snaps=wxmaxima \
+#     --channels=edge --acls package_push,package_release creds.txt
+# and pasted verbatim into Settings -> Secrets and variables -> Actions.
 
-on: [push]
+on:
+  push:
+  workflow_dispatch:
+  schedule:
+    # Every Monday at 04:00 UTC.
+    - cron: '0 4 * * 1'
 
 permissions:
   contents: read
@@ -34,3 +51,17 @@ jobs:
           name: wxmaxima-snap
           path: ${{ steps.build.outputs.snap }}
           if-no-files-found: error
+
+      # Only publish on the weekly schedule or a manual dispatch, never on an
+      # ordinary push. Skipped automatically on forks / whenever the secret is
+      # absent, so the build-only CI check keeps working without credentials.
+      - name: Publish to the edge channel
+        if: >-
+          (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+          && github.repository == 'wxMaxima-developers/wxmaxima'
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: edge

--- a/NEWS.md
+++ b/NEWS.md
@@ -158,6 +158,7 @@ stability fixes.
 - Windows: wxMaxima now repairs its own .wxmx/.wxm/.mac file association on startup, so updating to a new install location no longer makes Windows "forget" which program opens .wxmx files.
 - Windows: a new Help menu item registers wxMaxima as the tool TortoiseSVN and TortoiseGit use to compare .wxmx files.
 - Added a regression test guarding the worksheet's line-wrapping (line-breaking) layout pass.
+- Snap package: opening a link in the system web browser (the manual, "visit website", Maxima's online documentation) now works. The confined snap reaches the host's default browser through the XDG Desktop Portal instead of trying to launch a browser that is not visible inside the sandbox -- no browser is bundled and confinement stays strict.
 
 # 26.07.0
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,6 +18,16 @@ apps:
     extensions: [gnome]
     command: usr/bin/wxmaxima
     desktop: usr/share/applications/io.github.wxmaxima_developers.wxMaxima.desktop
+    environment:
+      # Route "open URL in the system browser" and native file dialogs through
+      # the XDG Desktop Portal instead of trying to exec a browser binary that
+      # does not exist inside the confinement. This is what lets clicking a link
+      # (help, "visit website", ...) open the host's default browser without
+      # bundling any browser or loosening confinement. GTK only consults the
+      # portal for these when GTK_USE_PORTAL is set. (The snapd-provided
+      # xdg-open shim already forwards to the host; this covers the GTK path
+      # wxLaunchDefaultBrowser() uses.)
+      GTK_USE_PORTAL: "1"
     plugs: [network, network-bind, home, removable-media, optical-drive, process-control, cups-control, upower-observe]
       # gtk-3-themes:
       #   interface: content

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -1582,7 +1582,17 @@ void wxMaxima::LaunchHelpBrowser(wxString uri) {
   } else
 #endif
     {
-      if (m_configuration.AutodetectHelpBrowser()) {
+      if (wxGetEnv(wxS("SNAP"), nullptr)) {
+        // Inside a confined snap the system browser lives on the host, outside
+        // the sandbox: exec-ing a mime-resolved (or hard-coded) browser command
+        // fails because that binary is hidden by the confinement. Route the URL
+        // through wxLaunchDefaultBrowser() instead -- it uses gtk_show_uri()
+        // and, with GTK_USE_PORTAL=1 set by the snap, reaches the host's default
+        // browser via the XDG Desktop Portal. No browser has to be bundled and
+        // confinement stays strict.
+        if (!wxLaunchDefaultBrowser(uri))
+          wxLogMessage(_("Launching the system's default help browser failed."));
+      } else if (m_configuration.AutodetectHelpBrowser()) {
         // see https://docs.wxwidgets.org/3.0/classwx_mime_types_manager.html
         auto *manager = wxTheMimeTypesManager;
         wxFileType *filetype = manager->GetFileTypeFromExtension("html");


### PR DESCRIPTION
Two snap improvements requested after the snapcraft store credentials were added as a repository secret.

## 1. The system web browser works again under strict confinement

Clicking a link — the manual, "visit website", Maxima's online documentation — silently did nothing in the snap. Under strict confinement the system browser lives **outside** the sandbox, so both `wxLaunchDefaultBrowser()` (which execs a browser binary directly) and the mime-resolved help-browser command failed: the target binary is hidden by the confinement.

This is the **portal** approach — no browser is bundled and confinement stays strict:

- **`snap/snapcraft.yaml`** sets `GTK_USE_PORTAL=1`, so GTK routes `gtk_show_uri()` (used by `wxLaunchDefaultBrowser`) and the native file dialogs through the **XDG Desktop Portal** to the host's default handler.
- **`LaunchHelpBrowser()`** detects the snap (the `SNAP` env var) and opens the URL with `wxLaunchDefaultBrowser()` instead of exec-ing a mime-resolved browser command the confinement hides. The internal webkit help sidebar (the default) was unaffected; this fixes the "use the system browser" path and the external website links.

## 2. Weekly Snap Store publish

`build_snap.yml` previously only built the snap and uploaded it as a CI artifact on every push. Now:

- **push** → build + artifact only (unchanged CI check).
- **weekly schedule** (Mondays 04:00 UTC) and **manual dispatch** → additionally publish to the Snap Store's **edge** channel.

Because `snapcraft.yaml` pulls Maxima in via `stage-snaps: [maxima]`, the weekly rebuild also picks up the newest Maxima snap plus the latest `core24` security fixes. Publishing uses the `SNAPCRAFT_STORE_CREDENTIALS` repository secret via `snapcore/action-publish`, and is guarded to the upstream repository so forks and credential-less runs keep the build-only check working.

## Verification

- `build_snap.yml` and `snapcraft.yaml` parse as valid YAML; the publish step is gated on `github.event_name` and `github.repository`.
- `src/wxMaxima.cpp` compiles (`wxGetEnv`/`wxLaunchDefaultBrowser` are already used the same way elsewhere in the file and in `main.cpp`).
- **Not** verified: the actual browser-opens-in-the-confined-snap behaviour — that needs a real `snap install` on a confined desktop, which can't be exercised in this environment. Worth a manual check on the first edge build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DU23YMfQHdrkGCNJxn7dJs