### PR TITLE
Export non-math output as text, not as math or an image

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Current development version
 
+- HTML export: non-math output (Maxima messages, warnings, errors and plain
+  strings) is now written as ordinary, HTML-escaped text instead of being
+  rendered to a PNG/SVG image or wrapped in a `<math>` element. Previously a
+  plain sentence could end up as a picture of text or as a run of MathML
+  operators that browsers rendered oddly; it now reads as text in every export
+  flavour and stays selectable and searchable.
 - Windows: the installer/ZIP now bundles the MinGW C++ runtime DLLs
   (libstdc++-6, libgcc_s_seh-1, libwinpthread-1) that wxmaxima.exe needs to
   start. They were relied on being pulled in automatically, which was

--- a/src/worksheet/WorksheetExport.cpp
+++ b/src/worksheet/WorksheetExport.cpp
@@ -552,6 +552,15 @@ void WriteHtmlStyleSheet(wxTextOutputStream &css, wxConfigBase *config,
   css << wxS("     exported equations line up: use left, center or right. */\n");
   css << wxS("  justify-self: left;\n");
   css << wxS("}\n");
+  // Plain (non-math) Maxima output -- messages, warnings, errors and strings
+  // -- shares the equation grid so it lines up with the equations above and
+  // below it, but is emitted as ordinary text rather than as a <math> element
+  // or a rendered image.
+  css << wxS(".equation > .outputtext {\n");
+  css << wxS("  grid-column: 2;\n");
+  css << wxS("  justify-self: left;\n");
+  css << wxS("  white-space: pre-wrap;\n");
+  css << wxS("}\n");
 
   // TABLES
   css << wxS("table {\n");
@@ -995,11 +1004,60 @@ void WriteHTMLHead(wxString &output, Configuration *configuration,
   output << wxS("<!-- *********") + versionPad + wxS("******** -->\n");
 }
 
-/*! Render one output chunk (equation, image or animation) of a code cell.
+//! Is this cell a piece of plain (non-math) Maxima output?
+bool CellIsProseText(const Cell *cell) {
+  switch (cell->GetTextStyle()) {
+  case TS_TEXT:
+  case TS_STRING:
+  case TS_ERROR:
+  case TS_WARNING:
+    return true;
+  default:
+    return false;
+  }
+}
 
-  Writes any image file into imgDir and appends the matching <img> tag (or, for
-  the native-MathML format, an inline <math> element) to output. The chunk is a
-  freshly-copied cell list owned by this call.
+/*! Is the whole output chunk (after its optional label) plain text?
+
+  True only when there is content and every top-level cell of it is prose
+  text (a message, warning, error or string). A chunk that mixes text with
+  actual math -- or is empty -- returns false so it keeps going through the
+  equation renderer. Strings nested *inside* a math expression don't count:
+  they are not top-level cells of the chunk.
+ */
+bool ChunkIsPlainText(const Cell *content) {
+  if (content == NULL)
+    return false;
+  for (const Cell *c = content; c != NULL; c = c->GetNext())
+    if (!CellIsProseText(c))
+      return false;
+  return true;
+}
+
+/*! Emit a plain-text output chunk as escaped HTML text.
+
+  Reuses the .equation grid so the text lines up with the equations around
+  it, but writes the content as ordinary text (CSS white-space:pre-wrap keeps
+  Maxima's line breaks) instead of a <math> element or a rendered image.
+ */
+void EmitPlainTextOutput(wxString &output, const wxString &labelText,
+                         const Cell *content) {
+  output << wxS("<div class=\"equation\">\n");
+  if (!labelText.IsEmpty())
+    output << wxS("  <span class=\"eqlabel\">")
+           << EditorCell::EscapeHTMLChars(labelText) << wxS("</span>\n");
+  output << wxS("  <span class=\"outputtext\">")
+         << EditorCell::EscapeHTMLChars(content->ListToString())
+         << wxS("</span>\n");
+  output << wxS("</div>\n");
+}
+
+/*! Render one output chunk (equation, image, animation or plain text).
+
+  Writes any image file into imgDir and appends the matching <img> tag, an
+  inline <math> element (native-MathML format) or -- for non-math output such
+  as messages, warnings, errors and strings -- escaped HTML text. The chunk is
+  a freshly-copied cell list owned by this call.
  */
 void ExportOutputChunk(wxString &output, std::unique_ptr<Cell> chunk,
                        Configuration *configuration, const wxString &imgDir,
@@ -1013,6 +1071,26 @@ void ExportOutputChunk(wxString &output, std::unique_ptr<Cell> chunk,
                            /*widthPx=*/-1, _("Animated Diagram"),
                            /*withBreak=*/false);
   } else if (dynamic_cast<ImgCellBase *>(&(*chunk)) == NULL) {
+    // Split off a leading output label (e.g. "(%o1)") so it can be shown
+    // beside the content rather than fed to the math renderer.
+    Cell *first = &(*chunk);
+    Cell *content = first;
+    wxString labelText;
+    if ((first->GetTextStyle() == TS_LABEL) ||
+        (first->GetTextStyle() == TS_USERLABEL)) {
+      labelText = first->ToString();
+      labelText.Trim(true).Trim(false);
+      content = first->GetNext();
+    }
+
+    if (ChunkIsPlainText(content)) {
+      // Non-math output: a message, warning, error or string. Emit it as
+      // text rather than a PNG/SVG of a sentence or prose wrapped in <math>
+      // (where a plain sentence turns into a run of <mo> operators).
+      EmitPlainTextOutput(output, labelText, content);
+      return;
+    }
+
     switch (configuration->HTMLequationFormat()) {
     case Configuration::svg: {
       auto const alttext =
@@ -1054,26 +1132,16 @@ void ExportOutputChunk(wxString &output, std::unique_ptr<Cell> chunk,
       // <mlabeledtr>, so an in-math label would silently vanish on
       // Chrome/Safari. The equation itself becomes a native <math>
       // element, with MathJax used only as a fill-in (see the header).
-      Cell *first = &(*chunk);
-      Cell *eqStart = first;
-      wxString labelText;
-      if ((first->GetTextStyle() == TS_LABEL) ||
-          (first->GetTextStyle() == TS_USERLABEL)) {
-        labelText = first->ToString();
-        labelText.Trim(true).Trim(false);
-        eqStart = first->GetNext();
-      }
-
       output << wxS("<div class=\"equation\">\n");
       if (!labelText.IsEmpty())
         output << wxS("  <span class=\"eqlabel\">")
                << EditorCell::EscapeHTMLChars(labelText)
                << wxS("</span>\n");
-      if (eqStart != NULL)
+      if (content != NULL)
         output
           << wxS("  <math xmlns=\"http://www.w3.org/1998/Math/MathML\" "
                  "display=\"block\">")
-          << eqStart->ListToMathML() << wxS("</math>\n");
+          << content->ListToMathML() << wxS("</math>\n");
       output << wxS("</div>\n");
     }
     }

--- a/test/unit_tests/test_WorksheetExport.cpp
+++ b/test/unit_tests/test_WorksheetExport.cpp
@@ -217,10 +217,7 @@ static wxString MakeExportDir(const wxString &name) {
   return dir;
 }
 
-static std::unique_ptr<GroupCell> ParseCorpusFile(const wxString &name) {
-  const wxString path =
-    wxFileName(wxString(wxS(WXM_CORPUS_DIR)), name).GetFullPath();
-  const wxString xml = ReadTextFile(path);
+static std::unique_ptr<GroupCell> ParseXmlString(const wxString &xml) {
   const wxScopedCharBuffer utf8 = xml.utf8_str();
   wxMemoryInputStream in(utf8.data(), utf8.length());
   wxXmlDocument doc;
@@ -232,11 +229,40 @@ static std::unique_ptr<GroupCell> ParseCorpusFile(const wxString &name) {
   return tree;
 }
 
+static std::unique_ptr<GroupCell> ParseCorpusFile(const wxString &name) {
+  const wxString path =
+    wxFileName(wxString(wxS(WXM_CORPUS_DIR)), name).GetFullPath();
+  return ParseXmlString(ReadTextFile(path));
+}
+
 // Sentinel texts that must be findable in every export format.
 static const wxChar *const kTitleSentinel = wxS("ExportNetDocumentTitle");
 static const wxChar *const kSectionSentinel = wxS("ExportNetSectionHeading");
 static const wxChar *const kTextSentinel = wxS("ExportNetTextParagraph");
 static const wxChar *const kCodeSentinel = wxS("factor(xexportnet^2-1);");
+
+// A code cell whose output is *non-math* text: a warning (whose message
+// contains characters that must be HTML-escaped) and a labelled string. Both
+// must be exported as plain text, not routed through the equation renderer.
+static const wxChar *const kStringSentinel = wxS("ExportNetString value");
+static const wxChar *const kTextOutputXml = wxS(
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+  "<wxMaximaDocument version=\"1.5\" zoom=\"100\">\n"
+  "<cell type=\"code\">\n"
+  "<input><editor type=\"input\"><line>warnexample;</line></editor></input>\n"
+  "<output>\n"
+  "<mth><t breakline=\"true\" type=\"warning\">ExportNetWarning: replaced a"
+  " &amp; b &lt; c</t></mth>\n"
+  "</output>\n"
+  "</cell>\n"
+  "<cell type=\"code\">\n"
+  "<input><editor type=\"input\"><line>strexample;</line></editor></input>\n"
+  "<output>\n"
+  "<mth><lbl altCopy=\"(%o9)&#9;\">(%o9) </lbl><st>ExportNetString value</st>"
+  "</mth>\n"
+  "</output>\n"
+  "</cell>\n"
+  "</wxMaximaDocument>\n");
 
 /*! Fills the worksheet with the real math corpus plus sentinel cells.
 
@@ -250,6 +276,10 @@ static void BuildDocumentOnce() {
   // A rich body of real math output, exported by actual wxMaxima.
   g_ws->InsertGroupCells(ParseCorpusFile(wxS("sampleWorksheet.xml")), nullptr);
   g_ws->InsertGroupCells(ParseCorpusFile(wxS("math-constructs.xml")),
+                         g_ws->GetLastCellInWorksheet());
+  // Non-math text output (a warning and a string), to pin that it is exported
+  // as text rather than as a <math> element or a rendered image.
+  g_ws->InsertGroupCells(ParseXmlString(kTextOutputXml),
                          g_ws->GetLastCellInWorksheet());
 
   // Sentinels for asserting content presence per format.
@@ -355,6 +385,13 @@ SCENARIO("HTML export succeeds, is deterministic and contains the document") {
       RequireIdenticalTrees(snap1, snap2);
       const wxString html = ReadTextFile(dir1 + wxS("/doc.html"));
       RequireContainsSentinels(html);
+      // Non-math output must be emitted as text in every flavor: it carries
+      // the .outputtext class, its message is HTML-escaped, and it is never
+      // wrapped in <math> (which would turn a sentence into a run of <mo>).
+      REQUIRE(html.Contains(wxS("class=\"outputtext\"")));
+      REQUIRE(html.Contains(wxS("replaced a &amp; b &lt; c")));
+      REQUIRE(html.Contains(kStringSentinel));
+      REQUIRE_FALSE(html.Contains(wxS("<mo>ExportNetWarning")));
       // The exported HTML must be structurally valid (skipped if tidy absent).
       RequireValidHtml(dir1 + wxS("/doc.html"));
       // Image links must not dangle (broken-link regression, see helper).


### PR DESCRIPTION
## What

Maxima output that is a plain **message, warning, error or string** used to go through the same per-chunk path as equations:

- in the **image** HTML-export modes (bitmap/SVG) it became a PNG/SVG **picture of a sentence**;
- in the **MathML** modes it was wrapped in `<math>`, where a sentence becomes a run of `<mo>` operators that browsers render oddly.

This detects a text-only output chunk in `ExportOutputChunk` and emits it as escaped HTML text instead.

## How

- `ChunkIsPlainText()`: an output chunk (after its optional `(%oN)` label) is plain text iff **every top-level cell** is `TS_TEXT`/`TS_STRING`/`TS_ERROR`/`TS_WARNING`. Strings nested *inside* a math expression are not top-level, so `a + "s"` still counts as math.
- `EmitPlainTextOutput()`: writes the (escaped) text into a `.outputtext` span that shares the existing `.equation` grid, so it lines up with the equations around it. Applies to **every** export flavour, not just MathML. A `.equation > .outputtext` CSS rule (`white-space: pre-wrap`) preserves Maxima's line breaks.
- Actual math is completely unaffected.

## Test

`test_WorksheetExport` gains a warning (with `&`/`<` that must be HTML-escaped) and a labelled string in the shared corpus, and asserts across all four HTML flavours that they carry `class="outputtext"`, are HTML-escaped, and are never `<mo>`-wrapped. Verified on a real export dump: the warning renders as `<span class="outputtext">…&amp;… &lt;…</span>`, real math still yields 7 `<math>` elements / 7 PNGs.

## Stacking

Based on #2145 (the `ExportToHTML` decomposition) — it hooks into the `ExportOutputChunk` seam that PR introduces. Please merge #2145 first, or review this on top of it.

The second symptom from the same to-do — gating the "Copy as MathML" *menu offer* to actual math — is intentionally left for a follow-up: it needs a math-detection predicate over arbitrary selection shapes and is a separate (menu-UX) concern from export rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)