### PR TITLE
Add support-routing: SUPPORT.md + issue-chooser contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+# Shown on the "New issue" chooser. Blank issues stay enabled so wxMaxima GUI
+# bugs can still be filed here directly; the links below route the things that
+# do NOT belong in this tracker (Maxima's mathematics, and general questions) to
+# the right place. See also .github/SUPPORT.md.
+blank_issues_enabled: true
+contact_links:
+  - name: wxMaxima questions & discussion (the GUI)
+    url: https://github.com/wxMaxima-developers/wxmaxima/discussions
+    about: Usage questions, ideas and general discussion about the wxMaxima interface belong in Discussions, not in the issue tracker.
+  - name: Maxima mathematics bugs (the CAS / math engine)
+    url: https://sourceforge.net/p/maxima/bugs/
+    about: A wrong or missing mathematical result comes from Maxima itself. Please report it in Maxima's SourceForge bug tracker — not here. (Reproduce it by running plain `maxima` in a terminal to be sure.)
+  - name: Maxima mailing list (using Maxima the CAS)
+    url: https://maxima.sourceforge.io/maximalist.html
+    about: Questions about Maxima the computer algebra system — as opposed to the wxMaxima GUI — are best asked on the Maxima mailing list.

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,33 @@
+# Getting help & reporting problems
+
+wxMaxima is the graphical **front-end**. **Maxima** is the computer algebra
+system — the "math engine" that does the actual calculations. They are two
+separate projects, so where to go depends on what your question or problem is
+about.
+
+## A quick test: wxMaxima or Maxima?
+
+Run the same command in a plain terminal with `maxima` (no wxMaxima). If you get
+the same wrong or missing **result** there, it is a **Maxima** issue. If the
+problem only happens **inside the wxMaxima window** (a crash, a display glitch, a
+menu, file loading/saving, …), it is a **wxMaxima** issue.
+
+## The wxMaxima GUI (this project)
+
+- **Questions, ideas, general discussion** →
+  [GitHub Discussions](https://github.com/wxMaxima-developers/wxmaxima/discussions)
+- **Bugs in the user interface** (crashes, rendering, menus, file handling, …) →
+  [GitHub Issues](https://github.com/wxMaxima-developers/wxmaxima/issues)
+
+## Maxima, the computer algebra system
+
+If the problem is about the **mathematics** — a wrong or missing result, an
+integral Maxima cannot solve, a function that misbehaves — it comes from Maxima
+itself, not from the GUI:
+
+- **Bugs in Maxima's mathematics** →
+  [Maxima bug tracker on SourceForge](https://sourceforge.net/p/maxima/bugs/)
+- **Questions about using Maxima** →
+  the [Maxima mailing list](https://maxima.sourceforge.io/maximalist.html)
+
+More about Maxima itself: <https://maxima.sourceforge.io/>.


### PR DESCRIPTION
wxMaxima (the GUI) and Maxima (the computer algebra system) are **separate projects**, but people reporting a problem don't always know which one it belongs to — so Maxima *mathematics* bugs and general usage questions sometimes land in this GUI issue tracker, where they can't be acted on.

This adds the two files GitHub uses to surface a "Support" route and steer people to the right place:

### `.github/SUPPORT.md`
A short "where do I go?" guide, with a quick disambiguation test:

> Run the same command in a plain terminal with `maxima` (no wxMaxima). Same wrong result there → **Maxima** issue. Only inside the wxMaxima window → **wxMaxima** issue.

Routes:
- wxMaxima GUI questions/ideas → **GitHub Discussions**
- wxMaxima GUI bugs → **GitHub Issues**
- Maxima math bugs → **[SourceForge bug tracker](https://sourceforge.net/p/maxima/bugs/)**
- Maxima usage → **[Maxima mailing list](https://maxima.sourceforge.io/maximalist.html)**

### `.github/ISSUE_TEMPLATE/config.yml`
Adds contact links to the **"New issue" chooser** pointing at Discussions, the Maxima SourceForge bug tracker, and the Maxima mailing list. `blank_issues_enabled: true` is kept so wxMaxima GUI bugs can still be filed directly (there are no issue templates to force otherwise).

### Notes
- URLs match what the README already uses (`maxima.sourceforge.io`); Discussions is assumed enabled (you mentioned the project has a Discussions page).
- `config.yml` had to be **force-added**: a broad `config.*` rule in `.gitignore` (intended for build-generated `config.h`) was catching it. It's now tracked, so future edits behave normally — but heads-up in case you want to narrow that ignore rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DU23YMfQHdrkGCNJxn7dJs