### PR TITLE
Snap: build arm64 snaps too, and bundle edge Maxima in the edge wxMaxima

### DIFF
--- a/.github/workflows/build_maxima_snap.yml
+++ b/.github/workflows/build_maxima_snap.yml
@@ -19,6 +19,11 @@ name: build_maxima_snap
 # It runs on Saturday, ahead of the wxMaxima stable (Sunday) and edge (Monday)
 # snap jobs, so those rebuilds bundle this fresh Maxima.
 #
+# Each channel is built for both amd64 and arm64 on native runners (arm64 uses
+# GitHub's ubuntu-24.04-arm runners, free for public repositories), so the store
+# serves a matching Maxima snap to users of either architecture. arm64 wxMaxima
+# snaps stage-snap the arm64 Maxima, so this must publish before them.
+#
 # The Maxima snapcraft.yaml hard-codes a stale `version:`; the real version lives
 # in configure.ac (AC_INIT([maxima], [X.Y.Z])) and is patched in at build time
 # (with a +git<sha> suffix on edge so each development build is distinguishable).
@@ -38,13 +43,19 @@ permissions:
 
 jobs:
   build_maxima_snap:
-    name: Build and publish the Maxima snap (${{ matrix.channel }})
-    runs-on: ubuntu-latest
+    name: Build and publish the Maxima snap (${{ matrix.channel }}, ${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
         channel: [stable, edge]
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       # No actions/checkout: this job builds Maxima, not wxMaxima. Clone the
       # Maxima source (which carries its own snap/snapcraft.yaml) into the empty
@@ -100,7 +111,7 @@ jobs:
       - name: Upload snap artifact
         uses: actions/upload-artifact@v4
         with:
-          name: maxima-snap-${{ matrix.channel }}
+          name: maxima-snap-${{ matrix.channel }}-${{ matrix.arch }}
           path: ${{ steps.build.outputs.snap }}
           if-no-files-found: error
 

--- a/.github/workflows/build_snap.yml
+++ b/.github/workflows/build_snap.yml
@@ -1,18 +1,24 @@
 name: build_snap
 
-# Builds the Snap package from snap/snapcraft.yaml so that breakage is caught
-# in CI instead of only when the Snap Store (or a maintainer) tries to build a
-# release. The snap silently rotted once already: base was bumped to core24
-# (Ubuntu 24.04) in 2024 while the build/stage packages stayed at wxWidgets 3.0,
-# which no longer exists on noble -- nothing in CI noticed because the snap was
-# never built here. This job closes that gap.
+# Builds the wxMaxima Snap for the *edge* channel (development HEAD), for both
+# amd64 and arm64, so breakage is caught in CI instead of only when the Snap
+# Store (or a maintainer) tries to build a release. The snap silently rotted
+# once already: base was bumped to core24 (Ubuntu 24.04) in 2024 while the
+# build/stage packages stayed at wxWidgets 3.0, which no longer exists on noble
+# -- nothing in CI noticed because the snap was never built here.
 #
-# On every push the snap is only built and uploaded as a workflow artifact (a
-# CI check). Once a week -- and on a manual "Run workflow" -- the freshly built
-# snap is additionally published to the Snap Store's "edge" channel. Because the
-# snapcraft.yaml pulls Maxima in via `stage-snaps: [maxima]`, the weekly rebuild
-# also picks up the newest Maxima snap (rebuilt on its own schedule) together
-# with the latest security fixes from the core24 runtime.
+# On every push each architecture's snap is only built and uploaded as a
+# workflow artifact (a CI check). Once a week -- and on a manual "Run workflow"
+# -- the freshly built snaps are additionally published to the Snap Store's
+# "edge" channel (one revision per architecture; the store serves each user the
+# right one).
+#
+# For the published edge snaps the bundled Maxima is switched from the store's
+# stable Maxima to its edge Maxima (`maxima/latest/edge`), so edge is "HEAD of
+# both". Push (build-only) runs keep bundling stable Maxima, which always exists,
+# so the CI check never depends on an edge Maxima revision having been published
+# yet. arm64 needs an arm64 Maxima snap in the store first -- build_maxima_snap
+# publishes those (run it before the first arm64 wxMaxima build).
 #
 # Publishing needs the SNAPCRAFT_STORE_CREDENTIALS repository secret, generated
 # with:
@@ -24,7 +30,7 @@ on:
   push:
   workflow_dispatch:
   schedule:
-    # Every Monday at 04:00 UTC.
+    # Every Monday at 04:00 UTC (after the Saturday Maxima rebuild).
     - cron: '0 4 * * 1'
 
 permissions:
@@ -32,14 +38,43 @@ permissions:
 
 jobs:
   build_snap:
-    name: Build the snap
-    runs-on: ubuntu-latest
+    name: Build the edge snap (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout wxMaxima
         uses: actions/checkout@v7
         with:
           fetch-depth: 15
+
+      # Only for the snaps we actually publish to edge: bundle Maxima's edge
+      # channel instead of its stable one, so the edge wxMaxima ships the newest
+      # Maxima too. Left as stable on push builds so the CI check doesn't depend
+      # on an edge Maxima revision existing yet.
+      - name: Bundle Maxima's edge channel when publishing
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: |
+          # snapcraft.yaml has CRLF line endings, so anchor-based sed on the bare
+          # "maxima" stage-snaps entry silently matches nothing. Use an explicit,
+          # line-ending-preserving replace that fails loudly if the entry moves.
+          python3 - <<'PY'
+          import re
+          p = "snap/snapcraft.yaml"
+          s = open(p, newline="").read()   # preserve CRLF/LF exactly
+          s2 = re.sub(r'(?m)^([^\S\r\n]*-[^\S\r\n]+)maxima([^\S\r\n]*\r?)$',
+                      r'\1maxima/latest/edge\2', s)
+          assert s2 != s, "did not find the '- maxima' stage-snaps entry to switch to edge"
+          open(p, "w", newline="").write(s2)
+          PY
+          grep -n 'maxima' snap/snapcraft.yaml
 
       - name: Build snap
         uses: snapcore/action-build@v1
@@ -48,7 +83,7 @@ jobs:
       - name: Upload snap artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wxmaxima-snap
+          name: wxmaxima-snap-edge-${{ matrix.arch }}
           path: ${{ steps.build.outputs.snap }}
           if-no-files-found: error
 

--- a/.github/workflows/build_snap_stable.yml
+++ b/.github/workflows/build_snap_stable.yml
@@ -35,9 +35,17 @@ permissions:
 
 jobs:
   build_snap_stable:
-    name: Build and publish the wxMaxima snap (stable)
-    runs-on: ubuntu-latest
+    name: Build and publish the wxMaxima snap (stable, ${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout wxMaxima
         uses: actions/checkout@v7
@@ -80,7 +88,7 @@ jobs:
       - name: Upload snap artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wxmaxima-snap-stable
+          name: wxmaxima-snap-stable-${{ matrix.arch }}
           path: ${{ steps.build.outputs.snap }}
           if-no-files-found: error
 


### PR DESCRIPTION
Follow-up to the snap automation: the snaps were **amd64-only**, and (deferred until #2123 merged) the edge wxMaxima snap still bundled *stable* Maxima.

## arm64 snaps

All three snap jobs built only amd64 (`snapcore/action-build` on `ubuntu-latest`). Now each also builds **arm64** natively on GitHub's **`ubuntu-24.04-arm`** runners (free for public repos), and publishes it — the store serves each user the revision matching their architecture.

- **`build_maxima_snap.yml`**: the channel matrix becomes channel × arch → Maxima for `{stable, edge} × {amd64, arm64}`.
- **`build_snap.yml`** (wxMaxima edge) and **`build_snap_stable.yml`** (wxMaxima stable): built for amd64 and arm64.

Ordering still matters: arm64 wxMaxima `stage-snaps` the arm64 Maxima, so the Saturday Maxima job must publish before the Sun/Mon wxMaxima jobs. (For the very first run, dispatch `build_maxima_snap` first so the arm64 Maxima revisions exist.)

## Edge wxMaxima now bundles edge Maxima ("HEAD of both")

On its published (schedule/dispatch) runs, the edge wxMaxima snap switches its staged Maxima from stable to `maxima/latest/edge`. Push (build-only) runs keep bundling **stable** Maxima, so the CI check never depends on an edge Maxima revision having been published yet.

### A real bug caught while doing this

`snapcraft.yaml` uses **CRLF** line endings. The natural `$`-anchored `sed` for the channel switch **silently matched nothing** (the line is `- maxima\r`), which would have shipped the edge snap with *stable* Maxima and no error. It's now a CRLF-safe Python replace that **asserts it matched**, so a future rename fails the job loudly instead of silently shipping the wrong Maxima.

## Resulting matrix

| snap | edge | stable | arches |
|---|---|---|---|
| maxima | dev HEAD | latest release | amd64 + arm64 |
| wxmaxima | dev HEAD + **edge Maxima** | latest release + stable Maxima | amd64 + arm64 |

## Verification

All three workflows parse as YAML; the edge-Maxima replace and the stable version/`source-tag` patch were dry-run against the real (CRLF) `snapcraft.yaml` and reparse to valid YAML with the expected values (`source-tag: Version-26.07.1`, `- maxima/latest/edge`, correct versions). **Not** verified: the actual arm64 builds/publishes — no snapcraft or store access here — so the first scheduled/`workflow_dispatch` run is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DU23YMfQHdrkGCNJxn7dJs