### PR TITLE
Windows: window icon shows the wxMaxima logo instead of the generic "W"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Current development version
 
+- Windows: the wxMaxima window and taskbar button again show the wxMaxima logo
+  instead of the generic wxWidgets "W" icon. The window icon now also falls back
+  to the logo compiled into the binary, so it no longer depends solely on the
+  .ico resource being the one Windows selects.
+
 # 26.07.1
 
 This release contains an unusually large batch of improvements -- many of them

--- a/src/wxMaximaFrame.cpp
+++ b/src/wxMaximaFrame.cpp
@@ -48,6 +48,7 @@
 #include "wxMaximaIcon.h"
 #include <wx/artprov.h>
 #include <wx/config.h>
+#include <wx/iconbndl.h>
 #include <wx/display.h>
 #include <wx/fileconf.h>
 #include <wx/filename.h>
@@ -176,11 +177,17 @@ wxMaximaFrame::wxMaximaFrame(wxWindow *parent, int id,
   StatusMaximaBusy(StatusBar::MaximaStatus::waiting);
 
 #if defined(__WXMSW__)
-  // On Windows the taskbar icon needs to reside in the Resources file the
-  // linker includes. Also it needs to be in Microsoft's own .ico format => This
-  // file we don't ship with the source, but take it from the Resources file
-  // instead.
-  SetIcon(wxICON(icon0));
+  // Explorer shows the exe file's .ico resource (icon0 -> maximaicon.ico) that
+  // the linker embeds. For the *window* icon (the title-bar icon and the running
+  // app's taskbar button) we build a bundle from that resource AND the wxMaxima
+  // logo that is compiled into the binary (wxMaximaIcon(), the same one GTK
+  // uses). Relying on the resource alone let the window fall back to wxWidgets'
+  // own generic icon (wxICON_AAA, i.e. the "W") whenever that resource icon was
+  // not the one selected; the embedded copy is always valid, so the wxMaxima
+  // logo is shown regardless.
+  wxIconBundle icons(wxT("icon0"), nullptr);
+  icons.AddIcon(wxMaximaIcon());
+  SetIcons(icons);
 #elif defined(__WXGTK__)
   // This icon we include in the executable [in its compressed form] so we avoid
   // the questions "Was the icon file packaged with wxMaxima?" and "Can we


### PR DESCRIPTION
**Reported by Gunter:** on Windows the window's top-left icon (and taskbar button) is a generic yellow **"W"**, not the red/blue wxMaxima **"M"**.

## What the "W" is, and did we cause it

The "W" is **wxWidgets' own fallback icon** — `wx/msw/wx.rc` defines `wxICON_AAA ICON "wx/msw/std.ico"`, and its comment notes it "may be used by Explorer as the application icon" when the app's own icon isn't selected.

We didn't cause it in recent work: the icon code and `wxmaxima.rc` weren't touched by the manifest cleanup or the dark-mode changes, and the last `.rc` icon change (Feb 2025) just moved `#include "wx/msw/wx.rc"` *after* the `ICON` lines — the wxWidgets-recommended order. The real weakness is older: on Windows the **window** icon was set *only* from the `.ico` resource:

```cpp
#if defined(__WXMSW__)
  SetIcon(wxICON(icon0));   // maximaicon.ico -- no fallback
```

If that resource isn't the icon Windows ends up selecting (it competes with `wxICON_AAA`), there's nothing to fall back to *but* wxWidgets' "W".

## Fix

Build the window icon from a bundle of the `.ico` resource **and** the wxMaxima logo that's compiled into the binary — `wxMaximaIcon()`, the exact icon the GTK build already uses:

```cpp
  wxIconBundle icons(wxT("icon0"), nullptr);
  icons.AddIcon(wxMaximaIcon());
  SetIcons(icons);
```

The embedded copy is always valid, so the title bar / taskbar show the wxMaxima logo regardless of how the resource icon is selected. Explorer's *file* icon still comes from the `.ico` resource, unchanged.

## Scope / verification

- MSW-only (inside the `__WXMSW__` branch); GTK and macOS paths untouched.
- `wxMaximaFrame.cpp` still **compiles on Linux** (verified) — the new `#include <wx/iconbndl.h>` and the GTK path are fine. The MSW branch is compiled by the Windows CI jobs (I have no Windows box here).
- Best confirmed by you on the resulting Windows build: the title-bar/taskbar icon should now be the wxMaxima "M".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DU23YMfQHdrkGCNJxn7dJs