### PR TITLE
testbench_simple: provides absent images + rationalization

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,8 @@
 # Compile a list of test files
 file(GLOB IMAGE_FILES automatic_test_files/*.png automatic_test_files/*.gif)
 file(GLOB TEST_FILES ${IMAGE_FILES} automatic_test_files/*.wxmx automatic_test_files/*.wxm automatic_test_files/*.mac automatic_test_files/*.cfg)
+file(GLOB TESTBENCH_IMAGE_FILES automatic_test_files/a.png automatic_test_files/b.png automatic_test_files/c.png automatic_test_files/d.png)
+file(GLOB TESTBENCH_FILES ${TESTBENCH_IMAGE_FILES} testbench_simple.wxmx testbench_simple.mac)
 
 find_program(MAXIMA maxima)
 if(MAXIMA)
@@ -103,14 +105,7 @@ file(
 
 file(
     COPY
-    testbench_simple.wxmx
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
-    FILE_PERMISSIONS OWNER_WRITE OWNER_READ
-)
-
-file(
-    COPY
-    testbench_simple.mac
+    ${TESTBENCH_FILES}
     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
     FILE_PERMISSIONS OWNER_WRITE OWNER_READ
 )


### PR DESCRIPTION
The testbench_simple test bench currently emits some `Error' messages. At least on an uptodate Debian Sid environment. This patch solves the Error messages related to the absence of the `{a,b,c,d}.png` images by introducing `TESTBENCH_FILES` list in the concerned `test/CMakeLists.txt` along some natural cleaning/rationalization.