### PR TITLE
openMacFiles: disable pm3d for wxplot3d to survive gnuplot 6

### DIFF
--- a/test/testbench_simple.wxm
+++ b/test/testbench_simple.wxm
@@ -1212,7 +1212,9 @@ Maxima's INSTALL.win32 does request to test the following commands:
 /* [wxMaxima: input   start ] */
     wxplot2d(sin(x),[x,0,10])$
     wxplot2d(sin(x),[x,0,10],[plot_format,xmaxima])$
-    wxplot3d(x*y,[x,-1,1],[y,-1,1])$
+/* The option [gnuplot_pm3d,false] is necessary for an issue with Maxima and Gnuplot 6 */
+/* see: wxMaxima issue 1960, Maxima issue 2947 */
+    wxplot3d(x*y,[x,-1,1],[y,-1,1],[gnuplot_pm3d,false])$
 /* [wxMaxima: input   end   ] */
 
 


### PR DESCRIPTION
## Problem

The `openMacFiles` CI test (`compile_ubuntu`, both `compile_latest_and_test` and `compile_and_test_sanitized`) fails on `main`. Once the recently-added `.wxm` header made `test/testbench_simple.wxm` actually load, its `wxplot3d` exposed a **Maxima 5.46 + gnuplot 6** incompatibility:

```
set pm3d hidden3d 100 border lw 0.5 lt rgb "#000000"
                  ^
"/tmp/maxout*.gnuplot" line 10: invalid pm3d option
```

The Ubuntu 24.04 runner ships Maxima 5.46.0, whose draw package emits `set pm3d hidden3d` for `plot3d`'s pm3d output; gnuplot 6.0 removed `hidden3d` as a pm3d option. Under wxmaxima's `--batch --exit-on-error`, that gnuplot stderr aborts the test. (Fixed in Maxima 5.47+.)

## Fix

The `.wxmx` twin (`testbench_simple.wxmx`, which passes CI) already carries the established remedy — `[gnuplot_pm3d,false]`, see Maxima issue 2947 / wxMaxima issue 1960. This applies the identical option to the `.wxm` so the two agree.

Verified by byte-equivalence to the CI-passing `.wxmx`; the runner-specific failure can't be reproduced on newer local Maxima, so CI is the real confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DU23YMfQHdrkGCNJxn7dJs