### PR TITLE
Download page: add the SignPath code-signing attribution

### DIFF
--- a/download.html
+++ b/download.html
@@ -76,6 +76,16 @@
       </div>
     </div>
 
+    <div class="alert alert-info" role="alert">
+      <h4>Code signing</h4>
+      <p>
+        Free code signing for the wxMaxima Windows installer is provided by
+        <a href="https://signpath.io/">SignPath.io</a>, with a code-signing
+        certificate issued by the
+        <a href="https://signpath.org/">SignPath Foundation</a>.
+      </p>
+    </div>
+
     <h3>Other</h3>
 
     <h4>Linux</h4>


### PR DESCRIPTION
The SignPath Foundation's free code-signing program for open-source projects requires the project to **acknowledge them on its download page** as a condition of applying for the free signing key.

This adds the required attribution to `download.html` (the project's Download page), directly below the download buttons where it's visible to anyone fetching the Windows installer:

> **Code signing** — Free code signing for the wxMaxima Windows installer is provided by [SignPath.io](https://signpath.io/), with a code-signing certificate issued by the [SignPath Foundation](https://signpath.org/).

Once this is live on the site (merging deploys GitHub Pages), the attribution is in place so the SignPath application can be submitted.

Notes:
- Applied to the **current** `download.html` via the GitHub Contents API and inserted as a Bootstrap `alert` block; the page's `<div>` nesting stays balanced.
- This is the prerequisite mention only. The actual signing (a SignPath GitHub Actions step on the Windows installer) is a separate follow-up once the key is granted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DU23YMfQHdrkGCNJxn7dJs