### PR TITLE
Fix equations clipped to a corner when rendered as bitmaps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Current development version
 
+- Bitmap rendering of equations no longer clips them to a corner of the image.
+  Anything rendered at a "Bitmap scale" other than 1 -- the HTML export's bitmap
+  equation flavor and the optional "Bitmap" clipboard format both use the
+  default scale of 3 -- was magnified once too often, so only the upper-left
+  third of each equation (or nothing at all) fit on the canvas. The explicit
+  "Copy as Bitmap" command was unaffected, as it always renders at scale 1.
 - Windows: the installer/ZIP now bundles the MinGW C++ runtime DLLs
   (libstdc++-6, libgcc_s_seh-1, libwinpthread-1) that wxmaxima.exe needs to
   start. They were relied on being pulled in automatically, which was

--- a/src/graphical_io/BitmapOut.cpp
+++ b/src/graphical_io/BitmapOut.cpp
@@ -34,7 +34,11 @@
 BitmapOut::BitmapOut(const Configuration * const *configuration, double scale)
   : m_cmn(configuration, BM_FULL_WIDTH, scale) {
   m_cmn.SetSize({10, 10});
-  m_bmp.CreateScaled(10, 10, 24, scale);
+  // A plain placeholder bitmap plus SetUserScale below: the same scale regime
+  // Layout() uses for the real canvas, so cell measurement during PrepareLayout
+  // and the final drawing agree. (Not CreateScaled, which would add a second
+  // scale factor on top of the user scale -- see the comment in Layout().)
+  m_bmp.Create(10, 10, 24);
   m_dc.SelectObject(m_bmp);
   m_dc.SetUserScale(scale, scale);
   m_dc.SetPen(wxNullPen);
@@ -68,7 +72,6 @@ bool BitmapOut::Layout(long int maxSize) {
 
   auto scale = m_cmn.GetScale();
   auto size = m_cmn.GetScaledSize();
-  auto rawSize = m_cmn.GetSize();
 
   // Bitmaps that are bigger than the available memory can lead to crashes within
   // MS Windows or the X server.
@@ -76,10 +79,21 @@ bool BitmapOut::Layout(long int maxSize) {
                        (size.x >= 20000) || (size.y >= 20000)))
     goto failed;
 
+  // Allocate the canvas at the full *device* size (the already-scaled size) and
+  // let SetUserScale(scale) below do the magnification. Using
+  // CreateScaled(rawSize, scale) here gave the bitmap its own scale factor on
+  // top of the user scale, so drawing was magnified by `scale` twice: at the
+  // default BitmapScale of 3 the content was laid down three times too large for
+  // the canvas and only its upper-left third survived (equations exported to
+  // HTML as bitmaps came out mostly blank). A plain bitmap sized to the scaled
+  // extent matches the single SetUserScale magnification. At scale == 1 this is
+  // identical to the old CreateScaled(size, 1), so the clipboard "copy as
+  // bitmap" path (which always renders at scale 1) is unchanged.
+  //
   // The depth 24 hinders wxWidgets from creating rgb0 bitmaps that some
   // windows applications will interpret as rgba if they appear on
   // the clipboards and therefore render them all-transparent.
-  m_bmp.CreateScaled(rawSize.x, rawSize.y, 24, scale);
+  m_bmp.Create(size.x, size.y, 24);
 
   if (!m_bmp.IsOk())
     goto failed;

--- a/test/unit_tests/test_WorksheetExport.cpp
+++ b/test/unit_tests/test_WorksheetExport.cpp
@@ -63,6 +63,7 @@
 #include "worksheet/Worksheet.h"
 #include "cells/GroupCell.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <map>
 #include <string>
@@ -297,6 +298,69 @@ static void RequireImgSrcsExist(const wxString &html, const wxString &htmlDir) {
   REQUIRE(checked > 0);
 }
 
+/*! Guard against clipped equation bitmaps in the HTML "bitmap" flavor.
+
+  BitmapOut sizes its canvas to the rendered content, so a correctly drawn
+  equation fills essentially the whole image. A scale-handling regression made
+  the exporter magnify the drawing by BitmapScale (default 3) once too often, so
+  at scale 3 the equation was laid down three times too large for the canvas and
+  only its upper-left third (or nothing at all) survived -- the exported images
+  came out mostly or entirely blank. The content assertions never noticed
+  because they only look at the HTML text, not the pixels.
+
+  For every exported equation PNG we therefore require that it contains ink at
+  all, and -- for images large enough that clipping is unambiguous -- that the
+  ink's bounding box covers at least half the canvas in both dimensions. Post-fix
+  the large images cover >=0.97 of the width and >=0.73 of the height; the buggy
+  ones dropped below 0.2 in at least one dimension or were completely blank, so
+  the 0.5 threshold separates them with a wide margin. Small glyph images (a lone
+  "1", a comma) legitimately leave more slack, so only the non-blank check
+  applies to them.
+*/
+static void RequireBitmapsNotClipped(const wxString &htmlDir) {
+  const wxString imgDir = htmlDir + wxS("/doc_htmlimg");
+  wxArrayString pngs;
+  wxDir::GetAllFiles(imgDir, &pngs, wxS("doc_*.png"), wxDIR_FILES);
+  REQUIRE(pngs.GetCount() > 0);
+  for (const wxString &png : pngs) {
+    wxImage img;
+    INFO("equation bitmap: " << png.ToStdString());
+    REQUIRE(img.LoadFile(png));
+    const int w = img.GetWidth(), h = img.GetHeight();
+    REQUIRE(w > 0);
+    REQUIRE(h > 0);
+
+    // The top-left pixel is background (the canvas is cleared to the text
+    // background colour before drawing); anything differing from it is ink.
+    const unsigned char bgR = img.GetRed(0, 0), bgG = img.GetGreen(0, 0),
+                        bgB = img.GetBlue(0, 0);
+    int minX = w, minY = h, maxX = -1, maxY = -1;
+    for (int y = 0; y < h; ++y)
+      for (int x = 0; x < w; ++x) {
+        const int dr = std::abs((int)img.GetRed(x, y) - bgR);
+        const int dg = std::abs((int)img.GetGreen(x, y) - bgG);
+        const int db = std::abs((int)img.GetBlue(x, y) - bgB);
+        if (dr + dg + db > 48) {
+          minX = std::min(minX, x); maxX = std::max(maxX, x);
+          minY = std::min(minY, y); maxY = std::max(maxY, y);
+        }
+      }
+
+    // Every exported equation must render *something*.
+    REQUIRE(maxX >= 0);
+
+    // On images big enough that a partial render is unambiguous, the ink must
+    // fill a good part of the canvas the exporter sized to fit it.
+    if (w >= 200 && h >= 100) {
+      const double coverX = double(maxX - minX + 1) / w;
+      const double coverY = double(maxY - minY + 1) / h;
+      INFO("ink coverage " << coverX << " x " << coverY << " of " << w << "x" << h);
+      REQUIRE(coverX >= 0.5);
+      REQUIRE(coverY >= 0.5);
+    }
+  }
+}
+
 /*! Validate an exported HTML file with HTML Tidy, when it is installed.
 
   Our HTML is assembled by string concatenation, so a structural slip (an
@@ -368,6 +432,10 @@ SCENARIO("HTML export succeeds, is deterministic and contains the document") {
       if (eq.format == Configuration::bitmap ||
           eq.format == Configuration::svg)
         RequireImgSrcsExist(html, dir1);
+      // The bitmap flavor must not clip equations to a corner of the canvas
+      // (a BitmapScale double-magnification regression, see helper).
+      if (eq.format == Configuration::bitmap)
+        RequireBitmapsNotClipped(dir1);
       // Both MathML flavors emit native <math> with the label beside it as
       // HTML. MathML Core dropped <mlabeledtr>, so it must never appear.
       if (eq.format == Configuration::mathML ||


### PR DESCRIPTION
## Problem

Rendering equations as bitmaps at any "Bitmap scale" other than 1 clipped them to the upper-left corner of the image — often leaving the PNG mostly or entirely blank. This affected the **HTML export's bitmap equation flavor** and the optional **"Bitmap" clipboard format**, both of which use the default `BitmapScale` of 3.

`BitmapOut` applied the render scale **twice**: `CreateScaled(size, scale)` gave the bitmap its own content-scale factor, and `SetUserScale(scale)` then scaled drawing again. At scale 3 the content was laid down three times too large for the canvas, so only its upper-left third fit.

Before / after (same exported equation, `BitmapScale=3`):

- **Before:** blank canvas with `∫1` / `(%o4)` fragments in a corner.
- **After:** the full square-root / integral / summation / matrix expression fills the image.

## Fix

Allocate a plain bitmap at the scaled device size and keep the single `SetUserScale` magnification. At `scale == 1` this is identical to the old `CreateScaled(size, 1)`, so the explicit **"Copy as Bitmap"** command (which always renders at scale 1) is byte-for-byte unchanged.

## Test

Adds a regression guard to `test_WorksheetExport`: every exported equation PNG must contain ink and, on images large enough for clipping to be unambiguous, its ink bounding box must cover at least half the canvas in both dimensions. The previous test passed with the broken (blank) images because it only inspected the HTML text, not the pixels. Guard calibrated red-pre / green-post on real export dumps; full suite green (420 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DU23YMfQHdrkGCNJxn7dJs