### PR TITLE
build_maxima_snap: read Maxima's version even with a suffix (edge fix)

### DIFF
--- a/.github/workflows/build_maxima_snap.yml
+++ b/.github/workflows/build_maxima_snap.yml
@@ -85,7 +85,11 @@ jobs:
           base = ""
           with open("configure.ac") as f:
               for line in f:
-                  m = re.search(r'AC_INIT\(\[maxima\],\s*\[([0-9.]+)\]', line)
+                  # Capture the whole version token, not just digits+dots:
+                  # Maxima's development HEAD uses a suffix, e.g.
+                  # AC_INIT([maxima], [5.49post]), which a [0-9.]+ pattern
+                  # can't match -> the edge build failed to read the version.
+                  m = re.search(r'AC_INIT\(\[maxima\],\s*\[([^\]]+)\]', line)
                   if m:
                       base = m.group(1)
                       break


### PR DESCRIPTION
## What

The **edge** Maxima-snap build fails: *"could not read the Maxima version from configure.ac"*.

## Why

Edge builds Maxima's development HEAD, whose `configure.ac` reads:
```
AC_INIT([maxima], [5.49post])
```
The version-patch step's regex captured only `[0-9.]+`, which can't match the `post` suffix → `base` stays empty → the step's `assert` aborts. (Stable is unaffected: it checks out the `X.Y.Z` release tag, whose version is purely numeric.)

## Fix

Capture the whole token inside the brackets — `\[([^\]]+)\]` — yielding `5.49post`, a valid snap version (edge then appends `+git<sha>`). Verified against the current `configure.ac`: extracts `5.49post`; YAML still parses.

## Not fixed here

The *"snapcraft without a command argument is deprecated, use `snapcraft pack`"* notice is a **non-fatal warning** from `snapcore/action-build@v1` running bare `snapcraft`. Silencing it means bumping or replacing that action, which is a separate change — left as a follow-up so this stays a minimal fix for the actual failure.

Stacks naturally with the desktop-file workaround (#2150, already merged) — same workflow, different step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)