### PR TITLE
LaTeX export: emit 2-D ASCII-art maths as verbatim, not as an equation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # Current development version
 
+- LaTeX export: 2-D ASCII-art maths -- what Maxima prints when it isn't asked
+  for XML, for example from the Lisp side -- is exported as a verbatim block
+  instead of being pushed through the math renderer. Its meaning is carried
+  entirely by the column alignment (fraction bars drawn out of hyphens,
+  exponents parked above their base), and math mode collapsed the spaces and
+  dropped the line breaks, so the art arrived as an unreadable single line. The
+  label in front of such a block is now written as coloured text, too, instead
+  of as the number of an otherwise empty equation.
+
 - LaTeX export: animations (slide shows) are exported again. Each frame is
   written as an image and embedded with the `animate` package's
   `\animategraphics`, which plays the animation in PDF viewers that support it

--- a/src/cells/GroupCell.cpp
+++ b/src/cells/GroupCell.cpp
@@ -1207,6 +1207,48 @@ wxString GroupCell::ToTeX(const wxString &imgDir, const wxString &filename,
   return str;
 }
 
+namespace {
+/*! Escape LaTeX's special characters in a piece of plain text.
+
+  Used for the label in front of ASCII-art output, which is emitted as ordinary
+  text instead of as an equation tag: a Maxima label like "(%o12)" contains a
+  percent sign, which LaTeX would otherwise read as the start of a comment and
+  swallow the rest of the line with.
+
+  The backslash is parked in a private-use character while the braces are
+  escaped, so that the braces of the \textbackslash{} we replace it with
+  afterwards don't get escaped in turn -- the ordering bug that used to produce
+  \ensuremath\{\backslash\} for a backslash in an error message.
+ */
+wxString TexEscapePlainText(wxString text) {
+  static const wxString marker(wxUniChar(0xE000));
+  text.Replace(wxS("\\"), marker);
+  text.Replace(wxS("{"), wxS("\\{"));
+  text.Replace(wxS("}"), wxS("\\}"));
+  text.Replace(wxS("$"), wxS("\\$"));
+  text.Replace(wxS("&"), wxS("\\&"));
+  text.Replace(wxS("#"), wxS("\\#"));
+  text.Replace(wxS("%"), wxS("\\%"));
+  text.Replace(wxS("_"), wxS("\\_"));
+  text.Replace(wxS("~"), wxS("\\textasciitilde{}"));
+  text.Replace(wxS("^"), wxS("\\textasciicircum{}"));
+  text.Replace(marker, wxS("\\textbackslash{}"));
+  return text;
+}
+
+/*! Make one line of 2-D ASCII art safe to put inside a verbatim environment.
+
+  Inside verbatim nothing is special except the literal string
+  "\end{verbatim}", which ends the environment early -- so that is the only
+  sequence that has to be broken up. (LaTeX ignores the space we insert when
+  looking for the end of a verbatim block, so the art keeps its width.)
+ */
+wxString TexProtectVerbatim(wxString line) {
+  line.Replace(wxS("\\end{verbatim}"), wxS("\\end {verbatim}"));
+  return line;
+}
+} // namespace
+
 wxString GroupCell::ToTeXCodeCell(const wxString &imgDir, const wxString &filename,
                                   std::size_t *imgCounter) const {
   wxString str;
@@ -1242,8 +1284,23 @@ wxString GroupCell::ToTeXCodeCell(const wxString &imgDir, const wxString &filena
       str += wxS("\\definecolor{labelcolor}{RGB}{100,0,0}\n");
 
     bool mathMode = false;
+    bool asciiArt = false;
 
     for (const Cell &tmp : OnDrawList(m_output.get())) {
+      // 2-D ASCII-art maths -- what maxima prints when it isn't asked for XML,
+      // e.g. from the Lisp side or with display2d in its plain-text mode --
+      // draws fraction bars, roots and matrices out of characters, so it only
+      // stays readable if its exact column alignment does. Math mode collapses
+      // runs of spaces and ignores the line breaks, so a run of ASCII-art lines
+      // is emitted as one verbatim block instead of as an equation.
+      const bool isAsciiArt = (tmp.GetTextStyle() == TS_ASCIIMATHS);
+
+      // Anything that isn't another art line ends the block.
+      if (asciiArt && !isAsciiArt) {
+        str += wxS("\\end{verbatim}\n");
+        asciiArt = false;
+      }
+
       if (tmp.GetType() == MC_TYPE_IMAGE) {
         str << ToTeXImage(&tmp, imgDir, filename, imgCounter);
       } else if (tmp.GetType() == MC_TYPE_SLIDE) {
@@ -1253,10 +1310,42 @@ wxString GroupCell::ToTeXCodeCell(const wxString &imgDir, const wxString &filena
           str << "\\text{[animated graphics - not shown in TeX export]}";
         else
           str << anim;
+      } else if (isAsciiArt) {
+        if (mathMode) {
+          str += wxS("\\mbox{}\n\\]");
+          mathMode = false;
+        }
+        if (!asciiArt) {
+          str += wxS("\n\\begin{verbatim}\n");
+          asciiArt = true;
+        }
+        // ToString() gives the art back as characters (it also undoes the
+        // unicode minus the parser substitutes for "-", which is what keeps
+        // fraction bars printable under pdfTeX) and appends the line break the
+        // next cell forces; we add exactly one line break ourselves.
+        wxString line = tmp.ToString();
+        while (line.EndsWith(wxS("\n")))
+          line.RemoveLast();
+        str += TexProtectVerbatim(line) + wxS("\n");
       } else {
         switch (tmp.GetTextStyle()) {
         case TS_LABEL:
-        case TS_USERLABEL:
+        case TS_USERLABEL: {
+          // A label in front of ASCII art must not open math mode: the art is
+          // about to leave it again, and all that would be left of the equation
+          // is an empty, numbered \[...\]. Emit the label as text instead.
+          const Cell *const next = tmp.GetNextToDraw();
+          if (next && (next->GetTextStyle() == TS_ASCIIMATHS)) {
+            if (mathMode) {
+              str += wxS("\\mbox{}\n\\]");
+              mathMode = false;
+            }
+            wxString label = tmp.GetValue();
+            label.Trim(true).Trim(false);
+            str += wxS("\n\\noindent\\textcolor{labelcolor}{\\texttt{") +
+              TexEscapePlainText(label) + wxS("}}\n");
+            break;
+          }
           if (mathMode)
             str += wxS("\\mbox{}\\]\n\\[\\displaystyle ");
           else {
@@ -1265,6 +1354,7 @@ wxString GroupCell::ToTeXCodeCell(const wxString &imgDir, const wxString &filena
           }
           str += tmp.ToTeX() + wxS("\n");
           break;
+        }
 
         case TS_STRING:
         case TS_TEXT:
@@ -1290,6 +1380,9 @@ wxString GroupCell::ToTeXCodeCell(const wxString &imgDir, const wxString &filena
         }
       }
     }
+
+    if (asciiArt)
+      str += wxS("\\end{verbatim}\n");
 
     if (mathMode) {
       // Some invisible dummy content that keeps TeX happy if there really is

--- a/test/unit_tests/test_WorksheetExport.cpp
+++ b/test/unit_tests/test_WorksheetExport.cpp
@@ -271,6 +271,21 @@ static const wxChar *const kTextOutputXml = wxS(
   "backslash=\\ nabla=&#8711; equiv=&#8801; approx=&#8776; ok</t></mth>\n"
   "</output>\n"
   "</cell>\n"
+  // A labelled block of 2-D ASCII-art maths: four lines whose meaning is
+  // carried entirely by their column alignment (a fraction bar drawn out of
+  // hyphens, an exponent parked above the base). Math mode would collapse the
+  // spaces and drop the line breaks, so this pins the verbatim block.
+  "<cell type=\"code\">\n"
+  "<input><editor type=\"input\"><line>asciiartexample;</line></editor></input>\n"
+  "<output>\n"
+  "<mth><lbl altCopy=\"(%o11)&#9;\">(%o11) </lbl>"
+  "<t breakline=\"true\" type=\"ASCII-Art\">                        2</t>\n"
+  "<t breakline=\"true\" type=\"ASCII-Art\">    ExportNetAsciiArt x  + 1</t>\n"
+  "<t breakline=\"true\" type=\"ASCII-Art\">    ------------------------</t>\n"
+  "<t breakline=\"true\" type=\"ASCII-Art\">         ExportNetAsciiArt x</t>\n"
+  "</mth>\n"
+  "</output>\n"
+  "</cell>\n"
   "</wxMaximaDocument>\n");
 
 /*! Fills the worksheet with the real math corpus plus sentinel cells.
@@ -569,6 +584,23 @@ SCENARIO("TeX export succeeds, is deterministic and contains the document") {
     REQUIRE_FALSE(tex.Contains(wxS("\\] \\texttt{%error")));
     // A plain text output line survives too.
     REQUIRE(tex.Contains(wxS("ExportNetTextOutput")));
+  }
+
+  THEN("2-D ASCII-art output keeps its alignment in a verbatim block") {
+    const wxString tex = ReadTextFile(dir1 + wxS("/doc.tex"));
+    REQUIRE(tex.Contains(wxS("\\begin{verbatim}")));
+    REQUIRE(tex.Contains(wxS("\\end{verbatim}")));
+    // The art is emitted character for character: the indentation that parks
+    // the exponent above its base, and the fraction bar as plain ASCII hyphens
+    // -- the parser turns "-" into a unicode minus for the screen, and a
+    // unicode minus would abort the pdfTeX run.
+    REQUIRE(tex.Contains(wxS("                        2")));
+    REQUIRE(tex.Contains(wxS("    ExportNetAsciiArt x  + 1")));
+    REQUIRE(tex.Contains(wxS("    ------------------------")));
+    // Its label is written as coloured text rather than as an equation tag,
+    // which would have left an empty numbered equation in front of the block.
+    REQUIRE(tex.Contains(wxS("\\textcolor{labelcolor}{\\texttt{(\\%o11)}}")));
+    REQUIRE_FALSE(tex.Contains(wxS("\\tag{%o11}")));
   }
 
   THEN("the exported LaTeX compiles under both engine families") {


### PR DESCRIPTION
Continues the LaTeX-export cleanup (#2151, #2154, #2156, #2157) with the case
[#2151](https://github.com/wxMaxima-developers/wxmaxima/pull/2151) deliberately
left out: 2-D ASCII-art output.

## The bug

ASCII-art maths -- what maxima prints when it isn't asked for XML, e.g. from the
Lisp side -- carries its meaning entirely in the column alignment: fraction bars
drawn out of hyphens, exponents parked above their base. `GroupCell::ToTeXCodeCell`
routed it through the `default:` branch into math mode, which collapses runs of
spaces and has no line breaks, so

```
                        2
    ExportNetAsciiArt x  + 1
    ------------------------
         ExportNetAsciiArt x
```

was exported as the single unreadable line

```
2ExportN etAsciiArtx+1−−−−−−−−−−−−−−−−−−−−−−−−ExportN etAsciiArtx
```

(verified by compiling the pre-fix output shape).

## The fix

* A **run** of consecutive `TS_ASCIIMATHS` cells is emitted as one `verbatim`
  block, closing math mode first. The run has to be grouped because each art
  *line* is its own `TextCell` -- `TextCell::Recalculate` force-breaks them, and
  both `MathParser::ParseText` and `DoRawConsoleAppend` tokenize on `\n`.
* The art text comes from `ToString()`, not `ToTeX()`: `ParseText` rewrites every
  `-` to a unicode minus for the screen, and `ToString()` is what undoes it -- a
  raw U+2212 does not print under pdfTeX. `ToString()` also appends the line break
  the *next* cell forces, so the trailing newline is normalised to exactly one.
* The **label** in front of an art run is emitted as coloured text rather than as
  an equation tag: the art leaves math mode at once, so all the equation would
  have contributed is an empty, numbered `\[...\]`.
* Two file-local helpers: `TexEscapePlainText` (parks the backslash in a
  private-use character while the braces are escaped, so the braces of
  `\textbackslash{}` are not escaped in turn -- the ordering bug that produced
  `\ensuremath\{\backslash\}` before #2151) and `TexProtectVerbatim` (breaks up a
  literal `\end{verbatim}`, the only thing that can end the environment early).

## Verification

* `test_WorksheetExport`'s corpus grows a labelled four-line art block; new
  assertions pin the indentation, the ASCII fraction bar and the text label.
* The existing dual-engine guard compiles the result with **pdflatex and
  lualatex**, and both were confirmed to actually run (not skipped).
* The exported PDF was rendered and inspected: alignment preserved, label in the
  label colour, following equations unaffected.
* All 35 `-L unittest` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XPDxkWgQan8Qbb89drnjz