### PR TITLE
HTML export: default to self-contained native MathML; MathJaX 4 as opt-in fallback

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # Current development version
 
+- HTML export now defaults to native MathML. Every current browser renders
+  MathML itself, so the exported page needs no JavaScript and, unlike before,
+  makes no requests to any external server -- removing both a privacy/security
+  dependency and the wait for a download. MathJaX is now offered only as an
+  optional fall-back ("MathML + MathJaX fall-back for old browsers"), which
+  downloads MathJaX from its CDN solely on browsers too old to support MathML.
+- HTML export: the separate "TeX, interpreted by MathJaX" option was removed;
+  existing configurations that used it fall back to the new MathML default.
+  (LaTeX export to a .tex file is unaffected.)
+- HTML export: equation labels (like `(%o1)`) and line-wrapped equations now
+  show up in browsers that render MathML natively. They previously relied on
+  `<mlabeledtr>`/`mtable side`, which the MathML Core standard (implemented by
+  Chrome and Safari) dropped; labels are now placed beside the equation as
+  HTML and the equation layout uses plain MathML-Core table rows.
+- HTML export: when the MathJaX fall-back is used it is now MathJaX version 4,
+  configured through the current API so the equation-alignment settings apply.
 - Windows: the wxMaxima window and taskbar button again show the wxMaxima logo
   instead of the generic wxWidgets "W" icon. The window icon now also falls back
   to the logo compiled into the binary, so it no longer depends solely on the

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -270,7 +270,7 @@ void Configuration::ResetAllToDefaults() {
   m_wxMathML_Filename.Clear();
 
   m_mathJaxURL =
-    wxS("https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js");
+    wxS("https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js");
   m_usePartialForDiff = false, m_documentclass = wxS("article");
   m_documentclassOptions = wxS("fleqn");
   m_incrementalSearch = true;
@@ -292,7 +292,7 @@ void Configuration::ResetAllToDefaults() {
   m_saveUntitled = true;
   m_cursorJump = true;
   m_autoSaveAsTempFile = false;
-  m_htmlEquationFormat = mathJaX_TeX;
+  m_htmlEquationFormat = mathML;
   m_autodetectMaxima = true;
   m_mathJaxURL_UseUser = false;
   m_TOCshowsSectionNumbers = false;
@@ -748,10 +748,11 @@ void Configuration::ReadConfig() {
   {
     int tmp = static_cast<int>(m_htmlEquationFormat);
     config->Read("HTMLequationFormat", &tmp);
-    if(tmp < 0)
-      tmp = mathJaX_TeX;
-    if(tmp > html_export_invalidChoice)
-      tmp = svg;
+    // The TeX-via-MathJaX HTML export was removed; migrate saved configs (whose
+    // old default was mathJaX_TeX) to native MathML. Also clamp anything out of
+    // range to the default.
+    if ((tmp < 0) || (tmp >= html_export_invalidChoice) || (tmp == mathJaX_TeX))
+      tmp = mathML;
     m_htmlEquationFormat = static_cast<Configuration::htmlExportFormat>(tmp);
   }
 

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -143,10 +143,18 @@ public:
   //! The export formats we support for HTML equations
   enum htmlExportFormat
   {
+    //! Deprecated: the TeX-via-MathJaX HTML export was removed. The value is
+    //! kept so saved configurations migrate to native MathML (see
+    //! Configuration.cpp) instead of silently shifting to another format.
     mathJaX_TeX = 0,
     bitmap = 1,
+    //! Native MathML, plus MathJaX downloaded as a fall-back only for the few
+    //! browsers that still lack MathML support.
     mathML_mathJaX = 2,
     svg = 3,
+    //! Native MathML with no MathJaX at all: the exported page makes no
+    //! external requests. This is the default.
+    mathML = 4,
     html_export_invalidChoice
   };
 
@@ -950,7 +958,7 @@ public:
 
   bool EnterEvaluates() const {return m_enterEvaluates;}
   void EnterEvaluates(bool enterEvaluates) {m_enterEvaluates = enterEvaluates;}
-  static wxString MathJaXURL_Auto() { return wxS("https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js");}
+  static wxString MathJaXURL_Auto() { return wxS("https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js");}
   //! Returns the URL MathJaX can be found at.
   void MathJaXURL(wxString url){m_mathJaxURL = std::move(url);}
 

--- a/src/cells/Cell.cpp
+++ b/src/cells/Cell.cpp
@@ -986,7 +986,7 @@ wxString Cell::ListToMathML(bool startofline) const {
     // Handle linebreaks
     if ((&tmp != this) && (tmp.HasHardLineBreak()))
       retval +=
-        wxS("</mtd></mlabeledtr>\n<mlabeledtr columnalign=\"left\"><mtd>");
+        wxS("</mtd></mtr>\n<mtr columnalign=\"left\"><mtd>");
 
     // If a linebreak isn't followed by a label we need to introduce an empty
     // one.
@@ -1013,10 +1013,16 @@ wxString Cell::ListToMathML(bool startofline) const {
   if ((multiCell) && (!needsTable))
     retval = wxS("<mrow>") + retval + wxS("</mrow>\n");
 
-  // If we put the region we exported into a table we need to end this table now
+  // If we put the region we exported into a table we need to end this table
+  // now. We deliberately use a plain <mtr> rather than <mlabeledtr side="left">:
+  // labeled rows and the mtable "side" attribute were dropped from MathML Core,
+  // so browsers that render MathML natively (Chrome, Safari, ...) ignore them.
+  // A plain multi-column <mtr> is part of MathML Core and renders everywhere;
+  // in the HTML export the equation label rides beside the <math> as HTML
+  // instead (see WorksheetExport.cpp).
   if (needsTable)
-    retval = wxS("<mtable side=\"left\">\n<mlabeledtr><mtd>") + retval +
-      wxS("</mtd></mlabeledtr>\n</mtable>");
+    retval = wxS("<mtable columnalign=\"left\">\n<mtr><mtd>") + retval +
+      wxS("</mtd></mtr>\n</mtable>");
   return retval;
 }
 

--- a/src/dialogs/ConfigDialogue.cpp
+++ b/src/dialogs/ConfigDialogue.cpp
@@ -82,6 +82,21 @@ extern size_t MEDIA_PLAYBACK_START_SVG_GZ_SIZE;
 
 #define CONFIG_ICON_SCALE (1.0)
 
+//! The order of the "Export equations to HTML as:" choice control.
+//
+// This deliberately differs from the htmlExportFormat enum values: the enum
+// keeps a deprecated mathJaX_TeX = 0 slot so old configs migrate cleanly, and
+// that removed option must not appear here. So the choice index is mapped to an
+// enum value explicitly (via this table) instead of relying on them matching.
+static const Configuration::htmlExportFormat s_htmlEqFormats[] = {
+  Configuration::mathML,         //!< default: native MathML, no external deps
+  Configuration::mathML_mathJaX, //!< native MathML + MathJaX fall-back
+  Configuration::bitmap,
+  Configuration::svg,
+};
+static const int s_htmlEqFormatCount =
+  sizeof(s_htmlEqFormats) / sizeof(s_htmlEqFormats[0]);
+
 int ConfigDialogue::GetImageSize() {
   int ppi;
 #if wxCHECK_VERSION(3, 1, 1)
@@ -403,14 +418,16 @@ void ConfigDialogue::SetCheckboxValues() {
                                 "bracket showing the extend of the cell and allowing to fold it. This "
                                 "setting now tells if this bracket is to be printed, as well."));
   m_exportWithMathJAX->SetToolTip(
-                                  _("MathJAX creates scalable High-Quality representations of 2D Maths "
-                                    "that can be used for Drag-And-Drop and provides accessibility "
-                                    "options. The disadvantage of MathJAX is that it needs JavaScript and "
-                                    "a little bit of time in order to typeset equations.\nMathML is much "
-                                    "faster than MathJaX, if it is supported by the browser. But many "
-                                    "MathML implementations tend to lack necessary features.\nBitmaps tend "
-                                    "to need more band width than the other two options. They lack support "
-                                    "for advanced features like drag-and-drop or accessibility. Also they "
+                                  _("\"MathML (rendered by the browser)\" is the recommended choice: "
+                                    "every current browser renders MathML natively and instantly, and "
+                                    "the exported page needs no JavaScript and makes no requests to any "
+                                    "external server.\n\"MathML + MathJaX fall-back for old browsers\" "
+                                    "behaves the same on current browsers, but additionally downloads "
+                                    "MathJaX from an external server (a CDN) as a fall-back on browsers "
+                                    "too old to support MathML. Only choose this if you need to support "
+                                    "such browsers and accept the external dependency.\nBitmaps tend to "
+                                    "need more band width than the other options. They lack support for "
+                                    "advanced features like drag-and-drop or accessibility. Also they "
                                     "have problems aligning and scaling with the rest of the text and "
                                     "might use fonts that don't match the rest of the document."));
   m_usesvg->SetToolTip(_("PNG images can be read by old wxMaxima versions - "
@@ -513,7 +530,17 @@ void ConfigDialogue::SetCheckboxValues() {
   m_wrapLatexMath->SetValue(configuration->WrapLatexMath());
   m_exportContainsWXMX->SetValue(configuration->ExportContainsWXMX());
   m_printBrackets->SetValue(configuration->PrintBrackets());
-  m_exportWithMathJAX->SetSelection(configuration->HTMLequationFormat());
+  {
+    // Map the stored format to a choice index; anything not offered anymore
+    // (e.g. the removed mathJaX_TeX) falls back to the default (index 0).
+    int sel = 0;
+    for (int i = 0; i < s_htmlEqFormatCount; ++i)
+      if (s_htmlEqFormats[i] == configuration->HTMLequationFormat()) {
+        sel = i;
+        break;
+      }
+    m_exportWithMathJAX->SetSelection(sel);
+  }
   m_matchParens->SetValue(configuration->GetMatchParens());
   m_showMatchingParens->SetValue(configuration->ShowMatchingParens());
   m_showLength->SetSelection(configuration->ShowLength());
@@ -1164,10 +1191,11 @@ wxWindow *ConfigDialogue::CreateExportPanel() {
   wxFlexGridSizer *htmlGrid_sizer = new wxFlexGridSizer(9, 2, 5, 5);
   wxStaticText *mju = new wxStaticText(html_sizer->GetStaticBox(), wxID_ANY,
                                        _("Export equations to HTML as:"));
+  // Keep this list in the same order as s_htmlEqFormats (see top of file).
   wxArrayString mathJaxChoices;
-  mathJaxChoices.Add(_("TeX, interpreted by MathJaX"));
+  mathJaxChoices.Add(_("MathML (rendered by the browser)"));
+  mathJaxChoices.Add(_("MathML + MathJaX fall-back for old browsers"));
   mathJaxChoices.Add(_("Bitmaps"));
-  mathJaxChoices.Add(_("MathML + MathJaX as Fill-In"));
   mathJaxChoices.Add(_("SVG graphics"));
   m_exportWithMathJAX =
     new wxChoice(html_sizer->GetStaticBox(), wxID_ANY, wxDefaultPosition,
@@ -2278,8 +2306,12 @@ void ConfigDialogue::WriteSettings() {
   configuration->WrapLatexMath(m_wrapLatexMath->GetValue());
   configuration->ExportContainsWXMX(m_exportContainsWXMX->GetValue());
   configuration->PrintBrackets(m_printBrackets->GetValue());
-  configuration->HTMLequationFormat(
-                                    (Configuration::htmlExportFormat)m_exportWithMathJAX->GetSelection());
+  {
+    int sel = m_exportWithMathJAX->GetSelection();
+    if ((sel < 0) || (sel >= s_htmlEqFormatCount))
+      sel = 0;
+    configuration->HTMLequationFormat(s_htmlEqFormats[sel]);
+  }
 
   if (m_linebreaksInLongNums->GetValue()) {
     configuration->ShowAllDigits(true);

--- a/src/worksheet/WorksheetExport.cpp
+++ b/src/worksheet/WorksheetExport.cpp
@@ -479,21 +479,53 @@ bool WorksheetExport::ExportToHTML(GroupCell *tree, Configuration *configuration
   // Write styles
   //////////////////////////////////////////////
 
-  if ((configuration->HTMLequationFormat() ==
-       Configuration::mathML_mathJaX) ||
-      (configuration->HTMLequationFormat() == Configuration::mathJaX_TeX)) {
-    output << wxS("<script type=\"text/x-mathjax-config\">\n");
-    output << wxS("  MathJax.Hub.Config({\n");
-    output << wxS("    displayAlign: \"left\",\n");
-    output << wxS("    context: \"MathJax\",\n");
-    output << wxS("    TeX: {TagSide: \"left\"}\n");
-    output << wxS("  })\n");
+  const Configuration::htmlExportFormat eqFormat =
+    configuration->HTMLequationFormat();
+  if (eqFormat == Configuration::mathML_mathJaX) {
+    // Equations are exported as MathML, which every current browser renders
+    // natively without any external dependency. In this mode MathJax is wanted
+    // only as a *fill-in* for the few browsers that still lack MathML support:
+    // we feature-detect native MathML once the page is parsed (by measuring an
+    // <mspace> of a known size) and download MathJax from its (external!) CDN
+    // only when it is missing. On modern browsers MathJax is never fetched.
+    //
+    // The default export format (Configuration::mathML) omits this block
+    // entirely, so the page makes no external requests at all.
+    //
+    // MathJax (3 and 4) is configured by assigning to window.MathJax *before*
+    // its loader runs; the old MathJax.Hub.Config() call was the MathJax 2 API
+    // and is silently ignored by MathJax >= 3. displayAlign is an output-jax
+    // option, so we set it for both CommonHTML (the CDN default) and SVG.
+    output << wxS("<script>\n");
+    output << wxS("  window.MathJax = {\n");
+    output << wxS("    chtml: {displayAlign: \"left\"},\n");
+    output << wxS("    svg: {displayAlign: \"left\"}\n");
+    output << wxS("  };\n");
     output << wxS("</script>\n");
-    output << wxS("<script id=\"MathJax-script\" async src=\"") +
-      configuration->MathJaXURL() + wxS("\">\n");
-    // prevent optimizing <script src="..."><script> to <script src=..."/>
-    output << wxS("  // A comment that hinders wxWidgets from optimizing this "
-                  "tag too much.\n");
+    output << wxS("<script>\n");
+    output << wxS("  (function() {\n");
+    output << wxS("    function loadMathJaxIfNeeded() {\n");
+    output << wxS("      var probe = document.createElement(\"div\");\n");
+    output << wxS("      probe.style.cssText =\n");
+    output << wxS("        \"position:absolute;visibility:hidden;height:0;overflow:hidden\";\n");
+    output << wxS("      probe.innerHTML =\n");
+    output << wxS("        '<math><mspace width=\"77px\" height=\"23px\"></mspace></math>';\n");
+    output << wxS("      document.body.appendChild(probe);\n");
+    output << wxS("      var box = probe.firstChild.firstChild.getBoundingClientRect();\n");
+    output << wxS("      document.body.removeChild(probe);\n");
+    output << wxS("      if (Math.abs(box.width - 77) < 2 && Math.abs(box.height - 23) < 2)\n");
+    output << wxS("        return; // the browser renders MathML natively\n");
+    output << wxS("      var s = document.createElement(\"script\");\n");
+    output << wxS("      s.id = \"MathJax-script\";\n");
+    output << wxS("      s.async = true;\n");
+    output << wxS("      s.src = \"") + configuration->MathJaXURL() + wxS("\";\n");
+    output << wxS("      document.head.appendChild(s);\n");
+    output << wxS("    }\n");
+    output << wxS("    if (document.readyState === \"loading\")\n");
+    output << wxS("      document.addEventListener(\"DOMContentLoaded\", loadMathJaxIfNeeded);\n");
+    output << wxS("    else\n");
+    output << wxS("      loadMathJaxIfNeeded();\n");
+    output << wxS("  })();\n");
     output << wxS("</script>\n");
   }
 
@@ -910,6 +942,33 @@ bool WorksheetExport::ExportToHTML(GroupCell *tree, Configuration *configuration
     css << wxS("  font-style: italic;\n");
   css << wxS("}\n");
 
+  // EQUATION + LABEL (MathML export)
+  // The equation label ("(%o1)") is laid out beside the <math> as HTML so it
+  // stays visible on native-MathML browsers, which no longer support
+  // <mlabeledtr>. A two-column grid keeps the label at the left margin; the
+  // equation lives in the second column, whose horizontal alignment is set in
+  // one place (justify-self below) so it is easy to override.
+  css << wxS(".equation {\n");
+  css << wxS("  display: grid;\n");
+  css << wxS("  grid-template-columns: auto 1fr;\n");
+  css << wxS("  align-items: baseline;\n");
+  css << wxS("  column-gap: 1em;\n");
+  css << wxS("  margin: 0.3em 0;\n");
+  css << wxS("}\n");
+  css << wxS(".eqlabel {\n");
+  css << wxS("  grid-column: 1;\n");
+  if (colorPrompt.Length()) {
+    wxColour color(colorPrompt);
+    css << wxS("  color: ") + color.GetAsString(wxC2S_CSS_SYNTAX) + wxS(";\n");
+  }
+  css << wxS("}\n");
+  css << wxS(".equation > math {\n");
+  css << wxS("  grid-column: 2;\n");
+  css << wxS("  /* Equation alignment. This is the single place to change how\n");
+  css << wxS("     exported equations line up: use left, center or right. */\n");
+  css << wxS("  justify-self: left;\n");
+  css << wxS("}\n");
+
   // TABLES
   css << wxS("table {\n");
   css << wxS("  border: 0px;\n");
@@ -926,23 +985,6 @@ bool WorksheetExport::ExportToHTML(GroupCell *tree, Configuration *configuration
   output << wxS("<!-- *********") + versionPad + wxS("******** -->\n");
   output << wxS("<!-- *        ") + versionString + wxS("       * -->\n");
   output << wxS("<!-- *********") + versionPad + wxS("******** -->\n");
-
-  if ((configuration->HTMLequationFormat() != Configuration::bitmap) &&
-      (configuration->HTMLequationFormat() != Configuration::svg)) {
-    // Tell users that have disabled JavaScript why they don't get 2d maths.
-    output << wxS("<noscript>");
-    output << wxS("<div class=\"error message\">");
-    output << wxS("<p>Please enable JavaScript in order to get a 2d display of "
-                  "the equations embedded in this web page.</p>");
-    output << wxS("</div>");
-    output << wxS("</noscript>");
-
-    // Tell mathJax about the \abs{} operator we define for LaTeX.
-    output << wxS("<p hidden = \"hidden\">\\(");
-    output << wxS("      \\DeclareMathOperator{\\abs}{abs}\n");
-    output << wxS("      \\newcommand{\\ensuremath}[1]{\\mbox{$#1$}}\n");
-    output << wxS("\\)</p>");
-  }
 
   //////////////////////////////////////////////
   // Write the actual contents
@@ -1017,28 +1059,6 @@ bool WorksheetExport::ExportToHTML(GroupCell *tree, Configuration *configuration
                                count);
           } else if (dynamic_cast<ImgCellBase *>(&(*chunk)) == NULL) {
             switch (configuration->HTMLequationFormat()) {
-            case Configuration::mathJaX_TeX: {
-              wxString line = chunk->ListToTeX();
-
-              line.Replace(wxS("<"), wxS("&lt;"));
-              line.Replace(wxS("&"), wxS("&amp;"));
-              line.Replace(wxS(">"), wxS("&gt;"));
-              // Work around a known limitation in MathJaX: According to
-              // https://github.com/mathjax/MathJax/issues/569 Non-Math Text
-              // will still be interpreted as Text, not as TeX for a long while.
-              //
-              // So instead of  "\%o1" print "%o1" - that works fine now.
-              // Since we are using a *fixed* Mathjax version for an export,
-              // nothing will happen, if Mathjax changes that behaviour and
-              // would interpret the % as TeX comment. When we would upgrade to
-              // the new MathJax version we would need to escape the % with \%,
-              // but now that is not necessary.
-              line.Replace(wxS("\\tag{\\% "), wxS("\\tag{%"));
-
-              output << wxS("<p>\n\\[") << line << wxS("\\]\n</p>\n");
-              break;
-            }
-
             case Configuration::svg: {
               auto const alttext =
                 EditorCell::EscapeHTMLChars(chunk->ListToString());
@@ -1086,11 +1106,33 @@ bool WorksheetExport::ExportToHTML(GroupCell *tree, Configuration *configuration
             }
 
             default: {
-              wxString line = chunk->ListToMathML();
-              output
-                << wxS("<math xmlns=\"http://www.w3.org/1998/Math/MathML\" "
-                       "display=\"block\">")
-                << line << wxS("</math>\n");
+              // MathML mode. A leading label cell (e.g. "(%o1)") is emitted
+              // beside the equation as plain HTML rather than inside the
+              // <math>: MathML Core (what native browsers implement) dropped
+              // <mlabeledtr>, so an in-math label would silently vanish on
+              // Chrome/Safari. The equation itself becomes a native <math>
+              // element, with MathJax used only as a fill-in (see the header).
+              Cell *first = &(*chunk);
+              Cell *eqStart = first;
+              wxString labelText;
+              if ((first->GetTextStyle() == TS_LABEL) ||
+                  (first->GetTextStyle() == TS_USERLABEL)) {
+                labelText = first->ToString();
+                labelText.Trim(true).Trim(false);
+                eqStart = first->GetNext();
+              }
+
+              output << wxS("<div class=\"equation\">\n");
+              if (!labelText.IsEmpty())
+                output << wxS("  <span class=\"eqlabel\">")
+                       << EditorCell::EscapeHTMLChars(labelText)
+                       << wxS("</span>\n");
+              if (eqStart != NULL)
+                output
+                  << wxS("  <math xmlns=\"http://www.w3.org/1998/Math/MathML\" "
+                         "display=\"block\">")
+                  << eqStart->ListToMathML() << wxS("</math>\n");
+              output << wxS("</div>\n");
             }
             }
           } else {

--- a/test/unit_tests/test_WorksheetExport.cpp
+++ b/test/unit_tests/test_WorksheetExport.cpp
@@ -303,9 +303,9 @@ SCENARIO("HTML export succeeds, is deterministic and contains the document") {
   // bitmap and svg additionally exercise the CopyToFile image rendering.
   struct EqFormat { Configuration::htmlExportFormat format; const wxChar *name; };
   const EqFormat formats[] = {
-    {Configuration::mathJaX_TeX, wxS("mathjax")},
+    {Configuration::mathML, wxS("mathml_native")},
+    {Configuration::mathML_mathJaX, wxS("mathml_fillin")},
     {Configuration::bitmap, wxS("bitmap")},
-    {Configuration::mathML_mathJaX, wxS("mathml")},
     {Configuration::svg, wxS("svg")},
   };
   const Configuration::htmlExportFormat oldFormat =
@@ -337,6 +337,30 @@ SCENARIO("HTML export succeeds, is deterministic and contains the document") {
       if (eq.format == Configuration::bitmap ||
           eq.format == Configuration::svg)
         RequireImgSrcsExist(html, dir1);
+      // Both MathML flavors emit native <math> with the label beside it as
+      // HTML. MathML Core dropped <mlabeledtr>, so it must never appear.
+      if (eq.format == Configuration::mathML ||
+          eq.format == Configuration::mathML_mathJaX) {
+        REQUIRE(html.Contains(wxS("<math")));
+        REQUIRE(html.Contains(wxS("class=\"equation\"")));
+        REQUIRE(html.Contains(wxS("class=\"eqlabel\"")));
+        REQUIRE_FALSE(html.Contains(wxS("mlabeledtr")));
+        // MathJax must never be loaded as an unconditional <script src>.
+        REQUIRE_FALSE(
+          html.Contains(wxS("<script id=\"MathJax-script\" async src=")));
+      }
+      // The default MathML mode must be fully self-contained: no MathJax, no
+      // JavaScript, no reference to any external server at all.
+      if (eq.format == Configuration::mathML) {
+        REQUIRE_FALSE(html.Contains(wxS("MathJax")));
+        REQUIRE_FALSE(html.Contains(wxS("mathjax")));
+        REQUIRE_FALSE(html.Contains(wxS("<script")));
+      }
+      // The fall-back mode adds MathJax, but only via feature detection.
+      if (eq.format == Configuration::mathML_mathJaX) {
+        REQUIRE(html.Contains(wxS("window.MathJax")));
+        REQUIRE(html.Contains(wxS("loadMathJaxIfNeeded")));
+      }
     }
   }
   g_cfg->HTMLequationFormat(oldFormat);


### PR DESCRIPTION
## What & why

Every current browser has rendered MathML natively for years (Chrome since 109 / early 2023; Firefox and Safari long before). This reworks the HTML export around that:

- **Native MathML is the new default.** The exported page needs no JavaScript and makes **no request to any external server** — removing both the CDN-download wait and an external-dependency privacy/security risk.
- **MathJaX is now opt-in**, offered only as *"MathML + MathJaX fall-back for old browsers"*. It feature-detects native MathML at load time and downloads MathJaX — now **version 4**, configured via the current `window.MathJax` API — solely on browsers too old to support MathML.
- **TeX-via-MathJaX HTML export removed.** Its enum value is kept as a deprecated alias so saved configs migrate to the native-MathML default instead of silently shifting format. (LaTeX export to a `.tex` file is unaffected.)
- **Equation labels & line-wrapped equations render natively again.** They relied on `<mlabeledtr>`/`mtable side`, which MathML Core (Chrome/Safari) dropped, so labels used to vanish. The label is now placed **beside** the equation as HTML — a two-column grid whose single `justify-self` rule is the one place to change alignment — and the equation layout uses plain MathML-Core `<mtr>` rows. This also fixes the clipboard *copy as MathML* path.
- **Bitmap and SVG HTML export are kept** — they're the only formats that survive restrictive consumers (email clients, "open HTML" in word processors) that render neither MathML, MathJaX, nor reliably SVG.

## Verification

- `test_WorksheetExport` passes, with new assertions: the default MathML export contains **no** MathJaX/`<script>` at all; the fallback loads MathJaX only via feature detection; labels come out as `eqlabel`; `mlabeledtr` never appears.
- Rendered a native-MathML export in headless Chromium: labels display beside left-aligned equations, all math renders, page is fully self-contained.

## Notes

- Supersedes branch `fix-mathjax3-config` (its `window.MathJax` v3 config change is subsumed by the v4 config here).
- Follow-ups intentionally left out of this PR: direct SVG/PNG output-export menu; the "non-math as MathML" mis-render; `ExportToHTML` decomposition; `EmitImgTag` de-duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)