### PR TITLE
Use the union merge driver for NEWS.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,10 @@
+# NEWS.md is an append-only changelog: every branch adds its own bullet at the
+# top, so branches routinely "conflict" there even though both edits should be
+# kept. The built-in union merge driver keeps both sides instead of emitting
+# conflict markers. NB this applies to local merges/rebases; GitHub's web-UI
+# merge does not run merge drivers, so resolve NEWS conflicts locally.
+NEWS.md merge=union
+
 *.wxmx binary
 *.wxm linguist-language=maxima-session
 *.wxmx linguist-language=maxima-session


### PR DESCRIPTION
## What

`NEWS.md` is an append-only changelog: nearly every branch adds a bullet at the top of the *Current development version* section, so two branches almost always "conflict" there even though both bullets should just be kept. This is the recurring source of merge conflicts in our PR workflow.

Mark `NEWS.md` with git's built-in **`union`** merge driver (`NEWS.md merge=union` in `.gitattributes`), which keeps **both** sides on a conflict instead of emitting conflict markers.

## Caveat

This applies to **local** merges/rebases (and so to the resolve-locally-then-push workflow). GitHub's web-UI "merge" button does **not** run merge drivers, so a NEWS conflict that surfaces there still has to be resolved locally (which the union driver then automates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)