### PR TITLE
LaTeX export: render arbitrary Unicode maths on XeLaTeX/LuaLaTeX

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Current development version
 
+- LaTeX export: on the Unicode engines (XeLaTeX/LuaLaTeX) the exported document
+  now loads `unicode-math`, so a Unicode symbol wxMaxima has no explicit LaTeX
+  translation for is typeset directly from the character instead of vanishing or
+  breaking the build. A few common symbols that were missing from the
+  translation table (nabla, approx, equiv) render under pdfTeX too now.
+
 - LaTeX export: non-math output (Maxima messages, warnings and errors) is now
   written as LaTeX text instead of being forced through the math renderer, and
   a backslash in such output no longer produces broken LaTeX -- the

--- a/src/cells/TextCell.cpp
+++ b/src/cells/TextCell.cpp
@@ -785,6 +785,9 @@ wxString TextCell::ToTeX() const {
   text.Replace(wxS("\u2263"), mathModeStart + wxS("\\equiv") + mathModeEnd);
   text.Replace(wxS("\u2211"), mathModeStart + wxS("\\sum") + mathModeEnd);
   text.Replace(wxS("\u220F"), mathModeStart + wxS("\\prod") + mathModeEnd);
+  text.Replace(wxS("\u2207"), mathModeStart + wxS("\\nabla") + mathModeEnd);
+  text.Replace(wxS("\u2261"), mathModeStart + wxS("\\equiv") + mathModeEnd);
+  text.Replace(wxS("\u2248"), mathModeStart + wxS("\\approx") + mathModeEnd);
   text.Replace(wxS("\u2225"), mathModeStart + wxS("\\parallel") + mathModeEnd);
   text.Replace(wxS("\u27C2"), mathModeStart + wxS("\\bot") + mathModeEnd);
   text.Replace(wxS("~"), mathModeStart + wxS("\\sim ") + mathModeEnd);

--- a/src/worksheet/WorksheetExport.cpp
+++ b/src/worksheet/WorksheetExport.cpp
@@ -719,6 +719,14 @@ bool WorksheetExport::ExportToTeX(GroupCell *tree, Configuration *configuration,
   // necessary logic for this to TeX.
   output << wxS("\\usepackage{color}\n");
   output << wxS("\\usepackage[leqno]{amsmath}\n");
+  // On the modern Unicode engines (XeLaTeX/LuaLaTeX) unicode-math lets the
+  // document typeset arbitrary Unicode maths directly -- so a symbol wxMaxima
+  // doesn't translate to a LaTeX command still renders instead of vanishing or
+  // breaking the build. It must be loaded after amsmath, and only there (pdfTeX
+  // has no Unicode-math font machinery; it keeps the inputenc path above).
+  output << wxS("\\ifPDFTeX\\else\n");
+  output << wxS("  \\usepackage{unicode-math}\n");
+  output << wxS("\\fi\n");
 
   // We want to shrink pictures the user has included if they are
   // higher or wider than the page.

--- a/test/unit_tests/test_WorksheetExport.cpp
+++ b/test/unit_tests/test_WorksheetExport.cpp
@@ -267,7 +267,7 @@ static const wxChar *const kTextOutputXml = wxS(
   "<input><editor type=\"input\"><line>textexample;</line></editor></input>\n"
   "<output>\n"
   "<mth><t breakline=\"true\">ExportNetTextOutput line: alpha=&#945; "
-  "backslash=\\ ok</t></mth>\n"
+  "backslash=\\ nabla=&#8711; equiv=&#8801; approx=&#8776; ok</t></mth>\n"
   "</output>\n"
   "</cell>\n"
   "</wxMaximaDocument>\n");
@@ -509,30 +509,35 @@ SCENARIO("HTML export succeeds, is deterministic and contains the document") {
   g_cfg->HTMLequationFormat(oldFormat);
 }
 
-/*! Compile an exported .tex with pdflatex, when it is installed.
+/*! Compile an exported .tex with a LaTeX engine, when it is installed.
 
   The LaTeX export is assembled by string concatenation across ~30 ToTeX() cell
   methods, so a malformed macro or an unbalanced math mode is easy to introduce
   and invisible to the content assertions -- but it breaks the whole document.
-  Actually compiling it is the real guard. Optional: if pdflatex isn't on PATH
-  (wxExecute returns -1) the check is skipped so the suite still runs everywhere
-  (e.g. CI without a TeX toolchain). pdflatex runs in the .tex's own directory
-  so the relative <name>_img/ graphics paths resolve.
+  Actually compiling it is the real guard. We exercise both engine families,
+  because the preamble branches on \ifPDFTeX: `pdflatex` (inputenc path) and
+  `lualatex` (fontspec + unicode-math path). Optional: if the engine isn't on
+  PATH (wxExecute returns -1) that engine is skipped so the suite still runs
+  everywhere (e.g. CI without a TeX toolchain). The engine runs in the .tex's
+  own directory so the relative <name>_img/ graphics paths resolve; a per-engine
+  jobname keeps their aux/pdf outputs from clobbering each other.
 */
-static void RequireTexCompiles(const wxString &texPath) {
+static void RequireTexCompiles(const wxString &texPath, const wxString &engine) {
   const wxFileName texFile(texPath);
   wxArrayString out, err;
   wxExecuteEnv env;
   env.cwd = texFile.GetPath();
-  const wxString cmd =
-    wxS("pdflatex -interaction=nonstopmode -halt-on-error \"") +
-    texFile.GetFullName() + wxS("\"");
+  const wxString cmd = engine +
+    wxS(" -interaction=nonstopmode -halt-on-error -jobname=out_") + engine +
+    wxS(" \"") + texFile.GetFullName() + wxS("\"");
   const long rc = wxExecute(cmd, out, err, wxEXEC_SYNC, &env);
   if (rc < 0)
-    return; // pdflatex not installed -> skip cleanly
-  if (rc != 0)
+    return; // this engine not installed -> skip cleanly
+  if (rc != 0) {
+    INFO("engine: " << engine.ToStdString());
     for (const auto &line : out)
-      INFO("pdflatex: " << line.ToStdString());
+      INFO(line.ToStdString());
+  }
   REQUIRE(rc == 0);
 }
 
@@ -565,8 +570,11 @@ SCENARIO("TeX export succeeds, is deterministic and contains the document") {
     REQUIRE(tex.Contains(wxS("ExportNetTextOutput")));
   }
 
-  THEN("the exported LaTeX compiles (skipped if pdflatex is absent)") {
-    RequireTexCompiles(dir1 + wxS("/doc.tex"));
+  THEN("the exported LaTeX compiles under both engine families") {
+    // pdfTeX (inputenc path) and a Unicode engine (fontspec + unicode-math
+    // path); each is skipped if that binary isn't installed.
+    RequireTexCompiles(dir1 + wxS("/doc.tex"), wxS("pdflatex"));
+    RequireTexCompiles(dir1 + wxS("/doc.tex"), wxS("lualatex"));
   }
 }
 


### PR DESCRIPTION
## What

The LaTeX exporter translated a fixed ~80-entry table of Unicode characters to LaTeX commands (`α` → `\alpha`, …) and left everything else as a raw Unicode byte. That's the "Unicode is very broken" report:

- under **pdfTeX**, any untranslated character **aborts the whole build** (`Unicode character … not set up for use with LaTeX`);
- under a **Unicode engine** it **silently vanished**, because the default Latin Modern font has no glyph for it.

## Fix (the modern-engine approach)

On the XeLaTeX/LuaLaTeX branch of the preamble (`\ifPDFTeX\else…\fi`, after `amsmath`), load **`unicode-math`**. That gives the document a Unicode math font, so a character wxMaxima didn't translate is typeset **directly from the character** instead of breaking or disappearing. pdfTeX keeps its `inputenc` path unchanged.

Also added the common symbols **`\nabla` `\approx` `\equiv`** that were missing from the translation table (so they work under pdfTeX too).

## Safety net (upgraded)

`test_WorksheetExport` now compiles the exported `.tex` with **both `pdflatex` and `lualatex`** (each skipped if that binary is absent), so both preamble branches are guarded — this is what proved the change. The corpus gains a text output containing `∇ ≡ ≈`. Verified: both engines produce a PDF (`unicode-math` present; the symbols render).

## Scope

This fixes arbitrary Unicode **maths** on the modern engines. Truly exotic **text** Unicode (e.g. CJK) additionally needs a font that has those glyphs — a font-configuration concern beyond this slice, noted for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)