### PR TITLE
HTML export cleanup: unify <img> emission + validate output with HTML Tidy

### DIFF
--- a/.github/workflows/compile_ubuntu.yml
+++ b/.github/workflows/compile_ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
       - name: install_packages
         run: |
              sudo apt-get update
-             sudo apt-get install appstream appstream-util cmake desktop-file-utils doxygen gettext gnuplot gnuplot-x11 graphviz libwxgtk3.2-dev libwxgtk-webview3.2-dev maxima maxima-share maxima-doc netcat-openbsd ninja-build pandoc xvfb at-spi2-core dbus dpkg-dev po4a rpmlint lintian weston rpm
+             sudo apt-get install appstream appstream-util cmake desktop-file-utils doxygen gettext gnuplot gnuplot-x11 graphviz libwxgtk3.2-dev libwxgtk-webview3.2-dev maxima maxima-share maxima-doc netcat-openbsd ninja-build pandoc xvfb at-spi2-core dbus dpkg-dev po4a rpmlint lintian weston rpm tidy
       - name: validate_appdata
         # Release-blocker gate, previously a manual checklist step: a malformed
         # appdata file breaks the flatpak/appImage/appstream builders. Catch it
@@ -123,7 +123,7 @@ jobs:
       - name: install_packages
         run: |
              sudo apt-get update
-             sudo apt-get install appstream cmake desktop-file-utils gettext gnuplot gnuplot-x11 libwxgtk3.2-dev libwxgtk-webview3.2-dev maxima maxima-share maxima-doc netcat-openbsd ninja-build pandoc po4a xvfb at-spi2-core dbus
+             sudo apt-get install appstream cmake desktop-file-utils gettext gnuplot gnuplot-x11 libwxgtk3.2-dev libwxgtk-webview3.2-dev maxima maxima-share maxima-doc netcat-openbsd ninja-build pandoc po4a xvfb at-spi2-core dbus tidy
       - name: configure
         run: |
              export LANG=en_US.UTF-8

--- a/src/worksheet/WorksheetExport.cpp
+++ b/src/worksheet/WorksheetExport.cpp
@@ -425,6 +425,39 @@ wxSize WorksheetExport::CopyToFile(const wxString &file, Cell *start, Cell *end,
   return retval;
 }
 
+namespace {
+/*! Emit one <img> tag pointing at an exported image in the _htmlimg/ subdir.
+
+  Every image the HTML export writes -- rendered equations (SVG/PNG), animations
+  (GIF) and embedded images -- uses the same tag shape; only the file extension,
+  the optional pixel width and the alt text differ. Centralizing it here keeps
+  those (formerly six, hand-copied) call sites from drifting apart.
+
+  \param filePrefix URL-encoded base name shared by the .html file and its
+                    _htmlimg/ directory.
+  \param count      Index that makes the image file name unique.
+  \param ext        File extension including the leading dot (e.g. ".svg").
+  \param widthPx    Pixel width for the width attribute, or -1 to omit it.
+  \param alt        Already-HTML-escaped alt text.
+  \param withBreak  Append a <br> after the tag (for equation images that sit
+                    in the running output flow).
+ */
+wxString HtmlImageTag(const wxString &filePrefix, int count,
+                      const wxString &ext, long widthPx, const wxString &alt,
+                      bool withBreak) {
+  wxString tag = wxS("  <img src=\"") + filePrefix + wxS("_htmlimg/") +
+                 filePrefix + wxString::Format(wxS("_%d"), count) + ext +
+                 wxS("\"");
+  if (widthPx >= 0)
+    tag += wxString::Format(wxS(" width=\"%li\""), widthPx);
+  tag += wxS(" style=\"max-width:90%;\" loading=\"lazy\" alt=\"") + alt +
+         wxS("\">");
+  if (withBreak)
+    tag += wxS("<br>");
+  return tag + wxS("\n");
+}
+} // namespace
+
 bool WorksheetExport::ExportToHTML(GroupCell *tree, Configuration *configuration,
                                    const wxString &file,
                                    ViewCellPointers *cellPointers, GroupCell *hCaret) {
@@ -1050,13 +1083,9 @@ bool WorksheetExport::ExportToHTML(GroupCell *tree, Configuration *configuration
             dynamic_cast<AnimationCell *>(&(*chunk))->ToGif(
                                                             imgDir + wxS("/") + filename +
                                                             wxString::Format(wxS("_%d.gif"), count));
-            output
-              << wxS("  <img src=\"") + filename_encoded + wxS("_htmlimg/") +
-              filename_encoded +
-              wxString::Format(
-                               _("_%d.gif\"  alt=\"Animated Diagram\" "
-                                 "loading=\"lazy\" style=\"max-width:90%%;\">\n"),
-                               count);
+            output << HtmlImageTag(filename_encoded, count, wxS(".gif"),
+                                   /*widthPx=*/-1, _("Animated Diagram"),
+                                   /*withBreak=*/false);
           } else if (dynamic_cast<ImgCellBase *>(&(*chunk)) == NULL) {
             switch (configuration->HTMLequationFormat()) {
             case Configuration::svg: {
@@ -1066,42 +1095,29 @@ bool WorksheetExport::ExportToHTML(GroupCell *tree, Configuration *configuration
                                                      imgDir, filename, count);
               Svgout svgout(&configuration, std::move(chunk), filepath);
 
-              wxString line =
-                wxS("  <img src=\"") + filename_encoded + wxS("_htmlimg/") +
-                filename_encoded +
-                wxString::Format(
-                                 wxS("_%d.svg\" width=\"%li\" style=\"max-width:90%%;\" "
-                                     "loading=\"lazy\" alt=\""),
-                                 count, static_cast<long>(svgout.GetSize().x)) +
-                alttext + wxS("\"><br>\n");
-
-              output << line + "\n";
+              output << HtmlImageTag(filename_encoded, count, wxS(".svg"),
+                                     static_cast<long>(svgout.GetSize().x),
+                                     alttext, /*withBreak=*/true)
+                     << wxS("\n");
               break;
             }
 
             case Configuration::bitmap: {
-              wxSize size;
-              size = CopyToFile(imgDir + wxS("/") + filename +
-                                wxString::Format(wxS("_%d.png"), count),
-                                &(*chunk), NULL, true,
-                                configuration->BitmapScale(), &configuration);
-              int borderwidth = 0;
+              wxSize size =
+                CopyToFile(imgDir + wxS("/") + filename +
+                             wxString::Format(wxS("_%d.png"), count),
+                           &(*chunk), NULL, true,
+                           configuration->BitmapScale(), &configuration);
               wxString alttext =
                 EditorCell::EscapeHTMLChars(chunk->ListToString());
-              borderwidth = chunk->GetImageBorderWidth();
+              int borderwidth = chunk->GetImageBorderWidth();
+              long const widthPx =
+                static_cast<long>(size.x) / configuration->BitmapScale() -
+                2 * borderwidth;
 
-              wxString line =
-                wxS("  <img src=\"") + filename_encoded + wxS("_htmlimg/") +
-                filename_encoded +
-                wxString::Format(
-                                 wxS("_%d.png\" width=\"%li\" style=\"max-width:90%%;\" "
-                                     "loading=\"lazy\" alt=\" "),
-                                 count,
-                                 static_cast<long>(size.x) / configuration->BitmapScale() -
-                                 2 * borderwidth) +
-                alttext + wxS("\"><br>\n");
-
-              output << line + "\n";
+              output << HtmlImageTag(filename_encoded, count, wxS(".png"),
+                                     widthPx, alttext, /*withBreak=*/true)
+                     << wxS("\n");
               break;
             }
 
@@ -1136,28 +1152,19 @@ bool WorksheetExport::ExportToHTML(GroupCell *tree, Configuration *configuration
             }
             }
           } else {
-            wxSize size;
             ext = wxS(".") +
               dynamic_cast<ImgCellBase *>(&(*chunk))->GetExtension();
-            size = dynamic_cast<ImgCellBase *>(&(*chunk))->ToImageFile(
+            wxSize size = dynamic_cast<ImgCellBase *>(&(*chunk))->ToImageFile(
                                                                        imgDir + wxS("/") + filename +
                                                                        wxString::Format(wxS("_%d"), count) + ext);
-            int borderwidth = 0;
             wxString alttext =
               EditorCell::EscapeHTMLChars(chunk->ListToString());
-            borderwidth = chunk->GetImageBorderWidth();
+            int borderwidth = chunk->GetImageBorderWidth();
 
-            wxString line =
-              wxS("  <img src=\"") + filename_encoded + wxS("_htmlimg/") +
-              filename_encoded +
-              wxString::Format(
-                               wxS("_%li%s\" width=\"%li\" style=\"max-width:90%%;\" "
-                                   "loading=\"lazy\" alt=\""),
-                               static_cast<long>(count),
-                               ext.utf8_str(), static_cast<long>(size.x) - 2 * borderwidth) +
-              alttext + wxS("\"><br>\n");
-
-            output << line + "\n";
+            output << HtmlImageTag(filename_encoded, count, ext,
+                                   static_cast<long>(size.x) - 2 * borderwidth,
+                                   alttext, /*withBreak=*/true)
+                   << wxS("\n");
           }
           count++;
 
@@ -1257,13 +1264,9 @@ bool WorksheetExport::ExportToHTML(GroupCell *tree, Configuration *configuration
                 dynamic_cast<AnimationCell *>(tmp.GetOutput())
                   ->ToGif(imgDir + wxS("/") + filename +
                           wxString::Format(wxS("_%d.gif"), count));
-                output << wxS("  <img src=\"") + filename_encoded + wxS("_htmlimg/") +
-                  filename_encoded +
-                  wxString::Format(
-                                   _("_%d.gif\" alt=\"Animated Diagram\" "
-                                     "style=\"max-width:90%%;\" loading=\"lazy\">"),
-                                   count)
-                       << wxS("\n");
+                output << HtmlImageTag(filename_encoded, count, wxS(".gif"),
+                                       /*widthPx=*/-1, _("Animated Diagram"),
+                                       /*withBreak=*/false);
               } else {
                 ImgCellBase *imgCell = dynamic_cast<ImgCellBase *>(out);
                 wxASSERT(imgCell);
@@ -1272,13 +1275,10 @@ bool WorksheetExport::ExportToHTML(GroupCell *tree, Configuration *configuration
                     imgCell->ToImageFile(imgDir + wxS("/") + filename +
                                          wxString::Format(wxS("_%d."), count) +
                                          imgCell->GetExtension());
-                    output
-                      << wxS("  <img src=\"") + filename_encoded + wxS("_htmlimg/") +
-                      filename_encoded +
-                      wxString::Format(
-                                       wxS("_%d.%s\" alt=\"Diagram\" "
-                                           "style=\"max-width:90%%;\" loading=\"lazy\">"),
-                                       count, imgCell->GetExtension().utf8_str());
+                    output << HtmlImageTag(
+                      filename_encoded, count,
+                      wxS(".") + imgCell->GetExtension(), /*widthPx=*/-1,
+                      _("Diagram"), /*withBreak=*/false);
                   }
               }
               output << wxS("</div>\n");

--- a/test/unit_tests/test_WorksheetExport.cpp
+++ b/test/unit_tests/test_WorksheetExport.cpp
@@ -54,6 +54,7 @@
 #include <wx/log.h>
 #include <wx/mstream.h>
 #include <wx/wfstream.h>
+#include <wx/utils.h>
 #include <wx/xml/xml.h>
 #include <wx/zipstrm.h>
 
@@ -296,6 +297,27 @@ static void RequireImgSrcsExist(const wxString &html, const wxString &htmlDir) {
   REQUIRE(checked > 0);
 }
 
+/*! Validate an exported HTML file with HTML Tidy, when it is installed.
+
+  Our HTML is assembled by string concatenation, so a structural slip (an
+  unbalanced tag, a stray attribute) is easy to introduce and invisible to the
+  content assertions. Tidy catches those. It is optional: if the `tidy` binary
+  isn't on PATH (wxExecute returns -1) the check is skipped so the suite still
+  runs everywhere. Tidy's exit code is 0 when the document is clean, 1 on
+  warnings and 2 on errors -- we require a completely clean bill of health,
+  since the exporter currently produces zero tidy messages for every flavor.
+*/
+static void RequireValidHtml(const wxString &htmlPath) {
+  wxArrayString out, err;
+  const wxString cmd = wxS("tidy -q -e \"") + htmlPath + wxS("\"");
+  const long rc = wxExecute(cmd, out, err, wxEXEC_SYNC);
+  if (rc < 0)
+    return; // tidy not installed -> skip cleanly
+  for (const auto &line : err)
+    INFO("tidy: " << line.ToStdString());
+  REQUIRE(rc == 0);
+}
+
 SCENARIO("HTML export succeeds, is deterministic and contains the document") {
   BuildDocumentOnce();
 
@@ -333,6 +355,8 @@ SCENARIO("HTML export succeeds, is deterministic and contains the document") {
       RequireIdenticalTrees(snap1, snap2);
       const wxString html = ReadTextFile(dir1 + wxS("/doc.html"));
       RequireContainsSentinels(html);
+      // The exported HTML must be structurally valid (skipped if tidy absent).
+      RequireValidHtml(dir1 + wxS("/doc.html"));
       // Image links must not dangle (broken-link regression, see helper).
       if (eq.format == Configuration::bitmap ||
           eq.format == Configuration::svg)


### PR DESCRIPTION
Two small, low-risk cleanups on the HTML exporter, split out from the MathML/MathJaX work.

### 1. Unify the six duplicated `<img>` emissions
The exporter hand-built the `<img src="..._htmlimg/...">` tag in six places (rendered equations as SVG/PNG, animations as GIF, embedded images — in both the code-output and image-cell paths). The copies had drifted: inconsistent attribute order, a stray leading space in the bitmap `alt`, and slightly different trailing markup. They now go through one `HtmlImageTag()` helper. Behaviour is unchanged apart from the tags being consistent.

### 2. Validate exported HTML with HTML Tidy
The HTML is assembled by string concatenation, so a structural slip would slip past the content assertions. `test_WorksheetExport` now runs `tidy` over each exported flavor and requires a clean bill of health. All four flavors — native MathML, the MathJaX fall-back, SVG and bitmap — pass with zero tidy messages, MathML included. The check is skipped if `tidy` isn't installed; `tidy` is added to the Ubuntu CI unit-test jobs so it actually runs there.

### Verification
`test_WorksheetExport` passes; bitmap/svg exports still render with resolving image links; tidy proven to catch broken HTML (exit 1) and pass ours (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)