### PR TITLE
Check the translation catalogues with msgfmt from ctest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/check-xml-validity.sh.in" check-xml-
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/check-wxmx-validity.sh.in" check-wxmx-validity.sh)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/check-wizard-commands.sh.in" check-wizard-commands.sh)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/check-markdown.sh.in" check-markdown.sh)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/check-translations.sh.in" check-translations.sh)
 
 # Create a headless wrapper script
 set(WXM_TEST_WRAPPER "${CMAKE_CURRENT_BINARY_DIR}/run_headless.sh")
@@ -185,6 +186,15 @@ add_test(
 add_test(
     NAME check-markdown
     COMMAND "${CMAKE_CURRENT_BINARY_DIR}/check-markdown.sh"
+)
+
+# Check every translation catalogue with msgfmt. Chiefly --check-format: a msgstr
+# whose format specifiers don't match its msgid makes wxWidgets format against
+# the wrong arguments at runtime, in a language we may not read.
+# Skipped with a warning where gettext isn't installed.
+add_test(
+    NAME check-translations
+    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/check-translations.sh"
 )
 
 add_test(

--- a/test/check-translations.sh.in
+++ b/test/check-translations.sh.in
@@ -1,0 +1,80 @@
+#!/bin/sh
+# Checks every translation catalogue with msgfmt.
+#
+# The one that really matters is --check-format: if a msgstr's format specifiers
+# don't match its msgid -- a "%s" that became "%d", or one that got lost in
+# translation -- then wxWidgets formats that string against the wrong arguments
+# at runtime, in a language the developers probably don't read. gettext catches
+# it statically, so nothing of the sort should ever reach a release.
+#
+# Header warnings ("field 'Language' still has the initial default value") are
+# reported as a count and do NOT fail: msgfmt exits 0 for them, they are cosmetic
+# metadata, and several catalogues have carried them for years.
+#
+# Accelerator mismatches (a "&File" whose translation lost the "&") are counted
+# and reported too, also without failing: there are ~205 of them across the
+# catalogues right now, so gating on them would mean editing translations rather
+# than guarding them. The number is printed so it can be watched, and driven down.
+#
+# Optional, like check-lintian/check-rpmlint/check-markdown: without msgfmt (i.e.
+# without gettext) the test passes with a warning.
+
+set -eu
+
+if ! command -v msgfmt >/dev/null 2>&1; then
+    echo "Warning: msgfmt not found. Skipping the translation checks."
+    echo "         It is part of gettext."
+    exit 0
+fi
+
+SRCDIR="@CMAKE_SOURCE_DIR@"
+cd "$SRCDIR" || exit 1
+
+# Every catalogue and template. Use git when it is available so that a stray .po
+# in a build tree can't join in, and fall back to find for a release tarball.
+if command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1; then
+    CATALOGUES="$(git ls-files '*.po' '*.pot')"
+else
+    CATALOGUES="$(find . \( -name '.?*' -o -name 'build' -o -name 'build-*' \) -prune -o \
+                       \( -name '*.po' -o -name '*.pot' \) -print | sed 's|^\./||')"
+fi
+
+if [ -z "$CATALOGUES" ]; then
+    echo "Error: found no translation catalogues to check."
+    exit 1
+fi
+
+BROKEN=""
+COUNT=0
+WARNED=0
+ACCEL=0
+
+for po in $CATALOGUES; do
+    COUNT=$((COUNT + 1))
+
+    # The gate. -c is --check-format plus --check-header and --check-domain; only
+    # a real error makes msgfmt exit non-zero.
+    if ! output="$(msgfmt -c -o /dev/null "$po" 2>&1)"; then
+        echo "FAILED: $po"
+        echo "$output"
+        BROKEN="$BROKEN $po"
+        continue
+    fi
+    if [ -n "$output" ]; then
+        WARNED=$((WARNED + 1))
+    fi
+
+    # Informational only.
+    n="$(msgfmt --check-accelerators='&' -o /dev/null "$po" 2>&1 \
+         | grep -c 'accelerator' || true)"
+    ACCEL=$((ACCEL + n))
+done
+
+if [ -n "$BROKEN" ]; then
+    echo
+    echo "Translation catalogues with errors:$BROKEN"
+    exit 1
+fi
+
+echo "Translations: $COUNT catalogues compile cleanly" \
+     "($WARNED with cosmetic header warnings, $ACCEL accelerator mismatches)."


### PR DESCRIPTION
A `msgstr` whose format specifiers don't match its `msgid` -- a `%s` that became
`%d`, or one dropped in translation -- makes wxWidgets format that string against
the wrong arguments at runtime, in a language the developers likely can't read.
gettext detects it statically, so there's no reason for one to ever reach a
release.

New ctest target **`check-translations`** runs `msgfmt -c` over all 32 catalogues
and templates and fails on any error. Like `check-lintian` / `check-rpmlint` /
`check-markdown` it's optional -- without gettext it passes with a warning -- and
it enumerates via `git ls-files` with a `find` fallback so a release tarball works
too.

Two classes of finding are **counted and reported but deliberately do not fail**,
because both are pre-existing and neither can crash anything:

* **Header fields still at their initial default value** (`Language`,
  `Last-Translator`). `msgfmt` only warns and exits 0; eleven catalogues have
  carried these for years.
* **Accelerator mismatches**, where a `&File` lost its `&` in translation. There
  are **209** across the catalogues, so gating on them would mean editing
  translations rather than guarding them. The count is printed so it can be
  watched and driven down.

Current output:

```text
Translations: 32 catalogues compile cleanly (11 with cosmetic header warnings, 209 accelerator mismatches).
```

Verified both directions: the suite passes as it stands, and a catalogue with a
deliberate `"%d items in %s"` → `"%s"` mismatch fails the test with
`number of format specifications in 'msgid' and 'msgstr' does not match`. The
no-gettext skip path was exercised with a stripped `PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XPDxkWgQan8Qbb89drnjz
