### PR TITLE
Only offer "Copy as MathML" when the selection has math

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
   plain sentence could end up as a picture of text or as a run of MathML
   operators that browsers rendered oddly; it now reads as text in every export
   flavour and stays selectable and searchable.
+- "Copy as MathML" is no longer offered (in the context menu or the Edit menu)
+  for a selection that contains no maths -- plain text, comments, labels or
+  strings. Copying those produced MathML that only wrapped the text in operator
+  elements, which word processors rendered oddly.
 - Bitmap rendering of equations no longer clips them to a corner of the image.
   Anything rendered at a "Bitmap scale" other than 1 -- the HTML export's bitmap
   equation flavor and the optional "Bitmap" clipboard format both use the

--- a/src/worksheet/Worksheet.cpp
+++ b/src/worksheet/Worksheet.cpp
@@ -1816,6 +1816,25 @@ wxString Worksheet::ConvertSelectionToMathML() const {
   return s;
 }
 
+bool Worksheet::CanCopyAsMathML() const {
+  // Judge the offer by exactly what the copy would produce, so the menu item
+  // never promises MathML the copy can't deliver. Prose (text/comments/
+  // strings/labels) serializes to <mtext>/<ms>/<mo> only; the presence of any
+  // genuine math *content* element is what makes "Copy as MathML" worthwhile.
+  // Note: <mtable> is deliberately NOT in this list -- ListToMathML also wraps
+  // multi-line or labelled *text* in a table, so it isn't a math signal (a
+  // matrix's entries are caught by <mn>/<mi> instead).
+  const wxString mathml = ConvertSelectionToMathML();
+  static const wxChar *const mathTags[] = {
+    wxS("<mi"),    wxS("<mn"),      wxS("<mfrac"), wxS("<msup"),
+    wxS("<msub"),  wxS("<msubsup"), wxS("<msqrt"), wxS("<mroot"),
+    wxS("<munder"), wxS("<mover"),  wxS("<munderover")};
+  for (const wxChar *const tag : mathTags)
+    if (mathml.Contains(tag))
+      return true;
+  return false;
+}
+
 bool Worksheet::CopyMathML() const {
   wxString s = ConvertSelectionToMathML();
 

--- a/src/worksheet/Worksheet.h
+++ b/src/worksheet/Worksheet.h
@@ -919,6 +919,16 @@ public:
          GetDocumentCellPointers().GetActiveCell()->CanCopy());
     }
 
+  /*! Would "Copy as MathML" of the current selection produce actual math?
+
+    True only when the selection would serialize to MathML that contains a
+    real math element (a variable, number, fraction, ...). A selection of
+    plain text, comments, labels or strings serializes to <mtext>/<ms>/<mo>
+    only, so offering "Copy as MathML" for it is pointless (and used to yield
+    prose wrapped as MathML operators that word processors render oddly).
+   */
+  bool CanCopyAsMathML() const;
+
   bool CanPaste() const
     { return GetDocumentCellPointers().GetActiveCell() || GetHCaretCursor().IsActive(); }
 

--- a/src/worksheet/WorksheetContextMenu.cpp
+++ b/src/worksheet/WorksheetContextMenu.cpp
@@ -127,7 +127,8 @@ void PopulateWorksheetContextMenu(Worksheet &worksheet, wxMenu &popupMenu,
                            wxITEM_NORMAL);
           popupMenu.Append(EventIDs::popid_copy_text, _("Copy as plain text"),
                            wxEmptyString, wxITEM_NORMAL);
-          if (worksheet.GetDocumentCellPointers().GetSelectionStart() == worksheet.GetDocumentCellPointers().GetSelectionEnd())
+          if ((worksheet.GetDocumentCellPointers().GetSelectionStart() == worksheet.GetDocumentCellPointers().GetSelectionEnd()) &&
+              worksheet.CanCopyAsMathML())
             popupMenu.Append(EventIDs::popid_copy_mathml,
                              _("Copy as MathML (e.g. to word processor)"),
                              wxEmptyString, wxITEM_NORMAL);
@@ -267,9 +268,10 @@ void PopulateWorksheetContextMenu(Worksheet &worksheet, wxMenu &popupMenu,
                            wxITEM_NORMAL);
           popupMenu.Append(EventIDs::popid_copy_text, _("Copy as plain text"),
                            wxEmptyString, wxITEM_NORMAL);
-          popupMenu.Append(EventIDs::popid_copy_mathml,
-                           _("Copy as MathML (e.g. to word processor)"),
-                           wxEmptyString, wxITEM_NORMAL);
+          if (worksheet.CanCopyAsMathML())
+            popupMenu.Append(EventIDs::popid_copy_mathml,
+                             _("Copy as MathML (e.g. to word processor)"),
+                             wxEmptyString, wxITEM_NORMAL);
 
           popupMenu.Append(EventIDs::popid_copy_image, _("Copy as Image"), wxEmptyString,
                            wxITEM_NORMAL);

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -2046,7 +2046,8 @@ void wxMaxima::UpdateMenus() {
   m_MenuBar->EnableItem(EventIDs::menu_copy_tex_from_worksheet, GetWorksheet()->CanCopy());
   m_MenuBar->EnableItem(EventIDs::menu_copy_matlab_from_worksheet,
                         GetWorksheet()->CanCopy());
-  m_MenuBar->EnableItem(EventIDs::popid_copy_mathml, GetWorksheet()->CanCopy());
+  m_MenuBar->EnableItem(EventIDs::popid_copy_mathml,
+                        GetWorksheet()->CanCopyAsMathML());
   m_MenuBar->EnableItem(EventIDs::menu_copy_as_bitmap, GetWorksheet()->CanCopy());
   m_MenuBar->EnableItem(EventIDs::menu_copy_as_svg, GetWorksheet()->CanCopy());
 #if wxUSE_ENH_METAFILE

--- a/test/unit_tests/test_WorksheetExport.cpp
+++ b/test/unit_tests/test_WorksheetExport.cpp
@@ -564,6 +564,40 @@ SCENARIO("The selection-to-string converters are deterministic and complete") {
     REQUIRE(m1.Contains(wxS("<math")));
   }
 
+  THEN("CanCopyAsMathML offers MathML only for selections with real math") {
+    // Selecting whole GroupCells or an in-output text message must not offer
+    // MathML; selecting a code cell's math output must. (A whole-GroupCell
+    // selection serializes to empty MathML -- GroupCell has no ToMathML -- so
+    // the offer is judged on in-output selections, which is the useful case.)
+    bool mathOutputOffered = false;
+    GroupCell *warn = nullptr;
+    for (GroupCell *g = g_ws->GetTree(); g != nullptr; g = g->GetNext()) {
+      if (g->GetEditable() &&
+          g->GetEditable()->ToString().Contains(wxS("warnexample")))
+        warn = g;
+      // Select this cell's whole output (label .. last output cell).
+      Cell *out = g->GetLabel();
+      if (out == nullptr)
+        continue;
+      Cell *outEnd = out;
+      while (outEnd->GetNext() != nullptr)
+        outEnd = outEnd->GetNext();
+      g_ws->SetSelection(out, outEnd);
+      if (g_ws->CanCopyAsMathML())
+        mathOutputOffered = true;
+    }
+    // At least one corpus cell has genuine math output.
+    REQUIRE(mathOutputOffered);
+
+    // The plain-text warning output serializes to <mo>/<mtext> only, so it
+    // must never offer MathML.
+    REQUIRE(warn != nullptr);
+    Cell *wout = warn->GetLabel();
+    REQUIRE(wout != nullptr);
+    g_ws->SetSelection(wout, wout);
+    REQUIRE_FALSE(g_ws->CanCopyAsMathML());
+  }
+
   THEN("the RTF frame is stable and well-formed") {
     const wxString start = g_ws->RTFStart();
     const wxString end = g_ws->RTFEnd();


### PR DESCRIPTION
## What

"Copy as MathML" was offered for **any** selection (gated only by `CanCopy()`), including plain text, comments, labels and strings. Converting those produced MathML that merely wrapped the text in `<mo>`/`<mtext>` operator elements — which word processors render oddly — and for a **whole-cell** selection it produced no usable MathML at all (a `GroupCell` has no `ToMathML`).

This is the second half of the "non-math output shouldn't go through the math machinery" to-do (the HTML-export half landed earlier).

## How

New `Worksheet::CanCopyAsMathML()` judges the offer by *exactly what the copy would produce*: it serializes the current selection with the existing `ConvertSelectionToMathML()` and looks for a genuine math **content** element (`<mi>`/`<mn>`/`<mfrac>`/`<msup>`/`<msub>`/`<msqrt>`/…). Prose only ever yields `<mtext>`/`<ms>`/`<mo>`. Correct-by-construction: the menu offer always matches what a copy would actually deliver.

`<mtable>` is deliberately **not** a signal — `ListToMathML` also wraps multi-line or labelled *text* in a table, so it isn't a math indicator (a matrix's entries are caught by `<mn>`/`<mi>` instead).

Both context-menu entries (`WorksheetContextMenu.cpp`) and the Edit-menu item (`wxMaxima.cpp`) now gate on `CanCopyAsMathML()` instead of `CanCopy()`.

### Note on whole-cell selections

Because `GroupCell::ToMathML()` returns empty, "Copy as MathML" on a *whole cell* already serialized to empty MathML — that path was effectively broken. Gating simply stops offering an option that never worked there; the useful path (selecting inside an output) is unaffected and now correctly gated.

## Test

`test_WorksheetExport` verifies a code cell's math output offers MathML while the plain-text warning output does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)