### PR TITLE
Add "Export output as SVG/PNG to a folder" right-click items

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Current development version
 
+- New right-click items "Export output as SVG to a folder..." and "...as PNG
+  to a folder...": for the selected cell(s) they write one image file per
+  output into a directory you choose, named after the output label (e.g.
+  `o12.svg`). Previously the only way to harvest the rendered equation images
+  was to run a full HTML export and dig the pictures out of its `_htmlimg/`
+  folder.
 - HTML export: non-math output (Maxima messages, warnings, errors and plain
   strings) is now written as ordinary, HTML-escaped text instead of being
   rendered to a PNG/SVG image or wrapped in a `<math>` element. Previously a

--- a/src/EventIDs.cpp
+++ b/src/EventIDs.cpp
@@ -591,6 +591,8 @@ const wxWindowIDRef EventIDs::popid_copy_animation(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::popid_copy_svg(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::popid_copy_emf(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::popid_copy_rtf(wxWindow::NewControlId());
+const wxWindowIDRef EventIDs::popid_export_output_svg(wxWindow::NewControlId());
+const wxWindowIDRef EventIDs::popid_export_output_png(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::popid_add_watch(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::popid_add_watch_label(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::popid_special_constant_percent(wxWindow::NewControlId());

--- a/src/EventIDs.h
+++ b/src/EventIDs.h
@@ -660,6 +660,8 @@ public:
   static const wxWindowIDRef popid_copy_svg;
   static const wxWindowIDRef popid_copy_emf;
   static const wxWindowIDRef popid_copy_rtf;
+  static const wxWindowIDRef popid_export_output_svg;
+  static const wxWindowIDRef popid_export_output_png;
   static const wxWindowIDRef popid_add_watch;
   static const wxWindowIDRef popid_add_watch_label;
   static const wxWindowIDRef popid_special_constant_percent;

--- a/src/MaximaCommandMenus.cpp
+++ b/src/MaximaCommandMenus.cpp
@@ -30,6 +30,7 @@
 #include "EventIDs.h"
 #include <wx/windowptr.h>
 #include <wx/colordlg.h>
+#include <wx/dirdlg.h>
 #include <wx/clipbrd.h>
 #include <wx/dataobj.h>
 #include <wx/process.h>
@@ -3394,6 +3395,28 @@ void MaximaCommandMenus::PopupMenu(wxCommandEvent &event) {
   else if(event.GetId() == EventIDs::popid_copy_svg){
     if (m_wxMaxima.GetWorksheet()->CanCopy())
       m_wxMaxima.GetWorksheet()->CopySVG();
+  }
+  else if((event.GetId() == EventIDs::popid_export_output_svg) ||
+          (event.GetId() == EventIDs::popid_export_output_png)){
+    const bool svg = (event.GetId() == EventIDs::popid_export_output_svg);
+    if (m_wxMaxima.GetWorksheet()->CanCopy()) {
+      wxDirDialog dirDialog(&m_wxMaxima,
+                            _("Export the selected output(s) to this folder"),
+                            m_wxMaxima.m_lastPath, wxDD_DEFAULT_STYLE);
+      if (dirDialog.ShowModal() == wxID_OK) {
+        const wxString dir = dirDialog.GetPath();
+        const int written =
+          m_wxMaxima.GetWorksheet()->ExportSelectionOutputToDir(dir, svg);
+        m_wxMaxima.m_lastPath = dir;
+        if (written > 0)
+          m_wxMaxima.StatusText(
+            wxString::Format(_("Exported %d output image(s) to %s"),
+                             written, dir));
+        else
+          m_wxMaxima.StatusText(
+            _("The selection contains no output that could be exported."));
+      }
+    }
   }
 #if wxUSE_ENH_METAFILE
   else if(event.GetId() == EventIDs::popid_copy_emf){

--- a/src/worksheet/Worksheet.cpp
+++ b/src/worksheet/Worksheet.cpp
@@ -3476,6 +3476,76 @@ wxSize Worksheet::CopyToFile(const wxString &file, Cell *start, Cell *end,
                                      &m_configuration);
 }
 
+//! Turn an output label like "(%o12)" into a file stem like "o12".
+static wxString OutputFileStem(const wxString &label) {
+  wxString stem;
+  for (size_t i = 0; i < label.length(); ++i) {
+    const wxChar c = label[i];
+    if (wxIsalnum(c) || (c == wxS('_')) || (c == wxS('-')))
+      stem += c;
+  }
+  // Keep the file name well within every filesystem's length limit even for a
+  // pathologically long "label".
+  if (stem.length() > 64)
+    stem = stem.Left(64);
+  return stem;
+}
+
+int Worksheet::ExportSelectionOutputToDir(const wxString &dir, bool svg) {
+  Cell *const selStart = GetDocumentCellPointers().GetSelectionStart();
+  Cell *const selEnd = GetDocumentCellPointers().GetSelectionEnd();
+  if ((selStart == NULL) || (selEnd == NULL))
+    return 0;
+
+  // Render the cells at full size, exactly like the HTML exporter does.
+  wxBusyCursor busy;
+  m_configuration->ClipToDrawRegion(false);
+
+  const wxString ext = svg ? wxS(".svg") : wxS(".png");
+  std::vector<wxString> usedNames;
+  int count = 0;
+  int index = 0;
+
+  const GroupCell *const lastGroup = selEnd->GetGroup();
+  for (auto &group : OnList(selStart->GetGroup())) {
+    Cell *const output = group.GetLabel();
+    if (output != NULL) {
+      ++index;
+      // Name the file after the (%oN)/(%iN) label when the output has one;
+      // otherwise (a warning, an error, a bare string, an image) use a running
+      // index. De-duplicate collisions below.
+      wxString base;
+      if ((output->GetTextStyle() == TS_LABEL) ||
+          (output->GetTextStyle() == TS_USERLABEL))
+        base = OutputFileStem(output->ToString());
+      if (base.IsEmpty())
+        base = wxString::Format(wxS("output_%d"), index);
+      wxString name = base;
+      for (int n = 2;
+           std::find(usedNames.begin(), usedNames.end(), name) !=
+             usedNames.end();
+           ++n)
+        name = base + wxString::Format(wxS("_%d"), n);
+      usedNames.push_back(name);
+
+      const wxString path = dir + wxS("/") + name + ext;
+      if (svg) {
+        Svgout out(&m_configuration, CopySelection(output, NULL, false), path);
+      } else {
+        CopyToFile(path, output, NULL, /*asData=*/true,
+                   m_configuration->BitmapScale());
+      }
+      ++count;
+    }
+    if (&group == lastGroup)
+      break;
+  }
+
+  m_configuration->ClipToDrawRegion(true);
+  RequestRecalculation();
+  return count;
+}
+
 std::unique_ptr<Cell> Worksheet::CopySelection(bool asData) const {
   return CopySelection(GetDocumentCellPointers().GetSelectionStart(),
                        GetDocumentCellPointers().GetSelectionEnd(), asData);

--- a/src/worksheet/Worksheet.h
+++ b/src/worksheet/Worksheet.h
@@ -1108,6 +1108,19 @@ public:
 
   wxSize CopyToFile(const wxString &file, Cell *start, Cell *end, bool asData = false, double scale = 1) const;
 
+  /*! Write each selected group cell's output to an image file in a folder.
+
+    One file per selected cell that has output, named after the cell's output
+    label (e.g. "o12.svg"), rendered with the same Svgout/BitmapOut path the
+    HTML export uses. This is the direct alternative to harvesting the images
+    an HTML export drops into its _htmlimg/ folder.
+
+    \param dir The target directory (must exist).
+    \param svg true for .svg files, false for .png files.
+    \return the number of image files written.
+  */
+  int ExportSelectionOutputToDir(const wxString &dir, bool svg);
+
   /*! Export the file to an html document
 
     \todo Worksheet and text cell background work fine, but their names might be interchanged.

--- a/src/worksheet/WorksheetContextMenu.cpp
+++ b/src/worksheet/WorksheetContextMenu.cpp
@@ -146,6 +146,12 @@ void PopulateWorksheetContextMenu(Worksheet &worksheet, wxMenu &popupMenu,
 #endif
           popupMenu.Append(EventIDs::popid_copy_rtf, _("Copy as RTF"), wxEmptyString,
                            wxITEM_NORMAL);
+          popupMenu.Append(EventIDs::popid_export_output_svg,
+                           _("Export output as SVG to a folder..."),
+                           wxEmptyString, wxITEM_NORMAL);
+          popupMenu.Append(EventIDs::popid_export_output_png,
+                           _("Export output as PNG to a folder..."),
+                           wxEmptyString, wxITEM_NORMAL);
           if (worksheet.CanDeleteSelection())
             popupMenu.Append(EventIDs::popid_delete, _("Delete Selection"), wxEmptyString,
                              wxITEM_NORMAL);

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -366,6 +366,8 @@ wxMaxima::wxMaxima(wxWindow *parent, int id,
   Bind(wxEVT_MENU, &MaximaCommandMenus::PopupMenu, &m_menuCommands, EventIDs::popid_copy_image);
   Bind(wxEVT_MENU, &MaximaCommandMenus::PopupMenu, &m_menuCommands, EventIDs::popid_copy_animation);
   Bind(wxEVT_MENU, &MaximaCommandMenus::PopupMenu, &m_menuCommands, EventIDs::popid_copy_svg);
+  Bind(wxEVT_MENU, &MaximaCommandMenus::PopupMenu, &m_menuCommands, EventIDs::popid_export_output_svg);
+  Bind(wxEVT_MENU, &MaximaCommandMenus::PopupMenu, &m_menuCommands, EventIDs::popid_export_output_png);
   Bind(wxEVT_MENU, &MaximaCommandMenus::PopupMenu, &m_menuCommands, EventIDs::popid_copy_emf);
   Bind(wxEVT_MENU, &MaximaCommandMenus::PopupMenu, &m_menuCommands, EventIDs::popid_copy_rtf);
   Bind(wxEVT_MENU, &MaximaCommandMenus::OnInsertMenu, &m_menuCommands, EventIDs::popid_insert_text);

--- a/test/unit_tests/test_WorksheetExport.cpp
+++ b/test/unit_tests/test_WorksheetExport.cpp
@@ -575,6 +575,32 @@ SCENARIO("The selection-to-string converters are deterministic and complete") {
   g_ws->ClearSelection();
 }
 
+SCENARIO("Per-cell output export writes one image file per selected output") {
+  BuildDocumentOnce();
+  g_ws->SetSelection(g_ws->GetTree(), g_ws->GetLastCellInWorksheet());
+
+  for (const bool svg : {true, false}) {
+    const wxString dir =
+      MakeExportDir(svg ? wxS("outimg_svg") : wxS("outimg_png"));
+    const int written = g_ws->ExportSelectionOutputToDir(dir, svg);
+
+    THEN("one non-empty file of the requested type is written per output") {
+      REQUIRE(written > 0);
+      const auto snap = SnapshotDir(dir);
+      // Exactly one file per exported output (names are de-duplicated).
+      REQUIRE(snap.size() == static_cast<size_t>(written));
+      const wxString ext = svg ? wxS(".svg") : wxS(".png");
+      for (const auto &entry : snap) {
+        INFO("file: " << entry.first.ToStdString());
+        REQUIRE(entry.first.EndsWith(ext));
+        REQUIRE_FALSE(entry.second.empty());
+      }
+    }
+  }
+
+  g_ws->ClearSelection();
+}
+
 class TestApp : public wxApp {
 public:
   bool OnInit() override { return true; }


### PR DESCRIPTION
## What

To harvest the rendered equation images, people had to run a full **HTML export** and dig the pictures out of its `_htmlimg/` folder. This offers it directly.

With one or more cells selected, the context menu gains:
- **Export output as SVG to a folder…**
- **Export output as PNG to a folder…**

Each asks for a directory and writes **one image per selected cell's output** into it.

## How

New `Worksheet::ExportSelectionOutputToDir(dir, svg)` walks the selected group cells and renders each cell's output with the **same `Svgout` / `CopyToFile` path the HTML exporter uses** (so PNGs honour the bitmap-scale, SVGs are vector). 

File naming:
- named after the `(%oN)` output label → `o12.svg`;
- outputs without a label (warnings, errors, strings, images) get a running `output_N`;
- both are length-capped (≤64 chars) and de-duplicated (`o1_2.svg`) so names are always valid and unique.

Wiring: two new `EventIDs`, bound to the existing popup-menu handler, which pops a `wxDirDialog` and reports the count via the status bar.

## Test

`test_WorksheetExport` selects the whole document and asserts that, for both SVG and PNG, exactly one **non-empty** file of the requested type is written per exported output. Verified on a real dump: genuine `.svg`/`.png` files with names like `o1.svg`, `o2.svg`, `output_4.svg`.

## Notes

- Reuses the bitmap-clip fix from earlier, so PNGs at the default bitmap-scale render fully.
- WebP as a third format is intentionally out of scope here (tracked separately — and for maths it only makes sense lossless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)