### PR TITLE
Windows: bundle the MinGW runtime DLLs so the installed exe starts

### DIFF
--- a/.github/workflows/compile_windows.yml
+++ b/.github/workflows/compile_windows.yml
@@ -172,6 +172,27 @@ jobs:
             cpack || type D:/a/wxmaxima/wxmaxima/wxMaxima/build/_CPack_Packages/win64/NSIS/NSISOutput.log
             cd ..
             cd ..
+      - name: Verify the package bundles the MinGW runtime DLLs
+        # Guards the fix for the "installer is missing DLLs" report: without the
+        # MinGW C++ runtime bundled, wxmaxima.exe won't start on a clean machine.
+        # We can't run a Windows GUI here, so instead assert the produced ZIP
+        # actually contains the three runtime DLLs. Fails the job if any is gone.
+        run: |
+            $zip = Get-ChildItem -Path wxMaxima\build -Filter *.zip -Recurse | Select-Object -First 1
+            if (-not $zip) { echo "::error::no ZIP package was produced"; exit 1 }
+            echo "Inspecting $($zip.FullName)"
+            Add-Type -AssemblyName System.IO.Compression.FileSystem
+            $names = [System.IO.Compression.ZipFile]::OpenRead($zip.FullName).Entries.Name
+            $missing = @()
+            foreach ($dll in @("libstdc++-6.dll","libgcc_s_seh-1.dll","libwinpthread-1.dll")) {
+              if ($names -contains $dll) { echo "ok: $dll" }
+              else { $missing += $dll }
+            }
+            if ($missing.Count -gt 0) {
+              echo "::error::the package is missing runtime DLL(s): $($missing -join ', ')"
+              exit 1
+            }
+            echo "All required MinGW runtime DLLs are present in the package."
       - name: Stage runtime DLLs next to wxmaxima.exe
         # The release wxmaxima.exe is built non-static, so it depends on the MinGW
         # runtime DLLs (libstdc++-6 / libgcc_s_seh-1 / libwinpthread-1) being found

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Current development version
 
+- Windows: the installer/ZIP now bundles the MinGW C++ runtime DLLs
+  (libstdc++-6, libgcc_s_seh-1, libwinpthread-1) that wxmaxima.exe needs to
+  start. They were relied on being pulled in automatically, which was
+  unreliable, so on some machines wxMaxima failed to launch with a missing-DLL
+  error. CI now also checks the package actually contains them.
 - HTML export now defaults to native MathML. Every current browser renders
   MathML itself, so the exported page needs no JavaScript and, unlike before,
   makes no requests to any external server -- removing both a privacy/security

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -423,6 +423,29 @@ if(WIN32)
     set(CPACK_NSIS_DEFINES "ManifestDPIAware true")
     include(InstallRequiredSystemLibraries)
     install(FILES ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} DESTINATION bin)
+
+    # The release wxmaxima.exe is linked against the MinGW C++ runtime
+    # dynamically, so it needs libstdc++-6.dll, libgcc_s_seh-1.dll and
+    # libwinpthread-1.dll at launch -- otherwise it fails to start on a clean
+    # Windows machine with a "missing DLL" error. InstallRequiredSystemLibraries
+    # is unreliable for MinGW (it frequently omits libwinpthread-1.dll, and
+    # sometimes the whole set), so bundle these explicitly, taken from the exact
+    # toolchain that built the exe. This is the packaging counterpart of the
+    # "Stage runtime DLLs next to wxmaxima.exe" step the test job already does.
+    if(MINGW)
+        get_filename_component(_mingw_bindir "${CMAKE_CXX_COMPILER}" DIRECTORY)
+        foreach(_runtime_dll
+                libstdc++-6.dll libgcc_s_seh-1.dll libwinpthread-1.dll)
+            if(EXISTS "${_mingw_bindir}/${_runtime_dll}")
+                install(FILES "${_mingw_bindir}/${_runtime_dll}" DESTINATION bin)
+            else()
+                message(WARNING
+                    "MinGW runtime ${_runtime_dll} not found in "
+                    "${_mingw_bindir}; the Windows package may ship without it "
+                    "and fail to start on a clean machine.")
+            endif()
+        endforeach()
+    endif()
 elseif(APPLE)
     # If we have generated an .apk bundle we can package this in a DMG image
     set(CPACK_GENERATOR "DragNDrop")


### PR DESCRIPTION
### The report
A Windows (Intel) user reported that the auto-uploaded release wxMaxima is missing some DLLs (which ones wasn't specified).

### Diagnosis
The release `wxmaxima.exe` is linked against the MinGW C++ runtime **dynamically**, so it needs `libstdc++-6.dll`, `libgcc_s_seh-1.dll` and `libwinpthread-1.dll` at launch. The NSIS/ZIP packaging relied solely on `InstallRequiredSystemLibraries` to supply them — which is well-known to be unreliable for MinGW (it commonly omits `libwinpthread-1.dll`). The workflow already hand-stages exactly these three DLLs for its *test* run, with a comment noting it has "no effect on the NSIS installer" — so the installer could ship without them, and the exe then fails to start on a clean machine with a missing-DLL error.

### Fix
- `src/CMakeLists.txt`: on a MinGW Windows build, explicitly `install()` the three runtime DLLs into the package, taken from the toolchain that built the exe (guarded by `if(EXISTS)` with a warning otherwise).
- `compile_windows.yml`: after `cpack`, assert the produced ZIP actually contains all three DLLs — fails the build if any is missing, so a regression is caught in CI rather than by users.

### Verification
CMake re-parses cleanly and the workflow YAML is valid. **I can't test the Windows build locally (no Windows box)** — the new CI check is the verification that the package now contains the DLLs. A Windows user confirming the installer launches would be the final confirmation.

### Note / possible follow-up
If the reporter's missing DLL turns out *not* to be one of these three, the next suspect is `WebView2Loader.dll` (needed when the Edge webview backend is enabled) — the CMake currently bundles its *license* but not the loader DLL. Happy to look into that if this doesn't fully resolve it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)