### PR TITLE
multithreadtest: preload draw package

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1086,7 +1086,7 @@ add_test(
 add_test(
     NAME multithreadtest
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/automatic_test_files
-    COMMAND wxmaxima --debug --logtostderr --pipe --single_process --batch --exit-on-error threadtest.wxm threadtest2.wxm)
+    COMMAND echo "load(draw);quit();" | ${MAXIMA} --very-very-quiet --quit-on-error ; wxmaxima --debug --logtostderr --pipe --single_process --batch --exit-on-error threadtest.wxm threadtest2.wxm)
 
 #add_test(
 #    NAME ipc_copypaste1


### PR DESCRIPTION
The multithreadtest test currently fails due to a concurrency issue associated with loading and compiling of the `draw` maxima package. At least on an uptodate Debian Sid environment.
This patch solves this issue by preloading/precompiling the `draw` maxima package.