### PR TITLE
build_maxima_snap: work around Maxima's stale desktop-file path

### DIFF
--- a/.github/workflows/build_maxima_snap.yml
+++ b/.github/workflows/build_maxima_snap.yml
@@ -104,6 +104,33 @@ jobs:
           print("Maxima snap version set to", ver)
           PY
 
+      # Maxima renamed its desktop launcher (maxima commit 181c06a5b,
+      # "Updates the name of the desktop launcher file for Xmaxima") -- it now
+      # installs desktopintegration/Xmaxima.desktop as
+      # usr/share/applications/Xmaxima.desktop. But Maxima's snap/snapcraft.yaml
+      # still points the xmaxima app's `desktop:` key at the old
+      # net.sourceforge.maxima.xmaxima.desktop, so snapcraft fails because that
+      # file no longer exists in the prime tree. The rename is already in the
+      # 5.49.0 release, so both channels are affected.
+      #
+      # Point `desktop:` at whatever .desktop file this Maxima ref actually
+      # installs (so it stays correct for older refs too). Drop this step once
+      # Maxima's own snapcraft.yaml is fixed upstream.
+      - name: Work around Maxima's stale desktop-file path in snapcraft.yaml
+        run: |
+          set -eu
+          desktop_src=$(ls desktopintegration/*.desktop 2>/dev/null | head -n1 || true)
+          if [ -z "$desktop_src" ]; then
+            echo "No .desktop file under desktopintegration/; leaving snapcraft.yaml unchanged."
+            exit 0
+          fi
+          desktop_file=$(basename "$desktop_src")
+          sed -i -E \
+            "s#^([[:space:]]*desktop:[[:space:]]*usr/share/applications/).*#\1${desktop_file}#" \
+            snap/snapcraft.yaml
+          echo "Patched the xmaxima app's desktop: entry to $desktop_file"
+          grep -n 'desktop:' snap/snapcraft.yaml
+
       - name: Build the Maxima snap
         uses: snapcore/action-build@v1
         id: build


### PR DESCRIPTION
## What

The weekly **Maxima snap** build (`build_maxima_snap.yml`) fails: snapcraft can't find the xmaxima desktop file.

## Why

Maxima renamed its desktop launcher (maxima commit `181c06a5b`, *"Updates the name of the desktop launcher file for Xmaxima"*). It now installs `desktopintegration/Xmaxima.desktop` as `usr/share/applications/Xmaxima.desktop`, but Maxima's own `snap/snapcraft.yaml` still points the `xmaxima` app's `desktop:` key at the old `net.sourceforge.maxima.xmaxima.desktop`. That file no longer exists in the prime tree, so snapcraft errors out.

The rename is already in the **5.49.0** release, so *both* the `stable` (latest release) and `edge` (HEAD) channels are affected.

## Fix

The proper fix belongs upstream in Maxima's `snapcraft.yaml`. Until that lands, this adds a workaround step to our workflow (which clones Maxima and builds its snap): after checkout, rewrite the `desktop:` entry to point at whatever `.desktop` file the cloned Maxima ref actually installs. Detecting the name from `desktopintegration/*.desktop` keeps it correct for older refs too (where the old name is still what's shipped, the rewrite is a no-op).

Verified the `sed` against the current Maxima `snap/snapcraft.yaml`: it rewrites line 54 to `desktop: usr/share/applications/Xmaxima.desktop`. Workflow YAML parses cleanly.

Drop this step once Maxima's snapcraft.yaml is fixed upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)