### PR TITLE
Snap: weekly Maxima-snap rebuild (edge+stable) and a wxMaxima stable channel

### DIFF
--- a/.github/workflows/build_maxima_snap.yml
+++ b/.github/workflows/build_maxima_snap.yml
@@ -1,0 +1,116 @@
+name: build_maxima_snap
+
+# Rebuilds and publishes the *Maxima* snap, to both the edge and stable channels.
+#
+# The wxMaxima snap embeds Maxima via `stage-snaps: [maxima]`, i.e. it pulls a
+# pre-built Maxima snap from the store at build time -- it never rebuilds Maxima
+# itself. The Maxima snap is defined in the Maxima source tree
+# (snap/snapcraft.yaml, hosted on SourceForge), which has no CI of its own, so
+# nothing rebuilt it on a schedule: it drifted to an old Maxima version and, more
+# importantly, stopped picking up security fixes from the core24 runtime and the
+# staged packages.
+#
+# This job closes that gap. Once a week it rebuilds the Maxima snap from Maxima's
+# own snapcraft.yaml so the bundled libraries and base get refreshed, in two
+# variants:
+#   * stable <- the latest Maxima *release* tag (X.Y.Z)
+#   * edge   <- the current development HEAD (Maxima releases infrequently, so
+#               edge lets users get newer Maxima between releases)
+# It runs on Saturday, ahead of the wxMaxima stable (Sunday) and edge (Monday)
+# snap jobs, so those rebuilds bundle this fresh Maxima.
+#
+# The Maxima snapcraft.yaml hard-codes a stale `version:`; the real version lives
+# in configure.ac (AC_INIT([maxima], [X.Y.Z])) and is patched in at build time
+# (with a +git<sha> suffix on edge so each development build is distinguishable).
+#
+# Publishing uses the SNAPCRAFT_STORE_CREDENTIALS repository secret (the same one
+# the wxMaxima snap jobs use; its ACLs must allow package_push/package_release on
+# the maxima snap).
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every Saturday at 04:00 UTC.
+    - cron: '0 4 * * 6'
+
+permissions:
+  contents: read
+
+jobs:
+  build_maxima_snap:
+    name: Build and publish the Maxima snap (${{ matrix.channel }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        channel: [stable, edge]
+    steps:
+      # No actions/checkout: this job builds Maxima, not wxMaxima. Clone the
+      # Maxima source (which carries its own snap/snapcraft.yaml) into the empty
+      # workspace root so snapcore/action-build finds snap/snapcraft.yaml there.
+      - name: Clone Maxima and select the ref for this channel
+        run: |
+          set -eu
+          git clone https://git.code.sf.net/p/maxima/code .
+          if [ "${{ matrix.channel }}" = stable ]; then
+            # Maxima release tags are plain X.Y.Z; the release-candidate tags
+            # look like "version-59399rc4" and must not be selected.
+            ref=$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)
+            test -n "$ref"
+            echo "Building Maxima release $ref for the stable channel"
+            git checkout --quiet "$ref"
+          else
+            echo "Building Maxima development HEAD ($(git rev-parse --short HEAD)) for the edge channel"
+          fi
+
+      - name: Patch the snap version to the real Maxima version
+        env:
+          CHANNEL: ${{ matrix.channel }}
+        run: |
+          set -eu
+          python3 - <<'PY'
+          import os, re, subprocess
+          base = ""
+          with open("configure.ac") as f:
+              for line in f:
+                  m = re.search(r'AC_INIT\(\[maxima\],\s*\[([0-9.]+)\]', line)
+                  if m:
+                      base = m.group(1)
+                      break
+          assert base, "could not read the Maxima version from configure.ac"
+          if os.environ["CHANNEL"] == "edge":
+              sha = subprocess.check_output(
+                  ["git", "rev-parse", "--short", "HEAD"]).decode().strip()
+              ver = "%s+git%s" % (base, sha)   # e.g. 5.49.0+gita1b2c3d
+          else:
+              ver = base                        # e.g. 5.49.0
+          ver = ver[:32]                        # snap version limit
+          p = "snap/snapcraft.yaml"
+          s = open(p).read()
+          s = re.sub(r'(?m)^version:.*', "version: '%s'" % ver, s)
+          open(p, "w").write(s)
+          print("Maxima snap version set to", ver)
+          PY
+
+      - name: Build the Maxima snap
+        uses: snapcore/action-build@v1
+        id: build
+
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: maxima-snap-${{ matrix.channel }}
+          path: ${{ steps.build.outputs.snap }}
+          if-no-files-found: error
+
+      # Skipped on forks / whenever the secret is absent, so the build-only run
+      # keeps working without credentials.
+      - name: Publish to the ${{ matrix.channel }} channel
+        if: github.repository == 'wxMaxima-developers/wxmaxima'
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: ${{ matrix.channel }}

--- a/.github/workflows/build_snap_stable.yml
+++ b/.github/workflows/build_snap_stable.yml
@@ -1,0 +1,95 @@
+name: build_snap_stable
+
+# Builds and publishes the wxMaxima snap for the *stable* channel: the latest
+# wxMaxima *release* bundled with the latest Maxima *release*.
+#
+# build_snap.yml handles the edge channel (wxMaxima development HEAD). This
+# companion handles stable. It builds the newest `Version-*` release tag rather
+# than the default branch, and -- because the committed snapcraft.yaml keeps
+# `stage-snaps: [maxima]`, which resolves to Maxima's stable channel -- bundles
+# the latest Maxima release (refreshed weekly by build_maxima_snap.yml).
+#
+# It runs:
+#   * on every `Version-*` tag push  -> a new release reaches stable immediately;
+#   * weekly (Sunday, after the Saturday Maxima rebuild) -> so the stable snap
+#     keeps picking up security fixes from the Maxima snap, the core24 runtime
+#     and the staged packages *between* wxMaxima releases, not only at release.
+#
+# The snap is built from the current repo's snapcraft.yaml (so packaging fixes
+# reach stable as soon as they land on the default branch) with `source-tag`
+# pinned to the release, and its version label set from the tag.
+#
+# Publishing uses the SNAPCRAFT_STORE_CREDENTIALS repository secret.
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'Version-*'
+  schedule:
+    # Every Sunday at 04:00 UTC (after the Saturday Maxima rebuild).
+    - cron: '0 4 * * 0'
+
+permissions:
+  contents: read
+
+jobs:
+  build_snap_stable:
+    name: Build and publish the wxMaxima snap (stable)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout wxMaxima
+        uses: actions/checkout@v7
+        with:
+          # Full history so the release tags are available on scheduled runs.
+          fetch-depth: 0
+
+      - name: Pin the snap to the latest wxMaxima release
+        run: |
+          set -eu
+          if [ "${GITHUB_REF_TYPE:-}" = tag ]; then
+            tag="${GITHUB_REF_NAME}"
+          else
+            tag=$(git tag -l 'Version-*' | sort -V | tail -n1)
+          fi
+          test -n "$tag"
+          echo "Building wxMaxima release $tag for the stable channel"
+          CHANNEL_TAG="$tag" python3 - <<'PY'
+          import os, re
+          tag = os.environ["CHANNEL_TAG"]
+          ver = tag[len("Version-"):] if tag.startswith("Version-") else tag
+          p = "snap/snapcraft.yaml"
+          s = open(p).read()
+          # Label the snap with the release version.
+          s = re.sub(r'(?m)^version:.*', "version: '%s-0'" % ver, s)
+          # Build the release tag instead of the default branch: add a
+          # source-tag right after the wxMaxima git source line (4-space indent,
+          # matching the surrounding part keys).
+          src = "source: https://github.com/wxMaxima-developers/wxmaxima.git"
+          assert src in s, "wxMaxima git source line not found in snapcraft.yaml"
+          s = s.replace(src, src + "\n    source-tag: " + tag, 1)
+          open(p, "w").write(s)
+          print("stable snap: version %s-0, source-tag %s" % (ver, tag))
+          PY
+
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: build
+
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wxmaxima-snap-stable
+          path: ${{ steps.build.outputs.snap }}
+          if-no-files-found: error
+
+      - name: Publish to the stable channel
+        if: >-
+          github.repository == 'wxMaxima-developers/wxmaxima'
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: stable


### PR DESCRIPTION
Follow-up to the snap automation, closing two gaps: the **Maxima snap was never rebuilt** (so it went stale and stopped getting security fixes), and the **wxMaxima snap only had an edge channel**.

## Why the Maxima snap was stale

The wxMaxima snap embeds Maxima via `stage-snaps: [maxima]` — it pulls a *prebuilt* Maxima snap from the store and never rebuilds Maxima. The Maxima snap is defined in the Maxima source tree (`snap/snapcraft.yaml`) hosted on **SourceForge, which has no CI**, so nothing refreshed it: its `version:` had drifted to `5.47.0-0` (real Maxima is `5.49.0`) and the bundled `core24` runtime + staged packages stopped getting security updates.

## Two new workflows

Both use the existing `SNAPCRAFT_STORE_CREDENTIALS` secret (its ACLs cover both snaps).

### `build_maxima_snap.yml` — weekly (Sat) + manual
Clones the Maxima source from SourceForge and rebuilds the Maxima snap in a 2-way matrix:
- **stable** ← latest Maxima release tag (`X.Y.Z`, e.g. `5.49.0`)
- **edge** ← Maxima development HEAD (releases are infrequent, so edge offers newer Maxima between releases)

Maxima's committed snapcraft.yaml hard-codes a stale version; the real one is read from `configure.ac` and patched in at build time (`+git<sha>` suffix on edge so each dev build is distinguishable). *(You noted the label was never right — so it's computed in CI rather than trusted from the file.)*

### `build_snap_stable.yml` — on every `Version-*` tag + weekly (Sun) + manual
Builds the newest wxMaxima **release** (`source-tag` pinned) bundling the latest Maxima **release**, and publishes to the wxMaxima **stable** channel. The weekly cadence is deliberate: it keeps the stable snap picking up security fixes (from the refreshed Maxima snap, core24, staged packages) **between** releases, not only at release time.

## Ordering

Sat (Maxima) → Sun (wxMaxima stable) → Mon (wxMaxima edge, from `build_snap.yml`) — so each downstream snap bundles the freshly rebuilt Maxima. Publish steps are guarded to the upstream repository so forks / credential-less runs keep building.

## Channel matrix after this lands

| snap | edge | stable |
|---|---|---|
| **maxima** | dev HEAD | latest release |
| **wxmaxima** | dev HEAD (existing `build_snap.yml`) | latest release (new) |

## Verification

- Both workflows parse as YAML; the version + `source-tag` patch scripts were **dry-run against the real Maxima `configure.ac` and both `snapcraft.yaml` files** (Maxima `5.47.0-0`→`5.49.0`; wxMaxima `source-tag: Version-26.07.1` inserted correctly).
- **Not** verified: the actual snap builds/publishes — there's no snapcraft or store access in this environment. The first scheduled or `workflow_dispatch` run is the real validation, and is the safe way to try it (build-only on forks; publish only on the upstream repo).

## Follow-up (not in this PR)

To make the wxMaxima **edge** snap bundle Maxima **edge** (true "HEAD of both"), `build_snap.yml` would swap `stage-snaps: [maxima]` → `[maxima/latest/edge]` for its build. Left out here to keep this PR independent of the still-open edge PR (#2123); easy to add once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DU23YMfQHdrkGCNJxn7dJs