### PR TITLE
Add a wxworksheettotex() Maxima command

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Current development version
 
+- New Maxima command `wxworksheettotex("file.tex")` exports the current
+  worksheet to LaTeX from within a Maxima session, the companion of
+  `wxworksheettohtml()`. Keyword options `documentclass=...` and
+  `documentclassoptions=...` override the LaTeX document class for that export.
 - LaTeX export: non-math output (Maxima messages, warnings and errors) is now
   written as LaTeX text instead of being forced through the math renderer, and
   a backslash in such output no longer produces broken LaTeX -- the

--- a/data/builtin_commands.txt
+++ b/data/builtin_commands.txt
@@ -2640,6 +2640,7 @@ wxstatusbar(<string>)
 wxsubscripts
 wxwidgetsversion
 wxworksheettohtml(<filename>)
+wxworksheettotex(<filename>)
 x
 xaxis
 xaxis_color

--- a/info/wxmaxima.md
+++ b/info/wxmaxima.md
@@ -481,7 +481,19 @@ A relative file name is interpreted relative to _Maxima_’s working directory. 
 
 The `flavor` values match the equation formats offered by the graphical **File → Export** dialog: `mathml` produces a self-contained page that needs no internet connection, `mathjax` adds a MathJaX fall-back for browsers that still lack MathML, and `svg`/`bitmap` render every equation to an image.
 
-Support for `wxworksheettotex()` and `wxworksheettopdf()` is planned.
+The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file the same way:
+
+```maxima
+wxworksheettotex("report.tex")$
+wxworksheettotex("report.tex", documentclass="report", documentclassoptions="12pt,a4paper")$
+```
+
+| option                 | meaning                                                              |
+| ---------------------- | -------------------------------------------------------------------- |
+| `documentclass`        | overrides the LaTeX `\documentclass` (e.g. `"article"`, `"report"`)  |
+| `documentclassoptions` | overrides its options (e.g. `"12pt,a4paper"`)                        |
+
+Support for `wxworksheettopdf()` is planned.
 
 ## Plotting
 

--- a/src/MaximaResponseReader.cpp
+++ b/src/MaximaResponseReader.cpp
@@ -75,6 +75,8 @@ void MaximaResponseReader::ReadWorksheetExport(const wxXmlDocument &xmldoc) {
   wxString file;
   wxString flavor = wxS("mathml");
   bool wxmx = false;
+  wxString documentclass;
+  wxString documentclassOptions;
   for (wxXmlNode *child = root->GetChildren(); child != NULL;
        child = child->GetNext()) {
     const wxString name = child->GetName();
@@ -90,17 +92,24 @@ void MaximaResponseReader::ReadWorksheetExport(const wxXmlDocument &xmldoc) {
         flavor = content;
       else if (key == wxS("wxmx"))
         wxmx = (content == wxS("true"));
+      else if (key == wxS("documentclass"))
+        documentclass = content;
+      else if (key == wxS("documentclassoptions"))
+        documentclassOptions = content;
     }
   }
 
   if (file.IsEmpty()) {
     m_wxMaxima.m_outputAppender.DoRawConsoleAppend(
-      _("wxworksheettohtml: no target file name was given."), MC_TYPE_WARNING);
+      _("wxworksheettohtml/totex: no target file name was given."),
+      MC_TYPE_WARNING);
     return;
   }
 
   if (type == wxS("html"))
     m_wxMaxima.ExportWorksheetToHtml(file, flavor, wxmx);
+  else if (type == wxS("tex"))
+    m_wxMaxima.ExportWorksheetToTex(file, documentclass, documentclassOptions);
   else
     m_wxMaxima.m_outputAppender.DoRawConsoleAppend(
       wxString::Format(

--- a/src/wxMathML.lisp
+++ b/src/wxMathML.lisp
@@ -210,6 +210,12 @@
 (defun $wxworksheettohtml (filename &rest opts)
   (wxexport-emit "html" filename opts))
 
+;; wxworksheettotex("file.tex" [, documentclass=..., documentclassoptions=...])
+;;   documentclass         overrides the LaTeX \documentclass (e.g. "report")
+;;   documentclassoptions  overrides its options (e.g. "12pt,a4paper")
+(defun $wxworksheettotex (filename &rest opts)
+  (wxexport-emit "tex" filename opts))
+
 ;; Muffles compiler-notes where we don't want to drown in debug messages.
 (defmacro no-warning (form)
   #+sbcl `(handler-bind

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -2095,6 +2095,43 @@ void wxMaxima::ExportWorksheetToHtml(const wxString &filename,
   }
 }
 
+void wxMaxima::ExportWorksheetToTex(const wxString &filename,
+                                    const wxString &documentclass,
+                                    const wxString &documentclassOptions) {
+  if (!GetWorksheet())
+    return;
+
+  // Apply the requested document-class overrides to the very Configuration the
+  // exporter reads, then restore them so the command has no lasting effect.
+  Configuration *const cfg = GetWorksheet()->GetConfig();
+  const wxString oldClass = cfg->Documentclass();
+  const wxString oldOptions = cfg->DocumentclassOptions();
+  if (!documentclass.IsEmpty())
+    cfg->Documentclass(documentclass);
+  if (!documentclassOptions.IsEmpty())
+    cfg->DocumentclassOptions(documentclassOptions);
+
+  StatusExportStart();
+  bool ok;
+  {
+    wxBusyCursor crs;
+    ok = GetWorksheet()->ExportToTeX(filename);
+  }
+
+  cfg->Documentclass(oldClass);
+  cfg->DocumentclassOptions(oldOptions);
+
+  if (ok) {
+    StatusExportFinished();
+    StatusText(wxString::Format(_("Exported the worksheet to %s"), filename));
+  } else {
+    StatusExportFailed();
+    m_outputAppender.DoRawConsoleAppend(
+      wxString::Format(_("wxworksheettotex: could not write \"%s\"."), filename),
+      MC_TYPE_ERROR);
+  }
+}
+
 ///--------------------------------------------------------------------------------
 ///  Menu and button events
 ///--------------------------------------------------------------------------------

--- a/src/wxMaxima.h
+++ b/src/wxMaxima.h
@@ -383,6 +383,18 @@ protected:
   */
   void ExportWorksheetToHtml(const wxString &filename, const wxString &flavor,
                              bool embedWxmx);
+
+  /*! Export the current worksheet to a LaTeX file (driven by wxworksheettotex).
+
+    \param filename The (absolute) target file.
+    \param documentclass Overrides the LaTeX document class (empty = keep the
+                         configured one).
+    \param documentclassOptions Overrides the document-class options (empty =
+                         keep the configured ones).
+  */
+  void ExportWorksheetToTex(const wxString &filename,
+                            const wxString &documentclass,
+                            const wxString &documentclassOptions);
 #ifdef __WXMSW__
   //! Register wxMaxima's own path as the .wxmx diff tool for TortoiseSVN/Git.
   void RegisterWxmxDiffTool();


### PR DESCRIPTION
## What

The companion of `wxworksheettohtml()` (#2149): export the current worksheet to **LaTeX** from within a Maxima session, for scripted/batch export.

```maxima
wxworksheettotex("report.tex")$
wxworksheettotex("report.tex", documentclass="report", documentclassoptions="12pt,a4paper")$
```

| option                 | meaning |
|------------------------|---------|
| `documentclass`        | overrides the LaTeX `\documentclass` (e.g. `"article"`, `"report"`) |
| `documentclassoptions` | overrides its options (e.g. `"12pt,a4paper"`) |

## How

Reuses the shared `<worksheetexport>` protocol tag — the reader (`ReadWorksheetExport`) already switched on the export `type`, and had a stub for the non-html case — so this adds **no** new XML tag:

- **Lisp**: `$wxworksheettotex` emits `<worksheetexport><type>tex</type>…</worksheetexport>` via the same emitter.
- **Reader**: dispatches `type=="tex"` and parses the two `<option>`s.
- **`wxMaxima::ExportWorksheetToTex`**: applies the document-class overrides to the `Configuration` the exporter reads, calls `ExportToTeX`, then restores them — so the command has no lasting session effect.
- Documented in `info/wxmaxima.md`, added to `data/builtin_commands.txt` autocomplete.

## Verification

Driven end-to-end through the batch driver: `wxworksheettotex("default.tex")` → `\documentclass[fleqn]{article}` (the configured default); `wxworksheettotex(..., documentclass="report", documentclassoptions="12pt,a4paper")` → `\documentclass[12pt,a4paper]{report}`. The override is restored (the plain export right after still uses `article`). Both `.tex` files **compile to a PDF** with pdflatex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)