### PR TITLE
Sync the translated manuals with the English source

### DIFF
--- a/info/wxmaxima.de.md
+++ b/info/wxmaxima.de.md
@@ -370,7 +370,6 @@ math input does not contain them; (b) if you save the document as
 changes will of course not work in command line Maxima); but they may occur,
 if you cut&paste a formula from another document.
 
-
 ### Seitenleisten
 
 Die meisten _Maxima_-Befehle, ein Inhaltsverzeichnis, Debug-Meldungen oder
@@ -406,7 +405,7 @@ _WxMaxima_ unterstützt einige
 Konstrukten kollidieren, die in mathematischen Formeln vorkommen. Eines
 dieser Elemente sind Aufzählungen:
 
-```
+```text
 Normaler Text
  * Ein eingerückter Aufzählungspunkt
  * Ein zweiter Aufzählungspunkt
@@ -418,13 +417,13 @@ Normaler text
 
 _WxMaxima_ erkennt Text, der mit einem `>` beginnt, als ein Zitat:
 
-``` Ordinary text > quote quote quote quote > quote quote quote quote >
+```text Ordinary text > quote quote quote quote > quote quote quote quote >
 quote quote quote quote Ordinary text ```
 
 Die TeX- und HTML-Ausgabe von _WxMaxima_ erkennt auch `=>` und ersetzt es
 durch das entsprechende Unicode-Symbol:
 
-``` cogito => sum. ```
+```text cogito => sum. ```
 
 Andere Symbole, die vom HTML- und TeX-Export erkannt werden, sind `<=` und
 `>=` (Vergleichsoperatoren), ein Doppelpfeil (`<=>`), einfache Pfeile
@@ -498,12 +497,12 @@ containing the cell contents as some special Maxima comments.
 
 It starts with the following comment:
 
-``` /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
+```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
 Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```
 
 And then the cells follow, encoded as Maxima comments, e.g. a section cell:
 
-```
+```maxima
 /* [wxMaxima: section start ]
 Title of the section
    [wxMaxima: section end   ] */
@@ -512,7 +511,7 @@ Title of the section
 or (in a Math cell the input is of course *not* commented out (the output is
 not saved in a `wxm` file)):
 
-```
+```maxima
 /* [wxMaxima: input   start ] */
 f(x):=x^2+1$
 f(2);
@@ -522,7 +521,7 @@ f(2);
 Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the
 image type as first line):
 
-```
+```maxima
 /* [wxMaxima: image   start ]
 jpg
 [very chaotic looking character sequence]
@@ -531,13 +530,13 @@ jpg
 
 A page break is just one line containing:
 
-```
+```maxima
 /* [wxMaxima: page break    ] */
 ```
 
 And folded cells marked by:
 
-```
+```maxima
 /* [wxMaxima: fold    start ] */
 ...
 /* [wxMaxima: fold    end   ] */
@@ -709,6 +708,43 @@ nicht weiter bearbeitet.
         ?sleep(3)
     )$
 ```
+
+## Exporting the worksheet from within Maxima
+
+The command `wxworksheettohtml()` exports the current worksheet to an HTML
+file from within a running _Maxima_ session, which is convenient for
+scripted or batch export. Like `wxstatusbar()` it is safe to use in code
+that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present
+the command is simply left unevaluated.
+
+```maxima wxworksheettohtml("report.html")$ wxworksheettohtml("report.html",
+flavor="svg", wxmx=true)$ ```
+
+A relative file name is interpreted relative to _Maxima_’s working
+directory. The optional keyword options are:
+
+| option   | values                                          | meaning                                             |
+| -------- | ----------------------------------------------- | --------------------------------------------------- |
+| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |
+| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |
+
+The `flavor` values match the equation formats offered by the graphical
+**File → Export** dialog: `mathml` produces a self-contained page that needs
+no internet connection, `mathjax` adds a MathJaX fall-back for browsers that
+still lack MathML, and `svg`/`bitmap` render every equation to an image.
+
+The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file
+the same way:
+
+```maxima wxworksheettotex("report.tex")$ wxworksheettotex("report.tex",
+documentclass="report", documentclassoptions="12pt,a4paper")$ ```
+
+| option                 | meaning                                                              |
+| ---------------------- | -------------------------------------------------------------------- |
+| `documentclass`        | overrides the LaTeX `\documentclass` (e.g. `"article"`, `"report"`)  |
+| `documentclassoptions` | overrides its options (e.g. `"12pt,a4paper"`)                        |
+
+Support for `wxworksheettopdf()` is planned.
 
 ## Diagramme
 
@@ -1155,14 +1191,21 @@ The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that
 allows for more flexible formatting of matrices in wxMaxima:
 
 **`wx_matrix( <matrix>, [options] )`**
-- **`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data.
-- **`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels.
-- **`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels.
-- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`.
+
+- **`lines=true`**: Draws internal separator lines between the cells. This
+  is required to visually separate headings from data.
+- **`rownames=true`**: Tells wxMaxima that the first column of the matrix
+  contains labels.
+- **`colnames=true`**: Tells wxMaxima that the first row of the matrix
+  contains labels.
+- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw
+  around the matrix. Supported styles are: `round` `()`, `square` `[]`,
+  `angled` `<>`, `straight` `||`, or `none`.
 
 Example:
+
 ```maxima
-wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]), 
+wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]),
           lines=true, rownames=true, colnames=true, parenstyle=square);
 ```
 
@@ -1173,7 +1216,6 @@ _WxMaxima_ bietet einige Funktionen für das Melden von Fehlern an:
 - `wxbuild_info()` sammelt Informationen über die derzeit ausgeführte
   Version von _wxMaxima_
 - `wxbug_report()` sagt, wo und wie Fehler gemeldet werden können
-
 
 ## Rotes Markieren von Formelteilen
 
@@ -1205,7 +1247,7 @@ tips, some example worksheets and in command line Maxima included demos (the
 
 Please notice, that the demos write:
 
-~~~ At the ’_’ prompt, type ’;’ and <enter> to proceed with the
+~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the
 demonstration.  ~~~
 
 That is valid for command-line Maxima, however in wxMaxima by default it is
@@ -1380,7 +1422,7 @@ Wo diese Datei abgelegt werden muss, ist systemabhängig. Aber ein mit SBCL
 compiliertes Maxima kann durch den folgenden Befehl angewiesen werden, den
 Ort zu nennen:
 
-``` :lisp (sb-impl::userinit-pathname)  ```
+```maxima :lisp (sb-impl::userinit-pathname)  ```
 
 ## Anmerkung bezüglich Wayland (aktuelle Linux/BSD Distributionen)
 
@@ -1477,7 +1519,7 @@ Verwenden Sie die Variable `wxplot_size`:
 ### Nach dem Upgrade auf MacOS 13.1 geben Plot- oder Draw Befehle
 Fehlermeldungen aus, wie
 
-``` 1 HIToolbox 0x00007ff80cd91726
+```text 1 HIToolbox 0x00007ff80cd91726
 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox
 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox
 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```

--- a/info/wxmaxima.es.md
+++ b/info/wxmaxima.es.md
@@ -401,7 +401,6 @@ math input does not contain them; (b) if you save the document as
 changes will of course not work in command line Maxima); but they may occur,
 if you cut&paste a formula from another document.
 
-
 ### Paneles Laterales
 
 Enlaces para las instrucciones de _Maxima_ más importantes, cosas como un
@@ -441,7 +440,7 @@ _WxMaxima_ ofrece un conjunto de convenciones de
 con la notación matemática.  Una vez que estos elementos son listados de
 puntos.
 
-```
+```text
 Texto ordinario
  * Un ítem, nivel 1 de sangrado
  * Otro ítem en nivel 1 de sangrado
@@ -454,13 +453,13 @@ Texto ordinario
 _WxMaxima_ reconocerá texto iniciando con los caracteres `>` como
 entrecomillado de bloque:
 
-``` Texto ordinario > comilla comilla comilla > comilla comilla comilla >
-comilla comilla comilla Texto ordinario ```
+```text Texto ordinario > comilla comilla comilla > comilla comilla comilla
+> comilla comilla comilla Texto ordinario ```
 
 Las salidas de TeX y HTML de _wxMaxima_ también reconocerán `=>` y lo
 reemplazarán por el signo correspondiente de Unicode:
 
-``` cogito => sum.  ```
+```text cogito => sum.  ```
 
 Otros símbolos de exportación HTML y TeX reconocerán son `<=` y `>=` para
 comparaciones, una flecha doble doble-apuntada (`<=>`), flechas con cabecera
@@ -538,13 +537,13 @@ especial.
 
 Comienza con el siguiente comentario:
 
-``` /* [archivo de guion wxMaxima versión 1] [ ¡NO LO EDITE A MANO! ]*/ /* [
-Creado con wxMaxima versión 24.02.2_DevelopmentSnapshot ] */ ```
+```maxima /* [archivo de guion wxMaxima versión 1] [ ¡NO LO EDITE A MANO!
+]*/ /* [ Creado con wxMaxima versión 24.02.2_DevelopmentSnapshot ] */ ```
 
 Y entonces las celdas siguientes, codificados como comentarios Maxima,
 p.ej., una celda de sección:
 
-```
+```maxima
 /* [wxMaxima: inicio de sesión ]
 Título de la sección
    [wxMaxima: final de sección   ] */
@@ -553,7 +552,7 @@ Título de la sección
 o (en una celda matemática la entrada es por supuesto *no* comentada afuera
 (la salida no es guardada en un archivo `wxm`)):
 
-```
+```maxima
 /* [wxMaxima: entrada   inicio ] */
 f(x):=x^2+1$
 f(2);
@@ -563,7 +562,7 @@ f(2);
 Imágenes están [codificadas en base64](https://es.wikipedia.org/wiki/Base64)
 con el tipo de imagen como primera línea):
 
-```
+```maxima
 /* [wxMaxima: imagen  inicio ]
 jpg
 [vista de secuencia de caracteres muy caótica]
@@ -572,13 +571,13 @@ jpg
 
 Un salto de página es tan solo una línea conteniendo:
 
-```
+```maxima
 /* [wxMaxima: salto de página    ] */
 ```
 
 Y las celdas encarpetadas marcadas por:
 
-```
+```maxima
 /* [wxMaxima: carpeta    inicio ] */
 ...
 /* [wxMaxima: carpeta    final  ] */
@@ -757,6 +756,43 @@ for i:1 thru 10 do (
     ?sleep(3)
 )$
 ```
+
+## Exporting the worksheet from within Maxima
+
+The command `wxworksheettohtml()` exports the current worksheet to an HTML
+file from within a running _Maxima_ session, which is convenient for
+scripted or batch export. Like `wxstatusbar()` it is safe to use in code
+that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present
+the command is simply left unevaluated.
+
+```maxima wxworksheettohtml("report.html")$ wxworksheettohtml("report.html",
+flavor="svg", wxmx=true)$ ```
+
+A relative file name is interpreted relative to _Maxima_’s working
+directory. The optional keyword options are:
+
+| option   | values                                          | meaning                                             |
+| -------- | ----------------------------------------------- | --------------------------------------------------- |
+| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |
+| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |
+
+The `flavor` values match the equation formats offered by the graphical
+**File → Export** dialog: `mathml` produces a self-contained page that needs
+no internet connection, `mathjax` adds a MathJaX fall-back for browsers that
+still lack MathML, and `svg`/`bitmap` render every equation to an image.
+
+The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file
+the same way:
+
+```maxima wxworksheettotex("report.tex")$ wxworksheettotex("report.tex",
+documentclass="report", documentclassoptions="12pt,a4paper")$ ```
+
+| option                 | meaning                                                              |
+| ---------------------- | -------------------------------------------------------------------- |
+| `documentclass`        | overrides the LaTeX `\documentclass` (e.g. `"article"`, `"report"`)  |
+| `documentclassoptions` | overrides its options (e.g. `"12pt,a4paper"`)                        |
+
+Support for `wxworksheettopdf()` is planned.
 
 ## Tramar
 
@@ -1224,14 +1260,21 @@ The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that
 allows for more flexible formatting of matrices in wxMaxima:
 
 **`wx_matrix( <matrix>, [options] )`**
-- **`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data.
-- **`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels.
-- **`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels.
-- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`.
+
+- **`lines=true`**: Draws internal separator lines between the cells. This
+  is required to visually separate headings from data.
+- **`rownames=true`**: Tells wxMaxima that the first column of the matrix
+  contains labels.
+- **`colnames=true`**: Tells wxMaxima that the first row of the matrix
+  contains labels.
+- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw
+  around the matrix. Supported styles are: `round` `()`, `square` `[]`,
+  `angled` `<>`, `straight` `||`, or `none`.
 
 Example:
+
 ```maxima
-wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]), 
+wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]),
           lines=true, rownames=true, colnames=true, parenstyle=square);
 ```
 
@@ -1243,7 +1286,6 @@ comunicados de fallos acerca del sistema actual:
 - `wxbuild_info()` gathers information about the currently running version
   of _wxMaxima_
 - `wxbug_report()` informa cómo y donde archivar los gazapos
-
 
 ## Marcar que la salida sea dibujada en rojo
 
@@ -1275,7 +1317,7 @@ instrucción de Maxima incluyó demos (la instrucción `demo()`).
 
 Infórmese, que las demos escriben:
 
-~~~ En la solicitud ’_’, teclee ’;’ y <entrar> para proceder con la
+~~~text En la solicitud ’_’, teclee ’;’ y <entrar> para proceder con la
 demostración.  ~~~
 
 Eso es válido para línea de instrucciones de Maxima, sin embargo en wxMaxima
@@ -1465,7 +1507,7 @@ e instalación.  Pero cualquier _Maxima_ basada en SBCL que ya ha evaluado
 una celda dentro de la sesión actual felizmente dirá donde puede ser
 encontrada tras obtener la instrucción siguiente:
 
-``` :lisp (sb-impl::userinit-pathname)  ```
+```maxima :lisp (sb-impl::userinit-pathname)  ```
 
 ## Nota concerniente a Wayland (distribuciones recientes de Linux/BSD)
 
@@ -1563,7 +1605,7 @@ wxdraw2d(
 ### Tras mejorar a MacOS 13.1 los mensajes de error de salida para las
 instrucciones de trama y/o dibujos como
 
-``` 1 HIToolbox 0x00007ff80cd91726
+```text 1 HIToolbox 0x00007ff80cd91726
 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox
 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox
 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```

--- a/info/wxmaxima.fr.md
+++ b/info/wxmaxima.fr.md
@@ -403,7 +403,6 @@ par Maxima en ligne de commande, mais ces substitutions ne fonctionneront
 peuvent apparaître si vous copiez-collez une formule depuis un autre
 document.
 
-
 ### Les panneaux latéraux
 
 Les raccourcis vers les commandes les plus importantes de _Maxima_, comme
@@ -441,7 +440,7 @@ _WxMaxima_ offers a set of standard
 [Markdown](https://en.wikipedia.org/wiki/Markdown) conventions that don’t
 collide with mathematical notation. One of these elements is bullet lists.
 
-```
+```text
 Texte ordinaire
 * Un élément, niveau d'indentation 1
 * Un autre élément au niveau d'indentation 1
@@ -454,14 +453,14 @@ Texte ordinaire
 _WxMaxima_ reconnaîtra le texte commençant par le caractère `>` comme des
 blocs de citations  :
 
-``` Texte ordinaire > citation citation citation citation > citation
+```text Texte ordinaire > citation citation citation citation > citation
 citation citation citation > citation citation citation citation Texte
 ordinaire```
 
 _WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by
 the corresponding Unicode sign:
 
-``` cogito => sum.  ```
+```text cogito => sum.  ```
 
 D’autres symboles reconnus par les exports HTML et TeX sont `<=` et `>=`
 pour les comparaisons, une double flèche à double pointe (`<=>`), des
@@ -542,13 +541,13 @@ commentaires spéciaux Maxima.
 
 Cela commence par le commentaire suivant :
 
-``` /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
+```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
 Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```
 
 Puis les cellules suivent, encodées sous forme de commentaires Maxima, par
 exemple une cellule de section :
 
-```
+```maxima
 /* [wxMaxima: section start ]
 Titre de la section
    [wxMaxima: section end   ] */
@@ -557,7 +556,7 @@ Titre de la section
 ou (dans une cellule Math, l'entrée n'est bien sûr *pas* mise en commentaire
 (la sortie n'est pas enregistrée dans un fichier `wxm`)) :
 
-```
+```maxima
 /* [wxMaxima: input   start ] */
 f(x):=x^2+1$
 f(2);
@@ -567,7 +566,7 @@ f(2);
 Les images sont [encodées en Base64](https://en.wikipedia.org/wiki/Base64)
 avec l'indication du type de l'image sur la première ligne):
 
-```
+```maxima
 /* [wxMaxima: image   start ]
 jpg
 [séquence de caractères très chaotique à première vue]
@@ -576,13 +575,13 @@ jpg
 
 Une saut de page est simplement une ligne contenant :
 
-```
+```maxima
 /* [wxMaxima: saut de page    ] */
 ```
 
 Et les cellules repliées sont marquées par :
 
-```
+```maxima
 /* [wxMaxima: fold    start ] */
 ...
 /* [wxMaxima: fold    end   ] */
@@ -764,6 +763,43 @@ for i:1 thru 10 do (
     ?sleep(3)
 )$
 ```
+
+## Exporting the worksheet from within Maxima
+
+The command `wxworksheettohtml()` exports the current worksheet to an HTML
+file from within a running _Maxima_ session, which is convenient for
+scripted or batch export. Like `wxstatusbar()` it is safe to use in code
+that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present
+the command is simply left unevaluated.
+
+```maxima wxworksheettohtml("report.html")$ wxworksheettohtml("report.html",
+flavor="svg", wxmx=true)$ ```
+
+A relative file name is interpreted relative to _Maxima_’s working
+directory. The optional keyword options are:
+
+| option   | values                                          | meaning                                             |
+| -------- | ----------------------------------------------- | --------------------------------------------------- |
+| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |
+| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |
+
+The `flavor` values match the equation formats offered by the graphical
+**File → Export** dialog: `mathml` produces a self-contained page that needs
+no internet connection, `mathjax` adds a MathJaX fall-back for browsers that
+still lack MathML, and `svg`/`bitmap` render every equation to an image.
+
+The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file
+the same way:
+
+```maxima wxworksheettotex("report.tex")$ wxworksheettotex("report.tex",
+documentclass="report", documentclassoptions="12pt,a4paper")$ ```
+
+| option                 | meaning                                                              |
+| ---------------------- | -------------------------------------------------------------------- |
+| `documentclass`        | overrides the LaTeX `\documentclass` (e.g. `"article"`, `"report"`)  |
+| `documentclassoptions` | overrides its options (e.g. `"12pt,a4paper"`)                        |
+
+Support for `wxworksheettopdf()` is planned.
 
 ## Graphiques
 
@@ -1235,14 +1271,21 @@ The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that
 allows for more flexible formatting of matrices in wxMaxima:
 
 **`wx_matrix( <matrix>, [options] )`**
-- **`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data.
-- **`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels.
-- **`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels.
-- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`.
+
+- **`lines=true`**: Draws internal separator lines between the cells. This
+  is required to visually separate headings from data.
+- **`rownames=true`**: Tells wxMaxima that the first column of the matrix
+  contains labels.
+- **`colnames=true`**: Tells wxMaxima that the first row of the matrix
+  contains labels.
+- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw
+  around the matrix. Supported styles are: `round` `()`, `square` `[]`,
+  `angled` `<>`, `straight` `||`, or `none`.
 
 Example:
+
 ```maxima
-wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]), 
+wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]),
           lines=true, rownames=true, colnames=true, parenstyle=square);
 ```
 
@@ -1254,7 +1297,6 @@ pour signaler un bug concernant le système actuel :
 - - `wxbuild_info()` : Rassemble des informations sur la version en cours
   d'exécution  de _wxMaxima_
 - `wxbug_report()` indique comment et où signaler les bogues
-
 
 ## Ecrire le résultat de la sortie en rouge
 
@@ -1289,7 +1331,7 @@ tips, some example worksheets and in command line Maxima included demos (the
 
 Veuillez noter que les exemples indiquent :
 
-~~~ At the ’_’ prompt, type ’;’ and <enter> to proceed with the
+~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the
 demonstration.  ~~~
 
 Cela est valable pour Maxima en ligne de commande, mais dans wxMaxima, par
@@ -1477,7 +1519,7 @@ l’installation. Cependant, toute version de _Maxima_ basée sur SBCL, ayant
 déjà évalué une cellule durant la session en cours, peut gentiment indiquer
 son emplacement après exécution de la commande suivante :
 
-``` :lisp (sb-impl::userinit-pathname)  ```
+```maxima :lisp (sb-impl::userinit-pathname)  ```
 
 ## Remarque concernant Wayland (distributions Linux/BSD récentes)
 
@@ -1578,7 +1620,7 @@ wxdraw2d(
 ## Après la mise à niveau vers macOS 13.1, les commandes plot et/ou draw
 affichent des messages d'erreur du type
 
-``` 1 HIToolbox 0x00007ff80cd91726
+```text 1 HIToolbox 0x00007ff80cd91726
 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox
 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox
 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```

--- a/info/wxmaxima.it.md
+++ b/info/wxmaxima.it.md
@@ -401,7 +401,6 @@ math input does not contain them; (b) if you save the document as
 changes will of course not work in command line Maxima); but they may occur,
 if you cut&paste a formula from another document.
 
-
 ### Pannelli laterali
 
 È possibile accedere più velocemente ai comandi _Maxima_ più importanti o a
@@ -449,13 +448,13 @@ Testo normale
 _wxMaxima_ riconoscerà il testo che inizia con i caratteri `>` come
 virgolette di blocco:
 
-``` Ordinary text > quote quote quote quote > quote quote quote quote >
+```text Ordinary text > quote quote quote quote > quote quote quote quote >
 quote quote quote quote Ordinary text ```
 
 Anche l'uscita TeX e HTML di _wxMaxima_ riconoscerà `=>` e lo sostituirà con
 il corrispondente simbolo Unicode:
 
-``` cogito => sum.  ```
+```text cogito => sum.  ```
 
 Altri simboli che l'esportazione HTML e TeX riconoscerà sono `<=` e `>=` per
 i confronti, una doppia freccia a doppia punta (`<=>`), frecce a punta
@@ -533,12 +532,12 @@ containing the cell contents as some special Maxima comments.
 
 It starts with the following comment:
 
-``` /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
+```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
 Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```
 
 And then the cells follow, encoded as Maxima comments, e.g. a section cell:
 
-```
+```maxima
 /* [wxMaxima: section start ]
 Title of the section
    [wxMaxima: section end   ] */
@@ -547,7 +546,7 @@ Title of the section
 or (in a Math cell the input is of course *not* commented out (the output is
 not saved in a `wxm` file)):
 
-```
+```maxima
 /* [wxMaxima: input   start ] */
 f(x):=x^2+1$
 f(2);
@@ -557,7 +556,7 @@ f(2);
 Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the
 image type as first line):
 
-```
+```maxima
 /* [wxMaxima: image   start ]
 jpg
 [very chaotic looking character sequence]
@@ -566,13 +565,13 @@ jpg
 
 A page break is just one line containing:
 
-```
+```maxima
 /* [wxMaxima: page break    ] */
 ```
 
 And folded cells marked by:
 
-```
+```maxima
 /* [wxMaxima: fold    start ] */
 ...
 /* [wxMaxima: fold    end   ] */
@@ -749,6 +748,43 @@ for i:1 thru 10 do (
     ?sleep(3)
 )$
 ```
+
+## Exporting the worksheet from within Maxima
+
+The command `wxworksheettohtml()` exports the current worksheet to an HTML
+file from within a running _Maxima_ session, which is convenient for
+scripted or batch export. Like `wxstatusbar()` it is safe to use in code
+that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present
+the command is simply left unevaluated.
+
+```maxima wxworksheettohtml("report.html")$ wxworksheettohtml("report.html",
+flavor="svg", wxmx=true)$ ```
+
+A relative file name is interpreted relative to _Maxima_’s working
+directory. The optional keyword options are:
+
+| option   | values                                          | meaning                                             |
+| -------- | ----------------------------------------------- | --------------------------------------------------- |
+| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |
+| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |
+
+The `flavor` values match the equation formats offered by the graphical
+**File → Export** dialog: `mathml` produces a self-contained page that needs
+no internet connection, `mathjax` adds a MathJaX fall-back for browsers that
+still lack MathML, and `svg`/`bitmap` render every equation to an image.
+
+The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file
+the same way:
+
+```maxima wxworksheettotex("report.tex")$ wxworksheettotex("report.tex",
+documentclass="report", documentclassoptions="12pt,a4paper")$ ```
+
+| option                 | meaning                                                              |
+| ---------------------- | -------------------------------------------------------------------- |
+| `documentclass`        | overrides the LaTeX `\documentclass` (e.g. `"article"`, `"report"`)  |
+| `documentclassoptions` | overrides its options (e.g. `"12pt,a4paper"`)                        |
+
+Support for `wxworksheettopdf()` is planned.
 
 ## Diagrammi
 
@@ -1202,14 +1238,21 @@ The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that
 allows for more flexible formatting of matrices in wxMaxima:
 
 **`wx_matrix( <matrix>, [options] )`**
-- **`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data.
-- **`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels.
-- **`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels.
-- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`.
+
+- **`lines=true`**: Draws internal separator lines between the cells. This
+  is required to visually separate headings from data.
+- **`rownames=true`**: Tells wxMaxima that the first column of the matrix
+  contains labels.
+- **`colnames=true`**: Tells wxMaxima that the first row of the matrix
+  contains labels.
+- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw
+  around the matrix. Supported styles are: `round` `()`, `square` `[]`,
+  `angled` `<>`, `straight` `||`, or `none`.
 
 Example:
+
 ```maxima
-wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]), 
+wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]),
           lines=true, rownames=true, colnames=true, parenstyle=square);
 ```
 
@@ -1221,7 +1264,6 @@ about the current system:
 - `wxbuild_info()` gathers information about the currently running version
   of _wxMaxima_
 - `wxbug_report()` tells how and where to file bugs
-
 
 ## Marking output being drawn in red
 
@@ -1253,7 +1295,7 @@ tips, some example worksheets and in command line Maxima included demos (the
 
 Please notice, that the demos write:
 
-~~~ At the ’_’ prompt, type ’;’ and <enter> to proceed with the
+~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the
 demonstration.  ~~~
 
 That is valid for command-line Maxima, however in wxMaxima by default it is
@@ -1432,7 +1474,7 @@ installation-specific. But any SBCL-based _Maxima_ that already has
 evaluated a cell in the current session will happily tell where it can be
 found after getting the following command:
 
-``` :lisp (sb-impl::userinit-pathname)  ```
+```maxima :lisp (sb-impl::userinit-pathname)  ```
 
 ## Note concerning Wayland (recent Linux/BSD distributions)
 
@@ -1527,7 +1569,7 @@ wxdraw2d(
 ## After upgrading to MacOS 13.1 plot and/or draw commands output error
 messages like
 
-``` 1 HIToolbox 0x00007ff80cd91726
+```text 1 HIToolbox 0x00007ff80cd91726
 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox
 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox
 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```

--- a/info/wxmaxima.ru.md
+++ b/info/wxmaxima.ru.md
@@ -390,7 +390,6 @@ wxMaxima заменит их соответствующими представл
 будут работать в командной строке Maxima); но они могут появиться при
 вырезании и вставке формулы из другого документа.
 
-
 ### Боковые панели
 
 Наиболее важные команды _Maxima_, а также содержание, окна с отладочными
@@ -425,7 +424,7 @@ _WxMaxima_ поддерживает стандартные элементы фо
 математической записью. Одним из таких элементов являются маркированные
 списки.
 
-```
+```text
 Обычный текст
  * Один элемент, уровень отступа 1
  * Другой элемент с уровнем отступа 1
@@ -437,13 +436,13 @@ _WxMaxima_ поддерживает стандартные элементы фо
 
 _WxMaxima_ считает цитатой текст, начинающийся символом `>`:
 
-``` Обычный текст > цитата цитата цитата цитата > цитата цитата цитата
+```text Обычный текст > цитата цитата цитата цитата > цитата цитата цитата
 цитата > цитата цитата цитата цитата Обычный текст ```
 
 Вывод _wxMaxima_ в формате TeX и HTML также распознаёт `=>` и заменяет его
 на соответствующий символ Юникода:
 
-``` cogito => sum.  ```
+```text cogito => sum.  ```
 
 Другие символы, которые распознаются при экспорте в HTML и TeX: `<=` и `>=`
 для сравнений, двойная двухсторонняя стрелка (`<=>`), односторонние стрелки
@@ -518,13 +517,13 @@ _wxMaxima_.
 
 Файл начинается со следующего комментария:
 
-``` /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
+```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
 Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```
 
 Затем следуют поля, записанные в виде комментариев Maxima. Например, поле
 раздела:
 
-```
+```maxima
 /* [wxMaxima: section start ]
 Заголовок раздела
    [wxMaxima: section end   ] */
@@ -533,7 +532,7 @@ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```
 или (разумеется, в математическом поле ввод будет *не* закомментирован
 (вывод не сохраняется в файле `wxm`)):
 
-```
+```maxima
 /* [wxMaxima: input   start ] */
 f(x):=x^2+1$
 f(2);
@@ -543,7 +542,7 @@ f(2);
 Изображения [закодированы в Base64](https://en.wikipedia.org/wiki/Base64). В
 первой строке находится тип изображения:
 
-```
+```maxima
 /* [wxMaxima: image   start ]
 jpg
 [кажущаяся беспорядочной последовательность символов]
@@ -552,13 +551,13 @@ jpg
 
 Разрыв страницы представляет собой одну строку следующего содержания:
 
-```
+```maxima
 /* [wxMaxima: page break    ] */
 ```
 
 Свёрнутые поля обозначаются так:
 
-```
+```maxima
 /* [wxMaxima: fold    start ] */
 ...
 /* [wxMaxima: fold    end   ] */
@@ -738,6 +737,43 @@ for i:1 thru 10 do (
     ?sleep(3)
 )$
 ```
+
+## Exporting the worksheet from within Maxima
+
+The command `wxworksheettohtml()` exports the current worksheet to an HTML
+file from within a running _Maxima_ session, which is convenient for
+scripted or batch export. Like `wxstatusbar()` it is safe to use in code
+that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present
+the command is simply left unevaluated.
+
+```maxima wxworksheettohtml("report.html")$ wxworksheettohtml("report.html",
+flavor="svg", wxmx=true)$ ```
+
+A relative file name is interpreted relative to _Maxima_’s working
+directory. The optional keyword options are:
+
+| option   | values                                          | meaning                                             |
+| -------- | ----------------------------------------------- | --------------------------------------------------- |
+| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |
+| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |
+
+The `flavor` values match the equation formats offered by the graphical
+**File → Export** dialog: `mathml` produces a self-contained page that needs
+no internet connection, `mathjax` adds a MathJaX fall-back for browsers that
+still lack MathML, and `svg`/`bitmap` render every equation to an image.
+
+The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file
+the same way:
+
+```maxima wxworksheettotex("report.tex")$ wxworksheettotex("report.tex",
+documentclass="report", documentclassoptions="12pt,a4paper")$ ```
+
+| option                 | meaning                                                              |
+| ---------------------- | -------------------------------------------------------------------- |
+| `documentclass`        | overrides the LaTeX `\documentclass` (e.g. `"article"`, `"report"`)  |
+| `documentclassoptions` | overrides its options (e.g. `"12pt,a4paper"`)                        |
+
+Support for `wxworksheettopdf()` is planned.
 
 ## Построение графиков
 
@@ -1205,14 +1241,21 @@ The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that
 allows for more flexible formatting of matrices in wxMaxima:
 
 **`wx_matrix( <matrix>, [options] )`**
-- **`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data.
-- **`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels.
-- **`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels.
-- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`.
+
+- **`lines=true`**: Draws internal separator lines between the cells. This
+  is required to visually separate headings from data.
+- **`rownames=true`**: Tells wxMaxima that the first column of the matrix
+  contains labels.
+- **`colnames=true`**: Tells wxMaxima that the first row of the matrix
+  contains labels.
+- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw
+  around the matrix. Supported styles are: `round` `()`, `square` `[]`,
+  `angled` `<>`, `straight` `||`, or `none`.
 
 Example:
+
 ```maxima
-wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]), 
+wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]),
           lines=true, rownames=true, colnames=true, parenstyle=square);
 ```
 
@@ -1224,7 +1267,6 @@ _WxMaxima_ предоставляет несколько функций, кот�
 - `wxbuild_info()` собирает информацию о версии запущенной программы
   _wxMaxima_.
 - `wxbug_report()` определяет, как и куда отправлять отчёты об ошибках.
-
 
 ## Выделение вывода красным цветом
 
@@ -1259,8 +1301,8 @@ Maxima.
 
 Обратите внимание на вывод демонстрационных примеров:
 
-~~~ При появлении приглашения в виде ’_’ введите ’;’ и нажмите <enter> для
-продолжения демонстрации.  ~~~
+~~~text При появлении приглашения в виде ’_’ введите ’;’ и нажмите <enter>
+для продолжения демонстрации.  ~~~
 
 Это работает в командной строке Maxima, но в wxMaxima для продолжения
 демонстрации необходимо использовать сочетание клавиш
@@ -1445,7 +1487,7 @@ evaluation” может помочь повторно синхронизиро�
 сеансе уже производилось вычисление поля, всегда укажет его местонахождение
 после получения следующей команды:
 
-``` :lisp (sb-impl::userinit-pathname)  ```
+```maxima :lisp (sb-impl::userinit-pathname)  ```
 
 ## Примечание касательно Wayland (свежие дистрибутивы Linux/BSD)
 
@@ -1544,7 +1586,7 @@ wxdraw2d(
 ## После обновления до MacOS 13.1 команды plot и/или draw возвращают
 сообщения об ошибках, например:
 
-``` 1 HIToolbox 0x00007ff80cd91726
+```text 1 HIToolbox 0x00007ff80cd91726
 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox
 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox
 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```

--- a/info/wxmaxima.tr.md
+++ b/info/wxmaxima.tr.md
@@ -383,7 +383,6 @@ math input does not contain them; (b) if you save the document as
 changes will of course not work in command line Maxima); but they may occur,
 if you cut&paste a formula from another document.
 
-
 ### Side Panes
 
 Shortcuts to the most important _Maxima_ commands, things like a table of
@@ -418,7 +417,7 @@ _WxMaxima_ offers a set of standard
 [Markdown](https://en.wikipedia.org/wiki/Markdown) conventions that don’t
 collide with mathematical notation. One of these elements is bullet lists.
 
-```
+```text
 Ordinary text
  * One item, indentation level 1
  * Another item at indentation level 1
@@ -430,13 +429,13 @@ Ordinary text
 
 _WxMaxima_ will recognize text starting with `>` chars as block quotes:
 
-``` Ordinary text > quote quote quote quote > quote quote quote quote >
+```text Ordinary text > quote quote quote quote > quote quote quote quote >
 quote quote quote quote Ordinary text ```
 
 _WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by
 the corresponding Unicode sign:
 
-``` cogito => sum.  ```
+```text cogito => sum.  ```
 
 Other symbols the HTML and TeX export will recognize are `<=` and `>=` for
 comparisons, a double-pointed double arrow (`<=>`), single-headed arrows
@@ -512,12 +511,12 @@ containing the cell contents as some special Maxima comments.
 
 It starts with the following comment:
 
-``` /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
+```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
 Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```
 
 And then the cells follow, encoded as Maxima comments, e.g. a section cell:
 
-```
+```maxima
 /* [wxMaxima: section start ]
 Title of the section
    [wxMaxima: section end   ] */
@@ -526,7 +525,7 @@ Title of the section
 or (in a Math cell the input is of course *not* commented out (the output is
 not saved in a `wxm` file)):
 
-```
+```maxima
 /* [wxMaxima: input   start ] */
 f(x):=x^2+1$
 f(2);
@@ -536,7 +535,7 @@ f(2);
 Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the
 image type as first line):
 
-```
+```maxima
 /* [wxMaxima: image   start ]
 jpg
 [very chaotic looking character sequence]
@@ -545,13 +544,13 @@ jpg
 
 A page break is just one line containing:
 
-```
+```maxima
 /* [wxMaxima: page break    ] */
 ```
 
 And folded cells marked by:
 
-```
+```maxima
 /* [wxMaxima: fold    start ] */
 ...
 /* [wxMaxima: fold    end   ] */
@@ -722,6 +721,43 @@ for i:1 thru 10 do (
     ?sleep(3)
 )$
 ```
+
+## Exporting the worksheet from within Maxima
+
+The command `wxworksheettohtml()` exports the current worksheet to an HTML
+file from within a running _Maxima_ session, which is convenient for
+scripted or batch export. Like `wxstatusbar()` it is safe to use in code
+that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present
+the command is simply left unevaluated.
+
+```maxima wxworksheettohtml("report.html")$ wxworksheettohtml("report.html",
+flavor="svg", wxmx=true)$ ```
+
+A relative file name is interpreted relative to _Maxima_’s working
+directory. The optional keyword options are:
+
+| option   | values                                          | meaning                                             |
+| -------- | ----------------------------------------------- | --------------------------------------------------- |
+| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |
+| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |
+
+The `flavor` values match the equation formats offered by the graphical
+**File → Export** dialog: `mathml` produces a self-contained page that needs
+no internet connection, `mathjax` adds a MathJaX fall-back for browsers that
+still lack MathML, and `svg`/`bitmap` render every equation to an image.
+
+The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file
+the same way:
+
+```maxima wxworksheettotex("report.tex")$ wxworksheettotex("report.tex",
+documentclass="report", documentclassoptions="12pt,a4paper")$ ```
+
+| option                 | meaning                                                              |
+| ---------------------- | -------------------------------------------------------------------- |
+| `documentclass`        | overrides the LaTeX `\documentclass` (e.g. `"article"`, `"report"`)  |
+| `documentclassoptions` | overrides its options (e.g. `"12pt,a4paper"`)                        |
+
+Support for `wxworksheettopdf()` is planned.
 
 ## Plotting
 
@@ -1174,14 +1210,21 @@ The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that
 allows for more flexible formatting of matrices in wxMaxima:
 
 **`wx_matrix( <matrix>, [options] )`**
-- **`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data.
-- **`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels.
-- **`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels.
-- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`.
+
+- **`lines=true`**: Draws internal separator lines between the cells. This
+  is required to visually separate headings from data.
+- **`rownames=true`**: Tells wxMaxima that the first column of the matrix
+  contains labels.
+- **`colnames=true`**: Tells wxMaxima that the first row of the matrix
+  contains labels.
+- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw
+  around the matrix. Supported styles are: `round` `()`, `square` `[]`,
+  `angled` `<>`, `straight` `||`, or `none`.
 
 Example:
+
 ```maxima
-wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]), 
+wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]),
           lines=true, rownames=true, colnames=true, parenstyle=square);
 ```
 
@@ -1193,7 +1236,6 @@ about the current system:
 - `wxbuild_info()` gathers information about the currently running version
   of _wxMaxima_
 - `wxbug_report ()`, hataların nasıl ve nerede dosyalanacağını söyler
-
 
 ## Marking output being drawn in red
 
@@ -1225,7 +1267,7 @@ tips, some example worksheets and in command line Maxima included demos (the
 
 Please notice, that the demos write:
 
-~~~ At the ’_’ prompt, type ’;’ and <enter> to proceed with the
+~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the
 demonstration.  ~~~
 
 That is valid for command-line Maxima, however in wxMaxima by default it is
@@ -1407,7 +1449,7 @@ installation-specific. But any SBCL-based _Maxima_ that already has
 evaluated a cell in the current session will happily tell where it can be
 found after getting the following command:
 
-``` :lisp (sb-impl::userinit-pathname)  ```
+```maxima :lisp (sb-impl::userinit-pathname)  ```
 
 ## Note concerning Wayland (recent Linux/BSD distributions)
 
@@ -1502,7 +1544,7 @@ wxdraw2d(
 ## After upgrading to MacOS 13.1 plot and/or draw commands output error
 messages like
 
-``` 1 HIToolbox 0x00007ff80cd91726
+```text 1 HIToolbox 0x00007ff80cd91726
 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox
 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox
 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```

--- a/info/wxmaxima.uk.md
+++ b/info/wxmaxima.uk.md
@@ -386,7 +386,6 @@ math input does not contain them; (b) if you save the document as
 changes will of course not work in command line Maxima); but they may occur,
 if you cut&paste a formula from another document.
 
-
 ### Side Panes
 
 Доступ до найважливіших команд _Maxima_ або речей, подібних до таблиці
@@ -421,7 +420,7 @@ _WxMaxima_ offers a set of standard
 [Markdown](https://en.wikipedia.org/wiki/Markdown) conventions that don’t
 collide with mathematical notation. One of these elements is bullet lists.
 
-```
+```text
 Ordinary text
  * One item, indentation level 1
  * Another item at indentation level 1
@@ -433,13 +432,13 @@ Ordinary text
 
 _WxMaxima_ will recognize text starting with `>` chars as block quotes:
 
-``` Ordinary text > quote quote quote quote > quote quote quote quote >
+```text Ordinary text > quote quote quote quote > quote quote quote quote >
 quote quote quote quote Ordinary text ```
 
 _WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by
 the corresponding Unicode sign:
 
-``` cogito => sum.  ```
+```text cogito => sum.  ```
 
 Other symbols the HTML and TeX export will recognize are `<=` and `>=` for
 comparisons, a double-pointed double arrow (`<=>`), single-headed arrows
@@ -515,12 +514,12 @@ containing the cell contents as some special Maxima comments.
 
 It starts with the following comment:
 
-``` /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
+```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
 Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```
 
 And then the cells follow, encoded as Maxima comments, e.g. a section cell:
 
-```
+```maxima
 /* [wxMaxima: section start ]
 Title of the section
    [wxMaxima: section end   ] */
@@ -529,7 +528,7 @@ Title of the section
 or (in a Math cell the input is of course *not* commented out (the output is
 not saved in a `wxm` file)):
 
-```
+```maxima
 /* [wxMaxima: input   start ] */
 f(x):=x^2+1$
 f(2);
@@ -539,7 +538,7 @@ f(2);
 Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the
 image type as first line):
 
-```
+```maxima
 /* [wxMaxima: image   start ]
 jpg
 [very chaotic looking character sequence]
@@ -548,13 +547,13 @@ jpg
 
 A page break is just one line containing:
 
-```
+```maxima
 /* [wxMaxima: page break    ] */
 ```
 
 And folded cells marked by:
 
-```
+```maxima
 /* [wxMaxima: fold    start ] */
 ...
 /* [wxMaxima: fold    end   ] */
@@ -729,6 +728,43 @@ for i:1 thru 10 do (
     ?sleep(3)
 )$
 ```
+
+## Exporting the worksheet from within Maxima
+
+The command `wxworksheettohtml()` exports the current worksheet to an HTML
+file from within a running _Maxima_ session, which is convenient for
+scripted or batch export. Like `wxstatusbar()` it is safe to use in code
+that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present
+the command is simply left unevaluated.
+
+```maxima wxworksheettohtml("report.html")$ wxworksheettohtml("report.html",
+flavor="svg", wxmx=true)$ ```
+
+A relative file name is interpreted relative to _Maxima_’s working
+directory. The optional keyword options are:
+
+| option   | values                                          | meaning                                             |
+| -------- | ----------------------------------------------- | --------------------------------------------------- |
+| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |
+| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |
+
+The `flavor` values match the equation formats offered by the graphical
+**File → Export** dialog: `mathml` produces a self-contained page that needs
+no internet connection, `mathjax` adds a MathJaX fall-back for browsers that
+still lack MathML, and `svg`/`bitmap` render every equation to an image.
+
+The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file
+the same way:
+
+```maxima wxworksheettotex("report.tex")$ wxworksheettotex("report.tex",
+documentclass="report", documentclassoptions="12pt,a4paper")$ ```
+
+| option                 | meaning                                                              |
+| ---------------------- | -------------------------------------------------------------------- |
+| `documentclass`        | overrides the LaTeX `\documentclass` (e.g. `"article"`, `"report"`)  |
+| `documentclassoptions` | overrides its options (e.g. `"12pt,a4paper"`)                        |
+
+Support for `wxworksheettopdf()` is planned.
 
 ## Plotting
 
@@ -1184,14 +1220,21 @@ The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that
 allows for more flexible formatting of matrices in wxMaxima:
 
 **`wx_matrix( <matrix>, [options] )`**
-- **`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data.
-- **`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels.
-- **`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels.
-- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`.
+
+- **`lines=true`**: Draws internal separator lines between the cells. This
+  is required to visually separate headings from data.
+- **`rownames=true`**: Tells wxMaxima that the first column of the matrix
+  contains labels.
+- **`colnames=true`**: Tells wxMaxima that the first row of the matrix
+  contains labels.
+- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw
+  around the matrix. Supported styles are: `round` `()`, `square` `[]`,
+  `angled` `<>`, `straight` `||`, or `none`.
 
 Example:
+
 ```maxima
-wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]), 
+wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]),
           lines=true, rownames=true, colnames=true, parenstyle=square);
 ```
 
@@ -1204,7 +1247,6 @@ wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]),
   of _wxMaxima_
 - `wxbug_report()` надає відомості щодо того, як і де слід повідомляти про
   вади
-
 
 ## Marking output being drawn in red
 
@@ -1236,7 +1278,7 @@ tips, some example worksheets and in command line Maxima included demos (the
 
 Please notice, that the demos write:
 
-~~~ At the ’_’ prompt, type ’;’ and <enter> to proceed with the
+~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the
 demonstration.  ~~~
 
 That is valid for command-line Maxima, however in wxMaxima by default it is
@@ -1418,7 +1460,7 @@ dialogue.
 обчислення у якійсь комірці протягом поточного сеансу, без проблем
 повідомить, де його можна знайти, у відповідь на таку команду:
 
-``` :lisp (sb-impl::userinit-pathname)  ```
+```maxima :lisp (sb-impl::userinit-pathname)  ```
 
 ## Note concerning Wayland (recent Linux/BSD distributions)
 
@@ -1513,7 +1555,7 @@ wxdraw2d(
 ## After upgrading to MacOS 13.1 plot and/or draw commands output error
 messages like
 
-``` 1 HIToolbox 0x00007ff80cd91726
+```text 1 HIToolbox 0x00007ff80cd91726
 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox
 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox
 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```

--- a/info/wxmaxima.zh_CN.md
+++ b/info/wxmaxima.zh_CN.md
@@ -358,7 +358,6 @@ math input does not contain them; (b) if you save the document as
 changes will of course not work in command line Maxima); but they may occur,
 if you cut&paste a formula from another document.
 
-
 ### Side Panes
 
 Shortcuts to the most important _Maxima_ commands, things like a table of
@@ -393,7 +392,7 @@ _WxMaxima_ offers a set of standard
 [Markdown](https://en.wikipedia.org/wiki/Markdown) conventions that don’t
 collide with mathematical notation. One of these elements is bullet lists.
 
-```
+```text
 Ordinary text
  * One item, indentation level 1
  * Another item at indentation level 1
@@ -405,13 +404,13 @@ Ordinary text
 
 _WxMaxima_ will recognize text starting with `>` chars as block quotes:
 
-``` Ordinary text > quote quote quote quote > quote quote quote quote >
+```text Ordinary text > quote quote quote quote > quote quote quote quote >
 quote quote quote quote Ordinary text ```
 
 _WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by
 the corresponding Unicode sign:
 
-``` cogito => sum.  ```
+```text cogito => sum.  ```
 
 Other symbols the HTML and TeX export will recognize are `<=` and `>=` for
 comparisons, a double-pointed double arrow (`<=>`), single-headed arrows
@@ -480,12 +479,12 @@ containing the cell contents as some special Maxima comments.
 
 It starts with the following comment:
 
-``` /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
+```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
 Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```
 
 And then the cells follow, encoded as Maxima comments, e.g. a section cell:
 
-```
+```maxima
 /* [wxMaxima: section start ]
 Title of the section
    [wxMaxima: section end   ] */
@@ -494,7 +493,7 @@ Title of the section
 or (in a Math cell the input is of course *not* commented out (the output is
 not saved in a `wxm` file)):
 
-```
+```maxima
 /* [wxMaxima: input   start ] */
 f(x):=x^2+1$
 f(2);
@@ -504,7 +503,7 @@ f(2);
 Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the
 image type as first line):
 
-```
+```maxima
 /* [wxMaxima: image   start ]
 jpg
 [very chaotic looking character sequence]
@@ -513,13 +512,13 @@ jpg
 
 A page break is just one line containing:
 
-```
+```maxima
 /* [wxMaxima: page break    ] */
 ```
 
 And folded cells marked by:
 
-```
+```maxima
 /* [wxMaxima: fold    start ] */
 ...
 /* [wxMaxima: fold    end   ] */
@@ -683,6 +682,43 @@ for i:1 thru 10 do (
     ?sleep(3)
 )$
 ```
+
+## Exporting the worksheet from within Maxima
+
+The command `wxworksheettohtml()` exports the current worksheet to an HTML
+file from within a running _Maxima_ session, which is convenient for
+scripted or batch export. Like `wxstatusbar()` it is safe to use in code
+that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present
+the command is simply left unevaluated.
+
+```maxima wxworksheettohtml("report.html")$ wxworksheettohtml("report.html",
+flavor="svg", wxmx=true)$ ```
+
+A relative file name is interpreted relative to _Maxima_’s working
+directory. The optional keyword options are:
+
+| option   | values                                          | meaning                                             |
+| -------- | ----------------------------------------------- | --------------------------------------------------- |
+| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |
+| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |
+
+The `flavor` values match the equation formats offered by the graphical
+**File → Export** dialog: `mathml` produces a self-contained page that needs
+no internet connection, `mathjax` adds a MathJaX fall-back for browsers that
+still lack MathML, and `svg`/`bitmap` render every equation to an image.
+
+The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file
+the same way:
+
+```maxima wxworksheettotex("report.tex")$ wxworksheettotex("report.tex",
+documentclass="report", documentclassoptions="12pt,a4paper")$ ```
+
+| option                 | meaning                                                              |
+| ---------------------- | -------------------------------------------------------------------- |
+| `documentclass`        | overrides the LaTeX `\documentclass` (e.g. `"article"`, `"report"`)  |
+| `documentclassoptions` | overrides its options (e.g. `"12pt,a4paper"`)                        |
+
+Support for `wxworksheettopdf()` is planned.
 
 ## Plotting
 
@@ -1105,14 +1141,21 @@ The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that
 allows for more flexible formatting of matrices in wxMaxima:
 
 **`wx_matrix( <matrix>, [options] )`**
-- **`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data.
-- **`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels.
-- **`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels.
-- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`.
+
+- **`lines=true`**: Draws internal separator lines between the cells. This
+  is required to visually separate headings from data.
+- **`rownames=true`**: Tells wxMaxima that the first column of the matrix
+  contains labels.
+- **`colnames=true`**: Tells wxMaxima that the first row of the matrix
+  contains labels.
+- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw
+  around the matrix. Supported styles are: `round` `()`, `square` `[]`,
+  `angled` `<>`, `straight` `||`, or `none`.
 
 Example:
+
 ```maxima
-wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]), 
+wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]),
           lines=true, rownames=true, colnames=true, parenstyle=square);
 ```
 
@@ -1124,7 +1167,6 @@ about the current system:
 - `wxbuild_info()` gathers information about the currently running version
   of _wxMaxima_
 - `wxbug_report()` 说明如何以及在何处提交错误报告。
-
 
 ## Marking output being drawn in red
 
@@ -1156,7 +1198,7 @@ tips, some example worksheets and in command line Maxima included demos (the
 
 Please notice, that the demos write:
 
-~~~ At the ’_’ prompt, type ’;’ and <enter> to proceed with the
+~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the
 demonstration.  ~~~
 
 That is valid for command-line Maxima, however in wxMaxima by default it is
@@ -1328,7 +1370,7 @@ installation-specific. But any SBCL-based _Maxima_ that already has
 evaluated a cell in the current session will happily tell where it can be
 found after getting the following command:
 
-``` :lisp (sb-impl::userinit-pathname)  ```
+```maxima :lisp (sb-impl::userinit-pathname)  ```
 
 ## Note concerning Wayland (recent Linux/BSD distributions)
 
@@ -1423,7 +1465,7 @@ wxdraw2d(
 ## After upgrading to MacOS 13.1 plot and/or draw commands output error
 messages like
 
-``` 1 HIToolbox 0x00007ff80cd91726
+```text 1 HIToolbox 0x00007ff80cd91726
 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox
 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox
 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```

--- a/locales/manual/de.po
+++ b/locales/manual/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-20 10:30+0200\n"
+"POT-Creation-Date: 2026-07-30 11:38+0200\n"
 "PO-Revision-Date: 2020-05-08 07:53+0200\n"
 "Last-Translator: Gunter Königsmann <wxMaxima@physikbuch.de>\n"
 "Language-Team: german <de@li.org>\n"
@@ -41,9 +41,9 @@ msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 msgstr "![wxMaxima Logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:426
-#: ../../info/wxmaxima.md:848 ../../info/wxmaxima.md:1043
-#: ../../info/wxmaxima.md:1090 ../../info/wxmaxima.md:1114
+#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:425
+#: ../../info/wxmaxima.md:880 ../../info/wxmaxima.md:1090
+#: ../../info/wxmaxima.md:1137 ../../info/wxmaxima.md:1161
 #, no-wrap
 msgid "______________________________________________________________________\n"
 msgstr ""
@@ -928,12 +928,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:224
+#: ../../info/wxmaxima.md:223
 msgid "### Side Panes"
 msgstr "### Seitenleisten"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:226
+#: ../../info/wxmaxima.md:225
 msgid ""
 "Shortcuts to the most important _Maxima_ commands, things like a table of "
 "contents, windows with debug messages or a history of the last issued "
@@ -950,14 +950,14 @@ msgstr ""
 "alternative Methode anbietet, griechische Buchstaben einzugeben."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:228
+#: ../../info/wxmaxima.md:227
 msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
 msgstr ""
 "![Beispiele verschiedener Seitenbereiche](./SidePanes.png)"
 "{ id=img_SidePanes }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:231
+#: ../../info/wxmaxima.md:230
 msgid ""
 "In the \"table of contents\" side pane, one can increase or decrease a "
 "heading by just clicking on the heading with the right mouse button and "
@@ -965,19 +965,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:233
+#: ../../info/wxmaxima.md:232
 msgid ""
 "![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-"
 "headings.png){ id=Sidepane-TOC-convert-headings }"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:235
+#: ../../info/wxmaxima.md:234
 msgid "### MathML output"
 msgstr "### MathML-Ausgabe"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:237
+#: ../../info/wxmaxima.md:236
 msgid ""
 "Several word processors and similar programs either recognize [MathML]"
 "(https://www.w3.org/Math/) input and automatically insert it as an editable "
@@ -992,12 +992,12 @@ msgstr ""
 "Optionen im Rechtsklick-Menü an. "
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:239
+#: ../../info/wxmaxima.md:238
 msgid "### Markdown support"
 msgstr "### Markdown Unterstützung"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:241
+#: ../../info/wxmaxima.md:240
 msgid ""
 "_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/wiki/"
 "Markdown) conventions that don’t collide with mathematical notation. One of "
@@ -1008,7 +1008,7 @@ msgstr ""
 "mathematischen Formeln vorkommen. Eines dieser Elemente sind Aufzählungen:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:251
+#: ../../info/wxmaxima.md:250
 #, no-wrap
 msgid ""
 "```text\n"
@@ -1032,12 +1032,12 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:253
+#: ../../info/wxmaxima.md:252
 msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
 msgstr "_WxMaxima_ erkennt Text, der mit einem `>` beginnt, als ein Zitat:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:261
+#: ../../info/wxmaxima.md:260
 #, fuzzy
 #| msgid ""
 #| "Ordinary text\n"
@@ -1057,7 +1057,7 @@ msgstr ""
 "Normaler Text\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:263
+#: ../../info/wxmaxima.md:262
 msgid ""
 "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by "
 "the corresponding Unicode sign:"
@@ -1066,12 +1066,12 @@ msgstr ""
 "durch das entsprechende Unicode-Symbol:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:267
+#: ../../info/wxmaxima.md:266
 msgid "```text cogito => sum.  ```"
 msgstr "```text cogito => sum. ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:269
+#: ../../info/wxmaxima.md:268
 msgid ""
 "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for "
 "comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<-"
@@ -1084,12 +1084,12 @@ msgstr ""
 "`>>`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:271
+#: ../../info/wxmaxima.md:270
 msgid "### Hotkeys"
 msgstr "### Tastenkürzel"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:273
+#: ../../info/wxmaxima.md:272
 msgid ""
 "Most hotkeys can be found in the text of the respective menus. Since they "
 "are actually taken from the menu text and thus can be customized by the "
@@ -1102,7 +1102,7 @@ msgstr ""
 "dies erforderlich macht. Nicht dort dokumentiert ist:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 msgid ""
 "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
 msgstr ""
@@ -1110,7 +1110,7 @@ msgstr ""
 "Zelle."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 msgid ""
 "<kbd>CTRL</kbd>+<kbd>TAB</kbd> or <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</"
 "kbd> triggers the auto-completion mechanism."
@@ -1119,19 +1119,19 @@ msgstr ""
 "kbd>+<kbd>TAB</kbd> aktiviert die Auto-Vervollständigung."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
 msgstr ""
 "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> fügt ein nicht-umbrechbares Leerzeichen "
 "ein."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:279
+#: ../../info/wxmaxima.md:278
 msgid "### Raw TeX in the TeX export"
 msgstr "### Direkte Eingabe von TeX-Befehlen im TeX-Export"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:281
+#: ../../info/wxmaxima.md:280
 msgid ""
 "If a text cell begins with `TeX:` the TeX export contains the literal text "
 "that follows the `TeX:` marker. Using this feature allows the entry of TeX "
@@ -1141,24 +1141,24 @@ msgstr ""
 "der Konvertierung des Dokuments nach TeX unverändert ausgegeben."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:283
+#: ../../info/wxmaxima.md:282
 msgid "## File Formats"
 msgstr "## Dateiformate"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:285
+#: ../../info/wxmaxima.md:284
 msgid ""
 "The material that is developed in a _wxMaxima_ session can be stored for "
 "later use in any of three ways:"
 msgstr "Das Arbeitsblatt kann auf verschiedene Weisen gespeichert werden:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:287
+#: ../../info/wxmaxima.md:286
 msgid "### .mac"
 msgstr "### .mac"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:289
+#: ../../info/wxmaxima.md:288
 msgid ""
 "`.mac` files are ordinary text files that contain _Maxima_ commands. They "
 "can be read using _Maxima_’s `batch()` or `load()` command or _wxMaxima_’s "
@@ -1169,7 +1169,7 @@ msgstr ""
 "File laden\" gelesen werden."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:292
+#: ../../info/wxmaxima.md:291
 msgid ""
 "One example is shown below. `Quadratic.mac` defines a function and afterward "
 "generates a plot with `wxdraw2d()`.  Afterward the contents of the file "
@@ -1177,13 +1177,13 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:294
+#: ../../info/wxmaxima.md:293
 msgid "![Loading a file with `batch()`](./BatchImage.png){ id=img_BatchImage }"
 msgstr ""
 "![Laden einer Datei mit `batch()`](./BatchImage.png){ id=img_BatchImage }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:296
+#: ../../info/wxmaxima.md:295
 msgid ""
 "Attention: Although the file `Quadratic.mac` has a usual _Maxima_ extension "
 "(`.mac`), it can only be read by _wxMaxima_, since the command `wxdraw2d()` "
@@ -1197,7 +1197,7 @@ msgstr ""
 "ausgeben."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:298
+#: ../../info/wxmaxima.md:297
 msgid ""
 "You can be use `.mac` files for writing your own library of macros. But "
 "since they don’t contain enough structural information they cannot be read "
@@ -1209,12 +1209,12 @@ msgstr ""
 "enthalten sie aber nicht."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:300
+#: ../../info/wxmaxima.md:299
 msgid "### .wxm"
 msgstr "### .wxm"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:303
+#: ../../info/wxmaxima.md:302
 #, fuzzy
 #| msgid ""
 #| "`.wxm` files contain the worksheet except for _Maxima_’s output. On "
@@ -1238,7 +1238,7 @@ msgstr ""
 "abwärtskompatibel zu älteren Versionen von _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:305
+#: ../../info/wxmaxima.md:304
 #, fuzzy
 #| msgid ""
 #| "`.wxm` files contain the worksheet except for _Maxima_’s output. On "
@@ -1258,37 +1258,37 @@ msgstr ""
 "abwärtskompatibel zu älteren Versionen von _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:307
+#: ../../info/wxmaxima.md:306
 msgid "#### File format of wxm files"
 msgstr "#### Dateiformat von wxm-Dateien"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:309
+#: ../../info/wxmaxima.md:308
 msgid ""
 "This is just a plain text file (you can open it with a text editor), "
 "containing the cell contents as some special Maxima comments."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:311
+#: ../../info/wxmaxima.md:310
 msgid "It starts with the following comment:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:316
+#: ../../info/wxmaxima.md:315
 msgid ""
 "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* "
 "[ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:318
+#: ../../info/wxmaxima.md:317
 msgid ""
 "And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:324
+#: ../../info/wxmaxima.md:323
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1299,14 +1299,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:326
+#: ../../info/wxmaxima.md:325
 msgid ""
 "or (in a Math cell the input is of course *not* commented out (the output is "
 "not saved in a `wxm` file)):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:333
+#: ../../info/wxmaxima.md:332
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1318,14 +1318,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:335
+#: ../../info/wxmaxima.md:334
 msgid ""
 "Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the "
 "image type as first line):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:342
+#: ../../info/wxmaxima.md:341
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1337,12 +1337,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:344
+#: ../../info/wxmaxima.md:343
 msgid "A page break is just one line containing:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:348
+#: ../../info/wxmaxima.md:347
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1351,12 +1351,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:350
+#: ../../info/wxmaxima.md:349
 msgid "And folded cells marked by:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:356
+#: ../../info/wxmaxima.md:355
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1367,12 +1367,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:358
+#: ../../info/wxmaxima.md:357
 msgid "### .wxmx"
 msgstr "### .wxmx"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:360
+#: ../../info/wxmaxima.md:359
 msgid ""
 "This XML-based file format saves the complete worksheet including things "
 "like the zoom factor and the watchlist. It is the preferred file format."
@@ -1382,12 +1382,12 @@ msgstr ""
 "Dateiformat für wxMaxima-Arbeitsblätter."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:362
+#: ../../info/wxmaxima.md:361
 msgid "#### File format of wxmx files"
 msgstr "#### Dateiformat von wxmx-Dateien"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:365
+#: ../../info/wxmaxima.md:364
 msgid ""
 "A `wxmx`-file seems to be a binary format, but one can handle it with tools, "
 "which are included in your OS. It is a zip file, one can decompress it with "
@@ -1399,39 +1399,39 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:367
+#: ../../info/wxmaxima.md:366
 msgid "It does contain the following files:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-"
 "wxmathml`"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`format.txt`: a short description about wxMaxima and the wxmx file format"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima "
 "session and included images."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`content.xml`: a XML document, which contains the various cells of your "
 "document in XML format."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:374
+#: ../../info/wxmaxima.md:373
 msgid ""
 "So, if something goes wrong, you can unzip a wxMaxima document (maybe rename "
 "it before to a `zip`-file), maybe make changes in the `content.xml` file "
@@ -1441,12 +1441,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:376
+#: ../../info/wxmaxima.md:375
 msgid "## Configuration options"
 msgstr "## Konfigurations-Optionen"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:378
+#: ../../info/wxmaxima.md:377
 msgid ""
 "For some common configuration variables _wxMaxima_ offers two ways of "
 "configuring:"
@@ -1455,14 +1455,14 @@ msgstr ""
 "eingestellt werden:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
+#: ../../info/wxmaxima.md:380
 msgid ""
 "The configuration dialog box below lets you change their default values for "
 "the current and subsequent sessions."
 msgstr "Die können global im Konfigurationsdialog eingestellt werden."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
+#: ../../info/wxmaxima.md:380
 msgid ""
 "Also, the values for most configuration variables can be changed for the "
 "current session only by overwriting their values from the worksheet, as "
@@ -1473,7 +1473,7 @@ msgstr ""
 "wie unten gezeigt."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:383
+#: ../../info/wxmaxima.md:382
 msgid ""
 "![wxMaxima configuration 1](./wxMaxima_configuration_001.png)"
 "{ id=img_wxMaxima_configuration_001 }"
@@ -1482,12 +1482,12 @@ msgstr ""
 "{ id=img_wxMaxima_configuration_001 }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:385
+#: ../../info/wxmaxima.md:384
 msgid "### Default animation framerate"
 msgstr "### Die Standard-Bildwiederholrate bei Animationen"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:387
+#: ../../info/wxmaxima.md:386
 msgid ""
 "The animation framerate that is used for new animations is kept in the "
 "variable `wxanimate_framerate`. The initial value this variable will contain "
@@ -1498,12 +1498,12 @@ msgstr ""
 "Konfigurationsdialog, wenn ein neues _Maxima_ gestartet wird."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:389
+#: ../../info/wxmaxima.md:388
 msgid "### Default plot size for new _maxima_ sessions"
 msgstr "### Standardgröße der Diagramme bei neuen _Maxima_ Sitzungen"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:391
+#: ../../info/wxmaxima.md:390
 msgid ""
 "After the next start, plots embedded into the worksheet will be created with "
 "this size if the value of `wxplot_size` isn’t changed by _maxima_."
@@ -1512,7 +1512,7 @@ msgstr ""
 "Größe erstellt, wenn der Wert von `wxplot_size` nicht geändert wird."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:393
+#: ../../info/wxmaxima.md:392
 msgid ""
 "In order to set the plot size of a single graph only use the following "
 "notation can be used that sets a variable’s value for one command only:"
@@ -1521,7 +1521,7 @@ msgstr ""
 "werden:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:402
+#: ../../info/wxmaxima.md:401
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1543,17 +1543,17 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:404
+#: ../../info/wxmaxima.md:403
 msgid "### Match parenthesis in text controls"
 msgstr "### Automatisches Schließen von Klammern"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:406
+#: ../../info/wxmaxima.md:405
 msgid "This option enables two things:"
 msgstr "Diese Option schaltet zwei Funktionen ein:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
+#: ../../info/wxmaxima.md:408
 msgid ""
 "If an opening parenthesis, bracket, or double quote is entered _wxMaxima_ "
 "will insert a closing one after it."
@@ -1563,7 +1563,7 @@ msgstr ""
 "ein."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
+#: ../../info/wxmaxima.md:408
 msgid ""
 "If text is selected if any of these keys is pressed the selected text will "
 "be put between the matched signs."
@@ -1572,12 +1572,12 @@ msgstr ""
 "automatisch in Klammern gesetzt."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:411
+#: ../../info/wxmaxima.md:410
 msgid "### Don’t save the worksheet automatically"
 msgstr "### Arbeitsblatt nicht automatisch speichern"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:413
+#: ../../info/wxmaxima.md:412
 msgid ""
 "If this option is set, the file where the worksheet is will be overwritten "
 "only the request of the user. In case of a crash/power loss/... a recent "
@@ -1588,7 +1588,7 @@ msgstr ""
 "Verzeichnis abgelegt."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:415
+#: ../../info/wxmaxima.md:414
 msgid ""
 "If this option isn’t set _wxMaxima_ behaves more like a modern cellphone app:"
 msgstr ""
@@ -1596,22 +1596,22 @@ msgstr ""
 "App:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
+#: ../../info/wxmaxima.md:417
 msgid "Files are saved automatically on exit"
 msgstr "Dateien werden beim Schließen automatisch gespeichert"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
+#: ../../info/wxmaxima.md:417
 msgid "And the file will automatically be saved every 3 minutes."
 msgstr "Und die Datei wird automatisch alle 3 Minuten gespeichert."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:420
+#: ../../info/wxmaxima.md:419
 msgid "### Where is the configuration saved?"
 msgstr "### Wo wird die Konfiguration gespeichert?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:423
+#: ../../info/wxmaxima.md:422
 msgid ""
 "If you are using Unix/Linux, the configuration information will be saved in "
 "a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< "
@@ -1633,7 +1633,7 @@ msgstr ""
 "eine versteckte Datei)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:425
+#: ../../info/wxmaxima.md:424
 msgid ""
 "If you are using Windows, the configuration will be stored in the registry. "
 "You will find the entries for _wxMaxima_ at the following position in the "
@@ -1643,12 +1643,12 @@ msgstr ""
 "`HKEY_CURRENT_USER\\Software\\wxMaxima` gespeichert."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:429
+#: ../../info/wxmaxima.md:428
 msgid "# Extensions to _Maxima_"
 msgstr "# Erweiterungen für _Maxima_"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:431
+#: ../../info/wxmaxima.md:430
 msgid ""
 "_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
 "its main purpose is to pass along commands to _Maxima_ and to report the "
@@ -1666,12 +1666,12 @@ msgstr ""
 "Graphiken in ein Arbeitsblatt verbessert"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:433
+#: ../../info/wxmaxima.md:432
 msgid "## Subscripted variables"
 msgstr "## Variablen mit tiefgestelltem Index"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:435
+#: ../../info/wxmaxima.md:434
 msgid ""
 "`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript "
 "variable names:"
@@ -1680,7 +1680,7 @@ msgstr ""
 "tiefstellen wird:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:437
+#: ../../info/wxmaxima.md:436
 msgid ""
 "If it is `false`, the functionality is off, wxMaxima will not autosubscript "
 "part of variable names after an underscore."
@@ -1689,7 +1689,7 @@ msgstr ""
 "nicht Teile von Variablennamen nach einem Unterstrich tiefstellen."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:439
+#: ../../info/wxmaxima.md:438
 msgid ""
 "If it is set to `'all`, everything after an underscore will be subscripted."
 msgstr ""
@@ -1697,7 +1697,7 @@ msgstr ""
 "tiefgestellt."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:441
+#: ../../info/wxmaxima.md:440
 msgid ""
 "If it is set to `true` variable names of the format `x_y` are displayed "
 "using a subscript if"
@@ -1706,17 +1706,17 @@ msgstr ""
 "einem tiefgestellten `y` dargestellt, wenn"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
+#: ../../info/wxmaxima.md:443
 msgid "Either `x` or `y` is a single letter or"
 msgstr "Entweder `x` oder `y` ist ein einzelner Buchstabe ist oder"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
+#: ../../info/wxmaxima.md:443
 msgid "`y` is an integer (can include more than one character)."
 msgstr "`y` ist eine ganze Zahl (kann länger als ein Zeichen lang sein)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:446
+#: ../../info/wxmaxima.md:445
 msgid ""
 "![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png)"
 "{ id=img_wxsubscripts }"
@@ -1725,7 +1725,7 @@ msgstr ""
 "wxsubscripts.png){ id=img_wxsubscripts }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:448
+#: ../../info/wxmaxima.md:447
 msgid ""
 "If the variable name doesn’t match these requirements, it can still be "
 "declared as \"to be subscripted\" using the command "
@@ -1741,19 +1741,19 @@ msgstr ""
 "`wxdeclare_subscript(variablenname,false);`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:450
+#: ../../info/wxmaxima.md:449
 msgid "You can use the menu \"View->Autosubscript\" to set these values."
 msgstr ""
 "Sie können das Menü \"Anzeige->Automatisches Tiefstellen\" verwenden, um "
 "diese Werte zu setzen."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:452
+#: ../../info/wxmaxima.md:451
 msgid "## User feedback in the status bar"
 msgstr "## Meldungen in der Statusleiste"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:454
+#: ../../info/wxmaxima.md:453
 msgid ""
 "Long-running commands can provide user feedback in the status bar. This user "
 "feedback is replaced by any new feedback that is placed there (allowing to "
@@ -1772,7 +1772,7 @@ msgstr ""
 "bearbeitet."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:465
+#: ../../info/wxmaxima.md:464
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1799,12 +1799,89 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:467
+#: ../../info/wxmaxima.md:466
+msgid "## Exporting the worksheet from within Maxima"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:468
+msgid ""
+"The command `wxworksheettohtml()` exports the current worksheet to an HTML "
+"file from within a running _Maxima_ session, which is convenient for "
+"scripted or batch export. Like `wxstatusbar()` it is safe to use in code "
+"that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present "
+"the command is simply left unevaluated."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:473
+msgid ""
+"```maxima wxworksheettohtml(\"report.html\")$ "
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:475
+msgid ""
+"A relative file name is interpreted relative to _Maxima_’s working "
+"directory. The optional keyword options are:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:480
+#, no-wrap
+msgid ""
+"| option   | values                                          | meaning                                             |\n"
+"| -------- | ----------------------------------------------- | --------------------------------------------------- |\n"
+"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |\n"
+"| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:482
+msgid ""
+"The `flavor` values match the equation formats offered by the graphical "
+"**File → Export** dialog: `mathml` produces a self-contained page that needs "
+"no internet connection, `mathjax` adds a MathJaX fall-back for browsers that "
+"still lack MathML, and `svg`/`bitmap` render every equation to an image."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:484
+msgid ""
+"The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file "
+"the same way:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:489
+msgid ""
+"```maxima wxworksheettotex(\"report.tex\")$ wxworksheettotex(\"report.tex\", "
+"documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:494
+#, no-wrap
+msgid ""
+"| option                 | meaning                                                              |\n"
+"| ---------------------- | -------------------------------------------------------------------- |\n"
+"| `documentclass`        | overrides the LaTeX `\\documentclass` (e.g. `\"article\"`, `\"report\"`)  |\n"
+"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:496
+msgid "Support for `wxworksheettopdf()` is planned."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:498
 msgid "## Plotting"
 msgstr "## Diagramme"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:469
+#: ../../info/wxmaxima.md:500
 msgid ""
 "Plotting (having fundamentally to do with graphics) is a place where a "
 "graphical user interface will have to provide some extensions to the "
@@ -1814,12 +1891,12 @@ msgstr ""
 "tun, weswegen an dieser Stelle Erweiterungen von Maxima zu erwarten sind."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:471
+#: ../../info/wxmaxima.md:502
 msgid "### Embedding a plot into the worksheet"
 msgstr "### Diagramme in das Arbeitsblatt einbetten"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:473
+#: ../../info/wxmaxima.md:504
 msgid ""
 "_Maxima_ normally instructs the external program _Gnuplot_ to open a "
 "separate window for every diagram it creates. Since many times it is "
@@ -1832,12 +1909,12 @@ msgstr ""
 "vorangestellt wird, wird das Bild stattdessen in das Arbeitsblatt eingebaut."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:475
+#: ../../info/wxmaxima.md:506
 msgid "The following plotting functions have wx-counterparts:"
 msgstr "Die folgenden Plot-Funktionen haben wx-Äquivalente:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:489
+#: ../../info/wxmaxima.md:520
 #, no-wrap
 msgid ""
 "| wxMaxima’s plot function | Maxima’s plot function                                                                          |\n"
@@ -1856,14 +1933,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:491
+#: ../../info/wxmaxima.md:522
 msgid ""
 "If a `wxm`-file is read by (console) Maxima, these functions are ignored "
 "(and printed as output, as other unknown functions in Maxima)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:493
+#: ../../info/wxmaxima.md:524
 msgid ""
 "If you got problems with one of these functions, please check, if the "
 "problem exists in the the Maxima function too (e.g. you got an error with "
@@ -1875,12 +1952,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:495
+#: ../../info/wxmaxima.md:526
 msgid "### Making embedded plots bigger or smaller"
 msgstr "### Eingebettete Diagramme größer oder kleiner machen"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:497
+#: ../../info/wxmaxima.md:528
 msgid ""
 "As noted above, the configure dialog provides a way to change the default "
 "size plots created which sets the starting value of `wxplot_size`. The "
@@ -1894,7 +1971,7 @@ msgstr ""
 "Inhalt kann jederzeit ausgelesen oder geändert werden:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:507
+#: ../../info/wxmaxima.md:538
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1918,7 +1995,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:509
+#: ../../info/wxmaxima.md:540
 msgid ""
 "If the size of only one plot is to be changed _Maxima_ provides a canonical "
 "way to change an attribute only for the current cell. In this usage the "
@@ -1931,7 +2008,7 @@ msgstr ""
 "nicht Teil des `wxdraw2d` Befehls."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:518
+#: ../../info/wxmaxima.md:549
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1953,7 +2030,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:520
+#: ../../info/wxmaxima.md:551
 msgid ""
 "Setting the size of embedded plot with `wxplot_size` works for embedded "
 "plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` "
@@ -1962,12 +2039,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:522
+#: ../../info/wxmaxima.md:553
 msgid "### Better quality plots"
 msgstr "### Hochqualitativere Diagramme"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:524
+#: ../../info/wxmaxima.md:555
 #, fuzzy
 #| msgid ""
 #| "_Gnuplot_ doesn’t seem to provide a portable way of determining whether "
@@ -1995,12 +2072,12 @@ msgstr ""
 "`wxplot_pngcairo:true` jedoch zu Fehlermeldungen anstelle von Plots."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:526
+#: ../../info/wxmaxima.md:557
 msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
 msgstr "### Öffnen eingebetteter Diagramme in interaktiven _Gnuplot_ Fenstern"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:528
+#: ../../info/wxmaxima.md:559
 msgid ""
 "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
 "`wxplot3d` isn’t supported by this feature) and the file size of the "
@@ -2013,12 +2090,12 @@ msgstr ""
 "an, der das Diagramm in einem interaktiven Gnuplot-Fenster öffnet."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:530
+#: ../../info/wxmaxima.md:561
 msgid "### Opening Gnuplot’s command console in `plot` windows"
 msgstr "### Öffnen der Gnuplot Kommandozeile in `plot` Fenstern"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:533
+#: ../../info/wxmaxima.md:564
 #, fuzzy
 #| msgid ""
 #| "On MS Windows, if in _Maxima_'s variable `gnuplot_command` \"gnuplot\" is "
@@ -2040,12 +2117,12 @@ msgstr ""
 "(die Zeichen, die währenddessen eingegeben werden, verschwinden)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:535
+#: ../../info/wxmaxima.md:566
 msgid "### Embedding animations into the spreadsheet"
 msgstr "### Einbetten von Animationen in das Arbeitsblatt"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:537
+#: ../../info/wxmaxima.md:568
 msgid ""
 "3D diagrams tend to make it hard to read quantitative data. A viable "
 "alternative might be to assign the 3rd parameter to the mouse wheel. The "
@@ -2061,7 +2138,7 @@ msgstr ""
 "Datei exportieren."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:539
+#: ../../info/wxmaxima.md:570
 msgid ""
 "The first two arguments for `with_slider_draw` are the name of the variable "
 "that is stepped between the plots and a list of the values of these "
@@ -2074,7 +2151,7 @@ msgstr ""
 "akzeptiert:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:550
+#: ../../info/wxmaxima.md:581
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2100,7 +2177,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:552
+#: ../../info/wxmaxima.md:583
 msgid ""
 "The same functionality for 3D plots is accessible as `with_slider_draw3d`, "
 "which allows for rotating 3d plots:"
@@ -2109,7 +2186,7 @@ msgstr ""
 "verfügbar, die auch rotierende 3D-Diagramme erstellen kann:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:569
+#: ../../info/wxmaxima.md:600
 #, fuzzy, no-wrap
 #| msgid ""
 #| "```maxima\n"
@@ -2164,7 +2241,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:571
+#: ../../info/wxmaxima.md:602
 msgid ""
 "If the general shape of the plot is what matters it might suffice to move "
 "the plot just a little bit in order to make its 3D nature available to the "
@@ -2174,7 +2251,7 @@ msgstr ""
 "ein wenig zu bewegen, so, dass es von der Intuition erfasst werden kann:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:588
+#: ../../info/wxmaxima.md:619
 #, fuzzy, no-wrap
 #| msgid ""
 #| "```maxima\n"
@@ -2229,7 +2306,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:590
+#: ../../info/wxmaxima.md:621
 msgid ""
 "For those more familiar with `plot` than with `draw`, there is a second set "
 "of functions:"
@@ -2238,17 +2315,17 @@ msgstr ""
 "Verfügung:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
+#: ../../info/wxmaxima.md:624
 msgid "`with_slider` and"
 msgstr "- `with_slider` und"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
+#: ../../info/wxmaxima.md:624
 msgid "`wxanimate`."
 msgstr "`wxanimate`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:595
+#: ../../info/wxmaxima.md:626
 msgid ""
 "Normally the animations are played back or exported with the frame rate "
 "chosen in the configuration of _wxMaxima_. To set the speed at an individual "
@@ -2259,7 +2336,7 @@ msgstr ""
 "Animation zu ändern, kann die Variable `wxanimate_framerate` geändert werden:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:600
+#: ../../info/wxmaxima.md:631
 #, fuzzy, no-wrap
 #| msgid ""
 #| "```maxima\n"
@@ -2278,7 +2355,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:602
+#: ../../info/wxmaxima.md:633
 msgid ""
 "The animation functions use _Maxima_’s `makelist` command and therefore "
 "share the pitfall that the slider variable’s value is substituted into the "
@@ -2291,7 +2368,7 @@ msgstr ""
 "Beispiel scheitert daher:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:612
+#: ../../info/wxmaxima.md:643
 #, fuzzy, no-wrap
 #| msgid ""
 #| "```maxima\n"
@@ -2325,7 +2402,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:614
+#: ../../info/wxmaxima.md:645
 msgid ""
 "If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
 "works fine instead:"
@@ -2334,7 +2411,7 @@ msgstr ""
 "Befehl stattdessen:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:627
+#: ../../info/wxmaxima.md:658
 #, fuzzy, no-wrap
 #| msgid ""
 #| "f:sin(a*x);\n"
@@ -2373,12 +2450,12 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:629
+#: ../../info/wxmaxima.md:660
 msgid "### Opening multiple plots in contemporaneous windows"
 msgstr "### Mehrere Diagramme gleichzeitig in Fenstern öffnen"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:631
+#: ../../info/wxmaxima.md:662
 msgid ""
 "While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups "
 "that support it) sometimes comes in handily. The following example comes "
@@ -2388,14 +2465,14 @@ msgstr ""
 "Systemen das folgende Beispiel von Mario Rodriguez auszuführen:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:634
+#: ../../info/wxmaxima.md:665
 #, fuzzy
 #| msgid "    load(draw);\n"
 msgid "```maxima load(draw);"
 msgstr "    load(draw);\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:637
+#: ../../info/wxmaxima.md:668
 #, fuzzy
 #| msgid ""
 #| "    /* Parabola in window #1 */\n"
@@ -2407,7 +2484,7 @@ msgstr ""
 "    draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:640
+#: ../../info/wxmaxima.md:671
 #, fuzzy
 #| msgid ""
 #| "    /* Parabola in window #2 */\n"
@@ -2419,7 +2496,7 @@ msgstr ""
 "    draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:644
+#: ../../info/wxmaxima.md:675
 #, fuzzy
 #| msgid ""
 #| "    /* Paraboloid in window #3 */\n"
@@ -2433,7 +2510,7 @@ msgstr ""
 "    draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:646
+#: ../../info/wxmaxima.md:677
 msgid ""
 "Plotting multiple plots in the same window is possible, too (the same is "
 "possible in command line Maxima with the standard `draw()` command):"
@@ -2442,7 +2519,7 @@ msgstr ""
 "in Kommandozeilen-Maxima mit dem Standard-`draw()`-Befehl:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:657
+#: ../../info/wxmaxima.md:688
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2458,12 +2535,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:659
+#: ../../info/wxmaxima.md:690
 msgid "### The \"Plot using draw\" side pane"
 msgstr "### Die \"Plotte mittels Draw\"-Seitenleiste"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:661
+#: ../../info/wxmaxima.md:692
 msgid ""
 "The \"Plot using draw\" sidebar hides a simple code generator that allows "
 "generating scenes that make use of some of the flexibility of the _draw_ "
@@ -2474,12 +2551,12 @@ msgstr ""
 "nutzen."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:663
+#: ../../info/wxmaxima.md:694
 msgid "#### 2D"
 msgstr "#### 2D"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:665
+#: ../../info/wxmaxima.md:696
 #, fuzzy
 #| msgid ""
 #| "Generates the skeleton of a `draw()` command that draws a 2D scene. This "
@@ -2496,7 +2573,7 @@ msgstr ""
 "Seitenleiste mit einer 2D-Szene gefüllt werden kann."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:667
+#: ../../info/wxmaxima.md:698
 #, fuzzy
 #| msgid ""
 #| "One helpful feature of the 2D button is that it allows to setup the scene "
@@ -2514,12 +2591,12 @@ msgstr ""
 "als ein räumliches Solches."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:669
+#: ../../info/wxmaxima.md:700
 msgid "#### 3D"
 msgstr "#### 3D"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:671
+#: ../../info/wxmaxima.md:702
 #, fuzzy
 #| msgid ""
 #| "Generates the skeleton of a `draw()` command that draws a 3D scene. If "
@@ -2532,12 +2609,12 @@ msgid ""
 msgstr "Wie \"2D\", aber für dreidimensionale Diagramme."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:673
+#: ../../info/wxmaxima.md:704
 msgid "#### Expression"
 msgstr "#### Ausdruck"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:675
+#: ../../info/wxmaxima.md:706
 msgid ""
 "Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or "
 "`x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is "
@@ -2550,12 +2627,12 @@ msgstr ""
 "beinhalten."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:677
+#: ../../info/wxmaxima.md:708
 msgid "#### Implicit plot"
 msgstr "#### Impliziter Plot"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:679
+#: ../../info/wxmaxima.md:710
 msgid ""
 "Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or "
 "`x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command "
@@ -2567,12 +2644,12 @@ msgstr ""
 "Diagramm ein. Gibt es kein aktuelles Diagramm, wird ein 2D-Diagramm erzeugt."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:681
+#: ../../info/wxmaxima.md:712
 msgid "#### Parametric plot"
 msgstr "#### Parametrischer Plot"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:683
+#: ../../info/wxmaxima.md:714
 msgid ""
 "Steps a variable from a lower limit to an upper limit and uses two "
 "expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in "
@@ -2584,12 +2661,12 @@ msgstr ""
 "3D-Diagrammen auch die z-) Koordinaten zu generieren."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:685
+#: ../../info/wxmaxima.md:716
 msgid "#### Points"
 msgstr "#### Punkte"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:687
+#: ../../info/wxmaxima.md:718
 msgid ""
 "Draws many points that can optionally be joined. The coordinates of the "
 "points are taken from a list of lists, a 2D array or one list or array for "
@@ -2601,32 +2678,32 @@ msgstr ""
 "werden."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:689
+#: ../../info/wxmaxima.md:720
 msgid "#### Diagram title"
 msgstr "#### Diagrammtitel"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:691
+#: ../../info/wxmaxima.md:722
 msgid "Draws a title on the upper end of the diagram,"
 msgstr "Bestimmt den Titel des Diagramms."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:693
+#: ../../info/wxmaxima.md:724
 msgid "#### Axis"
 msgstr "#### Achsen"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:695
+#: ../../info/wxmaxima.md:726
 msgid "Sets up the axis."
 msgstr "Die Einstellungen für die Achsen."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:697
+#: ../../info/wxmaxima.md:728
 msgid "#### Contour"
 msgstr "#### Höhenlinien"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:699
+#: ../../info/wxmaxima.md:730
 #, fuzzy
 #| msgid ""
 #| "(Only for 3D plots): Adds contour lines similar to the ones one can find "
@@ -2646,12 +2723,12 @@ msgstr ""
 "die Höhenlinien in der Ansicht von Oben zeichnen."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:701
+#: ../../info/wxmaxima.md:732
 msgid "#### Plot name"
 msgstr "#### Name des Plots"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:703
+#: ../../info/wxmaxima.md:734
 msgid ""
 "Adds a legend entry showing the next plot’s name to the legend of the "
 "diagram. An empty name disables generating legend entries for the following "
@@ -2662,12 +2739,12 @@ msgstr ""
 "erhalten."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:705
+#: ../../info/wxmaxima.md:736
 msgid "#### Line colour"
 msgstr "#### Linienfarbe"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:707
+#: ../../info/wxmaxima.md:738
 msgid ""
 "Sets the line colour for the following plots the current draw command "
 "contains."
@@ -2675,12 +2752,12 @@ msgstr ""
 "Setzt die Linienfarbe für die nun folgenden Plots des aktuellen draw-Befehls."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:709
+#: ../../info/wxmaxima.md:740
 msgid "#### Fill colour"
 msgstr "#### Füllfarbe"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:711
+#: ../../info/wxmaxima.md:742
 msgid ""
 "Sets the fill colour for the following plots the current draw command "
 "contains."
@@ -2689,22 +2766,22 @@ msgstr ""
 "Kommandos."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:713
+#: ../../info/wxmaxima.md:744
 msgid "#### Grid"
 msgstr "#### Gitternetz"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:715
+#: ../../info/wxmaxima.md:746
 msgid "Pops up a wizard that allows to set up grid lines."
 msgstr "Ein Assistent, der die Gitterlinien einzustellen hilft."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:717
+#: ../../info/wxmaxima.md:748
 msgid "#### Accuracy"
 msgstr "#### Genauigkeit"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:719
+#: ../../info/wxmaxima.md:750
 msgid ""
 "Allows to select an adequate point in the speed vs. accuracy tradeoff that "
 "is part of any plot program."
@@ -2713,12 +2790,12 @@ msgstr ""
 "Erstellung der folgenden Kurven."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:721
+#: ../../info/wxmaxima.md:752
 msgid "### Modify font and font size for plots"
 msgstr "### Schrift und Schriftgröße for Plots ändern"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:723
+#: ../../info/wxmaxima.md:754
 msgid ""
 "Especially when you use a high resolution display, the default font size "
 "might be very small. For the `draw`-based commands, you can set the font / "
@@ -2726,7 +2803,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:730
+#: ../../info/wxmaxima.md:761
 #, fuzzy, no-wrap
 #| msgid ""
 #| "pngdraw2d(\"Test\",\n"
@@ -2747,14 +2824,14 @@ msgstr ""
 "~~~~\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:732
+#: ../../info/wxmaxima.md:763
 msgid ""
 "For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts "
 "can be set using the `gnuplot_preamble` command, e.g.:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:737
+#: ../../info/wxmaxima.md:768
 #, no-wrap
 msgid ""
 "~~~maxima\n"
@@ -2764,14 +2841,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:739
+#: ../../info/wxmaxima.md:770
 msgid ""
 "This sets the font for the numbers to Arial with size 30, the size for the "
 "xlabel and ylabel font to 20 (with the default font)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:742
+#: ../../info/wxmaxima.md:773
 msgid ""
 "Read the Maxima and Gnuplot documentation for further information.  Note: "
 "Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue "
@@ -2779,12 +2856,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:744
+#: ../../info/wxmaxima.md:775
 msgid "## Embedding graphics"
 msgstr "## Einbetten von Bildern"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:746
+#: ../../info/wxmaxima.md:777
 msgid ""
 "If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
 "project can be done as easily as per drag-and-drop. But sometimes (for "
@@ -2796,7 +2873,7 @@ msgstr ""
 "könnten) ist es besser, die Bilddatei während der Auswertung zu laden:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:750
+#: ../../info/wxmaxima.md:781
 #, fuzzy
 #| msgid "show_image(\"man.png\");\n"
 msgid "```maxima show_image(\"man.png\"); ```"
@@ -2804,12 +2881,12 @@ msgstr "show_image(\"Mensch.png\");\n"
 
 # ## Startbefehle
 #. type: Plain text
-#: ../../info/wxmaxima.md:752
+#: ../../info/wxmaxima.md:783
 msgid "## Startup files"
 msgstr "## Startbefehle"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:754
+#: ../../info/wxmaxima.md:785
 msgid ""
 "The config dialogue of _wxMaxima_ offers to edit two files with commands "
 "that are executed on startup:"
@@ -2818,7 +2895,7 @@ msgstr ""
 "Befehlen zu bearbeiten:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
+#: ../../info/wxmaxima.md:788
 msgid ""
 "A file that contains commands that are executed on starting up _Maxima_: "
 "`maxima-init.mac`"
@@ -2827,7 +2904,7 @@ msgstr ""
 "init.mac`"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
+#: ../../info/wxmaxima.md:788
 #, fuzzy
 #| msgid ""
 #| "A file that contains commands that are executed on starting up _Maxima_: "
@@ -2840,7 +2917,7 @@ msgstr ""
 "init.mac`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:759
+#: ../../info/wxmaxima.md:790
 msgid ""
 "For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add "
 "`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` "
@@ -2848,7 +2925,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:761
+#: ../../info/wxmaxima.md:792
 #, fuzzy
 #| msgid ""
 #| "These files are in the Maxima user directory (usually `maxima` in "
@@ -2865,12 +2942,12 @@ msgstr ""
 "`maxima_userdir;` ermittelt werden."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:763
+#: ../../info/wxmaxima.md:794
 msgid "## Special variables wx..."
 msgstr "## Spezielle Variablen, die wxMaxima definiert"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxsubscripts` tells _Maxima_ if it should convert variable names that "
 "contain an underscore (`R_150` or the like) into subscripted variables. See "
@@ -2882,7 +2959,7 @@ msgstr ""
 "`wxdeclare_subscript` beschrieben."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxfilename`: This variable contains the name of the file currently opened "
 "in _wxMaxima_."
@@ -2891,7 +2968,7 @@ msgstr ""
 "_wxMaxima_ besitzt."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxdirname`: This variable contains the name the directory, in which the "
 "file currently opened in _wxMaxima_ is."
@@ -2900,7 +2977,7 @@ msgstr ""
 "die aktuelle Datei geöffnet wurde."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_’s pngcairo "
 "terminal that provides more line styles and a better overall graphics "
@@ -2911,12 +2988,12 @@ msgstr ""
 "unterstützt."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxplot_size` defines the resolution of embedded plots."
 msgstr "`wxplot_size` legt die Größe eingebetteter Diagramme fest."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
 "_Maxima_’s working directory to the directory of the current file. This "
@@ -2932,7 +3009,7 @@ msgstr ""
 "gesetzt werden."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxanimate_framerate`: The number of frames per second the following "
 "animations have to be played back with."
@@ -2941,30 +3018,30 @@ msgstr ""
 "werden sollen."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxanimate_autoplay`: Automatically play animations by default?"
 msgstr ""
 "`wxanimate_autoplay`: Sollen Animationen automatisch abgespielt werden?"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
 msgstr "`wxmaximaversion`: Ergibt die Versionsnummer von _wxMaxima_."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
 msgstr ""
 "`wxwidgetsversion`: Ergibt die Versionsnummer der verwendeten wxWidgets-"
 "Version."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:776
+#: ../../info/wxmaxima.md:807
 msgid "## Pretty-printing 2D output"
 msgstr "## 2D-Tabellen sauber ausgeben"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:778
+#: ../../info/wxmaxima.md:809
 msgid ""
 "The function `table_form()` displays a 2D list in a form that is more "
 "readable than the output from _Maxima_’s default output routine. The input "
@@ -2980,7 +3057,7 @@ msgstr ""
 "unterdrückt werden."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:787
+#: ../../info/wxmaxima.md:818
 #, fuzzy, no-wrap
 #| msgid ""
 #| "table_form(\n"
@@ -3007,7 +3084,7 @@ msgstr ""
 "    )$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:789
+#: ../../info/wxmaxima.md:820
 msgid ""
 "As the next example shows, the lists that are assembled by the `table_form` "
 "command can be created before the command is executed."
@@ -3016,7 +3093,7 @@ msgstr ""
 "Tabelle."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:791
+#: ../../info/wxmaxima.md:822
 msgid ""
 "![A third table example](./MatrixTableExample.png)"
 "{ id=img_MatrixTableExample }"
@@ -3025,7 +3102,7 @@ msgstr ""
 "{ id=img_MatrixTableExample }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:793
+#: ../../info/wxmaxima.md:824
 msgid ""
 "Also, because a matrix is a list of lists, matrices can be converted to "
 "tables in a similar fashion."
@@ -3034,35 +3111,65 @@ msgstr ""
 "verwandelt werden."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:795
+#: ../../info/wxmaxima.md:826
 msgid ""
 "![Another table_form example](./SecondTableExample.png)"
 "{ id=img_SecondTableExample }"
 msgstr "![Ein anderes table_form Beispiel](./SecondTableExample.png)"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:797
+#: ../../info/wxmaxima.md:828
 msgid ""
 "The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that "
 "allows for more flexible formatting of matrices in wxMaxima:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:803
+#: ../../info/wxmaxima.md:830
 #, no-wrap
+msgid "**`wx_matrix( <matrix>, [options] )`**\n"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
 msgid ""
-"**`wx_matrix( <matrix>, [options] )`**\n"
-"- **`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data.\n"
-"- **`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels.\n"
-"- **`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels.\n"
-"- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`.\n"
+"**`lines=true`**: Draws internal separator lines between the cells. This is "
+"required to visually separate headings from data."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`rownames=true`**: Tells wxMaxima that the first column of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`colnames=true`**: Tells wxMaxima that the first row of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
+"around the matrix. Supported styles are: `round` `()`, `square` `[]`, "
+"`angled` `<>`, `straight` `||`, or `none`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:809
+#: ../../info/wxmaxima.md:837
+#, fuzzy
+#| msgid "One Example:"
+msgid "Example:"
+msgstr "Ein Beispiel:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:842
 #, no-wrap
 msgid ""
-"Example:\n"
 "```maxima\n"
 "wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
 "          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
@@ -3070,19 +3177,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:811
+#: ../../info/wxmaxima.md:844
 msgid "## Bug reporting"
 msgstr "## Fehler melden"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:813
+#: ../../info/wxmaxima.md:846
 msgid ""
 "_WxMaxima_ provides a few functions that gather bug reporting information "
 "about the current system:"
 msgstr "_WxMaxima_ bietet einige Funktionen für das Melden von Fehlern an:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:816
+#: ../../info/wxmaxima.md:849
 msgid ""
 "`wxbuild_info()` gathers information about the currently running version of "
 "_wxMaxima_"
@@ -3091,17 +3198,17 @@ msgstr ""
 "von _wxMaxima_"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:816
+#: ../../info/wxmaxima.md:849
 msgid "`wxbug_report()` tells how and where to file bugs"
 msgstr "`wxbug_report()` sagt, wo und wie Fehler gemeldet werden können"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:819
+#: ../../info/wxmaxima.md:851
 msgid "## Marking output being drawn in red"
 msgstr "## Rotes Markieren von Formelteilen"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:822
+#: ../../info/wxmaxima.md:854
 #, fuzzy
 #| msgid ""
 #| "_Maxima_'s `box()` command causes _wxMaxima_ to print its argument with a "
@@ -3113,18 +3220,18 @@ msgid ""
 msgstr "Der `box()`-Befehl stellt sein Argument in _wxMaxima_ rot dar."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:824
+#: ../../info/wxmaxima.md:856
 msgid "## Output rendering."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:826
+#: ../../info/wxmaxima.md:858
 msgid "With `set_display()` one can set, how wxMaxima will render the output."
 msgstr ""
 "Mittels `set_display()` kann man angeben, wie wxMaxima die Ausgabe anzeigt."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:828
+#: ../../info/wxmaxima.md:860
 msgid ""
 "`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima "
 "using an (machine readable) XML-dialect (can be seen in the \"Raw XML "
@@ -3133,7 +3240,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:831
+#: ../../info/wxmaxima.md:863
 msgid ""
 "<!--- Currently that does not work as it should, the line with the output "
 "label is shifted right (issue: #2006) --> `set_display('ascii)` causes "
@@ -3141,7 +3248,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:833
+#: ../../info/wxmaxima.md:865
 msgid ""
 "`set_display('none)` causes 'one-line' ASCII results - the same as the "
 "command line Maxima command `display2d:false;` does."
@@ -3150,12 +3257,12 @@ msgstr ""
 "(Kommandozeilen-)Maxima mit `display2d:false;` macht."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:867
 msgid "# Help menu"
 msgstr "# Hilfemenü"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:837
+#: ../../info/wxmaxima.md:869
 msgid ""
 "WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, "
 "tips, some example worksheets and in command line Maxima included demos (the "
@@ -3163,19 +3270,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:839
+#: ../../info/wxmaxima.md:871
 msgid "Please notice, that the demos write:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:843
+#: ../../info/wxmaxima.md:875
 msgid ""
 "~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the "
 "demonstration.  ~~~"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:845
+#: ../../info/wxmaxima.md:877
 msgid ""
 "That is valid for command-line Maxima, however in wxMaxima by default it is "
 "necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</"
@@ -3183,24 +3290,24 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:847
+#: ../../info/wxmaxima.md:879
 msgid ""
 "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending "
 "commands to Maxima\" menu.)"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:851
+#: ../../info/wxmaxima.md:883
 msgid "# Troubleshooting"
 msgstr "# Fehlersuche"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:853
+#: ../../info/wxmaxima.md:885
 msgid "## Cannot connect to _Maxima_"
 msgstr "## Keine Verbindung zu _Maxima_ möglich"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:855
+#: ../../info/wxmaxima.md:887
 #, fuzzy
 #| msgid ""
 #| "Since _Maxima_ (the program that does the actual mathematics) and "
@@ -3236,7 +3343,7 @@ msgstr ""
 "unter Namen wie sbcl, gcl, ccl, lisp.exe oder ähnlichen firmiert."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:857
+#: ../../info/wxmaxima.md:889
 msgid ""
 "On Unix computers another possible reason would be that the loopback network "
 "that provides network connections between two programs in the same computer "
@@ -3247,12 +3354,12 @@ msgstr ""
 "Rechner) nicht korrekt eingestellt ist."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:859
+#: ../../info/wxmaxima.md:891
 msgid "## How to save data from a broken .wxmx file"
 msgstr "## Wie repariere ich kaputte .wxmx-Dateien?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:861
+#: ../../info/wxmaxima.md:893
 msgid ""
 "Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ "
 "doesn’t turn on compression, so the contents of `.wxmx` files can be viewed "
@@ -3263,7 +3370,7 @@ msgstr ""
 "ein, weswegen ihr Inhalt in einem normalen Texteditor lesbar ist."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:863
+#: ../../info/wxmaxima.md:895
 #, fuzzy
 #| msgid ""
 #| "If the zip signature at the end of the file is still intact after "
@@ -3291,7 +3398,7 @@ msgstr ""
 "funktionierende `wxmx~`-Datei."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:865
+#: ../../info/wxmaxima.md:897
 #, fuzzy
 #| msgid ""
 #| "And even if there isn’t such a file: The `.wxmx` file is a container "
@@ -3318,7 +3425,7 @@ msgstr ""
 "sein).\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:867
+#: ../../info/wxmaxima.md:899
 msgid ""
 "If a text file containing only these contents (e.g. copy and paste this text "
 "into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know "
@@ -3329,7 +3436,7 @@ msgstr ""
 "wie man den Text-Teil des Dokuments rekonstruiert."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:869
+#: ../../info/wxmaxima.md:901
 msgid ""
 "## I want some debug info to be displayed on the screen before my command "
 "has finished"
@@ -3338,7 +3445,7 @@ msgstr ""
 "ausgeführt wird"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:871
+#: ../../info/wxmaxima.md:903
 msgid ""
 "Normally _wxMaxima_ waits for the whole 2D formula to be transferred before "
 "it begins to typeset. This saves time for making many attempts to typeset a "
@@ -3350,7 +3457,7 @@ msgstr ""
 "steht. Das `disp`-Kommando wird hingegen sofort ausgeführt:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:881
+#: ../../info/wxmaxima.md:913
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -3375,19 +3482,19 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:883
+#: ../../info/wxmaxima.md:915
 msgid "Alternatively one can look for the `wxstatusbar()` command above."
 msgstr "Alternativ kann man sich das `wxstatusbar()`-Kommando oben ansehen."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:885
+#: ../../info/wxmaxima.md:917
 msgid "## Plotting only shows a closed empty envelope with an error message"
 msgstr ""
 "## Statt eines Diagramms wird ein Briefumschlag mit einer Fehlermeldung "
 "dargestellt"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:887
+#: ../../info/wxmaxima.md:919
 msgid ""
 "This means that _wxMaxima_ could not read the file _Maxima_ that was "
 "supposed to instruct _Gnuplot_ to create."
@@ -3396,12 +3503,12 @@ msgstr ""
 "generieren, nicht lesen."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:889
+#: ../../info/wxmaxima.md:921
 msgid "Possible reasons for this error are:"
 msgstr "Mögliche Gründe für diesen Fehler sind:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 msgid ""
 "The plotting command is part of a third-party package like `implicit_plot` "
 "but this package was not loaded by _Maxima_’s `load()` command before trying "
@@ -3410,7 +3517,7 @@ msgstr ""
 "`implicit_plot` wurde verwendet, ohne vorher via `load()` geladen zu werden."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, fuzzy
 #| msgid ""
 #| "_Maxima_ tried to do something the currently installed version of "
@@ -3433,7 +3540,7 @@ msgstr ""
 "Fehler zu suchen."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, fuzzy
 #| msgid ""
 #| "Gnuplot was instructed to use the pngcairo library that provides "
@@ -3453,17 +3560,17 @@ msgstr ""
 "Mac ein typisches Problem."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 msgid "Gnuplot didn’t output a valid `.png` file."
 msgstr "Gnuplot hat keine gültige `.png`-Datei ausgegeben."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:896
+#: ../../info/wxmaxima.md:928
 msgid "## Plotting an animation results in “error: undefined variable”"
 msgstr "## Animationen enden in \"Error: Undefined Variable\""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:898
+#: ../../info/wxmaxima.md:930
 #, fuzzy
 #| msgid ""
 #| "The value of the slider variable by default is only substituted into the "
@@ -3485,12 +3592,12 @@ msgstr ""
 "wie in einem Beispiel weiter oben gezeigt wird."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:900
+#: ../../info/wxmaxima.md:932
 msgid "## I lost cell content and undo doesn’t remember"
 msgstr "## Rückgängig-machen erinnert sich nicht an das, was ich brauche"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:902
+#: ../../info/wxmaxima.md:934
 msgid ""
 "There are separate undo functions for cell operations and for changes inside "
 "of cells so chances are low that this ever happens. If it does there are "
@@ -3500,7 +3607,7 @@ msgstr ""
 "enthalten können:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 #, fuzzy
 #| msgid ""
 #| "_wxMaxima_ actually has two undo features: The global undo buffer that is "
@@ -3519,7 +3626,7 @@ msgstr ""
 "alter Wert wiederhergestellt werden kann."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid ""
 "If you still have a way to find out what label _Maxima_ has assigned to the "
 "cell just type in the cell’s label and its contents will reappear."
@@ -3528,7 +3635,7 @@ msgstr ""
 "Marke eingegeben werden und der betreffende Text erscheint."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid ""
 "If you don’t: Don’t panic. In the “View” menu there is a way to show a "
 "history pane that shows all _Maxima_ commands that have been issued recently."
@@ -3537,25 +3644,25 @@ msgstr ""
 "eingeschaltet werden, die die letzten Befehle anzeigt."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid "If nothing else helps _Maxima_ contains a replay feature:"
 msgstr ""
 "Wenn nichts anderes funktioniert, bietet Maxima die Möglichkeit an, alle "
 "bisherigen Befehle nochmals auszuführen:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:911
+#: ../../info/wxmaxima.md:943
 msgid "```maxima playback(); ```"
 msgstr "```maxima playback(); ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:913
+#: ../../info/wxmaxima.md:945
 msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
 msgstr ""
 "## _WxMaxima_ meldet gleich beim Hochfahren \"Maxima hat sich beendet.\""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:915
+#: ../../info/wxmaxima.md:947
 msgid ""
 "One possible reason is that _Maxima_ cannot be found in the location that is "
 "set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore "
@@ -3567,12 +3674,12 @@ msgstr ""
 "angegebenen Pfades zum Programm löst dieses Problem."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:917
+#: ../../info/wxmaxima.md:949
 msgid "## Maxima is forever calculating and not responding to input"
 msgstr "## Maxima hört nicht auf zu rechnen und reagiert nicht auf Eingaben"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:919
+#: ../../info/wxmaxima.md:951
 msgid ""
 "It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ "
 "has finished calculating and therefore never gets informed it can send new "
@@ -3585,14 +3692,14 @@ msgstr ""
 "herstellen."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:921
+#: ../../info/wxmaxima.md:953
 msgid "## My SBCL-based _Maxima_ runs out of memory"
 msgstr ""
 "## _Maxima_ (mit SBCL compilliert) beschwert sich über einen Mangel an "
 "Speicher"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:923
+#: ../../info/wxmaxima.md:955
 #, fuzzy
 #| msgid ""
 #| "The Lisp compiler SBCL by default comes with a memory limit that allows "
@@ -3623,7 +3730,7 @@ msgstr ""
 "was notwendig ist um das Lapack-Paket zu compilieren."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:925
+#: ../../info/wxmaxima.md:957
 msgid ""
 "One way to provide _Maxima_ (and thus SBCL) with command line parameters is "
 "the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration "
@@ -3633,17 +3740,17 @@ msgstr ""
 "_wxMaxima_'s Konfigurationsdialog eingegeben werden."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:927
+#: ../../info/wxmaxima.md:959
 msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
 msgstr "![SBCL Speicherkonfiguration](./sbclMemory.png){ id=img_sbclMemory }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:929
+#: ../../info/wxmaxima.md:961
 msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
 msgstr "## Ubuntu: Die Tastatur ist langsam oder ignoriert einzelne Tasten"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:931
+#: ../../info/wxmaxima.md:963
 msgid ""
 "Installing the package `ibus-gtk` should resolve this issue. See ([https://"
 "bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://"
@@ -3655,14 +3762,14 @@ msgstr ""
 "genauere Angaben dazu."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:933
+#: ../../info/wxmaxima.md:965
 msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
 msgstr ""
 "## _WxMaxima_ stoppt, wenn _Maxima_ griechische Buchstaben oder Umlaute "
 "verarbeitet"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:935
+#: ../../info/wxmaxima.md:967
 msgid ""
 "If your _Maxima_ is based on SBCL the following lines have to be added to "
 "your `.sbclrc`:"
@@ -3671,14 +3778,14 @@ msgstr ""
 "zur `.sbclrc` hinzugefügt werden:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:971
 #, fuzzy
 #| msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
 msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
 msgstr "(setf sb-impl::*default-external-format* :utf-8)\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:941
+#: ../../info/wxmaxima.md:973
 msgid ""
 "The folder where this file has to be placed is system- and installation-"
 "specific. But any SBCL-based _Maxima_ that already has evaluated a cell in "
@@ -3690,60 +3797,92 @@ msgstr ""
 "Ort zu nennen:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:945
+#: ../../info/wxmaxima.md:977
 #, fuzzy
 #| msgid ":lisp (sb-impl::userinit-pathname)\n"
 msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
 msgstr ":lisp (sb-impl::userinit-pathname)\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:947
+#: ../../info/wxmaxima.md:979
 msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
 msgstr "## Anmerkung bezüglich Wayland (aktuelle Linux/BSD Distributionen)"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:950
+#: ../../info/wxmaxima.md:982
 msgid ""
 "There seem to be issues with the Wayland Display Server and wxWidgets.  "
 "WxMaxima may be affected, e.g. that sidebars are not moveable."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:954
+#: ../../info/wxmaxima.md:986
 msgid ""
 "You can either disable Wayland and use X11 instead (globally)  or just tell, "
 "that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:956
+#: ../../info/wxmaxima.md:988
 msgid "E.g. start wxMaxima with:"
 msgstr "z.B. Wxmaxima wie folgt starten:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:958
+#: ../../info/wxmaxima.md:990
 msgid "`GDK_BACKEND=x11 wxmaxima`"
 msgstr "`GDK_BACKEND=x11 wxmaxima`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:960
+#: ../../info/wxmaxima.md:992
+msgid "## The menu bar disappears on KDE Plasma"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:997
+msgid ""
+"On some KDE Plasma installations the global menu bar disappears when "
+"clicked.  As this is a bug in the global menu proxy, the only way to avoid "
+"it is to tell that wxMaxima should use its own menu bar instead of the "
+"global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1001
+msgid ""
+"Starting with version 26.05.0, wxMaxima attempts to set this variable "
+"automatically if it detects an affected system (KDE, Unity, or Ubuntu with "
+"older wxWidgets versions)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1003
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1005
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1007
 msgid "## Why is the integrated manual browser not offered on my Windows PC?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:963
+#: ../../info/wxmaxima.md:1010
 msgid ""
 "Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or "
 "Microsoft’s webview2 isn’t installed."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:965
+#: ../../info/wxmaxima.md:1012
 msgid "## Why is the external manual browser not working on my Linux box?"
 msgstr "## Warum funktioniert der externe Hilfebrowser nicht unter Linux?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:971
+#: ../../info/wxmaxima.md:1018
 msgid ""
 "The HTML browser might be a snap, flatpack or appimage version. All of these "
 "typically cannot access files that are installed on your local system. "
@@ -3754,14 +3893,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:973
+#: ../../info/wxmaxima.md:1020
 msgid ""
 "## Can I make _wxMaxima_ output both image files and embedded plots at once?"
 msgstr ""
 "### Kann _wxMaxima_ das eingebettete Diagramm gleich noch als Datei ausgeben?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:975
+#: ../../info/wxmaxima.md:1022
 msgid ""
 "The worksheet embeds `.png files. _WxMaxima_ allows the user to specify "
 "where they should be generated:"
@@ -3770,7 +3909,7 @@ msgstr ""
 "wo sie generiert werden sollen:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:982
+#: ../../info/wxmaxima.md:1029
 #, fuzzy, no-wrap
 #| msgid ""
 #| "~~~~\n"
@@ -3793,7 +3932,7 @@ msgstr ""
 ");\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:984
+#: ../../info/wxmaxima.md:1031
 msgid ""
 "If a different format is to be used, it is easier to generate the images and "
 "then import them into the worksheet again:"
@@ -3802,7 +3941,7 @@ msgstr ""
 "generieren und dann in das Arbeitsblatt zu importieren:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1003
+#: ../../info/wxmaxima.md:1050
 #, fuzzy, no-wrap
 #| msgid ""
 #| "~~~~\n"
@@ -3863,7 +4002,7 @@ msgstr ""
 "    pngdraw(name,gr2d(contents)\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1008
+#: ../../info/wxmaxima.md:1055
 #, fuzzy, no-wrap
 #| msgid ""
 #| "pngdraw2d(\"Test\",\n"
@@ -3882,17 +4021,17 @@ msgstr ""
 "~~~~\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1010
+#: ../../info/wxmaxima.md:1057
 msgid "## Can I set the aspect ratio of an embedded plot?"
 msgstr "Kann ich das Seitenverhältnis eines eingebetteten Plots angeben?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1012
+#: ../../info/wxmaxima.md:1059
 msgid "Use the variable `wxplot_size`:"
 msgstr "Verwenden Sie die Variable `wxplot_size`:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1018
+#: ../../info/wxmaxima.md:1065
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -3909,7 +4048,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1020
+#: ../../info/wxmaxima.md:1067
 msgid ""
 "## After upgrading to MacOS 13.1 plot and/or draw commands output error "
 "messages like"
@@ -3918,7 +4057,7 @@ msgstr ""
 "Fehlermeldungen aus, wie"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1027
+#: ../../info/wxmaxima.md:1074
 msgid ""
 "```text 1 HIToolbox 0x00007ff80cd91726 "
 "_ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox "
@@ -3927,7 +4066,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1029
+#: ../../info/wxmaxima.md:1076
 msgid ""
 "This might be an issue with the operating system. Disable the hiding of the "
 "menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the "
@@ -3936,12 +4075,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1031
+#: ../../info/wxmaxima.md:1078
 msgid "## Logging"
 msgstr "## Fehlerprotokollierung"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1035
+#: ../../info/wxmaxima.md:1082
 msgid ""
 "Log messages might be helpful to debug problems. WxMaxima can log many "
 "events. Most log entries will be helpful for developers, especially in case "
@@ -3952,7 +4091,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1037
+#: ../../info/wxmaxima.md:1084
 msgid ""
 "Messages are not 'lost', if the log window is not shown, if you select to "
 "show the log window later, you will see past log messages (if you did not "
@@ -3960,14 +4099,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1039
+#: ../../info/wxmaxima.md:1086
 msgid ""
 "Such messages may be helpful, when you create bug reports (or trying to find "
 "a bug by yourself)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1042
+#: ../../info/wxmaxima.md:1089
 msgid ""
 "Log messages can (additionally) be printed to STDERR, when using the command "
 "line option \"--logtostderr\". On Windows a separate text console will be "
@@ -3975,18 +4114,18 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1046
+#: ../../info/wxmaxima.md:1093
 msgid "# FAQ"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1048
+#: ../../info/wxmaxima.md:1095
 msgid "## Is there a way to make more text fit on a LaTeX page?"
 msgstr ""
 "## Gibt es eine Möglichkeit mehr Text auf eine LaTeX-Seite zu schreiben?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1050
+#: ../../info/wxmaxima.md:1097
 msgid ""
 "Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to "
 "specify the size of the borders."
@@ -3995,7 +4134,7 @@ msgstr ""
 "geometry) um die Größe der Ränder anzugeben."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1052
+#: ../../info/wxmaxima.md:1099
 msgid ""
 "You can add the following line to the LaTeX preamble (for example by using "
 "the respective field in the config dialogue (\"Export\"->\"Additional lines "
@@ -4007,7 +4146,7 @@ msgstr ""
 "zu setzen):"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1056
+#: ../../info/wxmaxima.md:1103
 #, fuzzy
 #| msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
 msgid ""
@@ -4015,12 +4154,12 @@ msgid ""
 msgstr "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1058
+#: ../../info/wxmaxima.md:1105
 msgid "## Is there a dark mode?"
 msgstr "## Gibt es einen Dark Mode?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1060
+#: ../../info/wxmaxima.md:1107
 #, fuzzy
 #| msgid ""
 #| "If wxWidgets is new enough _wxMaxima_ will automatically be in dark mode "
@@ -4044,14 +4183,14 @@ msgstr ""
 "und dunkel umzustellen."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1062
+#: ../../info/wxmaxima.md:1109
 msgid ""
 "## _WxMaxima_ sometimes hangs for several seconds once in the first minute"
 msgstr ""
 "## _WxMaxima_ hängt manchmal in der ersten Minute einmal für mehrere Sekunden"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1064
+#: ../../info/wxmaxima.md:1111
 msgid ""
 "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-"
 "manual to background tasks, which normally goes totally unnoticed. At the "
@@ -4066,7 +4205,7 @@ msgstr ""
 "beendet ist."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1066
+#: ../../info/wxmaxima.md:1113
 msgid ""
 "## Especially when testing new locale settings, a message box \"locale "
 "’xx_YY’ can not be set\" occurs"
@@ -4075,12 +4214,12 @@ msgstr ""
 "Nachrichtenbox \"locale 'xx_YY' can not be set\" angezeigt werden."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1068
+#: ../../info/wxmaxima.md:1115
 msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
 msgstr "![Locale Warnung](./locale-warning.png){ id=img_locale_warning}"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1072
+#: ../../info/wxmaxima.md:1119
 msgid ""
 "(The same problem can occur with other applications too). The translations "
 "seem okay after you click on ’OK’. WxMaxima does not only use its own "
@@ -4092,7 +4231,7 @@ msgstr ""
 "Übersetzungen des wxWidgets Frameworks."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1075
+#: ../../info/wxmaxima.md:1122
 msgid ""
 "These locales maybe not present in the system. On Ubuntu/Debian systems they "
 "can be generated using: `dpkg-reconfigure locales`"
@@ -4102,7 +4241,7 @@ msgstr ""
 "erzeugt werden."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1077
+#: ../../info/wxmaxima.md:1124
 msgid ""
 "## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
 msgstr ""
@@ -4110,7 +4249,7 @@ msgstr ""
 "verwenden?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1079
+#: ../../info/wxmaxima.md:1126
 msgid ""
 "You can find these symbols in the Unicode sidebar (search for ’double-struck "
 "capital’). But the selected font must also support these symbols. If they do "
@@ -4118,7 +4257,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1081
+#: ../../info/wxmaxima.md:1128
 msgid ""
 "## How can a Maxima script determine, if it is running under wxMaxima or "
 "command line Maxima?"
@@ -4127,7 +4266,7 @@ msgstr ""
 "Kommandozeilen-Maxima läuft?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1083
+#: ../../info/wxmaxima.md:1130
 msgid ""
 "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to "
 "`wxmaxima`. The Maxima variable `maxima_frontend_version` contains the "
@@ -4138,7 +4277,7 @@ msgstr ""
 "die wxMaxima-Version."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1085
+#: ../../info/wxmaxima.md:1132
 msgid ""
 "If no frontend is used (you are using command line Maxima), these variables "
 "are `false`."
@@ -4147,12 +4286,12 @@ msgstr ""
 "dann haben diese Variablen den Wert `false`)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1087
+#: ../../info/wxmaxima.md:1134
 msgid "## Help! I can not save my document!"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1089
+#: ../../info/wxmaxima.md:1136
 msgid ""
 "If saving as wxmx file does not work, try saving the document as wxm file "
 "(and vice versa). And you can also try to remove all output (Menu Cell-"
@@ -4161,12 +4300,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1093
+#: ../../info/wxmaxima.md:1140
 msgid "# Command-line arguments"
 msgstr "# Kommandozeilen-Optionen"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1095
+#: ../../info/wxmaxima.md:1142
 msgid ""
 "Usually you can start programs with a graphical user interface just by "
 "clicking on a desktop icon or desktop menu entry. WxMaxima - if started from "
@@ -4178,17 +4317,17 @@ msgstr ""
 "bietet doch einige Kommandozeilen-Optionen."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-v` or `--version`: Output the version information"
 msgstr "`-v` oder `--version`: Gibt die Versionsnummer aus"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-h` or `--help`: Output a short help text"
 msgstr "`-h` oder `--help`: Gibt einen kurzen Hilfetext aus"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid ""
 "`-o` or `--open=<str>`: Open the filename given as an argument to this "
 "command-line switch"
@@ -4197,12 +4336,12 @@ msgstr ""
 "Kommandozeilenoption angegeben wurde."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-e` or `--eval`: Evaluate the file after opening it."
 msgstr "`-e` oder `--eval`: Evaluiere die Datei nach dem Öffnen."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, fuzzy
 #| msgid ""
 #| "`-b` or `--batch`: If the command-line opens a file all cells in this "
@@ -4229,7 +4368,7 @@ msgstr ""
 "User weitergereicht."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, fuzzy, no-wrap
 #| msgid ""
 #| "* `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
@@ -4264,7 +4403,7 @@ msgstr ""
 "* `--enableipc`: Lässt Maxima wxMaxima über Interprozesskommunikation ansteuern. Diese Option vorsichtig verwenden.\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1113
+#: ../../info/wxmaxima.md:1160
 msgid ""
 "Instead of a minus, some operating systems might use a dash in front of the "
 "command-line switches."
@@ -4273,12 +4412,12 @@ msgstr ""
 "Schrägstrich statt eines Minuszeichens."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1117
+#: ../../info/wxmaxima.md:1164
 msgid "# About the program, contributing to wxMaxima"
 msgstr "# Über das Programm, zu wxMaxima beitragen"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1119
+#: ../../info/wxmaxima.md:1166
 msgid ""
 "wxMaxima is mainly developed using the programming language C++ using the "
 "[wxWidgets framework](https://www.wxwidgets.org), as build system we use "
@@ -4297,7 +4436,7 @@ msgstr ""
 "beitragen können."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1121
+#: ../../info/wxmaxima.md:1168
 msgid ""
 "But not only programmers are necessary! You can also contribute to wxMaxima, "
 "if you help to improve the documentation, find and report bugs (and maybe "
@@ -4314,12 +4453,12 @@ msgstr ""
 "übersetzen funktioniert."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1123
+#: ../../info/wxmaxima.md:1170
 msgid "Or answer questions of other users in the discussion forum."
 msgstr "Oder Fragen von anderen Benutzern im Diskussionsforum beantworten."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1125
+#: ../../info/wxmaxima.md:1172
 msgid ""
 "The source code of wxMaxima is documented using Doxygen [here](https://"
 "wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
@@ -4328,7 +4467,7 @@ msgstr ""
 "developers.github.io/wxmaxima/Doxygen-documentation/) dokumentiert."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1127
+#: ../../info/wxmaxima.md:1174
 msgid ""
 "The program is nearly self-contained, so except for system libraries (and "
 "the wxWidgets library), no external dependencies (like graphic files or the "
@@ -4341,7 +4480,7 @@ msgstr ""
 "Dateien sind alle in wxMaxima eingebaut."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1128
+#: ../../info/wxmaxima.md:1175
 #, fuzzy
 #| msgid ""
 #| "If you are a developer, you might want to try out a modified "
@@ -4523,9 +4662,6 @@ msgstr ""
 
 #~ msgid "a title, section or a subsection."
 #~ msgstr "Eine Überschrift"
-
-#~ msgid "One Example:"
-#~ msgstr "Ein Beispiel:"
 
 #~ msgid ""
 #~ "A .mac file named Quadratic.mac was created. It consists of two commands: "

--- a/locales/manual/es.po
+++ b/locales/manual/es.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: wxmaxima 20.12.2 manual\n"
-"POT-Creation-Date: 2026-05-20 10:30+0200\n"
+"POT-Creation-Date: 2026-07-30 11:38+0200\n"
 "PO-Revision-Date: 2024-08-27 11:15+0200\n"
 "Last-Translator: Fco. Javier F. Serrador <serrador@proton.me>\n"
 "Language-Team: Spanish\n"
@@ -43,9 +43,9 @@ msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 msgstr "![Logotipo wxMaxima](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:426
-#: ../../info/wxmaxima.md:848 ../../info/wxmaxima.md:1043
-#: ../../info/wxmaxima.md:1090 ../../info/wxmaxima.md:1114
+#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:425
+#: ../../info/wxmaxima.md:880 ../../info/wxmaxima.md:1090
+#: ../../info/wxmaxima.md:1137 ../../info/wxmaxima.md:1161
 #, no-wrap
 msgid "______________________________________________________________________\n"
 msgstr "______________________________________________________________________\n"
@@ -993,12 +993,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:224
+#: ../../info/wxmaxima.md:223
 msgid "### Side Panes"
 msgstr "### Paneles Laterales"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:226
+#: ../../info/wxmaxima.md:225
 msgid ""
 "Shortcuts to the most important _Maxima_ commands, things like a table of "
 "contents, windows with debug messages or a history of the last issued "
@@ -1016,14 +1016,14 @@ msgstr ""
 "introducir letras griegas utilizando el ratón."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:228
+#: ../../info/wxmaxima.md:227
 msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
 msgstr ""
 "![Ejemplo de diferentes paneles laterales](./SidePanes.png)"
 "{ id=img_SidePanes }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:231
+#: ../../info/wxmaxima.md:230
 msgid ""
 "In the \"table of contents\" side pane, one can increase or decrease a "
 "heading by just clicking on the heading with the right mouse button and "
@@ -1035,7 +1035,7 @@ msgstr ""
 "bajo."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:233
+#: ../../info/wxmaxima.md:232
 msgid ""
 "![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-"
 "headings.png){ id=Sidepane-TOC-convert-headings }"
@@ -1044,12 +1044,12 @@ msgstr ""
 "TOC-convert-headings.png){ id=Sidepane-TOC-convert-headings }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:235
+#: ../../info/wxmaxima.md:234
 msgid "### MathML output"
 msgstr "### Salida MathML"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:237
+#: ../../info/wxmaxima.md:236
 msgid ""
 "Several word processors and similar programs either recognize [MathML]"
 "(https://www.w3.org/Math/) input and automatically insert it as an editable "
@@ -1066,12 +1066,12 @@ msgstr ""
 "del menú."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:239
+#: ../../info/wxmaxima.md:238
 msgid "### Markdown support"
 msgstr "### Asistente Markdown"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:241
+#: ../../info/wxmaxima.md:240
 msgid ""
 "_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/wiki/"
 "Markdown) conventions that don’t collide with mathematical notation. One of "
@@ -1082,7 +1082,7 @@ msgstr ""
 "matemática.  Una vez que estos elementos son listados de puntos."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:251
+#: ../../info/wxmaxima.md:250
 #, no-wrap
 msgid ""
 "```text\n"
@@ -1106,23 +1106,23 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:253
+#: ../../info/wxmaxima.md:252
 msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
 msgstr ""
 "_WxMaxima_ reconocerá texto iniciando con los caracteres `>` como "
 "entrecomillado de bloque:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:261
+#: ../../info/wxmaxima.md:260
 msgid ""
 "```text Ordinary text > quote quote quote quote > quote quote quote quote > "
 "quote quote quote quote Ordinary text ```"
 msgstr ""
-"```text Texto ordinario > comilla comilla comilla > comilla comilla comilla > "
-"comilla comilla comilla Texto ordinario ```"
+"```text Texto ordinario > comilla comilla comilla > comilla comilla comilla "
+"> comilla comilla comilla Texto ordinario ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:263
+#: ../../info/wxmaxima.md:262
 msgid ""
 "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by "
 "the corresponding Unicode sign:"
@@ -1131,12 +1131,12 @@ msgstr ""
 "reemplazarán por el signo correspondiente de Unicode:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:267
+#: ../../info/wxmaxima.md:266
 msgid "```text cogito => sum.  ```"
 msgstr "```text cogito => sum.  ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:269
+#: ../../info/wxmaxima.md:268
 msgid ""
 "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for "
 "comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<-"
@@ -1149,12 +1149,12 @@ msgstr ""
 "TeX además son reconocidos `<<` y `>>`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:271
+#: ../../info/wxmaxima.md:270
 msgid "### Hotkeys"
 msgstr "### Teclas rápidas"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:273
+#: ../../info/wxmaxima.md:272
 msgid ""
 "Most hotkeys can be found in the text of the respective menus. Since they "
 "are actually taken from the menu text and thus can be customized by the "
@@ -1170,14 +1170,14 @@ msgstr ""
 "están documentadas dentro de los menús:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 msgid ""
 "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
 msgstr ""
 "<kbd>CTRL</kbd>+<kbd>MAYÚS</kbd>+<kbd>SUPR</kbd> borra una celda completa."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 #, fuzzy
 #| msgid ""
 #| "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete "
@@ -1189,17 +1189,17 @@ msgstr ""
 "<kbd>CTRL</kbd>+<kbd>MAYÚS</kbd>+<kbd>SUPR</kbd> borra una celda completa."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
 msgstr "<kbd>MAYÚS</kbd>+<kbd>ESPACIO</kbd> introduce un espacio sin ruptura."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:279
+#: ../../info/wxmaxima.md:278
 msgid "### Raw TeX in the TeX export"
 msgstr "## TeX crudo dentro de la exportación TeX"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:281
+#: ../../info/wxmaxima.md:280
 msgid ""
 "If a text cell begins with `TeX:` the TeX export contains the literal text "
 "that follows the `TeX:` marker. Using this feature allows the entry of TeX "
@@ -1210,12 +1210,12 @@ msgstr ""
 "característica permite al apunte del marcado TeX sin el cuaderno _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:283
+#: ../../info/wxmaxima.md:282
 msgid "## File Formats"
 msgstr "## Formatos de Archivos"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:285
+#: ../../info/wxmaxima.md:284
 msgid ""
 "The material that is developed in a _wxMaxima_ session can be stored for "
 "later use in any of three ways:"
@@ -1224,12 +1224,12 @@ msgstr ""
 "un posterior uso en cualquiera de estas tras maneras:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:287
+#: ../../info/wxmaxima.md:286
 msgid "### .mac"
 msgstr "### .mac"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:289
+#: ../../info/wxmaxima.md:288
 msgid ""
 "`.mac` files are ordinary text files that contain _Maxima_ commands. They "
 "can be read using _Maxima_’s `batch()` or `load()` command or _wxMaxima_’s "
@@ -1241,7 +1241,7 @@ msgstr ""
 "«Archivo/Menú de archivo guion» de _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:292
+#: ../../info/wxmaxima.md:291
 msgid ""
 "One example is shown below. `Quadratic.mac` defines a function and afterward "
 "generates a plot with `wxdraw2d()`.  Afterward the contents of the file "
@@ -1253,13 +1253,13 @@ msgstr ""
 "nueva definida es evaluada."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:294
+#: ../../info/wxmaxima.md:293
 msgid "![Loading a file with `batch()`](./BatchImage.png){ id=img_BatchImage }"
 msgstr ""
 "![Cargando un archivo con `batch()`](./BatchImage.png){ id=img_BatchImage }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:296
+#: ../../info/wxmaxima.md:295
 #, fuzzy
 #| msgid ""
 #| "Attention: Although the file `Quadratic.mac` has a usual _Maxima_ "
@@ -1276,7 +1276,7 @@ msgstr ""
 "instrucción `wxdraw2d()` es una extensión de wxMaxima para _Maxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:298
+#: ../../info/wxmaxima.md:297
 msgid ""
 "You can be use `.mac` files for writing your own library of macros. But "
 "since they don’t contain enough structural information they cannot be read "
@@ -1287,12 +1287,12 @@ msgstr ""
 "pueden releer como una sesión _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:300
+#: ../../info/wxmaxima.md:299
 msgid "### .wxm"
 msgstr "### .wxm"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:303
+#: ../../info/wxmaxima.md:302
 #, fuzzy
 #| msgid ""
 #| "`.wxm` files contain the worksheet except for _Maxima_’s output. On "
@@ -1317,7 +1317,7 @@ msgstr ""
 "versiones más antiguas de _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:305
+#: ../../info/wxmaxima.md:304
 #, fuzzy
 #| msgid ""
 #| "`.wxm` files contain the worksheet except for _Maxima_’s output. On "
@@ -1338,12 +1338,12 @@ msgstr ""
 "versiones más antiguas de _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:307
+#: ../../info/wxmaxima.md:306
 msgid "#### File format of wxm files"
 msgstr "#### Formato de archivo de archivos wxm"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:309
+#: ../../info/wxmaxima.md:308
 msgid ""
 "This is just a plain text file (you can open it with a text editor), "
 "containing the cell contents as some special Maxima comments."
@@ -1353,21 +1353,22 @@ msgstr ""
 "especial."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:311
+#: ../../info/wxmaxima.md:310
 msgid "It starts with the following comment:"
 msgstr "Comienza con el siguiente comentario:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:316
+#: ../../info/wxmaxima.md:315
 msgid ""
 "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* "
 "[ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
 msgstr ""
-"```maxima /* [archivo de guion wxMaxima versión 1] [ ¡NO LO EDITE A MANO! ]*/ /* "
-"[ Creado con wxMaxima versión 24.02.2_DevelopmentSnapshot ] */ ```"
+"```maxima /* [archivo de guion wxMaxima versión 1] [ ¡NO LO EDITE A "
+"MANO! ]*/ /* [ Creado con wxMaxima versión 24.02.2_DevelopmentSnapshot ] */ "
+"```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:318
+#: ../../info/wxmaxima.md:317
 msgid ""
 "And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
 msgstr ""
@@ -1375,7 +1376,7 @@ msgstr ""
 "p.ej., una celda de sección:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:324
+#: ../../info/wxmaxima.md:323
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1391,7 +1392,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:326
+#: ../../info/wxmaxima.md:325
 msgid ""
 "or (in a Math cell the input is of course *not* commented out (the output is "
 "not saved in a `wxm` file)):"
@@ -1400,7 +1401,7 @@ msgstr ""
 "(la salida no es guardada en un archivo `wxm`)):"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:333
+#: ../../info/wxmaxima.md:332
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1418,7 +1419,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:335
+#: ../../info/wxmaxima.md:334
 msgid ""
 "Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the "
 "image type as first line):"
@@ -1427,7 +1428,7 @@ msgstr ""
 "con el tipo de imagen como primera línea):"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:342
+#: ../../info/wxmaxima.md:341
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1445,12 +1446,12 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:344
+#: ../../info/wxmaxima.md:343
 msgid "A page break is just one line containing:"
 msgstr "Un salto de página es tan solo una línea conteniendo:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:348
+#: ../../info/wxmaxima.md:347
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1462,12 +1463,12 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:350
+#: ../../info/wxmaxima.md:349
 msgid "And folded cells marked by:"
 msgstr "Y las celdas encarpetadas marcadas por:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:356
+#: ../../info/wxmaxima.md:355
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1483,12 +1484,12 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:358
+#: ../../info/wxmaxima.md:357
 msgid "### .wxmx"
 msgstr "### .wxmx"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:360
+#: ../../info/wxmaxima.md:359
 msgid ""
 "This XML-based file format saves the complete worksheet including things "
 "like the zoom factor and the watchlist. It is the preferred file format."
@@ -1498,12 +1499,12 @@ msgstr ""
 "el formato de archivo preferido."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:362
+#: ../../info/wxmaxima.md:361
 msgid "#### File format of wxmx files"
 msgstr "#### Formato de archivo de archivos wxm"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:365
+#: ../../info/wxmaxima.md:364
 msgid ""
 "A `wxmx`-file seems to be a binary format, but one can handle it with tools, "
 "which are included in your OS. It is a zip file, one can decompress it with "
@@ -1515,41 +1516,41 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:367
+#: ../../info/wxmaxima.md:366
 #, fuzzy
 #| msgid "It starts with the following comment:"
 msgid "It does contain the following files:"
 msgstr "Comienza con el siguiente comentario:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-"
 "wxmathml`"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`format.txt`: a short description about wxMaxima and the wxmx file format"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima "
 "session and included images."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`content.xml`: a XML document, which contains the various cells of your "
 "document in XML format."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:374
+#: ../../info/wxmaxima.md:373
 msgid ""
 "So, if something goes wrong, you can unzip a wxMaxima document (maybe rename "
 "it before to a `zip`-file), maybe make changes in the `content.xml` file "
@@ -1559,12 +1560,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:376
+#: ../../info/wxmaxima.md:375
 msgid "## Configuration options"
 msgstr "## Opciones de configuración"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:378
+#: ../../info/wxmaxima.md:377
 msgid ""
 "For some common configuration variables _wxMaxima_ offers two ways of "
 "configuring:"
@@ -1573,7 +1574,7 @@ msgstr ""
 "maneras de configurarlas:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
+#: ../../info/wxmaxima.md:380
 msgid ""
 "The configuration dialog box below lets you change their default values for "
 "the current and subsequent sessions."
@@ -1582,7 +1583,7 @@ msgstr ""
 "valores predeterminados para las sesiones actuales y subsecuentes."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
+#: ../../info/wxmaxima.md:380
 #, fuzzy
 #| msgid ""
 #| "- The configuration dialog box below lets you change their default values "
@@ -1601,7 +1602,7 @@ msgstr ""
 "trabajo, tal como muestra a continuación."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:383
+#: ../../info/wxmaxima.md:382
 msgid ""
 "![wxMaxima configuration 1](./wxMaxima_configuration_001.png)"
 "{ id=img_wxMaxima_configuration_001 }"
@@ -1610,12 +1611,12 @@ msgstr ""
 "{ id=img_wxMaxima_configuration_001 }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:385
+#: ../../info/wxmaxima.md:384
 msgid "### Default animation framerate"
 msgstr "### Velocidad de cuadros de animación predeterminada"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:387
+#: ../../info/wxmaxima.md:386
 msgid ""
 "The animation framerate that is used for new animations is kept in the "
 "variable `wxanimate_framerate`. The initial value this variable will contain "
@@ -1627,12 +1628,12 @@ msgstr ""
 "modificada utilizando el diálogo de configuración."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:389
+#: ../../info/wxmaxima.md:388
 msgid "### Default plot size for new _maxima_ sessions"
 msgstr "### Tamaño de trama predet. para sesiones _maxima_ nuevas"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:391
+#: ../../info/wxmaxima.md:390
 msgid ""
 "After the next start, plots embedded into the worksheet will be created with "
 "this size if the value of `wxplot_size` isn’t changed by _maxima_."
@@ -1642,7 +1643,7 @@ msgstr ""
 "_maxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:393
+#: ../../info/wxmaxima.md:392
 msgid ""
 "In order to set the plot size of a single graph only use the following "
 "notation can be used that sets a variable’s value for one command only:"
@@ -1652,7 +1653,7 @@ msgstr ""
 "valor de variable solamente para una sola instrucción:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:402
+#: ../../info/wxmaxima.md:401
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1674,17 +1675,17 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:404
+#: ../../info/wxmaxima.md:403
 msgid "### Match parenthesis in text controls"
 msgstr "### Coincide paréntesis en controles de texto"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:406
+#: ../../info/wxmaxima.md:405
 msgid "This option enables two things:"
 msgstr "Esta opción habilita dos cosas:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
+#: ../../info/wxmaxima.md:408
 #, fuzzy
 #| msgid ""
 #| "- If an opening parenthesis, bracket, or double quote is entered "
@@ -1701,7 +1702,7 @@ msgstr ""
 "entre los signos coincidentes."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
+#: ../../info/wxmaxima.md:408
 msgid ""
 "If text is selected if any of these keys is pressed the selected text will "
 "be put between the matched signs."
@@ -1710,12 +1711,12 @@ msgstr ""
 "texto seleccionado será puedes entre los signos coincidan."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:411
+#: ../../info/wxmaxima.md:410
 msgid "### Don’t save the worksheet automatically"
 msgstr "### No guardar automáticamente la hoja de trabajo"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:413
+#: ../../info/wxmaxima.md:412
 msgid ""
 "If this option is set, the file where the worksheet is will be overwritten "
 "only the request of the user. In case of a crash/power loss/... a recent "
@@ -1727,7 +1728,7 @@ msgstr ""
 "dentro del directorio temporal ‘temp’."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:415
+#: ../../info/wxmaxima.md:414
 msgid ""
 "If this option isn’t set _wxMaxima_ behaves more like a modern cellphone app:"
 msgstr ""
@@ -1735,12 +1736,12 @@ msgstr ""
 "telefónica moderna:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
+#: ../../info/wxmaxima.md:417
 msgid "Files are saved automatically on exit"
 msgstr "Ficheros son guardados automáticamente al salir"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
+#: ../../info/wxmaxima.md:417
 #, fuzzy
 #| msgid ""
 #| "- Files are saved automatically on exit - And the file will automatically "
@@ -1751,12 +1752,12 @@ msgstr ""
 "auto-guardado cada 3 minutos."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:420
+#: ../../info/wxmaxima.md:419
 msgid "### Where is the configuration saved?"
 msgstr "### ¿Donde está la configuración guardada?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:423
+#: ../../info/wxmaxima.md:422
 msgid ""
 "If you are using Unix/Linux, the configuration information will be saved in "
 "a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< "
@@ -1778,7 +1779,7 @@ msgstr ""
 "punto, `.wxmaxima` o `.config` estarán ocultos)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:425
+#: ../../info/wxmaxima.md:424
 msgid ""
 "If you are using Windows, the configuration will be stored in the registry. "
 "You will find the entries for _wxMaxima_ at the following position in the "
@@ -1790,12 +1791,12 @@ msgstr ""
 "`HKEY_CURRENT_USER\\Software\\wxMaxima`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:429
+#: ../../info/wxmaxima.md:428
 msgid "# Extensions to _Maxima_"
 msgstr "# Extensiones para _Maxima_"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:431
+#: ../../info/wxmaxima.md:430
 msgid ""
 "_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
 "its main purpose is to pass along commands to _Maxima_ and to report the "
@@ -1814,12 +1815,12 @@ msgstr ""
 "_wxMaxima_ mejora la inclusión de gráficos dentro de una sesión."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:433
+#: ../../info/wxmaxima.md:432
 msgid "## Subscripted variables"
 msgstr "## Variables subescritas"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:435
+#: ../../info/wxmaxima.md:434
 msgid ""
 "`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript "
 "variable names:"
@@ -1828,7 +1829,7 @@ msgstr ""
 "nombres de variable:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:437
+#: ../../info/wxmaxima.md:436
 msgid ""
 "If it is `false`, the functionality is off, wxMaxima will not autosubscript "
 "part of variable names after an underscore."
@@ -1837,14 +1838,14 @@ msgstr ""
 "parte de nombres de variable tras un subrayado."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:439
+#: ../../info/wxmaxima.md:438
 msgid ""
 "If it is set to `'all`, everything after an underscore will be subscripted."
 msgstr ""
 "Si está fijado a `all`, todo será escrito debajo tras un guion bajo (_)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:441
+#: ../../info/wxmaxima.md:440
 msgid ""
 "If it is set to `true` variable names of the format `x_y` are displayed "
 "using a subscript if"
@@ -1853,14 +1854,14 @@ msgstr ""
 "`x_y` están representados utilizando un subguion ‘if’"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
+#: ../../info/wxmaxima.md:443
 #, fuzzy
 #| msgid "`y` is a single letter"
 msgid "Either `x` or `y` is a single letter or"
 msgstr "‘y’ es una letra única"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
+#: ../../info/wxmaxima.md:443
 #, fuzzy
 #| msgid ""
 #| "- Either `x` or `y` is a single letter or - `y` is an integer (can "
@@ -1871,7 +1872,7 @@ msgstr ""
 "incluir más de un carácter)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:446
+#: ../../info/wxmaxima.md:445
 msgid ""
 "![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png)"
 "{ id=img_wxsubscripts }"
@@ -1880,7 +1881,7 @@ msgstr ""
 "wxsubscripts.png){ id=img_wxsubscripts }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:448
+#: ../../info/wxmaxima.md:447
 msgid ""
 "If the variable name doesn’t match these requirements, it can still be "
 "declared as \"to be subscripted\" using the command "
@@ -1897,17 +1898,17 @@ msgstr ""
 "siguiente: `wxdeclare_subscript(nombre_variable,false);`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:450
+#: ../../info/wxmaxima.md:449
 msgid "You can use the menu \"View->Autosubscript\" to set these values."
 msgstr "Puede utilizar el menú «Vista→Auto-subguion» para fijar estos valores."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:452
+#: ../../info/wxmaxima.md:451
 msgid "## User feedback in the status bar"
 msgstr "## Comentario del usuario en la barra de estado"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:454
+#: ../../info/wxmaxima.md:453
 msgid ""
 "Long-running commands can provide user feedback in the status bar. This user "
 "feedback is replaced by any new feedback that is placed there (allowing to "
@@ -1927,7 +1928,7 @@ msgstr ""
 "presente la instrucción `wxstatusbar()` será tan solo dejada sin evaluar."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:465
+#: ../../info/wxmaxima.md:464
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1953,12 +1954,89 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:467
+#: ../../info/wxmaxima.md:466
+msgid "## Exporting the worksheet from within Maxima"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:468
+msgid ""
+"The command `wxworksheettohtml()` exports the current worksheet to an HTML "
+"file from within a running _Maxima_ session, which is convenient for "
+"scripted or batch export. Like `wxstatusbar()` it is safe to use in code "
+"that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present "
+"the command is simply left unevaluated."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:473
+msgid ""
+"```maxima wxworksheettohtml(\"report.html\")$ "
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:475
+msgid ""
+"A relative file name is interpreted relative to _Maxima_’s working "
+"directory. The optional keyword options are:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:480
+#, no-wrap
+msgid ""
+"| option   | values                                          | meaning                                             |\n"
+"| -------- | ----------------------------------------------- | --------------------------------------------------- |\n"
+"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |\n"
+"| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:482
+msgid ""
+"The `flavor` values match the equation formats offered by the graphical "
+"**File → Export** dialog: `mathml` produces a self-contained page that needs "
+"no internet connection, `mathjax` adds a MathJaX fall-back for browsers that "
+"still lack MathML, and `svg`/`bitmap` render every equation to an image."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:484
+msgid ""
+"The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file "
+"the same way:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:489
+msgid ""
+"```maxima wxworksheettotex(\"report.tex\")$ wxworksheettotex(\"report.tex\", "
+"documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:494
+#, no-wrap
+msgid ""
+"| option                 | meaning                                                              |\n"
+"| ---------------------- | -------------------------------------------------------------------- |\n"
+"| `documentclass`        | overrides the LaTeX `\\documentclass` (e.g. `\"article\"`, `\"report\"`)  |\n"
+"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:496
+msgid "Support for `wxworksheettopdf()` is planned."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:498
 msgid "## Plotting"
 msgstr "## Tramar"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:469
+#: ../../info/wxmaxima.md:500
 msgid ""
 "Plotting (having fundamentally to do with graphics) is a place where a "
 "graphical user interface will have to provide some extensions to the "
@@ -1969,12 +2047,12 @@ msgstr ""
 "para el programa original."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:471
+#: ../../info/wxmaxima.md:502
 msgid "### Embedding a plot into the worksheet"
 msgstr "### Empotrar una trama dentro de la hoja de trabajo"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:473
+#: ../../info/wxmaxima.md:504
 msgid ""
 "_Maxima_ normally instructs the external program _Gnuplot_ to open a "
 "separate window for every diagram it creates. Since many times it is "
@@ -1990,12 +2068,12 @@ msgstr ""
 "todo está prefijado por un “wx”."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:475
+#: ../../info/wxmaxima.md:506
 msgid "The following plotting functions have wx-counterparts:"
 msgstr "Las siguientes funciones de tramado tienen contrapartes wx:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:489
+#: ../../info/wxmaxima.md:520
 #, no-wrap
 msgid ""
 "| wxMaxima’s plot function | Maxima’s plot function                                                                          |\n"
@@ -2027,7 +2105,7 @@ msgstr ""
 "| `wxboxplot()`            | [boxplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#boxplot)             |\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:491
+#: ../../info/wxmaxima.md:522
 msgid ""
 "If a `wxm`-file is read by (console) Maxima, these functions are ignored "
 "(and printed as output, as other unknown functions in Maxima)."
@@ -2037,7 +2115,7 @@ msgstr ""
 "Maxima)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:493
+#: ../../info/wxmaxima.md:524
 msgid ""
 "If you got problems with one of these functions, please check, if the "
 "problem exists in the the Maxima function too (e.g. you got an error with "
@@ -2049,12 +2127,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:495
+#: ../../info/wxmaxima.md:526
 msgid "### Making embedded plots bigger or smaller"
 msgstr "### Creación de tramas empotradas más mayores o menores"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:497
+#: ../../info/wxmaxima.md:528
 msgid ""
 "As noted above, the configure dialog provides a way to change the default "
 "size plots created which sets the starting value of `wxplot_size`. The "
@@ -2069,7 +2147,7 @@ msgstr ""
 "ser solicitado o utilizado para fijar el tamaño de las tramas siguientes:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:507
+#: ../../info/wxmaxima.md:538
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2093,7 +2171,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:509
+#: ../../info/wxmaxima.md:540
 msgid ""
 "If the size of only one plot is to be changed _Maxima_ provides a canonical "
 "way to change an attribute only for the current cell. In this usage the "
@@ -2107,7 +2185,7 @@ msgstr ""
 "instrucción `wxdraw2d`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:518
+#: ../../info/wxmaxima.md:549
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2129,7 +2207,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:520
+#: ../../info/wxmaxima.md:551
 msgid ""
 "Setting the size of embedded plot with `wxplot_size` works for embedded "
 "plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` "
@@ -2142,12 +2220,12 @@ msgstr ""
 "instrucciones `with_slider_draw` y `wxanimate`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:522
+#: ../../info/wxmaxima.md:553
 msgid "### Better quality plots"
 msgstr "## Tramas de mayor calidad"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:524
+#: ../../info/wxmaxima.md:555
 msgid ""
 "_Gnuplot_ doesn’t seem to provide a portable way of determining whether it "
 "supports the high-quality bitmap output that the Cairo library provides. On "
@@ -2167,12 +2245,12 @@ msgstr ""
 "gráficos."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:526
+#: ../../info/wxmaxima.md:557
 msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
 msgstr "### Abriendo tramados empotrados en ventanas _Gnuplot_ interactivas"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:528
+#: ../../info/wxmaxima.md:559
 msgid ""
 "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
 "`wxplot3d` isn’t supported by this feature) and the file size of the "
@@ -2186,12 +2264,12 @@ msgstr ""
 "permita abrir el tramado dentro de una ventana interactiva de _Gnuplot_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:530
+#: ../../info/wxmaxima.md:561
 msgid "### Opening Gnuplot’s command console in `plot` windows"
 msgstr "### Abrir consola para instrucciones Gnuplot en las ventanas `tramado`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:533
+#: ../../info/wxmaxima.md:564
 #, fuzzy
 #| msgid ""
 #| "On MS Windows, if in _Maxima_’s variable `gnuplot_command` \"gnuplot\" is "
@@ -2215,12 +2293,12 @@ msgstr ""
 "tiempo mientras se prepara un tramado."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:535
+#: ../../info/wxmaxima.md:566
 msgid "### Embedding animations into the spreadsheet"
 msgstr "### Empotrar animaciones dentro de la hoja de cálculo"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:537
+#: ../../info/wxmaxima.md:568
 msgid ""
 "3D diagrams tend to make it hard to read quantitative data. A viable "
 "alternative might be to assign the 3rd parameter to the mouse wheel. The "
@@ -2236,7 +2314,7 @@ msgstr ""
 "animado."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:539
+#: ../../info/wxmaxima.md:570
 msgid ""
 "The first two arguments for `with_slider_draw` are the name of the variable "
 "that is stepped between the plots and a list of the values of these "
@@ -2249,7 +2327,7 @@ msgstr ""
 "para `wxdraw2d`:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:550
+#: ../../info/wxmaxima.md:581
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2275,7 +2353,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:552
+#: ../../info/wxmaxima.md:583
 msgid ""
 "The same functionality for 3D plots is accessible as `with_slider_draw3d`, "
 "which allows for rotating 3d plots:"
@@ -2284,7 +2362,7 @@ msgstr ""
 "‘with_slider:draw3d’, el cual permite rotación en tramas de 3D:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:569
+#: ../../info/wxmaxima.md:600
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2322,7 +2400,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:571
+#: ../../info/wxmaxima.md:602
 msgid ""
 "If the general shape of the plot is what matters it might suffice to move "
 "the plot just a little bit in order to make its 3D nature available to the "
@@ -2333,7 +2411,7 @@ msgstr ""
 "intuición:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:588
+#: ../../info/wxmaxima.md:619
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2371,7 +2449,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:590
+#: ../../info/wxmaxima.md:621
 msgid ""
 "For those more familiar with `plot` than with `draw`, there is a second set "
 "of functions:"
@@ -2380,19 +2458,19 @@ msgstr ""
 "conjunto de funciones:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
+#: ../../info/wxmaxima.md:624
 #, fuzzy
 #| msgid "- `with_slider` and - `wxanimate`."
 msgid "`with_slider` and"
 msgstr "- `with_slider` y - `wxanimate`."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
+#: ../../info/wxmaxima.md:624
 msgid "`wxanimate`."
 msgstr "`wxanimate`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:595
+#: ../../info/wxmaxima.md:626
 msgid ""
 "Normally the animations are played back or exported with the frame rate "
 "chosen in the configuration of _wxMaxima_. To set the speed at an individual "
@@ -2404,7 +2482,7 @@ msgstr ""
 "`wxanimate_framerate` puede utilizarse:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:600
+#: ../../info/wxmaxima.md:631
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2418,7 +2496,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:602
+#: ../../info/wxmaxima.md:633
 msgid ""
 "The animation functions use _Maxima_’s `makelist` command and therefore "
 "share the pitfall that the slider variable’s value is substituted into the "
@@ -2432,7 +2510,7 @@ msgstr ""
 "fallará:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:612
+#: ../../info/wxmaxima.md:643
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2456,7 +2534,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:614
+#: ../../info/wxmaxima.md:645
 msgid ""
 "If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
 "works fine instead:"
@@ -2465,7 +2543,7 @@ msgstr ""
 "deslizante funciona bien en su lugar:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:627
+#: ../../info/wxmaxima.md:658
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2495,12 +2573,12 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:629
+#: ../../info/wxmaxima.md:660
 msgid "### Opening multiple plots in contemporaneous windows"
 msgstr "### Abrir múltiples tramas en ventanas contemporáneas"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:631
+#: ../../info/wxmaxima.md:662
 msgid ""
 "While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups "
 "that support it) sometimes comes in handily. The following example comes "
@@ -2512,7 +2590,7 @@ msgstr ""
 "Rodríguez al listado de correo de _Maxima_:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:634
+#: ../../info/wxmaxima.md:665
 #, fuzzy
 #| msgid ""
 #| "```maxima\n"
@@ -2523,7 +2601,7 @@ msgstr ""
 "    load(dibujo);\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:637
+#: ../../info/wxmaxima.md:668
 #, fuzzy
 #| msgid ""
 #| "    /* Parabola in window #1 */\n"
@@ -2535,7 +2613,7 @@ msgstr ""
 "    draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:640
+#: ../../info/wxmaxima.md:671
 #, fuzzy
 #| msgid ""
 #| "    /* Parabola in window #2 */\n"
@@ -2547,7 +2625,7 @@ msgstr ""
 "    draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:644
+#: ../../info/wxmaxima.md:675
 #, fuzzy
 #| msgid ""
 #| "    /* Paraboloid in window #3 */\n"
@@ -2562,14 +2640,14 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:646
+#: ../../info/wxmaxima.md:677
 msgid ""
 "Plotting multiple plots in the same window is possible, too (the same is "
 "possible in command line Maxima with the standard `draw()` command):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:657
+#: ../../info/wxmaxima.md:688
 #, fuzzy, no-wrap
 #| msgid ""
 #| "```maxima\n"
@@ -2606,12 +2684,12 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:659
+#: ../../info/wxmaxima.md:690
 msgid "### The \"Plot using draw\" side pane"
 msgstr "### El panel lateral «Tramado utilizando dibujo»"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:661
+#: ../../info/wxmaxima.md:692
 msgid ""
 "The \"Plot using draw\" sidebar hides a simple code generator that allows "
 "generating scenes that make use of some of the flexibility of the _draw_ "
@@ -2622,12 +2700,12 @@ msgstr ""
 "flexibilidad del paquete _draw_ con el que _maxima_ viene."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:663
+#: ../../info/wxmaxima.md:694
 msgid "#### 2D"
 msgstr "#### 2D"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:665
+#: ../../info/wxmaxima.md:696
 msgid ""
 "Generates the skeleton of a `draw()` command that draws a 2D scene. This "
 "scene later has to be filled with commands that generate the scene’s "
@@ -2640,7 +2718,7 @@ msgstr ""
 "las filas debajo del botón \"2D\"."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:667
+#: ../../info/wxmaxima.md:698
 msgid ""
 "One helpful feature of the 2D button is that it allows to set up the scene "
 "as an animation in which a variable (by default it is _t_) has a different "
@@ -2654,12 +2732,12 @@ msgstr ""
 "movimiento 3D."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:669
+#: ../../info/wxmaxima.md:700
 msgid "#### 3D"
 msgstr "#### 3D"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:671
+#: ../../info/wxmaxima.md:702
 msgid ""
 "Generates the skeleton of a `draw()` command that draws a 3D scene. If "
 "neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D "
@@ -2670,12 +2748,12 @@ msgstr ""
 "configuran una escena 2D que contenga la instrucción que el botón genera."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:673
+#: ../../info/wxmaxima.md:704
 msgid "#### Expression"
 msgstr "#### Expresión"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:675
+#: ../../info/wxmaxima.md:706
 msgid ""
 "Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or "
 "`x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is "
@@ -2688,12 +2766,12 @@ msgstr ""
 "generada.  Cada escena puede ser completada con cualquier número de tramas."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:677
+#: ../../info/wxmaxima.md:708
 msgid "#### Implicit plot"
 msgstr "#### Tramado implícito"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:679
+#: ../../info/wxmaxima.md:710
 msgid ""
 "Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or "
 "`x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command "
@@ -2706,12 +2784,12 @@ msgstr ""
 "hay instrucción de dibujo en escena de 2D con el trama es generado."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:681
+#: ../../info/wxmaxima.md:712
 msgid "#### Parametric plot"
 msgstr "#### Trama paramétrica"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:683
+#: ../../info/wxmaxima.md:714
 msgid ""
 "Steps a variable from a lower limit to an upper limit and uses two "
 "expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in "
@@ -2724,12 +2802,12 @@ msgstr ""
 "dentro de la instrucción de actual del dibujo."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:685
+#: ../../info/wxmaxima.md:716
 msgid "#### Points"
 msgstr "#### Puntos"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:687
+#: ../../info/wxmaxima.md:718
 msgid ""
 "Draws many points that can optionally be joined. The coordinates of the "
 "points are taken from a list of lists, a 2D array or one list or array for "
@@ -2740,34 +2818,34 @@ msgstr ""
 "listado o unimatriz por cada eje."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:689
+#: ../../info/wxmaxima.md:720
 msgid "#### Diagram title"
 msgstr "#### Título del diagrama"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:691
+#: ../../info/wxmaxima.md:722
 msgid "Draws a title on the upper end of the diagram,"
 msgstr "Dibuja un título sobre el final superior del diagrama,"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:693
+#: ../../info/wxmaxima.md:724
 #, fuzzy
 #| msgid "#### 2D"
 msgid "#### Axis"
 msgstr "#### 2D"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:695
+#: ../../info/wxmaxima.md:726
 msgid "Sets up the axis."
 msgstr "Establece los ejes."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:697
+#: ../../info/wxmaxima.md:728
 msgid "#### Contour"
 msgstr "#### Contorno"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:699
+#: ../../info/wxmaxima.md:730
 msgid ""
 "(Only for 3D plots): Adds contour lines similar to the ones one can find in "
 "a map of a mountain to the plot commands that follow in the current `draw()` "
@@ -2782,12 +2860,12 @@ msgstr ""
 "descartar el dibujo de las curvas completamente."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:701
+#: ../../info/wxmaxima.md:732
 msgid "#### Plot name"
 msgstr "#### Nombre de trama"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:703
+#: ../../info/wxmaxima.md:734
 msgid ""
 "Adds a legend entry showing the next plot’s name to the legend of the "
 "diagram. An empty name disables generating legend entries for the following "
@@ -2798,12 +2876,12 @@ msgstr ""
 "leyenda para las tramas siguientes."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:705
+#: ../../info/wxmaxima.md:736
 msgid "#### Line colour"
 msgstr "#### Color de línea"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:707
+#: ../../info/wxmaxima.md:738
 msgid ""
 "Sets the line colour for the following plots the current draw command "
 "contains."
@@ -2812,12 +2890,12 @@ msgstr ""
 "instrucción de dibujo actual."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:709
+#: ../../info/wxmaxima.md:740
 msgid "#### Fill colour"
 msgstr "#### Color de relleno"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:711
+#: ../../info/wxmaxima.md:742
 msgid ""
 "Sets the fill colour for the following plots the current draw command "
 "contains."
@@ -2826,24 +2904,24 @@ msgstr ""
 "instrucción de dibujo actual."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:713
+#: ../../info/wxmaxima.md:744
 #, fuzzy
 #| msgid "#### 2D"
 msgid "#### Grid"
 msgstr "#### 2D"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:715
+#: ../../info/wxmaxima.md:746
 msgid "Pops up a wizard that allows to set up grid lines."
 msgstr "Aparece un asistente que permite establecer las líneas de rejilla."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:717
+#: ../../info/wxmaxima.md:748
 msgid "#### Accuracy"
 msgstr "#### Precisión"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:719
+#: ../../info/wxmaxima.md:750
 msgid ""
 "Allows to select an adequate point in the speed vs. accuracy tradeoff that "
 "is part of any plot program."
@@ -2852,12 +2930,12 @@ msgstr ""
 "exactitud compensada que es parte de cualquier programa de trama."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:721
+#: ../../info/wxmaxima.md:752
 msgid "### Modify font and font size for plots"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:723
+#: ../../info/wxmaxima.md:754
 msgid ""
 "Especially when you use a high resolution display, the default font size "
 "might be very small. For the `draw`-based commands, you can set the font / "
@@ -2865,7 +2943,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:730
+#: ../../info/wxmaxima.md:761
 #, fuzzy, no-wrap
 #| msgid ""
 #| "pngdraw2d(\"Test\",\n"
@@ -2886,14 +2964,14 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:732
+#: ../../info/wxmaxima.md:763
 msgid ""
 "For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts "
 "can be set using the `gnuplot_preamble` command, e.g.:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:737
+#: ../../info/wxmaxima.md:768
 #, no-wrap
 msgid ""
 "~~~maxima\n"
@@ -2903,14 +2981,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:739
+#: ../../info/wxmaxima.md:770
 msgid ""
 "This sets the font for the numbers to Arial with size 30, the size for the "
 "xlabel and ylabel font to 20 (with the default font)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:742
+#: ../../info/wxmaxima.md:773
 msgid ""
 "Read the Maxima and Gnuplot documentation for further information.  Note: "
 "Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue "
@@ -2918,12 +2996,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:744
+#: ../../info/wxmaxima.md:775
 msgid "## Embedding graphics"
 msgstr "## Gráficos empotrados"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:746
+#: ../../info/wxmaxima.md:777
 msgid ""
 "If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
 "project can be done as easily as per drag-and-drop. But sometimes (for "
@@ -2937,17 +3015,17 @@ msgstr ""
 "archivo que cargue la imagen al evaluar:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:750
+#: ../../info/wxmaxima.md:781
 msgid "```maxima show_image(\"man.png\"); ```"
 msgstr "```maxima show_image(\"man.png\"); ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:752
+#: ../../info/wxmaxima.md:783
 msgid "## Startup files"
 msgstr "## Archivos de inicio"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:754
+#: ../../info/wxmaxima.md:785
 msgid ""
 "The config dialogue of _wxMaxima_ offers to edit two files with commands "
 "that are executed on startup:"
@@ -2956,7 +3034,7 @@ msgstr ""
 "instrucciones que son ejecutadas al inicializar:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
+#: ../../info/wxmaxima.md:788
 msgid ""
 "A file that contains commands that are executed on starting up _Maxima_: "
 "`maxima-init.mac`"
@@ -2965,7 +3043,7 @@ msgstr ""
 "_Maxima_: «maxima-init.mac»"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
+#: ../../info/wxmaxima.md:788
 #, fuzzy
 #| msgid ""
 #| "A file that contains commands that are executed on starting up _Maxima_: "
@@ -2978,7 +3056,7 @@ msgstr ""
 "_Maxima_: «maxima-init.mac»"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:759
+#: ../../info/wxmaxima.md:790
 msgid ""
 "For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add "
 "`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` "
@@ -2986,7 +3064,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:761
+#: ../../info/wxmaxima.md:792
 #, fuzzy
 #| msgid ""
 #| "These files are in the Maxima user directory (usually `maxima` in "
@@ -3004,12 +3082,12 @@ msgstr ""
 "la instrucción: `maxima_userdir;`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:763
+#: ../../info/wxmaxima.md:794
 msgid "## Special variables wx..."
 msgstr "## Variables especiales wx..."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxsubscripts` tells _Maxima_ if it should convert variable names that "
 "contain an underscore (`R_150` or the like) into subscripted variables. See "
@@ -3022,7 +3100,7 @@ msgstr ""
 "variables son convertidos automáticamente."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxfilename`: This variable contains the name of the file currently opened "
 "in _wxMaxima_."
@@ -3031,7 +3109,7 @@ msgstr ""
 "abierto en _wxMaxima_."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, fuzzy
 #| msgid ""
 #| "`wxfilename`: This variable contains the name of the file currently "
@@ -3044,7 +3122,7 @@ msgstr ""
 "abierto en _wxMaxima_."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, fuzzy
 #| msgid ""
 #| "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _gnuplot_’s "
@@ -3060,12 +3138,12 @@ msgstr ""
 "gráfica sobre todo."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxplot_size` defines the resolution of embedded plots."
 msgstr "`wxplot_size` define la resolución de tramas empotradas."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
 "_Maxima_’s working directory to the directory of the current file. This "
@@ -3083,7 +3161,7 @@ msgstr ""
 "`false` desde el dialogo de configuración."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxanimate_framerate`: The number of frames per second the following "
 "animations have to be played back with."
@@ -3092,29 +3170,29 @@ msgstr ""
 "animaciones con las que tienen que ser representadas."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxanimate_autoplay`: Automatically play animations by default?"
 msgstr ""
 "`wxanimate_autoplay`: Reproduce automáticamente animaciones "
 "predeterminadamente?"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:776
+#: ../../info/wxmaxima.md:807
 msgid "## Pretty-printing 2D output"
 msgstr "## Salida de 2D con impresión bonita"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:778
+#: ../../info/wxmaxima.md:809
 msgid ""
 "The function `table_form()` displays a 2D list in a form that is more "
 "readable than the output from _Maxima_’s default output routine. The input "
@@ -3131,7 +3209,7 @@ msgstr ""
 "con un enunciado \"done\"."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:787
+#: ../../info/wxmaxima.md:818
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -3153,7 +3231,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:789
+#: ../../info/wxmaxima.md:820
 msgid ""
 "As the next example shows, the lists that are assembled by the `table_form` "
 "command can be created before the command is executed."
@@ -3163,7 +3241,7 @@ msgstr ""
 "sea ejecutada."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:791
+#: ../../info/wxmaxima.md:822
 msgid ""
 "![A third table example](./MatrixTableExample.png)"
 "{ id=img_MatrixTableExample }"
@@ -3172,7 +3250,7 @@ msgstr ""
 "{ id=img_MatrixTableExample }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:793
+#: ../../info/wxmaxima.md:824
 msgid ""
 "Also, because a matrix is a list of lists, matrices can be converted to "
 "tables in a similar fashion."
@@ -3181,7 +3259,7 @@ msgstr ""
 "convertirse a tablas de una aparición similar."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:795
+#: ../../info/wxmaxima.md:826
 msgid ""
 "![Another table_form example](./SecondTableExample.png)"
 "{ id=img_SecondTableExample }"
@@ -3190,28 +3268,56 @@ msgstr ""
 "{ id=img_EjemploSegundaTabla }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:797
+#: ../../info/wxmaxima.md:828
 msgid ""
 "The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that "
 "allows for more flexible formatting of matrices in wxMaxima:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:803
+#: ../../info/wxmaxima.md:830
 #, no-wrap
+msgid "**`wx_matrix( <matrix>, [options] )`**\n"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
 msgid ""
-"**`wx_matrix( <matrix>, [options] )`**\n"
-"- **`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data.\n"
-"- **`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels.\n"
-"- **`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels.\n"
-"- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`.\n"
+"**`lines=true`**: Draws internal separator lines between the cells. This is "
+"required to visually separate headings from data."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`rownames=true`**: Tells wxMaxima that the first column of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`colnames=true`**: Tells wxMaxima that the first row of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
+"around the matrix. Supported styles are: `round` `()`, `square` `[]`, "
+"`angled` `<>`, `straight` `||`, or `none`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:809
+#: ../../info/wxmaxima.md:837
+msgid "Example:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:842
 #, no-wrap
 msgid ""
-"Example:\n"
 "```maxima\n"
 "wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
 "          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
@@ -3219,12 +3325,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:811
+#: ../../info/wxmaxima.md:844
 msgid "## Bug reporting"
 msgstr "## Comunicar fallo"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:813
+#: ../../info/wxmaxima.md:846
 msgid ""
 "_WxMaxima_ provides a few functions that gather bug reporting information "
 "about the current system:"
@@ -3233,7 +3339,7 @@ msgstr ""
 "comunicados de fallos acerca del sistema actual:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:816
+#: ../../info/wxmaxima.md:849
 #, fuzzy
 #| msgid ""
 #| "- `wxbuild_info()` gathers information about the currently running "
@@ -3247,17 +3353,17 @@ msgstr ""
 "archivos de fallos"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:816
+#: ../../info/wxmaxima.md:849
 msgid "`wxbug_report()` tells how and where to file bugs"
 msgstr "`wxbug_report()` informa cómo y donde archivar los gazapos"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:819
+#: ../../info/wxmaxima.md:851
 msgid "## Marking output being drawn in red"
 msgstr "## Marcar que la salida sea dibujada en rojo"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:822
+#: ../../info/wxmaxima.md:854
 msgid ""
 "_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a "
 "red foreground, if the second argument to the command is the text "
@@ -3268,17 +3374,17 @@ msgstr ""
 "`resaltado`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:824
+#: ../../info/wxmaxima.md:856
 msgid "## Output rendering."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:826
+#: ../../info/wxmaxima.md:858
 msgid "With `set_display()` one can set, how wxMaxima will render the output."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:828
+#: ../../info/wxmaxima.md:860
 msgid ""
 "`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima "
 "using an (machine readable) XML-dialect (can be seen in the \"Raw XML "
@@ -3287,7 +3393,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:831
+#: ../../info/wxmaxima.md:863
 msgid ""
 "<!--- Currently that does not work as it should, the line with the output "
 "label is shifted right (issue: #2006) --> `set_display('ascii)` causes "
@@ -3295,19 +3401,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:833
+#: ../../info/wxmaxima.md:865
 msgid ""
 "`set_display('none)` causes 'one-line' ASCII results - the same as the "
 "command line Maxima command `display2d:false;` does."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:867
 msgid "# Help menu"
 msgstr "# Menú de ayuda"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:837
+#: ../../info/wxmaxima.md:869
 msgid ""
 "WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, "
 "tips, some example worksheets and in command line Maxima included demos (the "
@@ -3318,12 +3424,12 @@ msgstr ""
 "instrucción de Maxima incluyó demos (la instrucción `demo()`)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:839
+#: ../../info/wxmaxima.md:871
 msgid "Please notice, that the demos write:"
 msgstr "Infórmese, que las demos escriben:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:843
+#: ../../info/wxmaxima.md:875
 msgid ""
 "~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the "
 "demonstration.  ~~~"
@@ -3332,7 +3438,7 @@ msgstr ""
 "demostración.  ~~~"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:845
+#: ../../info/wxmaxima.md:877
 msgid ""
 "That is valid for command-line Maxima, however in wxMaxima by default it is "
 "necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</"
@@ -3343,7 +3449,7 @@ msgstr ""
 "kbd>+<kbd>ENTRAR</kbd>"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:847
+#: ../../info/wxmaxima.md:879
 msgid ""
 "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending "
 "commands to Maxima\" menu.)"
@@ -3352,17 +3458,17 @@ msgstr ""
 "directas para enviar instrucciones a Maxima\".)"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:851
+#: ../../info/wxmaxima.md:883
 msgid "# Troubleshooting"
 msgstr "# Solución de problemas"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:853
+#: ../../info/wxmaxima.md:885
 msgid "## Cannot connect to _Maxima_"
 msgstr "## No se puede conectar a _Maxima_"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:855
+#: ../../info/wxmaxima.md:887
 msgid ""
 "Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ "
 "(providing the easy-to-use user interface) are separate programs that "
@@ -3391,7 +3497,7 @@ msgstr ""
 "sería sbcl, gcl, ccl, lisp.exe o nombres similares."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:857
+#: ../../info/wxmaxima.md:889
 msgid ""
 "On Unix computers another possible reason would be that the loopback network "
 "that provides network connections between two programs in the same computer "
@@ -3402,12 +3508,12 @@ msgstr ""
 "mismo equipo no está configurado apropiadamente."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:859
+#: ../../info/wxmaxima.md:891
 msgid "## How to save data from a broken .wxmx file"
 msgstr "## Cómo guardar datos desde un archivo .wxmx defectuoso"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:861
+#: ../../info/wxmaxima.md:893
 msgid ""
 "Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ "
 "doesn’t turn on compression, so the contents of `.wxmx` files can be viewed "
@@ -3418,7 +3524,7 @@ msgstr ""
 "los archivos `.wxmx` pueden verse en cualquier editor de texto."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:863
+#: ../../info/wxmaxima.md:895
 msgid ""
 "If the zip signature at the end of the file is still intact after renaming a "
 "broken `.wxmx` file to `.zip` most operating systems will provide a way to "
@@ -3438,7 +3544,7 @@ msgstr ""
 "erróneo habrá un archivo `.wxmx~` cuyo contenido quizá ayude."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:865
+#: ../../info/wxmaxima.md:897
 msgid ""
 "And even if there isn’t such a file: The `.wxmx` file is a container format "
 "and the XML portion is stored uncompressed. It it is possible to rename the "
@@ -3456,7 +3562,7 @@ msgstr ""
 "binario no legible dentro del editor del texto)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:867
+#: ../../info/wxmaxima.md:899
 msgid ""
 "If a text file containing only these contents (e.g. copy and paste this text "
 "into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know "
@@ -3468,7 +3574,7 @@ msgstr ""
 "documento."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:869
+#: ../../info/wxmaxima.md:901
 msgid ""
 "## I want some debug info to be displayed on the screen before my command "
 "has finished"
@@ -3477,7 +3583,7 @@ msgstr ""
 "pantalla antes de que mi instrucción haya finalizado"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:871
+#: ../../info/wxmaxima.md:903
 msgid ""
 "Normally _wxMaxima_ waits for the whole 2D formula to be transferred before "
 "it begins to typeset. This saves time for making many attempts to typeset a "
@@ -3493,7 +3599,7 @@ msgstr ""
 "instrucción de _Maxima_ finalice:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:881
+#: ../../info/wxmaxima.md:913
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -3517,20 +3623,20 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:883
+#: ../../info/wxmaxima.md:915
 msgid "Alternatively one can look for the `wxstatusbar()` command above."
 msgstr ""
 "Alternativamente uno puede buscar la instrucción `wxstatusbar()` arriba."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:885
+#: ../../info/wxmaxima.md:917
 msgid "## Plotting only shows a closed empty envelope with an error message"
 msgstr ""
 "## El tramado solamente muestra una cobertura de sobre vacío cerrado con un "
 "mensaje de error"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:887
+#: ../../info/wxmaxima.md:919
 msgid ""
 "This means that _wxMaxima_ could not read the file _Maxima_ that was "
 "supposed to instruct _Gnuplot_ to create."
@@ -3539,12 +3645,12 @@ msgstr ""
 "proporcionado a la instrucción _Gnuplot_ para crear."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:889
+#: ../../info/wxmaxima.md:921
 msgid "Possible reasons for this error are:"
 msgstr "Las posibles razones de este error son:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 msgid ""
 "The plotting command is part of a third-party package like `implicit_plot` "
 "but this package was not loaded by _Maxima_’s `load()` command before trying "
@@ -3555,7 +3661,7 @@ msgstr ""
 "de _Maxima_ porque está intentando puntear."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 msgid ""
 "_Maxima_ tried to do something the currently installed version of _Gnuplot_ "
 "isn’t able to understand. In this case, a file ending in `.gnuplot` located "
@@ -3571,7 +3677,7 @@ msgstr ""
 "ayuda cuando se depura el problema."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 msgid ""
 "Gnuplot was instructed to use the pngCairo library that provides "
 "antialiasing and additional line styles, but it was not compiled to support "
@@ -3586,17 +3692,17 @@ msgstr ""
 "establezca `wxplot_pngcairo` a cierto desde _Maxima_."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 msgid "Gnuplot didn’t output a valid `.png` file."
 msgstr "Gnuplot no saca un fichero «.png» válido."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:896
+#: ../../info/wxmaxima.md:928
 msgid "## Plotting an animation results in “error: undefined variable”"
 msgstr "## Tramar una animación de resultados en «error: variable no definida»"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:898
+#: ../../info/wxmaxima.md:930
 msgid ""
 "The value of the slider variable by default is only substituted into the "
 "expression that is to be plotted if it is visible there. Using a `subst` "
@@ -3613,12 +3719,12 @@ msgstr ""
 "animations-into-the-spreadsheet), puede consultar un ejemplo."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:900
+#: ../../info/wxmaxima.md:932
 msgid "## I lost cell content and undo doesn’t remember"
 msgstr "## He perdido el contenido de una celda y al deshacer no lo recuerda"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:902
+#: ../../info/wxmaxima.md:934
 msgid ""
 "There are separate undo functions for cell operations and for changes inside "
 "of cells so chances are low that this ever happens. If it does there are "
@@ -3629,7 +3735,7 @@ msgstr ""
 "veces ocurran.  Si no hay varios métodos para cubrir datos:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid ""
 "_WxMaxima_ actually has two undo features: The global undo buffer that is "
 "active if no cell is selected and a per-cell undo buffer that is active if "
@@ -3643,7 +3749,7 @@ msgstr ""
 "anterior aún puede ser accedido."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid ""
 "If you still have a way to find out what label _Maxima_ has assigned to the "
 "cell just type in the cell’s label and its contents will reappear."
@@ -3653,7 +3759,7 @@ msgstr ""
 "contenidos aparecerán."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid ""
 "If you don’t: Don’t panic. In the “View” menu there is a way to show a "
 "history pane that shows all _Maxima_ commands that have been issued recently."
@@ -3663,23 +3769,23 @@ msgstr ""
 "emitidas recientemente."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid "If nothing else helps _Maxima_ contains a replay feature:"
 msgstr ""
 "Si nada más ayuda _Maxima_ contiene una característica de reproducción:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:911
+#: ../../info/wxmaxima.md:943
 msgid "```maxima playback(); ```"
 msgstr "```maxima playback(); ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:913
+#: ../../info/wxmaxima.md:945
 msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
 msgstr "## _WxMaxima_ arranca con el mensaje «Proceso de Maxima terminado.»"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:915
+#: ../../info/wxmaxima.md:947
 msgid ""
 "One possible reason is that _Maxima_ cannot be found in the location that is "
 "set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore "
@@ -3693,12 +3799,12 @@ msgstr ""
 "problema."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:917
+#: ../../info/wxmaxima.md:949
 msgid "## Maxima is forever calculating and not responding to input"
 msgstr "## ‘Maxima’ está calculando para siempre y no responde a la entrada"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:919
+#: ../../info/wxmaxima.md:951
 msgid ""
 "It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ "
 "has finished calculating and therefore never gets informed it can send new "
@@ -3711,12 +3817,12 @@ msgstr ""
 "los dos programas."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:921
+#: ../../info/wxmaxima.md:953
 msgid "## My SBCL-based _Maxima_ runs out of memory"
 msgstr "## Mi _Maxima_ basada en SBCL se ejecuta fuera de la memoria"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:923
+#: ../../info/wxmaxima.md:955
 msgid ""
 "The Lisp compiler SBCL by default comes with a memory limit that allows it "
 "to run even on low-end computers. When compiling a big software package like "
@@ -3739,7 +3845,7 @@ msgstr ""
 "megabytes compilando las necesidades Lapack."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:925
+#: ../../info/wxmaxima.md:957
 msgid ""
 "One way to provide _Maxima_ (and thus SBCL) with command line parameters is "
 "the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration "
@@ -3750,17 +3856,17 @@ msgstr ""
 "diálogo de configuración de _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:927
+#: ../../info/wxmaxima.md:959
 msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
 msgstr "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:929
+#: ../../info/wxmaxima.md:961
 msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
 msgstr "## Algunas veces las teclas de entrada son vagas/perezosas en Ubuntu"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:931
+#: ../../info/wxmaxima.md:963
 msgid ""
 "Installing the package `ibus-gtk` should resolve this issue. See ([https://"
 "bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://"
@@ -3772,13 +3878,13 @@ msgstr ""
 "los detalles."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:933
+#: ../../info/wxmaxima.md:965
 msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
 msgstr ""
 "## _WxMaxima_ se detiene cuando _Maxima_ procesa caracteres griegos o ümlaut"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:935
+#: ../../info/wxmaxima.md:967
 msgid ""
 "If your _Maxima_ is based on SBCL the following lines have to be added to "
 "your `.sbclrc`:"
@@ -3787,12 +3893,12 @@ msgstr ""
 "agregadas a su `.sbclrc`:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:971
 msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
 msgstr "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:941
+#: ../../info/wxmaxima.md:973
 msgid ""
 "The folder where this file has to be placed is system- and installation-"
 "specific. But any SBCL-based _Maxima_ that already has evaluated a cell in "
@@ -3805,17 +3911,17 @@ msgstr ""
 "encontrada tras obtener la instrucción siguiente:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:945
+#: ../../info/wxmaxima.md:977
 msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
 msgstr "```maxima :lisp (sb-impl::userinit-pathname)  ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:947
+#: ../../info/wxmaxima.md:979
 msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
 msgstr "## Nota concerniente a Wayland (distribuciones recientes de Linux/BSD)"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:950
+#: ../../info/wxmaxima.md:982
 msgid ""
 "There seem to be issues with the Wayland Display Server and wxWidgets.  "
 "WxMaxima may be affected, e.g. that sidebars are not moveable."
@@ -3824,7 +3930,7 @@ msgstr ""
 "WxMaxima puede ser afectado, p.ej. esas barras laterales no son movibles."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:954
+#: ../../info/wxmaxima.md:986
 msgid ""
 "You can either disable Wayland and use X11 instead (globally)  or just tell, "
 "that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
@@ -3834,23 +3940,55 @@ msgstr ""
 "`GDK_BACKEND=x11`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:956
+#: ../../info/wxmaxima.md:988
 msgid "E.g. start wxMaxima with:"
 msgstr "P.ej. inicia wxMaxima con:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:958
+#: ../../info/wxmaxima.md:990
 msgid "`GDK_BACKEND=x11 wxmaxima`"
 msgstr "`GDK_BACKEND=x11 wxmaxima`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:960
+#: ../../info/wxmaxima.md:992
+msgid "## The menu bar disappears on KDE Plasma"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:997
+msgid ""
+"On some KDE Plasma installations the global menu bar disappears when "
+"clicked.  As this is a bug in the global menu proxy, the only way to avoid "
+"it is to tell that wxMaxima should use its own menu bar instead of the "
+"global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1001
+msgid ""
+"Starting with version 26.05.0, wxMaxima attempts to set this variable "
+"automatically if it detects an affected system (KDE, Unity, or Ubuntu with "
+"older wxWidgets versions)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1003
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1005
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1007
 msgid "## Why is the integrated manual browser not offered on my Windows PC?"
 msgstr ""
 "### ¿Por qué no es ofrecido el explorador manual integrado en mi PC Windows?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:963
+#: ../../info/wxmaxima.md:1010
 msgid ""
 "Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or "
 "Microsoft’s webview2 isn’t installed."
@@ -3859,13 +3997,13 @@ msgstr ""
 "webview2 de Microsoft no está instalado."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:965
+#: ../../info/wxmaxima.md:1012
 msgid "## Why is the external manual browser not working on my Linux box?"
 msgstr ""
 "### ¿Por qué el explorador manual externo no funciona en mi caja Linux?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:971
+#: ../../info/wxmaxima.md:1018
 msgid ""
 "The HTML browser might be a snap, flatpack or appimage version. All of these "
 "typically cannot access files that are installed on your local system. "
@@ -3883,7 +4021,7 @@ msgstr ""
 "accedida."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:973
+#: ../../info/wxmaxima.md:1020
 msgid ""
 "## Can I make _wxMaxima_ output both image files and embedded plots at once?"
 msgstr ""
@@ -3891,7 +4029,7 @@ msgstr ""
 "tramas empotradas a la vez?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:975
+#: ../../info/wxmaxima.md:1022
 msgid ""
 "The worksheet embeds `.png files. _WxMaxima_ allows the user to specify "
 "where they should be generated:"
@@ -3900,7 +4038,7 @@ msgstr ""
 "especificar donde serían generados:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:982
+#: ../../info/wxmaxima.md:1029
 #, fuzzy, no-wrap
 #| msgid ""
 #| "```maxima\n"
@@ -3925,7 +4063,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:984
+#: ../../info/wxmaxima.md:1031
 msgid ""
 "If a different format is to be used, it is easier to generate the images and "
 "then import them into the worksheet again:"
@@ -3934,7 +4072,7 @@ msgstr ""
 "imágenes y después importarlas dentro de la hoja de trabajo de nuevo:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1003
+#: ../../info/wxmaxima.md:1050
 #, fuzzy, no-wrap
 #| msgid ""
 #| "```maxima\n"
@@ -3995,7 +4133,7 @@ msgstr ""
 "    pngdraw(name,gr2d(contents));\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1008
+#: ../../info/wxmaxima.md:1055
 #, fuzzy, no-wrap
 #| msgid ""
 #| "pngdraw2d(\"Test\",\n"
@@ -4014,17 +4152,17 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1010
+#: ../../info/wxmaxima.md:1057
 msgid "## Can I set the aspect ratio of an embedded plot?"
 msgstr "### ¿Se puede establecer la proporción de aspecto de una trama?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1012
+#: ../../info/wxmaxima.md:1059
 msgid "Use the variable `wxplot_size`:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1018
+#: ../../info/wxmaxima.md:1065
 #, fuzzy, no-wrap
 #| msgid ""
 #| "```maxima\n"
@@ -4048,7 +4186,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1020
+#: ../../info/wxmaxima.md:1067
 msgid ""
 "## After upgrading to MacOS 13.1 plot and/or draw commands output error "
 "messages like"
@@ -4057,7 +4195,7 @@ msgstr ""
 "instrucciones de trama y/o dibujos como"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1027
+#: ../../info/wxmaxima.md:1074
 #, fuzzy
 #| msgid ""
 #| "1 HIToolbox 0x00007ff80cd91726 "
@@ -4076,7 +4214,7 @@ msgstr ""
 "0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1029
+#: ../../info/wxmaxima.md:1076
 msgid ""
 "This might be an issue with the operating system. Disable the hiding of the "
 "menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the "
@@ -4089,12 +4227,12 @@ msgstr ""
 "wxMaxima-developers/wxmaxima/issues/1746) para más información."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1031
+#: ../../info/wxmaxima.md:1078
 msgid "## Logging"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1035
+#: ../../info/wxmaxima.md:1082
 msgid ""
 "Log messages might be helpful to debug problems. WxMaxima can log many "
 "events. Most log entries will be helpful for developers, especially in case "
@@ -4105,7 +4243,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1037
+#: ../../info/wxmaxima.md:1084
 msgid ""
 "Messages are not 'lost', if the log window is not shown, if you select to "
 "show the log window later, you will see past log messages (if you did not "
@@ -4113,14 +4251,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1039
+#: ../../info/wxmaxima.md:1086
 msgid ""
 "Such messages may be helpful, when you create bug reports (or trying to find "
 "a bug by yourself)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1042
+#: ../../info/wxmaxima.md:1089
 msgid ""
 "Log messages can (additionally) be printed to STDERR, when using the command "
 "line option \"--logtostderr\". On Windows a separate text console will be "
@@ -4128,17 +4266,17 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1046
+#: ../../info/wxmaxima.md:1093
 msgid "# FAQ"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1048
+#: ../../info/wxmaxima.md:1095
 msgid "## Is there a way to make more text fit on a LaTeX page?"
 msgstr "## ¿Hay una manera de crear más texto que quepa en una página LaTeX?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1050
+#: ../../info/wxmaxima.md:1097
 msgid ""
 "Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to "
 "specify the size of the borders."
@@ -4147,7 +4285,7 @@ msgstr ""
 "geometry) para especificar el tamaño de los bordes."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1052
+#: ../../info/wxmaxima.md:1099
 msgid ""
 "You can add the following line to the LaTeX preamble (for example by using "
 "the respective field in the config dialogue (\"Export\"->\"Additional lines "
@@ -4158,19 +4296,19 @@ msgstr ""
 "«Líneas adicionales para el preámbulo TeX»), para fijar bordes de 1cm):"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1056
+#: ../../info/wxmaxima.md:1103
 msgid ""
 "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
 msgstr ""
 "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1058
+#: ../../info/wxmaxima.md:1105
 msgid "## Is there a dark mode?"
 msgstr "## ¿Hay un modo oscuro?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1060
+#: ../../info/wxmaxima.md:1107
 msgid ""
 "If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if "
 "the rest of the operating system is. The worksheet itself is by default "
@@ -4186,7 +4324,7 @@ msgstr ""
 "rápidamente la hoja de trabajo desde oscuro a claro y viceversa."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1062
+#: ../../info/wxmaxima.md:1109
 msgid ""
 "## _WxMaxima_ sometimes hangs for several seconds once in the first minute"
 msgstr ""
@@ -4194,7 +4332,7 @@ msgstr ""
 "primer minuto"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1064
+#: ../../info/wxmaxima.md:1111
 msgid ""
 "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-"
 "manual to background tasks, which normally goes totally unnoticed. At the "
@@ -4208,7 +4346,7 @@ msgstr ""
 "antes de poder continuar su trabajo."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1066
+#: ../../info/wxmaxima.md:1113
 msgid ""
 "## Especially when testing new locale settings, a message box \"locale "
 "’xx_YY’ can not be set\" occurs"
@@ -4217,12 +4355,12 @@ msgstr ""
 "con el mensaje \"locale ’xx_YY’ no puede ser fijada\""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1068
+#: ../../info/wxmaxima.md:1115
 msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
 msgstr "![Aviso local](./locale-warning.png){ id=img_locale_warning}"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1072
+#: ../../info/wxmaxima.md:1119
 msgid ""
 "(The same problem can occur with other applications too). The translations "
 "seem okay after you click on ’OK’. WxMaxima does not only use its own "
@@ -4234,7 +4372,7 @@ msgstr ""
 "trabajo de wxWidgets."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1075
+#: ../../info/wxmaxima.md:1122
 msgid ""
 "These locales maybe not present in the system. On Ubuntu/Debian systems they "
 "can be generated using: `dpkg-reconfigure locales`"
@@ -4243,14 +4381,14 @@ msgstr ""
 "Debian pueden ser generados utilizando: `dpkg-reconfigure locales`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1077
+#: ../../info/wxmaxima.md:1124
 msgid ""
 "## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
 msgstr ""
 "## ¿Cómo puedo utilizar símbolos para números reales, naturales (ℝ, ℕ), etc.?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1079
+#: ../../info/wxmaxima.md:1126
 msgid ""
 "You can find these symbols in the Unicode sidebar (search for ’double-struck "
 "capital’). But the selected font must also support these symbols. If they do "
@@ -4261,7 +4399,7 @@ msgstr ""
 "símbolos. Si no representan apropiadamente, seleccione otra tipografía."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1081
+#: ../../info/wxmaxima.md:1128
 msgid ""
 "## How can a Maxima script determine, if it is running under wxMaxima or "
 "command line Maxima?"
@@ -4270,7 +4408,7 @@ msgstr ""
 "wxMaxima o línea de instrucción de Maxima?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1083
+#: ../../info/wxmaxima.md:1130
 msgid ""
 "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to "
 "`wxmaxima`. The Maxima variable `maxima_frontend_version` contains the "
@@ -4281,7 +4419,7 @@ msgstr ""
 "versión de wxMaxima en este caso."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1085
+#: ../../info/wxmaxima.md:1132
 msgid ""
 "If no frontend is used (you are using command line Maxima), these variables "
 "are `false`."
@@ -4290,12 +4428,12 @@ msgstr ""
 "instrucción), estas variables son falsas."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1087
+#: ../../info/wxmaxima.md:1134
 msgid "## Help! I can not save my document!"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1089
+#: ../../info/wxmaxima.md:1136
 msgid ""
 "If saving as wxmx file does not work, try saving the document as wxm file "
 "(and vice versa). And you can also try to remove all output (Menu Cell-"
@@ -4304,12 +4442,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1093
+#: ../../info/wxmaxima.md:1140
 msgid "# Command-line arguments"
 msgstr "# Argumentos de línea de instrucción"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1095
+#: ../../info/wxmaxima.md:1142
 msgid ""
 "Usually you can start programs with a graphical user interface just by "
 "clicking on a desktop icon or desktop menu entry. WxMaxima - if started from "
@@ -4321,17 +4459,17 @@ msgstr ""
 "interruptores en línea de instrucción, sin embargo."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-v` or `--version`: Output the version information"
 msgstr "‘-v’ o ‘--version’: extrae la información de la versión"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-h` or `--help`: Output a short help text"
 msgstr "‘-h’ o ‘--help’: extrae un texto breve de ayuda"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid ""
 "`-o` or `--open=<str>`: Open the filename given as an argument to this "
 "command-line switch"
@@ -4340,12 +4478,12 @@ msgstr ""
 "argumento a este interruptor de línea de instrucción"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-e` or `--eval`: Evaluate the file after opening it."
 msgstr "‘-e’ o ‘--eval’: evalúa el archivo tras abrirlo."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid ""
 "`-b` or `--batch`: If the command-line opens a file all cells in this file "
 "are evaluated and the file is saved afterward. This is for example useful if "
@@ -4365,7 +4503,7 @@ msgstr ""
 "ser garantizado completamente."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, no-wrap
 msgid ""
 "- `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
@@ -4396,7 +4534,7 @@ msgstr ""
 "                                     mayormente para desarrolladores).\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1113
+#: ../../info/wxmaxima.md:1160
 msgid ""
 "Instead of a minus, some operating systems might use a dash in front of the "
 "command-line switches."
@@ -4405,12 +4543,12 @@ msgstr ""
 "breve al frente de los conmutadores de línea de instrucciones."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1117
+#: ../../info/wxmaxima.md:1164
 msgid "# About the program, contributing to wxMaxima"
 msgstr "# Sobre el programa, contribuyendo a wxMaxima"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1119
+#: ../../info/wxmaxima.md:1166
 msgid ""
 "wxMaxima is mainly developed using the programming language C++ using the "
 "[wxWidgets framework](https://www.wxwidgets.org), as build system we use "
@@ -4429,7 +4567,7 @@ msgstr ""
 "contribuir al proyecto de software libre de wxMaxima."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1121
+#: ../../info/wxmaxima.md:1168
 msgid ""
 "But not only programmers are necessary! You can also contribute to wxMaxima, "
 "if you help to improve the documentation, find and report bugs (and maybe "
@@ -4446,12 +4584,12 @@ msgstr ""
 "tree/main/locales) como wxMaxima y el manual puede ser traducido)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1123
+#: ../../info/wxmaxima.md:1170
 msgid "Or answer questions of other users in the discussion forum."
 msgstr "O responda preguntas de otros usuarios en el foro de debate."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1125
+#: ../../info/wxmaxima.md:1172
 msgid ""
 "The source code of wxMaxima is documented using Doxygen [here](https://"
 "wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
@@ -4460,7 +4598,7 @@ msgstr ""
 "(https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1127
+#: ../../info/wxmaxima.md:1174
 msgid ""
 "The program is nearly self-contained, so except for system libraries (and "
 "the wxWidgets library), no external dependencies (like graphic files or the "
@@ -4473,7 +4611,7 @@ msgstr ""
 "incluyen estos archivos dentro del ejecutable."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1128
+#: ../../info/wxmaxima.md:1175
 msgid ""
 "If you are a developer, you might want to try out a modified `wxmathML.lisp`-"
 "file without recompiling everything, one can use the command line option `--"

--- a/locales/manual/fr.po
+++ b/locales/manual/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Traduction manuel de wxMaxima\n"
-"POT-Creation-Date: 2026-01-11 15:04+0100\n"
+"POT-Creation-Date: 2026-07-30 11:38+0200\n"
 "PO-Revision-Date: 2026-06-16 13:24+0200\n"
 "Last-Translator: Michel Gosse <michel.gosse@free.fr>\n"
 "Language-Team: \n"
@@ -11,147 +11,771 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-msgid ""
-"WxMaxima is a graphical user interface (GUI) for the _Maxima_ computer algebra system (CAS). WxMaxima allows one to use all of _Maxima_âs functions. In addition, it provides convenient wizards for accessing the most commonly used features. This manual describes some of the features that make wxMaxima "
-"one of the most popular GUIs for _Maxima_."
-msgstr ""
-"WxMaxima est une interface graphique (GUI) pour le système de calcul formel (CAS) _Maxima_.  WxMaxima permet d’utiliser toutes les fonctions de _Maxima_. De plus, il fournit des assistants pratiques pour accéder aux fonctionnalités les plus couramment utilisées. Ce manuel décrit certaines des "
-"caractéristiques qui font de wxMaxima l’une des interfaces graphiques les plus populaires pour _Maxima_."
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#. type: Plain text
+#: ../../info/wxmaxima.md:2
+msgid "# The wxMaxima user manual"
+msgstr "# Manuel de l'utilisateur de wxMaxima"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:4
+#, fuzzy
+#| msgid ""
+#| "WxMaxima is a graphical user interface (GUI) for the _Maxima_ computer "
+#| "algebra system (CAS). WxMaxima allows one to use all of _Maxima_âs "
+#| "functions. In addition, it provides convenient wizards for accessing the "
+#| "most commonly used features. This manual describes some of the features "
+#| "that make wxMaxima one of the most popular GUIs for _Maxima_."
 msgid ""
-"In the open-source domain, big systems are normally split into smaller projects that are easier to handle for small groups of developers. For example a CD burner program will consist of a command-line tool that actually burns the CD and a graphical user interface that allows users to implement it "
-"without having to learn about all the command line switches and in fact without using the command line at all. One advantage of this approach is that the developing work that was invested into the command-line program can be shared by many programs: The same CD-burner command-line program can be used "
-"as a âsend-to-CDâ-plug-in for a file manager application, for the âburn to CDâ function of a music player and as the CD writer for a DVD backup tool. Another advantage is that splitting one big task into smaller parts allows the developers to provide several user interfaces for the same program."
+"WxMaxima is a graphical user interface (GUI) for the _Maxima_ computer "
+"algebra system (CAS). WxMaxima allows one to use all of _Maxima_’s "
+"functions. In addition, it provides convenient wizards for accessing the "
+"most commonly used features. This manual describes some of the features that "
+"make wxMaxima one of the most popular GUIs for _Maxima_."
 msgstr ""
-"Dans le domaine open-source, les grands systèmes sont généralement divisés en projets plus petits, plus faciles à gérer pour de petits groupes de développeurs. Par exemple, un programme de gravure de CD peut se composer d’un outil en ligne de commande qui effectue réellement la gravure du CD, et "
-"d’une interface graphique permettant aux utilisateurs de l’utiliser sans avoir à apprendre toutes les options de la ligne de commande, voire sans jamais y recourir. Un avantage de cette méthode est que le travail de développement réalisé dans le programme en ligne de commande peut être partagé par de "
-"nombreuses applications : le même programme de gravure en ligne de commande peut servir de module \"Envoyer vers un CD\",  pour un gestionnaire de fichiers, de fonction \"Graver sur CD\" pour un lecteur multimédia, ou encore de graveur de CD pour un outil de sauvegarde sur DVD. Un autre avantage est "
-"que la division d’une tâche complexe en parties plus réduites permet aux développeurs de proposer plusieurs interfaces utilisateur pour un même programme."
+"WxMaxima est une interface graphique (GUI) pour le système de calcul formel "
+"(CAS) _Maxima_.  WxMaxima permet d’utiliser toutes les fonctions de "
+"_Maxima_. De plus, il fournit des assistants pratiques pour accéder aux "
+"fonctionnalités les plus couramment utilisées. Ce manuel décrit certaines "
+"des caractéristiques qui font de wxMaxima l’une des interfaces graphiques "
+"les plus populaires pour _Maxima_."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:6
+msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
+msgstr "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:425
+#: ../../info/wxmaxima.md:880 ../../info/wxmaxima.md:1090
+#: ../../info/wxmaxima.md:1137 ../../info/wxmaxima.md:1161
+#, no-wrap
+msgid "______________________________________________________________________\n"
+msgstr "______________________________________________________________________\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:10
+msgid "# Introduction to wxMaxima"
+msgstr "# Présentation de wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:12
+msgid "## _Maxima_ and wxMaxima"
+msgstr "## _Maxima_ et wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:14
+#, fuzzy
+#| msgid ""
+#| "In the open-source domain, big systems are normally split into smaller "
+#| "projects that are easier to handle for small groups of developers. For "
+#| "example a CD burner program will consist of a command-line tool that "
+#| "actually burns the CD and a graphical user interface that allows users to "
+#| "implement it without having to learn about all the command line switches "
+#| "and in fact without using the command line at all. One advantage of this "
+#| "approach is that the developing work that was invested into the command-"
+#| "line program can be shared by many programs: The same CD-burner command-"
+#| "line program can be used as a âsend-to-CDâ-plug-in for a file manager "
+#| "application, for the âburn to CDâ function of a music player and as the "
+#| "CD writer for a DVD backup tool. Another advantage is that splitting one "
+#| "big task into smaller parts allows the developers to provide several user "
+#| "interfaces for the same program."
 msgid ""
-"A computer algebra system (CAS) like _Maxima_ fits into this framework. A CAS can provide the logic behind an arbitrary precision calculator application or it can do automatic transforms of formulas in the background of a bigger system (e.g., [Sage](https://www.sagemath.org/)). Alternatively, it can "
-"be used directly as a free-standing system. _Maxima_ can be accessed via a command line. Often, however, an interface like _wxMaxima_ proves a more efficient way to access the software, especially for newcomers."
+"In the open-source domain, big systems are normally split into smaller "
+"projects that are easier to handle for small groups of developers. For "
+"example a CD burner program will consist of a command-line tool that "
+"actually burns the CD and a graphical user interface that allows users to "
+"implement it without having to learn about all the command line switches and "
+"in fact without using the command line at all. One advantage of this "
+"approach is that the developing work that was invested into the command-line "
+"program can be shared by many programs: The same CD-burner command-line "
+"program can be used as a “send-to-CD”-plug-in for a file manager "
+"application, for the “burn to CD” function of a music player and as the CD "
+"writer for a DVD backup tool. Another advantage is that splitting one big "
+"task into smaller parts allows the developers to provide several user "
+"interfaces for the same program."
 msgstr ""
-"Un système de calcul formel (CAS) comme _Maxima_ s'intègre dans ce cadre. Un CAS peut fournir la logique derrière une application de type calculatrice à précision arbitraire ou effectuer des transformations automatiques de formules en arrière-plan d'un système plus large (par exemple, [Sage](https://"
-"www.sagemath.org/)). Alternativement, il peut être utilisé directement comme un logiciel autonome. _Maxima_ peut être accessible via une ligne de commande. Cependant, une interface comme _wxMaxima_ s'avère souvent un moyen plus efficace d'accéder au logiciel, surtout pour les nouveaux utilisateurs."
+"Dans le domaine open-source, les grands systèmes sont généralement divisés "
+"en projets plus petits, plus faciles à gérer pour de petits groupes de "
+"développeurs. Par exemple, un programme de gravure de CD peut se composer "
+"d’un outil en ligne de commande qui effectue réellement la gravure du CD, et "
+"d’une interface graphique permettant aux utilisateurs de l’utiliser sans "
+"avoir à apprendre toutes les options de la ligne de commande, voire sans "
+"jamais y recourir. Un avantage de cette méthode est que le travail de "
+"développement réalisé dans le programme en ligne de commande peut être "
+"partagé par de nombreuses applications : le même programme de gravure en "
+"ligne de commande peut servir de module \"Envoyer vers un CD\",  pour un "
+"gestionnaire de fichiers, de fonction \"Graver sur CD\" pour un lecteur "
+"multimédia, ou encore de graveur de CD pour un outil de sauvegarde sur DVD. "
+"Un autre avantage est que la division d’une tâche complexe en parties plus "
+"réduites permet aux développeurs de proposer plusieurs interfaces "
+"utilisateur pour un même programme."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:16
 msgid ""
-"_Maxima_ is a full-featured computer algebra system (CAS). A CAS is a program that can solve mathematical problems by rearranging formulas and finding a formula that solves the problem as opposed to just outputting the numeric value of the result. In other words, _Maxima_ can serve as a calculator "
-"that gives numerical representations of variables, and it can also provide analytical solutions. Furthermore, it offers a range of numerical methods of analysis for equations or systems of equations that cannot be solved analytically."
+"A computer algebra system (CAS) like _Maxima_ fits into this framework. A "
+"CAS can provide the logic behind an arbitrary precision calculator "
+"application or it can do automatic transforms of formulas in the background "
+"of a bigger system (e.g., [Sage](https://www.sagemath.org/)). Alternatively, "
+"it can be used directly as a free-standing system. _Maxima_ can be accessed "
+"via a command line. Often, however, an interface like _wxMaxima_ proves a "
+"more efficient way to access the software, especially for newcomers."
 msgstr ""
-"_Maxima_ est un système complet de calcul formel (CAS). Un CAS est un programme capable de résoudre des problèmes mathématiques en manipulant des formules et en retournant des expressions algébriques qui résolvent le problème, plutôt que de simplement fournir une valeur numérique du résultat. "
-"Autrement dit, _Maxima_ peut fonctionner comme une calculatrice qui donne  des valeurs numériques des variables, mais il peut aussi fournir des solutions analytiques formelles. De plus, il propose une gamme de méthodes numériques pour analyser des équations ou des systèmes d’équations qui ne peuvent "
-"pas être résolus de manière formelle."
+"Un système de calcul formel (CAS) comme _Maxima_ s'intègre dans ce cadre. Un "
+"CAS peut fournir la logique derrière une application de type calculatrice à "
+"précision arbitraire ou effectuer des transformations automatiques de "
+"formules en arrière-plan d'un système plus large (par exemple, [Sage]"
+"(https://www.sagemath.org/)). Alternativement, il peut être utilisé "
+"directement comme un logiciel autonome. _Maxima_ peut être accessible via "
+"une ligne de commande. Cependant, une interface comme _wxMaxima_ s'avère "
+"souvent un moyen plus efficace d'accéder au logiciel, surtout pour les "
+"nouveaux utilisateurs."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:18
+msgid "### _Maxima_"
+msgstr "### _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:20
 msgid ""
-"Extensive documentation for _Maxima_ is [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaximaâs help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_âs context-sensitive help feature "
-"to automatically jump to _Maxima_âs manual page for the command at the cursor."
+"_Maxima_ is a full-featured computer algebra system (CAS). A CAS is a "
+"program that can solve mathematical problems by rearranging formulas and "
+"finding a formula that solves the problem as opposed to just outputting the "
+"numeric value of the result. In other words, _Maxima_ can serve as a "
+"calculator that gives numerical representations of variables, and it can "
+"also provide analytical solutions. Furthermore, it offers a range of "
+"numerical methods of analysis for equations or systems of equations that "
+"cannot be solved analytically."
 msgstr ""
-"Une documentation complète pour _Maxima_ est [disponible en ligne](https://maxima.sourceforge.io/documentation.html). Une partie de cette documentation est également accessible via le menu d’aide de wxMaxima. En appuyant sur la touche d’aide (généralement la touche <kbd>F1</kbd> sur la plupart des "
-"systèmes), la fonction d’aide contextuelle de _wxMaxima_ ouvre automatiquement la page du manuel de _Maxima_ correspondant à la commande située sous le curseur."
+"_Maxima_ est un système complet de calcul formel (CAS). Un CAS est un "
+"programme capable de résoudre des problèmes mathématiques en manipulant des "
+"formules et en retournant des expressions algébriques qui résolvent le "
+"problème, plutôt que de simplement fournir une valeur numérique du résultat. "
+"Autrement dit, _Maxima_ peut fonctionner comme une calculatrice qui donne  "
+"des valeurs numériques des variables, mais il peut aussi fournir des "
+"solutions analytiques formelles. De plus, il propose une gamme de méthodes "
+"numériques pour analyser des équations ou des systèmes d’équations qui ne "
+"peuvent pas être résolus de manière formelle."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:22
 msgid ""
-"_WxMaxima_ is a graphical user interface that provides the full functionality and flexibility of _Maxima_. WxMaxima offers users a graphical display and many features that make working with _Maxima_ easier. For example _wxMaxima_ allows one to export any cellâs contents (or, if that is needed, any "
-"part of a formula, as well) as text, as LaTeX or as MathML specification at a simple right-click. Indeed, an entire workbook can be exported, either as a HTML file or as a LaTeX file. Documentation for _wxMaxima_, including workbooks to illustrate aspects of its use, is online at the _wxMaxima_ [help "
-"site](https://wxMaxima-developers.github.io/wxmaxima/help.html), as well as via the help menu."
+"![Maxima screenshot, command line](./maxima_screenshot.png)"
+"{ id=img_maxima_screenshot }"
 msgstr ""
-"_WxMaxima_ est une interface graphique qui offre toute les fonctionnalités et la flexibilité de _Maxima_. WxMaxima propose aux utilisateurs un affichage graphique ainsi que de nombreuses fonctionnalités qui facilitent l’utilisation de _Maxima_. Par exemple, _wxMaxima_ permet d’exporter le contenu de "
-"n’importe quelle cellule (ou, si nécessaire, une partie d’une formule) sous forme de texte, de code LaTeX ou de codage MathML, simplement en effectuant un clic droit. En outre, un notebook entier peut être exporté, soit en tant que fichier HTML, soit en tant que fichier LaTeX. La documentation de "
-"_wxMaxima_, incluant des notebooks d’exemples illustrant ses différentes fonctionnalités, est disponible en ligne sur le [site d’aide de wxMaxima](https://wxMaxima-developers.github.io/wxmaxima/help.html), ainsi que via le menu d’aide."
+"![Copie d'écran Maxima, ligne de commande](./maxima_screenshot.png)"
+"{ id=img_maxima_screenshot }"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:24
+#, fuzzy
+#| msgid ""
+#| "Extensive documentation for _Maxima_ is [available in the internet]"
+#| "(https://maxima.sourceforge.io/documentation.html). Part of this "
+#| "documentation is also available in wxMaximaâs help menu. Pressing the "
+#| "Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_âs "
+#| "context-sensitive help feature to automatically jump to _Maxima_âs manual "
+#| "page for the command at the cursor."
 msgid ""
-"Much of _wxMaxima_ is self-explaining, but some details require attention. [This site](https://wxMaxima-developers.github.io/wxmaxima/help.html) contains a number of workbooks that address various aspects of _wxMaxima_. Working through some of these (particularly the \"10 minute _(wx)Maxima_ "
-"tutorial\") will increase oneâs familiarity with both the content of _Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. This manual concentrates on describing aspects of _wxMaxima_ that are not likely to be self-evident and that might not be covered in the online material."
+"Extensive documentation for _Maxima_ is [available in the internet](https://"
+"maxima.sourceforge.io/documentation.html). Part of this documentation is "
+"also available in wxMaxima’s help menu. Pressing the Help key (on most "
+"systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help "
+"feature to automatically jump to _Maxima_’s manual page for the command at "
+"the cursor."
 msgstr ""
-"Une grande partie de wxMaxima est intuitive, mais certains détails nécessitent une attention particulière. [Ce site](https://wxMaxima-developers.github.io/wxmaxima/help.html) contient plusieurs notebooks qui abordent divers aspects de _wxMaxima_. Parcourir certains d’entre eux (notamment le "
-"« tutoriel de 10 minutes sur (wx)Maxima ») permettra de mieux maîtriser à la fois le contenu de _Maxima_ et l’utilisation de _wxMaxima_ pour interagir avec _Maxima_. Ce manuel se concentre sur la description des aspects de _wxMaxima_ qui ne sont pas nécessairement évidents et qui pourraient ne pas "
-"être présentés dans les ressources en ligne."
+"Une documentation complète pour _Maxima_ est [disponible en ligne](https://"
+"maxima.sourceforge.io/documentation.html). Une partie de cette documentation "
+"est également accessible via le menu d’aide de wxMaxima. En appuyant sur la "
+"touche d’aide (généralement la touche <kbd>F1</kbd> sur la plupart des "
+"systèmes), la fonction d’aide contextuelle de _wxMaxima_ ouvre "
+"automatiquement la page du manuel de _Maxima_ correspondant à la commande "
+"située sous le curseur."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:26
+msgid "### WxMaxima"
+msgstr "### WxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:28
+#, fuzzy
+#| msgid ""
+#| "_WxMaxima_ is a graphical user interface that provides the full "
+#| "functionality and flexibility of _Maxima_. WxMaxima offers users a "
+#| "graphical display and many features that make working with _Maxima_ "
+#| "easier. For example _wxMaxima_ allows one to export any cellâs contents "
+#| "(or, if that is needed, any part of a formula, as well) as text, as LaTeX "
+#| "or as MathML specification at a simple right-click. Indeed, an entire "
+#| "workbook can be exported, either as a HTML file or as a LaTeX file. "
+#| "Documentation for _wxMaxima_, including workbooks to illustrate aspects "
+#| "of its use, is online at the _wxMaxima_ [help site](https://wxMaxima-"
+#| "developers.github.io/wxmaxima/help.html), as well as via the help menu."
 msgid ""
-"One of the very few things that are not standard in _wxMaxima_ is that it organizes the data for _Maxima_ into cells that are evaluated (which means: sent to _Maxima_) only when the user requests this. When a cell is evaluated, all commands in that cell, and only that cell, are evaluated as a batch. "
-"(The preceding statement is not quite accurate: One can select a set of adjacent cells and evaluate them together. Also, one can instruct _Maxima_ to evaluate all cells in a workbook in one pass.) _WxMaxima_âs approach to submitting commands for execution might feel unfamiliar at the first sight. It "
-"does, however, drastically ease work with big documents (where the user does not want every change to automatically trigger a full re-evaluation of the whole document). Also, this approach is very handy for debugging."
+"_WxMaxima_ is a graphical user interface that provides the full "
+"functionality and flexibility of _Maxima_. WxMaxima offers users a graphical "
+"display and many features that make working with _Maxima_ easier. For "
+"example _wxMaxima_ allows one to export any cell’s contents (or, if that is "
+"needed, any part of a formula, as well) as text, as LaTeX or as MathML "
+"specification at a simple right-click. Indeed, an entire workbook can be "
+"exported, either as a HTML file or as a LaTeX file. Documentation for "
+"_wxMaxima_, including workbooks to illustrate aspects of its use, is online "
+"at the _wxMaxima_ [help site](https://wxMaxima-developers.github.io/wxmaxima/"
+"help.html), as well as via the help menu."
 msgstr ""
-"L'une des très rares choses qui ne sont pas standard avec _wxMaxima_ est qu'il organise les données pour _Maxima_ en cellules qui ne sont évaluées (c'est-à-dire envoyées à _Maxima_) que lorsque l'utilisateur le demande. Lorsqu'une cellule est évaluée, toutes les commandes de cette cellule, et "
-"uniquement de cette cellule, sont évaluées en bloc. (La phrase précédente n'est pas tout à fait exacte : on peut sélectionner un ensemble de cellules adjacentes et les évaluer ensemble. On peut aussi demander à _Maxima_ d'évaluer toutes les cellules d'un notebook  en une seule fois.) L'approche de "
-"_wxMaxima_ pour exécuter les commandes peut sembler inhabituelle au premier abord. Elle facilite cependant grandement le travail avec de grands documents (où l'utilisateur ne souhaite pas que chaque modification déclenche automatiquement une réévaluation complète de l'ensemble du document). De plus, "
-"cette approche est très pratique pour le débogage."
+"_WxMaxima_ est une interface graphique qui offre toute les fonctionnalités "
+"et la flexibilité de _Maxima_. WxMaxima propose aux utilisateurs un "
+"affichage graphique ainsi que de nombreuses fonctionnalités qui facilitent "
+"l’utilisation de _Maxima_. Par exemple, _wxMaxima_ permet d’exporter le "
+"contenu de n’importe quelle cellule (ou, si nécessaire, une partie d’une "
+"formule) sous forme de texte, de code LaTeX ou de codage MathML, simplement "
+"en effectuant un clic droit. En outre, un notebook entier peut être exporté, "
+"soit en tant que fichier HTML, soit en tant que fichier LaTeX. La "
+"documentation de _wxMaxima_, incluant des notebooks d’exemples illustrant "
+"ses différentes fonctionnalités, est disponible en ligne sur le [site d’aide "
+"de wxMaxima](https://wxMaxima-developers.github.io/wxmaxima/help.html), "
+"ainsi que via le menu d’aide."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:30
+msgid "![wxMaxima window](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
+msgstr "![fenêtre de wxMaxima](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:32
 msgid ""
-"If text is typed into _wxMaxima_ it automatically creates a new worksheet cell. The type of this cell can be selected in the toolbar. If a code cell is created the cell can be sent to _Maxima_, which causes the result of the calculation to be displayed below the code. A pair of such commands is shown "
+"The calculations that are entered in _wxMaxima_ are performed by the "
+"_Maxima_ command-line tool in the background."
+msgstr ""
+"Les calculs saisis dans _wxMaxima_ sont exécutés en arrière-plan par l'outil "
+"en ligne de commande _Maxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:34
+msgid "## Workbook basics"
+msgstr "## Notions de base d'un notebook"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:36
+#, fuzzy
+#| msgid ""
+#| "Much of _wxMaxima_ is self-explaining, but some details require "
+#| "attention. [This site](https://wxMaxima-developers.github.io/wxmaxima/"
+#| "help.html) contains a number of workbooks that address various aspects of "
+#| "_wxMaxima_. Working through some of these (particularly the \"10 minute "
+#| "_(wx)Maxima_ tutorial\") will increase oneâs familiarity with both the "
+#| "content of _Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. "
+#| "This manual concentrates on describing aspects of _wxMaxima_ that are not "
+#| "likely to be self-evident and that might not be covered in the online "
+#| "material."
+msgid ""
+"Much of _wxMaxima_ is self-explaining, but some details require attention. "
+"[This site](https://wxMaxima-developers.github.io/wxmaxima/help.html) "
+"contains a number of workbooks that address various aspects of _wxMaxima_. "
+"Working through some of these (particularly the \"10 minute _(wx)Maxima_ "
+"tutorial\") will increase one’s familiarity with both the content of "
+"_Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. This manual "
+"concentrates on describing aspects of _wxMaxima_ that are not likely to be "
+"self-evident and that might not be covered in the online material."
+msgstr ""
+"Une grande partie de wxMaxima est intuitive, mais certains détails "
+"nécessitent une attention particulière. [Ce site](https://wxMaxima-"
+"developers.github.io/wxmaxima/help.html) contient plusieurs notebooks qui "
+"abordent divers aspects de _wxMaxima_. Parcourir certains d’entre eux "
+"(notamment le « tutoriel de 10 minutes sur (wx)Maxima ») permettra de mieux "
+"maîtriser à la fois le contenu de _Maxima_ et l’utilisation de _wxMaxima_ "
+"pour interagir avec _Maxima_. Ce manuel se concentre sur la description des "
+"aspects de _wxMaxima_ qui ne sont pas nécessairement évidents et qui "
+"pourraient ne pas être présentés dans les ressources en ligne."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:38
+msgid "### The workbook approach"
+msgstr "### Fondamentaux du notebook"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:40
+#, fuzzy
+#| msgid ""
+#| "One of the very few things that are not standard in _wxMaxima_ is that it "
+#| "organizes the data for _Maxima_ into cells that are evaluated (which "
+#| "means: sent to _Maxima_) only when the user requests this. When a cell is "
+#| "evaluated, all commands in that cell, and only that cell, are evaluated "
+#| "as a batch. (The preceding statement is not quite accurate: One can "
+#| "select a set of adjacent cells and evaluate them together. Also, one can "
+#| "instruct _Maxima_ to evaluate all cells in a workbook in one pass.) "
+#| "_WxMaxima_âs approach to submitting commands for execution might feel "
+#| "unfamiliar at the first sight. It does, however, drastically ease work "
+#| "with big documents (where the user does not want every change to "
+#| "automatically trigger a full re-evaluation of the whole document). Also, "
+#| "this approach is very handy for debugging."
+msgid ""
+"One of the very few things that are not standard in _wxMaxima_ is that it "
+"organizes the data for _Maxima_ into cells that are evaluated (which means: "
+"sent to _Maxima_) only when the user requests this. When a cell is "
+"evaluated, all commands in that cell, and only that cell, are evaluated as a "
+"batch. (The preceding statement is not quite accurate: One can select a set "
+"of adjacent cells and evaluate them together. Also, one can instruct "
+"_Maxima_ to evaluate all cells in a workbook in one pass.) _WxMaxima_’s "
+"approach to submitting commands for execution might feel unfamiliar at the "
+"first sight. It does, however, drastically ease work with big documents "
+"(where the user does not want every change to automatically trigger a full "
+"re-evaluation of the whole document). Also, this approach is very handy for "
+"debugging."
+msgstr ""
+"L'une des très rares choses qui ne sont pas standard avec _wxMaxima_ est "
+"qu'il organise les données pour _Maxima_ en cellules qui ne sont évaluées "
+"(c'est-à-dire envoyées à _Maxima_) que lorsque l'utilisateur le demande. "
+"Lorsqu'une cellule est évaluée, toutes les commandes de cette cellule, et "
+"uniquement de cette cellule, sont évaluées en bloc. (La phrase précédente "
+"n'est pas tout à fait exacte : on peut sélectionner un ensemble de cellules "
+"adjacentes et les évaluer ensemble. On peut aussi demander à _Maxima_ "
+"d'évaluer toutes les cellules d'un notebook  en une seule fois.) L'approche "
+"de _wxMaxima_ pour exécuter les commandes peut sembler inhabituelle au "
+"premier abord. Elle facilite cependant grandement le travail avec de grands "
+"documents (où l'utilisateur ne souhaite pas que chaque modification "
+"déclenche automatiquement une réévaluation complète de l'ensemble du "
+"document). De plus, cette approche est très pratique pour le débogage."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:42
+msgid ""
+"If text is typed into _wxMaxima_ it automatically creates a new worksheet "
+"cell. The type of this cell can be selected in the toolbar. If a code cell "
+"is created the cell can be sent to _Maxima_, which causes the result of the "
+"calculation to be displayed below the code. A pair of such commands is shown "
 "below."
 msgstr ""
-"Si du texte est saisi dans _wxMaxima_, une nouvelle cellule est automatiquement créée dans le notebook. Le type de cette cellule peut être sélectionné dans la barre d'outils. Si une cellule de code est créée, elle peut être envoyée à _Maxima_, ce qui affiche le résultat du calcul en dessous du code. "
-"Une paire de ce type de commandes est présentée ci-dessous."
+"Si du texte est saisi dans _wxMaxima_, une nouvelle cellule est "
+"automatiquement créée dans le notebook. Le type de cette cellule peut être "
+"sélectionné dans la barre d'outils. Si une cellule de code est créée, elle "
+"peut être envoyée à _Maxima_, ce qui affiche le résultat du calcul en "
+"dessous du code. Une paire de ce type de commandes est présentée ci-dessous."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:44
+msgid "![Input/output cell](./InputCell.png){ id=img_InputCell }"
+msgstr "![Cellules entrée/sortie cell](./InputCell.png){ id=img_InputCell }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:46
+#, fuzzy
+#| msgid ""
+#| "On evaluation of an input cellâs contents the input cell _Maxima_ assigns "
+#| "a label to the input (by default shown in red and recognizable by the "
+#| "`%i`) by which it can be referenced later in the _wxMaxima_ session. The "
+#| "output that _Maxima_ generates also gets a label that begins with `%o` "
+#| "and by default is hidden, except if the user assigns the output a name. "
+#| "In this case by default the user-defined label is displayed. The `%o`-"
+#| "style label _Maxima_ auto-generates will also be accessible, though."
 msgid ""
-"On evaluation of an input cellâs contents the input cell _Maxima_ assigns a label to the input (by default shown in red and recognizable by the `%i`) by which it can be referenced later in the _wxMaxima_ session. The output that _Maxima_ generates also gets a label that begins with `%o` and by "
-"default is hidden, except if the user assigns the output a name. In this case by default the user-defined label is displayed. The `%o`-style label _Maxima_ auto-generates will also be accessible, though."
+"On evaluation of an input cell’s contents the input cell _Maxima_ assigns a "
+"label to the input (by default shown in red and recognizable by the `%i`) by "
+"which it can be referenced later in the _wxMaxima_ session. The output that "
+"_Maxima_ generates also gets a label that begins with `%o` and by default is "
+"hidden, except if the user assigns the output a name. In this case by "
+"default the user-defined label is displayed. The `%o`-style label _Maxima_ "
+"auto-generates will also be accessible, though."
 msgstr ""
-"Lors de l’évaluation du contenu d’une cellule d’entrée, _Maxima_ attribue un identifiant à l’entrée (affiché par défaut en rouge et reconnaissable par le `%i`), ce qui permet d’y faire référence plus tard dans la session _wxMaxima_. La sortie générée par _Maxima_ reçoit également un identifiant "
-"commençant par `%o`, masqué par défaut, sauf si l’utilisateur attribue un nom à cette sortie. Dans ce cas, l’identifiant défini par l’utilisateur s’affiche par défaut, mais l’identifiant automatique de type `%o` reste accessible."
+"Lors de l’évaluation du contenu d’une cellule d’entrée, _Maxima_ attribue un "
+"identifiant à l’entrée (affiché par défaut en rouge et reconnaissable par le "
+"`%i`), ce qui permet d’y faire référence plus tard dans la session "
+"_wxMaxima_. La sortie générée par _Maxima_ reçoit également un identifiant "
+"commençant par `%o`, masqué par défaut, sauf si l’utilisateur attribue un "
+"nom à cette sortie. Dans ce cas, l’identifiant défini par l’utilisateur "
+"s’affiche par défaut, mais l’identifiant automatique de type `%o` reste "
+"accessible."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:48
 msgid ""
-"Besides the input cells _wxMaxima_ allows for text cells for documentation, image cells, title cells, chapter cells and section cells. Every cell has its own undo buffer so debugging by changing the values of several cells and then gradually reverting the unneeded changes is rather easy. Furthermore "
-"the worksheet itself has a global undo buffer that can undo cell edits, adds and deletes."
+"Besides the input cells _wxMaxima_ allows for text cells for documentation, "
+"image cells, title cells, chapter cells and section cells. Every cell has "
+"its own undo buffer so debugging by changing the values of several cells and "
+"then gradually reverting the unneeded changes is rather easy. Furthermore "
+"the worksheet itself has a global undo buffer that can undo cell edits, adds "
+"and deletes."
 msgstr ""
-"Outre les cellules d’entrée, _wxMaxima_ permet d’insérer des cellules de texte pour la documentation, des cellules d’image, des cellules de titre, de chapitre et de section. Chaque cellule dispose de son propre historique d’annulation, ce qui facilite le débogage en modifiant les valeurs de plusieurs "
-"cellules puis en annulant progressivement les changements inutiles. De plus, le notebook en lui-même possède un historique d’annulation global qui permet d’annuler les modifications, ajouts et suppressions de cellules."
+"Outre les cellules d’entrée, _wxMaxima_ permet d’insérer des cellules de "
+"texte pour la documentation, des cellules d’image, des cellules de titre, de "
+"chapitre et de section. Chaque cellule dispose de son propre historique "
+"d’annulation, ce qui facilite le débogage en modifiant les valeurs de "
+"plusieurs cellules puis en annulant progressivement les changements "
+"inutiles. De plus, le notebook en lui-même possède un historique "
+"d’annulation global qui permet d’annuler les modifications, ajouts et "
+"suppressions de cellules."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:50
 msgid ""
-"The default behavior of _wxMaxima_ when text is entered is to automatically create a math cell. Cells of other types can be created using the Cell menu, using the hot keys shown in the menu or using the drop-down list in the toolbar. Once the non-math cell is created, whatever is typed into the file "
+"The figure below shows different cell types (title cells, section cells, "
+"subsection cells, text cells, input/output cells and image cells)."
+msgstr ""
+"La figure ci-dessous montre différents types de cellules (cellules de titre, "
+"cellules de section, cellules de sous-section, cellules de texte, cellules "
+"d’entrée/sortie et cellules d’image)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:52
+msgid ""
+"![Example of different wxMaxima cells](./cell-example.png){ id=img_cell-"
+"example }"
+msgstr ""
+"![Exemple de cellules différentes de wxMaxima](./cell-example.png)"
+"{ id=img_cell-example }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:54
+msgid "### Cells"
+msgstr "### Cellules"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:56
+msgid ""
+"The worksheet is organized in cells. WxMaxima knows the following cell types:"
+msgstr ""
+"Le notebook est organisé en cellules. WxMaxima distingue les types de "
+"cellules suivants  :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Math cells, containing one or more lines of _Maxima_ input."
+msgstr ""
+"Cellules mathématiques, contenant une ou plusieurs lignes de saisie _Maxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Output of, or a question from, _Maxima_."
+msgstr "Sortie de, ou une question de, _Maxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Image cells."
+msgstr "Cellules image."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Text cells, that can for example be used for documentation."
+msgstr ""
+"Cellules de texte, qui peuvent par exemple être utilisées pour la "
+"documentation."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid ""
+"A title, section or a subsection. 6 levels of different headings are "
+"possible."
+msgstr ""
+"Un titre, une section ou une sous-section. 6 niveaux de titres différents "
+"sont possibles."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Page breaks."
+msgstr "Sauts de page."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:65
+msgid ""
+"The default behavior of _wxMaxima_ when text is entered is to automatically "
+"create a math cell. Cells of other types can be created using the Cell menu, "
+"using the hot keys shown in the menu or using the drop-down list in the "
+"toolbar. Once the non-math cell is created, whatever is typed into the file "
 "is interpreted as text."
 msgstr ""
-"Par défaut, _wxMaxima_ crée automatiquement une cellule de calcul lorsque du texte est saisi. Pour créer des cellules d’un autre type, utilisez le menu Cellule, les raccourcis clavier indiqués dans ce menu ou la liste déroulante de la barre d’outils. Une fois qu’une cellule non mathématique est "
-"créée, tout ce qui y est saisi est interprété comme du texte."
+"Par défaut, _wxMaxima_ crée automatiquement une cellule de calcul lorsque du "
+"texte est saisi. Pour créer des cellules d’un autre type, utilisez le menu "
+"Cellule, les raccourcis clavier indiqués dans ce menu ou la liste déroulante "
+"de la barre d’outils. Une fois qu’une cellule non mathématique est créée, "
+"tout ce qui y est saisi est interprété comme du texte."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:67
 msgid ""
-"When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</"
+"A (C-style) [comment text](https://maxima.sourceforge.io/docs/manual/"
+"maxima_singlepage.html#Comments) can be part of a math cell as follows: `/* "
+"This comment will be ignored by Maxima */`"
+msgstr ""
+"Un [commentaire (style C)](https://maxima.sourceforge.io/docs/manual/"
+"maxima_singlepage.html#Comments) peut être inséré dans une cellule de calcul "
+"comme suit : `/* Ce commentaire sera ignoré par Maxima */`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:69
+msgid "\"`/*`\" marks the start of the comment, \"`*/`\" the end."
+msgstr "\"`/*`\" indique le début du commentaire, \"`*/`\" la fin."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:71
+msgid "### Horizontal and vertical cursors"
+msgstr "### curseurs horizontaux et verticaux"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:73
+msgid ""
+"If the user tries to select a complete sentence, a word processor will try "
+"to extend the selection to automatically begin and end with a word boundary. "
+"Likewise, if more than one cell is selected, _wxMaxima_ will extend the "
+"selection to whole cells."
+msgstr ""
+"Si l’utilisateur tente de sélectionner une phrase complète, un traitement de "
+"texte étendra automatiquement la sélection pour qu’elle commence et se "
+"termine aux limites d’un mot. De même, si plusieurs cellules sont  "
+"sélectionnées, _wxMaxima_ étendra la sélection aux cellules entières."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:75
+#, fuzzy
+#| msgid ""
+#| "What isnât standard is that _wxMaxima_ provides drag-and-drop flexibility "
+#| "by defining two types of cursors. _WxMaxima_ will switch between them "
+#| "automatically when needed:"
+msgid ""
+"What isn’t standard is that _wxMaxima_ provides drag-and-drop flexibility by "
+"defining two types of cursors. _WxMaxima_ will switch between them "
+"automatically when needed:"
+msgstr ""
+"Ce qui est moins conventionnel, c’est que _wxMaxima_ offre une facilité de "
+"glisser-déposer en définissant deux types de curseurs. _wxMaxima_ basculera "
+"automatiquement entre eux selon le besoin :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:78
+msgid ""
+"The cursor is drawn horizontally if it is moved in the space between two "
+"cells or by clicking there."
+msgstr ""
+"Le curseur est dessiné horizontalement s’il est déplacé dans l’espace entre "
+"deux cellules ou en cliquant à cet endroit."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:78
+msgid ""
+"A vertical cursor that works inside a cell. This cursor is activated by "
+"moving the cursor inside a cell using the mouse pointer or the cursor keys "
+"and works much like the cursor in a text editor."
+msgstr ""
+"Un curseur vertical qui fonctionne à l’intérieur d’une cellule. Ce curseur "
+"est activé en déplaçant le curseur à l’intérieur d’une cellule à l’aide du "
+"pointeur de la souris ou des touches de direction, et fonctionne de manière "
+"similaire à celui d’un éditeur de texte."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:80
+msgid ""
+"When you start wxMaxima, you will only see the blinking horizontal cursor. "
+"If you start typing, a math cell will be automatically created and the "
+"cursor will change to a regular vertical one (you will see a right arrow as "
+"\"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</"
 "kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`)."
 msgstr ""
-"Quand vous lancez wxMaxima, vous ne verrez que le curseur horizontal clignotant. Si vous commencez à taper, une cellule mathématique sera automatiquement créée et le curseur deviendra un curseur vertical classique (vous verrez une flèche vers la droite comme \"invite\", et après avoir évalué la "
-"cellule mathématique (<kbd>CTRL</kbd>+<kbd>ENTRÉE</kbd>), les étiquettes apparaîtront, par exemple `(%i1)`, `(%o1)`."
+"Quand vous lancez wxMaxima, vous ne verrez que le curseur horizontal "
+"clignotant. Si vous commencez à taper, une cellule mathématique sera "
+"automatiquement créée et le curseur deviendra un curseur vertical classique "
+"(vous verrez une flèche vers la droite comme \"invite\", et après avoir "
+"évalué la cellule mathématique (<kbd>CTRL</kbd>+<kbd>ENTRÉE</kbd>), les "
+"étiquettes apparaîtront, par exemple `(%i1)`, `(%o1)`."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:82
 msgid ""
-"The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is "
-"entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>."
+"![(blinking) horizontal cursor after wxMaxima start](./horizontal-cursor-"
+"only.png){ id=img_horizontal_cursor_only }"
 msgstr ""
-"La commande dans une cellule de code est exécutée en appuyant une fois sur <kbd>CTRL</kbd>+<kbd>ENTRÉE</kbd>, <kbd>MAJ</kbd>+<kbd>ENTRÉE</kbd> ou la touche <kbd>ENTRÉE</kbd> du pavé numérique. Par défaut, _wxMaxima_ exécute les commandes lorsque <kbd>CTRL</kbd>+<kbd>ENTRÉE</kbd> ou <kbd>MAJ</"
-"kbd>+<kbd>ENTRÉE</kbd> est pressé, mais il est possible de configurer _wxMaxima_ pour qu’il exécute les commandes en réponse à la touche <kbd>ENTRÉE</kbd>."
+"![curseur horizontal (clignotant) après le démarrage de wxMaxima](./"
+"horizontal-cursor-only.png){ id=img_horizontal_cursor_only }"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:84
 msgid ""
-"_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer "
-"a list of applicable units."
+"You might want to create a different cell type (using the \"Cell\" menu), "
+"maybe a title cell or text cell, which describes, what will be done, when "
+"you start creating your worksheet."
 msgstr ""
-"_wxMaxima_ dispose d’une fonction de complétion automatique, accessible via le menu (Cellule/Compléter le mot) ou en appuyant sur la combinaison de touches <kbd>CTRL</kbd>+<kbd>ESPACE</kbd>. Cette complétion est sensible au contexte : par exemple, si elle est activée lors d'une spécification d’unité "
+"Vous pourrez peut-être vouloir créer un type de cellule différent (via le "
+"menu \"Cellule\"), comme une cellule de titre ou une cellule de texte, pour "
+"décrire ce que vous allez faire lorsque vous commencerez à créer votre "
+"notebook."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:86
+msgid ""
+"If you navigate between the different cells, you will also see the "
+"(blinking) horizontal cursor, where you can insert a cell into your "
+"worksheet (either a math cell, by just start typing your formula - or a "
+"different cell type using the menu)."
+msgstr ""
+"Si vous naviguez entre les différentes cellules, vous verrez également le "
+"curseur horizontal (clignotant), indiquant l'endroit où vous pouvez insérer "
+"une nouvelle cellule dans votre notebook (soit une cellule mathématique, en "
+"commençant simplement à saisir votre formule, soit un autre type de cellule "
+"en utilisant le menu)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:88
+msgid ""
+"![(blinking) horizontal cursor between cells](./horizontal-cursor-between-"
+"cells.png){ id=img_horizontal_cursor_between_cells }"
+msgstr ""
+"![curseur horizontal (clignotant) entre deux cellules](./horizontal-cursor-"
+"between-cells.png){ id=img_horizontal_cursor_between_cells }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:90
+msgid "### Sending cells to Maxima"
+msgstr "### Envoyer des cellules à Maxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:92
+msgid ""
+"The command in a code cell is executed once by pressing <kbd>CTRL</"
+"kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</"
+"kbd> key on the keypad. The _wxMaxima_ default is to enter commands when "
+"either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> "
+"is entered, but _wxMaxima_ can be configured to execute commands in response "
+"to <kbd>ENTER</kbd>."
+msgstr ""
+"La commande dans une cellule de code est exécutée en appuyant une fois sur "
+"<kbd>CTRL</kbd>+<kbd>ENTRÉE</kbd>, <kbd>MAJ</kbd>+<kbd>ENTRÉE</kbd> ou la "
+"touche <kbd>ENTRÉE</kbd> du pavé numérique. Par défaut, _wxMaxima_ exécute "
+"les commandes lorsque <kbd>CTRL</kbd>+<kbd>ENTRÉE</kbd> ou <kbd>MAJ</"
+"kbd>+<kbd>ENTRÉE</kbd> est pressé, mais il est possible de configurer "
+"_wxMaxima_ pour qu’il exécute les commandes en réponse à la touche "
+"<kbd>ENTRÉE</kbd>."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:94
+msgid "### Command autocompletion"
+msgstr "### Complétion automatique des commandes"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:96
+msgid ""
+"_WxMaxima_ contains an autocompletion feature that is triggered via the menu "
+"(Cell/Complete Word) or alternatively by pressing the key combination "
+"<kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. "
+"For example, if activated within a unit specification for ezUnits it will "
+"offer a list of applicable units."
+msgstr ""
+"_wxMaxima_ dispose d’une fonction de complétion automatique, accessible via "
+"le menu (Cellule/Compléter le mot) ou en appuyant sur la combinaison de "
+"touches <kbd>CTRL</kbd>+<kbd>ESPACE</kbd>. Cette complétion est sensible au "
+"contexte : par exemple, si elle est activée lors d'une spécification d’unité "
 "pour ezUnits, elle proposera une liste des unités applicables."
 
-msgid ""
-"Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</"
-"kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template)."
-msgstr ""
-"Outre la complétion des noms de fichiers, d’unités, de commandes ou de variables, la complétion automatique peut aussi afficher un modèle pour la plupart des commandes, indiquant le type (et la signification) des paramètres attendus par le programme. Pour activer cette fonctionnalité, appuyez sur "
-"<kbd>MAJ</kbd>+<kbd>CTRL</kbd>+<kbd>ESPACE</kbd> ou sélectionnez l’option correspondante dans le menu (Cellule/Afficher le modèle)."
+#. type: Plain text
+#: ../../info/wxmaxima.md:98
+msgid "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
+msgstr "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:100
 msgid ""
-"Computers traditionally stored characters in 8-bit values. This allows for a maximum of 256 different characters. All letters, numbers, and control symbols (end of transmission, end of string, lines and edges for drawing rectangles for menus _etc_.) of nearly any given language can fit within that "
-"limit."
+"Besides completing a file name, a unit name, or the current command or "
+"variable name, the autocompletion is able to show a template for most of the "
+"commands indicating the type (and meaning) of the parameters this program "
+"expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</"
+"kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show "
+"Template)."
 msgstr ""
-"Traditionnellement, les ordinateurs stockaient les caractères sur 8 bits, ce qui permet un maximum de 256 caractères différents. Toutes les lettres, chiffres et symboles de contrôle (fin de transmission, fin de chaîne, lignes et bordures pour dessiner des rectangles autour des menus, etc.) de presque "
+"Outre la complétion des noms de fichiers, d’unités, de commandes ou de "
+"variables, la complétion automatique peut aussi afficher un modèle pour la "
+"plupart des commandes, indiquant le type (et la signification) des "
+"paramètres attendus par le programme. Pour activer cette fonctionnalité, "
+"appuyez sur <kbd>MAJ</kbd>+<kbd>CTRL</kbd>+<kbd>ESPACE</kbd> ou sélectionnez "
+"l’option correspondante dans le menu (Cellule/Afficher le modèle)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:102
+msgid "#### Greek characters"
+msgstr "#### Caractères grecs"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:104
+msgid ""
+"Computers traditionally stored characters in 8-bit values. This allows for a "
+"maximum of 256 different characters. All letters, numbers, and control "
+"symbols (end of transmission, end of string, lines and edges for drawing "
+"rectangles for menus _etc_.) of nearly any given language can fit within "
+"that limit."
+msgstr ""
+"Traditionnellement, les ordinateurs stockaient les caractères sur 8 bits, ce "
+"qui permet un maximum de 256 caractères différents. Toutes les lettres, "
+"chiffres et symboles de contrôle (fin de transmission, fin de chaîne, lignes "
+"et bordures pour dessiner des rectangles autour des menus, etc.) de presque "
 "n'importe quelle langue pouvaient tenir avec cette limite."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:106
 msgid ""
-"For most countries, the codepage of 256 characters that has been chosen does not include things like Greek letters, though, that are frequently used in mathematics. To overcome this type of limitation [Unicode](https://home.unicode.org/) has been invented: An encoding that makes English text work "
-"like normal, but to use much more than 256 characters."
+"For most countries, the codepage of 256 characters that has been chosen does "
+"not include things like Greek letters, though, that are frequently used in "
+"mathematics. To overcome this type of limitation [Unicode](https://"
+"home.unicode.org/) has been invented: An encoding that makes English text "
+"work like normal, but to use much more than 256 characters."
 msgstr ""
-"Pour la plupart des pays, la page de codes de 256 caractères choisie n'inclut cependant pas des éléments comme les lettres grecques, pourtant fréquemment utilisées en mathématiques. Pour surmonter ce type de limitation, [Unicode](https://home.unicode.org/) a été inventé : il s'agit d'un encodage qui "
-"permet aux textes en anglais de s'afficher normalement, tout en utilisant bien plus que 256 caractères."
+"Pour la plupart des pays, la page de codes de 256 caractères choisie "
+"n'inclut cependant pas des éléments comme les lettres grecques, pourtant "
+"fréquemment utilisées en mathématiques. Pour surmonter ce type de "
+"limitation, [Unicode](https://home.unicode.org/) a été inventé : il s'agit "
+"d'un encodage qui permet aux textes en anglais de s'afficher normalement, "
+"tout en utilisant bien plus que 256 caractères."
 
-msgid "_Maxima_ allows Unicode if it was compiled using a Lisp compiler that either supports Unicode or that doesnât care about the font encoding. As at least one of this pair of conditions is likely to be true. _WxMaxima_ provides a method of entering Greek characters using the keyboard:"
+#. type: Plain text
+#: ../../info/wxmaxima.md:108
+#, fuzzy
+#| msgid ""
+#| "_Maxima_ allows Unicode if it was compiled using a Lisp compiler that "
+#| "either supports Unicode or that doesnât care about the font encoding. As "
+#| "at least one of this pair of conditions is likely to be true. _WxMaxima_ "
+#| "provides a method of entering Greek characters using the keyboard:"
+msgid ""
+"_Maxima_ allows Unicode if it was compiled using a Lisp compiler that either "
+"supports Unicode or that doesn’t care about the font encoding. As at least "
+"one of this pair of conditions is likely to be true. _WxMaxima_ provides a "
+"method of entering Greek characters using the keyboard:"
 msgstr ""
-"_Maxima_ prend en charge Unicode s'il a été compilé avec un compilateur Lisp qui supporte Unicode ou qui ne tient pas compte de l'encodage de la police. Comme au moins une de ces deux conditions est probablement remplie, _wxMaxima_ fournit une méthode pour saisir des caractères grecs à l'aide du "
+"_Maxima_ prend en charge Unicode s'il a été compilé avec un compilateur Lisp "
+"qui supporte Unicode ou qui ne tient pas compte de l'encodage de la police. "
+"Comme au moins une de ces deux conditions est probablement remplie, "
+"_wxMaxima_ fournit une méthode pour saisir des caractères grecs à l'aide du "
 "clavier :"
 
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:111
+#, fuzzy
+#| msgid ""
+#| "A Greek letter can be entered by pressing the <kbd>ESC</kbd> key and then "
+#| "starting to type the Greek characterâs name."
+msgid ""
+"A Greek letter can be entered by pressing the <kbd>ESC</kbd> key and then "
+"starting to type the Greek character’s name."
+msgstr ""
+"Une lettre grecque peut être saisie en appuyant sur la touche <kbd>ÉCHAP</"
+"kbd>, puis en commençant à taper le nom du caractère grec."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:111
+msgid ""
+"Alternatively it can be entered by pressing <kbd>ESC</kbd>, one letter (or "
+"two for the Greek letter omicron) and <kbd>ESC</kbd> again. In this case the "
+"following letters are supported:"
+msgstr ""
+"- Une lettre grecque peut être saisie en appuyant sur la touche <kbd>ÉCHAP</"
+"kbd>, puis en commençant à taper le nom du caractère grec. \n"
+"- Elle peut aussi être saisie en appuyant sur <kbd>ÉCHAP</kbd>, une lettre "
+"(ou deux pour la lettre grecque omicron), puis à nouveau sur <kbd>ÉCHAP</"
+"kbd>. Dans ce cas, les lettres suivantes sont prises en charge :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:130
+#, no-wrap
 msgid ""
 "| key | Greek letter | key | Greek letter | key | Greek letter |\n"
 "| :-: | :----------: | :-: | :----------: | :-: | :----------: |\n"
@@ -191,11 +815,67 @@ msgstr ""
 "|  H  |     Eta      | Om  |   Omicron    |  Y  |     Psi      |\n"
 "|  T  |    Theta     |  P  |      Pi      |  O  |    Omega     |\n"
 
-msgid "This might be problematic, if you assign a value to the variable A and later use the Greek letter Alpha to do something with this variable, especially on printouts.  For the Greek letter my (which is also used as prefix for micro) there are also two different Unicode code points."
+#. type: Plain text
+#: ../../info/wxmaxima.md:132
+msgid ""
+"You can also use the \"Greek letters\"-sidebar to enter the Greek letters."
 msgstr ""
-"Cela peut poser problème si vous attribuez une valeur à la variable A et que vous utilisez ensuite la lettre grecque Alpha pour faire quelque chose avec cette variable, notamment sur les impressions. Pour la lettre grecque mu (utilisée aussi comme préfixe pour micro), il existe également deux codages "
+"Vous pouvez également utiliser la barre latérale « Lettres grecques » pour "
+"insérer les lettres grecques."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:134
+msgid "##### Attention: Lookalike characters"
+msgstr "##### Attention aux caractères similaires"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:138
+msgid ""
+"Several Latin letters look like the Greek letters, e.g. the Latin letter "
+"\"A\" and the Greek letter \"Alpha\". Although they look identical, they are "
+"two different Unicode characters, represented by different Unicode code "
+"points (numbers)."
+msgstr ""
+"Plusieurs lettres latines ressemblent aux lettres grecques, par exemple la "
+"lettre latine \"A\" et la lettre grecque \"Alpha\". Bien qu'elles aient la "
+"même apparence, ce sont deux caractères Unicode distincts, représentés par "
+"des codages Unicode (nombres) différents."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:143
+msgid ""
+"This might be problematic, if you assign a value to the variable A and later "
+"use the Greek letter Alpha to do something with this variable, especially on "
+"printouts.  For the Greek letter my (which is also used as prefix for micro) "
+"there are also two different Unicode code points."
+msgstr ""
+"Cela peut poser problème si vous attribuez une valeur à la variable A et que "
+"vous utilisez ensuite la lettre grecque Alpha pour faire quelque chose avec "
+"cette variable, notamment sur les impressions. Pour la lettre grecque mu "
+"(utilisée aussi comme préfixe pour micro), il existe également deux codages "
 "Unicode différents."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:146
+msgid ""
+"The \"Greek letters\"-sidebar therefore has the option, that lookalike "
+"characters are not available (which can be changed using a right-click menu)."
+msgstr ""
+"La barre latérale « Lettres grecques » offre donc l’option de désactiver les "
+"caractères similaires (ce paramètre peut être modifié via un menu accessible "
+"par un clic droit)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:148
+msgid ""
+"The same mechanism also allows to enter some miscellaneous mathematical "
+"symbols:"
+msgstr ""
+"Le même mécanisme permet également de saisir divers symboles mathématiques :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:199
+#, no-wrap
 msgid ""
 "| keys to enter  | mathematical symbol                                   |\n"
 "| -------------- | ----------------------------------------------------- |\n"
@@ -299,45 +979,261 @@ msgstr ""
 "| ->             | flèche vers la droite                                           |\n"
 "| -->            | longue flèche vers la droite                                    |\n"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:201
 msgid ""
-"If a special symbol isnât in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols "
-"one can add to this toolbar or to the worksheet."
+"You can also use the \"Symbols\"-sidebar to enter these Mathematical symbols."
 msgstr ""
-"Si un symbole spécial ne figure pas dans la liste, il est possible de saisir des caractères Unicode arbitraires en appuyant sur <kbd>ÉCHAP</kbd> \\[numéro du caractère (en hexadécimal)\\] <kbd>ÉCHAP</kbd>. De plus, la barre latérale « Symboles » dispose d’un menu accessible par un clic droit, qui "
-"permet d’afficher une liste de tous les symboles Unicode disponibles que l’on peut ajouter à cette barre d’outils ou insérer dans le notebook."
+"Vous pouvez aussi utiliser la barre latérale « Symboles » pour saisir ces "
+"symboles mathématiques."
 
-msgid "Please note that most of these symbols (notable exceptions are the logic symbols) do not have a special meaning in _Maxima_ and therefore will be interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp that doesnât support Unicode characters they might cause an error message."
+#. type: Plain text
+#: ../../info/wxmaxima.md:203
+#, fuzzy
+#| msgid ""
+#| "If a special symbol isnât in the list, it is possible to input arbitrary "
+#| "Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character "
+#| "(hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has "
+#| "a right-click menu that allow to display a list of all available Unicode "
+#| "symbols one can add to this toolbar or to the worksheet."
+msgid ""
+"If a special symbol isn’t in the list, it is possible to input arbitrary "
+"Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character "
+"(hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a "
+"right-click menu that allow to display a list of all available Unicode "
+"symbols one can add to this toolbar or to the worksheet."
 msgstr ""
-"Veuillez noter que la plupart de ces symboles (à l'exception notable des symboles logiques) n'ont pas de signification particulière dans _Maxima_ et seront donc interprétés comme des caractères ordinaires. Si _Maxima_ est compilé avec un Lisp qui ne supporte pas les caractères Unicode, ceux-ci "
+"Si un symbole spécial ne figure pas dans la liste, il est possible de saisir "
+"des caractères Unicode arbitraires en appuyant sur <kbd>ÉCHAP</kbd> \\"
+"[numéro du caractère (en hexadécimal)\\] <kbd>ÉCHAP</kbd>. De plus, la barre "
+"latérale « Symboles » dispose d’un menu accessible par un clic droit, qui "
+"permet d’afficher une liste de tous les symboles Unicode disponibles que "
+"l’on peut ajouter à cette barre d’outils ou insérer dans le notebook."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:205
+msgid ""
+"<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an "
+"`a`."
+msgstr ""
+"<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd>  est une séquence qui "
+"produit un `a`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:207
+#, fuzzy
+#| msgid ""
+#| "Please note that most of these symbols (notable exceptions are the logic "
+#| "symbols) do not have a special meaning in _Maxima_ and therefore will be "
+#| "interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp "
+#| "that doesnât support Unicode characters they might cause an error message."
+msgid ""
+"Please note that most of these symbols (notable exceptions are the logic "
+"symbols) do not have a special meaning in _Maxima_ and therefore will be "
+"interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp "
+"that doesn’t support Unicode characters they might cause an error message."
+msgstr ""
+"Veuillez noter que la plupart de ces symboles (à l'exception notable des "
+"symboles logiques) n'ont pas de signification particulière dans _Maxima_ et "
+"seront donc interprétés comme des caractères ordinaires. Si _Maxima_ est "
+"compilé avec un Lisp qui ne supporte pas les caractères Unicode, ceux-ci "
 "peuvent provoquer un message d'erreur."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:210
 msgid ""
-"wxMaxima will replace several Unicode characters with their respective Maxima expressions, e.g. `Â²` with `^2`, `Â³` with `^3`, the square root sign with the function `sqrt()`, the (mathematical) Sigma sign (which is not the same Unicode character as the corresponding Greek letter) with `sum()`, etc."
+"It may be the case that e.g. Greek characters or mathematical symbols are "
+"not included in the selected font, then they can not be displayed.  To solve "
+"that problem, select other fonts (using: Edit -> Configure -> Style)."
 msgstr ""
-"wxMaxima remplacera plusieurs caractères Unicode par leurs expressions Maxima correspondantes, par exemple `Â²` par `^2`, `Â³` par `^3`, le symbole de la racine carrée par la fonction `sqrt()`, le symbole Sigma mathématique (qui n’est pas le même caractère Unicode que la lettre grecque "
+"Il est possible que, par exemple, les caractères grecs ou les symboles "
+"mathématiques ne soient pas inclus dans la police sélectionnée et ne "
+"puissent donc pas s'afficher. Pour résoudre ce problème, choisissez une "
+"autre police (via : Édition -> Configurer -> Style)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:212
+msgid "### Unicode replacement"
+msgstr "### Remplacement de caractères Unicode"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:214
+#, fuzzy
+#| msgid ""
+#| "wxMaxima will replace several Unicode characters with their respective "
+#| "Maxima expressions, e.g. `Â²` with `^2`, `Â³` with `^3`, the square root "
+#| "sign with the function `sqrt()`, the (mathematical) Sigma sign (which is "
+#| "not the same Unicode character as the corresponding Greek letter) with "
+#| "`sum()`, etc."
+msgid ""
+"wxMaxima will replace several Unicode characters with their respective "
+"Maxima expressions, e.g. `²` with `^2`, `³` with `^3`, the square root sign "
+"with the function `sqrt()`, the (mathematical) Sigma sign (which is not the "
+"same Unicode character as the corresponding Greek letter) with `sum()`, etc."
+msgstr ""
+"wxMaxima remplacera plusieurs caractères Unicode par leurs expressions "
+"Maxima correspondantes, par exemple `Â²` par `^2`, `Â³` par `^3`, le symbole "
+"de la racine carrée par la fonction `sqrt()`, le symbole Sigma mathématique "
+"(qui n’est pas le même caractère Unicode que la lettre grecque "
 "correspondante) par `sum()`, etc."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:217
+#, fuzzy
+#| msgid ""
+#| "Unicode has several \"common\" fractions encoded as one Unicode code "
+#| "point: `Â¼, Â½, Â¾, â, â, â, â, â, â, â, â, â, â, â, â, â, â, â`"
 msgid ""
-"It is recommended to use **Maxima code** (not these Unicode code points) in input cells (Rationale: (a) it might be possible, that the used font for math input does not contain them; (b) if you save the document as `wxm`-file, it is usually readable by (command line) Maxima, but these changes will of "
-"course not work in command line Maxima); but they may occur, if you cut&paste a formula from another document."
+"Unicode has several \"common\" fractions encoded as one Unicode code point: "
+"`¼, ½, ¾, ⅐, ⅑, ⅒, ⅓, ⅔, ⅕, ⅖, ⅗, ⅘, ⅙, ⅚, ⅛, ⅜, ⅝, ⅞`"
 msgstr ""
-"Il est recommandé d’utiliser le **code Maxima** (et non ces points de code Unicode) dans les cellules de saisie. Raisons : (a) il se peut que la police utilisée pour la saisie mathématique ne les contienne pas ;  (b) si vous enregistrez le document au format `wxm`, celui-ci est généralement lisible "
-"par Maxima en ligne de commande, mais ces substitutions ne fonctionneront évidemment pas dans Maxima en ligne de commande. Toutefois, ces caractères peuvent apparaître si vous copiez-collez une formule depuis un autre document."
+"Unicode comprend plusieurs fractions « courantes » encodées sous la forme "
+"d’un seul point de code : `¼, ½, ¾, ⅐, ⅑, ⅒, ⅓, ⅔, ⅕, ⅖, ⅗, ⅘, ⅙, ⅚, ⅛, ⅜, "
+"⅝, ⅞`"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:219
+#, fuzzy
+#| msgid ""
+#| "wxMaxima will replace them with their Maxima representations, e.g `(1/4)` "
+#| "before the input is sent do Maxima. There are also `â`, which will be replaced by `1/` and `â` (used in baseball), which will "
+#| "be replaced by `(0/3)`."
 msgid ""
-"Shortcuts to the most important _Maxima_ commands, things like a table of contents, windows with debug messages or a history of the last issued commands can be accessed using the side panes. They can be enabled using the \"View\" menu. They all can be moved to other locations inside or outside the "
-"_wxMaxima_ window. Other useful panes is the one that allows to input Greek letters using the mouse."
+"wxMaxima will replace them with their Maxima representations, e.g `(1/4)` "
+"before the input is sent do Maxima. There are also `⅟`, which will be "
+"replaced by `1/` and `↉` (used in baseball), which will be replaced by "
+"`(0/3)`."
 msgstr ""
-"Les raccourcis vers les commandes les plus importantes de _Maxima_, comme une table des matières, des fenêtres avec des messages de débogage ou un historique des dernières commandes exécutées, peuvent être accessibles via les panneaux latéraux. Ceux-ci peuvent être activés depuis le menu "
-"« Affichage ». Ils peuvent tous être déplacés vers d’autres emplacements, à l’intérieur ou à l’extérieur de la fenêtre de _wxMaxima_. Un autre volet utile est celui qui permet de saisir des lettres grecques avec la souris."
+"wxMaxima les remplacera par leurs représentations dans Maxima, par exemple "
+"`(1/4)` avant que l’entrée ne soit envoyée à Maxima. Il existe aussi `⅟`, "
+"qui sera remplacé par `1/`, et `↉` (utilisé au baseball), qui sera remplacé "
+"par `(0/3)`."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:221
 msgid ""
-"Several word processors and similar programs either recognize [MathML](https://www.w3.org/Math/) input and automatically insert it as an editable 2D equation - or (like LibreOffice) have an equation editor that offers an âimport MathML from clipboardâ feature. Others support RTF maths. _WxMaxima_, "
-"therefore, offers several entries in the right-click menu."
+"It is recommended to use **Maxima code** (not these Unicode code points) in "
+"input cells (Rationale: (a) it might be possible, that the used font for "
+"math input does not contain them; (b) if you save the document as `wxm`-"
+"file, it is usually readable by (command line) Maxima, but these changes "
+"will of course not work in command line Maxima); but they may occur, if you "
+"cut&paste a formula from another document."
 msgstr ""
-"Plusieurs logiciels de traitement de texte et programmes similaires reconnaissent soit  une entrée  [MathML](https://www.w3.org/Math/)  et l'insère automatiquement sous forme d'équation 2D modifiable, soit (comme LibreOffice) disposent d'un éditeur d'équations proposant une fonction « Importer du "
-"MathML depuis le presse-papiers ». D'autres prennent en charge les équations en RTF. _WxMaxima_ offre donc plusieurs options dans le menu contextuel (clic droit)."
+"Il est recommandé d’utiliser le **code Maxima** (et non ces points de code "
+"Unicode) dans les cellules de saisie. Raisons : (a) il se peut que la police "
+"utilisée pour la saisie mathématique ne les contienne pas ;  (b) si vous "
+"enregistrez le document au format `wxm`, celui-ci est généralement lisible "
+"par Maxima en ligne de commande, mais ces substitutions ne fonctionneront "
+"évidemment pas dans Maxima en ligne de commande. Toutefois, ces caractères "
+"peuvent apparaître si vous copiez-collez une formule depuis un autre "
+"document."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:223
+msgid "### Side Panes"
+msgstr "### Les panneaux latéraux"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:225
+msgid ""
+"Shortcuts to the most important _Maxima_ commands, things like a table of "
+"contents, windows with debug messages or a history of the last issued "
+"commands can be accessed using the side panes. They can be enabled using the "
+"\"View\" menu. They all can be moved to other locations inside or outside "
+"the _wxMaxima_ window. Other useful panes is the one that allows to input "
+"Greek letters using the mouse."
+msgstr ""
+"Les raccourcis vers les commandes les plus importantes de _Maxima_, comme "
+"une table des matières, des fenêtres avec des messages de débogage ou un "
+"historique des dernières commandes exécutées, peuvent être accessibles via "
+"les panneaux latéraux. Ceux-ci peuvent être activés depuis le menu "
+"« Affichage ». Ils peuvent tous être déplacés vers d’autres emplacements, à "
+"l’intérieur ou à l’extérieur de la fenêtre de _wxMaxima_. Un autre volet "
+"utile est celui qui permet de saisir des lettres grecques avec la souris."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:227
+msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
+msgstr ""
+"![Illustration de différents volets latéraux](./SidePanes.png)"
+"{ id=img_SidePanes }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:230
+msgid ""
+"In the \"table of contents\" side pane, one can increase or decrease a "
+"heading by just clicking on the heading with the right mouse button and "
+"select the next higher or lower heading type."
+msgstr ""
+"Dans le volet latéral « table des matières », vous pouvez augmenter ou "
+"diminuer le niveau d’un titre en cliquant simplement dessus avec le bouton "
+"droit de la souris et en sélectionnant le niveau de titre supérieur ou "
+"inférieur."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:232
+msgid ""
+"![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-"
+"headings.png){ id=Sidepane-TOC-convert-headings }"
+msgstr ""
+"![Augmenter ou diminuer le niveau de titres dans le panneau latéral Table "
+"des Matières](./Sidepane-TOC-convert-headings.png){ id=Sidepane-TOC-convert-"
+"headings }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:234
+msgid "### MathML output"
+msgstr "### Export MathML"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:236
+#, fuzzy
+#| msgid ""
+#| "Several word processors and similar programs either recognize [MathML]"
+#| "(https://www.w3.org/Math/) input and automatically insert it as an "
+#| "editable 2D equation - or (like LibreOffice) have an equation editor that "
+#| "offers an âimport MathML from clipboardâ feature. Others support RTF "
+#| "maths. _WxMaxima_, therefore, offers several entries in the right-click "
+#| "menu."
+msgid ""
+"Several word processors and similar programs either recognize [MathML]"
+"(https://www.w3.org/Math/) input and automatically insert it as an editable "
+"2D equation - or (like LibreOffice) have an equation editor that offers an "
+"“import MathML from clipboard” feature. Others support RTF maths. "
+"_WxMaxima_, therefore, offers several entries in the right-click menu."
+msgstr ""
+"Plusieurs logiciels de traitement de texte et programmes similaires "
+"reconnaissent soit  une entrée  [MathML](https://www.w3.org/Math/)  et "
+"l'insère automatiquement sous forme d'équation 2D modifiable, soit (comme "
+"LibreOffice) disposent d'un éditeur d'équations proposant une fonction "
+"« Importer du MathML depuis le presse-papiers ». D'autres prennent en charge "
+"les équations en RTF. _WxMaxima_ offre donc plusieurs options dans le menu "
+"contextuel (clic droit)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:238
+msgid "### Markdown support"
+msgstr "### Prise en charge de Markdown"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:240
+#, fuzzy
+#| msgid ""
+#| "_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/"
+#| "wiki/Markdown) conventions that donât collide with mathematical notation. "
+#| "One of these elements is bullet lists."
+msgid ""
+"_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/wiki/"
+"Markdown) conventions that don’t collide with mathematical notation. One of "
+"these elements is bullet lists."
+msgstr ""
+"_WxMaxima_ propose un ensemble de balises [Markdown](https://"
+"en.wikipedia.org/wiki/Markdown) standard qui n’entrent pas en conflit avec "
+"la notation mathématique. L’un de ces éléments est les listes à puces."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:250
+#, no-wrap
 msgid ""
 "```text\n"
 "Ordinary text\n"
@@ -359,26 +1255,286 @@ msgstr ""
 "Texte ordinaire\n"
 "```\n"
 
-msgid ""
-"Most hotkeys can be found in the text of the respective menus. Since they are actually taken from the menu text and thus can be customized by the translations of _wxMaxima_ to match the needs of users of the local keyboard, we do not document them here. A few hotkeys or hotkey aliases, though, are "
-"not documented in the menus:"
+#. type: Plain text
+#: ../../info/wxmaxima.md:252
+msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
 msgstr ""
-"La plupart des raccourcis clavier peuvent être trouvés dans le texte des menus associés. Comme ils sont effectivement tirés du texte des menus, ils peuvent ainsi être personnalisés par les traductions de _wxMaxima_ pour correspondre aux besoins des utilisateurs des claviers locaux, nous ne les "
-"documentons pas ici. Cependant, quelques raccourcis clavier ou alias de raccourcis ne sont pas documentés dans les menus :"
+"_WxMaxima_ reconnaîtra le texte commençant par le caractère `>` comme des "
+"blocs de citations  :"
 
-msgid "Attention: Although the file `Quadratic.mac` has a usual _Maxima_ extension (`.mac`), it can only be read by _wxMaxima_, since the command `wxdraw2d()` is a wxMaxima-extension to _Maxima_. (Command line) Maxima will ignore the unknown command `wxdraw2d()` and print it as output again."
+#. type: Plain text
+#: ../../info/wxmaxima.md:260
+msgid ""
+"```text Ordinary text > quote quote quote quote > quote quote quote quote > "
+"quote quote quote quote Ordinary text ```"
 msgstr ""
-"Attention : Bien que le fichier `Quadratic.mac` ait l'extension habituelle de _Maxima_ (`.mac`), il ne peut être lu que par _wxMaxima_, car la commande `wxdraw2d()` est une extension de wxMaxima à _Maxima_. _Maxima_ en ligne de commande ignorera la commande inconnue `wxdraw2d()` et l'affichera à "
+"```text Texte ordinaire > citation citation citation citation > citation "
+"citation citation citation > citation citation citation citation Texte "
+"ordinaire```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:262
+#, fuzzy
+#| msgid ""
+#| "_WxMaxima_âs TeX and HTML output will also recognize `=>` and replace it "
+#| "by the corresponding Unicode sign:"
+msgid ""
+"_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by "
+"the corresponding Unicode sign:"
+msgstr ""
+"_WxMaxima_ reconnaîtra `=>` dans ses sorties TeX et HTML et le remplacera "
+"par le symbole Unicode correspondant :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:266
+msgid "```text cogito => sum.  ```"
+msgstr "```text cogito => sum.  ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:268
+msgid ""
+"Other symbols the HTML and TeX export will recognize are `<=` and `>=` for "
+"comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<-"
+">`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also "
+"`<<` and `>>` are recognized."
+msgstr ""
+"D’autres symboles reconnus par les exports HTML et TeX sont `<=` et `>=` "
+"pour les comparaisons, une double flèche à double pointe (`<=>`), des "
+"flèches à une seule direction (`<->`, `->` et `<-`) ainsi que `+/-` pour le "
+"symbole correspondant. Pour la sortie TeX, les symboles `<<` et `>>` sont "
+"également reconnus."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:270
+msgid "### Hotkeys"
+msgstr "### Raccourcis clavier"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:272
+msgid ""
+"Most hotkeys can be found in the text of the respective menus. Since they "
+"are actually taken from the menu text and thus can be customized by the "
+"translations of _wxMaxima_ to match the needs of users of the local "
+"keyboard, we do not document them here. A few hotkeys or hotkey aliases, "
+"though, are not documented in the menus:"
+msgstr ""
+"La plupart des raccourcis clavier peuvent être trouvés dans le texte des "
+"menus associés. Comme ils sont effectivement tirés du texte des menus, ils "
+"peuvent ainsi être personnalisés par les traductions de _wxMaxima_ pour "
+"correspondre aux besoins des utilisateurs des claviers locaux, nous ne les "
+"documentons pas ici. Cependant, quelques raccourcis clavier ou alias de "
+"raccourcis ne sont pas documentés dans les menus :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid ""
+"<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
+msgstr ""
+"<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> supprime complètement une "
+"cellule."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid ""
+"<kbd>CTRL</kbd>+<kbd>TAB</kbd> or <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</"
+"kbd> triggers the auto-completion mechanism."
+msgstr ""
+"<kbd>CTRL</kbd>+<kbd>TAB</kbd> or <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</"
+"kbd> déclenche le mécanisme de saisie automatique."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
+msgstr "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> insère un espace insécable."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:278
+msgid "### Raw TeX in the TeX export"
+msgstr "### TeX brut dans l'export TeX"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:280
+msgid ""
+"If a text cell begins with `TeX:` the TeX export contains the literal text "
+"that follows the `TeX:` marker. Using this feature allows the entry of TeX "
+"markup within the _wxMaxima_ workbook."
+msgstr ""
+"Si une cellule de texte commence par `TeX:`, l'export TeX inclut le texte "
+"littéral qui suit le marqueur `TeX:`. Cette fonctionnalité permet d'insérer "
+"du code TeX directement dans le classeur _wxMaxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:282
+msgid "## File Formats"
+msgstr "## Formats de fichiers"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:284
+msgid ""
+"The material that is developed in a _wxMaxima_ session can be stored for "
+"later use in any of three ways:"
+msgstr ""
+"Le contenu développé lors d'une session _wxMaxima_ peut être enregistré pour "
+"une utilisation ultérieure de trois manières différentes :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:286
+msgid "### .mac"
+msgstr "### .mac"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:288
+#, fuzzy
+#| msgid ""
+#| "`.mac` files are ordinary text files that contain _Maxima_ commands. They "
+#| "can be read using _Maxima_âs `batch()` or `load()` command or "
+#| "_wxMaxima_âs File/Batch File menu entry."
+msgid ""
+"`.mac` files are ordinary text files that contain _Maxima_ commands. They "
+"can be read using _Maxima_’s `batch()` or `load()` command or _wxMaxima_’s "
+"File/Batch File menu entry."
+msgstr ""
+"Les fichiers `.mac` sont des fichiers texte ordinaires qui contiennent des "
+"commandes _Maxima_. Ils peuvent être lus à l'aide de la commande `batch()` "
+"ou `load()` de _Maxima_, ou via l'entrée de menu Fichier/Charger un "
+"packetage de _wxMaxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:291
+msgid ""
+"One example is shown below. `Quadratic.mac` defines a function and afterward "
+"generates a plot with `wxdraw2d()`.  Afterward the contents of the file "
+"`Quadratic.mac` are printed and newly defined function `f()` is evaluated."
+msgstr ""
+"Un exemple est présenté ci-dessous. `Quadratic.mac` définit une fonction, "
+"puis génère un tracé avec `wxdraw2d()`. Ensuite, le contenu du fichier "
+"`Quadratic.mac` est affiché et la fonction nouvellement définie `f()` est "
+"évaluée."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:293
+msgid "![Loading a file with `batch()`](./BatchImage.png){ id=img_BatchImage }"
+msgstr ""
+"![Chargement d'un fichier avec `batch()`](./BatchImage.png)"
+"{ id=img_BatchImage }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:295
+msgid ""
+"Attention: Although the file `Quadratic.mac` has a usual _Maxima_ extension "
+"(`.mac`), it can only be read by _wxMaxima_, since the command `wxdraw2d()` "
+"is a wxMaxima-extension to _Maxima_. (Command line) Maxima will ignore the "
+"unknown command `wxdraw2d()` and print it as output again."
+msgstr ""
+"Attention : Bien que le fichier `Quadratic.mac` ait l'extension habituelle "
+"de _Maxima_ (`.mac`), il ne peut être lu que par _wxMaxima_, car la commande "
+"`wxdraw2d()` est une extension de wxMaxima à _Maxima_. _Maxima_ en ligne de "
+"commande ignorera la commande inconnue `wxdraw2d()` et l'affichera à "
 "l'identique en sortie."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:297
+#, fuzzy
+#| msgid ""
+#| "You can be use `.mac` files for writing your own library of macros. But "
+#| "since they donât contain enough structural information they cannot be "
+#| "read back as a _wxMaxima_ session."
 msgid ""
-"`.wxm` files contain the worksheet except for _Maxima_âs output. On Maxima versions >5.38 they can be read using _Maxima_âs `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested "
-"after loading), but that can Maxima not evaluate.  You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know."
+"You can be use `.mac` files for writing your own library of macros. But "
+"since they don’t contain enough structural information they cannot be read "
+"back as a _wxMaxima_ session."
 msgstr ""
-"Les fichiers `.wxm` contiennent la feuille de travail, à l’exception de la sortie de _Maxima_.  Dans les versions de Maxima supérieures à 5.38, ils peuvent être lus à l’aide de la fonction `load()` de _Maxima_, tout comme les fichiers `.mac` — enfin, pour la plupart.  Les questions (comme "
-"`asksign(x)`) posent problème, car la réponse est écrite dans le fichier `.wxm` (afin qu’elle puisse être proposée après le chargement), mais Maxima ne peut pas l’évaluer.  Vous pouvez empêcher Maxima de poser des questions en utilisant `assume()` pour déclarer certaines propriétés que Maxima a "
+"Vous pouvez utiliser les fichiers `.mac` pour écrire votre propre "
+"bibliothèque de macros. Cependant, comme ils ne contiennent pas assez "
+"d’informations structurelles, ils ne peuvent pas être relus en tant que "
+"session _wxMaxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:299
+msgid "### .wxm"
+msgstr "### .wxm"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:302
+#, fuzzy
+#| msgid ""
+#| "`.wxm` files contain the worksheet except for _Maxima_âs output. On "
+#| "Maxima versions >5.38 they can be read using _Maxima_âs `load()` function "
+#| "just as .mac files. Well - mostly. Questions (like `asksign(x)`) are "
+#| "problematic, as the answer is written in the `.wxm` file (so that it can "
+#| "be suggested after loading), but that can Maxima not evaluate.  You can "
+#| "prevent Maxima from asking questions by using `assume()` to declare some "
+#| "properties, Maxima wants to know."
+msgid ""
+"`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima "
+"versions >5.38 they can be read using _Maxima_’s `load()` function just "
+"as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, "
+"as the answer is written in the `.wxm` file (so that it can be suggested "
+"after loading), but that can Maxima not evaluate.  You can prevent Maxima "
+"from asking questions by using `assume()` to declare some properties, Maxima "
+"wants to know."
+msgstr ""
+"Les fichiers `.wxm` contiennent la feuille de travail, à l’exception de la "
+"sortie de _Maxima_.  Dans les versions de Maxima supérieures à 5.38, ils "
+"peuvent être lus à l’aide de la fonction `load()` de _Maxima_, tout comme "
+"les fichiers `.mac` — enfin, pour la plupart.  Les questions (comme "
+"`asksign(x)`) posent problème, car la réponse est écrite dans le fichier "
+"`.wxm` (afin qu’elle puisse être proposée après le chargement), mais Maxima "
+"ne peut pas l’évaluer.  Vous pouvez empêcher Maxima de poser des questions "
+"en utilisant `assume()` pour déclarer certaines propriétés que Maxima a "
 "besoin de connaître."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:304
+msgid ""
+"With this plain-text format, it sometimes is unavoidable that worksheets "
+"that use new features are not downwards-compatible with older versions of "
+"_wxMaxima_."
+msgstr ""
+"Avec ce format en texte brut, il est parfois inévitable que les feuilles de "
+"calcul utilisant de nouvelles fonctionnalités ne soient pas rétrocompatibles "
+"avec les anciennes versions de _wxMaxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:306
+msgid "#### File format of wxm files"
+msgstr "#### Format de fichier des fichiers wxm"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:308
+msgid ""
+"This is just a plain text file (you can open it with a text editor), "
+"containing the cell contents as some special Maxima comments."
+msgstr ""
+"Il s'agit simplement d'un fichier texte brut (vous pouvez l'ouvrir avec un "
+"éditeur de texte), contenant le contenu des cellules sous forme de "
+"commentaires spéciaux Maxima."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:310
+msgid "It starts with the following comment:"
+msgstr "Cela commence par le commentaire suivant :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:315
+msgid ""
+"```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* "
+"[ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
+msgstr ""
+"```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* "
+"[ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:317
+msgid ""
+"And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
+msgstr ""
+"Puis les cellules suivent, encodées sous forme de commentaires Maxima, par "
+"exemple une cellule de section :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:323
+#, no-wrap
 msgid ""
 "```maxima\n"
 "/* [wxMaxima: section start ]\n"
@@ -392,6 +1548,18 @@ msgstr ""
 "   [wxMaxima: section end   ] */\n"
 "```\n"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:325
+msgid ""
+"or (in a Math cell the input is of course *not* commented out (the output is "
+"not saved in a `wxm` file)):"
+msgstr ""
+"ou (dans une cellule Math, l'entrée n'est bien sûr *pas* mise en commentaire "
+"(la sortie n'est pas enregistrée dans un fichier `wxm`)) :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:332
+#, no-wrap
 msgid ""
 "```maxima\n"
 "/* [wxMaxima: input   start ] */\n"
@@ -407,6 +1575,18 @@ msgstr ""
 "/* [wxMaxima: input   end   ] */\n"
 "```\n"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:334
+msgid ""
+"Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the "
+"image type as first line):"
+msgstr ""
+"Les images sont [encodées en Base64](https://en.wikipedia.org/wiki/Base64) "
+"avec l'indication du type de l'image sur la première ligne):"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:341
+#, no-wrap
 msgid ""
 "```maxima\n"
 "/* [wxMaxima: image   start ]\n"
@@ -422,6 +1602,14 @@ msgstr ""
 "   [wxMaxima: image   end   ] */\n"
 "```\n"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:343
+msgid "A page break is just one line containing:"
+msgstr "Une saut de page est simplement une ligne contenant :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:347
+#, no-wrap
 msgid ""
 "```maxima\n"
 "/* [wxMaxima: page break    ] */\n"
@@ -431,6 +1619,14 @@ msgstr ""
 "/* [wxMaxima: saut de page    ] */\n"
 "```\n"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:349
+msgid "And folded cells marked by:"
+msgstr "Et les cellules repliées sont marquées par :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:355
+#, no-wrap
 msgid ""
 "```maxima\n"
 "/* [wxMaxima: fold    start ] */\n"
@@ -444,20 +1640,198 @@ msgstr ""
 "/* [wxMaxima: fold    end   ] */\n"
 "```\n"
 
-msgid ""
-"A `wxmx`-file seems to be a binary format, but one can handle it with tools, which are included in your OS. It is a zip file, one can decompress it with `unzip` (maybe rename it before, so that is recognized by the unzip program of your OS).  We do not use the compression function, just the "
-"possibility to merge several files into one file - images are already compressed and the rest is simple text (probably much smaller, than huge images, which are included)."
-msgstr ""
-"Un fichier `wxmx` semble être un format binaire, mais on peut le gérer avec des outils inclus dans votre système d'exploitation. Il s'agit d'un fichier zip, que l'on peut décompresser avec `unzip` (peut-être faut-il le renommer au préalable pour qu'il soit reconnu par le programme de décompression de "
-"votre OS). Nous n'utilisons pas la fonction de compression, seulement la possibilité de regrouper plusieurs fichiers en un seul — les images sont déjà compressées et le reste est du texte simple (probablement bien plus petit que les images volumineuses qu'il contient)."
+#. type: Plain text
+#: ../../info/wxmaxima.md:357
+msgid "### .wxmx"
+msgstr "### .wxmx"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:359
 msgid ""
-"So, if something goes wrong, you can unzip a wxMaxima document (maybe rename it before to a `zip`-file), maybe make changes in the `content.xml` file with a text editor, or replace an broken image, zip the files again, probably rename the `zip` to a `wxmx`-file - and you get another modified `wxmx`-"
-"file."
+"This XML-based file format saves the complete worksheet including things "
+"like the zoom factor and the watchlist. It is the preferred file format."
 msgstr ""
-"Donc, si quelque chose ne va pas, vous pouvez décompresser un document wxMaxima (peut-être en le renommant au préalable en `.zip`), éventuellement modifier le fichier `content.xml` avec un éditeur de texte ou remplacer une image corrompue, recompresser les fichiers, probablement renommer le `.zip` en "
-"`.wxmx` — et vous obtiendrez un autre fichier `wxmx` modifié."
+"Ce format de fichier basé sur le XML enregistre la feuille de travail "
+"complète, y compris des éléments comme le facteur de zoom et la liste de "
+"suivi du notebook. C'est le format de fichier recommandé."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:361
+msgid "#### File format of wxmx files"
+msgstr "#### Format de fichier des fichiers wxmx"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:364
+msgid ""
+"A `wxmx`-file seems to be a binary format, but one can handle it with tools, "
+"which are included in your OS. It is a zip file, one can decompress it with "
+"`unzip` (maybe rename it before, so that is recognized by the unzip program "
+"of your OS).  We do not use the compression function, just the possibility "
+"to merge several files into one file - images are already compressed and the "
+"rest is simple text (probably much smaller, than huge images, which are "
+"included)."
+msgstr ""
+"Un fichier `wxmx` semble être un format binaire, mais on peut le gérer avec "
+"des outils inclus dans votre système d'exploitation. Il s'agit d'un fichier "
+"zip, que l'on peut décompresser avec `unzip` (peut-être faut-il le renommer "
+"au préalable pour qu'il soit reconnu par le programme de décompression de "
+"votre OS). Nous n'utilisons pas la fonction de compression, seulement la "
+"possibilité de regrouper plusieurs fichiers en un seul — les images sont "
+"déjà compressées et le reste est du texte simple (probablement bien plus "
+"petit que les images volumineuses qu'il contient)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:366
+msgid "It does contain the following files:"
+msgstr "Il contient les fichiers suivants :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-"
+"wxmathml`"
+msgstr ""
+"`mimetype` : ce fichier contient le type MIME des fichiers wxMaxima : `text/"
+"x-wxmathml`"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`format.txt`: a short description about wxMaxima and the wxmx file format"
+msgstr ""
+"`format.txt` : une brève description de wxMaxima et du format de fichier wxmx"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima "
+"session and included images."
+msgstr ""
+"Images (par ex. png, jpeg) : graphiques intégrés produits lors de la session "
+"wxMaxima et images incluses."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`content.xml`: a XML document, which contains the various cells of your "
+"document in XML format."
+msgstr ""
+"`content.xml` : un document XML contenant les différentes cellules de votre "
+"document au format XML."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:373
+msgid ""
+"So, if something goes wrong, you can unzip a wxMaxima document (maybe rename "
+"it before to a `zip`-file), maybe make changes in the `content.xml` file "
+"with a text editor, or replace an broken image, zip the files again, "
+"probably rename the `zip` to a `wxmx`-file - and you get another modified "
+"`wxmx`-file."
+msgstr ""
+"Donc, si quelque chose ne va pas, vous pouvez décompresser un document "
+"wxMaxima (peut-être en le renommant au préalable en `.zip`), éventuellement "
+"modifier le fichier `content.xml` avec un éditeur de texte ou remplacer une "
+"image corrompue, recompresser les fichiers, probablement renommer le `.zip` "
+"en `.wxmx` — et vous obtiendrez un autre fichier `wxmx` modifié."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:375
+msgid "## Configuration options"
+msgstr "## Options pour la configuration"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:377
+msgid ""
+"For some common configuration variables _wxMaxima_ offers two ways of "
+"configuring:"
+msgstr ""
+"Pour certaines variables courantes liées à la configuration, _wxMaxima_ "
+"propose deux méthodes de configuration :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:380
+msgid ""
+"The configuration dialog box below lets you change their default values for "
+"the current and subsequent sessions."
+msgstr ""
+"La boîte de dialogue de configuration ci-dessous vous permet de modifier "
+"leurs valeurs par défaut pour la session en cours et les suivantes."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:380
+msgid ""
+"Also, the values for most configuration variables can be changed for the "
+"current session only by overwriting their values from the worksheet, as "
+"shown below."
+msgstr ""
+"De plus, les valeurs de la plupart des variables de configuration peuvent "
+"être modifiées uniquement pour la session en cours en remplaçant leurs "
+"valeurs depuis la feuille de calcul, comme illustré ci-dessous."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:382
+msgid ""
+"![wxMaxima configuration 1](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
+msgstr ""
+"![configuration 1 de wxMaxima](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:384
+msgid "### Default animation framerate"
+msgstr "### Fréquence par défaut des images pour les animations"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:386
+msgid ""
+"The animation framerate that is used for new animations is kept in the "
+"variable `wxanimate_framerate`. The initial value this variable will contain "
+"in a new worksheet can be changed using the configuration dialogue."
+msgstr ""
+"La fréquence des images utilisée pour les nouvelles animations est stockée "
+"dans la variable `wxanimate_framerate`. La valeur initiale de cette variable "
+"dans un nouveau notebook peut être modifiée via la boîte de dialogue de "
+"configuration."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:388
+msgid "### Default plot size for new _maxima_ sessions"
+msgstr ""
+"### Dimensions par défaut des graphiques pour les nouvelles sessions de "
+"_maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:390
+#, fuzzy
+#| msgid ""
+#| "After the next start, plots embedded into the worksheet will be created "
+#| "with this size if the value of `wxplot_size` isnât changed by _maxima_."
+msgid ""
+"After the next start, plots embedded into the worksheet will be created with "
+"this size if the value of `wxplot_size` isn’t changed by _maxima_."
+msgstr ""
+"Lors du prochain démarrage, les graphiques intégrés au notebook seront créés "
+"avec ces dimensions, sauf si la valeur de `wxplot_size` est modifiée par "
+"_Maxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:392
+#, fuzzy
+#| msgid ""
+#| "In order to set the plot size of a single graph only use the following "
+#| "notation can be used that sets a variableâs value for one command only:"
+msgid ""
+"In order to set the plot size of a single graph only use the following "
+"notation can be used that sets a variable’s value for one command only:"
+msgstr ""
+"Afin de définir la taille d'un seul graphique, la notation suivante peut "
+"être utilisée afin d'affecter une valeur à une variable pour une seule "
+"commande :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:401
+#, no-wrap
 msgid ""
 "```maxima\n"
 "wxdraw2d(\n"
@@ -477,35 +1851,277 @@ msgstr ""
 "), wxplot_size=[480,480]$\n"
 "```\n"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:403
+msgid "### Match parenthesis in text controls"
+msgstr "### Correspondance des parenthèses dans les zones de texte"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:405
+msgid "This option enables two things:"
+msgstr "Cette option active deux fonctionnalités :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:408
 msgid ""
-"If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command "
-"`wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).  (Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden)."
+"If an opening parenthesis, bracket, or double quote is entered _wxMaxima_ "
+"will insert a closing one after it."
 msgstr ""
-"Si vous utilisez Unix/Linux, les informations de configuration sont enregistrées dans un fichier `.wxMaxima` de votre répertoire personnel (si vous utilisez wxWidgets < 3.1.1), ou dans `.config/wxMaxima.conf` (norme XDG, si wxWidgets >= 3.1.1 est utilisé). Vous pouvez connaître la version de "
-"wxWidgets avec la commande `wxbuild_info();` ou via le menu Aide → À propos. [wxWidgets](https://www.wxwidgets.org/) est la bibliothèque d'interface graphique multiplateforme sur laquelle repose _wxMaxima_ (d'où le `wx` dans le nom). (Ces fichiers ou dossiers, commençant par un point, `.wxMaxima` ou "
+"Si une parenthèse ouvrante, un crochet ouvrant ou un guillemet double est "
+"saisi, _wxMaxima_ insère automatiquement le caractère de fermeture "
+"correspondant."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:408
+msgid ""
+"If text is selected if any of these keys is pressed the selected text will "
+"be put between the matched signs."
+msgstr ""
+"Si du texte est sélectionné lorsque l’une de ces touches est enfoncée, le "
+"texte sélectionné est placé entre les signes correspondants appariés."
+
+# Entrées ajoutées depuis fr2.po
+#. type: Plain text
+#: ../../info/wxmaxima.md:410
+msgid "### Don’t save the worksheet automatically"
+msgstr "### Ne pas enregistrer automatiquement le notebook"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:412
+msgid ""
+"If this option is set, the file where the worksheet is will be overwritten "
+"only the request of the user. In case of a crash/power loss/... a recent "
+"backup copy is still made available in the temp directory, though."
+msgstr ""
+"Si cette option est activée, le fichier du notebook ne sera écrasé que sur "
+"demande de l'utilisateur. En cas de plantage, de coupure de courant ou autre "
+"incident, une copie de sauvegarde récente reste cependant disponible dans le "
+"dossier temporaire."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:414
+#, fuzzy
+#| msgid ""
+#| "If this option isnât set _wxMaxima_ behaves more like a modern cellphone "
+#| "app:"
+msgid ""
+"If this option isn’t set _wxMaxima_ behaves more like a modern cellphone app:"
+msgstr ""
+"Si cette option n'est pas activée, _wxMaxima_ se comporte davantage comme "
+"une application moderne de smartphone :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:417
+msgid "Files are saved automatically on exit"
+msgstr ""
+"Les fichiers sont sauvegardés automatiquement lorsque l'on quitte le "
+"programme"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:417
+msgid "And the file will automatically be saved every 3 minutes."
+msgstr "Et le fichier sera automatiquement sauvegardé toutes les 3 minutes."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:419
+msgid "### Where is the configuration saved?"
+msgstr "### Où est enregistrée la configuration  ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:422
+msgid ""
+"If you are using Unix/Linux, the configuration information will be saved in "
+"a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< "
+"3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is "
+"used). You can retrieve the wxWidgets version from the command "
+"`wxbuild_info();` or by using the menu option Help->About. [wxWidgets]"
+"(https://www.wxwidgets.org/) is the cross-platform GUI library, which is the "
+"base for _wxMaxima_ (therefore the `wx` in the name).  (Since the filename "
+"starts with a dot, `.wxMaxima` or `.config` will be hidden)."
+msgstr ""
+"Si vous utilisez Unix/Linux, les informations de configuration sont "
+"enregistrées dans un fichier `.wxMaxima` de votre répertoire personnel (si "
+"vous utilisez wxWidgets < 3.1.1), ou dans `.config/wxMaxima.conf` (norme "
+"XDG, si wxWidgets >= 3.1.1 est utilisé). Vous pouvez connaître la version de "
+"wxWidgets avec la commande `wxbuild_info();` ou via le menu Aide → À propos. "
+"[wxWidgets](https://www.wxwidgets.org/) est la bibliothèque d'interface "
+"graphique multiplateforme sur laquelle repose _wxMaxima_ (d'où le `wx` dans "
+"le nom). (Ces fichiers ou dossiers, commençant par un point, `.wxMaxima` ou "
 "`.config`, sont donc des fichiers cachés)."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:424
 msgid ""
-"_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, its main purpose is to pass along commands to _Maxima_ and to report the results of executing those commands. In some cases, however, _wxMaxima_ adds functionality to _Maxima_. _WxMaxima_âs ability to generate reports by "
-"exporting a workbookâs contents to HTML and LaTeX files has been mentioned. This section considers some ways that _wxMaxima_ enhances the inclusion of graphics in a session."
+"If you are using Windows, the configuration will be stored in the registry. "
+"You will find the entries for _wxMaxima_ at the following position in the "
+"registry: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
 msgstr ""
-"_WxMaxima_ est avant tout une interface graphique pour _Maxima_. Ainsi, son rôle principal consiste à transmettre les commandes à _Maxima_ et à afficher les résultats de leur exécution. Cependant, _WxMaxima_ ajoute également certaines fonctionnalités à _Maxima_. La capacité de _WxMaxima_ à générer "
-"des rapports en exportant le contenu d'un notebook vers des fichiers HTML et LaTeX a déjà été évoquée. Cette section aborde certaines améliorations apportées par _WxMaxima_ pour l'inclusion de graphiques dans une session."
+"Si vous utilisez Windows, la configuration est stockée dans le registre. "
+"Vous trouverez les entrées pour _wxMaxima_ à l'emplacement suivant du "
+"registre : `HKEY_CURRENT_USER\\Software\\wxMaxima`"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:428
+msgid "# Extensions to _Maxima_"
+msgstr "# Extensions pour _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:430
+#, fuzzy
+#| msgid ""
+#| "_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
+#| "its main purpose is to pass along commands to _Maxima_ and to report the "
+#| "results of executing those commands. In some cases, however, _wxMaxima_ "
+#| "adds functionality to _Maxima_. _WxMaxima_âs ability to generate reports "
+#| "by exporting a workbookâs contents to HTML and LaTeX files has been "
+#| "mentioned. This section considers some ways that _wxMaxima_ enhances the "
+#| "inclusion of graphics in a session."
 msgid ""
-"If the variable name doesnât match these requirements, it can still be declared as \"to be subscripted\" using the command `wxdeclare_subscript(variable_name);` or `wxdeclare_subscript([variable_name1,variable_name2,...]);` Declaring a variable as subscripted can be reverted using the following "
-"command: `wxdeclare_subscript(variable_name,false);`"
+"_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
+"its main purpose is to pass along commands to _Maxima_ and to report the "
+"results of executing those commands. In some cases, however, _wxMaxima_ adds "
+"functionality to _Maxima_. _WxMaxima_’s ability to generate reports by "
+"exporting a workbook’s contents to HTML and LaTeX files has been mentioned. "
+"This section considers some ways that _wxMaxima_ enhances the inclusion of "
+"graphics in a session."
 msgstr ""
-"Si le nom de la variable ne répond pas à ces exigences, il peut toujours être déclaré comme « à mettre en indice » en utilisant la commande `wxdeclare_subscript(nom_variable);` ou `wxdeclare_subscript([nom_variable1, nom_variable2, ...]);`Une déclaration de variable en tant qu’indice peut être "
-"annulée avec la commande suivante : `wxdeclare_subscript(nom_variable, false);`"
+"_WxMaxima_ est avant tout une interface graphique pour _Maxima_. Ainsi, son "
+"rôle principal consiste à transmettre les commandes à _Maxima_ et à afficher "
+"les résultats de leur exécution. Cependant, _WxMaxima_ ajoute également "
+"certaines fonctionnalités à _Maxima_. La capacité de _WxMaxima_ à générer "
+"des rapports en exportant le contenu d'un notebook vers des fichiers HTML et "
+"LaTeX a déjà été évoquée. Cette section aborde certaines améliorations "
+"apportées par _WxMaxima_ pour l'inclusion de graphiques dans une session."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:432
+msgid "## Subscripted variables"
+msgstr "## Variables en indice"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:434
 msgid ""
-"Long-running commands can provide user feedback in the status bar. This user feedback is replaced by any new feedback that is placed there (allowing to use it as a progress indicator) and is deleted as soon as the current command sent to _Maxima_ is finished. It is safe to use `wxstatusbar()` even in "
-"libraries that might be used with plain _Maxima_ (as opposed to _wxMaxima_): If _wxMaxima_ isnât present the `wxstatusbar()` command will just be left unevaluated."
+"`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript "
+"variable names:"
 msgstr ""
-"Les commandes qui durent longtemps peuvent générer un message pour l'utilisateur dans la barre d'état. Ce dernier est remplacé par tout nouveau message qui apparait dans cette barre (ce qui permet de l'utiliser comme indicateur de progression) et est supprimé dès que la commande actuelle envoyée à "
-"_Maxima_ est terminée. Il n'y a pas de risque à utiliser `wxstatusbar()` même avec des bibliothèques qui pourraient être utilisées avec _Maxima_ standard (par opposition à _wxMaxima_) : si _wxMaxima_ n'est pas présent, la commande `wxstatusbar()` restera simplement non évaluée."
+"`wxsubscripts` définit si (et comment) _wxMaxima appliquera automatiquement "
+"des indices aux noms de variables :"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:436
+msgid ""
+"If it is `false`, the functionality is off, wxMaxima will not autosubscript "
+"part of variable names after an underscore."
+msgstr ""
+"Si sa valeur est `false`, cette fonctionnalité est désactivée : wxMaxima ne "
+"transformera pas automatiquement en indices les parties des noms de "
+"variables suivant un tiret bas."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:438
+msgid ""
+"If it is set to `'all`, everything after an underscore will be subscripted."
+msgstr ""
+"Si elle est définie sur `'all`, tout ce qui suit un tiret bas sera converti "
+"en indice."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:440
+msgid ""
+"If it is set to `true` variable names of the format `x_y` are displayed "
+"using a subscript if"
+msgstr ""
+"Si elle est définie sur `true`, les noms de variables au format `x_y` "
+"s'affichent avec un indice uniquement si"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:443
+msgid "Either `x` or `y` is a single letter or"
+msgstr "Soit `x` soit `y` est une lettre unique ou"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:443
+msgid "`y` is an integer (can include more than one character)."
+msgstr "`y` est un entier (peut inclure plus d'un caractère)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:445
+msgid ""
+"![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png)"
+"{ id=img_wxsubscripts }"
+msgstr ""
+"![Comment les variables sont automatiquement mises en indices en utilisant "
+"wxsubscripts](./wxsubscripts.png){ id=img_wxsubscripts }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:447
+#, fuzzy
+#| msgid ""
+#| "If the variable name doesnât match these requirements, it can still be "
+#| "declared as \"to be subscripted\" using the command "
+#| "`wxdeclare_subscript(variable_name);` or "
+#| "`wxdeclare_subscript([variable_name1,variable_name2,...]);` Declaring a "
+#| "variable as subscripted can be reverted using the following command: "
+#| "`wxdeclare_subscript(variable_name,false);`"
+msgid ""
+"If the variable name doesn’t match these requirements, it can still be "
+"declared as \"to be subscripted\" using the command "
+"`wxdeclare_subscript(variable_name);` or "
+"`wxdeclare_subscript([variable_name1,variable_name2,...]);` Declaring a "
+"variable as subscripted can be reverted using the following command: "
+"`wxdeclare_subscript(variable_name,false);`"
+msgstr ""
+"Si le nom de la variable ne répond pas à ces exigences, il peut toujours "
+"être déclaré comme « à mettre en indice » en utilisant la commande "
+"`wxdeclare_subscript(nom_variable);` ou `wxdeclare_subscript([nom_variable1, "
+"nom_variable2, ...]);`Une déclaration de variable en tant qu’indice peut "
+"être annulée avec la commande suivante : `wxdeclare_subscript(nom_variable, "
+"false);`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:449
+msgid "You can use the menu \"View->Autosubscript\" to set these values."
+msgstr ""
+"Vous pouvez utiliser le menu \"Affichage->Mise en indice automatique\" pour "
+"définir ces valeurs."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:451
+msgid "## User feedback in the status bar"
+msgstr "## Message utilisateur dans la barre d'état"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:453
+#, fuzzy
+#| msgid ""
+#| "Long-running commands can provide user feedback in the status bar. This "
+#| "user feedback is replaced by any new feedback that is placed there "
+#| "(allowing to use it as a progress indicator) and is deleted as soon as "
+#| "the current command sent to _Maxima_ is finished. It is safe to use "
+#| "`wxstatusbar()` even in libraries that might be used with plain _Maxima_ "
+#| "(as opposed to _wxMaxima_): If _wxMaxima_ isnât present the "
+#| "`wxstatusbar()` command will just be left unevaluated."
+msgid ""
+"Long-running commands can provide user feedback in the status bar. This user "
+"feedback is replaced by any new feedback that is placed there (allowing to "
+"use it as a progress indicator) and is deleted as soon as the current "
+"command sent to _Maxima_ is finished. It is safe to use `wxstatusbar()` even "
+"in libraries that might be used with plain _Maxima_ (as opposed to "
+"_wxMaxima_): If _wxMaxima_ isn’t present the `wxstatusbar()` command will "
+"just be left unevaluated."
+msgstr ""
+"Les commandes qui durent longtemps peuvent générer un message pour "
+"l'utilisateur dans la barre d'état. Ce dernier est remplacé par tout nouveau "
+"message qui apparait dans cette barre (ce qui permet de l'utiliser comme "
+"indicateur de progression) et est supprimé dès que la commande actuelle "
+"envoyée à _Maxima_ est terminée. Il n'y a pas de risque à utiliser "
+"`wxstatusbar()` même avec des bibliothèques qui pourraient être utilisées "
+"avec _Maxima_ standard (par opposition à _wxMaxima_) : si _wxMaxima_ n'est "
+"pas présent, la commande `wxstatusbar()` restera simplement non évaluée."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:464
+#, no-wrap
 msgid ""
 "```maxima\n"
 "for i:1 thru 10 do (\n"
@@ -529,15 +2145,153 @@ msgstr ""
 ")$\n"
 "```\n"
 
-msgid ""
-"_Maxima_ normally instructs the external program _Gnuplot_ to open a separate window for every diagram it creates. Since many times it is convenient to embed graphs into the worksheet instead _wxMaxima_ provides its own set of plot functions that donât differ from the corresponding _maxima_ functions "
-"save in their name: They are all prefixed by a âwxâ."
+#. type: Plain text
+#: ../../info/wxmaxima.md:466
+msgid "## Exporting the worksheet from within Maxima"
 msgstr ""
-"Normalement, _Maxima_ demande au programme externe _Gnuplot_ d'ouvrir une fenêtre séparée pour chaque graphique qu'il génère. Comme il est souvent plus pratique d'intégrer les graphiques directement dans le notebook, _wxMaxima_ propose son propre ensemble de fonctions graphiques. Celles-ci ne "
-"diffèrent des fonctions _Maxima_ correspondantes que par leur nom : elles sont toutes préfixées par « wx »."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:468
 msgid ""
-"| wxMaximaâs plot function | Maximaâs plot function                                                                          |\n"
+"The command `wxworksheettohtml()` exports the current worksheet to an HTML "
+"file from within a running _Maxima_ session, which is convenient for "
+"scripted or batch export. Like `wxstatusbar()` it is safe to use in code "
+"that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present "
+"the command is simply left unevaluated."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:473
+msgid ""
+"```maxima wxworksheettohtml(\"report.html\")$ "
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:475
+msgid ""
+"A relative file name is interpreted relative to _Maxima_’s working "
+"directory. The optional keyword options are:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:480
+#, no-wrap
+msgid ""
+"| option   | values                                          | meaning                                             |\n"
+"| -------- | ----------------------------------------------- | --------------------------------------------------- |\n"
+"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |\n"
+"| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:482
+msgid ""
+"The `flavor` values match the equation formats offered by the graphical "
+"**File → Export** dialog: `mathml` produces a self-contained page that needs "
+"no internet connection, `mathjax` adds a MathJaX fall-back for browsers that "
+"still lack MathML, and `svg`/`bitmap` render every equation to an image."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:484
+msgid ""
+"The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file "
+"the same way:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:489
+msgid ""
+"```maxima wxworksheettotex(\"report.tex\")$ wxworksheettotex(\"report.tex\", "
+"documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:494
+#, no-wrap
+msgid ""
+"| option                 | meaning                                                              |\n"
+"| ---------------------- | -------------------------------------------------------------------- |\n"
+"| `documentclass`        | overrides the LaTeX `\\documentclass` (e.g. `\"article\"`, `\"report\"`)  |\n"
+"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:496
+msgid "Support for `wxworksheettopdf()` is planned."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:498
+msgid "## Plotting"
+msgstr "## Graphiques"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:500
+msgid ""
+"Plotting (having fundamentally to do with graphics) is a place where a "
+"graphical user interface will have to provide some extensions to the "
+"original program."
+msgstr ""
+"La création de courbes (qui repose fondamentalement sur des éléments "
+"graphiques) est un domaine où une interface utilisateur graphique devra "
+"apporter certaines extensions au programme d'origine."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:502
+msgid "### Embedding a plot into the worksheet"
+msgstr "### Intégrer un graphique dans le notebook"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:504
+#, fuzzy
+#| msgid ""
+#| "_Maxima_ normally instructs the external program _Gnuplot_ to open a "
+#| "separate window for every diagram it creates. Since many times it is "
+#| "convenient to embed graphs into the worksheet instead _wxMaxima_ provides "
+#| "its own set of plot functions that donât differ from the corresponding "
+#| "_maxima_ functions save in their name: They are all prefixed by a âwxâ."
+msgid ""
+"_Maxima_ normally instructs the external program _Gnuplot_ to open a "
+"separate window for every diagram it creates. Since many times it is "
+"convenient to embed graphs into the worksheet instead _wxMaxima_ provides "
+"its own set of plot functions that don’t differ from the corresponding "
+"_maxima_ functions save in their name: They are all prefixed by a “wx”."
+msgstr ""
+"Normalement, _Maxima_ demande au programme externe _Gnuplot_ d'ouvrir une "
+"fenêtre séparée pour chaque graphique qu'il génère. Comme il est souvent "
+"plus pratique d'intégrer les graphiques directement dans le notebook, "
+"_wxMaxima_ propose son propre ensemble de fonctions graphiques. Celles-ci ne "
+"diffèrent des fonctions _Maxima_ correspondantes que par leur nom : elles "
+"sont toutes préfixées par « wx »."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:506
+msgid "The following plotting functions have wx-counterparts:"
+msgstr ""
+"Les fonctions graphiques suivantes ont leurs équivalents préfixés par "
+"« wx » :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:520
+#, fuzzy, no-wrap
+#| msgid ""
+#| "| wxMaximaâs plot function | Maximaâs plot function                                                                          |\n"
+#| "| ------------------------ | ----------------------------------------------------------------------------------------------- |\n"
+#| "| `wxplot2d()`             | [plot2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot2d)               |\n"
+#| "| `wxplot3d()`             | [plot3d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot3d)               |\n"
+#| "| `wxdraw2d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw2d)               |\n"
+#| "| `wxdraw3d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw3d)               |\n"
+#| "| `wxdraw()`               | [draw](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw)                   |\n"
+#| "| `wximplicit_plot()`      | [implicit_plot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#implicit_plot) |\n"
+#| "| `wxhistogram()`          | [histogram](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#histogram)         |\n"
+#| "| `wxscatterplot()`        | [scatterplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#scatterplot)     |\n"
+#| "| `wxbarsplot()`           | [barsplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#barsplot)           |\n"
+#| "| `wxpiechart()`           | [piechart](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#piechart)           |\n"
+#| "| `wxboxplot()`            | [boxplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#boxplot)             |\n"
+msgid ""
+"| wxMaxima’s plot function | Maxima’s plot function                                                                          |\n"
 "| ------------------------ | ----------------------------------------------------------------------------------------------- |\n"
 "| `wxplot2d()`             | [plot2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot2d)               |\n"
 "| `wxplot3d()`             | [plot3d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot3d)               |\n"
@@ -565,20 +2319,60 @@ msgstr ""
 "| `wxpiechart()`           | [piechart](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#piechart)           |\n"
 "| `wxboxplot()`            | [boxplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#boxplot)             |\n"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:522
 msgid ""
-"If you got problems with one of these functions, please check, if the problem exists in the the Maxima function too (e.g. you got an error with `wxplot2d()`, check the same plot in the Maxima command `plot2d()` (which opens the plot in a separate Window)). If the problem does not disappear, it is "
-"most likely a Maxima issue and should be reported in the [Maxima bugtracker](https://sourceforge.net/p/maxima/bugs/). Or maybe a Gnuplot issue."
+"If a `wxm`-file is read by (console) Maxima, these functions are ignored "
+"(and printed as output, as other unknown functions in Maxima)."
 msgstr ""
-"Si vous rencontrez des problèmes avec l'une de ces fonctions, veuillez vérifier si le problème existe également pour la fonction Maxima correspondante (par exemple, si vous obtenez une erreur avec `wxplot2d()`, testez le même graphique avec la commande Maxima `plot2d()` (qui ouvre le graphique dans "
-"une fenêtre séparée)). Si le problème persiste, il s'agit probablement d'un problème de Maxima qui devrait être signalé dans le [suivi des bogues de Maxima](https://sourceforge.net/p/maxima/bugs/). Ou peut-être un problème de Gnuplot."
+"Si un fichier `.wxm` est lu par _Maxima_ (en mode console), ces fonctions "
+"sont ignorées (et affichées à l'identique en sortie, comme toute autre "
+"fonction inconnue dans _Maxima_)."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:524
 msgid ""
-"As noted above, the configure dialog provides a way to change the default size plots created which sets the starting value of `wxplot_size`. The plotting routines of _wxMaxima_ respect this variable that specifies the size of a plot in pixels. It can always be queried or used to set the size of the "
-"following plots:"
+"If you got problems with one of these functions, please check, if the "
+"problem exists in the the Maxima function too (e.g. you got an error with "
+"`wxplot2d()`, check the same plot in the Maxima command `plot2d()` (which "
+"opens the plot in a separate Window)). If the problem does not disappear, it "
+"is most likely a Maxima issue and should be reported in the [Maxima "
+"bugtracker](https://sourceforge.net/p/maxima/bugs/). Or maybe a Gnuplot "
+"issue."
 msgstr ""
-"Comme indiqué précédemment, la boîte de dialogue de configuration permet de modifier la taille par défaut des graphiques créés, en définissant la valeur initiale de `wxplot_size`. Les routines graphiques de _wxMaxima_ tiennent compte de cette variable, qui spécifie la taille d'un graphique en pixels. "
-"Il est toujours possible d'interroger ou de définir cette variable pour ajuster la taille des graphiques suivants :"
+"Si vous rencontrez des problèmes avec l'une de ces fonctions, veuillez "
+"vérifier si le problème existe également pour la fonction Maxima "
+"correspondante (par exemple, si vous obtenez une erreur avec `wxplot2d()`, "
+"testez le même graphique avec la commande Maxima `plot2d()` (qui ouvre le "
+"graphique dans une fenêtre séparée)). Si le problème persiste, il s'agit "
+"probablement d'un problème de Maxima qui devrait être signalé dans le [suivi "
+"des bogues de Maxima](https://sourceforge.net/p/maxima/bugs/). Ou peut-être "
+"un problème de Gnuplot."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:526
+msgid "### Making embedded plots bigger or smaller"
+msgstr "### Agrandir ou diminuer les graphiques intégrés"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:528
+msgid ""
+"As noted above, the configure dialog provides a way to change the default "
+"size plots created which sets the starting value of `wxplot_size`. The "
+"plotting routines of _wxMaxima_ respect this variable that specifies the "
+"size of a plot in pixels. It can always be queried or used to set the size "
+"of the following plots:"
+msgstr ""
+"Comme indiqué précédemment, la boîte de dialogue de configuration permet de "
+"modifier la taille par défaut des graphiques créés, en définissant la valeur "
+"initiale de `wxplot_size`. Les routines graphiques de _wxMaxima_ tiennent "
+"compte de cette variable, qui spécifie la taille d'un graphique en pixels. "
+"Il est toujours possible d'interroger ou de définir cette variable pour "
+"ajuster la taille des graphiques suivants :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:538
+#, no-wrap
 msgid ""
 "```maxima\n"
 "wxplot_size:[1200,800]$\n"
@@ -600,11 +2394,23 @@ msgstr ""
 ")$\n"
 "```\n"
 
-msgid "If the size of only one plot is to be changed _Maxima_ provides a canonical way to change an attribute only for the current cell. In this usage the specification `wxplot_size = [value1, value2]` is appended to the `wxdraw2d( )` command, and is not part of the `wxdraw2d` command."
+#. type: Plain text
+#: ../../info/wxmaxima.md:540
+msgid ""
+"If the size of only one plot is to be changed _Maxima_ provides a canonical "
+"way to change an attribute only for the current cell. In this usage the "
+"specification `wxplot_size = [value1, value2]` is appended to the "
+"`wxdraw2d( )` command, and is not part of the `wxdraw2d` command."
 msgstr ""
-"Si la dimension d'un seul graphique doit être modifiée, _Maxima_ offre une méthode standard pour changer l'attribut de taille uniquement pour la cellule actuelle. Dans ce cas, la spécification `wxplot_size = [valeur1, valeur2]` est ajoutée à la commande `wxdraw2d()`, sans faire partie intégrante de "
-"cette commande."
+"Si la dimension d'un seul graphique doit être modifiée, _Maxima_ offre une "
+"méthode standard pour changer l'attribut de taille uniquement pour la "
+"cellule actuelle. Dans ce cas, la spécification `wxplot_size = [valeur1, "
+"valeur2]` est ajoutée à la commande `wxdraw2d()`, sans faire partie "
+"intégrante de cette commande."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:549
+#, no-wrap
 msgid ""
 "```maxima\n"
 "wxdraw2d(\n"
@@ -624,32 +2430,142 @@ msgstr ""
 "),wxplot_size=[1600,800]$\n"
 "```\n"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:551
 msgid ""
-"_Gnuplot_ doesnât seem to provide a portable way of determining whether it supports the high-quality bitmap output that the Cairo library provides. On systems where _Gnuplot_ is compiled to use this library the pngCairo option from the configuration menu (that can be overridden by the variable "
-"`wxplot_pngcairo`) enables support for antialiasing and additional line styles. If `wxplot_pngCairo` is set without _Gnuplot_ supporting this the result will be error messages instead of graphics."
+"Setting the size of embedded plot with `wxplot_size` works for embedded "
+"plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` "
+"commands and for embedded animations with `with_slider_draw` and `wxanimate` "
+"commands."
 msgstr ""
-"Il semble que _Gnuplot_ ne propose pas de méthode portable pour déterminer s'il prend en charge la sortie bitmap haute qualité fournie par la bibliothèque Cairo. Sur les systèmes où _Gnuplot_ est compilé pour utiliser cette bibliothèque, l'option pngCairo du menu de configuration (qui peut être "
-"écrasée par la variable `wxplot_pngcairo`) active la prise en charge de l'antialiasing et des styles de ligne supplémentaires. Si `wxplot_pngcairo` est définie alors que _Gnuplot_ ne supporte pas cette fonctionnalité, le résultat résultera en des messages d'erreur au lieu des graphiques."
+"Le réglage de la taille des graphiques intégrés avec `wxplot_size` "
+"fonctionne pour les graphiques en ligne utilisant par exemple les commandes "
+"`wxplot`, `wxdraw`, `wxcontour_plot` et `wximplicit_plot`, ainsi que pour "
+"les animations intégrées avec les commandes `with_slider_draw` et "
+"`wxanimate`."
 
-msgid "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and `wxplot3d` isnât supported by this feature) and the file size of the underlying _Gnuplot_ project isnât way too high _wxMaxima_ offers a right-click menu that allows to open the plot in an interactive _Gnuplot_ window."
-msgstr ""
-"Si un graphique a été généré avec des commandes de type `wxdraw` (`wxplot2d` et `wxplot3d` ne sont pas pris en charge par cette fonctionnalité) et que la taille du fichier du projet _Gnuplot_ correspondant n'est pas trop élevée, _wxMaxima_ propose un menu contextuel (clic droit) permettant d'ouvrir "
-"le graphique dans une fenêtre interactive _Gnuplot_."
+#. type: Plain text
+#: ../../info/wxmaxima.md:553
+msgid "### Better quality plots"
+msgstr "### Des graphiques de meilleur qualité"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:555
+#, fuzzy
+#| msgid ""
+#| "_Gnuplot_ doesnât seem to provide a portable way of determining whether "
+#| "it supports the high-quality bitmap output that the Cairo library "
+#| "provides. On systems where _Gnuplot_ is compiled to use this library the "
+#| "pngCairo option from the configuration menu (that can be overridden by "
+#| "the variable `wxplot_pngcairo`) enables support for antialiasing and "
+#| "additional line styles. If `wxplot_pngCairo` is set without _Gnuplot_ "
+#| "supporting this the result will be error messages instead of graphics."
 msgid ""
-"On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and `wgnuplot.exe`.  You can configure, which command should be used using the configuration menu. `wgnuplot.exe` offers the possibility to open a console window, where _gnuplot_ commands can be entered into, `gnuplot.exe` does not offer "
-"this possibility. Unfortunately, `wgnuplot.exe` causes _Gnuplot_ to \"steal\" the keyboard focus for a short time every time a plot is prepared."
+"_Gnuplot_ doesn’t seem to provide a portable way of determining whether it "
+"supports the high-quality bitmap output that the Cairo library provides. On "
+"systems where _Gnuplot_ is compiled to use this library the pngCairo option "
+"from the configuration menu (that can be overridden by the variable "
+"`wxplot_pngcairo`) enables support for antialiasing and additional line "
+"styles. If `wxplot_pngCairo` is set without _Gnuplot_ supporting this the "
+"result will be error messages instead of graphics."
 msgstr ""
-"Sous MS Windows, il existe deux programmes Gnuplot : `gnuplot.exe` et `wgnuplot.exe`. Vous pouvez configurer lequel utiliser via le menu de configuration. `wgnuplot.exe` permet d'ouvrir une fenêtre de console où les commandes _Gnuplot_ peuvent être saisies, ce que `gnuplot.exe` ne propose pas. "
-"Malheureusement, `wgnuplot.exe` provoque un bref \"décrochage\" du focus clavier à chaque génération d'un graphique."
+"Il semble que _Gnuplot_ ne propose pas de méthode portable pour déterminer "
+"s'il prend en charge la sortie bitmap haute qualité fournie par la "
+"bibliothèque Cairo. Sur les systèmes où _Gnuplot_ est compilé pour utiliser "
+"cette bibliothèque, l'option pngCairo du menu de configuration (qui peut "
+"être écrasée par la variable `wxplot_pngcairo`) active la prise en charge de "
+"l'antialiasing et des styles de ligne supplémentaires. Si `wxplot_pngcairo` "
+"est définie alors que _Gnuplot_ ne supporte pas cette fonctionnalité, le "
+"résultat résultera en des messages d'erreur au lieu des graphiques."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:557
+msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
+msgstr ""
+"### Ouvrir les graphiques intégrés dans les fenêtres interactives de "
+"_Gnuplot_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:559
+#, fuzzy
+#| msgid ""
+#| "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
+#| "`wxplot3d` isnât supported by this feature) and the file size of the "
+#| "underlying _Gnuplot_ project isnât way too high _wxMaxima_ offers a right-"
+#| "click menu that allows to open the plot in an interactive _Gnuplot_ "
+#| "window."
 msgid ""
-"3D diagrams tend to make it hard to read quantitative data. A viable alternative might be to assign the 3rd parameter to the mouse wheel. The `with_slider_draw` command is a version of `wxdraw2d` that does prepare multiple plots and allows to switch between them by moving the slider on top of the "
-"screen. _WxMaxima_ allows to export this animation as an animated gif."
+"If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
+"`wxplot3d` isn’t supported by this feature) and the file size of the "
+"underlying _Gnuplot_ project isn’t way too high _wxMaxima_ offers a right-"
+"click menu that allows to open the plot in an interactive _Gnuplot_ window."
 msgstr ""
-"Les diagrammes en 3D impliquent souvent que la lecture des données quantitatives soit difficile. Une alternative intéressante consiste à associer le 3ᵉ paramètre à la molette de la souris. La commande `with_slider_draw` est une version de `wxdraw2d` qui génère plusieurs graphiques et permet de "
-"basculer entre eux à l'aide d'un curseur situé en haut de l'écran. _WxMaxima_ permet d'exporter cette animation au format GIF animé."
+"Si un graphique a été généré avec des commandes de type `wxdraw` (`wxplot2d` "
+"et `wxplot3d` ne sont pas pris en charge par cette fonctionnalité) et que la "
+"taille du fichier du projet _Gnuplot_ correspondant n'est pas trop élevée, "
+"_wxMaxima_ propose un menu contextuel (clic droit) permettant d'ouvrir le "
+"graphique dans une fenêtre interactive _Gnuplot_."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:561
+msgid "### Opening Gnuplot’s command console in `plot` windows"
+msgstr "### Ouvrir la console de commandes de Gnuplot dans les fenêtres `plot`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:564
+msgid ""
+"On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and "
+"`wgnuplot.exe`.  You can configure, which command should be used using the "
+"configuration menu. `wgnuplot.exe` offers the possibility to open a console "
+"window, where _gnuplot_ commands can be entered into, `gnuplot.exe` does not "
+"offer this possibility. Unfortunately, `wgnuplot.exe` causes _Gnuplot_ to "
+"\"steal\" the keyboard focus for a short time every time a plot is prepared."
+msgstr ""
+"Sous MS Windows, il existe deux programmes Gnuplot : `gnuplot.exe` et "
+"`wgnuplot.exe`. Vous pouvez configurer lequel utiliser via le menu de "
+"configuration. `wgnuplot.exe` permet d'ouvrir une fenêtre de console où les "
+"commandes _Gnuplot_ peuvent être saisies, ce que `gnuplot.exe` ne propose "
+"pas. Malheureusement, `wgnuplot.exe` provoque un bref \"décrochage\" du "
+"focus clavier à chaque génération d'un graphique."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:566
+msgid "### Embedding animations into the spreadsheet"
+msgstr "### Intégrer des animations dans le notebook"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:568
+msgid ""
+"3D diagrams tend to make it hard to read quantitative data. A viable "
+"alternative might be to assign the 3rd parameter to the mouse wheel. The "
+"`with_slider_draw` command is a version of `wxdraw2d` that does prepare "
+"multiple plots and allows to switch between them by moving the slider on top "
+"of the screen. _WxMaxima_ allows to export this animation as an animated gif."
+msgstr ""
+"Les diagrammes en 3D impliquent souvent que la lecture des données "
+"quantitatives soit difficile. Une alternative intéressante consiste à "
+"associer le 3ᵉ paramètre à la molette de la souris. La commande "
+"`with_slider_draw` est une version de `wxdraw2d` qui génère plusieurs "
+"graphiques et permet de basculer entre eux à l'aide d'un curseur situé en "
+"haut de l'écran. _WxMaxima_ permet d'exporter cette animation au format GIF "
+"animé."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:570
+msgid ""
+"The first two arguments for `with_slider_draw` are the name of the variable "
+"that is stepped between the plots and a list of the values of these "
+"variable. The arguments that follow are the ordinary arguments for "
+"`wxdraw2d`:"
+msgstr ""
+"Les deux premiers arguments de `with_slider_draw` sont le nom du paramètre "
+"qui varie entre les graphiques et une liste des valeurs prises par ce "
+"paramètre. Les arguments suivants sont les arguments classiques de la "
+"commande `wxdraw2d` :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:581
+#, no-wrap
 msgid ""
 "```maxima\n"
 "with_slider_draw(\n"
@@ -673,7 +2589,53 @@ msgstr ""
 ");\n"
 "```\n"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:583
 msgid ""
+"The same functionality for 3D plots is accessible as `with_slider_draw3d`, "
+"which allows for rotating 3d plots:"
+msgstr ""
+"La même fonctionnalité pour les graphiques 3D est accessible avec "
+"`with_slider_draw3d`, qui permet de faire tourner les graphiques 3D :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:600
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxanimate_autoplay:true;\n"
+#| "wxanimate_framerate:20;\n"
+#| "with_slider_draw3d(\n"
+#| "    Î±,makelist(i,i,1,360,3),\n"
+#| "    title=sconcat(\"Î±=\",Î±),\n"
+#| "    surface_hide=true,\n"
+#| "    contour=both,\n"
+#| "    view=[60,Î±],\n"
+#| "    explicit(\n"
+#| "        sin(x)*sin(y),\n"
+#| "        x,-Ï,Ï,\n"
+#| "        y,-Ï,Ï\n"
+#| "    )\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"```maxima\n"
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    α,makelist(i,i,1,360,3),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,α],\n"
+"    explicit(\n"
+"        sin(x)*sin(y),\n"
+"        x,-π,π,\n"
+"        y,-π,π\n"
+"    )\n"
+")$\n"
+"```\n"
+msgstr ""
 "```maxima\n"
 "wxanimate_autoplay:true;\n"
 "wxanimate_framerate:20;\n"
@@ -690,25 +2652,55 @@ msgid ""
 "    )\n"
 ")$\n"
 "```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:602
+msgid ""
+"If the general shape of the plot is what matters it might suffice to move "
+"the plot just a little bit in order to make its 3D nature available to the "
+"intuition:"
 msgstr ""
+"Si c'est plutôt la forme générale du graphique qui importe, un léger "
+"déplacement peut suffire pour rendre la visualisation 3D plus intuitive :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:619
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxanimate_autoplay:true;\n"
+#| "wxanimate_framerate:20;\n"
+#| "with_slider_draw3d(\n"
+#| "    t,makelist(i,i,0,2*Ï,.05*Ï),\n"
+#| "    title=sconcat(\"Î±=\",Î±),\n"
+#| "    surface_hide=true,\n"
+#| "    contour=both,\n"
+#| "    view=[60,30+5*sin(t)],\n"
+#| "    explicit(\n"
+#| "        sin(x)*y^2,\n"
+#| "        x,-2*Ï,2*Ï,\n"
+#| "        y,-2*Ï,2*Ï\n"
+#| "    )\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
 "```maxima\n"
 "wxanimate_autoplay:true;\n"
 "wxanimate_framerate:20;\n"
 "with_slider_draw3d(\n"
-"    Î±,makelist(i,i,1,360,3),\n"
-"    title=sconcat(\"Î±=\",Î±),\n"
+"    t,makelist(i,i,0,2*π,.05*π),\n"
+"    title=sconcat(\"α=\",α),\n"
 "    surface_hide=true,\n"
 "    contour=both,\n"
-"    view=[60,Î±],\n"
+"    view=[60,30+5*sin(t)],\n"
 "    explicit(\n"
-"        sin(x)*sin(y),\n"
-"        x,-Ï,Ï,\n"
-"        y,-Ï,Ï\n"
+"        sin(x)*y^2,\n"
+"        x,-2*π,2*π,\n"
+"        y,-2*π,2*π\n"
 "    )\n"
 ")$\n"
 "```\n"
-
-msgid ""
+msgstr ""
 "```maxima\n"
 "wxanimate_autoplay:true;\n"
 "wxanimate_framerate:20;\n"
@@ -725,24 +2717,41 @@ msgid ""
 "    )\n"
 ")$\n"
 "```\n"
-msgstr ""
-"```maxima\n"
-"wxanimate_autoplay:true;\n"
-"wxanimate_framerate:20;\n"
-"with_slider_draw3d(\n"
-"    t,makelist(i,i,0,2*Ï,.05*Ï),\n"
-"    title=sconcat(\"Î±=\",Î±),\n"
-"    surface_hide=true,\n"
-"    contour=both,\n"
-"    view=[60,30+5*sin(t)],\n"
-"    explicit(\n"
-"        sin(x)*y^2,\n"
-"        x,-2*Ï,2*Ï,\n"
-"        y,-2*Ï,2*Ï\n"
-"    )\n"
-")$\n"
-"```\n"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:621
+msgid ""
+"For those more familiar with `plot` than with `draw`, there is a second set "
+"of functions:"
+msgstr ""
+"Pour ceux qui maîtrisent mieux la commande `plot` que `draw`, il existe un "
+"second ensemble de fonctions :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:624
+msgid "`with_slider` and"
+msgstr "- `with_slider` et"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:624
+msgid "`wxanimate`."
+msgstr "`wxanimate`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:626
+msgid ""
+"Normally the animations are played back or exported with the frame rate "
+"chosen in the configuration of _wxMaxima_. To set the speed at an individual "
+"animation is played back the variable `wxanimate_framerate` can be used:"
+msgstr ""
+"Normalement, les animations sont lues ou exportées avec le taux de "
+"rafraîchissement défini dans la configuration de _wxMaxima_. Pour régler la "
+"vitesse de lecture d'une animation donnée, on peut utiliser la variable "
+"`wxanimate_framerate` :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:631
+#, no-wrap
 msgid ""
 "```maxima\n"
 "wxanimate(a, 10,\n"
@@ -754,9 +2763,28 @@ msgstr ""
 "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
 "```\n"
 
-msgid "The animation functions use _Maxima_âs `makelist` command and therefore share the pitfall that the slider variableâs value is substituted into the expression only if the variable is directly visible in the expression. Therefore the following example will fail:"
-msgstr "Les fonctions d'animation utilisent la commande `makelist` de _Maxima_ et partagent donc le même écueil : la valeur de la variable du curseur n'est substituée dans l'expression que si cette variable y apparaît explicitement. Par conséquent, l'exemple suivant échouera :"
+#. type: Plain text
+#: ../../info/wxmaxima.md:633
+#, fuzzy
+#| msgid ""
+#| "The animation functions use _Maxima_âs `makelist` command and therefore "
+#| "share the pitfall that the slider variableâs value is substituted into "
+#| "the expression only if the variable is directly visible in the "
+#| "expression. Therefore the following example will fail:"
+msgid ""
+"The animation functions use _Maxima_’s `makelist` command and therefore "
+"share the pitfall that the slider variable’s value is substituted into the "
+"expression only if the variable is directly visible in the expression. "
+"Therefore the following example will fail:"
+msgstr ""
+"Les fonctions d'animation utilisent la commande `makelist` de _Maxima_ et "
+"partagent donc le même écueil : la valeur de la variable du curseur n'est "
+"substituée dans l'expression que si cette variable y apparaît explicitement. "
+"Par conséquent, l'exemple suivant échouera :"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:643
+#, no-wrap
 msgid ""
 "```maxima\n"
 "f:sin(a*x);\n"
@@ -777,6 +2805,22 @@ msgstr ""
 "    explicit(f,x,0,10)\n"
 ")$\n"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:645
+#, fuzzy
+#| msgid ""
+#| "If _Maxima_ is explicitly asked to substitute the sliderâs value plotting "
+#| "works fine instead:"
+msgid ""
+"If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
+"works fine instead:"
+msgstr ""
+"Si _Maxima_ est explicitement invité à substituer la valeur du curseur, le "
+"tracé fonctionne correctement :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:658
+#, no-wrap
 msgid ""
 "```maxima\n"
 "f:sin(a*x);\n"
@@ -804,6 +2848,67 @@ msgstr ""
 ")$\n"
 "```\n"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:660
+msgid "### Opening multiple plots in contemporaneous windows"
+msgstr ""
+"### Ouvrir plusieurs graphiques dans des fenêtres de manière simultanée"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:662
+msgid ""
+"While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups "
+"that support it) sometimes comes in handily. The following example comes "
+"from a post from Mario Rodriguez to the _Maxima_ mailing list:"
+msgstr ""
+"Cette fonctionnalité de _Maxima_ (sur les configurations qui la supportent), "
+"bien qu'elle ne soit pas disponible via  _wxMaxima_, s'avère parfois bien "
+"pratique. L'exemple suivant provient d'un message de Mario Rodriguez sur la "
+"_liste de diffusion de Maxima_ :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:665
+msgid "```maxima load(draw);"
+msgstr "```maxima load(draw);"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:668
+msgid ""
+"/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
+msgstr ""
+"/* Une parabole dans une fenêtre #1 */ "
+"draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:671
+msgid ""
+"/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
+msgstr ""
+"/* Une parabole dans une fenêtre #2 */ "
+"draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:675
+msgid ""
+"/* Paraboloid in window #3 */ "
+"draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```"
+msgstr ""
+"/* Un paraboloide dans une fenêtre #3 */ "
+"draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:677
+msgid ""
+"Plotting multiple plots in the same window is possible, too (the same is "
+"possible in command line Maxima with the standard `draw()` command):"
+msgstr ""
+"Il est également possible de tracer plusieurs graphiques dans une même "
+"fenêtre (la même chose est réalisable avec la commande standard `draw()` de "
+"Maxima en ligne de commande) :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:688
+#, no-wrap
 msgid ""
 "```maxima\n"
 "wxdraw(\n"
@@ -827,18 +2932,279 @@ msgstr ""
 ");\n"
 "```\n"
 
-msgid "One helpful feature of the 2D button is that it allows to set up the scene as an animation in which a variable (by default it is _t_) has a different value in each frame: Often a moving 2D plot allows easier interpretation than the same data in a non-moving 3D one."
+#. type: Plain text
+#: ../../info/wxmaxima.md:690
+msgid "### The \"Plot using draw\" side pane"
+msgstr "### Le panneau latéral \"Graphiques avec draw\""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:692
+msgid ""
+"The \"Plot using draw\" sidebar hides a simple code generator that allows "
+"generating scenes that make use of some of the flexibility of the _draw_ "
+"package _maxima_ comes with."
 msgstr ""
-"Une fonctionnalité utile du bouton 2D est qu'il permet de configurer la scène comme une animation dans laquelle un paramètre (par défaut, _t_) prend une valeur différente à chaque image : une courbe 2D animée facilite souvent l'interprétation des données plus qu'une représentation 3D statique des "
+"Le panneau latéral \"Graphiques avec draw\" cache un générateur simple de "
+"code qui permet de créer des représentations graphiques exploitant une "
+"partie des fonctionnalités du package _draw_ intégré à _Maxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:694
+msgid "#### 2D"
+msgstr "#### 2D"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:696
+#, fuzzy
+#| msgid ""
+#| "Generates the skeleton of a `draw()` command that draws a 2D scene. This "
+#| "scene later has to be filled with commands that generate the sceneâs "
+#| "contents, for example by using the buttons in the rows below the \"2D\" "
+#| "button."
+msgid ""
+"Generates the skeleton of a `draw()` command that draws a 2D scene. This "
+"scene later has to be filled with commands that generate the scene’s "
+"contents, for example by using the buttons in the rows below the \"2D\" "
+"button."
+msgstr ""
+"Génère le squelette d'une commande `draw()` pour dessiner une scène 2D. "
+"Cette scène doit ensuite être complétée avec des commandes qui génèrent son "
+"contenu, par exemple en utilisant les boutons situés dans les lignes en "
+"dessous du bouton \"2D\"."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:698
+msgid ""
+"One helpful feature of the 2D button is that it allows to set up the scene "
+"as an animation in which a variable (by default it is _t_) has a different "
+"value in each frame: Often a moving 2D plot allows easier interpretation "
+"than the same data in a non-moving 3D one."
+msgstr ""
+"Une fonctionnalité utile du bouton 2D est qu'il permet de configurer la "
+"scène comme une animation dans laquelle un paramètre (par défaut, _t_) prend "
+"une valeur différente à chaque image : une courbe 2D animée facilite souvent "
+"l'interprétation des données plus qu'une représentation 3D statique des "
 "mêmes informations."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:700
+msgid "#### 3D"
+msgstr "#### 3D"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:702
 msgid ""
-"(Only for 3D plots): Adds contour lines similar to the ones one can find in a map of a mountain to the plot commands that follow in the current `draw()` command and/or to the ground plane of the diagram. Alternatively, this wizard allows skipping drawing the curves entirely only showing the contour "
+"Generates the skeleton of a `draw()` command that draws a 3D scene. If "
+"neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D "
+"scene that contains the command the button generates."
+msgstr ""
+"Génère le squelette d'une commande `draw()` pour tracer une scène 3D. Si "
+"aucune scène 2D ou 3D n'est définie, tous les autres boutons configurent "
+"automatiquement une scène 2D contenant la commande générée par le bouton."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:704
+msgid "#### Expression"
+msgstr "#### Expression"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:706
+msgid ""
+"Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or "
+"`x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is "
+"no draw command a 2D scene with the plot is generated. Each scene can be "
+"filled with any number of plots."
+msgstr ""
+"Ajoute un tracé standard d'une expression comme `sin(x)`, `x*sin(x)` ou "
+"`x^2+2*x-4` à la commande `draw()` où se trouve actuellement le curseur. Si "
+"aucune commande `draw()` n'existe, une scène 2D avec ce tracé est générée. "
+"Chaque scène peut contenir un nombre illimité de graphiques."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:708
+msgid "#### Implicit plot"
+msgstr "#### Courbe définie de manière implicite"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:710
+msgid ""
+"Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or "
+"`x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command "
+"the cursor currently is in. If there is no draw command a 2D scene with the "
+"plot is generated."
+msgstr ""
+"Tente de trouver tous les points où une expression comme `y=sin(x)`, "
+"`y*sin(x)=3` ou `x^2+y^2=4` est vérifiée et trace la courbe résultante dans "
+"la commande `draw()` où se trouve le curseur. Si aucune commande `draw()` "
+"n'existe, une scène 2D avec ce tracé est générée."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:712
+msgid "#### Parametric plot"
+msgstr "#### Courbe paramétrique"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:714
+msgid ""
+"Steps a variable from a lower limit to an upper limit and uses two "
+"expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in "
+"3D plots also z) coordinates of a curve that is put into the current draw "
+"command."
+msgstr ""
+"Fait varier une variable entre une borne inférieure et une borne supérieure, "
+"puis utilise deux expressions comme `t*sin(t)` et `t*cos(t)` pour générer "
+"les coordonnées x, y (et z dans le cas des tracés 3D) d'une courbe, qui est "
+"ensuite insérée dans la commande `draw()` actuelle."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:716
+msgid "#### Points"
+msgstr "#### Points"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:718
+msgid ""
+"Draws many points that can optionally be joined. The coordinates of the "
+"points are taken from a list of lists, a 2D array or one list or array for "
+"each axis."
+msgstr ""
+"Trace plusieurs points, éventuellement reliés entre eux. Les coordonnées des "
+"points peuvent provenir d'une liste de listes, d'un tableau 2D, ou d'une "
+"liste ou d'un tableau pour chaque axe."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:720
+msgid "#### Diagram title"
+msgstr "#### Titre du graphique"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:722
+msgid "Draws a title on the upper end of the diagram,"
+msgstr "Ajoute un titre en haut du graphique,"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:724
+msgid "#### Axis"
+msgstr "#### Axes"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:726
+msgid "Sets up the axis."
+msgstr "Configurer l'axe."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:728
+msgid "#### Contour"
+msgstr "#### Lignes de niveau"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:730
+msgid ""
+"(Only for 3D plots): Adds contour lines similar to the ones one can find in "
+"a map of a mountain to the plot commands that follow in the current `draw()` "
+"command and/or to the ground plane of the diagram. Alternatively, this "
+"wizard allows skipping drawing the curves entirely only showing the contour "
 "plot."
 msgstr ""
-"(Uniquement pour les tracés 3D) : Ajoute des lignes de niveau similaires à celles que l'on trouve sur une carte de montagne aux commandes du tracé qui suivent dans la commande `draw()` actuelle et/ou au plan de base du graphique. Alternativement, cet assistant permet de sauter entièrement le tracé "
-"des courbes et d'afficher uniquement le tracé des lignes de niveau."
+"(Uniquement pour les tracés 3D) : Ajoute des lignes de niveau similaires à "
+"celles que l'on trouve sur une carte de montagne aux commandes du tracé qui "
+"suivent dans la commande `draw()` actuelle et/ou au plan de base du "
+"graphique. Alternativement, cet assistant permet de sauter entièrement le "
+"tracé des courbes et d'afficher uniquement le tracé des lignes de niveau."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:732
+msgid "#### Plot name"
+msgstr "#### Légende du graphique"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:734
+#, fuzzy
+#| msgid ""
+#| "Adds a legend entry showing the next plotâs name to the legend of the "
+#| "diagram. An empty name disables generating legend entries for the "
+#| "following plots."
+msgid ""
+"Adds a legend entry showing the next plot’s name to the legend of the "
+"diagram. An empty name disables generating legend entries for the following "
+"plots."
+msgstr ""
+"Ajoute une nouvelle entrée pour la légende affichant le nom du prochain "
+"tracé à la légende actuelle du graphique. Un nom vide désactive la "
+"génération d'entrées des légende pour les tracés suivants."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:736
+msgid "#### Line colour"
+msgstr "#### Couleur de la ligne du tracé"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:738
+msgid ""
+"Sets the line colour for the following plots the current draw command "
+"contains."
+msgstr ""
+"Définit la couleur de ligne pour les tracés suivants contenus dans la "
+"commande `draw()` actuelle."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:740
+msgid "#### Fill colour"
+msgstr "#### Couleur de remplissage"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:742
+msgid ""
+"Sets the fill colour for the following plots the current draw command "
+"contains."
+msgstr ""
+"Définit la couleur de remplissage pour les tracés suivants contenus dans la "
+"commande `draw()` actuelle."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:744
+msgid "#### Grid"
+msgstr "#### Quadrillage"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:746
+msgid "Pops up a wizard that allows to set up grid lines."
+msgstr "Ouvre un assistant permettant de configurer les lignes du quadrillage."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:748
+msgid "#### Accuracy"
+msgstr "#### Précision"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:750
+msgid ""
+"Allows to select an adequate point in the speed vs. accuracy tradeoff that "
+"is part of any plot program."
+msgstr ""
+"Permet de choisir un compromis adapté entre vitesse et précision, inhérent à "
+"tout programme de tracé graphique."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:752
+msgid "### Modify font and font size for plots"
+msgstr "### Modifier la police et la taille de police pour les graphiques"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:754
+msgid ""
+"Especially when you use a high resolution display, the default font size "
+"might be very small. For the `draw`-based commands, you can set the font / "
+"font size using options like `font=...`, `font_size=...`, e.g.:"
+msgstr ""
+"Surtout lorsque vous utilisez un affichage haute résolution, la taille de "
+"police par défaut peut être très petite. Pour les commandes basées sur "
+"`draw`, vous pouvez définir la police et la taille de police à l'aide "
+"d'options comme `font=...`, `font_size=...`, par exemple :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:761
+#, no-wrap
 msgid ""
 "~~~maxima\n"
 "wxdraw2d(\n"
@@ -854,6 +3220,19 @@ msgstr ""
 "     explicit(sin(x),x,1,10));\n"
 "~~~\n"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:763
+msgid ""
+"For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts "
+"can be set using the `gnuplot_preamble` command, e.g.:"
+msgstr ""
+"Pour les commandes de type `plot` (par exemple `wxplot2d`, `wxplot3d`), les "
+"tailles et polices de caractères peuvent être définies à l'aide de la "
+"commande `gnuplot_preamble`, par exemple :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:768
+#, no-wrap
 msgid ""
 "~~~maxima\n"
 "wxplot2d(sin(x),[x,1,10],\n"
@@ -865,25 +3244,256 @@ msgstr ""
 "         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
 "~~~\n"
 
-msgid "If the `.wxmx` file format is being used embedding files in a _wxMaxima_ project can be done as easily as per drag-and-drop. But sometimes (for example if an imageâs contents might change later on in a session) it is better to tell the file to load the image on evaluation:"
+#. type: Plain text
+#: ../../info/wxmaxima.md:770
+msgid ""
+"This sets the font for the numbers to Arial with size 30, the size for the "
+"xlabel and ylabel font to 20 (with the default font)."
 msgstr ""
-"Si le format de fichier `.wxmx` est utilisé, l'intégration de fichiers dans un notebook _wxMaxima_ peut se faire simplement par glisser-déposer. Mais parfois (par exemple si le contenu d'une image est susceptible de changer plus tard dans une session), il est préférable d'indiquer au fichier de "
+"Cela définit la police pour les nombres en Arial avec une taille de 30, et "
+"la taille de la police des étiquettes xlabel et ylabel à 20 (avec la police "
+"par défaut)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:773
+msgid ""
+"Read the Maxima and Gnuplot documentation for further information.  Note: "
+"Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue "
+"1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966)."
+msgstr ""
+"Consultez la documentation de Maxima et Gnuplot pour plus d'informations. "
+"Remarque : Gnuplot semble rencontrer des problèmes avec les polices de "
+"grande taille, voir [wxMaxima issue 1966](https://github.com/wxMaxima-"
+"developers/wxmaxima/issues/1966)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:775
+msgid "## Embedding graphics"
+msgstr "## Graphiques intégrés"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:777
+#, fuzzy
+#| msgid ""
+#| "If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
+#| "project can be done as easily as per drag-and-drop. But sometimes (for "
+#| "example if an imageâs contents might change later on in a session) it is "
+#| "better to tell the file to load the image on evaluation:"
+msgid ""
+"If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
+"project can be done as easily as per drag-and-drop. But sometimes (for "
+"example if an image’s contents might change later on in a session) it is "
+"better to tell the file to load the image on evaluation:"
+msgstr ""
+"Si le format de fichier `.wxmx` est utilisé, l'intégration de fichiers dans "
+"un notebook _wxMaxima_ peut se faire simplement par glisser-déposer. Mais "
+"parfois (par exemple si le contenu d'une image est susceptible de changer "
+"plus tard dans une session), il est préférable d'indiquer au fichier de "
 "charger l'image lors de l'évaluation :"
 
-msgid ""
-"`wxchangedir`: On most operating systems _wxMaxima_ automatically sets _Maxima_âs working directory to the directory of the current file. This allows file I/O (e.g. by `read_matrix`) to work without specifying the whole path to the file that has to be read or written. On Windows this feature "
-"sometimes causes error messages and therefore can be set to `false` from the config dialogue."
-msgstr ""
-"`wxchangedir` : Sur la plupart des systèmes d'exploitation, _wxMaxima_ définit automatiquement le répertoire de travail de _Maxima_ à partir du répertoire du fichier actuel. Cela permet aux opérations d'entrée/sortie de fichiers (par exemple avec `read_matrix`) de fonctionner sans spécifier le chemin "
-"complet vers le fichier à lire ou à écrire. Sur Windows, cette fonctionnalité peut parfois causer des messages d'erreur et peut donc être désactivée en la réglant à `false` depuis la boîte de dialogue de configuration."
+#. type: Plain text
+#: ../../info/wxmaxima.md:781
+msgid "```maxima show_image(\"man.png\"); ```"
+msgstr "```maxima show_image(\"man.png\"); ```"
 
-msgid ""
-"The function `table_form()` displays a 2D list in a form that is more readable than the output from _Maxima_âs default output routine. The input is a list of one or more lists. Like the \"print\" command, this command displays output even when ended with a dollar sign. Ending the command with a "
-"semicolon results in the same table along with a \"done\" statement."
-msgstr ""
-"La fonction `table_form()` affiche une liste 2D sous une forme plus lisible que le résultat produit par la sortie par défaut de _Maxima_. L'argument doit être une liste contenant une ou plusieurs listes. Comme la commande \"print\", cette commande affiche le résultat même si elle se termine par un "
-"dollar (`$`). Si elle se termine par un point-virgule (`;`), le tableau s'affiche accompagné d'un message \"done\"."
+#. type: Plain text
+#: ../../info/wxmaxima.md:783
+msgid "## Startup files"
+msgstr "## Fichiers au démarrage"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:785
+msgid ""
+"The config dialogue of _wxMaxima_ offers to edit two files with commands "
+"that are executed on startup:"
+msgstr ""
+"La boîte de dialogue de configuration de _wxMaxima_ permet de modifier deux "
+"fichiers contenant des commandes exécutées au démarrage :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:788
+msgid ""
+"A file that contains commands that are executed on starting up _Maxima_: "
+"`maxima-init.mac`"
+msgstr ""
+"Un fichier contenant des commandes exécutées au démarrage de _Maxima_ : "
+"`maxima-init.mac`"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:788
+msgid ""
+"one file of additional commands that are executed if _wxMaxima_ is starting "
+"_Maxima_: `wxmaxima-init.mac`"
+msgstr ""
+"un fichier d'instructions supplémentaires exécutées lorsque _wxMaxima_ "
+"démarre _Maxima_ : `wxmaxima-init.mac`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:790
+msgid ""
+"For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add "
+"`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` "
+"or any other path) to these files."
+msgstr ""
+"Par exemple, si Gnuplot est installé dans `/opt` (peut-être sur macOS), vous "
+"pouvez ajouter `gnuplot_command:\"/opt/local/bin/gnuplot\"$` (ou `/opt/"
+"gnuplot/bin/gnuplot` ou tout autre chemin) à ces fichiers."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:792
+msgid ""
+"These files are in the Maxima user directory (usually `%USERPROFILE%/maxima` "
+"in Windows, `$HOME/.maxima` otherwise). The location can be found out with "
+"the command: `maxima_userdir;`"
+msgstr ""
+"Ces fichiers se trouvent dans le répertoire utilisateur de Maxima "
+"(généralement `%USERPROFILE%/maxima` sous Windows, ou `$HOME/.maxima` "
+"sinon). Vous pouvez connaître leur emplacement avec la commande : "
+"`maxima_userdir;`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:794
+msgid "## Special variables wx..."
+msgstr "## Variables spéciales wx..."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:805
+msgid ""
+"`wxsubscripts` tells _Maxima_ if it should convert variable names that "
+"contain an underscore (`R_150` or the like) into subscripted variables. See "
+"`wxdeclare_subscript` for details which variable names are automatically "
+"converted."
+msgstr ""
+"`wxsubscripts` indique à _Maxima_ s'il doit convertir les noms de variables "
+"contenant un tiret bas (`R_150` ou similaire) en variables avec indices en "
+"bas de ligne. Voir `wxdeclare_subscript` pour les détails sur les noms de "
+"variables automatiquement convertis."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:805
+msgid ""
+"`wxfilename`: This variable contains the name of the file currently opened "
+"in _wxMaxima_."
+msgstr ""
+"`wxfilename` : Cette variable contient le nom du fichier actuellement ouvert "
+"dans _wxMaxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:805
+msgid ""
+"`wxdirname`: This variable contains the name the directory, in which the "
+"file currently opened in _wxMaxima_ is."
+msgstr ""
+"`wxdirname` : Cette variable contient le nom du répertoire dans lequel se "
+"trouve le fichier actuellement ouvert dans _wxMaxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:805
+#, fuzzy
+#| msgid ""
+#| "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_âs "
+#| "pngcairo terminal that provides more line styles and a better overall "
+#| "graphics quality."
+msgid ""
+"`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_’s pngcairo "
+"terminal that provides more line styles and a better overall graphics "
+"quality."
+msgstr ""
+"`wxplot_pngcairo` indique si _wxMaxima_ essaie d'utiliser le terminal "
+"pngcairo de _Gnuplot_ qui fournit plus de styles de lignes et une meilleure "
+"qualité graphique globale."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:805
+msgid "`wxplot_size` defines the resolution of embedded plots."
+msgstr "`wxplot_size` définit la résolution des graphiques intégrés."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:805
+#, fuzzy
+#| msgid ""
+#| "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
+#| "_Maxima_âs working directory to the directory of the current file. This "
+#| "allows file I/O (e.g. by `read_matrix`) to work without specifying the "
+#| "whole path to the file that has to be read or written. On Windows this "
+#| "feature sometimes causes error messages and therefore can be set to "
+#| "`false` from the config dialogue."
+msgid ""
+"`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
+"_Maxima_’s working directory to the directory of the current file. This "
+"allows file I/O (e.g. by `read_matrix`) to work without specifying the whole "
+"path to the file that has to be read or written. On Windows this feature "
+"sometimes causes error messages and therefore can be set to `false` from the "
+"config dialogue."
+msgstr ""
+"`wxchangedir` : Sur la plupart des systèmes d'exploitation, _wxMaxima_ "
+"définit automatiquement le répertoire de travail de _Maxima_ à partir du "
+"répertoire du fichier actuel. Cela permet aux opérations d'entrée/sortie de "
+"fichiers (par exemple avec `read_matrix`) de fonctionner sans spécifier le "
+"chemin complet vers le fichier à lire ou à écrire. Sur Windows, cette "
+"fonctionnalité peut parfois causer des messages d'erreur et peut donc être "
+"désactivée en la réglant à `false` depuis la boîte de dialogue de "
+"configuration."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:805
+msgid ""
+"`wxanimate_framerate`: The number of frames per second the following "
+"animations have to be played back with."
+msgstr ""
+"`wxanimate_framerate` : Le nombre d'images par seconde pour la lecture des "
+"animations suivantes."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:805
+msgid "`wxanimate_autoplay`: Automatically play animations by default?"
+msgstr ""
+"`wxanimate_autoplay` : Jouer automatiquement les animations par défaut ?"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:805
+msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
+msgstr "`wxmaximaversion` : Retourne le numéro de version de _wxMaxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:805
+msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
+msgstr ""
+"`wxwidgetsversion` : Retourne la version de wxWidgets utilisée par "
+"_wxMaxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:807
+msgid "## Pretty-printing 2D output"
+msgstr "## Affichage formaté en 2D"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:809
+#, fuzzy
+#| msgid ""
+#| "The function `table_form()` displays a 2D list in a form that is more "
+#| "readable than the output from _Maxima_âs default output routine. The "
+#| "input is a list of one or more lists. Like the \"print\" command, this "
+#| "command displays output even when ended with a dollar sign. Ending the "
+#| "command with a semicolon results in the same table along with a \"done\" "
+#| "statement."
+msgid ""
+"The function `table_form()` displays a 2D list in a form that is more "
+"readable than the output from _Maxima_’s default output routine. The input "
+"is a list of one or more lists. Like the \"print\" command, this command "
+"displays output even when ended with a dollar sign. Ending the command with "
+"a semicolon results in the same table along with a \"done\" statement."
+msgstr ""
+"La fonction `table_form()` affiche une liste 2D sous une forme plus lisible "
+"que le résultat produit par la sortie par défaut de _Maxima_. L'argument "
+"doit être une liste contenant une ou plusieurs listes. Comme la commande "
+"\"print\", cette commande affiche le résultat même si elle se termine par un "
+"dollar (`$`). Si elle se termine par un point-virgule (`;`), le tableau "
+"s'affiche accompagné d'un message \"done\"."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:818
+#, no-wrap
 msgid ""
 "```maxima\n"
 "table_form(\n"
@@ -903,41 +3513,440 @@ msgstr ""
 ")$\n"
 "```\n"
 
-msgid "`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima using an (machine readable) XML-dialect (can be seen in the \"Raw XML sidebar\") and outputs the resulting formulas nicely rendered, e.g. pretty Matrices, Square root signs, fractions, etc."
-msgstr ""
-"`set_display('xml)` est la valeur par défaut. Ici, Maxima communique avec wxMaxima en utilisant un dialecte XML (lisible par machine) (visible dans la barre latérale « XML brut ») et affiche les formules résultantes avec un visuel mathématique, par exemple des matrices bien délimitées et structurées, "
-"des signes de racine carrée, des fractions, etc."
-
+#. type: Plain text
+#: ../../info/wxmaxima.md:820
 msgid ""
-"Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ (providing the easy-to-use user interface) are separate programs that communicate by the means of a local network connection. Therefore the most probable cause is that this connection is somehow not working. For example, a "
-"firewall could be set up in a way that it doesnât just prevent unauthorized connections from the internet (and perhaps intercept some connections to the internet, too), but also blocks inter-process-communication inside the same computer. Note that since _Maxima_ is being run by a Lisp processor the "
-"process communication that is blocked does not necessarily have to be named \"maxima\". Common names of the program that opens the network connection would be sbcl, gcl, ccl, lisp.exe, or similar names."
+"As the next example shows, the lists that are assembled by the `table_form` "
+"command can be created before the command is executed."
 msgstr ""
-"Puisque _Maxima_ (le programme qui effectue les calculs mathématiques) et _wxMaxima_ (qui fournit l’interface utilisateur conviviale) sont deux programmes distincts qui communiquent via une connexion réseau locale, la cause la plus probable d'un dysfonctionnement est que cette connexion ne s'établit "
-"pas correctement. Par exemple, un pare-feu peut être configuré non seulement pour bloquer les connexions non autorisées depuis Internet (et éventuellement intercepter certaines connexions sortantes), mais aussi pour empêcher la communication entre processus sur un même ordinateur. Notez que, comme "
-"Maxima est exécuté via un processeur Lisp, le processus bloqué ne porte pas nécessairement le nom \"maxima\". Les noms usuels pour le programme ouvrant la connexion réseau peuvent être sbcl, gcl, ccl, lisp.exe, ou des noms similaires."
+"Comme le montre l'exemple suivant, les listes utilisées par la commande "
+"`table_form` peuvent être créées avant son exécution."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:822
 msgid ""
-"If the zip signature at the end of the file is still intact after renaming a broken `.wxmx` file to `.zip` most operating systems will provide a way to extract any portion of the information that is stored inside it. This can be done when there is a need of recovering the original image files from a "
-"text processor document. If the zip signature isnât intact that does not need to be the end of the world: If _wxMaxima_ during saving detected that something went wrong there will be a `.wxmx~` file whose contents might help."
+"![A third table example](./MatrixTableExample.png)"
+"{ id=img_MatrixTableExample }"
 msgstr ""
-"Si la signature du zip à la fin du fichier est toujours intacte après avoir renommé un fichier `.wxmx` corrompu en `.zip`, la plupart des systèmes d’exploitation permettront d’extraire une partie des informations qu’il contient. Cette méthode est souvent utilisée pour récupérer les fichiers image "
-"originaux d’un document issu d'un traitement de texte. Si la signature du zip n’est plus intacte, ce n’est pas forcément une impasse : si _wxMaxima_ a détecté une erreur lors de l’enregistrement, un fichier `.wxmx~` aura probablement été créé et son contenu pourrait s’avérer utile."
+"![Un troisième exemple de tableau](./MatrixTableExample.png)"
+"{ id=img_MatrixTableExample }"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:824
 msgid ""
-"And even if there isnât such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the fileâs contents (it starts with `<?xml version=\"1.0\" "
-"encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor)."
+"Also, because a matrix is a list of lists, matrices can be converted to "
+"tables in a similar fashion."
 msgstr ""
-"Et même s’il n’existe pas un tel fichier : le format `.wxmx` est un format conteneur et la partie XML y est stockée sans compression. Il est possible de renommer le fichier `.wxmx` en `.txt` et d’utiliser un éditeur de texte pour récupérer la portion XML du contenu (elle commence par `<?xml "
-"version=\"1.0\" encoding=\"UTF-8\"?>` et se termine par `</wxMaximaDocument>`. Avant et après ce texte, vous verrez du contenu binaire illisible dans l’éditeur)."
+"De même, comme une matrice est une liste de listes, elle peut être convertie "
+"en tableau de manière similaire."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:826
 msgid ""
-"Normally _wxMaxima_ waits for the whole 2D formula to be transferred before it begins to typeset. This saves time for making many attempts to typeset a only partially completed equation. There is a `disp` command, though, that will provide debug output immediately and without waiting for the current "
+"![Another table_form example](./SecondTableExample.png)"
+"{ id=img_SecondTableExample }"
+msgstr ""
+"![Un autre exemple avec table_form](./SecondTableExample.png)"
+"{ id=img_SecondTableExample }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:828
+msgid ""
+"The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that "
+"allows for more flexible formatting of matrices in wxMaxima:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:830
+#, no-wrap
+msgid "**`wx_matrix( <matrix>, [options] )`**\n"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`lines=true`**: Draws internal separator lines between the cells. This is "
+"required to visually separate headings from data."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`rownames=true`**: Tells wxMaxima that the first column of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`colnames=true`**: Tells wxMaxima that the first row of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
+"around the matrix. Supported styles are: `round` `()`, `square` `[]`, "
+"`angled` `<>`, `straight` `||`, or `none`."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:837
+msgid "Example:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:842
+#, no-wrap
+msgid ""
+"```maxima\n"
+"wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
+"          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
+"```\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:844
+msgid "## Bug reporting"
+msgstr "## Signalement de bugs"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:846
+msgid ""
+"_WxMaxima_ provides a few functions that gather bug reporting information "
+"about the current system:"
+msgstr ""
+"_WxMaxima_ propose quelques fonctions qui collectent des informations utiles "
+"pour signaler un bug concernant le système actuel :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:849
+msgid ""
+"`wxbuild_info()` gathers information about the currently running version of "
+"_wxMaxima_"
+msgstr ""
+"- `wxbuild_info()` : Rassemble des informations sur la version en cours "
+"d'exécution  de _wxMaxima_"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:849
+msgid "`wxbug_report()` tells how and where to file bugs"
+msgstr "`wxbug_report()` indique comment et où signaler les bogues"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:851
+msgid "## Marking output being drawn in red"
+msgstr "## Ecrire le résultat de la sortie en rouge"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:854
+#, fuzzy
+#| msgid ""
+#| "_Maxima_âs `box()` command causes _wxMaxima_ to print its argument with a "
+#| "red foreground, if the second argument to the command is the text "
+#| "`highlight`."
+msgid ""
+"_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a "
+"red foreground, if the second argument to the command is the text "
+"`highlight`."
+msgstr ""
+"La commande `box()` de _Maxima_ permet à _wxMaxima_ d'afficher son argument "
+"en rouge, si le deuxième argument de la commande est le texte `highlight`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:856
+msgid "## Output rendering."
+msgstr "## Rendu de la sortie."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:858
+msgid "With `set_display()` one can set, how wxMaxima will render the output."
+msgstr ""
+"Avec `set_display()`, on peut définir de quelle manière wxMaxima affichera "
+"la sortie."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:860
+msgid ""
+"`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima "
+"using an (machine readable) XML-dialect (can be seen in the \"Raw XML "
+"sidebar\") and outputs the resulting formulas nicely rendered, e.g. pretty "
+"Matrices, Square root signs, fractions, etc."
+msgstr ""
+"`set_display('xml)` est la valeur par défaut. Ici, Maxima communique avec "
+"wxMaxima en utilisant un dialecte XML (lisible par machine) (visible dans la "
+"barre latérale « XML brut ») et affiche les formules résultantes avec un "
+"visuel mathématique, par exemple des matrices bien délimitées et "
+"structurées, des signes de racine carrée, des fractions, etc."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:863
+msgid ""
+"<!--- Currently that does not work as it should, the line with the output "
+"label is shifted right (issue: #2006) --> `set_display('ascii)` causes "
+"wxMaxima to output formulas as in command line Maxima - as ASCII-Art."
+msgstr ""
+"<!--- Actuellement, cela ne fonctionne pas comme prévu : la ligne avec "
+"l’étiquette de sortie est décalée vers la droite (problème : #2006) --> "
+"`set_display('ascii)` fait en sorte que wxMaxima affiche les formules comme "
+"dans Maxima en ligne de commande — en ASCII-Art."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:865
+msgid ""
+"`set_display('none)` causes 'one-line' ASCII results - the same as the "
+"command line Maxima command `display2d:false;` does."
+msgstr ""
+"`set_display('none)` produit des résultats ASCII « sur une seule ligne » — "
+"comme le fait la commande de Maxima en ligne de commande `display2d:false;`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:867
+msgid "# Help menu"
+msgstr "# Menu d'aide"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:869
+#, fuzzy
+#| msgid ""
+#| "WxMaximaâs help menu provides access to the Maxima and wxMaxima manual, "
+#| "tips, some example worksheets and in command line Maxima included demos "
+#| "(the `demo()` command)."
+msgid ""
+"WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, "
+"tips, some example worksheets and in command line Maxima included demos (the "
+"`demo()` command)."
+msgstr ""
+"Le menu d'aide de _wxMaxima_ donne accès au manuel de Maxima et à celui de "
+"wxMaxima, à des astuces, à des exemples de notebooks, ainsi qu'aux exemples "
+"intégrés dans Maxima en ligne de commande (via la commande `demo()`)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:871
+msgid "Please notice, that the demos write:"
+msgstr "Veuillez noter que les exemples indiquent :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:875
+#, fuzzy
+#| msgid ""
+#| "~~~ At the â_â prompt, type â;â and <enter> to proceed with the "
+#| "demonstration.  ~~~"
+msgid ""
+"~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the "
+"demonstration.  ~~~"
+msgstr ""
+"~~~ À l’invite `’_’`, tapez `;` puis `<entrée>` pour poursuivre la "
+"démonstration.  ~~~"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:877
+msgid ""
+"That is valid for command-line Maxima, however in wxMaxima by default it is "
+"necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</"
+"kbd>"
+msgstr ""
+"Cela est valable pour Maxima en ligne de commande, mais dans wxMaxima, par "
+"défaut, il est nécessaire de poursuivre la démonstration avec : <kbd>CTRL</"
+"kbd> + <kbd>ENTRÉE</kbd>"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:879
+msgid ""
+"(That can be configured in the Configure->Worksheet->\"Hotkeys for sending "
+"commands to Maxima\" menu.)"
+msgstr ""
+"(Ce comportement peut être configuré dans le menu Configurer → Notebook → "
+"\" Raccourcis pour envoyer des commandes à Maxima\".)"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:883
+msgid "# Troubleshooting"
+msgstr "# Résolution des problèmes"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:885
+msgid "## Cannot connect to _Maxima_"
+msgstr "## Impossible de se connecter à _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:887
+#, fuzzy
+#| msgid ""
+#| "Since _Maxima_ (the program that does the actual mathematics) and "
+#| "_wxMaxima_ (providing the easy-to-use user interface) are separate "
+#| "programs that communicate by the means of a local network connection. "
+#| "Therefore the most probable cause is that this connection is somehow not "
+#| "working. For example, a firewall could be set up in a way that it doesnât "
+#| "just prevent unauthorized connections from the internet (and perhaps "
+#| "intercept some connections to the internet, too), but also blocks inter-"
+#| "process-communication inside the same computer. Note that since _Maxima_ "
+#| "is being run by a Lisp processor the process communication that is "
+#| "blocked does not necessarily have to be named \"maxima\". Common names of "
+#| "the program that opens the network connection would be sbcl, gcl, ccl, "
+#| "lisp.exe, or similar names."
+msgid ""
+"Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ "
+"(providing the easy-to-use user interface) are separate programs that "
+"communicate by the means of a local network connection. Therefore the most "
+"probable cause is that this connection is somehow not working. For example, "
+"a firewall could be set up in a way that it doesn’t just prevent "
+"unauthorized connections from the internet (and perhaps intercept some "
+"connections to the internet, too), but also blocks inter-process-"
+"communication inside the same computer. Note that since _Maxima_ is being "
+"run by a Lisp processor the process communication that is blocked does not "
+"necessarily have to be named \"maxima\". Common names of the program that "
+"opens the network connection would be sbcl, gcl, ccl, lisp.exe, or similar "
+"names."
+msgstr ""
+"Puisque _Maxima_ (le programme qui effectue les calculs mathématiques) et "
+"_wxMaxima_ (qui fournit l’interface utilisateur conviviale) sont deux "
+"programmes distincts qui communiquent via une connexion réseau locale, la "
+"cause la plus probable d'un dysfonctionnement est que cette connexion ne "
+"s'établit pas correctement. Par exemple, un pare-feu peut être configuré non "
+"seulement pour bloquer les connexions non autorisées depuis Internet (et "
+"éventuellement intercepter certaines connexions sortantes), mais aussi pour "
+"empêcher la communication entre processus sur un même ordinateur. Notez que, "
+"comme Maxima est exécuté via un processeur Lisp, le processus bloqué ne "
+"porte pas nécessairement le nom \"maxima\". Les noms usuels pour le "
+"programme ouvrant la connexion réseau peuvent être sbcl, gcl, ccl, lisp.exe, "
+"ou des noms similaires."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:889
+#, fuzzy
+#| msgid ""
+#| "On Unix computers another possible reason would be that the loopback "
+#| "network that provides network connections between two programs in the "
+#| "same computer isnât properly configured."
+msgid ""
+"On Unix computers another possible reason would be that the loopback network "
+"that provides network connections between two programs in the same computer "
+"isn’t properly configured."
+msgstr ""
+"Sur les ordinateurs Unix, une autre cause possible serait que le réseau "
+"loopback, qui permet les connexions entre deux programmes sur le même "
+"ordinateur, ne soit pas correctement configuré."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:891
+msgid "## How to save data from a broken .wxmx file"
+msgstr "## Comment récupérer les données d’un fichier .wxmx corrompu"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:893
+#, fuzzy
+#| msgid ""
+#| "Internally most modern XML-based formats are ordinary zip files. "
+#| "_WxMaxima_ doesnât turn on compression, so the contents of `.wxmx` files "
+#| "can be viewed in any text editor."
+msgid ""
+"Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ "
+"doesn’t turn on compression, so the contents of `.wxmx` files can be viewed "
+"in any text editor."
+msgstr ""
+"En informatique, la plupart des formats modernes basés sur XML sont en "
+"réalité des fichiers zip ordinaires. _WxMaxima_ n’active pas la compression, "
+"donc le contenu des fichiers `.wxmx` peut être consulté avec n’importe quel "
+"éditeur de texte."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:895
+#, fuzzy
+#| msgid ""
+#| "If the zip signature at the end of the file is still intact after "
+#| "renaming a broken `.wxmx` file to `.zip` most operating systems will "
+#| "provide a way to extract any portion of the information that is stored "
+#| "inside it. This can be done when there is a need of recovering the "
+#| "original image files from a text processor document. If the zip signature "
+#| "isnât intact that does not need to be the end of the world: If _wxMaxima_ "
+#| "during saving detected that something went wrong there will be a `.wxmx~` "
+#| "file whose contents might help."
+msgid ""
+"If the zip signature at the end of the file is still intact after renaming a "
+"broken `.wxmx` file to `.zip` most operating systems will provide a way to "
+"extract any portion of the information that is stored inside it. This can be "
+"done when there is a need of recovering the original image files from a text "
+"processor document. If the zip signature isn’t intact that does not need to "
+"be the end of the world: If _wxMaxima_ during saving detected that something "
+"went wrong there will be a `.wxmx~` file whose contents might help."
+msgstr ""
+"Si la signature du zip à la fin du fichier est toujours intacte après avoir "
+"renommé un fichier `.wxmx` corrompu en `.zip`, la plupart des systèmes "
+"d’exploitation permettront d’extraire une partie des informations qu’il "
+"contient. Cette méthode est souvent utilisée pour récupérer les fichiers "
+"image originaux d’un document issu d'un traitement de texte. Si la signature "
+"du zip n’est plus intacte, ce n’est pas forcément une impasse : si "
+"_wxMaxima_ a détecté une erreur lors de l’enregistrement, un fichier "
+"`.wxmx~` aura probablement été créé et son contenu pourrait s’avérer utile."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:897
+#, fuzzy
+#| msgid ""
+#| "And even if there isnât such a file: The `.wxmx` file is a container "
+#| "format and the XML portion is stored uncompressed. It it is possible to "
+#| "rename the `.wxmx` file to a `.txt` file and to use a text editor to "
+#| "recover the XML portion of the fileâs contents (it starts with `<?xml "
+#| "version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</"
+#| "wxMaximaDocument>`. Before and after that text you will see some "
+#| "unreadable binary contents in the text editor)."
+msgid ""
+"And even if there isn’t such a file: The `.wxmx` file is a container format "
+"and the XML portion is stored uncompressed. It it is possible to rename the "
+"`.wxmx` file to a `.txt` file and to use a text editor to recover the XML "
+"portion of the file’s contents (it starts with `<?xml version=\"1.0\" "
+"encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after "
+"that text you will see some unreadable binary contents in the text editor)."
+msgstr ""
+"Et même s’il n’existe pas un tel fichier : le format `.wxmx` est un format "
+"conteneur et la partie XML y est stockée sans compression. Il est possible "
+"de renommer le fichier `.wxmx` en `.txt` et d’utiliser un éditeur de texte "
+"pour récupérer la portion XML du contenu (elle commence par `<?xml "
+"version=\"1.0\" encoding=\"UTF-8\"?>` et se termine par `</"
+"wxMaximaDocument>`. Avant et après ce texte, vous verrez du contenu binaire "
+"illisible dans l’éditeur)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:899
+msgid ""
+"If a text file containing only these contents (e.g. copy and paste this text "
+"into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know "
+"how to recover the text from the document."
+msgstr ""
+"Si vous enregistrez un fichier texte contenant uniquement ce contenu (par "
+"exemple, en copiant et collant ce texte dans un nouveau fichier) avec une "
+"extension `.xml`, _wxMaxima_ saura comment récupérer le texte du document."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:901
+msgid ""
+"## I want some debug info to be displayed on the screen before my command "
+"has finished"
+msgstr ""
+"## Je souhaite afficher des informations de débogage à l’écran avant que ma "
+"commande ne soit terminée"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:903
+msgid ""
+"Normally _wxMaxima_ waits for the whole 2D formula to be transferred before "
+"it begins to typeset. This saves time for making many attempts to typeset a "
+"only partially completed equation. There is a `disp` command, though, that "
+"will provide debug output immediately and without waiting for the current "
 "_Maxima_ command to finish:"
 msgstr ""
-"Normalement, _wxMaxima_ attend que la formule 2D soit transférée en totalité avant de commencer la composition typographique. Cela permet d’économiser du temps en évitant de tenter d'écrire une équation incomplète. Cependant, il existe une commande `disp` qui affiche immédiatement des informations de "
-"débogage, sans attendre la fin de l’exécution de la commande _Maxima_ en cours :"
+"Normalement, _wxMaxima_ attend que la formule 2D soit transférée en totalité "
+"avant de commencer la composition typographique. Cela permet d’économiser du "
+"temps en évitant de tenter d'écrire une équation incomplète. Cependant, il "
+"existe une commande `disp` qui affiche immédiatement des informations de "
+"débogage, sans attendre la fin de l’exécution de la commande _Maxima_ en "
+"cours :"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:913
+#, no-wrap
 msgid ""
 "```maxima\n"
 "for i:1 thru 10 do (\n"
@@ -959,47 +3968,490 @@ msgstr ""
 ")$\n"
 "```\n"
 
-msgid ""
-"_Maxima_ tried to do something the currently installed version of _Gnuplot_ isnât able to understand. In this case, a file ending in `.gnuplot` located in the directory, which _Maxima_âs variable `maxima_userdir` is pointing, contains the instructions from _Maxima_ to _Gnuplot_. Most of the time, "
-"this fileâs contents therefore are helpful when debugging the problem."
+#. type: Plain text
+#: ../../info/wxmaxima.md:915
+msgid "Alternatively one can look for the `wxstatusbar()` command above."
 msgstr ""
-"_Maxima_ a tenté de faire quelque chose que la version actuellement installée de _Gnuplot_ ne peut pas interpréter. Dans ce cas, un fichier se terminant par `.gnuplot`, situé dans le répertoire vers lequel pointe la variable `maxima_userdir` de _Maxima_, contient les instructions envoyées par "
-"_Maxima_ à _Gnuplot_. Le contenu de ce fichier est donc souvent utile pour déboguer le problème."
+"Sinon, on peut utiliser la commande `wxstatusbar()` mentionnée ci-dessus."
 
-msgid ""
-"Gnuplot was instructed to use the pngCairo library that provides antialiasing and additional line styles, but it was not compiled to support this possibility. Solution: Uncheck the \"Use the Cairo terminal for the plot\" checkbox in the configuration dialog and donât set `wxplot_pngcairo` to true "
-"from _Maxima_."
+#. type: Plain text
+#: ../../info/wxmaxima.md:917
+msgid "## Plotting only shows a closed empty envelope with an error message"
 msgstr ""
-"Gnuplot a reçu la consigne d’utiliser la bibliothèque pngCairo, qui fournit l’anticrénelage et des styles de ligne supplémentaires, mais il n’a pas été compilé pour prendre en charge cette fonctionnalité.  Solution : décochez la case « Utiliser le terminal Cairo pour le tracé » dans la boîte de "
-"dialogue de configuration et ne définissez pas `wxplot_pngcairo` sur true depuis _Maxima_."
+"## La création d'un graphique n'affiche qu'une enveloppe vide encadrée avec "
+"un message d'erreur"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:919
 msgid ""
-"The value of the slider variable by default is only substituted into the expression that is to be plotted if it is visible there. Using a `subst` command that substitutes the slider variable into the equation to plot resolves this problem. At the end of section [Embedding animations into the "
-"spreadsheet](#embedding-animations-into-the-spreadsheet), you can see an example."
+"This means that _wxMaxima_ could not read the file _Maxima_ that was "
+"supposed to instruct _Gnuplot_ to create."
 msgstr ""
-"Par défaut, la valeur du paramètre pour le curseur n'est substituée dans l'expression à tracer que si elle y est visible. L'utilisation d'une commande `subst` qui substitue la variable du curseur dans l'équation à tracer résout ce problème. À la fin de la section [Intégrer des animations dans le "
-"notebook](#embedding-animations-into-the-spreadsheet), vous pouvez voir un exemple."
+"Cela signifie que _wxMaxima_ n'a pas pu lire le fichier généré par _Maxima_, "
+"qui était censé donner les instructions à _Gnuplot_ pour créer le graphique."
 
-msgid "_WxMaxima_ actually has two undo features: The global undo buffer that is active if no cell is selected and a per-cell undo buffer that is active if the cursor is inside a cell. It is worth trying to use both undo options in order to see if an old value can still be accessed."
+#. type: Plain text
+#: ../../info/wxmaxima.md:921
+msgid "Possible reasons for this error are:"
+msgstr "Les causes possibles de cette erreur sont :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:926
+#, fuzzy
+#| msgid ""
+#| "The plotting command is part of a third-party package like "
+#| "`implicit_plot` but this package was not loaded by _Maxima_âs `load()` "
+#| "command before trying to plot."
+msgid ""
+"The plotting command is part of a third-party package like `implicit_plot` "
+"but this package was not loaded by _Maxima_’s `load()` command before trying "
+"to plot."
 msgstr ""
-"_WxMaxima_ dispose en fait de deux fonctions d’annulation : une mémoire d’annulation globale, active lorsqu’aucune cellule n’est sélectionnée, et une mémoire d’annulation par cellule, active lorsque le curseur se trouve à l’intérieur d’une cellule. Cela vaut la peine d’essayer les deux options "
+"La commande de tracé fait partie d’un paquet externe comme `implicit_plot`, "
+"mais ce paquet n’a pas été chargé par la commande `load()` de _Maxima_ avant "
+"le lancement de cette commande."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:926
+#, fuzzy
+#| msgid ""
+#| "_Maxima_ tried to do something the currently installed version of "
+#| "_Gnuplot_ isnât able to understand. In this case, a file ending in "
+#| "`.gnuplot` located in the directory, which _Maxima_âs variable "
+#| "`maxima_userdir` is pointing, contains the instructions from _Maxima_ to "
+#| "_Gnuplot_. Most of the time, this fileâs contents therefore are helpful "
+#| "when debugging the problem."
+msgid ""
+"_Maxima_ tried to do something the currently installed version of _Gnuplot_ "
+"isn’t able to understand. In this case, a file ending in `.gnuplot` located "
+"in the directory, which _Maxima_’s variable `maxima_userdir` is pointing, "
+"contains the instructions from _Maxima_ to _Gnuplot_. Most of the time, this "
+"file’s contents therefore are helpful when debugging the problem."
+msgstr ""
+"_Maxima_ a tenté de faire quelque chose que la version actuellement "
+"installée de _Gnuplot_ ne peut pas interpréter. Dans ce cas, un fichier se "
+"terminant par `.gnuplot`, situé dans le répertoire vers lequel pointe la "
+"variable `maxima_userdir` de _Maxima_, contient les instructions envoyées "
+"par _Maxima_ à _Gnuplot_. Le contenu de ce fichier est donc souvent utile "
+"pour déboguer le problème."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:926
+#, fuzzy
+#| msgid ""
+#| "Gnuplot was instructed to use the pngCairo library that provides "
+#| "antialiasing and additional line styles, but it was not compiled to "
+#| "support this possibility. Solution: Uncheck the \"Use the Cairo terminal "
+#| "for the plot\" checkbox in the configuration dialog and donât set "
+#| "`wxplot_pngcairo` to true from _Maxima_."
+msgid ""
+"Gnuplot was instructed to use the pngCairo library that provides "
+"antialiasing and additional line styles, but it was not compiled to support "
+"this possibility. Solution: Uncheck the \"Use the Cairo terminal for the "
+"plot\" checkbox in the configuration dialog and don’t set `wxplot_pngcairo` "
+"to true from _Maxima_."
+msgstr ""
+"Gnuplot a reçu la consigne d’utiliser la bibliothèque pngCairo, qui fournit "
+"l’anticrénelage et des styles de ligne supplémentaires, mais il n’a pas été "
+"compilé pour prendre en charge cette fonctionnalité.  Solution : décochez la "
+"case « Utiliser le terminal Cairo pour le tracé » dans la boîte de dialogue "
+"de configuration et ne définissez pas `wxplot_pngcairo` sur true depuis "
+"_Maxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:926
+msgid "Gnuplot didn’t output a valid `.png` file."
+msgstr "Gnuplot n'a pas produit un fichier .png valide."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:928
+msgid "## Plotting an animation results in “error: undefined variable”"
+msgstr ""
+"## Le tracé d'une animation génère l'erreur \"error: undefined variable\""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:930
+msgid ""
+"The value of the slider variable by default is only substituted into the "
+"expression that is to be plotted if it is visible there. Using a `subst` "
+"command that substitutes the slider variable into the equation to plot "
+"resolves this problem. At the end of section [Embedding animations into the "
+"spreadsheet](#embedding-animations-into-the-spreadsheet), you can see an "
+"example."
+msgstr ""
+"Par défaut, la valeur du paramètre pour le curseur n'est substituée dans "
+"l'expression à tracer que si elle y est visible. L'utilisation d'une "
+"commande `subst` qui substitue la variable du curseur dans l'équation à "
+"tracer résout ce problème. À la fin de la section [Intégrer des animations "
+"dans le notebook](#embedding-animations-into-the-spreadsheet), vous pouvez "
+"voir un exemple."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:932
+msgid "## I lost cell content and undo doesn’t remember"
+msgstr ""
+"## J’ai perdu le contenu d’une cellule et la fonction Annuler ne le restaure "
+"pas"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:934
+msgid ""
+"There are separate undo functions for cell operations and for changes inside "
+"of cells so chances are low that this ever happens. If it does there are "
+"several methods to recover data:"
+msgstr ""
+"Il existe des fonctions Annuler distinctes pour les opérations sur les "
+"cellules et pour les modifications à l’intérieur des cellules, donc il est "
+"peu probable que cela arrive. Si cela se produit, plusieurs méthodes "
+"permettent de récupérer les données :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:939
+msgid ""
+"_WxMaxima_ actually has two undo features: The global undo buffer that is "
+"active if no cell is selected and a per-cell undo buffer that is active if "
+"the cursor is inside a cell. It is worth trying to use both undo options in "
+"order to see if an old value can still be accessed."
+msgstr ""
+"_WxMaxima_ dispose en fait de deux fonctions d’annulation : une mémoire "
+"d’annulation globale, active lorsqu’aucune cellule n’est sélectionnée, et "
+"une mémoire d’annulation par cellule, active lorsque le curseur se trouve à "
+"l’intérieur d’une cellule. Cela vaut la peine d’essayer les deux options "
 "d’annulation pour voir si une ancienne valeur peut encore être récupérée."
 
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:939
+#, fuzzy
+#| msgid ""
+#| "If you still have a way to find out what label _Maxima_ has assigned to "
+#| "the cell just type in the cellâs label and its contents will reappear."
 msgid ""
-"The Lisp compiler SBCL by default comes with a memory limit that allows it to run even on low-end computers. When compiling a big software package like Lapack or dealing with extremely big lists of equations this limit might be too low. In order to extend the limits, SBCL can be provided with the "
-"command line parameter `--dynamic-space-size` that tells SBCL how many megabytes it should reserve. A 32bit Windows-SBCL can reserve up to 999 Megabytes. A 64-bit SBCL version running on Windows can be instructed to use more than the about 1280 Megabytes compiling Lapack needs."
+"If you still have a way to find out what label _Maxima_ has assigned to the "
+"cell just type in the cell’s label and its contents will reappear."
 msgstr ""
-"Le compilateur Lisp SBCL est configuré par défaut avec une limite de mémoire qui lui permet de fonctionner même sur des ordinateurs peu puissants. Cependant, lors de la compilation de gros packages logiciels comme Lapack ou du traitement de listes d'équations extrêmement longues, cette limite peut "
-"s'avérer insuffisante. Pour l'augmenter, vous pouvez utiliser le paramètre en ligne de commande `--dynamic-space-size` lors du lancement de SBCL, qui indique combien de mégaoctets doivent être réservés. - Une version 32 bits de SBCL sous Windows peut réserver jusqu'à 999 Mo. - Une version 64 bits "
+"Si vous avez encore un moyen de retrouver l’étiquette que _Maxima_ a "
+"attribuée à la cellule, il vous suffit de taper cette étiquette, et le "
+"contenu de la cellule réapparaîtra."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:939
+#, fuzzy
+#| msgid ""
+#| "If you donât: Donât panic. In the âViewâ menu there is a way to show a "
+#| "history pane that shows all _Maxima_ commands that have been issued "
+#| "recently."
+msgid ""
+"If you don’t: Don’t panic. In the “View” menu there is a way to show a "
+"history pane that shows all _Maxima_ commands that have been issued recently."
+msgstr ""
+"Si ce n’est pas le cas, ne paniquez pas. Le menu « Affichage » propose une "
+"option permettant d’afficher un panneau d’historique qui montre toutes les "
+"commandes _Maxima_ exécutées récemment."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:939
+msgid "If nothing else helps _Maxima_ contains a replay feature:"
+msgstr ""
+"Si rien d’autre ne fonctionne, _Maxima_ contient une fonction de replay :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:943
+msgid "```maxima playback(); ```"
+msgstr "```maxima playback(); ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:945
+msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
+msgstr "## _WxMaxima_ démarre avec le message  Maxima process terminated"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:947
+#, fuzzy
+#| msgid ""
+#| "One possible reason is that _Maxima_ cannot be found in the location that "
+#| "is set in the âMaximaâ tab of _wxMaxima_âs configuration dialog and "
+#| "therefore wonât run at all. Setting the path to a working _Maxima_ binary "
+#| "should fix this problem."
+msgid ""
+"One possible reason is that _Maxima_ cannot be found in the location that is "
+"set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore "
+"won’t run at all. Setting the path to a working _Maxima_ binary should fix "
+"this problem."
+msgstr ""
+"Une cause possible est que le programme _Maxima_ n’est pas trouvé à "
+"l’emplacement indiqué dans l’onglet Maxima de la boîte de dialogue de "
+"configuration de _wxMaxima_, ce qui l’empêche de démarrer. Vérifiez et "
+"corrigez le chemin vers l’exécutable _Maxima_ pour résoudre ce problème."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:949
+msgid "## Maxima is forever calculating and not responding to input"
+msgstr "## Maxima calcule indéfiniment et ne répond plus aux commandes entrées"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:951
+#, fuzzy
+#| msgid ""
+#| "It is theoretically possible that _wxMaxima_ doesnât realize that "
+#| "_Maxima_ has finished calculating and therefore never gets informed it "
+#| "can send new data to _Maxima_. If this is the case âTrigger evaluationâ "
+#| "might resynchronize the two programs."
+msgid ""
+"It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ "
+"has finished calculating and therefore never gets informed it can send new "
+"data to _Maxima_. If this is the case “Trigger evaluation” might "
+"resynchronize the two programs."
+msgstr ""
+"Il est théoriquement possible que _wxMaxima_ ne détecte pas que _Maxima_ a "
+"terminé ses calculs et, de ce fait, n’autorise pas l’envoi de nouvelles "
+"données. Dans ce cas, l’option Déclencher l’évaluation (« Trigger "
+"evaluation ») peut resynchroniser les deux programmes."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:953
+msgid "## My SBCL-based _Maxima_ runs out of memory"
+msgstr "## Mon _Maxima_ basé sur SBCL manque de mémoire"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:955
+msgid ""
+"The Lisp compiler SBCL by default comes with a memory limit that allows it "
+"to run even on low-end computers. When compiling a big software package like "
+"Lapack or dealing with extremely big lists of equations this limit might be "
+"too low. In order to extend the limits, SBCL can be provided with the "
+"command line parameter `--dynamic-space-size` that tells SBCL how many "
+"megabytes it should reserve. A 32bit Windows-SBCL can reserve up to 999 "
+"Megabytes. A 64-bit SBCL version running on Windows can be instructed to use "
+"more than the about 1280 Megabytes compiling Lapack needs."
+msgstr ""
+"Le compilateur Lisp SBCL est configuré par défaut avec une limite de mémoire "
+"qui lui permet de fonctionner même sur des ordinateurs peu puissants. "
+"Cependant, lors de la compilation de gros packages logiciels comme Lapack ou "
+"du traitement de listes d'équations extrêmement longues, cette limite peut "
+"s'avérer insuffisante. Pour l'augmenter, vous pouvez utiliser le paramètre "
+"en ligne de commande `--dynamic-space-size` lors du lancement de SBCL, qui "
+"indique combien de mégaoctets doivent être réservés. - Une version 32 bits "
+"de SBCL sous Windows peut réserver jusqu'à 999 Mo. - Une version 64 bits "
 "sous Windows peut aller au-delà des 1280 Mo nécessaires pour compiler Lapack."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:957
+#, fuzzy
+#| msgid ""
+#| "One way to provide _Maxima_ (and thus SBCL) with command line parameters "
+#| "is the \"Additional parameters for Maxima\" field of _wxMaxima_âs "
+#| "configuration dialogue."
 msgid ""
-"The HTML browser might be a snap, flatpack or appimage version. All of these typically cannot access files that are installed on your local system. Another reason might be that maxima or wxMaxima is installed as a snap, flatpack or something else that doesnât give the host system access to its "
-"contents. A third reason might be that the maxima HTML manual isnât installed and the online one cannot be accessed."
+"One way to provide _Maxima_ (and thus SBCL) with command line parameters is "
+"the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration "
+"dialogue."
 msgstr ""
-"Plusieurs raisons peuvent expliquer ce problème : - Le navigateur HTML peut être une version Snap, Flatpak ou AppImage, qui ne peut généralement pas accéder aux fichiers installés localement sur votre système. - Maxima ou wxMaxima peut être installé en tant que Snap, Flatpak ou autre format limitant "
-"l’accès aux fichiers du système hôte. - Le manuel HTML de Maxima peut ne pas être installé, et la version en ligne n’est pas accessible."
+"Une façon de fournir des paramètres en ligne de commande à _Maxima_ (et donc "
+"à SBCL) est d’utiliser le champ \"Paramètres supplémentaires pour Maxima\" "
+"dans la boîte de dialogue de configuration de _wxMaxima_."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:959
+msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
+msgstr "![mémoire pour sbcl](./sbclMemory.png){ id=img_sbclMemory }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:961
+msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgstr ""
+"## Sous Ubuntu, la saisie est parfois lente ou certaines touches sont "
+"ignorées"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:963
+msgid ""
+"Installing the package `ibus-gtk` should resolve this issue. See ([https://"
+"bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://"
+"bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) for details."
+msgstr ""
+"L'installation du paquet 'ibus-gtk' devrait résoudre ce problème. Pour plus "
+"de détails, voir : [https://bugs.launchpad.net/ubuntu/+source/"
+"wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/"
+"wxwidgets3.0/+bug/1421558)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:965
+msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgstr ""
+"## _WxMaxima_ se fige lorsque _Maxima_ traite des caractères grecs ou des "
+"lettres accentuées (comme les umlauts)"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:967
+msgid ""
+"If your _Maxima_ is based on SBCL the following lines have to be added to "
+"your `.sbclrc`:"
+msgstr ""
+"Si votre _Maxima_ est basé sur SBCL, ajoutez les lignes suivantes à votre "
+"fichier `.sbclrc` :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:971
+msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
+msgstr "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:973
+msgid ""
+"The folder where this file has to be placed is system- and installation-"
+"specific. But any SBCL-based _Maxima_ that already has evaluated a cell in "
+"the current session will happily tell where it can be found after getting "
+"the following command:"
+msgstr ""
+"Le dossier où ce fichier doit être placé dépend du système et de "
+"l’installation. Cependant, toute version de _Maxima_ basée sur SBCL, ayant "
+"déjà évalué une cellule durant la session en cours, peut gentiment indiquer "
+"son emplacement après exécution de la commande suivante :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:977
+msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
+msgstr "```maxima :lisp (sb-impl::userinit-pathname)  ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:979
+msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
+msgstr "## Remarque concernant Wayland (distributions Linux/BSD récentes)"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:982
+msgid ""
+"There seem to be issues with the Wayland Display Server and wxWidgets.  "
+"WxMaxima may be affected, e.g. that sidebars are not moveable."
+msgstr ""
+"Il semble y avoir des problèmes de compatibilité entre le serveur "
+"d'affichage Wayland et wxWidgets. WxMaxima peut en être affecté, par exemple "
+"avec des barres latérales qui ne peuvent pas être déplacées."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:986
+msgid ""
+"You can either disable Wayland and use X11 instead (globally)  or just tell, "
+"that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
+msgstr ""
+"Vous pouvez soit : - désactiver Wayland et utiliser X11 à la place (de "
+"manière globale), - ou forcer WxMaxima à utiliser le système X Window en "
+"définissant la variable d’environnement :  `GDK_BACKEND=x11`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:988
+msgid "E.g. start wxMaxima with:"
+msgstr "Par exemple, lancez WxMaxima avec la commande :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:990
+msgid "`GDK_BACKEND=x11 wxmaxima`"
+msgstr "`GDK_BACKEND=x11 wxmaxima`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:992
+msgid "## The menu bar disappears on KDE Plasma"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:997
+msgid ""
+"On some KDE Plasma installations the global menu bar disappears when "
+"clicked.  As this is a bug in the global menu proxy, the only way to avoid "
+"it is to tell that wxMaxima should use its own menu bar instead of the "
+"global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1001
+msgid ""
+"Starting with version 26.05.0, wxMaxima attempts to set this variable "
+"automatically if it detects an affected system (KDE, Unity, or Ubuntu with "
+"older wxWidgets versions)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1003
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1005
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1007
+msgid "## Why is the integrated manual browser not offered on my Windows PC?"
+msgstr ""
+"## Pourquoi le navigateur pour le manuel intégré n’est-il pas disponible sur "
+"mon PC Windows ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1010
+#, fuzzy
+#| msgid ""
+#| "Either wxWidgets wasnât compiled with support for Microsoftâs webview2 or "
+#| "Microsoftâs webview2 isnât installed."
+msgid ""
+"Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or "
+"Microsoft’s webview2 isn’t installed."
+msgstr ""
+"Soit wxWidgets n’a pas été compilé avec le support de Microsoft WebView2, "
+"soit WebView2 n’est pas installé sur votre système."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1012
+msgid "## Why is the external manual browser not working on my Linux box?"
+msgstr ""
+"## Pourquoi le navigateur pour le manuel externe ne fonctionne-t-il pas sur "
+"ma machine Linux ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1018
+#, fuzzy
+#| msgid ""
+#| "The HTML browser might be a snap, flatpack or appimage version. All of "
+#| "these typically cannot access files that are installed on your local "
+#| "system. Another reason might be that maxima or wxMaxima is installed as a "
+#| "snap, flatpack or something else that doesnât give the host system access "
+#| "to its contents. A third reason might be that the maxima HTML manual "
+#| "isnât installed and the online one cannot be accessed."
+msgid ""
+"The HTML browser might be a snap, flatpack or appimage version. All of these "
+"typically cannot access files that are installed on your local system. "
+"Another reason might be that maxima or wxMaxima is installed as a snap, "
+"flatpack or something else that doesn’t give the host system access to its "
+"contents. A third reason might be that the maxima HTML manual isn’t "
+"installed and the online one cannot be accessed."
+msgstr ""
+"Plusieurs raisons peuvent expliquer ce problème : - Le navigateur HTML peut "
+"être une version Snap, Flatpak ou AppImage, qui ne peut généralement pas "
+"accéder aux fichiers installés localement sur votre système. - Maxima ou "
+"wxMaxima peut être installé en tant que Snap, Flatpak ou autre format "
+"limitant l’accès aux fichiers du système hôte. - Le manuel HTML de Maxima "
+"peut ne pas être installé, et la version en ligne n’est pas accessible."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1020
+msgid ""
+"## Can I make _wxMaxima_ output both image files and embedded plots at once?"
+msgstr ""
+"## Puis-je faire en sorte que _wxMaxima_ génère à la fois des fichiers image "
+"et des graphiques en ligne en même temps ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1022
+msgid ""
+"The worksheet embeds `.png files. _WxMaxima_ allows the user to specify "
+"where they should be generated:"
+msgstr ""
+"Le notebook intègre les fichiers `.png`. _WxMaxima_ permet à l'utilisateur "
+"de spécifier où ces fichiers doivent être générés :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1029
+#, no-wrap
 msgid ""
 "```maxima\n"
 "wxdraw2d(\n"
@@ -1015,6 +4467,18 @@ msgstr ""
 ");\n"
 "```\n"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:1031
+msgid ""
+"If a different format is to be used, it is easier to generate the images and "
+"then import them into the worksheet again:"
+msgstr ""
+"Si vous souhaitez utiliser un format différent, il est plus simple de "
+"générer les images séparément, puis de les réimporter dans le notebook :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1050
+#, no-wrap
 msgid ""
 "```maxima\n"
 "load(\"draw\");\n"
@@ -1054,6 +4518,9 @@ msgstr ""
 "pngdraw2d(name,[contents]):=\n"
 "    pngdraw(name,gr2d(contents));\n"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:1055
+#, no-wrap
 msgid ""
 "pngdraw2d(\"Test\",\n"
 "        explicit(sin(x),x,1,10)\n"
@@ -1065,6 +4532,21 @@ msgstr ""
 ");\n"
 "```\n"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:1057
+msgid "## Can I set the aspect ratio of an embedded plot?"
+msgstr ""
+"## Puis-je définir le rapport hauteur/largeur (aspect ratio) d’un graphique "
+"en ligne ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1059
+msgid "Use the variable `wxplot_size`:"
+msgstr "Utilisez la variable `wxplot_size` :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1065
+#, no-wrap
 msgid ""
 "```maxima\n"
 "wxdraw2d(\n"
@@ -1078,37 +4560,368 @@ msgstr ""
 "),wxplot_size=[1000,1000];\n"
 "```\n"
 
-msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information."
-msgstr ""
-"Ce problème pourrait être lié au système d'exploitation. Désactiver le masquage automatique de la barre de menus (via Réglages Système => Bureau et Dock => Barre des menus) pourrait résoudre le problème. Pour plus d'informations, voir [l'issue wxMaxima #1746](https://github.com/wxMaxima-developers/"
-"wxmaxima/issues/1746)."
-
+#. type: Plain text
+#: ../../info/wxmaxima.md:1067
 msgid ""
-"Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build, the log windows is not shown by default, if you run a development version, it is shown by default as "
-"a second window. You can enable and disable this window using the \"View->Toggle log window\" menu entry."
+"## After upgrading to MacOS 13.1 plot and/or draw commands output error "
+"messages like"
 msgstr ""
-"Les messages du journal peuvent être utiles pour déboguer des problèmes. WxMaxima peut enregistrer de nombreux événements. La plupart des entrées du journal seront utiles aux développeurs, notamment en cas de problème ou de bogue. Si vous exécutez une version « Release », la fenêtre du journal n’est "
-"pas affichée par défaut ; si vous exécutez une version de développement, elle est affichée par défaut comme une seconde fenêtre. Vous pouvez activer ou désactiver cette fenêtre via le menu « Affichage -> Basculer la fenêtre du journal »."
+"## Après la mise à niveau vers macOS 13.1, les commandes plot et/ou draw "
+"affichent des messages d'erreur du type"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:1074
 msgid ""
-"If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if the rest of the operating system is. The worksheet itself is by default equipped with a bright background. But it can be configured otherwise. Alternatively, there is a `View/Invert worksheet brightness` menu entry that "
+"```text 1 HIToolbox 0x00007ff80cd91726 "
+"_ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox "
+"0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox "
+"0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```"
+msgstr ""
+"```text 1 HIToolbox 0x00007ff80cd91726 "
+"_ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox "
+"0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox "
+"0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1076
+msgid ""
+"This might be an issue with the operating system. Disable the hiding of the "
+"menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the "
+"issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/"
+"wxmaxima/issues/1746) for more information."
+msgstr ""
+"Ce problème pourrait être lié au système d'exploitation. Désactiver le "
+"masquage automatique de la barre de menus (via Réglages Système => Bureau et "
+"Dock => Barre des menus) pourrait résoudre le problème. Pour plus "
+"d'informations, voir [l'issue wxMaxima #1746](https://github.com/wxMaxima-"
+"developers/wxmaxima/issues/1746)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1078
+msgid "## Logging"
+msgstr "## Journalisation"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1082
+msgid ""
+"Log messages might be helpful to debug problems. WxMaxima can log many "
+"events. Most log entries will be helpful for developers, especially in case "
+"of problems or bugs. If you run a \"Release\"-Build, the log windows is not "
+"shown by default, if you run a development version, it is shown by default "
+"as a second window. You can enable and disable this window using the \"View-"
+">Toggle log window\" menu entry."
+msgstr ""
+"Les messages du journal peuvent être utiles pour déboguer des problèmes. "
+"WxMaxima peut enregistrer de nombreux événements. La plupart des entrées du "
+"journal seront utiles aux développeurs, notamment en cas de problème ou de "
+"bogue. Si vous exécutez une version « Release », la fenêtre du journal n’est "
+"pas affichée par défaut ; si vous exécutez une version de développement, "
+"elle est affichée par défaut comme une seconde fenêtre. Vous pouvez activer "
+"ou désactiver cette fenêtre via le menu « Affichage -> Basculer la fenêtre "
+"du journal »."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1084
+msgid ""
+"Messages are not 'lost', if the log window is not shown, if you select to "
+"show the log window later, you will see past log messages (if you did not "
+"clear the messages)."
+msgstr ""
+"Les messages ne sont pas « perdus » si la fenêtre du journal n’est pas "
+"affichée. Si vous choisissez d’afficher la fenêtre du journal plus tard, "
+"vous verrez les anciens messages du journal (à condition de ne pas les avoir "
+"effacés)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1086
+msgid ""
+"Such messages may be helpful, when you create bug reports (or trying to find "
+"a bug by yourself)."
+msgstr ""
+"Ces messages peuvent être utiles lorsque vous créez des rapports de bogues "
+"(ou que vous essayez de résoudre un bogue par vous-même)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1089
+msgid ""
+"Log messages can (additionally) be printed to STDERR, when using the command "
+"line option \"--logtostderr\". On Windows a separate text console will be "
+"opened, as a Windows GUI application does not have the standard IO connected."
+msgstr ""
+"Les messages du journal peuvent également être envoyés vers STDERR en "
+"utilisant l’option de ligne de commande « --logtostderr ». Sous Windows, une "
+"console texte distincte sera ouverte, car une application graphique Windows "
+"n’a pas de flux d’entrée/sortie standard connecté."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1093
+msgid "# FAQ"
+msgstr "# FAQ"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1095
+msgid "## Is there a way to make more text fit on a LaTeX page?"
+msgstr "## Comment faire tenir plus de texte sur une page LaTeX ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1097
+msgid ""
+"Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to "
+"specify the size of the borders."
+msgstr ""
+"Oui. Utilisez le [package LaTeX \"geometry\"](https://ctan.org/pkg/geometry) "
+"pour définir la taille des marges."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1099
+msgid ""
+"You can add the following line to the LaTeX preamble (for example by using "
+"the respective field in the config dialogue (\"Export\"->\"Additional lines "
+"for the TeX preamble\"), to set borders of 1cm):"
+msgstr ""
+"Vous pouvez ajouter la ligne suivante dans le préambule LaTeX (par exemple "
+"via le champ dédié dans la fenêtre de configuration : (\"Export\" → \"Lignes "
+"supplémentaires pour le préambule TeX\") pour régler les marges à 1 cm :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1103
+msgid ""
+"```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
+msgstr ""
+"```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1105
+msgid "## Is there a dark mode?"
+msgstr "## Un mode sombre existe-t-il ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1107
+msgid ""
+"If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if "
+"the rest of the operating system is. The worksheet itself is by default "
+"equipped with a bright background. But it can be configured otherwise. "
+"Alternatively, there is a `View/Invert worksheet brightness` menu entry that "
 "allows to quickly convert the worksheet from dark to bright and vice versa."
 msgstr ""
-"Si wxWidgets est suffisamment récent, _wxMaxima_ passera automatiquement en mode sombre si le système d'exploitation l'est également. Par défaut, la feuille de travail a un fond clair, mais cela peut être personnalisé. Sinon, il existe une option 'Affichage/Inverser la luminosité de la feuille' qui "
+"Si wxWidgets est suffisamment récent, _wxMaxima_ passera automatiquement en "
+"mode sombre si le système d'exploitation l'est également. Par défaut, la "
+"feuille de travail a un fond clair, mais cela peut être personnalisé. Sinon, "
+"il existe une option 'Affichage/Inverser la luminosité de la feuille' qui "
 "permet de basculer rapidement entre un fond clair et un fond sombre."
 
-msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_âs >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work."
+#. type: Plain text
+#: ../../info/wxmaxima.md:1109
+msgid ""
+"## _WxMaxima_ sometimes hangs for several seconds once in the first minute"
 msgstr ""
-"_WxMaxima_ délègue certaines tâches lourdes, comme la recherche dans le manuel de _Maxima_ (plus de 1000 pages), à des processus en arrière-plan, ce qui passe généralement inaperçu. Cependant, lorsque le résultat de ces tâches est requis, il est possible que _wxMaxima_ doive attendre quelques "
+"## _WxMaxima_ se fige parfois pendant plusieurs secondes lors de la première "
+"minute d'utilisation"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1111
+#, fuzzy
+#| msgid ""
+#| "_WxMaxima_ delegates some big tasks like parsing _Maxima_âs >1000-page-"
+#| "manual to background tasks, which normally goes totally unnoticed. At the "
+#| "moment the result of such a task is needed, though, it is possible that "
+#| "_wxMaxima_ needs to wait a couple of seconds before it can continue its "
+#| "work."
+msgid ""
+"_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-"
+"manual to background tasks, which normally goes totally unnoticed. At the "
+"moment the result of such a task is needed, though, it is possible that "
+"_wxMaxima_ needs to wait a couple of seconds before it can continue its work."
+msgstr ""
+"_WxMaxima_ délègue certaines tâches lourdes, comme la recherche dans le "
+"manuel de _Maxima_ (plus de 1000 pages), à des processus en arrière-plan, ce "
+"qui passe généralement inaperçu. Cependant, lorsque le résultat de ces "
+"tâches est requis, il est possible que _wxMaxima_ doive attendre quelques "
 "secondes avant de pouvoir reprendre son fonctionnement normal."
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:1113
+#, fuzzy
+#| msgid ""
+#| "## Especially when testing new locale settings, a message box \"locale "
+#| "âxx_YYâ can not be set\" occurs"
 msgid ""
-"`-b` or `--batch`: If the command-line opens a file all cells in this file are evaluated and the file is saved afterward. This is for example useful if the session described in the file makes _Maxima_ generate output files. Batch-processing will be stopped if _wxMaxima_ detects that _Maxima_ has "
-"output an error and will pause if _Maxima_ has a question: Mathematics is somewhat interactive by nature so a completely interaction-free batch processing cannot always be guaranteed."
+"## Especially when testing new locale settings, a message box \"locale "
+"’xx_YY’ can not be set\" occurs"
 msgstr ""
-"`-b` ou `--batch` : si un fichier est ouvert en ligne de commande, toutes ses cellules sont évaluées et le fichier est ensuite enregistré. Cela peut être utile, par exemple, si la session décrite dans le fichier amène _Maxima_ à générer des fichiers de sortie. Le traitement en mode batch s'arrête si "
-"_wxMaxima_ détecte une erreur émise par _Maxima_, et s'interrompt au cas où _Maxima_ pose une question : la nature interactive des mathématiques ne permet pas toujours un traitement entièrement automatisé."
+"## Lors des tests pour les nouveaux paramètres de langue locale, un message "
+"d'erreur \"la locale ‘xx_YY’ ne peut pas être définie\" peut apparaître"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:1115
+msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
+msgstr ""
+"![Avertissement sur la langue locale](./locale-warning.png)"
+"{ id=img_locale_warning}"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1119
+#, fuzzy
+#| msgid ""
+#| "(The same problem can occur with other applications too). The "
+#| "translations seem okay after you click on âOKâ. WxMaxima does not only "
+#| "use its own translations but the translations of the wxWidgets framework "
+#| "too."
+msgid ""
+"(The same problem can occur with other applications too). The translations "
+"seem okay after you click on ’OK’. WxMaxima does not only use its own "
+"translations but the translations of the wxWidgets framework too."
+msgstr ""
+"(Ce problème peut également survenir avec d'autres applications). Les "
+"traductions semblent correctes après avoir cliqué sur OK. _WxMaxima_ "
+"n'utilise pas seulement ses propres traductions, mais aussi celles du "
+"framework wxWidgets."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1122
+msgid ""
+"These locales maybe not present in the system. On Ubuntu/Debian systems they "
+"can be generated using: `dpkg-reconfigure locales`"
+msgstr ""
+"Ces langues locales peuvent ne pas être présentes dans le système. Sur les "
+"systèmes Ubuntu/Debian, elles peuvent être générées avec : `dpkg-reconfigure "
+"locales`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1124
+#, fuzzy
+#| msgid ""
+#| "## How can I use symbols for real numbers, natural numbers (â, â), etc.?"
+msgid ""
+"## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
+msgstr ""
+"## Comment utiliser les symboles pour les nombres réels, pour les entiers "
+"naturels (ℝ, ℕ), etc. ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1126
+#, fuzzy
+#| msgid ""
+#| "You can find these symbols in the Unicode sidebar (search for âdouble-"
+#| "struck capitalâ). But the selected font must also support these symbols. "
+#| "If they do not display properly, select another font."
+msgid ""
+"You can find these symbols in the Unicode sidebar (search for ’double-struck "
+"capital’). But the selected font must also support these symbols. If they do "
+"not display properly, select another font."
+msgstr ""
+"Vous pouvez trouver ces symboles dans la barre latérale des symboles Unicode "
+"(recherchez « double-struck capital »). Cependant, la police sélectionnée "
+"doit également les prendre en charge. Si ceux-ci ne s'affichent pas "
+"correctement, choisissez une autre police."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1128
+msgid ""
+"## How can a Maxima script determine, if it is running under wxMaxima or "
+"command line Maxima?"
+msgstr ""
+"## Comment un script Maxima peut-il déterminer s'il s'exécute sous wxMaxima "
+"ou en ligne de commande ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1130
+msgid ""
+"If wxMaxima is used, the Maxima variable `maxima_frontend` is set to "
+"`wxmaxima`. The Maxima variable `maxima_frontend_version` contains the "
+"wxMaxima version in this case."
+msgstr ""
+"Si wxMaxima est utilisé, la variable Maxima `maxima_frontend` est définie "
+"sur `wxmaxima`. Dans ce cas, la variable Maxima `maxima_frontend_version` "
+"contient la version de wxMaxima."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1132
+msgid ""
+"If no frontend is used (you are using command line Maxima), these variables "
+"are `false`."
+msgstr ""
+"Si aucun programme pour le frontend n'est utilisé (si vous utilisez Maxima "
+"en ligne de commande), ces variables valent `false`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1134
+msgid "## Help! I can not save my document!"
+msgstr "## De l'aide ! Je ne peux pas sauvegarder mon document !"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1136
+msgid ""
+"If saving as wxmx file does not work, try saving the document as wxm file "
+"(and vice versa). And you can also try to remove all output (Menu Cell-"
+">Remove all output) and save that file, maybe some unexpected output causes "
+"issues during the save process."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1140
+msgid "# Command-line arguments"
+msgstr "# Arguments en ligne de commande"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1142
+msgid ""
+"Usually you can start programs with a graphical user interface just by "
+"clicking on a desktop icon or desktop menu entry. WxMaxima - if started from "
+"the command line - still provides some command-line switches, though."
+msgstr ""
+"Généralement, les programmes dotés d'une interface graphique se lancent "
+"simplement en cliquant sur une icône ou une entrée de menu. WxMaxima, "
+"lorsqu'il est démarré depuis la ligne de commande, accepte néanmoins "
+"certains arguments."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1158
+msgid "`-v` or `--version`: Output the version information"
+msgstr "`-v` ou `--version` : affiche les informations de version"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1158
+msgid "`-h` or `--help`: Output a short help text"
+msgstr "`-h` ou `--help` : affiche un texte d'aide succinct"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1158
+msgid ""
+"`-o` or `--open=<str>`: Open the filename given as an argument to this "
+"command-line switch"
+msgstr ""
+"`-o` ou `--open=<fichier>` : ouvre le fichier spécifié en argument de cette "
+"option de la ligne de commande"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1158
+msgid "`-e` or `--eval`: Evaluate the file after opening it."
+msgstr "`-e` ou `--eval` : évalue le fichier après l'avoir ouvert."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1158
+msgid ""
+"`-b` or `--batch`: If the command-line opens a file all cells in this file "
+"are evaluated and the file is saved afterward. This is for example useful if "
+"the session described in the file makes _Maxima_ generate output files. "
+"Batch-processing will be stopped if _wxMaxima_ detects that _Maxima_ has "
+"output an error and will pause if _Maxima_ has a question: Mathematics is "
+"somewhat interactive by nature so a completely interaction-free batch "
+"processing cannot always be guaranteed."
+msgstr ""
+"`-b` ou `--batch` : si un fichier est ouvert en ligne de commande, toutes "
+"ses cellules sont évaluées et le fichier est ensuite enregistré. Cela peut "
+"être utile, par exemple, si la session décrite dans le fichier amène "
+"_Maxima_ à générer des fichiers de sortie. Le traitement en mode batch "
+"s'arrête si _wxMaxima_ détecte une erreur émise par _Maxima_, et "
+"s'interrompt au cas où _Maxima_ pose une question : la nature interactive "
+"des mathématiques ne permet pas toujours un traitement entièrement "
+"automatisé."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1158
+#, no-wrap
 msgid ""
 "- `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
 "- `--pipe`:                        Pipe messages from Maxima to stdout.\n"
@@ -1132,1753 +4945,243 @@ msgstr ""
 "- `--enableipc` : permet à Maxima de contrôler wxMaxima via une communication inter-processus (à utiliser avec prudence).\n"
 "- `--wxmathml-lisp=<fichier>` : indique l’emplacement de `wxMathML.lisp` (pour remplacer la version intégrée, principalement pour les développeur·ses).\n"
 
+#. type: Plain text
+#: ../../info/wxmaxima.md:1160
 msgid ""
-"wxMaxima is mainly developed using the programming language C++ using the [wxWidgets framework](https://www.wxwidgets.org), as build system we use [CMake](https://www.cmake.org), a small part is written in Lisp. You can contribute to wxMaxima, join the wxMaxima project at <https://github.com/wxMaxima-"
-"developers/wxmaxima>, if you have knowledge of these programming languages and want to help and contribute to the open source project wxMaxima."
+"Instead of a minus, some operating systems might use a dash in front of the "
+"command-line switches."
 msgstr ""
-"wxMaxima est principalement développé en C++ avec le framework [wxWidgets](https://www.wxwidgets.org), et utilise [CMake](https://www.cmake.org) comme système de build. Une petite partie est écrite en Lisp. Si vous maîtrisez ces langages et souhaitez contribuer à ce projet open source, vous pouvez "
-"rejoindre l’équipe sur [GitHub](https://github.com/wxMaxima-developers/wxmaxima)."
+"Certains systèmes d'exploitation peuvent utiliser un tiret long (—) au lieu "
+"d'un tiret court (-) devant les options en ligne de commande."
 
-msgid ""
-"But not only programmers are necessary! You can also contribute to wxMaxima, if you help to improve the documentation, find and report bugs (and maybe bugfixes), suggest new features, help to translate wxMaxima or the manual to your language (read the README.md in the [locale subdirectory](https://"
-"github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and the manual can be translated)."
-msgstr ""
-"Mais les programmeurs ne sont pas les seul·es à pouvoir contribuer ! Vous pouvez aussi aider à améliorer wxMaxima en améliorant la documentation, en signalant (ou corrigeant) des bugs, en proposant de nouvelles fonctionnalités, en traduisant l’interface ou le manuel dans votre langue (consultez le "
-"fichier README.md dans le [dossier locales](https://github.com/wxMaxima-developers/wxmaxima/tree/main/locales) pour savoir comment procéder)."
-
-# SOME DESCRIPTIVE TITLE
-# Copyright (C) YEAR Free Software Foundation, Inc.
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-#. type: Plain text
-#: ../../info/wxmaxima.md:2
-msgid "# The wxMaxima user manual"
-msgstr "# Manuel de l'utilisateur de wxMaxima"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:4 ../../info/wxmaxima.md:6
-msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
-msgstr "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:426 ../../info/wxmaxima.md:834 ../../info/wxmaxima.md:1029 ../../info/wxmaxima.md:1072 ../../info/wxmaxima.md:1096
-#, no-wrap
-msgid "______________________________________________________________________\n"
-msgstr "______________________________________________________________________\n"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:10
-msgid "# Introduction to wxMaxima"
-msgstr "# Présentation de wxMaxima"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:12
-msgid "## _Maxima_ and wxMaxima"
-msgstr "## _Maxima_ et wxMaxima"
-
-#. type: Plain text
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:14 ../../info/wxmaxima.md:16 ../../info/wxmaxima.md:18
-msgid "### _Maxima_"
-msgstr "### _Maxima_"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:20 ../../info/wxmaxima.md:22
-msgid "![Maxima screenshot, command line](./maxima_screenshot.png){ id=img_maxima_screenshot }"
-msgstr "![Copie d'écran Maxima, ligne de commande](./maxima_screenshot.png){ id=img_maxima_screenshot }"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:24 ../../info/wxmaxima.md:26
-msgid "### WxMaxima"
-msgstr "### WxMaxima"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:28 ../../info/wxmaxima.md:30
-msgid "![wxMaxima window](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
-msgstr "![fenêtre de wxMaxima](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:32
-msgid "The calculations that are entered in _wxMaxima_ are performed by the _Maxima_ command-line tool in the background."
-msgstr "Les calculs saisis dans _wxMaxima_ sont exécutés en arrière-plan par l'outil en ligne de commande _Maxima_."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:34
-msgid "## Workbook basics"
-msgstr "## Notions de base d'un notebook"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:36 ../../info/wxmaxima.md:38
-msgid "### The workbook approach"
-msgstr "### Fondamentaux du notebook"
-
-#. type: Plain text
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:40 ../../info/wxmaxima.md:42 ../../info/wxmaxima.md:44
-msgid "![Input/output cell](./InputCell.png){ id=img_InputCell }"
-msgstr "![Cellules entrée/sortie cell](./InputCell.png){ id=img_InputCell }"
-
-#. type: Plain text
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:46 ../../info/wxmaxima.md:48 ../../info/wxmaxima.md:50
-msgid "The figure below shows different cell types (title cells, section cells, subsection cells, text cells, input/output cells and image cells)."
-msgstr "La figure ci-dessous montre différents types de cellules (cellules de titre, cellules de section, cellules de sous-section, cellules de texte, cellules d’entrée/sortie et cellules d’image)."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:52
-msgid "![Example of different wxMaxima cells](./cell-example.png){ id=img_cell-example }"
-msgstr "![Exemple de cellules différentes de wxMaxima](./cell-example.png){ id=img_cell-example }"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:54
-msgid "### Cells"
-msgstr "### Cellules"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:56
-msgid "The worksheet is organized in cells. WxMaxima knows the following cell types:"
-msgstr "Le notebook est organisé en cellules. WxMaxima distingue les types de cellules suivants  :"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:63
-msgid "Math cells, containing one or more lines of _Maxima_ input."
-msgstr "Cellules mathématiques, contenant une ou plusieurs lignes de saisie _Maxima_."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:63
-msgid "Output of, or a question from, _Maxima_."
-msgstr "Sortie de, ou une question de, _Maxima_."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:63
-msgid "Image cells."
-msgstr "Cellules image."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:63
-msgid "Text cells, that can for example be used for documentation."
-msgstr "Cellules de texte, qui peuvent par exemple être utilisées pour la documentation."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:63
-msgid "A title, section or a subsection. 6 levels of different headings are possible."
-msgstr "Un titre, une section ou une sous-section. 6 niveaux de titres différents sont possibles."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:63
-msgid "Page breaks."
-msgstr "Sauts de page."
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:65 ../../info/wxmaxima.md:67
-msgid "A (C-style) [comment text](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#Comments) can be part of a math cell as follows: `/* This comment will be ignored by Maxima */`"
-msgstr "Un [commentaire (style C)](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#Comments) peut être inséré dans une cellule de calcul comme suit : `/* Ce commentaire sera ignoré par Maxima */`"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:69
-msgid "\"`/*`\" marks the start of the comment, \"`*/`\" the end."
-msgstr "\"`/*`\" indique le début du commentaire, \"`*/`\" la fin."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:71
-msgid "### Horizontal and vertical cursors"
-msgstr "### curseurs horizontaux et verticaux"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:73
-msgid "If the user tries to select a complete sentence, a word processor will try to extend the selection to automatically begin and end with a word boundary. Likewise, if more than one cell is selected, _wxMaxima_ will extend the selection to whole cells."
-msgstr "Si l’utilisateur tente de sélectionner une phrase complète, un traitement de texte étendra automatiquement la sélection pour qu’elle commence et se termine aux limites d’un mot. De même, si plusieurs cellules sont  sélectionnées, _wxMaxima_ étendra la sélection aux cellules entières."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:75
-msgid "What isnât standard is that _wxMaxima_ provides drag-and-drop flexibility by defining two types of cursors. _WxMaxima_ will switch between them automatically when needed:"
-msgstr "Ce qui est moins conventionnel, c’est que _wxMaxima_ offre une facilité de glisser-déposer en définissant deux types de curseurs. _wxMaxima_ basculera automatiquement entre eux selon le besoin :"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:78
-msgid "The cursor is drawn horizontally if it is moved in the space between two cells or by clicking there."
-msgstr "Le curseur est dessiné horizontalement s’il est déplacé dans l’espace entre deux cellules ou en cliquant à cet endroit."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:78
-msgid "A vertical cursor that works inside a cell. This cursor is activated by moving the cursor inside a cell using the mouse pointer or the cursor keys and works much like the cursor in a text editor."
-msgstr "Un curseur vertical qui fonctionne à l’intérieur d’une cellule. Ce curseur est activé en déplaçant le curseur à l’intérieur d’une cellule à l’aide du pointeur de la souris ou des touches de direction, et fonctionne de manière similaire à celui d’un éditeur de texte."
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:80 ../../info/wxmaxima.md:82
-msgid "![(blinking) horizontal cursor after wxMaxima start](./horizontal-cursor-only.png){ id=img_horizontal_cursor_only }"
-msgstr "![curseur horizontal (clignotant) après le démarrage de wxMaxima](./horizontal-cursor-only.png){ id=img_horizontal_cursor_only }"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:84
-msgid "You might want to create a different cell type (using the \"Cell\" menu), maybe a title cell or text cell, which describes, what will be done, when you start creating your worksheet."
-msgstr "Vous pourrez peut-être vouloir créer un type de cellule différent (via le menu \"Cellule\"), comme une cellule de titre ou une cellule de texte, pour décrire ce que vous allez faire lorsque vous commencerez à créer votre notebook."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:86
-msgid "If you navigate between the different cells, you will also see the (blinking) horizontal cursor, where you can insert a cell into your worksheet (either a math cell, by just start typing your formula - or a different cell type using the menu)."
-msgstr ""
-"Si vous naviguez entre les différentes cellules, vous verrez également le curseur horizontal (clignotant), indiquant l'endroit où vous pouvez insérer une nouvelle cellule dans votre notebook (soit une cellule mathématique, en commençant simplement à saisir votre formule, soit un autre type de cellule "
-"en utilisant le menu)."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:88
-msgid "![(blinking) horizontal cursor between cells](./horizontal-cursor-between-cells.png){ id=img_horizontal_cursor_between_cells }"
-msgstr "![curseur horizontal (clignotant) entre deux cellules](./horizontal-cursor-between-cells.png){ id=img_horizontal_cursor_between_cells }"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:90
-msgid "### Sending cells to Maxima"
-msgstr "### Envoyer des cellules à Maxima"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:92 ../../info/wxmaxima.md:94
-msgid "### Command autocompletion"
-msgstr "### Complétion automatique des commandes"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:96 ../../info/wxmaxima.md:98
-msgid "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
-msgstr "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:100 ../../info/wxmaxima.md:102
-msgid "#### Greek characters"
-msgstr "#### Caractères grecs"
-
-#. type: Plain text
-#. type: Plain text
-#. type: Plain text
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:104 ../../info/wxmaxima.md:106 ../../info/wxmaxima.md:108 ../../info/wxmaxima.md:111
-msgid "A Greek letter can be entered by pressing the <kbd>ESC</kbd> key and then starting to type the Greek characterâs name."
-msgstr "Une lettre grecque peut être saisie en appuyant sur la touche <kbd>ÉCHAP</kbd>, puis en commençant à taper le nom du caractère grec."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:111
-msgid "Alternatively it can be entered by pressing <kbd>ESC</kbd>, one letter (or two for the Greek letter omicron) and <kbd>ESC</kbd> again. In this case the following letters are supported:"
-msgstr ""
-"- Une lettre grecque peut être saisie en appuyant sur la touche <kbd>ÉCHAP</kbd>, puis en commençant à taper le nom du caractère grec. \n"
-"- Elle peut aussi être saisie en appuyant sur <kbd>ÉCHAP</kbd>, une lettre (ou deux pour la lettre grecque omicron), puis à nouveau sur <kbd>ÉCHAP</kbd>. Dans ce cas, les lettres suivantes sont prises en charge :"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:130 ../../info/wxmaxima.md:132
-#, no-wrap
-msgid "You can also use the \"Greek letters\"-sidebar to enter the Greek letters."
-msgstr "Vous pouvez également utiliser la barre latérale « Lettres grecques » pour insérer les lettres grecques."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:134
-msgid "##### Attention: Lookalike characters"
-msgstr "##### Attention aux caractères similaires"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:138
-msgid "Several Latin letters look like the Greek letters, e.g. the Latin letter \"A\" and the Greek letter \"Alpha\". Although they look identical, they are two different Unicode characters, represented by different Unicode code points (numbers)."
-msgstr "Plusieurs lettres latines ressemblent aux lettres grecques, par exemple la lettre latine \"A\" et la lettre grecque \"Alpha\". Bien qu'elles aient la même apparence, ce sont deux caractères Unicode distincts, représentés par des codages Unicode (nombres) différents."
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:143 ../../info/wxmaxima.md:146
-msgid "The \"Greek letters\"-sidebar therefore has the option, that lookalike characters are not available (which can be changed using a right-click menu)."
-msgstr "La barre latérale « Lettres grecques » offre donc l’option de désactiver les caractères similaires (ce paramètre peut être modifié via un menu accessible par un clic droit)."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:148
-msgid "The same mechanism also allows to enter some miscellaneous mathematical symbols:"
-msgstr "Le même mécanisme permet également de saisir divers symboles mathématiques :"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:199 ../../info/wxmaxima.md:201
-#, no-wrap
-msgid "You can also use the \"Symbols\"-sidebar to enter these Mathematical symbols."
-msgstr "Vous pouvez aussi utiliser la barre latérale « Symboles » pour saisir ces symboles mathématiques."
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:203 ../../info/wxmaxima.md:205
-msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`."
-msgstr "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd>  est une séquence qui produit un `a`."
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:207 ../../info/wxmaxima.md:210
-msgid "It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.  To solve that problem, select other fonts (using: Edit -> Configure -> Style)."
-msgstr "Il est possible que, par exemple, les caractères grecs ou les symboles mathématiques ne soient pas inclus dans la police sélectionnée et ne puissent donc pas s'afficher. Pour résoudre ce problème, choisissez une autre police (via : Édition -> Configurer -> Style)."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:212
-msgid "### Unicode replacement"
-msgstr "### Remplacement de caractères Unicode"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:214 ../../info/wxmaxima.md:217
-msgid "Unicode has several \"common\" fractions encoded as one Unicode code point: `Â¼, Â½, Â¾, â, â, â, â, â, â, â, â, â, â, â, â, â, â, â`"
-msgstr "Unicode comprend plusieurs fractions « courantes » encodées sous la forme d’un seul point de code : `¼, ½, ¾, ⅐, ⅑, ⅒, ⅓, ⅔, ⅕, ⅖, ⅗, ⅘, ⅙, ⅚, ⅛, ⅜, ⅝, ⅞`"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:219
-msgid "wxMaxima will replace them with their Maxima representations, e.g `(1/4)` before the input is sent do Maxima. There are also `â`, which will be replaced by `1/` and `â` (used in baseball), which will be replaced by `(0/3)`."
-msgstr "wxMaxima les remplacera par leurs représentations dans Maxima, par exemple `(1/4)` avant que l’entrée ne soit envoyée à Maxima. Il existe aussi `⅟`, qui sera remplacé par `1/`, et `↉` (utilisé au baseball), qui sera remplacé par `(0/3)`."
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:221 ../../info/wxmaxima.md:224
-msgid "### Side Panes"
-msgstr "### Les panneaux latéraux"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:226 ../../info/wxmaxima.md:228
-msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
-msgstr "![Illustration de différents volets latéraux](./SidePanes.png){ id=img_SidePanes }"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:231
-msgid "In the \"table of contents\" side pane, one can increase or decrease a heading by just clicking on the heading with the right mouse button and select the next higher or lower heading type."
-msgstr "Dans le volet latéral « table des matières », vous pouvez augmenter ou diminuer le niveau d’un titre en cliquant simplement dessus avec le bouton droit de la souris et en sélectionnant le niveau de titre supérieur ou inférieur."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:233
-msgid "![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-headings.png){ id=Sidepane-TOC-convert-headings }"
-msgstr "![Augmenter ou diminuer le niveau de titres dans le panneau latéral Table des Matières](./Sidepane-TOC-convert-headings.png){ id=Sidepane-TOC-convert-headings }"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:235
-msgid "### MathML output"
-msgstr "### Export MathML"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:237 ../../info/wxmaxima.md:239
-msgid "### Markdown support"
-msgstr "### Prise en charge de Markdown"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:241
-msgid "_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/wiki/Markdown) conventions that donât collide with mathematical notation. One of these elements is bullet lists."
-msgstr "_WxMaxima_ propose un ensemble de balises [Markdown](https://en.wikipedia.org/wiki/Markdown) standard qui n’entrent pas en conflit avec la notation mathématique. L’un de ces éléments est les listes à puces."
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:251 ../../info/wxmaxima.md:253
-#, no-wrap
-msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
-msgstr "_WxMaxima_ reconnaîtra le texte commençant par le caractère `>` comme des blocs de citations  :"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:261
-msgid "```text Ordinary text > quote quote quote quote > quote quote quote quote > quote quote quote quote Ordinary text ```"
-msgstr "```text Texte ordinaire > citation citation citation citation > citation citation citation citation > citation citation citation citation Texte ordinaire```"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:263
-msgid "_WxMaxima_âs TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:"
-msgstr "_WxMaxima_ reconnaîtra `=>` dans ses sorties TeX et HTML et le remplacera par le symbole Unicode correspondant :"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:267
-msgid "```text cogito => sum.  ```"
-msgstr "```text cogito => sum.  ```"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:269
-msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized."
-msgstr ""
-"D’autres symboles reconnus par les exports HTML et TeX sont `<=` et `>=` pour les comparaisons, une double flèche à double pointe (`<=>`), des flèches à une seule direction (`<->`, `->` et `<-`) ainsi que `+/-` pour le symbole correspondant. Pour la sortie TeX, les symboles `<<` et `>>` sont "
-"également reconnus."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:271
-msgid "### Hotkeys"
-msgstr "### Raccourcis clavier"
-
-#. type: Plain text
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:273 ../../info/wxmaxima.md:277
-msgid "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
-msgstr "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> supprime complètement une cellule."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
-msgid "<kbd>CTRL</kbd>+<kbd>TAB</kbd> or <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</kbd> triggers the auto-completion mechanism."
-msgstr "<kbd>CTRL</kbd>+<kbd>TAB</kbd> or <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</kbd> déclenche le mécanisme de saisie automatique."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
-msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
-msgstr "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> insère un espace insécable."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:279
-msgid "### Raw TeX in the TeX export"
-msgstr "### TeX brut dans l'export TeX"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:281
-msgid "If a text cell begins with `TeX:` the TeX export contains the literal text that follows the `TeX:` marker. Using this feature allows the entry of TeX markup within the _wxMaxima_ workbook."
-msgstr "Si une cellule de texte commence par `TeX:`, l'export TeX inclut le texte littéral qui suit le marqueur `TeX:`. Cette fonctionnalité permet d'insérer du code TeX directement dans le classeur _wxMaxima_."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:283
-msgid "## File Formats"
-msgstr "## Formats de fichiers"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:285
-msgid "The material that is developed in a _wxMaxima_ session can be stored for later use in any of three ways:"
-msgstr "Le contenu développé lors d'une session _wxMaxima_ peut être enregistré pour une utilisation ultérieure de trois manières différentes :"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:287
-msgid "### .mac"
-msgstr "### .mac"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:289
-msgid "`.mac` files are ordinary text files that contain _Maxima_ commands. They can be read using _Maxima_âs `batch()` or `load()` command or _wxMaxima_âs File/Batch File menu entry."
-msgstr "Les fichiers `.mac` sont des fichiers texte ordinaires qui contiennent des commandes _Maxima_. Ils peuvent être lus à l'aide de la commande `batch()` ou `load()` de _Maxima_, ou via l'entrée de menu Fichier/Charger un packetage de _wxMaxima_."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:292
-msgid "One example is shown below. `Quadratic.mac` defines a function and afterward generates a plot with `wxdraw2d()`.  Afterward the contents of the file `Quadratic.mac` are printed and newly defined function `f()` is evaluated."
-msgstr "Un exemple est présenté ci-dessous. `Quadratic.mac` définit une fonction, puis génère un tracé avec `wxdraw2d()`. Ensuite, le contenu du fichier `Quadratic.mac` est affiché et la fonction nouvellement définie `f()` est évaluée."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:294
-msgid "![Loading a file with `batch()`](./BatchImage.png){ id=img_BatchImage }"
-msgstr "![Chargement d'un fichier avec `batch()`](./BatchImage.png){ id=img_BatchImage }"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:296 ../../info/wxmaxima.md:298
-msgid "You can be use `.mac` files for writing your own library of macros. But since they donât contain enough structural information they cannot be read back as a _wxMaxima_ session."
-msgstr "Vous pouvez utiliser les fichiers `.mac` pour écrire votre propre bibliothèque de macros. Cependant, comme ils ne contiennent pas assez d’informations structurelles, ils ne peuvent pas être relus en tant que session _wxMaxima_."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:300
-msgid "### .wxm"
-msgstr "### .wxm"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:303 ../../info/wxmaxima.md:305
-msgid "With this plain-text format, it sometimes is unavoidable that worksheets that use new features are not downwards-compatible with older versions of _wxMaxima_."
-msgstr "Avec ce format en texte brut, il est parfois inévitable que les feuilles de calcul utilisant de nouvelles fonctionnalités ne soient pas rétrocompatibles avec les anciennes versions de _wxMaxima_."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:307
-msgid "#### File format of wxm files"
-msgstr "#### Format de fichier des fichiers wxm"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:309
-msgid "This is just a plain text file (you can open it with a text editor), containing the cell contents as some special Maxima comments."
-msgstr "Il s'agit simplement d'un fichier texte brut (vous pouvez l'ouvrir avec un éditeur de texte), contenant le contenu des cellules sous forme de commentaires spéciaux Maxima."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:311
-msgid "It starts with the following comment:"
-msgstr "Cela commence par le commentaire suivant :"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:316
-msgid "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
-msgstr "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:318
-msgid "And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
-msgstr "Puis les cellules suivent, encodées sous forme de commentaires Maxima, par exemple une cellule de section :"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:324 ../../info/wxmaxima.md:326
-#, no-wrap
-msgid "or (in a Math cell the input is of course *not* commented out (the output is not saved in a `wxm` file)):"
-msgstr "ou (dans une cellule Math, l'entrée n'est bien sûr *pas* mise en commentaire (la sortie n'est pas enregistrée dans un fichier `wxm`)) :"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:333 ../../info/wxmaxima.md:335
-#, no-wrap
-msgid "Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the image type as first line):"
-msgstr "Les images sont [encodées en Base64](https://en.wikipedia.org/wiki/Base64) avec l'indication du type de l'image sur la première ligne):"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:342 ../../info/wxmaxima.md:344
-#, no-wrap
-msgid "A page break is just one line containing:"
-msgstr "Une saut de page est simplement une ligne contenant :"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:348 ../../info/wxmaxima.md:350
-#, no-wrap
-msgid "And folded cells marked by:"
-msgstr "Et les cellules repliées sont marquées par :"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:356 ../../info/wxmaxima.md:358
-#, no-wrap
-msgid "### .wxmx"
-msgstr "### .wxmx"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:360
-msgid "This XML-based file format saves the complete worksheet including things like the zoom factor and the watchlist. It is the preferred file format."
-msgstr "Ce format de fichier basé sur le XML enregistre la feuille de travail complète, y compris des éléments comme le facteur de zoom et la liste de suivi du notebook. C'est le format de fichier recommandé."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:362
-msgid "#### File format of wxmx files"
-msgstr "#### Format de fichier des fichiers wxmx"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:365 ../../info/wxmaxima.md:367
-msgid "It does contain the following files:"
-msgstr "Il contient les fichiers suivants :"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
-msgid "`mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-wxmathml`"
-msgstr "`mimetype` : ce fichier contient le type MIME des fichiers wxMaxima : `text/x-wxmathml`"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
-msgid "`format.txt`: a short description about wxMaxima and the wxmx file format"
-msgstr "`format.txt` : une brève description de wxMaxima et du format de fichier wxmx"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
-msgid "Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima session and included images."
-msgstr "Images (par ex. png, jpeg) : graphiques intégrés produits lors de la session wxMaxima et images incluses."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
-msgid "`content.xml`: a XML document, which contains the various cells of your document in XML format."
-msgstr "`content.xml` : un document XML contenant les différentes cellules de votre document au format XML."
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:374 ../../info/wxmaxima.md:376
-msgid "## Configuration options"
-msgstr "## Options pour la configuration"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:378
-msgid "For some common configuration variables _wxMaxima_ offers two ways of configuring:"
-msgstr "Pour certaines variables courantes liées à la configuration, _wxMaxima_ propose deux méthodes de configuration :"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
-msgid "The configuration dialog box below lets you change their default values for the current and subsequent sessions."
-msgstr "La boîte de dialogue de configuration ci-dessous vous permet de modifier leurs valeurs par défaut pour la session en cours et les suivantes."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
-msgid "Also, the values for most configuration variables can be changed for the current session only by overwriting their values from the worksheet, as shown below."
-msgstr "De plus, les valeurs de la plupart des variables de configuration peuvent être modifiées uniquement pour la session en cours en remplaçant leurs valeurs depuis la feuille de calcul, comme illustré ci-dessous."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:383
-msgid "![wxMaxima configuration 1](./wxMaxima_configuration_001.png){ id=img_wxMaxima_configuration_001 }"
-msgstr "![configuration 1 de wxMaxima](./wxMaxima_configuration_001.png){ id=img_wxMaxima_configuration_001 }"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:385
-msgid "### Default animation framerate"
-msgstr "### Fréquence par défaut des images pour les animations"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:387
-msgid "The animation framerate that is used for new animations is kept in the variable `wxanimate_framerate`. The initial value this variable will contain in a new worksheet can be changed using the configuration dialogue."
-msgstr "La fréquence des images utilisée pour les nouvelles animations est stockée dans la variable `wxanimate_framerate`. La valeur initiale de cette variable dans un nouveau notebook peut être modifiée via la boîte de dialogue de configuration."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:389
-msgid "### Default plot size for new _maxima_ sessions"
-msgstr "### Dimensions par défaut des graphiques pour les nouvelles sessions de _maxima_"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:391
-msgid "After the next start, plots embedded into the worksheet will be created with this size if the value of `wxplot_size` isnât changed by _maxima_."
-msgstr "Lors du prochain démarrage, les graphiques intégrés au notebook seront créés avec ces dimensions, sauf si la valeur de `wxplot_size` est modifiée par _Maxima_."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:393
-msgid "In order to set the plot size of a single graph only use the following notation can be used that sets a variableâs value for one command only:"
-msgstr "Afin de définir la taille d'un seul graphique, la notation suivante peut être utilisée afin d'affecter une valeur à une variable pour une seule commande :"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:402 ../../info/wxmaxima.md:404
-#, no-wrap
-msgid "### Match parenthesis in text controls"
-msgstr "### Correspondance des parenthèses dans les zones de texte"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:406
-msgid "This option enables two things:"
-msgstr "Cette option active deux fonctionnalités :"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
-msgid "If an opening parenthesis, bracket, or double quote is entered _wxMaxima_ will insert a closing one after it."
-msgstr "Si une parenthèse ouvrante, un crochet ouvrant ou un guillemet double est saisi, _wxMaxima_ insère automatiquement le caractère de fermeture correspondant."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
-msgid "If text is selected if any of these keys is pressed the selected text will be put between the matched signs."
-msgstr "Si du texte est sélectionné lorsque l’une de ces touches est enfoncée, le texte sélectionné est placé entre les signes correspondants appariés."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:411
-msgid "### Donât save the worksheet automatically"
-msgstr "### Ne pas enregistrer automatiquement le notebook"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:413
-msgid "If this option is set, the file where the worksheet is will be overwritten only the request of the user. In case of a crash/power loss/... a recent backup copy is still made available in the temp directory, though."
-msgstr "Si cette option est activée, le fichier du notebook ne sera écrasé que sur demande de l'utilisateur. En cas de plantage, de coupure de courant ou autre incident, une copie de sauvegarde récente reste cependant disponible dans le dossier temporaire."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:415
-msgid "If this option isnât set _wxMaxima_ behaves more like a modern cellphone app:"
-msgstr "Si cette option n'est pas activée, _wxMaxima_ se comporte davantage comme une application moderne de smartphone :"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
-msgid "Files are saved automatically on exit"
-msgstr "Les fichiers sont sauvegardés automatiquement lorsque l'on quitte le programme"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
-msgid "And the file will automatically be saved every 3 minutes."
-msgstr "Et le fichier sera automatiquement sauvegardé toutes les 3 minutes."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:420
-msgid "### Where is the configuration saved?"
-msgstr "### Où est enregistrée la configuration  ?"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:423 ../../info/wxmaxima.md:425
-msgid "If you are using Windows, the configuration will be stored in the registry. You will find the entries for _wxMaxima_ at the following position in the registry: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
-msgstr "Si vous utilisez Windows, la configuration est stockée dans le registre. Vous trouverez les entrées pour _wxMaxima_ à l'emplacement suivant du registre : `HKEY_CURRENT_USER\\Software\\wxMaxima`"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:429
-msgid "# Extensions to _Maxima_"
-msgstr "# Extensions pour _Maxima_"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:431 ../../info/wxmaxima.md:433
-msgid "## Subscripted variables"
-msgstr "## Variables en indice"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:435
-msgid "`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript variable names:"
-msgstr "`wxsubscripts` définit si (et comment) _wxMaxima appliquera automatiquement des indices aux noms de variables :"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:437
-msgid "If it is `false`, the functionality is off, wxMaxima will not autosubscript part of variable names after an underscore."
-msgstr "Si sa valeur est `false`, cette fonctionnalité est désactivée : wxMaxima ne transformera pas automatiquement en indices les parties des noms de variables suivant un tiret bas."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:439
-msgid "If it is set to `'all`, everything after an underscore will be subscripted."
-msgstr "Si elle est définie sur `'all`, tout ce qui suit un tiret bas sera converti en indice."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:441
-msgid "If it is set to `true` variable names of the format `x_y` are displayed using a subscript if"
-msgstr "Si elle est définie sur `true`, les noms de variables au format `x_y` s'affichent avec un indice uniquement si"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
-msgid "Either `x` or `y` is a single letter or"
-msgstr "Soit `x` soit `y` est une lettre unique ou"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
-msgid "`y` is an integer (can include more than one character)."
-msgstr "`y` est un entier (peut inclure plus d'un caractère)."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:446
-msgid "![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png){ id=img_wxsubscripts }"
-msgstr "![Comment les variables sont automatiquement mises en indices en utilisant wxsubscripts](./wxsubscripts.png){ id=img_wxsubscripts }"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:448 ../../info/wxmaxima.md:450
-msgid "You can use the menu \"View->Autosubscript\" to set these values."
-msgstr "Vous pouvez utiliser le menu \"Affichage->Mise en indice automatique\" pour définir ces valeurs."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:452
-msgid "## User feedback in the status bar"
-msgstr "## Message utilisateur dans la barre d'état"
-
-#. type: Plain text
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:454 ../../info/wxmaxima.md:465 ../../info/wxmaxima.md:467
-#, no-wrap
-msgid "## Plotting"
-msgstr "## Graphiques"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:469
-msgid "Plotting (having fundamentally to do with graphics) is a place where a graphical user interface will have to provide some extensions to the original program."
-msgstr "La création de courbes (qui repose fondamentalement sur des éléments graphiques) est un domaine où une interface utilisateur graphique devra apporter certaines extensions au programme d'origine."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:471
-msgid "### Embedding a plot into the worksheet"
-msgstr "### Intégrer un graphique dans le notebook"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:473 ../../info/wxmaxima.md:475
-msgid "The following plotting functions have wx-counterparts:"
-msgstr "Les fonctions graphiques suivantes ont leurs équivalents préfixés par « wx » :"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:489 ../../info/wxmaxima.md:491
-#, no-wrap
-msgid "If a `wxm`-file is read by (console) Maxima, these functions are ignored (and printed as output, as other unknown functions in Maxima)."
-msgstr "Si un fichier `.wxm` est lu par _Maxima_ (en mode console), ces fonctions sont ignorées (et affichées à l'identique en sortie, comme toute autre fonction inconnue dans _Maxima_)."
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:493 ../../info/wxmaxima.md:495
-msgid "### Making embedded plots bigger or smaller"
-msgstr "### Agrandir ou diminuer les graphiques intégrés"
-
-#. type: Plain text
-#. type: Plain text
-#. type: Plain text
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:497 ../../info/wxmaxima.md:507 ../../info/wxmaxima.md:509 ../../info/wxmaxima.md:518 ../../info/wxmaxima.md:520
-#, no-wrap
-msgid "Setting the size of embedded plot with `wxplot_size` works for embedded plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` commands and for embedded animations with `with_slider_draw` and `wxanimate` commands."
-msgstr "Le réglage de la taille des graphiques intégrés avec `wxplot_size` fonctionne pour les graphiques en ligne utilisant par exemple les commandes `wxplot`, `wxdraw`, `wxcontour_plot` et `wximplicit_plot`, ainsi que pour les animations intégrées avec les commandes `with_slider_draw` et `wxanimate`."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:522
-msgid "### Better quality plots"
-msgstr "### Des graphiques de meilleur qualité"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:524 ../../info/wxmaxima.md:526
-msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
-msgstr "### Ouvrir les graphiques intégrés dans les fenêtres interactives de _Gnuplot_"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:528 ../../info/wxmaxima.md:530
-msgid "### Opening Gnuplotâs command console in `plot` windows"
-msgstr "### Ouvrir la console de commandes de Gnuplot dans les fenêtres `plot`"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:533 ../../info/wxmaxima.md:535
-msgid "### Embedding animations into the spreadsheet"
-msgstr "### Intégrer des animations dans le notebook"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:537 ../../info/wxmaxima.md:539
-msgid "The first two arguments for `with_slider_draw` are the name of the variable that is stepped between the plots and a list of the values of these variable. The arguments that follow are the ordinary arguments for `wxdraw2d`:"
-msgstr "Les deux premiers arguments de `with_slider_draw` sont le nom du paramètre qui varie entre les graphiques et une liste des valeurs prises par ce paramètre. Les arguments suivants sont les arguments classiques de la commande `wxdraw2d` :"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:550 ../../info/wxmaxima.md:552
-#, no-wrap
-msgid "The same functionality for 3D plots is accessible as `with_slider_draw3d`, which allows for rotating 3d plots:"
-msgstr "La même fonctionnalité pour les graphiques 3D est accessible avec `with_slider_draw3d`, qui permet de faire tourner les graphiques 3D :"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:569 ../../info/wxmaxima.md:571
-#, no-wrap
-msgid "If the general shape of the plot is what matters it might suffice to move the plot just a little bit in order to make its 3D nature available to the intuition:"
-msgstr "Si c'est plutôt la forme générale du graphique qui importe, un léger déplacement peut suffire pour rendre la visualisation 3D plus intuitive :"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:588 ../../info/wxmaxima.md:590
-#, no-wrap
-msgid "For those more familiar with `plot` than with `draw`, there is a second set of functions:"
-msgstr "Pour ceux qui maîtrisent mieux la commande `plot` que `draw`, il existe un second ensemble de fonctions :"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
-msgid "`with_slider` and"
-msgstr "- `with_slider` et"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
-msgid "`wxanimate`."
-msgstr "`wxanimate`."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:595
-msgid "Normally the animations are played back or exported with the frame rate chosen in the configuration of _wxMaxima_. To set the speed at an individual animation is played back the variable `wxanimate_framerate` can be used:"
-msgstr "Normalement, les animations sont lues ou exportées avec le taux de rafraîchissement défini dans la configuration de _wxMaxima_. Pour régler la vitesse de lecture d'une animation donnée, on peut utiliser la variable `wxanimate_framerate` :"
-
-#. type: Plain text
-#. type: Plain text
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:600 ../../info/wxmaxima.md:602 ../../info/wxmaxima.md:612 ../../info/wxmaxima.md:614
-#, no-wrap
-msgid "If _Maxima_ is explicitly asked to substitute the sliderâs value plotting works fine instead:"
-msgstr "Si _Maxima_ est explicitement invité à substituer la valeur du curseur, le tracé fonctionne correctement :"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:627 ../../info/wxmaxima.md:629
-#, no-wrap
-msgid "### Opening multiple plots in contemporaneous windows"
-msgstr "### Ouvrir plusieurs graphiques dans des fenêtres de manière simultanée"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:631
-msgid "While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups that support it) sometimes comes in handily. The following example comes from a post from Mario Rodriguez to the _Maxima_ mailing list:"
-msgstr "Cette fonctionnalité de _Maxima_ (sur les configurations qui la supportent), bien qu'elle ne soit pas disponible via  _wxMaxima_, s'avère parfois bien pratique. L'exemple suivant provient d'un message de Mario Rodriguez sur la _liste de diffusion de Maxima_ :"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:634
-msgid "```maxima load(draw);"
-msgstr "```maxima load(draw);"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:637
-msgid "/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
-msgstr "/* Une parabole dans une fenêtre #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:640
-msgid "/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
-msgstr "/* Une parabole dans une fenêtre #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:644
-msgid "/* Paraboloid in window #3 */ draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```"
-msgstr "/* Un paraboloide dans une fenêtre #3 */ draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:646
-msgid "Plotting multiple plots in the same window is possible, too (the same is possible in command line Maxima with the standard `draw()` command):"
-msgstr "Il est également possible de tracer plusieurs graphiques dans une même fenêtre (la même chose est réalisable avec la commande standard `draw()` de Maxima en ligne de commande) :"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:657 ../../info/wxmaxima.md:659
-#, no-wrap
-msgid "### The \"Plot using draw\" side pane"
-msgstr "### Le panneau latéral \"Graphiques avec draw\""
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:661
-msgid "The \"Plot using draw\" sidebar hides a simple code generator that allows generating scenes that make use of some of the flexibility of the _draw_ package _maxima_ comes with."
-msgstr "Le panneau latéral \"Graphiques avec draw\" cache un générateur simple de code qui permet de créer des représentations graphiques exploitant une partie des fonctionnalités du package _draw_ intégré à _Maxima_."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:663
-msgid "#### 2D"
-msgstr "#### 2D"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:665
-msgid "Generates the skeleton of a `draw()` command that draws a 2D scene. This scene later has to be filled with commands that generate the sceneâs contents, for example by using the buttons in the rows below the \"2D\" button."
-msgstr "Génère le squelette d'une commande `draw()` pour dessiner une scène 2D. Cette scène doit ensuite être complétée avec des commandes qui génèrent son contenu, par exemple en utilisant les boutons situés dans les lignes en dessous du bouton \"2D\"."
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:667 ../../info/wxmaxima.md:669
-msgid "#### 3D"
-msgstr "#### 3D"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:671
-msgid "Generates the skeleton of a `draw()` command that draws a 3D scene. If neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D scene that contains the command the button generates."
-msgstr "Génère le squelette d'une commande `draw()` pour tracer une scène 3D. Si aucune scène 2D ou 3D n'est définie, tous les autres boutons configurent automatiquement une scène 2D contenant la commande générée par le bouton."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:673
-msgid "#### Expression"
-msgstr "#### Expression"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:675
-msgid "Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or `x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is no draw command a 2D scene with the plot is generated. Each scene can be filled with any number of plots."
-msgstr "Ajoute un tracé standard d'une expression comme `sin(x)`, `x*sin(x)` ou `x^2+2*x-4` à la commande `draw()` où se trouve actuellement le curseur. Si aucune commande `draw()` n'existe, une scène 2D avec ce tracé est générée. Chaque scène peut contenir un nombre illimité de graphiques."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:677
-msgid "#### Implicit plot"
-msgstr "#### Courbe définie de manière implicite"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:679
-msgid "Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or `x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command the cursor currently is in. If there is no draw command a 2D scene with the plot is generated."
-msgstr "Tente de trouver tous les points où une expression comme `y=sin(x)`, `y*sin(x)=3` ou `x^2+y^2=4` est vérifiée et trace la courbe résultante dans la commande `draw()` où se trouve le curseur. Si aucune commande `draw()` n'existe, une scène 2D avec ce tracé est générée."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:681
-msgid "#### Parametric plot"
-msgstr "#### Courbe paramétrique"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:683
-msgid "Steps a variable from a lower limit to an upper limit and uses two expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in 3D plots also z) coordinates of a curve that is put into the current draw command."
-msgstr "Fait varier une variable entre une borne inférieure et une borne supérieure, puis utilise deux expressions comme `t*sin(t)` et `t*cos(t)` pour générer les coordonnées x, y (et z dans le cas des tracés 3D) d'une courbe, qui est ensuite insérée dans la commande `draw()` actuelle."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:685
-msgid "#### Points"
-msgstr "#### Points"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:687
-msgid "Draws many points that can optionally be joined. The coordinates of the points are taken from a list of lists, a 2D array or one list or array for each axis."
-msgstr "Trace plusieurs points, éventuellement reliés entre eux. Les coordonnées des points peuvent provenir d'une liste de listes, d'un tableau 2D, ou d'une liste ou d'un tableau pour chaque axe."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:689
-msgid "#### Diagram title"
-msgstr "#### Titre du graphique"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:691
-msgid "Draws a title on the upper end of the diagram,"
-msgstr "Ajoute un titre en haut du graphique,"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:693
-msgid "#### Axis"
-msgstr "#### Axes"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:695
-msgid "Sets up the axis."
-msgstr "Configurer l'axe."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:697
-msgid "#### Contour"
-msgstr "#### Lignes de niveau"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:699 ../../info/wxmaxima.md:701
-msgid "#### Plot name"
-msgstr "#### Légende du graphique"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:703
-msgid "Adds a legend entry showing the next plotâs name to the legend of the diagram. An empty name disables generating legend entries for the following plots."
-msgstr "Ajoute une nouvelle entrée pour la légende affichant le nom du prochain tracé à la légende actuelle du graphique. Un nom vide désactive la génération d'entrées des légende pour les tracés suivants."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:705
-msgid "#### Line colour"
-msgstr "#### Couleur de la ligne du tracé"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:707
-msgid "Sets the line colour for the following plots the current draw command contains."
-msgstr "Définit la couleur de ligne pour les tracés suivants contenus dans la commande `draw()` actuelle."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:709
-msgid "#### Fill colour"
-msgstr "#### Couleur de remplissage"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:711
-msgid "Sets the fill colour for the following plots the current draw command contains."
-msgstr "Définit la couleur de remplissage pour les tracés suivants contenus dans la commande `draw()` actuelle."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:713
-msgid "#### Grid"
-msgstr "#### Quadrillage"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:715
-msgid "Pops up a wizard that allows to set up grid lines."
-msgstr "Ouvre un assistant permettant de configurer les lignes du quadrillage."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:717
-msgid "#### Accuracy"
-msgstr "#### Précision"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:719
-msgid "Allows to select an adequate point in the speed vs. accuracy tradeoff that is part of any plot program."
-msgstr "Permet de choisir un compromis adapté entre vitesse et précision, inhérent à tout programme de tracé graphique."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:721
-msgid "### Modify font and font size for plots"
-msgstr "### Modifier la police et la taille de police pour les graphiques"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:723
-msgid "Especially when you use a high resolution display, the default font size might be very small. For the `draw`-based commands, you can set the font / font size using options like `font=...`, `font_size=...`, e.g.:"
-msgstr "Surtout lorsque vous utilisez un affichage haute résolution, la taille de police par défaut peut être très petite. Pour les commandes basées sur `draw`, vous pouvez définir la police et la taille de police à l'aide d'options comme `font=...`, `font_size=...`, par exemple :"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:730 ../../info/wxmaxima.md:732
-#, no-wrap
-msgid "For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts can be set using the `gnuplot_preamble` command, e.g.:"
-msgstr "Pour les commandes de type `plot` (par exemple `wxplot2d`, `wxplot3d`), les tailles et polices de caractères peuvent être définies à l'aide de la commande `gnuplot_preamble`, par exemple :"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:737 ../../info/wxmaxima.md:739
-#, no-wrap
-msgid "This sets the font for the numbers to Arial with size 30, the size for the xlabel and ylabel font to 20 (with the default font)."
-msgstr "Cela définit la police pour les nombres en Arial avec une taille de 30, et la taille de la police des étiquettes xlabel et ylabel à 20 (avec la police par défaut)."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:742
-msgid "Read the Maxima and Gnuplot documentation for further information.  Note: Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue 1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966)."
-msgstr "Consultez la documentation de Maxima et Gnuplot pour plus d'informations. Remarque : Gnuplot semble rencontrer des problèmes avec les polices de grande taille, voir [wxMaxima issue 1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966)."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:744
-msgid "## Embedding graphics"
-msgstr "## Graphiques intégrés"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:746 ../../info/wxmaxima.md:750
-msgid "```maxima show_image(\"man.png\"); ```"
-msgstr "```maxima show_image(\"man.png\"); ```"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:752
-msgid "## Startup files"
-msgstr "## Fichiers au démarrage"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:754
-msgid "The config dialogue of _wxMaxima_ offers to edit two files with commands that are executed on startup:"
-msgstr "La boîte de dialogue de configuration de _wxMaxima_ permet de modifier deux fichiers contenant des commandes exécutées au démarrage :"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
-msgid "A file that contains commands that are executed on starting up _Maxima_: `maxima-init.mac`"
-msgstr "Un fichier contenant des commandes exécutées au démarrage de _Maxima_ : `maxima-init.mac`"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
-msgid "one file of additional commands that are executed if _wxMaxima_ is starting _Maxima_: `wxmaxima-init.mac`"
-msgstr "un fichier d'instructions supplémentaires exécutées lorsque _wxMaxima_ démarre _Maxima_ : `wxmaxima-init.mac`"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:759
-msgid "For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add `gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` or any other path) to these files."
-msgstr "Par exemple, si Gnuplot est installé dans `/opt` (peut-être sur macOS), vous pouvez ajouter `gnuplot_command:\"/opt/local/bin/gnuplot\"$` (ou `/opt/gnuplot/bin/gnuplot` ou tout autre chemin) à ces fichiers."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:761
-msgid "These files are in the Maxima user directory (usually `%USERPROFILE%/maxima` in Windows, `$HOME/.maxima` otherwise). The location can be found out with the command: `maxima_userdir;`"
-msgstr "Ces fichiers se trouvent dans le répertoire utilisateur de Maxima (généralement `%USERPROFILE%/maxima` sous Windows, ou `$HOME/.maxima` sinon). Vous pouvez connaître leur emplacement avec la commande : `maxima_userdir;`"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:763
-msgid "## Special variables wx..."
-msgstr "## Variables spéciales wx..."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
-msgid "`wxsubscripts` tells _Maxima_ if it should convert variable names that contain an underscore (`R_150` or the like) into subscripted variables. See `wxdeclare_subscript` for details which variable names are automatically converted."
-msgstr "`wxsubscripts` indique à _Maxima_ s'il doit convertir les noms de variables contenant un tiret bas (`R_150` ou similaire) en variables avec indices en bas de ligne. Voir `wxdeclare_subscript` pour les détails sur les noms de variables automatiquement convertis."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
-msgid "`wxfilename`: This variable contains the name of the file currently opened in _wxMaxima_."
-msgstr "`wxfilename` : Cette variable contient le nom du fichier actuellement ouvert dans _wxMaxima_."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
-msgid "`wxdirname`: This variable contains the name the directory, in which the file currently opened in _wxMaxima_ is."
-msgstr "`wxdirname` : Cette variable contient le nom du répertoire dans lequel se trouve le fichier actuellement ouvert dans _wxMaxima_."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
-msgid "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_âs pngcairo terminal that provides more line styles and a better overall graphics quality."
-msgstr "`wxplot_pngcairo` indique si _wxMaxima_ essaie d'utiliser le terminal pngcairo de _Gnuplot_ qui fournit plus de styles de lignes et une meilleure qualité graphique globale."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
-msgid "`wxplot_size` defines the resolution of embedded plots."
-msgstr "`wxplot_size` définit la résolution des graphiques intégrés."
-
-#. type: Bullet: '- '
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
-msgid "`wxanimate_framerate`: The number of frames per second the following animations have to be played back with."
-msgstr "`wxanimate_framerate` : Le nombre d'images par seconde pour la lecture des animations suivantes."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
-msgid "`wxanimate_autoplay`: Automatically play animations by default?"
-msgstr "`wxanimate_autoplay` : Jouer automatiquement les animations par défaut ?"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
-msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
-msgstr "`wxmaximaversion` : Retourne le numéro de version de _wxMaxima_."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
-msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
-msgstr "`wxwidgetsversion` : Retourne la version de wxWidgets utilisée par _wxMaxima_."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:776
-msgid "## Pretty-printing 2D output"
-msgstr "## Affichage formaté en 2D"
-
-#. type: Plain text
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:778 ../../info/wxmaxima.md:787 ../../info/wxmaxima.md:789
-#, no-wrap
-msgid "As the next example shows, the lists that are assembled by the `table_form` command can be created before the command is executed."
-msgstr "Comme le montre l'exemple suivant, les listes utilisées par la commande `table_form` peuvent être créées avant son exécution."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:791
-msgid "![A third table example](./MatrixTableExample.png){ id=img_MatrixTableExample }"
-msgstr "![Un troisième exemple de tableau](./MatrixTableExample.png){ id=img_MatrixTableExample }"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:793
-msgid "Also, because a matrix is a list of lists, matrices can be converted to tables in a similar fashion."
-msgstr "De même, comme une matrice est une liste de listes, elle peut être convertie en tableau de manière similaire."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:795
-msgid "![Another table_form example](./SecondTableExample.png){ id=img_SecondTableExample }"
-msgstr "![Un autre exemple avec table_form](./SecondTableExample.png){ id=img_SecondTableExample }"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:797
-msgid "## Bug reporting"
-msgstr "## Signalement de bugs"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:799
-msgid "_WxMaxima_ provides a few functions that gather bug reporting information about the current system:"
-msgstr "_WxMaxima_ propose quelques fonctions qui collectent des informations utiles pour signaler un bug concernant le système actuel :"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:802
-msgid "`wxbuild_info()` gathers information about the currently running version of _wxMaxima_"
-msgstr "- `wxbuild_info()` : Rassemble des informations sur la version en cours d'exécution  de _wxMaxima_"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:802
-msgid "`wxbug_report()` tells how and where to file bugs"
-msgstr "`wxbug_report()` indique comment et où signaler les bogues"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:805
-msgid "## Marking output being drawn in red"
-msgstr "## Ecrire le résultat de la sortie en rouge"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:808
-msgid "_Maxima_âs `box()` command causes _wxMaxima_ to print its argument with a red foreground, if the second argument to the command is the text `highlight`."
-msgstr "La commande `box()` de _Maxima_ permet à _wxMaxima_ d'afficher son argument en rouge, si le deuxième argument de la commande est le texte `highlight`."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:810
-msgid "## Output rendering."
-msgstr "## Rendu de la sortie."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:812
-msgid "With `set_display()` one can set, how wxMaxima will render the output."
-msgstr "Avec `set_display()`, on peut définir de quelle manière wxMaxima affichera la sortie."
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:814 ../../info/wxmaxima.md:817
-msgid "<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) --> `set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art."
-msgstr "<!--- Actuellement, cela ne fonctionne pas comme prévu : la ligne avec l’étiquette de sortie est décalée vers la droite (problème : #2006) --> `set_display('ascii)` fait en sorte que wxMaxima affiche les formules comme dans Maxima en ligne de commande — en ASCII-Art."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:819
-msgid "`set_display('none)` causes 'one-line' ASCII results - the same as the command line Maxima command `display2d:false;` does."
-msgstr "`set_display('none)` produit des résultats ASCII « sur une seule ligne » — comme le fait la commande de Maxima en ligne de commande `display2d:false;`."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:821
-msgid "# Help menu"
-msgstr "# Menu d'aide"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:823
-msgid "WxMaximaâs help menu provides access to the Maxima and wxMaxima manual, tips, some example worksheets and in command line Maxima included demos (the `demo()` command)."
-msgstr "Le menu d'aide de _wxMaxima_ donne accès au manuel de Maxima et à celui de wxMaxima, à des astuces, à des exemples de notebooks, ainsi qu'aux exemples intégrés dans Maxima en ligne de commande (via la commande `demo()`)."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:825
-msgid "Please notice, that the demos write:"
-msgstr "Veuillez noter que les exemples indiquent :"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:829
-msgid "~~~ At the â_â prompt, type â;â and <enter> to proceed with the demonstration.  ~~~"
-msgstr "~~~ À l’invite `’_’`, tapez `;` puis `<entrée>` pour poursuivre la démonstration.  ~~~"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:831
-msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>"
-msgstr "Cela est valable pour Maxima en ligne de commande, mais dans wxMaxima, par défaut, il est nécessaire de poursuivre la démonstration avec : <kbd>CTRL</kbd> + <kbd>ENTRÉE</kbd>"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:833
-msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)"
-msgstr "(Ce comportement peut être configuré dans le menu Configurer → Notebook → \" Raccourcis pour envoyer des commandes à Maxima\".)"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:837
-msgid "# Troubleshooting"
-msgstr "# Résolution des problèmes"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:839
-msgid "## Cannot connect to _Maxima_"
-msgstr "## Impossible de se connecter à _Maxima_"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:841 ../../info/wxmaxima.md:843
-msgid "On Unix computers another possible reason would be that the loopback network that provides network connections between two programs in the same computer isnât properly configured."
-msgstr "Sur les ordinateurs Unix, une autre cause possible serait que le réseau loopback, qui permet les connexions entre deux programmes sur le même ordinateur, ne soit pas correctement configuré."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:845
-msgid "## How to save data from a broken .wxmx file"
-msgstr "## Comment récupérer les données d’un fichier .wxmx corrompu"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:847
-msgid "Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ doesnât turn on compression, so the contents of `.wxmx` files can be viewed in any text editor."
-msgstr "En informatique, la plupart des formats modernes basés sur XML sont en réalité des fichiers zip ordinaires. _WxMaxima_ n’active pas la compression, donc le contenu des fichiers `.wxmx` peut être consulté avec n’importe quel éditeur de texte."
-
-#. type: Plain text
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:849 ../../info/wxmaxima.md:851 ../../info/wxmaxima.md:853
-msgid "If a text file containing only these contents (e.g. copy and paste this text into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know how to recover the text from the document."
-msgstr "Si vous enregistrez un fichier texte contenant uniquement ce contenu (par exemple, en copiant et collant ce texte dans un nouveau fichier) avec une extension `.xml`, _wxMaxima_ saura comment récupérer le texte du document."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:855
-msgid "## I want some debug info to be displayed on the screen before my command has finished"
-msgstr "## Je souhaite afficher des informations de débogage à l’écran avant que ma commande ne soit terminée"
-
-#. type: Plain text
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:857 ../../info/wxmaxima.md:867 ../../info/wxmaxima.md:869
-#, no-wrap
-msgid "Alternatively one can look for the `wxstatusbar()` command above."
-msgstr "Sinon, on peut utiliser la commande `wxstatusbar()` mentionnée ci-dessus."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:871
-msgid "## Plotting only shows a closed empty envelope with an error message"
-msgstr "## La création d'un graphique n'affiche qu'une enveloppe vide encadrée avec un message d'erreur"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:873
-msgid "This means that _wxMaxima_ could not read the file _Maxima_ that was supposed to instruct _Gnuplot_ to create."
-msgstr "Cela signifie que _wxMaxima_ n'a pas pu lire le fichier généré par _Maxima_, qui était censé donner les instructions à _Gnuplot_ pour créer le graphique."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:875
-msgid "Possible reasons for this error are:"
-msgstr "Les causes possibles de cette erreur sont :"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:880
-msgid "The plotting command is part of a third-party package like `implicit_plot` but this package was not loaded by _Maxima_âs `load()` command before trying to plot."
-msgstr "La commande de tracé fait partie d’un paquet externe comme `implicit_plot`, mais ce paquet n’a pas été chargé par la commande `load()` de _Maxima_ avant le lancement de cette commande."
-
-#. type: Bullet: '- '
-#. type: Bullet: '- '
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:880
-msgid "Gnuplot didnât output a valid `.png` file."
-msgstr "Gnuplot n’a pas produit de fichier `.png` valide."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:882
-msgid "## Plotting an animation results in âerror: undefined variableâ"
-msgstr "## Le tracé d'une animation génère l'erreur \"error: undefined variable\""
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:884 ../../info/wxmaxima.md:886
-msgid "## I lost cell content and undo doesnât remember"
-msgstr "## J’ai perdu le contenu d’une cellule et la fonction Annuler ne le restaure pas"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:888
-msgid "There are separate undo functions for cell operations and for changes inside of cells so chances are low that this ever happens. If it does there are several methods to recover data:"
-msgstr "Il existe des fonctions Annuler distinctes pour les opérations sur les cellules et pour les modifications à l’intérieur des cellules, donc il est peu probable que cela arrive. Si cela se produit, plusieurs méthodes permettent de récupérer les données :"
-
-#. type: Bullet: '- '
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:893
-msgid "If you still have a way to find out what label _Maxima_ has assigned to the cell just type in the cellâs label and its contents will reappear."
-msgstr "Si vous avez encore un moyen de retrouver l’étiquette que _Maxima_ a attribuée à la cellule, il vous suffit de taper cette étiquette, et le contenu de la cellule réapparaîtra."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:893
-msgid "If you donât: Donât panic. In the âViewâ menu there is a way to show a history pane that shows all _Maxima_ commands that have been issued recently."
-msgstr "Si ce n’est pas le cas, ne paniquez pas. Le menu « Affichage » propose une option permettant d’afficher un panneau d’historique qui montre toutes les commandes _Maxima_ exécutées récemment."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:893
-msgid "If nothing else helps _Maxima_ contains a replay feature:"
-msgstr "Si rien d’autre ne fonctionne, _Maxima_ contient une fonction de replay :"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:897
-msgid "```maxima playback(); ```"
-msgstr "```maxima playback(); ```"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:899
-msgid "## _WxMaxima_ starts up with the message âMaxima process terminated.â"
-msgstr "## _WxMaxima_ démarre avec le message  Maxima process terminated"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:901
-msgid "One possible reason is that _Maxima_ cannot be found in the location that is set in the âMaximaâ tab of _wxMaxima_âs configuration dialog and therefore wonât run at all. Setting the path to a working _Maxima_ binary should fix this problem."
-msgstr "Une cause possible est que le programme _Maxima_ n’est pas trouvé à l’emplacement indiqué dans l’onglet Maxima de la boîte de dialogue de configuration de _wxMaxima_, ce qui l’empêche de démarrer. Vérifiez et corrigez le chemin vers l’exécutable _Maxima_ pour résoudre ce problème."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:903
-msgid "## Maxima is forever calculating and not responding to input"
-msgstr "## Maxima calcule indéfiniment et ne répond plus aux commandes entrées"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:905
-msgid "It is theoretically possible that _wxMaxima_ doesnât realize that _Maxima_ has finished calculating and therefore never gets informed it can send new data to _Maxima_. If this is the case âTrigger evaluationâ might resynchronize the two programs."
-msgstr "Il est théoriquement possible que _wxMaxima_ ne détecte pas que _Maxima_ a terminé ses calculs et, de ce fait, n’autorise pas l’envoi de nouvelles données. Dans ce cas, l’option Déclencher l’évaluation (« Trigger evaluation ») peut resynchroniser les deux programmes."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:907
-msgid "## My SBCL-based _Maxima_ runs out of memory"
-msgstr "## Mon _Maxima_ basé sur SBCL manque de mémoire"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:909 ../../info/wxmaxima.md:911
-msgid "One way to provide _Maxima_ (and thus SBCL) with command line parameters is the \"Additional parameters for Maxima\" field of _wxMaxima_âs configuration dialogue."
-msgstr "Une façon de fournir des paramètres en ligne de commande à _Maxima_ (et donc à SBCL) est d’utiliser le champ \"Paramètres supplémentaires pour Maxima\" dans la boîte de dialogue de configuration de _wxMaxima_."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:913
-msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
-msgstr "![mémoire pour sbcl](./sbclMemory.png){ id=img_sbclMemory }"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:915
-msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
-msgstr "## Sous Ubuntu, la saisie est parfois lente ou certaines touches sont ignorées"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:917
-msgid "Installing the package `ibus-gtk` should resolve this issue. See ([https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) for details."
-msgstr "L'installation du paquet 'ibus-gtk' devrait résoudre ce problème. Pour plus de détails, voir : [https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:919
-msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
-msgstr "## _WxMaxima_ se fige lorsque _Maxima_ traite des caractères grecs ou des lettres accentuées (comme les umlauts)"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:921
-msgid "If your _Maxima_ is based on SBCL the following lines have to be added to your `.sbclrc`:"
-msgstr "Si votre _Maxima_ est basé sur SBCL, ajoutez les lignes suivantes à votre fichier `.sbclrc` :"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:925
-msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
-msgstr "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:927
-msgid "The folder where this file has to be placed is system- and installation-specific. But any SBCL-based _Maxima_ that already has evaluated a cell in the current session will happily tell where it can be found after getting the following command:"
-msgstr "Le dossier où ce fichier doit être placé dépend du système et de l’installation. Cependant, toute version de _Maxima_ basée sur SBCL, ayant déjà évalué une cellule durant la session en cours, peut gentiment indiquer son emplacement après exécution de la commande suivante :"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:931
-msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
-msgstr "```maxima :lisp (sb-impl::userinit-pathname)  ```"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:933
-msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
-msgstr "## Remarque concernant Wayland (distributions Linux/BSD récentes)"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:936
-msgid "There seem to be issues with the Wayland Display Server and wxWidgets.  WxMaxima may be affected, e.g. that sidebars are not moveable."
-msgstr "Il semble y avoir des problèmes de compatibilité entre le serveur d'affichage Wayland et wxWidgets. WxMaxima peut en être affecté, par exemple avec des barres latérales qui ne peuvent pas être déplacées."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:940
-msgid "You can either disable Wayland and use X11 instead (globally)  or just tell, that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
-msgstr "Vous pouvez soit : - désactiver Wayland et utiliser X11 à la place (de manière globale), - ou forcer WxMaxima à utiliser le système X Window en définissant la variable d’environnement :  `GDK_BACKEND=x11`"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:942
-msgid "E.g. start wxMaxima with:"
-msgstr "Par exemple, lancez WxMaxima avec la commande :"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:944
-msgid "`GDK_BACKEND=x11 wxmaxima`"
-msgstr "`GDK_BACKEND=x11 wxmaxima`"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:946
-msgid "## Why is the integrated manual browser not offered on my Windows PC?"
-msgstr "## Pourquoi le navigateur pour le manuel intégré n’est-il pas disponible sur mon PC Windows ?"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:949
-msgid "Either wxWidgets wasnât compiled with support for Microsoftâs webview2 or Microsoftâs webview2 isnât installed."
-msgstr "Soit wxWidgets n’a pas été compilé avec le support de Microsoft WebView2, soit WebView2 n’est pas installé sur votre système."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:951
-msgid "## Why is the external manual browser not working on my Linux box?"
-msgstr "## Pourquoi le navigateur pour le manuel externe ne fonctionne-t-il pas sur ma machine Linux ?"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:957 ../../info/wxmaxima.md:959
-msgid "## Can I make _wxMaxima_ output both image files and embedded plots at once?"
-msgstr "## Puis-je faire en sorte que _wxMaxima_ génère à la fois des fichiers image et des graphiques en ligne en même temps ?"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:961
-msgid "The worksheet embeds `.png files. _WxMaxima_ allows the user to specify where they should be generated:"
-msgstr "Le notebook intègre les fichiers `.png`. _WxMaxima_ permet à l'utilisateur de spécifier où ces fichiers doivent être générés :"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:968 ../../info/wxmaxima.md:970
-#, no-wrap
-msgid "If a different format is to be used, it is easier to generate the images and then import them into the worksheet again:"
-msgstr "Si vous souhaitez utiliser un format différent, il est plus simple de générer les images séparément, puis de les réimporter dans le notebook :"
-
-#. type: Plain text
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:989 ../../info/wxmaxima.md:994 ../../info/wxmaxima.md:996
-#, no-wrap
-msgid "## Can I set the aspect ratio of an embedded plot?"
-msgstr "## Puis-je définir le rapport hauteur/largeur (aspect ratio) d’un graphique en ligne ?"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:998
-msgid "Use the variable `wxplot_size`:"
-msgstr "Utilisez la variable `wxplot_size` :"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:1004 ../../info/wxmaxima.md:1006
-#, no-wrap
-msgid "## After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
-msgstr "## Après la mise à niveau vers macOS 13.1, les commandes plot et/ou draw affichent des messages d'erreur du type"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1013
-msgid "```text 1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```"
-msgstr "```text 1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:1015 ../../info/wxmaxima.md:1017
-msgid "## Logging"
-msgstr "## Journalisation"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:1021 ../../info/wxmaxima.md:1023
-msgid "Messages are not 'lost', if the log window is not shown, if you select to show the log window later, you will see past log messages (if you did not clear the messages)."
-msgstr "Les messages ne sont pas « perdus » si la fenêtre du journal n’est pas affichée. Si vous choisissez d’afficher la fenêtre du journal plus tard, vous verrez les anciens messages du journal (à condition de ne pas les avoir effacés)."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1025
-msgid "Such messages may be helpful, when you create bug reports (or trying to find a bug by yourself)."
-msgstr "Ces messages peuvent être utiles lorsque vous créez des rapports de bogues (ou que vous essayez de résoudre un bogue par vous-même)."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1028
-msgid "Log messages can (additionally) be printed to STDERR, when using the command line option \"--logtostderr\". On Windows a separate text console will be opened, as a Windows GUI application does not have the standard IO connected."
-msgstr "Les messages du journal peuvent également être envoyés vers STDERR en utilisant l’option de ligne de commande « --logtostderr ». Sous Windows, une console texte distincte sera ouverte, car une application graphique Windows n’a pas de flux d’entrée/sortie standard connecté."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1032
-msgid "# FAQ"
-msgstr "# FAQ"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1034
-msgid "## Is there a way to make more text fit on a LaTeX page?"
-msgstr "## Comment faire tenir plus de texte sur une page LaTeX ?"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1036
-msgid "Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to specify the size of the borders."
-msgstr "Oui. Utilisez le [package LaTeX \"geometry\"](https://ctan.org/pkg/geometry) pour définir la taille des marges."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1038
-msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):"
-msgstr "Vous pouvez ajouter la ligne suivante dans le préambule LaTeX (par exemple via le champ dédié dans la fenêtre de configuration : (\"Export\" → \"Lignes supplémentaires pour le préambule TeX\") pour régler les marges à 1 cm :"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1042
-msgid "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
-msgstr "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1044
-msgid "## Is there a dark mode?"
-msgstr "## Un mode sombre existe-t-il ?"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:1046 ../../info/wxmaxima.md:1048
-msgid "## _WxMaxima_ sometimes hangs for several seconds once in the first minute"
-msgstr "## _WxMaxima_ se fige parfois pendant plusieurs secondes lors de la première minute d'utilisation"
-
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:1050 ../../info/wxmaxima.md:1052
-msgid "## Especially when testing new locale settings, a message box \"locale âxx_YYâ can not be set\" occurs"
-msgstr "## Lors des tests pour les nouveaux paramètres de langue locale, un message d'erreur \"la locale ‘xx_YY’ ne peut pas être définie\" peut apparaître"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1054
-msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
-msgstr "![Avertissement sur la langue locale](./locale-warning.png){ id=img_locale_warning}"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1058
-msgid "(The same problem can occur with other applications too). The translations seem okay after you click on âOKâ. WxMaxima does not only use its own translations but the translations of the wxWidgets framework too."
-msgstr "(Ce problème peut également survenir avec d'autres applications). Les traductions semblent correctes après avoir cliqué sur OK. _WxMaxima_ n'utilise pas seulement ses propres traductions, mais aussi celles du framework wxWidgets."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1061
-msgid "These locales maybe not present in the system. On Ubuntu/Debian systems they can be generated using: `dpkg-reconfigure locales`"
-msgstr "Ces langues locales peuvent ne pas être présentes dans le système. Sur les systèmes Ubuntu/Debian, elles peuvent être générées avec : `dpkg-reconfigure locales`"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1063
-msgid "## How can I use symbols for real numbers, natural numbers (â, â), etc.?"
-msgstr "## Comment utiliser les symboles pour les nombres réels, pour les entiers naturels (ℝ, ℕ), etc. ?"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1065
-msgid "You can find these symbols in the Unicode sidebar (search for âdouble-struck capitalâ). But the selected font must also support these symbols. If they do not display properly, select another font."
-msgstr "Vous pouvez trouver ces symboles dans la barre latérale des symboles Unicode (recherchez « double-struck capital »). Cependant, la police sélectionnée doit également les prendre en charge. Si ceux-ci ne s'affichent pas correctement, choisissez une autre police."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1067
-msgid "## How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
-msgstr "## Comment un script Maxima peut-il déterminer s'il s'exécute sous wxMaxima ou en ligne de commande ?"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1069
-msgid "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to `wxmaxima`. The Maxima variable `maxima_frontend_version` contains the wxMaxima version in this case."
-msgstr "Si wxMaxima est utilisé, la variable Maxima `maxima_frontend` est définie sur `wxmaxima`. Dans ce cas, la variable Maxima `maxima_frontend_version` contient la version de wxMaxima."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1071
-msgid "If no frontend is used (you are using command line Maxima), these variables are `false`."
-msgstr "Si aucun programme pour le frontend n'est utilisé (si vous utilisez Maxima en ligne de commande), ces variables valent `false`."
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1075
-msgid "# Command-line arguments"
-msgstr "# Arguments en ligne de commande"
-
-#. type: Plain text
-#: ../../info/wxmaxima.md:1077
-msgid "Usually you can start programs with a graphical user interface just by clicking on a desktop icon or desktop menu entry. WxMaxima - if started from the command line - still provides some command-line switches, though."
-msgstr "Généralement, les programmes dotés d'une interface graphique se lancent simplement en cliquant sur une icône ou une entrée de menu. WxMaxima, lorsqu'il est démarré depuis la ligne de commande, accepte néanmoins certains arguments."
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1093
-msgid "`-v` or `--version`: Output the version information"
-msgstr "`-v` ou `--version` : affiche les informations de version"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1093
-msgid "`-h` or `--help`: Output a short help text"
-msgstr "`-h` ou `--help` : affiche un texte d'aide succinct"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1093
-msgid "`-o` or `--open=<str>`: Open the filename given as an argument to this command-line switch"
-msgstr "`-o` ou `--open=<fichier>` : ouvre le fichier spécifié en argument de cette option de la ligne de commande"
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1093
-msgid "`-e` or `--eval`: Evaluate the file after opening it."
-msgstr "`-e` ou `--eval` : évalue le fichier après l'avoir ouvert."
-
-#. type: Bullet: '- '
-#. type: Plain text
-#. type: Plain text
-#: ../../info/wxmaxima.md:1093 ../../info/wxmaxima.md:1095
-#, no-wrap
-msgid "Instead of a minus, some operating systems might use a dash in front of the command-line switches."
-msgstr "Certains systèmes d'exploitation peuvent utiliser un tiret long (—) au lieu d'un tiret court (-) devant les options en ligne de commande."
-
 #. type: Plain text
-#: ../../info/wxmaxima.md:1099
+#: ../../info/wxmaxima.md:1164
 msgid "# About the program, contributing to wxMaxima"
 msgstr "# À propos du logiciel et des contributions à wxMaxima"
 
 #. type: Plain text
+#: ../../info/wxmaxima.md:1166
+msgid ""
+"wxMaxima is mainly developed using the programming language C++ using the "
+"[wxWidgets framework](https://www.wxwidgets.org), as build system we use "
+"[CMake](https://www.cmake.org), a small part is written in Lisp. You can "
+"contribute to wxMaxima, join the wxMaxima project at <https://github.com/"
+"wxMaxima-developers/wxmaxima>, if you have knowledge of these programming "
+"languages and want to help and contribute to the open source project "
+"wxMaxima."
+msgstr ""
+"wxMaxima est principalement développé en C++ avec le framework [wxWidgets]"
+"(https://www.wxwidgets.org), et utilise [CMake](https://www.cmake.org) comme "
+"système de build. Une petite partie est écrite en Lisp. Si vous maîtrisez "
+"ces langages et souhaitez contribuer à ce projet open source, vous pouvez "
+"rejoindre l’équipe sur [GitHub](https://github.com/wxMaxima-developers/"
+"wxmaxima)."
+
 #. type: Plain text
+#: ../../info/wxmaxima.md:1168
+msgid ""
+"But not only programmers are necessary! You can also contribute to wxMaxima, "
+"if you help to improve the documentation, find and report bugs (and maybe "
+"bugfixes), suggest new features, help to translate wxMaxima or the manual to "
+"your language (read the README.md in the [locale subdirectory](https://"
+"github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and "
+"the manual can be translated)."
+msgstr ""
+"Mais les programmeurs ne sont pas les seul·es à pouvoir contribuer ! Vous "
+"pouvez aussi aider à améliorer wxMaxima en améliorant la documentation, en "
+"signalant (ou corrigeant) des bugs, en proposant de nouvelles "
+"fonctionnalités, en traduisant l’interface ou le manuel dans votre langue "
+"(consultez le fichier README.md dans le [dossier locales](https://github.com/"
+"wxMaxima-developers/wxmaxima/tree/main/locales) pour savoir comment "
+"procéder)."
+
 #. type: Plain text
-#: ../../info/wxmaxima.md:1101 ../../info/wxmaxima.md:1103 ../../info/wxmaxima.md:1105
+#: ../../info/wxmaxima.md:1170
 msgid "Or answer questions of other users in the discussion forum."
-msgstr "Ou répondre aux questions d'autres utilisateurs sur le forum de discussion."
+msgstr ""
+"Ou répondre aux questions d'autres utilisateurs sur le forum de discussion."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1107
-msgid "The source code of wxMaxima is documented using Doxygen [here](https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
-msgstr "Le code source de wxMaxima est documenté avec Doxygen, disponible [ici](https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+#: ../../info/wxmaxima.md:1172
+msgid ""
+"The source code of wxMaxima is documented using Doxygen [here](https://"
+"wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+msgstr ""
+"Le code source de wxMaxima est documenté avec Doxygen, disponible [ici]"
+"(https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1109
-msgid "The program is nearly self-contained, so except for system libraries (and the wxWidgets library), no external dependencies (like graphic files or the Lisp part (the `wxmathML.lisp`-file) is needed, these files are included in the executable."
-msgstr "Le programme est quasi complet : hormis les bibliothèques système (et la bibliothèque wxWidgets), il ne nécessite aucune dépendance externe (comme des fichiers graphiques ou le logiciel Lisp.   Les éléments comme le fichier ( `wxmathML.lisp`) sont intégrés directement dans l'exécutable."
+#: ../../info/wxmaxima.md:1174
+msgid ""
+"The program is nearly self-contained, so except for system libraries (and "
+"the wxWidgets library), no external dependencies (like graphic files or the "
+"Lisp part (the `wxmathML.lisp`-file) is needed, these files are included in "
+"the executable."
+msgstr ""
+"Le programme est quasi complet : hormis les bibliothèques système (et la "
+"bibliothèque wxWidgets), il ne nécessite aucune dépendance externe (comme "
+"des fichiers graphiques ou le logiciel Lisp.   Les éléments comme le fichier "
+"( `wxmathML.lisp`) sont intégrés directement dans l'exécutable."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1110
-msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one."
-msgstr "Si vous êtes développeur et que vous souhaitez tester une version modifiée du fichier `wxmathML.lisp`  sans tout recompiler, vous pouvez utiliser l'option en ligne de commande : `--wxmathml-lisp=<chemin>` pour spécifier un autre fichier Lisp à la place de celui intégré à la version actuelle."
+#: ../../info/wxmaxima.md:1175
+msgid ""
+"If you are a developer, you might want to try out a modified `wxmathML.lisp`-"
+"file without recompiling everything, one can use the command line option `--"
+"wxmathml-lisp=<str>` to use another Lisp file, not the included one."
+msgstr ""
+"Si vous êtes développeur et que vous souhaitez tester une version modifiée "
+"du fichier `wxmathML.lisp`  sans tout recompiler, vous pouvez utiliser "
+"l'option en ligne de commande : `--wxmathml-lisp=<chemin>` pour spécifier un "
+"autre fichier Lisp à la place de celui intégré à la version actuelle."
 
-# Entrées ajoutées depuis fr2.po
-msgid "### Don’t save the worksheet automatically"
-msgstr "### Ne pas enregistrer automatiquement le notebook"
+#~ msgid "### Donât save the worksheet automatically"
+#~ msgstr "### Ne pas enregistrer automatiquement le notebook"
 
-msgid "### Opening Gnuplot’s command console in `plot` windows"
-msgstr "### Ouvrir la console de commandes de Gnuplot dans les fenêtres `plot`"
-
-msgid "Gnuplot didn’t output a valid `.png` file."
-msgstr "Gnuplot n'a pas produit un fichier .png valide."
-
-msgid "## Plotting an animation results in “error: undefined variable”"
-msgstr "## Le tracé d'une animation génère l'erreur \"error: undefined variable\""
-
-msgid "## I lost cell content and undo doesn’t remember"
-msgstr "## J’ai perdu le contenu d’une cellule et la fonction Annuler ne le restaure pas"
-
-msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
-msgstr "## _WxMaxima_ démarre avec le message  Maxima process terminated"
-
-msgid "## Help! I can not save my document!"
-msgstr "## De l'aide ! Je ne peux pas sauvegarder mon document !"
-
-#~ msgid "- Math cells, containing one or more lines of _Maxima_ input.  - Output of, or a question from, _Maxima_.  - Image cells.  - Text cells, that can for example be used for documentation.  - A title, section or a subsection. 6 levels of different headings are possible.  - Page breaks."
+#~ msgid "### Opening Gnuplotâs command console in `plot` windows"
 #~ msgstr ""
-#~ "-  Cellules de calcul, contenant une ou plusieurs lignes de code d’entrée pour _Maxima_. - Cellules de sortie, affichant le résultat ou une question de _Maxima_. Cellules d’image. - Cellules de texte, qui peuvent être utilisées par exemple pour la documentation. - Cellules de titre, de section ou "
-#~ "de sous-section,  jusqu’à 6 niveaux de titres différents sont possibles. - Sauts de page."
+#~ "### Ouvrir la console de commandes de Gnuplot dans les fenêtres `plot`"
+
+#~ msgid "Gnuplot didnât output a valid `.png` file."
+#~ msgstr "Gnuplot n’a pas produit de fichier `.png` valide."
+
+#~ msgid "## Plotting an animation results in âerror: undefined variableâ"
+#~ msgstr ""
+#~ "## Le tracé d'une animation génère l'erreur \"error: undefined variable\""
+
+#~ msgid "## I lost cell content and undo doesnât remember"
+#~ msgstr ""
+#~ "## J’ai perdu le contenu d’une cellule et la fonction Annuler ne le "
+#~ "restaure pas"
 
 #~ msgid ""
-#~ "- `mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-wxmathml` - `format.txt`: a short description about wxMaxima and the wxmx file format - Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima session and included images.  - `content.xml`: a XML "
-#~ "document, which contains the various cells of your document in XML format."
-#~ msgstr ""
-#~ "- `mimetype` : ce fichier contient le type MIME des fichiers wxMaxima : `text/x-wxmathml` - `format.txt` : une brève description de wxMaxima et du format de fichier wxmx - Images (par exemple png, jpeg) : graphiques en ligne produits lors de la session wxMaxima et images incluses - `content.xml` : "
-#~ "un document XML contenant les différentes cellules de votre document au format XML."
+#~ "## _WxMaxima_ starts up with the message âMaxima process terminated.â"
+#~ msgstr "## _WxMaxima_ démarre avec le message  Maxima process terminated"
 
 #~ msgid ""
-#~ "- `wxsubscripts` tells _Maxima_ if it should convert variable names that contain an underscore (`R_150` or the like) into subscripted variables. See `wxdeclare_subscript` for details which variable names are automatically converted.  - `wxfilename`: This variable contains the name of the file "
-#~ "currently opened in _wxMaxima_.  - `wxdirname`: This variable contains the name the directory, in which the file currently opened in _wxMaxima_ is.  - `wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_âs pngcairo terminal that provides more line styles and a better overall graphics "
-#~ "quality.  - `wxplot_size` defines the resolution of embedded plots.  - `wxchangedir`: On most operating systems _wxMaxima_ automatically sets _Maxima_âs working directory to the directory of the current file. This allows file I/O (e.g. by `read_matrix`) to work without specifying the whole path to "
-#~ "the file that has to be read or written. On Windows this feature sometimes causes error messages and therefore can be set to `false` from the config dialogue.  - `wxanimate_framerate`: The number of frames per second the following animations have to be played back with.  - `wxanimate_autoplay`: "
-#~ "Automatically play animations by default? - `wxmaximaversion`: Returns the version number of _wxMaxima_.  - `wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
+#~ "- Math cells, containing one or more lines of _Maxima_ input.  - Output "
+#~ "of, or a question from, _Maxima_.  - Image cells.  - Text cells, that can "
+#~ "for example be used for documentation.  - A title, section or a "
+#~ "subsection. 6 levels of different headings are possible.  - Page breaks."
 #~ msgstr ""
-#~ "- `wxsubscripts` : Indique à _Maxima_ s'il doit convertir les noms de variables contenant un tiret bas (`R_150` ou similaire) en variables avec indices. Voir `wxdeclare_subscript` pour plus de détails sur les noms de variables automatiquement convertis. - `wxfilename` : Cette variable contient le "
-#~ "nom du fichier actuellement ouvert dans _wxMaxima_. - `wxdirname` : Cette variable contient le nom du répertoire dans lequel se trouve le fichier actuellement ouvert dans _wxMaxima_. - `wxplot_pngcairo` : Détermine si _wxMaxima_ utilise le terminal _pngcairo_ de _Gnuplot_, qui offre plus de styles "
-#~ "de ligne et une meilleure qualité graphique globale. -`wxplot_size` : Définit la résolution des graphiques intégrés. - `wxchangedir` : Sur la plupart des systèmes d'exploitation, _wxMaxima_ définit automatiquement le répertoire de travail de _Maxima_ comme étant celui du fichier courant. Cela "
-#~ "permet d'effectuer des opérations de lecture/écriture de fichiers (par exemple avec `read_matrix`) sans avoir à spécifier le chemin complet. Sous Windows, cette fonctionnalité peut parfois générer des messages d'erreur et peut donc être désactivée (`false`) depuis la boîte de dialogue de "
-#~ "configuration. -`wxanimate_framerate` : Définit le nombre d'images par seconde pour la lecture des animations suivantes. - `wxanimate_autoplay` : Lecture automatique des animations par défaut ? -`wxmaximaversion` : Retourne le numéro de version de _wxMaxima_. -`wxwidgetsversion` : Retourne la "
-#~ "version de wxWidgets utilisée par _wxMaxima_."
+#~ "-  Cellules de calcul, contenant une ou plusieurs lignes de code d’entrée "
+#~ "pour _Maxima_. - Cellules de sortie, affichant le résultat ou une "
+#~ "question de _Maxima_. Cellules d’image. - Cellules de texte, qui peuvent "
+#~ "être utilisées par exemple pour la documentation. - Cellules de titre, de "
+#~ "section ou de sous-section,  jusqu’à 6 niveaux de titres différents sont "
+#~ "possibles. - Sauts de page."
 
 #~ msgid ""
-#~ "- The plotting command is part of a third-party package like `implicit_plot` but this package was not loaded by _Maxima_âs `load()` command before trying to plot.  - _Maxima_ tried to do something the currently installed version of _Gnuplot_ isnât able to understand. In this case, a file ending in "
-#~ "`.gnuplot` located in the directory, which _Maxima_âs variable `maxima_userdir` is pointing, contains the instructions from _Maxima_ to _Gnuplot_. Most of the time, this fileâs contents therefore are helpful when debugging the problem.  - Gnuplot was instructed to use the pngCairo library that "
-#~ "provides antialiasing and additional line styles, but it was not compiled to support this possibility. Solution: Uncheck the \"Use the Cairo terminal for the plot\" checkbox in the configuration dialog and donât set `wxplot_pngcairo` to true from _Maxima_.  - Gnuplot didnât output a valid `.png` "
-#~ "file."
+#~ "- `mimetype`: this file does contain the mimetype of wxMaxima files: "
+#~ "`text/x-wxmathml` - `format.txt`: a short description about wxMaxima and "
+#~ "the wxmx file format - Images (e.g. png, jpeg): inline plots which were "
+#~ "produced in the wxMaxima session and included images.  - `content.xml`: a "
+#~ "XML document, which contains the various cells of your document in XML "
+#~ "format."
 #~ msgstr ""
-#~ "- La commande pour le tracé fait partie d’un package tiers comme `implicit_plot`, mais ce package n’a pas été chargé avec la commande `load()` de _Maxima_ avant d’essayer de tracer le graphique. - _Maxima_ a tenté d’exécuter une instruction que la version installée de _Gnuplot_ ne peut pas "
-#~ "interpréter. Dans ce cas, un fichier se terminant par `.gnuplot`, situé dans le répertoire indiqué par la variable `maxima_userdir` de _Maxima_, contient les instructions envoyées par _Maxima_ à _Gnuplot_. La plupart du temps, le contenu de ce fichier est utile pour trouver la source du problème. "
-#~ "- _Gnuplot_ a été configuré pour utiliser la bibliothèque pngCairo (qui offre un antialiasing et des styles de ligne supplémentaires), mais il n’a pas été compilé pour supporter cette fonctionnalité. Solution : Désactivez la case \"Utiliser le terminal Cairo pour le graphique\" dans la boîte de "
-#~ "dialogue de configuration et ne définissez pas `wxplot_pngcairo` sur true depuis _Maxima_. -_Gnuplot_ n’a pas généré un fichier `.png` valide."
+#~ "- `mimetype` : ce fichier contient le type MIME des fichiers wxMaxima : "
+#~ "`text/x-wxmathml` - `format.txt` : une brève description de wxMaxima et "
+#~ "du format de fichier wxmx - Images (par exemple png, jpeg) : graphiques "
+#~ "en ligne produits lors de la session wxMaxima et images incluses - "
+#~ "`content.xml` : un document XML contenant les différentes cellules de "
+#~ "votre document au format XML."
 
 #~ msgid ""
-#~ "- _WxMaxima_ actually has two undo features: The global undo buffer that is active if no cell is selected and a per-cell undo buffer that is active if the cursor is inside a cell. It is worth trying to use both undo options in order to see if an old value can still be accessed.  - If you still "
-#~ "have a way to find out what label _Maxima_ has assigned to the cell just type in the cellâs label and its contents will reappear.  - If you donât: Donât panic. In the âViewâ menu there is a way to show a history pane that shows all _Maxima_ commands that have been issued recently.  - If nothing "
-#~ "else helps _Maxima_ contains a replay feature:"
+#~ "- `wxsubscripts` tells _Maxima_ if it should convert variable names that "
+#~ "contain an underscore (`R_150` or the like) into subscripted variables. "
+#~ "See `wxdeclare_subscript` for details which variable names are "
+#~ "automatically converted.  - `wxfilename`: This variable contains the name "
+#~ "of the file currently opened in _wxMaxima_.  - `wxdirname`: This variable "
+#~ "contains the name the directory, in which the file currently opened in "
+#~ "_wxMaxima_ is.  - `wxplot_pngcairo` tells whether _wxMaxima_ tries to use "
+#~ "_Gnuplot_âs pngcairo terminal that provides more line styles and a better "
+#~ "overall graphics quality.  - `wxplot_size` defines the resolution of "
+#~ "embedded plots.  - `wxchangedir`: On most operating systems _wxMaxima_ "
+#~ "automatically sets _Maxima_âs working directory to the directory of the "
+#~ "current file. This allows file I/O (e.g. by `read_matrix`) to work "
+#~ "without specifying the whole path to the file that has to be read or "
+#~ "written. On Windows this feature sometimes causes error messages and "
+#~ "therefore can be set to `false` from the config dialogue.  - "
+#~ "`wxanimate_framerate`: The number of frames per second the following "
+#~ "animations have to be played back with.  - `wxanimate_autoplay`: "
+#~ "Automatically play animations by default? - `wxmaximaversion`: Returns "
+#~ "the version number of _wxMaxima_.  - `wxwidgetsversion`: Returns the "
+#~ "wxWidgets version _wxMaxima_ is using."
 #~ msgstr ""
-#~ "- _WxMaxima_ dispose en réalité de deux fonctions Annuler :  une mise en mémoire globale est active quand aucune cellule n’est sélectionnée,\n"
-#~ "  et une mise en mémoire pour la cellule active quand le curseur est à l’intérieur d’une cellule. Cela vaut la peine d’essayer les deux options pour voir si une ancienne valeur peut encore être récupérée. - Si vous savez quel étiquette _Maxima_ a attribué à la cellule, il suffit de taper cette "
-#~ "étiquette pour que son contenu réapparaisse. - Sinon : ne paniquez pas. Dans le menu  Affichage, une option permet d’afficher un volet d’historique qui liste toutes les commandes _Maxima_ récemment exécutées. - En dernier recours, _Maxima_ propose une fonction de  relecture :"
+#~ "- `wxsubscripts` : Indique à _Maxima_ s'il doit convertir les noms de "
+#~ "variables contenant un tiret bas (`R_150` ou similaire) en variables avec "
+#~ "indices. Voir `wxdeclare_subscript` pour plus de détails sur les noms de "
+#~ "variables automatiquement convertis. - `wxfilename` : Cette variable "
+#~ "contient le nom du fichier actuellement ouvert dans _wxMaxima_. - "
+#~ "`wxdirname` : Cette variable contient le nom du répertoire dans lequel se "
+#~ "trouve le fichier actuellement ouvert dans _wxMaxima_. - "
+#~ "`wxplot_pngcairo` : Détermine si _wxMaxima_ utilise le terminal "
+#~ "_pngcairo_ de _Gnuplot_, qui offre plus de styles de ligne et une "
+#~ "meilleure qualité graphique globale. -`wxplot_size` : Définit la "
+#~ "résolution des graphiques intégrés. - `wxchangedir` : Sur la plupart des "
+#~ "systèmes d'exploitation, _wxMaxima_ définit automatiquement le répertoire "
+#~ "de travail de _Maxima_ comme étant celui du fichier courant. Cela permet "
+#~ "d'effectuer des opérations de lecture/écriture de fichiers (par exemple "
+#~ "avec `read_matrix`) sans avoir à spécifier le chemin complet. Sous "
+#~ "Windows, cette fonctionnalité peut parfois générer des messages d'erreur "
+#~ "et peut donc être désactivée (`false`) depuis la boîte de dialogue de "
+#~ "configuration. -`wxanimate_framerate` : Définit le nombre d'images par "
+#~ "seconde pour la lecture des animations suivantes. - "
+#~ "`wxanimate_autoplay` : Lecture automatique des animations par défaut ? "
+#~ "-`wxmaximaversion` : Retourne le numéro de version de _wxMaxima_. "
+#~ "-`wxwidgetsversion` : Retourne la version de wxWidgets utilisée par "
+#~ "_wxMaxima_."
+
+#~ msgid ""
+#~ "- The plotting command is part of a third-party package like "
+#~ "`implicit_plot` but this package was not loaded by _Maxima_âs `load()` "
+#~ "command before trying to plot.  - _Maxima_ tried to do something the "
+#~ "currently installed version of _Gnuplot_ isnât able to understand. In "
+#~ "this case, a file ending in `.gnuplot` located in the directory, which "
+#~ "_Maxima_âs variable `maxima_userdir` is pointing, contains the "
+#~ "instructions from _Maxima_ to _Gnuplot_. Most of the time, this fileâs "
+#~ "contents therefore are helpful when debugging the problem.  - Gnuplot was "
+#~ "instructed to use the pngCairo library that provides antialiasing and "
+#~ "additional line styles, but it was not compiled to support this "
+#~ "possibility. Solution: Uncheck the \"Use the Cairo terminal for the "
+#~ "plot\" checkbox in the configuration dialog and donât set "
+#~ "`wxplot_pngcairo` to true from _Maxima_.  - Gnuplot didnât output a valid "
+#~ "`.png` file."
+#~ msgstr ""
+#~ "- La commande pour le tracé fait partie d’un package tiers comme "
+#~ "`implicit_plot`, mais ce package n’a pas été chargé avec la commande "
+#~ "`load()` de _Maxima_ avant d’essayer de tracer le graphique. - _Maxima_ a "
+#~ "tenté d’exécuter une instruction que la version installée de _Gnuplot_ ne "
+#~ "peut pas interpréter. Dans ce cas, un fichier se terminant par "
+#~ "`.gnuplot`, situé dans le répertoire indiqué par la variable "
+#~ "`maxima_userdir` de _Maxima_, contient les instructions envoyées par "
+#~ "_Maxima_ à _Gnuplot_. La plupart du temps, le contenu de ce fichier est "
+#~ "utile pour trouver la source du problème. - _Gnuplot_ a été configuré "
+#~ "pour utiliser la bibliothèque pngCairo (qui offre un antialiasing et des "
+#~ "styles de ligne supplémentaires), mais il n’a pas été compilé pour "
+#~ "supporter cette fonctionnalité. Solution : Désactivez la case \"Utiliser "
+#~ "le terminal Cairo pour le graphique\" dans la boîte de dialogue de "
+#~ "configuration et ne définissez pas `wxplot_pngcairo` sur true depuis "
+#~ "_Maxima_. -_Gnuplot_ n’a pas généré un fichier `.png` valide."
+
+#~ msgid ""
+#~ "- _WxMaxima_ actually has two undo features: The global undo buffer that "
+#~ "is active if no cell is selected and a per-cell undo buffer that is "
+#~ "active if the cursor is inside a cell. It is worth trying to use both "
+#~ "undo options in order to see if an old value can still be accessed.  - If "
+#~ "you still have a way to find out what label _Maxima_ has assigned to the "
+#~ "cell just type in the cellâs label and its contents will reappear.  - If "
+#~ "you donât: Donât panic. In the âViewâ menu there is a way to show a "
+#~ "history pane that shows all _Maxima_ commands that have been issued "
+#~ "recently.  - If nothing else helps _Maxima_ contains a replay feature:"
+#~ msgstr ""
+#~ "- _WxMaxima_ dispose en réalité de deux fonctions Annuler :  une mise en "
+#~ "mémoire globale est active quand aucune cellule n’est sélectionnée,\n"
+#~ "  et une mise en mémoire pour la cellule active quand le curseur est à "
+#~ "l’intérieur d’une cellule. Cela vaut la peine d’essayer les deux options "
+#~ "pour voir si une ancienne valeur peut encore être récupérée. - Si vous "
+#~ "savez quel étiquette _Maxima_ a attribué à la cellule, il suffit de taper "
+#~ "cette étiquette pour que son contenu réapparaisse. - Sinon : ne paniquez "
+#~ "pas. Dans le menu  Affichage, une option permet d’afficher un volet "
+#~ "d’historique qui liste toutes les commandes _Maxima_ récemment exécutées. "
+#~ "- En dernier recours, _Maxima_ propose une fonction de  relecture :"

--- a/locales/manual/it.po
+++ b/locales/manual/it.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2026-05-20 10:30+0200\n"
+"POT-Creation-Date: 2026-07-30 11:38+0200\n"
 "PO-Revision-Date: 2023-05-29 14:33+0200\n"
 "Last-Translator: Marco Ciampa <ciampix@posteo.net>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -42,9 +42,9 @@ msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 msgstr "![logo wxMaxima](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:426
-#: ../../info/wxmaxima.md:848 ../../info/wxmaxima.md:1043
-#: ../../info/wxmaxima.md:1090 ../../info/wxmaxima.md:1114
+#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:425
+#: ../../info/wxmaxima.md:880 ../../info/wxmaxima.md:1090
+#: ../../info/wxmaxima.md:1137 ../../info/wxmaxima.md:1161
 #, no-wrap
 msgid "______________________________________________________________________\n"
 msgstr ""
@@ -1028,12 +1028,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:224
+#: ../../info/wxmaxima.md:223
 msgid "### Side Panes"
 msgstr "### Pannelli laterali"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:226
+#: ../../info/wxmaxima.md:225
 msgid ""
 "Shortcuts to the most important _Maxima_ commands, things like a table of "
 "contents, windows with debug messages or a history of the last issued "
@@ -1051,13 +1051,13 @@ msgstr ""
 "lettere greche utilizzando il mouse."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:228
+#: ../../info/wxmaxima.md:227
 msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
 msgstr ""
 "![Esempio di diversi pannelli laterali](./SidePanes.png){ id=img_SidePanes }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:231
+#: ../../info/wxmaxima.md:230
 msgid ""
 "In the \"table of contents\" side pane, one can increase or decrease a "
 "heading by just clicking on the heading with the right mouse button and "
@@ -1069,7 +1069,7 @@ msgstr ""
 "superiore o inferiore."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:233
+#: ../../info/wxmaxima.md:232
 msgid ""
 "![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-"
 "headings.png){ id=Sidepane-TOC-convert-headings }"
@@ -1078,12 +1078,12 @@ msgstr ""
 "Sidepane-TOC-convert-headings.png){ id=Sidepane-TOC-convert-headings }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:235
+#: ../../info/wxmaxima.md:234
 msgid "### MathML output"
 msgstr "### Uscita MathML"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:237
+#: ../../info/wxmaxima.md:236
 #, fuzzy
 #| msgid ""
 #| "Several word processors and similar programs either recognize MathML "
@@ -1106,12 +1106,12 @@ msgstr ""
 "scelta rapida."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:239
+#: ../../info/wxmaxima.md:238
 msgid "### Markdown support"
 msgstr "### Supporto Markdown"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:241
+#: ../../info/wxmaxima.md:240
 #, fuzzy
 #| msgid ""
 #| "_wxMaxima_ offers a set of standard markdown conventions that don't "
@@ -1126,7 +1126,7 @@ msgstr ""
 "puntati."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:251
+#: ../../info/wxmaxima.md:250
 #, no-wrap
 msgid ""
 "```text\n"
@@ -1148,14 +1148,14 @@ msgstr ""
 "Testo normale\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:253
+#: ../../info/wxmaxima.md:252
 msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
 msgstr ""
 "_wxMaxima_ riconoscerà il testo che inizia con i caratteri `>` come "
 "virgolette di blocco:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:261
+#: ../../info/wxmaxima.md:260
 #, fuzzy
 #| msgid ""
 #| "Ordinary text\n"
@@ -1174,7 +1174,7 @@ msgstr ""
 "Testo normale\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:263
+#: ../../info/wxmaxima.md:262
 msgid ""
 "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by "
 "the corresponding Unicode sign:"
@@ -1183,14 +1183,14 @@ msgstr ""
 "il corrispondente simbolo Unicode:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:267
+#: ../../info/wxmaxima.md:266
 #, fuzzy
 #| msgid "cogito => sum.\n"
 msgid "```text cogito => sum.  ```"
 msgstr "cogito => sum.\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:269
+#: ../../info/wxmaxima.md:268
 msgid ""
 "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for "
 "comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<-"
@@ -1203,12 +1203,12 @@ msgstr ""
 "riconosciuti anche `<<` e `>>`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:271
+#: ../../info/wxmaxima.md:270
 msgid "### Hotkeys"
 msgstr "### Scorciatoie da tastiera"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:273
+#: ../../info/wxmaxima.md:272
 msgid ""
 "Most hotkeys can be found in the text of the respective menus. Since they "
 "are actually taken from the menu text and thus can be customized by the "
@@ -1224,14 +1224,14 @@ msgstr ""
 "rapida, tuttavia, non sono documentati neanche nei menu:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 msgid ""
 "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
 msgstr ""
 "<kbd>CTRL</kbd>+<kbd>MAIUSC</kbd>+<kbd>CANC</kbd> elimina una cella intera."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 #, fuzzy
 #| msgid ""
 #| "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete "
@@ -1243,18 +1243,18 @@ msgstr ""
 "<kbd>CTRL</kbd>+<kbd>MAIUSC</kbd>+<kbd>CANC</kbd> elimina una cella intera."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
 msgstr ""
 "<kbd>MAIUSC</kbd>+<kbd>SPAZIO</kbd> inserisce uno spazio non divisibile."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:279
+#: ../../info/wxmaxima.md:278
 msgid "### Raw TeX in the TeX export"
 msgstr "### TeX grezzo nell'esportazione TeX"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:281
+#: ../../info/wxmaxima.md:280
 msgid ""
 "If a text cell begins with `TeX:` the TeX export contains the literal text "
 "that follows the `TeX:` marker. Using this feature allows the entry of TeX "
@@ -1266,12 +1266,12 @@ msgstr ""
 "lavoro _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:283
+#: ../../info/wxmaxima.md:282
 msgid "## File Formats"
 msgstr "## Formati di file"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:285
+#: ../../info/wxmaxima.md:284
 msgid ""
 "The material that is developed in a _wxMaxima_ session can be stored for "
 "later use in any of three ways:"
@@ -1280,12 +1280,12 @@ msgstr ""
 "un uso successivo in uno dei seguenti tre modi:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:287
+#: ../../info/wxmaxima.md:286
 msgid "### .mac"
 msgstr "### .mac"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:289
+#: ../../info/wxmaxima.md:288
 msgid ""
 "`.mac` files are ordinary text files that contain _Maxima_ commands. They "
 "can be read using _Maxima_’s `batch()` or `load()` command or _wxMaxima_’s "
@@ -1296,7 +1296,7 @@ msgstr ""
 "voce di menu File/File batch di _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:292
+#: ../../info/wxmaxima.md:291
 msgid ""
 "One example is shown below. `Quadratic.mac` defines a function and afterward "
 "generates a plot with `wxdraw2d()`.  Afterward the contents of the file "
@@ -1308,7 +1308,7 @@ msgstr ""
 "funzione definita `f()`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:294
+#: ../../info/wxmaxima.md:293
 #, fuzzy
 #| msgid ""
 #| "![Loading a `.mac` file with `batch()`](./BatchImage.png)"
@@ -1319,7 +1319,7 @@ msgstr ""
 "{ id=img_BatchImage }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:296
+#: ../../info/wxmaxima.md:295
 #, fuzzy
 #| msgid ""
 #| "Attention: Although the file `Quadratic.mac` has a usual _Maxima_ "
@@ -1336,7 +1336,7 @@ msgstr ""
 "`wxdraw2d()` è un'estensione wxMaxima di _Maxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:298
+#: ../../info/wxmaxima.md:297
 msgid ""
 "You can be use `.mac` files for writing your own library of macros. But "
 "since they don’t contain enough structural information they cannot be read "
@@ -1347,12 +1347,12 @@ msgstr ""
 "essere rilette come sessioni _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:300
+#: ../../info/wxmaxima.md:299
 msgid "### .wxm"
 msgstr "### .wxm"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:303
+#: ../../info/wxmaxima.md:302
 #, fuzzy
 #| msgid ""
 #| ".wxm files contain the worksheet except _Maxima_'s output. On Maxima "
@@ -1377,7 +1377,7 @@ msgstr ""
 "versioni precedenti di _wxMaxima_.\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:305
+#: ../../info/wxmaxima.md:304
 #, fuzzy
 #| msgid ""
 #| ".wxm files contain the worksheet except _Maxima_'s output. On Maxima "
@@ -1398,39 +1398,39 @@ msgstr ""
 "versioni precedenti di _wxMaxima_.\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:307
+#: ../../info/wxmaxima.md:306
 #, fuzzy
 #| msgid "File Formats"
 msgid "#### File format of wxm files"
 msgstr "Formati di file"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:309
+#: ../../info/wxmaxima.md:308
 msgid ""
 "This is just a plain text file (you can open it with a text editor), "
 "containing the cell contents as some special Maxima comments."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:311
+#: ../../info/wxmaxima.md:310
 msgid "It starts with the following comment:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:316
+#: ../../info/wxmaxima.md:315
 msgid ""
 "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* "
 "[ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:318
+#: ../../info/wxmaxima.md:317
 msgid ""
 "And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:324
+#: ../../info/wxmaxima.md:323
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1441,14 +1441,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:326
+#: ../../info/wxmaxima.md:325
 msgid ""
 "or (in a Math cell the input is of course *not* commented out (the output is "
 "not saved in a `wxm` file)):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:333
+#: ../../info/wxmaxima.md:332
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1460,14 +1460,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:335
+#: ../../info/wxmaxima.md:334
 msgid ""
 "Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the "
 "image type as first line):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:342
+#: ../../info/wxmaxima.md:341
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1479,12 +1479,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:344
+#: ../../info/wxmaxima.md:343
 msgid "A page break is just one line containing:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:348
+#: ../../info/wxmaxima.md:347
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1493,12 +1493,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:350
+#: ../../info/wxmaxima.md:349
 msgid "And folded cells marked by:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:356
+#: ../../info/wxmaxima.md:355
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1509,13 +1509,13 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:358
+#: ../../info/wxmaxima.md:357
 msgid "### .wxmx"
 msgstr "### .wxmx"
 
 # FIXME: translation of watchlist
 #. type: Plain text
-#: ../../info/wxmaxima.md:360
+#: ../../info/wxmaxima.md:359
 msgid ""
 "This XML-based file format saves the complete worksheet including things "
 "like the zoom factor and the watchlist. It is the preferred file format."
@@ -1525,14 +1525,14 @@ msgstr ""
 "file preferito."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:362
+#: ../../info/wxmaxima.md:361
 #, fuzzy
 #| msgid "File Formats"
 msgid "#### File format of wxmx files"
 msgstr "Formati di file"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:365
+#: ../../info/wxmaxima.md:364
 msgid ""
 "A `wxmx`-file seems to be a binary format, but one can handle it with tools, "
 "which are included in your OS. It is a zip file, one can decompress it with "
@@ -1544,39 +1544,39 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:367
+#: ../../info/wxmaxima.md:366
 msgid "It does contain the following files:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-"
 "wxmathml`"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`format.txt`: a short description about wxMaxima and the wxmx file format"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima "
 "session and included images."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`content.xml`: a XML document, which contains the various cells of your "
 "document in XML format."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:374
+#: ../../info/wxmaxima.md:373
 msgid ""
 "So, if something goes wrong, you can unzip a wxMaxima document (maybe rename "
 "it before to a `zip`-file), maybe make changes in the `content.xml` file "
@@ -1586,12 +1586,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:376
+#: ../../info/wxmaxima.md:375
 msgid "## Configuration options"
 msgstr "## Opzioni di configurazione"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:378
+#: ../../info/wxmaxima.md:377
 msgid ""
 "For some common configuration variables _wxMaxima_ offers two ways of "
 "configuring:"
@@ -1600,7 +1600,7 @@ msgstr ""
 "di configurazione:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
+#: ../../info/wxmaxima.md:380
 msgid ""
 "The configuration dialog box below lets you change their default values for "
 "the current and subsequent sessions."
@@ -1609,7 +1609,7 @@ msgstr ""
 "i valori predefiniti per le sessioni correnti e successive."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
+#: ../../info/wxmaxima.md:380
 msgid ""
 "Also, the values for most configuration variables can be changed for the "
 "current session only by overwriting their values from the worksheet, as "
@@ -1620,7 +1620,7 @@ msgstr ""
 "loro valori dal foglio di lavoro, come mostrato di seguito."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:383
+#: ../../info/wxmaxima.md:382
 msgid ""
 "![wxMaxima configuration 1](./wxMaxima_configuration_001.png)"
 "{ id=img_wxMaxima_configuration_001 }"
@@ -1629,12 +1629,12 @@ msgstr ""
 "{ id=img_wxMaxima_configuration_001 }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:385
+#: ../../info/wxmaxima.md:384
 msgid "### Default animation framerate"
 msgstr "### Frequenza di quadro animazioni predefinita"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:387
+#: ../../info/wxmaxima.md:386
 msgid ""
 "The animation framerate that is used for new animations is kept in the "
 "variable `wxanimate_framerate`. The initial value this variable will contain "
@@ -1646,12 +1646,12 @@ msgstr ""
 "utilizzando la finestra di configurazione."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:389
+#: ../../info/wxmaxima.md:388
 msgid "### Default plot size for new _maxima_ sessions"
 msgstr "### Dimensione predefinita dei grafici per le nuove sessioni _maxima_"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:391
+#: ../../info/wxmaxima.md:390
 msgid ""
 "After the next start, plots embedded into the worksheet will be created with "
 "this size if the value of `wxplot_size` isn’t changed by _maxima_."
@@ -1661,7 +1661,7 @@ msgstr ""
 "modificato da _maxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:393
+#: ../../info/wxmaxima.md:392
 msgid ""
 "In order to set the plot size of a single graph only use the following "
 "notation can be used that sets a variable’s value for one command only:"
@@ -1671,7 +1671,7 @@ msgstr ""
 "per un solo comando:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:402
+#: ../../info/wxmaxima.md:401
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxdraw2d(\n"
@@ -1698,17 +1698,17 @@ msgstr ""
 "), wxplot_size=[480,480]$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:404
+#: ../../info/wxmaxima.md:403
 msgid "### Match parenthesis in text controls"
 msgstr "### Abbina parentesi nei controlli di testo"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:406
+#: ../../info/wxmaxima.md:405
 msgid "This option enables two things:"
 msgstr "Questa opzione abilita due cose:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
+#: ../../info/wxmaxima.md:408
 msgid ""
 "If an opening parenthesis, bracket, or double quote is entered _wxMaxima_ "
 "will insert a closing one after it."
@@ -1717,7 +1717,7 @@ msgstr ""
 "_wxMaxima_ ne inserirà una di chiusura dopo di essa."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
+#: ../../info/wxmaxima.md:408
 msgid ""
 "If text is selected if any of these keys is pressed the selected text will "
 "be put between the matched signs."
@@ -1726,12 +1726,12 @@ msgstr ""
 "inserito in una coppia di segni corrispondenti."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:411
+#: ../../info/wxmaxima.md:410
 msgid "### Don’t save the worksheet automatically"
 msgstr "### Non salvare il foglio di lavoro automaticamente"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:413
+#: ../../info/wxmaxima.md:412
 msgid ""
 "If this option is set, the file where the worksheet is will be overwritten "
 "only the request of the user. In case of a crash/power loss/... a recent "
@@ -1743,7 +1743,7 @@ msgstr ""
 "recente sarà ancora disponibile nella directory temp."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:415
+#: ../../info/wxmaxima.md:414
 msgid ""
 "If this option isn’t set _wxMaxima_ behaves more like a modern cellphone app:"
 msgstr ""
@@ -1751,22 +1751,22 @@ msgstr ""
 "moderna app per cellulari:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
+#: ../../info/wxmaxima.md:417
 msgid "Files are saved automatically on exit"
 msgstr "I file vengono salvati automaticamente all'uscita"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
+#: ../../info/wxmaxima.md:417
 msgid "And the file will automatically be saved every 3 minutes."
 msgstr "E il file verrà automaticamente salvato ogni 3 minuti."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:420
+#: ../../info/wxmaxima.md:419
 msgid "### Where is the configuration saved?"
 msgstr "### Dove viene salvata la configurazione?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:423
+#: ../../info/wxmaxima.md:422
 #, fuzzy
 #| msgid ""
 #| "If you are using Unix/Linux, the configuration information will be saved "
@@ -1799,7 +1799,7 @@ msgstr ""
 "saranno nascosti).\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:425
+#: ../../info/wxmaxima.md:424
 msgid ""
 "If you are using Windows, the configuration will be stored in the registry. "
 "You will find the entries for _wxMaxima_ at the following position in the "
@@ -1810,12 +1810,12 @@ msgstr ""
 "registro: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:429
+#: ../../info/wxmaxima.md:428
 msgid "# Extensions to _Maxima_"
 msgstr "# Estensioni a _Maxima_"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:431
+#: ../../info/wxmaxima.md:430
 msgid ""
 "_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
 "its main purpose is to pass along commands to _Maxima_ and to report the "
@@ -1834,32 +1834,32 @@ msgstr ""
 "in cui _wxMaxima_ migliora l'inclusione della grafica in una sessione."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:433
+#: ../../info/wxmaxima.md:432
 msgid "## Subscripted variables"
 msgstr "## Variabili pedice"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:435
+#: ../../info/wxmaxima.md:434
 msgid ""
 "`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript "
 "variable names:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:437
+#: ../../info/wxmaxima.md:436
 msgid ""
 "If it is `false`, the functionality is off, wxMaxima will not autosubscript "
 "part of variable names after an underscore."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:439
+#: ../../info/wxmaxima.md:438
 msgid ""
 "If it is set to `'all`, everything after an underscore will be subscripted."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:441
+#: ../../info/wxmaxima.md:440
 msgid ""
 "If it is set to `true` variable names of the format `x_y` are displayed "
 "using a subscript if"
@@ -1868,26 +1868,26 @@ msgstr ""
 "`x_y` vengono visualizzati utilizzando un pedice se"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
+#: ../../info/wxmaxima.md:443
 #, fuzzy
 #| msgid "`y` is a single letter"
 msgid "Either `x` or `y` is a single letter or"
 msgstr "`y` è una singola lettera"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
+#: ../../info/wxmaxima.md:443
 msgid "`y` is an integer (can include more than one character)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:446
+#: ../../info/wxmaxima.md:445
 msgid ""
 "![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png)"
 "{ id=img_wxsubscripts }"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:448
+#: ../../info/wxmaxima.md:447
 msgid ""
 "If the variable name doesn’t match these requirements, it can still be "
 "declared as \"to be subscripted\" using the command "
@@ -1904,17 +1904,17 @@ msgstr ""
 "`wxdeclare_subscript(nome_variabile,false);`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:450
+#: ../../info/wxmaxima.md:449
 msgid "You can use the menu \"View->Autosubscript\" to set these values."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:452
+#: ../../info/wxmaxima.md:451
 msgid "## User feedback in the status bar"
 msgstr "## Feedback utente nella barra di stato"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:454
+#: ../../info/wxmaxima.md:453
 msgid ""
 "Long-running commands can provide user feedback in the status bar. This user "
 "feedback is replaced by any new feedback that is placed there (allowing to "
@@ -1934,7 +1934,7 @@ msgstr ""
 "`wxstatusbar()` non viene valutato."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:465
+#: ../../info/wxmaxima.md:464
 #, fuzzy, no-wrap
 #| msgid ""
 #| "for i:1 thru 10 do (\n"
@@ -1967,12 +1967,89 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:467
+#: ../../info/wxmaxima.md:466
+msgid "## Exporting the worksheet from within Maxima"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:468
+msgid ""
+"The command `wxworksheettohtml()` exports the current worksheet to an HTML "
+"file from within a running _Maxima_ session, which is convenient for "
+"scripted or batch export. Like `wxstatusbar()` it is safe to use in code "
+"that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present "
+"the command is simply left unevaluated."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:473
+msgid ""
+"```maxima wxworksheettohtml(\"report.html\")$ "
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:475
+msgid ""
+"A relative file name is interpreted relative to _Maxima_’s working "
+"directory. The optional keyword options are:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:480
+#, no-wrap
+msgid ""
+"| option   | values                                          | meaning                                             |\n"
+"| -------- | ----------------------------------------------- | --------------------------------------------------- |\n"
+"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |\n"
+"| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:482
+msgid ""
+"The `flavor` values match the equation formats offered by the graphical "
+"**File → Export** dialog: `mathml` produces a self-contained page that needs "
+"no internet connection, `mathjax` adds a MathJaX fall-back for browsers that "
+"still lack MathML, and `svg`/`bitmap` render every equation to an image."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:484
+msgid ""
+"The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file "
+"the same way:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:489
+msgid ""
+"```maxima wxworksheettotex(\"report.tex\")$ wxworksheettotex(\"report.tex\", "
+"documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:494
+#, no-wrap
+msgid ""
+"| option                 | meaning                                                              |\n"
+"| ---------------------- | -------------------------------------------------------------------- |\n"
+"| `documentclass`        | overrides the LaTeX `\\documentclass` (e.g. `\"article\"`, `\"report\"`)  |\n"
+"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:496
+msgid "Support for `wxworksheettopdf()` is planned."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:498
 msgid "## Plotting"
 msgstr "## Diagrammi"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:469
+#: ../../info/wxmaxima.md:500
 msgid ""
 "Plotting (having fundamentally to do with graphics) is a place where a "
 "graphical user interface will have to provide some extensions to the "
@@ -1983,12 +2060,12 @@ msgstr ""
 "al programma originale."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:471
+#: ../../info/wxmaxima.md:502
 msgid "### Embedding a plot into the worksheet"
 msgstr "### Incorporare un diagramma nel foglio di lavoro"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:473
+#: ../../info/wxmaxima.md:504
 #, fuzzy
 #| msgid ""
 #| "_Maxima_ normally instructs the external program _gnuplot_ to open a "
@@ -2016,12 +2093,12 @@ msgstr ""
 "corrisponde a `histogram`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:475
+#: ../../info/wxmaxima.md:506
 msgid "The following plotting functions have wx-counterparts:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:489
+#: ../../info/wxmaxima.md:520
 #, no-wrap
 msgid ""
 "| wxMaxima’s plot function | Maxima’s plot function                                                                          |\n"
@@ -2040,14 +2117,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:491
+#: ../../info/wxmaxima.md:522
 msgid ""
 "If a `wxm`-file is read by (console) Maxima, these functions are ignored "
 "(and printed as output, as other unknown functions in Maxima)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:493
+#: ../../info/wxmaxima.md:524
 msgid ""
 "If you got problems with one of these functions, please check, if the "
 "problem exists in the the Maxima function too (e.g. you got an error with "
@@ -2059,12 +2136,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:495
+#: ../../info/wxmaxima.md:526
 msgid "### Making embedded plots bigger or smaller"
 msgstr "### Rendere i diagrammi incorporati più grandi o più piccoli"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:497
+#: ../../info/wxmaxima.md:528
 msgid ""
 "As noted above, the configure dialog provides a way to change the default "
 "size plots created which sets the starting value of `wxplot_size`. The "
@@ -2080,7 +2157,7 @@ msgstr ""
 "la dimensione dei seguenti grafici:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:507
+#: ../../info/wxmaxima.md:538
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxplot_size:[1200,800]$\n"
@@ -2110,7 +2187,7 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:509
+#: ../../info/wxmaxima.md:540
 msgid ""
 "If the size of only one plot is to be changed _Maxima_ provides a canonical "
 "way to change an attribute only for the current cell. In this usage the "
@@ -2124,7 +2201,7 @@ msgstr ""
 "`wxdraw2d`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:518
+#: ../../info/wxmaxima.md:549
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2144,7 +2221,7 @@ msgstr ""
 "),wxplot_size=[1600,800]$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:520
+#: ../../info/wxmaxima.md:551
 msgid ""
 "Setting the size of embedded plot with `wxplot_size` works for embedded "
 "plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` "
@@ -2153,12 +2230,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:522
+#: ../../info/wxmaxima.md:553
 msgid "### Better quality plots"
 msgstr "### Grafici di qualità superiore"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:524
+#: ../../info/wxmaxima.md:555
 #, fuzzy
 #| msgid ""
 #| "_Gnuplot_ doesn’t seem to provide a portable way of determining whether "
@@ -2186,12 +2263,12 @@ msgstr ""
 "supporti, il risultato saranno messaggi di errore invece di grafici."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:526
+#: ../../info/wxmaxima.md:557
 msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
 msgstr "### Aprire grafici incorporati in finestre interattive _gnuplot_"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:528
+#: ../../info/wxmaxima.md:559
 #, fuzzy
 #| msgid ""
 #| "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
@@ -2213,12 +2290,12 @@ msgstr ""
 "interattiva."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:530
+#: ../../info/wxmaxima.md:561
 msgid "### Opening Gnuplot’s command console in `plot` windows"
 msgstr "### Apertura della console dei comandi di gnuplot in finestra `plot`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:533
+#: ../../info/wxmaxima.md:564
 #, fuzzy
 #| msgid ""
 #| "On MS Windows, if in _Maxima_'s variable `gnuplot_command` \"gnuplot\" is "
@@ -2242,12 +2319,12 @@ msgstr ""
 "preparato un grafico."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:535
+#: ../../info/wxmaxima.md:566
 msgid "### Embedding animations into the spreadsheet"
 msgstr "### Incorporamento di animazioni nel foglio di calcolo"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:537
+#: ../../info/wxmaxima.md:568
 msgid ""
 "3D diagrams tend to make it hard to read quantitative data. A viable "
 "alternative might be to assign the 3rd parameter to the mouse wheel. The "
@@ -2263,7 +2340,7 @@ msgstr ""
 "di esportare questa animazione come gif animata."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:539
+#: ../../info/wxmaxima.md:570
 msgid ""
 "The first two arguments for `with_slider_draw` are the name of the variable "
 "that is stepped between the plots and a list of the values of these "
@@ -2275,7 +2352,7 @@ msgstr ""
 "argomenti che seguono sono gli argomenti ordinari per `wxdraw2d`:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:550
+#: ../../info/wxmaxima.md:581
 #, fuzzy, no-wrap
 #| msgid ""
 #| "with_slider_draw(\n"
@@ -2308,7 +2385,7 @@ msgstr ""
 ");\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:552
+#: ../../info/wxmaxima.md:583
 msgid ""
 "The same functionality for 3D plots is accessible as `with_slider_draw3d`, "
 "which allows for rotating 3d plots:"
@@ -2317,7 +2394,7 @@ msgstr ""
 "`with_slider_draw3d`, che consente di ruotare i grafici 3D:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:569
+#: ../../info/wxmaxima.md:600
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxanimate_autoplay:true;\n"
@@ -2368,7 +2445,7 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:571
+#: ../../info/wxmaxima.md:602
 msgid ""
 "If the general shape of the plot is what matters it might suffice to move "
 "the plot just a little bit in order to make its 3D nature available to the "
@@ -2378,7 +2455,7 @@ msgstr ""
 "leggermente il grafico per rendere intuibile la sua natura 3D:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:588
+#: ../../info/wxmaxima.md:619
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxanimate_autoplay:true;\n"
@@ -2429,7 +2506,7 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:590
+#: ../../info/wxmaxima.md:621
 msgid ""
 "For those more familiar with `plot` than with `draw`, there is a second set "
 "of functions:"
@@ -2438,17 +2515,17 @@ msgstr ""
 "secondo insieme di funzioni:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
+#: ../../info/wxmaxima.md:624
 msgid "`with_slider` and"
 msgstr "`with_slider` e"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
+#: ../../info/wxmaxima.md:624
 msgid "`wxanimate`."
 msgstr "`wxanimate`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:595
+#: ../../info/wxmaxima.md:626
 msgid ""
 "Normally the animations are played back or exported with the frame rate "
 "chosen in the configuration of _wxMaxima_. To set the speed at an individual "
@@ -2460,7 +2537,7 @@ msgstr ""
 "variabile `wxanimate_framerate`:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:600
+#: ../../info/wxmaxima.md:631
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxanimate(a, 10,\n"
@@ -2475,7 +2552,7 @@ msgstr ""
 "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:602
+#: ../../info/wxmaxima.md:633
 msgid ""
 "The animation functions use _Maxima_’s `makelist` command and therefore "
 "share the pitfall that the slider variable’s value is substituted into the "
@@ -2488,7 +2565,7 @@ msgstr ""
 "nell'espressione. Pertanto il seguente esempio fallirà:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:612
+#: ../../info/wxmaxima.md:643
 #, fuzzy, no-wrap
 #| msgid ""
 #| "f:sin(a*x);\n"
@@ -2518,7 +2595,7 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:614
+#: ../../info/wxmaxima.md:645
 msgid ""
 "If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
 "works fine instead:"
@@ -2527,7 +2604,7 @@ msgstr ""
 "dispositivo di scorrimento, il tracciato funziona invece correttamente:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:627
+#: ../../info/wxmaxima.md:658
 #, fuzzy, no-wrap
 #| msgid ""
 #| "f:sin(a*x);\n"
@@ -2566,12 +2643,12 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:629
+#: ../../info/wxmaxima.md:660
 msgid "### Opening multiple plots in contemporaneous windows"
 msgstr "### Apertura di più grafici in più finestre contemporaneamente"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:631
+#: ../../info/wxmaxima.md:662
 msgid ""
 "While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups "
 "that support it) sometimes comes in handily. The following example comes "
@@ -2582,38 +2659,38 @@ msgstr ""
 "post di Mario Rodriguez alla mailing list _Maxima_:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:634
+#: ../../info/wxmaxima.md:665
 msgid "```maxima load(draw);"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:637
+#: ../../info/wxmaxima.md:668
 msgid ""
 "/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:640
+#: ../../info/wxmaxima.md:671
 msgid ""
 "/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:644
+#: ../../info/wxmaxima.md:675
 msgid ""
 "/* Paraboloid in window #3 */ "
 "draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:646
+#: ../../info/wxmaxima.md:677
 msgid ""
 "Plotting multiple plots in the same window is possible, too (the same is "
 "possible in command line Maxima with the standard `draw()` command):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:657
+#: ../../info/wxmaxima.md:688
 #, fuzzy, no-wrap
 #| msgid ""
 #| "\twxdraw(\n"
@@ -2646,12 +2723,12 @@ msgstr ""
 "\t );\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:659
+#: ../../info/wxmaxima.md:690
 msgid "### The \"Plot using draw\" side pane"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:661
+#: ../../info/wxmaxima.md:692
 msgid ""
 "The \"Plot using draw\" sidebar hides a simple code generator that allows "
 "generating scenes that make use of some of the flexibility of the _draw_ "
@@ -2659,12 +2736,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:663
+#: ../../info/wxmaxima.md:694
 msgid "#### 2D"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:665
+#: ../../info/wxmaxima.md:696
 msgid ""
 "Generates the skeleton of a `draw()` command that draws a 2D scene. This "
 "scene later has to be filled with commands that generate the scene’s "
@@ -2673,7 +2750,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:667
+#: ../../info/wxmaxima.md:698
 msgid ""
 "One helpful feature of the 2D button is that it allows to set up the scene "
 "as an animation in which a variable (by default it is _t_) has a different "
@@ -2682,12 +2759,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:669
+#: ../../info/wxmaxima.md:700
 msgid "#### 3D"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:671
+#: ../../info/wxmaxima.md:702
 msgid ""
 "Generates the skeleton of a `draw()` command that draws a 3D scene. If "
 "neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D "
@@ -2695,12 +2772,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:673
+#: ../../info/wxmaxima.md:704
 msgid "#### Expression"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:675
+#: ../../info/wxmaxima.md:706
 msgid ""
 "Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or "
 "`x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is "
@@ -2709,12 +2786,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:677
+#: ../../info/wxmaxima.md:708
 msgid "#### Implicit plot"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:679
+#: ../../info/wxmaxima.md:710
 msgid ""
 "Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or "
 "`x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command "
@@ -2723,12 +2800,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:681
+#: ../../info/wxmaxima.md:712
 msgid "#### Parametric plot"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:683
+#: ../../info/wxmaxima.md:714
 msgid ""
 "Steps a variable from a lower limit to an upper limit and uses two "
 "expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in "
@@ -2737,12 +2814,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:685
+#: ../../info/wxmaxima.md:716
 msgid "#### Points"
 msgstr "#### Punti"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:687
+#: ../../info/wxmaxima.md:718
 msgid ""
 "Draws many points that can optionally be joined. The coordinates of the "
 "points are taken from a list of lists, a 2D array or one list or array for "
@@ -2750,32 +2827,32 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:689
+#: ../../info/wxmaxima.md:720
 msgid "#### Diagram title"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:691
+#: ../../info/wxmaxima.md:722
 msgid "Draws a title on the upper end of the diagram,"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:693
+#: ../../info/wxmaxima.md:724
 msgid "#### Axis"
 msgstr "#### Assi"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:695
+#: ../../info/wxmaxima.md:726
 msgid "Sets up the axis."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:697
+#: ../../info/wxmaxima.md:728
 msgid "#### Contour"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:699
+#: ../../info/wxmaxima.md:730
 msgid ""
 "(Only for 3D plots): Adds contour lines similar to the ones one can find in "
 "a map of a mountain to the plot commands that follow in the current `draw()` "
@@ -2785,12 +2862,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:701
+#: ../../info/wxmaxima.md:732
 msgid "#### Plot name"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:703
+#: ../../info/wxmaxima.md:734
 msgid ""
 "Adds a legend entry showing the next plot’s name to the legend of the "
 "diagram. An empty name disables generating legend entries for the following "
@@ -2798,58 +2875,58 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:705
+#: ../../info/wxmaxima.md:736
 msgid "#### Line colour"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:707
+#: ../../info/wxmaxima.md:738
 msgid ""
 "Sets the line colour for the following plots the current draw command "
 "contains."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:709
+#: ../../info/wxmaxima.md:740
 msgid "#### Fill colour"
 msgstr "#### Colore riempimento"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:711
+#: ../../info/wxmaxima.md:742
 msgid ""
 "Sets the fill colour for the following plots the current draw command "
 "contains."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:713
+#: ../../info/wxmaxima.md:744
 msgid "#### Grid"
 msgstr "#### Griglia"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:715
+#: ../../info/wxmaxima.md:746
 msgid "Pops up a wizard that allows to set up grid lines."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:717
+#: ../../info/wxmaxima.md:748
 msgid "#### Accuracy"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:719
+#: ../../info/wxmaxima.md:750
 msgid ""
 "Allows to select an adequate point in the speed vs. accuracy tradeoff that "
 "is part of any plot program."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:721
+#: ../../info/wxmaxima.md:752
 msgid "### Modify font and font size for plots"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:723
+#: ../../info/wxmaxima.md:754
 msgid ""
 "Especially when you use a high resolution display, the default font size "
 "might be very small. For the `draw`-based commands, you can set the font / "
@@ -2857,7 +2934,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:730
+#: ../../info/wxmaxima.md:761
 #, no-wrap
 msgid ""
 "~~~maxima\n"
@@ -2869,14 +2946,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:732
+#: ../../info/wxmaxima.md:763
 msgid ""
 "For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts "
 "can be set using the `gnuplot_preamble` command, e.g.:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:737
+#: ../../info/wxmaxima.md:768
 #, no-wrap
 msgid ""
 "~~~maxima\n"
@@ -2886,14 +2963,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:739
+#: ../../info/wxmaxima.md:770
 msgid ""
 "This sets the font for the numbers to Arial with size 30, the size for the "
 "xlabel and ylabel font to 20 (with the default font)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:742
+#: ../../info/wxmaxima.md:773
 msgid ""
 "Read the Maxima and Gnuplot documentation for further information.  Note: "
 "Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue "
@@ -2901,12 +2978,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:744
+#: ../../info/wxmaxima.md:775
 msgid "## Embedding graphics"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:746
+#: ../../info/wxmaxima.md:777
 msgid ""
 "If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
 "project can be done as easily as per drag-and-drop. But sometimes (for "
@@ -2915,38 +2992,38 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:750
+#: ../../info/wxmaxima.md:781
 msgid "```maxima show_image(\"man.png\"); ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:752
+#: ../../info/wxmaxima.md:783
 msgid "## Startup files"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:754
+#: ../../info/wxmaxima.md:785
 msgid ""
 "The config dialogue of _wxMaxima_ offers to edit two files with commands "
 "that are executed on startup:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
+#: ../../info/wxmaxima.md:788
 msgid ""
 "A file that contains commands that are executed on starting up _Maxima_: "
 "`maxima-init.mac`"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
+#: ../../info/wxmaxima.md:788
 msgid ""
 "one file of additional commands that are executed if _wxMaxima_ is starting "
 "_Maxima_: `wxmaxima-init.mac`"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:759
+#: ../../info/wxmaxima.md:790
 msgid ""
 "For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add "
 "`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` "
@@ -2954,7 +3031,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:761
+#: ../../info/wxmaxima.md:792
 msgid ""
 "These files are in the Maxima user directory (usually `%USERPROFILE%/maxima` "
 "in Windows, `$HOME/.maxima` otherwise). The location can be found out with "
@@ -2962,12 +3039,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:763
+#: ../../info/wxmaxima.md:794
 msgid "## Special variables wx..."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxsubscripts` tells _Maxima_ if it should convert variable names that "
 "contain an underscore (`R_150` or the like) into subscripted variables. See "
@@ -2976,21 +3053,21 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxfilename`: This variable contains the name of the file currently opened "
 "in _wxMaxima_."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxdirname`: This variable contains the name the directory, in which the "
 "file currently opened in _wxMaxima_ is."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_’s pngcairo "
 "terminal that provides more line styles and a better overall graphics "
@@ -2998,12 +3075,12 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxplot_size` defines the resolution of embedded plots."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
 "_Maxima_’s working directory to the directory of the current file. This "
@@ -3014,34 +3091,34 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxanimate_framerate`: The number of frames per second the following "
 "animations have to be played back with."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxanimate_autoplay`: Automatically play animations by default?"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:776
+#: ../../info/wxmaxima.md:807
 msgid "## Pretty-printing 2D output"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:778
+#: ../../info/wxmaxima.md:809
 msgid ""
 "The function `table_form()` displays a 2D list in a form that is more "
 "readable than the output from _Maxima_’s default output routine. The input "
@@ -3051,7 +3128,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:787
+#: ../../info/wxmaxima.md:818
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -3065,56 +3142,84 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:789
+#: ../../info/wxmaxima.md:820
 msgid ""
 "As the next example shows, the lists that are assembled by the `table_form` "
 "command can be created before the command is executed."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:791
+#: ../../info/wxmaxima.md:822
 msgid ""
 "![A third table example](./MatrixTableExample.png)"
 "{ id=img_MatrixTableExample }"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:793
+#: ../../info/wxmaxima.md:824
 msgid ""
 "Also, because a matrix is a list of lists, matrices can be converted to "
 "tables in a similar fashion."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:795
+#: ../../info/wxmaxima.md:826
 msgid ""
 "![Another table_form example](./SecondTableExample.png)"
 "{ id=img_SecondTableExample }"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:797
+#: ../../info/wxmaxima.md:828
 msgid ""
 "The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that "
 "allows for more flexible formatting of matrices in wxMaxima:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:803
+#: ../../info/wxmaxima.md:830
 #, no-wrap
+msgid "**`wx_matrix( <matrix>, [options] )`**\n"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
 msgid ""
-"**`wx_matrix( <matrix>, [options] )`**\n"
-"- **`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data.\n"
-"- **`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels.\n"
-"- **`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels.\n"
-"- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`.\n"
+"**`lines=true`**: Draws internal separator lines between the cells. This is "
+"required to visually separate headings from data."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`rownames=true`**: Tells wxMaxima that the first column of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`colnames=true`**: Tells wxMaxima that the first row of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
+"around the matrix. Supported styles are: `round` `()`, `square` `[]`, "
+"`angled` `<>`, `straight` `||`, or `none`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:809
+#: ../../info/wxmaxima.md:837
+msgid "Example:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:842
 #, no-wrap
 msgid ""
-"Example:\n"
 "```maxima\n"
 "wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
 "          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
@@ -3122,36 +3227,36 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:811
+#: ../../info/wxmaxima.md:844
 msgid "## Bug reporting"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:813
+#: ../../info/wxmaxima.md:846
 msgid ""
 "_WxMaxima_ provides a few functions that gather bug reporting information "
 "about the current system:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:816
+#: ../../info/wxmaxima.md:849
 msgid ""
 "`wxbuild_info()` gathers information about the currently running version of "
 "_wxMaxima_"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:816
+#: ../../info/wxmaxima.md:849
 msgid "`wxbug_report()` tells how and where to file bugs"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:819
+#: ../../info/wxmaxima.md:851
 msgid "## Marking output being drawn in red"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:822
+#: ../../info/wxmaxima.md:854
 msgid ""
 "_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a "
 "red foreground, if the second argument to the command is the text "
@@ -3159,17 +3264,17 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:824
+#: ../../info/wxmaxima.md:856
 msgid "## Output rendering."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:826
+#: ../../info/wxmaxima.md:858
 msgid "With `set_display()` one can set, how wxMaxima will render the output."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:828
+#: ../../info/wxmaxima.md:860
 msgid ""
 "`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima "
 "using an (machine readable) XML-dialect (can be seen in the \"Raw XML "
@@ -3178,7 +3283,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:831
+#: ../../info/wxmaxima.md:863
 msgid ""
 "<!--- Currently that does not work as it should, the line with the output "
 "label is shifted right (issue: #2006) --> `set_display('ascii)` causes "
@@ -3186,19 +3291,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:833
+#: ../../info/wxmaxima.md:865
 msgid ""
 "`set_display('none)` causes 'one-line' ASCII results - the same as the "
 "command line Maxima command `display2d:false;` does."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:867
 msgid "# Help menu"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:837
+#: ../../info/wxmaxima.md:869
 msgid ""
 "WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, "
 "tips, some example worksheets and in command line Maxima included demos (the "
@@ -3206,19 +3311,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:839
+#: ../../info/wxmaxima.md:871
 msgid "Please notice, that the demos write:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:843
+#: ../../info/wxmaxima.md:875
 msgid ""
 "~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the "
 "demonstration.  ~~~"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:845
+#: ../../info/wxmaxima.md:877
 msgid ""
 "That is valid for command-line Maxima, however in wxMaxima by default it is "
 "necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</"
@@ -3226,24 +3331,24 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:847
+#: ../../info/wxmaxima.md:879
 msgid ""
 "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending "
 "commands to Maxima\" menu.)"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:851
+#: ../../info/wxmaxima.md:883
 msgid "# Troubleshooting"
 msgstr "# Risoluzione dei problemi"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:853
+#: ../../info/wxmaxima.md:885
 msgid "## Cannot connect to _Maxima_"
 msgstr "## Estensioni a _Maxima_"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:855
+#: ../../info/wxmaxima.md:887
 msgid ""
 "Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ "
 "(providing the easy-to-use user interface) are separate programs that "
@@ -3260,7 +3365,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:857
+#: ../../info/wxmaxima.md:889
 msgid ""
 "On Unix computers another possible reason would be that the loopback network "
 "that provides network connections between two programs in the same computer "
@@ -3268,12 +3373,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:859
+#: ../../info/wxmaxima.md:891
 msgid "## How to save data from a broken .wxmx file"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:861
+#: ../../info/wxmaxima.md:893
 msgid ""
 "Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ "
 "doesn’t turn on compression, so the contents of `.wxmx` files can be viewed "
@@ -3281,7 +3386,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:863
+#: ../../info/wxmaxima.md:895
 msgid ""
 "If the zip signature at the end of the file is still intact after renaming a "
 "broken `.wxmx` file to `.zip` most operating systems will provide a way to "
@@ -3293,7 +3398,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:865
+#: ../../info/wxmaxima.md:897
 msgid ""
 "And even if there isn’t such a file: The `.wxmx` file is a container format "
 "and the XML portion is stored uncompressed. It it is possible to rename the "
@@ -3304,7 +3409,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:867
+#: ../../info/wxmaxima.md:899
 msgid ""
 "If a text file containing only these contents (e.g. copy and paste this text "
 "into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know "
@@ -3312,14 +3417,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:869
+#: ../../info/wxmaxima.md:901
 msgid ""
 "## I want some debug info to be displayed on the screen before my command "
 "has finished"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:871
+#: ../../info/wxmaxima.md:903
 msgid ""
 "Normally _wxMaxima_ waits for the whole 2D formula to be transferred before "
 "it begins to typeset. This saves time for making many attempts to typeset a "
@@ -3329,7 +3434,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:881
+#: ../../info/wxmaxima.md:913
 #, fuzzy, no-wrap
 #| msgid ""
 #| "for i:1 thru 10 do (\n"
@@ -3361,29 +3466,29 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:883
+#: ../../info/wxmaxima.md:915
 msgid "Alternatively one can look for the `wxstatusbar()` command above."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:885
+#: ../../info/wxmaxima.md:917
 msgid "## Plotting only shows a closed empty envelope with an error message"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:887
+#: ../../info/wxmaxima.md:919
 msgid ""
 "This means that _wxMaxima_ could not read the file _Maxima_ that was "
 "supposed to instruct _Gnuplot_ to create."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:889
+#: ../../info/wxmaxima.md:921
 msgid "Possible reasons for this error are:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 msgid ""
 "The plotting command is part of a third-party package like `implicit_plot` "
 "but this package was not loaded by _Maxima_’s `load()` command before trying "
@@ -3391,7 +3496,7 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 msgid ""
 "_Maxima_ tried to do something the currently installed version of _Gnuplot_ "
 "isn’t able to understand. In this case, a file ending in `.gnuplot` located "
@@ -3401,7 +3506,7 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 msgid ""
 "Gnuplot was instructed to use the pngCairo library that provides "
 "antialiasing and additional line styles, but it was not compiled to support "
@@ -3411,17 +3516,17 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 msgid "Gnuplot didn’t output a valid `.png` file."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:896
+#: ../../info/wxmaxima.md:928
 msgid "## Plotting an animation results in “error: undefined variable”"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:898
+#: ../../info/wxmaxima.md:930
 msgid ""
 "The value of the slider variable by default is only substituted into the "
 "expression that is to be plotted if it is visible there. Using a `subst` "
@@ -3432,12 +3537,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:900
+#: ../../info/wxmaxima.md:932
 msgid "## I lost cell content and undo doesn’t remember"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:902
+#: ../../info/wxmaxima.md:934
 msgid ""
 "There are separate undo functions for cell operations and for changes inside "
 "of cells so chances are low that this ever happens. If it does there are "
@@ -3445,7 +3550,7 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid ""
 "_WxMaxima_ actually has two undo features: The global undo buffer that is "
 "active if no cell is selected and a per-cell undo buffer that is active if "
@@ -3454,36 +3559,36 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid ""
 "If you still have a way to find out what label _Maxima_ has assigned to the "
 "cell just type in the cell’s label and its contents will reappear."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid ""
 "If you don’t: Don’t panic. In the “View” menu there is a way to show a "
 "history pane that shows all _Maxima_ commands that have been issued recently."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid "If nothing else helps _Maxima_ contains a replay feature:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:911
+#: ../../info/wxmaxima.md:943
 msgid "```maxima playback(); ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:913
+#: ../../info/wxmaxima.md:945
 msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:915
+#: ../../info/wxmaxima.md:947
 msgid ""
 "One possible reason is that _Maxima_ cannot be found in the location that is "
 "set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore "
@@ -3492,12 +3597,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:917
+#: ../../info/wxmaxima.md:949
 msgid "## Maxima is forever calculating and not responding to input"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:919
+#: ../../info/wxmaxima.md:951
 msgid ""
 "It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ "
 "has finished calculating and therefore never gets informed it can send new "
@@ -3506,12 +3611,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:921
+#: ../../info/wxmaxima.md:953
 msgid "## My SBCL-based _Maxima_ runs out of memory"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:923
+#: ../../info/wxmaxima.md:955
 msgid ""
 "The Lisp compiler SBCL by default comes with a memory limit that allows it "
 "to run even on low-end computers. When compiling a big software package like "
@@ -3524,7 +3629,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:925
+#: ../../info/wxmaxima.md:957
 msgid ""
 "One way to provide _Maxima_ (and thus SBCL) with command line parameters is "
 "the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration "
@@ -3532,17 +3637,17 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:927
+#: ../../info/wxmaxima.md:959
 msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:929
+#: ../../info/wxmaxima.md:961
 msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:931
+#: ../../info/wxmaxima.md:963
 msgid ""
 "Installing the package `ibus-gtk` should resolve this issue. See ([https://"
 "bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://"
@@ -3550,24 +3655,24 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:933
+#: ../../info/wxmaxima.md:965
 msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:935
+#: ../../info/wxmaxima.md:967
 msgid ""
 "If your _Maxima_ is based on SBCL the following lines have to be added to "
 "your `.sbclrc`:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:971
 msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:941
+#: ../../info/wxmaxima.md:973
 msgid ""
 "The folder where this file has to be placed is system- and installation-"
 "specific. But any SBCL-based _Maxima_ that already has evaluated a cell in "
@@ -3576,58 +3681,90 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:945
+#: ../../info/wxmaxima.md:977
 msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:947
+#: ../../info/wxmaxima.md:979
 msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:950
+#: ../../info/wxmaxima.md:982
 msgid ""
 "There seem to be issues with the Wayland Display Server and wxWidgets.  "
 "WxMaxima may be affected, e.g. that sidebars are not moveable."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:954
+#: ../../info/wxmaxima.md:986
 msgid ""
 "You can either disable Wayland and use X11 instead (globally)  or just tell, "
 "that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:956
+#: ../../info/wxmaxima.md:988
 msgid "E.g. start wxMaxima with:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:958
+#: ../../info/wxmaxima.md:990
 msgid "`GDK_BACKEND=x11 wxmaxima`"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:960
+#: ../../info/wxmaxima.md:992
+msgid "## The menu bar disappears on KDE Plasma"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:997
+msgid ""
+"On some KDE Plasma installations the global menu bar disappears when "
+"clicked.  As this is a bug in the global menu proxy, the only way to avoid "
+"it is to tell that wxMaxima should use its own menu bar instead of the "
+"global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1001
+msgid ""
+"Starting with version 26.05.0, wxMaxima attempts to set this variable "
+"automatically if it detects an affected system (KDE, Unity, or Ubuntu with "
+"older wxWidgets versions)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1003
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1005
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1007
 msgid "## Why is the integrated manual browser not offered on my Windows PC?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:963
+#: ../../info/wxmaxima.md:1010
 msgid ""
 "Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or "
 "Microsoft’s webview2 isn’t installed."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:965
+#: ../../info/wxmaxima.md:1012
 msgid "## Why is the external manual browser not working on my Linux box?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:971
+#: ../../info/wxmaxima.md:1018
 msgid ""
 "The HTML browser might be a snap, flatpack or appimage version. All of these "
 "typically cannot access files that are installed on your local system. "
@@ -3638,20 +3775,20 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:973
+#: ../../info/wxmaxima.md:1020
 msgid ""
 "## Can I make _wxMaxima_ output both image files and embedded plots at once?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:975
+#: ../../info/wxmaxima.md:1022
 msgid ""
 "The worksheet embeds `.png files. _WxMaxima_ allows the user to specify "
 "where they should be generated:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:982
+#: ../../info/wxmaxima.md:1029
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -3663,14 +3800,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:984
+#: ../../info/wxmaxima.md:1031
 msgid ""
 "If a different format is to be used, it is easier to generate the images and "
 "then import them into the worksheet again:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1003
+#: ../../info/wxmaxima.md:1050
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -3694,7 +3831,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1008
+#: ../../info/wxmaxima.md:1055
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxdraw2d(\n"
@@ -3717,17 +3854,17 @@ msgstr ""
 "),wxplot_size=[1600,800]$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1010
+#: ../../info/wxmaxima.md:1057
 msgid "## Can I set the aspect ratio of an embedded plot?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1012
+#: ../../info/wxmaxima.md:1059
 msgid "Use the variable `wxplot_size`:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1018
+#: ../../info/wxmaxima.md:1065
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxdraw2d(\n"
@@ -3751,14 +3888,14 @@ msgstr ""
 "),wxplot_size=[1600,800]$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1020
+#: ../../info/wxmaxima.md:1067
 msgid ""
 "## After upgrading to MacOS 13.1 plot and/or draw commands output error "
 "messages like"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1027
+#: ../../info/wxmaxima.md:1074
 msgid ""
 "```text 1 HIToolbox 0x00007ff80cd91726 "
 "_ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox "
@@ -3767,7 +3904,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1029
+#: ../../info/wxmaxima.md:1076
 msgid ""
 "This might be an issue with the operating system. Disable the hiding of the "
 "menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the "
@@ -3776,12 +3913,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1031
+#: ../../info/wxmaxima.md:1078
 msgid "## Logging"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1035
+#: ../../info/wxmaxima.md:1082
 msgid ""
 "Log messages might be helpful to debug problems. WxMaxima can log many "
 "events. Most log entries will be helpful for developers, especially in case "
@@ -3792,7 +3929,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1037
+#: ../../info/wxmaxima.md:1084
 msgid ""
 "Messages are not 'lost', if the log window is not shown, if you select to "
 "show the log window later, you will see past log messages (if you did not "
@@ -3800,14 +3937,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1039
+#: ../../info/wxmaxima.md:1086
 msgid ""
 "Such messages may be helpful, when you create bug reports (or trying to find "
 "a bug by yourself)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1042
+#: ../../info/wxmaxima.md:1089
 msgid ""
 "Log messages can (additionally) be printed to STDERR, when using the command "
 "line option \"--logtostderr\". On Windows a separate text console will be "
@@ -3815,24 +3952,24 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1046
+#: ../../info/wxmaxima.md:1093
 msgid "# FAQ"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1048
+#: ../../info/wxmaxima.md:1095
 msgid "## Is there a way to make more text fit on a LaTeX page?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1050
+#: ../../info/wxmaxima.md:1097
 msgid ""
 "Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to "
 "specify the size of the borders."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1052
+#: ../../info/wxmaxima.md:1099
 msgid ""
 "You can add the following line to the LaTeX preamble (for example by using "
 "the respective field in the config dialogue (\"Export\"->\"Additional lines "
@@ -3840,18 +3977,18 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1056
+#: ../../info/wxmaxima.md:1103
 msgid ""
 "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1058
+#: ../../info/wxmaxima.md:1105
 msgid "## Is there a dark mode?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1060
+#: ../../info/wxmaxima.md:1107
 msgid ""
 "If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if "
 "the rest of the operating system is. The worksheet itself is by default "
@@ -3861,13 +3998,13 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1062
+#: ../../info/wxmaxima.md:1109
 msgid ""
 "## _WxMaxima_ sometimes hangs for several seconds once in the first minute"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1064
+#: ../../info/wxmaxima.md:1111
 msgid ""
 "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-"
 "manual to background tasks, which normally goes totally unnoticed. At the "
@@ -3876,19 +4013,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1066
+#: ../../info/wxmaxima.md:1113
 msgid ""
 "## Especially when testing new locale settings, a message box \"locale "
 "’xx_YY’ can not be set\" occurs"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1068
+#: ../../info/wxmaxima.md:1115
 msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1072
+#: ../../info/wxmaxima.md:1119
 msgid ""
 "(The same problem can occur with other applications too). The translations "
 "seem okay after you click on ’OK’. WxMaxima does not only use its own "
@@ -3896,20 +4033,20 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1075
+#: ../../info/wxmaxima.md:1122
 msgid ""
 "These locales maybe not present in the system. On Ubuntu/Debian systems they "
 "can be generated using: `dpkg-reconfigure locales`"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1077
+#: ../../info/wxmaxima.md:1124
 msgid ""
 "## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1079
+#: ../../info/wxmaxima.md:1126
 msgid ""
 "You can find these symbols in the Unicode sidebar (search for ’double-struck "
 "capital’). But the selected font must also support these symbols. If they do "
@@ -3917,14 +4054,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1081
+#: ../../info/wxmaxima.md:1128
 msgid ""
 "## How can a Maxima script determine, if it is running under wxMaxima or "
 "command line Maxima?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1083
+#: ../../info/wxmaxima.md:1130
 msgid ""
 "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to "
 "`wxmaxima`. The Maxima variable `maxima_frontend_version` contains the "
@@ -3932,19 +4069,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1085
+#: ../../info/wxmaxima.md:1132
 msgid ""
 "If no frontend is used (you are using command line Maxima), these variables "
 "are `false`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1087
+#: ../../info/wxmaxima.md:1134
 msgid "## Help! I can not save my document!"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1089
+#: ../../info/wxmaxima.md:1136
 msgid ""
 "If saving as wxmx file does not work, try saving the document as wxm file "
 "(and vice versa). And you can also try to remove all output (Menu Cell-"
@@ -3953,12 +4090,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1093
+#: ../../info/wxmaxima.md:1140
 msgid "# Command-line arguments"
 msgstr "# Argomenti della riga di comando"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1095
+#: ../../info/wxmaxima.md:1142
 msgid ""
 "Usually you can start programs with a graphical user interface just by "
 "clicking on a desktop icon or desktop menu entry. WxMaxima - if started from "
@@ -3966,29 +4103,29 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-v` or `--version`: Output the version information"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-h` or `--help`: Output a short help text"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid ""
 "`-o` or `--open=<str>`: Open the filename given as an argument to this "
 "command-line switch"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-e` or `--eval`: Evaluate the file after opening it."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid ""
 "`-b` or `--batch`: If the command-line opens a file all cells in this file "
 "are evaluated and the file is saved afterward. This is for example useful if "
@@ -4000,7 +4137,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, no-wrap
 msgid ""
 "- `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
@@ -4016,19 +4153,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1113
+#: ../../info/wxmaxima.md:1160
 msgid ""
 "Instead of a minus, some operating systems might use a dash in front of the "
 "command-line switches."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1117
+#: ../../info/wxmaxima.md:1164
 msgid "# About the program, contributing to wxMaxima"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1119
+#: ../../info/wxmaxima.md:1166
 msgid ""
 "wxMaxima is mainly developed using the programming language C++ using the "
 "[wxWidgets framework](https://www.wxwidgets.org), as build system we use "
@@ -4040,7 +4177,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1121
+#: ../../info/wxmaxima.md:1168
 msgid ""
 "But not only programmers are necessary! You can also contribute to wxMaxima, "
 "if you help to improve the documentation, find and report bugs (and maybe "
@@ -4051,19 +4188,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1123
+#: ../../info/wxmaxima.md:1170
 msgid "Or answer questions of other users in the discussion forum."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1125
+#: ../../info/wxmaxima.md:1172
 msgid ""
 "The source code of wxMaxima is documented using Doxygen [here](https://"
 "wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1127
+#: ../../info/wxmaxima.md:1174
 msgid ""
 "The program is nearly self-contained, so except for system libraries (and "
 "the wxWidgets library), no external dependencies (like graphic files or the "
@@ -4072,7 +4209,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1128
+#: ../../info/wxmaxima.md:1175
 msgid ""
 "If you are a developer, you might want to try out a modified `wxmathML.lisp`-"
 "file without recompiling everything, one can use the command line option `--"

--- a/locales/manual/ru.po
+++ b/locales/manual/ru.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-05-20 10:30+0200\n"
+"POT-Creation-Date: 2026-07-30 11:38+0200\n"
 "PO-Revision-Date: 2026-01-29 10:50+0300\n"
 "Last-Translator: Olesya Gerasimenko <goa@altlinux.org>\n"
 "Language-Team: Basealt Translation Team\n"
@@ -45,9 +45,9 @@ msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 msgstr "![Логотип wxMaxima](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:426
-#: ../../info/wxmaxima.md:848 ../../info/wxmaxima.md:1043
-#: ../../info/wxmaxima.md:1090 ../../info/wxmaxima.md:1114
+#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:425
+#: ../../info/wxmaxima.md:880 ../../info/wxmaxima.md:1090
+#: ../../info/wxmaxima.md:1137 ../../info/wxmaxima.md:1161
 #, no-wrap
 msgid "______________________________________________________________________\n"
 msgstr "______________________________________________________________________\n"
@@ -981,12 +981,12 @@ msgstr ""
 "вырезании и вставке формулы из другого документа."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:224
+#: ../../info/wxmaxima.md:223
 msgid "### Side Panes"
 msgstr "### Боковые панели"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:226
+#: ../../info/wxmaxima.md:225
 msgid ""
 "Shortcuts to the most important _Maxima_ commands, things like a table of "
 "contents, windows with debug messages or a history of the last issued "
@@ -1002,13 +1002,13 @@ msgstr ""
 "панель, позволяющую вводить греческие буквы с помощью мыши."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:228
+#: ../../info/wxmaxima.md:227
 msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
 msgstr ""
 "![Пример различных боковых панелей](./SidePanes.png){ id=img_SidePanes }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:231
+#: ../../info/wxmaxima.md:230
 msgid ""
 "In the \"table of contents\" side pane, one can increase or decrease a "
 "heading by just clicking on the heading with the right mouse button and "
@@ -1019,7 +1019,7 @@ msgstr ""
 "ближайшего более высокого или низкого уровня."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:233
+#: ../../info/wxmaxima.md:232
 msgid ""
 "![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-"
 "headings.png){ id=Sidepane-TOC-convert-headings }"
@@ -1028,12 +1028,12 @@ msgstr ""
 "(./Sidepane-TOC-convert-headings.png){ id=Sidepane-TOC-convert-headings}"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:235
+#: ../../info/wxmaxima.md:234
 msgid "### MathML output"
 msgstr "### Вывод MathML"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:237
+#: ../../info/wxmaxima.md:236
 msgid ""
 "Several word processors and similar programs either recognize [MathML]"
 "(https://www.w3.org/Math/) input and automatically insert it as an editable "
@@ -1049,12 +1049,12 @@ msgstr ""
 "_wxMaxima_ доступно несколько пунктов."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:239
+#: ../../info/wxmaxima.md:238
 msgid "### Markdown support"
 msgstr "### Поддержка Markdown"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:241
+#: ../../info/wxmaxima.md:240
 msgid ""
 "_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/wiki/"
 "Markdown) conventions that don’t collide with mathematical notation. One of "
@@ -1066,7 +1066,7 @@ msgstr ""
 "списки."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:251
+#: ../../info/wxmaxima.md:250
 #, no-wrap
 msgid ""
 "```text\n"
@@ -1090,12 +1090,12 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:253
+#: ../../info/wxmaxima.md:252
 msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
 msgstr "_WxMaxima_ считает цитатой текст, начинающийся символом `>`:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:261
+#: ../../info/wxmaxima.md:260
 msgid ""
 "```text Ordinary text > quote quote quote quote > quote quote quote quote > "
 "quote quote quote quote Ordinary text ```"
@@ -1104,7 +1104,7 @@ msgstr ""
 "цитата > цитата цитата цитата цитата Обычный текст ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:263
+#: ../../info/wxmaxima.md:262
 msgid ""
 "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by "
 "the corresponding Unicode sign:"
@@ -1113,12 +1113,12 @@ msgstr ""
 "на соответствующий символ Юникода:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:267
+#: ../../info/wxmaxima.md:266
 msgid "```text cogito => sum.  ```"
 msgstr "```text cogito => sum.  ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:269
+#: ../../info/wxmaxima.md:268
 msgid ""
 "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for "
 "comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<-"
@@ -1131,12 +1131,12 @@ msgstr ""
 "TeX также распознаются `<<` и `>>`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:271
+#: ../../info/wxmaxima.md:270
 msgid "### Hotkeys"
 msgstr "### Сочетания клавиш"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:273
+#: ../../info/wxmaxima.md:272
 msgid ""
 "Most hotkeys can be found in the text of the respective menus. Since they "
 "are actually taken from the menu text and thus can be customized by the "
@@ -1151,14 +1151,14 @@ msgstr ""
 "сочетаний клавиш с их псевдонимами в меню отсутствуют:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 msgid ""
 "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
 msgstr ""
 "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> полностью удаляет поле."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 msgid ""
 "<kbd>CTRL</kbd>+<kbd>TAB</kbd> or <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</"
 "kbd> triggers the auto-completion mechanism."
@@ -1167,17 +1167,17 @@ msgstr ""
 "kbd>+<kbd>TAB</kbd> запускает механизм автодополнения."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
 msgstr "<kbd>SHIFT</kbd>+<kbd>ПРОБЕЛ</kbd> вставляет неразрывный пробел."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:279
+#: ../../info/wxmaxima.md:278
 msgid "### Raw TeX in the TeX export"
 msgstr "### Код TeX при экспорте в TeX"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:281
+#: ../../info/wxmaxima.md:280
 msgid ""
 "If a text cell begins with `TeX:` the TeX export contains the literal text "
 "that follows the `TeX:` marker. Using this feature allows the entry of TeX "
@@ -1188,12 +1188,12 @@ msgstr ""
 "позволяет вводить разметку TeX непосредственно в рабочую книгу _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:283
+#: ../../info/wxmaxima.md:282
 msgid "## File Formats"
 msgstr "## Форматы файлов"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:285
+#: ../../info/wxmaxima.md:284
 msgid ""
 "The material that is developed in a _wxMaxima_ session can be stored for "
 "later use in any of three ways:"
@@ -1202,12 +1202,12 @@ msgstr ""
 "дальнейшего использования одним из трёх способов:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:287
+#: ../../info/wxmaxima.md:286
 msgid "### .mac"
 msgstr "### .mac"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:289
+#: ../../info/wxmaxima.md:288
 msgid ""
 "`.mac` files are ordinary text files that contain _Maxima_ commands. They "
 "can be read using _Maxima_’s `batch()` or `load()` command or _wxMaxima_’s "
@@ -1218,7 +1218,7 @@ msgstr ""
 "`load()`, либо с помощью пункта меню _wxMaxima_ «Файл/Пакетный файл»."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:292
+#: ../../info/wxmaxima.md:291
 msgid ""
 "One example is shown below. `Quadratic.mac` defines a function and afterward "
 "generates a plot with `wxdraw2d()`.  Afterward the contents of the file "
@@ -1229,13 +1229,13 @@ msgstr ""
 "файла `Quadratic.mac` и вычисляется вновь определённая функция `f()`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:294
+#: ../../info/wxmaxima.md:293
 msgid "![Loading a file with `batch()`](./BatchImage.png){ id=img_BatchImage }"
 msgstr ""
 "![Загрузка файла с помощью `batch()`](./BatchImage.png){ id=img_BatchImage }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:296
+#: ../../info/wxmaxima.md:295
 msgid ""
 "Attention: Although the file `Quadratic.mac` has a usual _Maxima_ extension "
 "(`.mac`), it can only be read by _wxMaxima_, since the command `wxdraw2d()` "
@@ -1249,7 +1249,7 @@ msgstr ""
 "её имя в выводе."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:298
+#: ../../info/wxmaxima.md:297
 msgid ""
 "You can be use `.mac` files for writing your own library of macros. But "
 "since they don’t contain enough structural information they cannot be read "
@@ -1260,12 +1260,12 @@ msgstr ""
 "они не могут быть считаны как сеанс _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:300
+#: ../../info/wxmaxima.md:299
 msgid "### .wxm"
 msgstr "### .wxm"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:303
+#: ../../info/wxmaxima.md:302
 #, fuzzy
 #| msgid ""
 #| "`.wxm` files contain the worksheet except for _Maxima_’s output. On "
@@ -1289,7 +1289,7 @@ msgstr ""
 "новые функции, со старыми версиями _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:305
+#: ../../info/wxmaxima.md:304
 #, fuzzy
 #| msgid ""
 #| "`.wxm` files contain the worksheet except for _Maxima_’s output. On "
@@ -1309,12 +1309,12 @@ msgstr ""
 "новые функции, со старыми версиями _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:307
+#: ../../info/wxmaxima.md:306
 msgid "#### File format of wxm files"
 msgstr "#### Формат файлов wxm"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:309
+#: ../../info/wxmaxima.md:308
 msgid ""
 "This is just a plain text file (you can open it with a text editor), "
 "containing the cell contents as some special Maxima comments."
@@ -1323,12 +1323,12 @@ msgstr ""
 "содержимое полей хранится в виде специальных комментариев Maxima."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:311
+#: ../../info/wxmaxima.md:310
 msgid "It starts with the following comment:"
 msgstr "Файл начинается со следующего комментария:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:316
+#: ../../info/wxmaxima.md:315
 msgid ""
 "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* "
 "[ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
@@ -1337,7 +1337,7 @@ msgstr ""
 "[ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:318
+#: ../../info/wxmaxima.md:317
 msgid ""
 "And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
 msgstr ""
@@ -1345,7 +1345,7 @@ msgstr ""
 "раздела:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:324
+#: ../../info/wxmaxima.md:323
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1361,7 +1361,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:326
+#: ../../info/wxmaxima.md:325
 msgid ""
 "or (in a Math cell the input is of course *not* commented out (the output is "
 "not saved in a `wxm` file)):"
@@ -1370,7 +1370,7 @@ msgstr ""
 "(вывод не сохраняется в файле `wxm`)):"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:333
+#: ../../info/wxmaxima.md:332
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1388,7 +1388,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:335
+#: ../../info/wxmaxima.md:334
 msgid ""
 "Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the "
 "image type as first line):"
@@ -1397,7 +1397,7 @@ msgstr ""
 "первой строке находится тип изображения:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:342
+#: ../../info/wxmaxima.md:341
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1415,12 +1415,12 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:344
+#: ../../info/wxmaxima.md:343
 msgid "A page break is just one line containing:"
 msgstr "Разрыв страницы представляет собой одну строку следующего содержания:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:348
+#: ../../info/wxmaxima.md:347
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1432,12 +1432,12 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:350
+#: ../../info/wxmaxima.md:349
 msgid "And folded cells marked by:"
 msgstr "Свёрнутые поля обозначаются так:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:356
+#: ../../info/wxmaxima.md:355
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1453,12 +1453,12 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:358
+#: ../../info/wxmaxima.md:357
 msgid "### .wxmx"
 msgstr "### .wxmx"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:360
+#: ../../info/wxmaxima.md:359
 msgid ""
 "This XML-based file format saves the complete worksheet including things "
 "like the zoom factor and the watchlist. It is the preferred file format."
@@ -1468,12 +1468,12 @@ msgstr ""
 "рекомендуемый формат."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:362
+#: ../../info/wxmaxima.md:361
 msgid "#### File format of wxmx files"
 msgstr "#### Формат файлов wxmx"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:365
+#: ../../info/wxmaxima.md:364
 msgid ""
 "A `wxmx`-file seems to be a binary format, but one can handle it with tools, "
 "which are included in your OS. It is a zip file, one can decompress it with "
@@ -1492,12 +1492,12 @@ msgstr ""
 "(занимает куда меньший объём, чем громадные включаемые изображения)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:367
+#: ../../info/wxmaxima.md:366
 msgid "It does contain the following files:"
 msgstr "Содержит следующие файлы:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-"
 "wxmathml`"
@@ -1505,13 +1505,13 @@ msgstr ""
 "`mimetype`: этот файл содержит тип MIME файлов wxMaxima: `text/x-wxmathml`."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`format.txt`: a short description about wxMaxima and the wxmx file format"
 msgstr "`format.txt`: краткое описание wxMaxima и формата файлов wxmx."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima "
 "session and included images."
@@ -1520,7 +1520,7 @@ msgstr ""
 "в сеансе wxMaxima, и включённые изображения."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`content.xml`: a XML document, which contains the various cells of your "
 "document in XML format."
@@ -1529,7 +1529,7 @@ msgstr ""
 "XML."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:374
+#: ../../info/wxmaxima.md:373
 msgid ""
 "So, if something goes wrong, you can unzip a wxMaxima document (maybe rename "
 "it before to a `zip`-file), maybe make changes in the `content.xml` file "
@@ -1544,12 +1544,12 @@ msgstr ""
 "`zip` на `wxmx` — и получаем отредактированный файл `wxmx`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:376
+#: ../../info/wxmaxima.md:375
 msgid "## Configuration options"
 msgstr "## Параметры конфигурации"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:378
+#: ../../info/wxmaxima.md:377
 msgid ""
 "For some common configuration variables _wxMaxima_ offers two ways of "
 "configuring:"
@@ -1558,7 +1558,7 @@ msgstr ""
 "настройки:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
+#: ../../info/wxmaxima.md:380
 msgid ""
 "The configuration dialog box below lets you change their default values for "
 "the current and subsequent sessions."
@@ -1567,7 +1567,7 @@ msgstr ""
 "изменять значения параметров по умолчанию для текущего и последующих сеансов."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
+#: ../../info/wxmaxima.md:380
 msgid ""
 "Also, the values for most configuration variables can be changed for the "
 "current session only by overwriting their values from the worksheet, as "
@@ -1578,7 +1578,7 @@ msgstr ""
 "показано ниже."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:383
+#: ../../info/wxmaxima.md:382
 msgid ""
 "![wxMaxima configuration 1](./wxMaxima_configuration_001.png)"
 "{ id=img_wxMaxima_configuration_001 }"
@@ -1587,12 +1587,12 @@ msgstr ""
 "{ id=img_wxMaxima_configuration_001 }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:385
+#: ../../info/wxmaxima.md:384
 msgid "### Default animation framerate"
 msgstr "### Частота кадров анимации по умолчанию"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:387
+#: ../../info/wxmaxima.md:386
 msgid ""
 "The animation framerate that is used for new animations is kept in the "
 "variable `wxanimate_framerate`. The initial value this variable will contain "
@@ -1604,12 +1604,12 @@ msgstr ""
 "изменить в диалоговом окне настройки параметров конфигурации."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:389
+#: ../../info/wxmaxima.md:388
 msgid "### Default plot size for new _maxima_ sessions"
 msgstr "### Размер графика по умолчанию для новых сеансов _Maxima_"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:391
+#: ../../info/wxmaxima.md:390
 msgid ""
 "After the next start, plots embedded into the worksheet will be created with "
 "this size if the value of `wxplot_size` isn’t changed by _maxima_."
@@ -1619,7 +1619,7 @@ msgstr ""
 "`wxplot_size` не изменялось _Maxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:393
+#: ../../info/wxmaxima.md:392
 msgid ""
 "In order to set the plot size of a single graph only use the following "
 "notation can be used that sets a variable’s value for one command only:"
@@ -1628,7 +1628,7 @@ msgstr ""
 "установке значения переменной для одной команды:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:402
+#: ../../info/wxmaxima.md:401
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1650,17 +1650,17 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:404
+#: ../../info/wxmaxima.md:403
 msgid "### Match parenthesis in text controls"
 msgstr "### Проверять расстановку скобок в текстовом вводе"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:406
+#: ../../info/wxmaxima.md:405
 msgid "This option enables two things:"
 msgstr "Этот параметр активирует сразу две функции:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
+#: ../../info/wxmaxima.md:408
 msgid ""
 "If an opening parenthesis, bracket, or double quote is entered _wxMaxima_ "
 "will insert a closing one after it."
@@ -1669,7 +1669,7 @@ msgstr ""
 "_wxMaxima_ вставляет закрывающую после неё."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
+#: ../../info/wxmaxima.md:408
 msgid ""
 "If text is selected if any of these keys is pressed the selected text will "
 "be put between the matched signs."
@@ -1678,12 +1678,12 @@ msgstr ""
 "помещается между парой этих знаков."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:411
+#: ../../info/wxmaxima.md:410
 msgid "### Don’t save the worksheet automatically"
 msgstr "### Не сохранять рабочий лист автоматически"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:413
+#: ../../info/wxmaxima.md:412
 msgid ""
 "If this option is set, the file where the worksheet is will be overwritten "
 "only the request of the user. In case of a crash/power loss/... a recent "
@@ -1694,7 +1694,7 @@ msgstr ""
 "резервная копия остаётся доступной во временном каталоге."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:415
+#: ../../info/wxmaxima.md:414
 msgid ""
 "If this option isn’t set _wxMaxima_ behaves more like a modern cellphone app:"
 msgstr ""
@@ -1702,22 +1702,22 @@ msgstr ""
 "современное приложение сотового телефона:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
+#: ../../info/wxmaxima.md:417
 msgid "Files are saved automatically on exit"
 msgstr "Файлы автоматически сохраняются при выходе."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
+#: ../../info/wxmaxima.md:417
 msgid "And the file will automatically be saved every 3 minutes."
 msgstr "Также файл автоматически сохраняется каждые 3 минуты."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:420
+#: ../../info/wxmaxima.md:419
 msgid "### Where is the configuration saved?"
 msgstr "### Где сохраняется конфигурация параметров?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:423
+#: ../../info/wxmaxima.md:422
 msgid ""
 "If you are using Unix/Linux, the configuration information will be saved in "
 "a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< "
@@ -1739,7 +1739,7 @@ msgstr ""
 "`.wxMaxima` или `.config` будут скрытыми файлами.)"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:425
+#: ../../info/wxmaxima.md:424
 msgid ""
 "If you are using Windows, the configuration will be stored in the registry. "
 "You will find the entries for _wxMaxima_ at the following position in the "
@@ -1750,12 +1750,12 @@ msgstr ""
 "`HKEY_CURRENT_USER\\Software\\wxMaxima`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:429
+#: ../../info/wxmaxima.md:428
 msgid "# Extensions to _Maxima_"
 msgstr "# Расширения _Maxima_"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:431
+#: ../../info/wxmaxima.md:430
 msgid ""
 "_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
 "its main purpose is to pass along commands to _Maxima_ and to report the "
@@ -1775,12 +1775,12 @@ msgstr ""
 "графики в сеансе."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:433
+#: ../../info/wxmaxima.md:432
 msgid "## Subscripted variables"
 msgstr "## Переменные в нижнем индексе"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:435
+#: ../../info/wxmaxima.md:434
 msgid ""
 "`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript "
 "variable names:"
@@ -1789,7 +1789,7 @@ msgstr ""
 "переводить в нижний индекс имена переменных:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:437
+#: ../../info/wxmaxima.md:436
 msgid ""
 "If it is `false`, the functionality is off, wxMaxima will not autosubscript "
 "part of variable names after an underscore."
@@ -1799,7 +1799,7 @@ msgstr ""
 "символа подчёркивания."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:439
+#: ../../info/wxmaxima.md:438
 msgid ""
 "If it is set to `'all`, everything after an underscore will be subscripted."
 msgstr ""
@@ -1807,7 +1807,7 @@ msgstr ""
 "переводиться в нижний индекс."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:441
+#: ../../info/wxmaxima.md:440
 msgid ""
 "If it is set to `true` variable names of the format `x_y` are displayed "
 "using a subscript if"
@@ -1816,18 +1816,18 @@ msgstr ""
 "индекс, если:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
+#: ../../info/wxmaxima.md:443
 msgid "Either `x` or `y` is a single letter or"
 msgstr "Либо `x` или `y` представлены одной буквой,"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
+#: ../../info/wxmaxima.md:443
 msgid "`y` is an integer (can include more than one character)."
 msgstr ""
 "либо `y` представлена целым числом (может включать более одного символа)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:446
+#: ../../info/wxmaxima.md:445
 msgid ""
 "![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png)"
 "{ id=img_wxsubscripts }"
@@ -1836,7 +1836,7 @@ msgstr ""
 "wxsubscripts](./wxsubscripts.png){ id=img_wxsubscripts }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:448
+#: ../../info/wxmaxima.md:447
 msgid ""
 "If the variable name doesn’t match these requirements, it can still be "
 "declared as \"to be subscripted\" using the command "
@@ -1853,19 +1853,19 @@ msgstr ""
 "команды: `wxdeclare_subscript(variable_name,false);`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:450
+#: ../../info/wxmaxima.md:449
 msgid "You can use the menu \"View->Autosubscript\" to set these values."
 msgstr ""
 "Для установки этих значений можно воспользоваться меню «Вид -> Автоперевод в "
 "нижний индекс»."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:452
+#: ../../info/wxmaxima.md:451
 msgid "## User feedback in the status bar"
 msgstr "## Информация в строке состояния"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:454
+#: ../../info/wxmaxima.md:453
 msgid ""
 "Long-running commands can provide user feedback in the status bar. This user "
 "feedback is replaced by any new feedback that is placed there (allowing to "
@@ -1885,7 +1885,7 @@ msgstr ""
 "`wxstatusbar()` просто не будет обрабатываться."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:465
+#: ../../info/wxmaxima.md:464
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1911,12 +1911,89 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:467
+#: ../../info/wxmaxima.md:466
+msgid "## Exporting the worksheet from within Maxima"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:468
+msgid ""
+"The command `wxworksheettohtml()` exports the current worksheet to an HTML "
+"file from within a running _Maxima_ session, which is convenient for "
+"scripted or batch export. Like `wxstatusbar()` it is safe to use in code "
+"that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present "
+"the command is simply left unevaluated."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:473
+msgid ""
+"```maxima wxworksheettohtml(\"report.html\")$ "
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:475
+msgid ""
+"A relative file name is interpreted relative to _Maxima_’s working "
+"directory. The optional keyword options are:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:480
+#, no-wrap
+msgid ""
+"| option   | values                                          | meaning                                             |\n"
+"| -------- | ----------------------------------------------- | --------------------------------------------------- |\n"
+"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |\n"
+"| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:482
+msgid ""
+"The `flavor` values match the equation formats offered by the graphical "
+"**File → Export** dialog: `mathml` produces a self-contained page that needs "
+"no internet connection, `mathjax` adds a MathJaX fall-back for browsers that "
+"still lack MathML, and `svg`/`bitmap` render every equation to an image."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:484
+msgid ""
+"The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file "
+"the same way:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:489
+msgid ""
+"```maxima wxworksheettotex(\"report.tex\")$ wxworksheettotex(\"report.tex\", "
+"documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:494
+#, no-wrap
+msgid ""
+"| option                 | meaning                                                              |\n"
+"| ---------------------- | -------------------------------------------------------------------- |\n"
+"| `documentclass`        | overrides the LaTeX `\\documentclass` (e.g. `\"article\"`, `\"report\"`)  |\n"
+"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:496
+msgid "Support for `wxworksheettopdf()` is planned."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:498
 msgid "## Plotting"
 msgstr "## Построение графиков"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:469
+#: ../../info/wxmaxima.md:500
 msgid ""
 "Plotting (having fundamentally to do with graphics) is a place where a "
 "graphical user interface will have to provide some extensions to the "
@@ -1927,12 +2004,12 @@ msgstr ""
 "расширений для исходной программы."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:471
+#: ../../info/wxmaxima.md:502
 msgid "### Embedding a plot into the worksheet"
 msgstr "### Встраивание графика в рабочий лист"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:473
+#: ../../info/wxmaxima.md:504
 msgid ""
 "_Maxima_ normally instructs the external program _Gnuplot_ to open a "
 "separate window for every diagram it creates. Since many times it is "
@@ -1947,12 +2024,12 @@ msgstr ""
 "функций _Maxima_ только именем: все они имеют префикс “wx”."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:475
+#: ../../info/wxmaxima.md:506
 msgid "The following plotting functions have wx-counterparts:"
 msgstr "Следующие графические функции имеют wx-аналоги:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:489
+#: ../../info/wxmaxima.md:520
 #, no-wrap
 msgid ""
 "| wxMaxima’s plot function | Maxima’s plot function                                                                          |\n"
@@ -1984,7 +2061,7 @@ msgstr ""
 "| `wxboxplot()`            | [boxplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#boxplot)             |\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:491
+#: ../../info/wxmaxima.md:522
 msgid ""
 "If a `wxm`-file is read by (console) Maxima, these functions are ignored "
 "(and printed as output, as other unknown functions in Maxima)."
@@ -1993,7 +2070,7 @@ msgstr ""
 "(печатаются в выводе, как и другие неизвестные функции в Maxima)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:493
+#: ../../info/wxmaxima.md:524
 msgid ""
 "If you got problems with one of these functions, please check, if the "
 "problem exists in the the Maxima function too (e.g. you got an error with "
@@ -2012,12 +2089,12 @@ msgstr ""
 "sourceforge.net/p/maxima/bugs/). Либо это может быть ошибкой Gnuplot."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:495
+#: ../../info/wxmaxima.md:526
 msgid "### Making embedded plots bigger or smaller"
 msgstr "### Увеличение или уменьшение встроенных графиков"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:497
+#: ../../info/wxmaxima.md:528
 msgid ""
 "As noted above, the configure dialog provides a way to change the default "
 "size plots created which sets the starting value of `wxplot_size`. The "
@@ -2033,7 +2110,7 @@ msgstr ""
 "последующих графиков:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:507
+#: ../../info/wxmaxima.md:538
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2057,7 +2134,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:509
+#: ../../info/wxmaxima.md:540
 msgid ""
 "If the size of only one plot is to be changed _Maxima_ provides a canonical "
 "way to change an attribute only for the current cell. In this usage the "
@@ -2070,7 +2147,7 @@ msgstr ""
 "добавляется к команде `wxdraw2d( )` и не является частью команды `wxdraw2d`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:518
+#: ../../info/wxmaxima.md:549
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2092,7 +2169,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:520
+#: ../../info/wxmaxima.md:551
 msgid ""
 "Setting the size of embedded plot with `wxplot_size` works for embedded "
 "plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` "
@@ -2105,12 +2182,12 @@ msgstr ""
 "анимаций при использовании команд `with_slider_draw` и `wxanimate`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:522
+#: ../../info/wxmaxima.md:553
 msgid "### Better quality plots"
 msgstr "### Улучшение качества графиков"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:524
+#: ../../info/wxmaxima.md:555
 msgid ""
 "_Gnuplot_ doesn’t seem to provide a portable way of determining whether it "
 "supports the high-quality bitmap output that the Cairo library provides. On "
@@ -2130,12 +2207,12 @@ msgstr ""
 "вместо графического изображения будут получены сообщения об ошибке."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:526
+#: ../../info/wxmaxima.md:557
 msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
 msgstr "### Открытие встроенных графиков в интерактивных окнах _Gnuplot_"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:528
+#: ../../info/wxmaxima.md:559
 msgid ""
 "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
 "`wxplot3d` isn’t supported by this feature) and the file size of the "
@@ -2148,12 +2225,12 @@ msgstr ""
 "_wxMaxima_, которое позволяет открыть график в интерактивном окне _Gnuplot_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:530
+#: ../../info/wxmaxima.md:561
 msgid "### Opening Gnuplot’s command console in `plot` windows"
 msgstr "### Открытие командной строки Gnuplot в окне `plot`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:533
+#: ../../info/wxmaxima.md:564
 msgid ""
 "On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and "
 "`wgnuplot.exe`.  You can configure, which command should be used using the "
@@ -2171,12 +2248,12 @@ msgstr ""
 "подготовке графика."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:535
+#: ../../info/wxmaxima.md:566
 msgid "### Embedding animations into the spreadsheet"
 msgstr "### Встраивание анимаций в электронную таблицу"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:537
+#: ../../info/wxmaxima.md:568
 msgid ""
 "3D diagrams tend to make it hard to read quantitative data. A viable "
 "alternative might be to assign the 3rd parameter to the mouse wheel. The "
@@ -2192,7 +2269,7 @@ msgstr ""
 "анимацию в виде анимированного файла gif."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:539
+#: ../../info/wxmaxima.md:570
 msgid ""
 "The first two arguments for `with_slider_draw` are the name of the variable "
 "that is stepped between the plots and a list of the values of these "
@@ -2204,7 +2281,7 @@ msgstr ""
 "значений этой переменной. За ними следуют обычные аргументы для `wxdraw2d`:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:550
+#: ../../info/wxmaxima.md:581
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2230,7 +2307,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:552
+#: ../../info/wxmaxima.md:583
 msgid ""
 "The same functionality for 3D plots is accessible as `with_slider_draw3d`, "
 "which allows for rotating 3d plots:"
@@ -2239,7 +2316,7 @@ msgstr ""
 "команды `with_slider_draw3d`, которая позволяет вращать трёхмерные графики:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:569
+#: ../../info/wxmaxima.md:600
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2277,7 +2354,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:571
+#: ../../info/wxmaxima.md:602
 msgid ""
 "If the general shape of the plot is what matters it might suffice to move "
 "the plot just a little bit in order to make its 3D nature available to the "
@@ -2288,7 +2365,7 @@ msgstr ""
 "интуитивно узнаваемой:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:588
+#: ../../info/wxmaxima.md:619
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2326,7 +2403,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:590
+#: ../../info/wxmaxima.md:621
 msgid ""
 "For those more familiar with `plot` than with `draw`, there is a second set "
 "of functions:"
@@ -2335,17 +2412,17 @@ msgstr ""
 "функций:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
+#: ../../info/wxmaxima.md:624
 msgid "`with_slider` and"
 msgstr "`with_slider` и"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
+#: ../../info/wxmaxima.md:624
 msgid "`wxanimate`."
 msgstr "`wxanimate`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:595
+#: ../../info/wxmaxima.md:626
 msgid ""
 "Normally the animations are played back or exported with the frame rate "
 "chosen in the configuration of _wxMaxima_. To set the speed at an individual "
@@ -2356,7 +2433,7 @@ msgstr ""
 "отдельной анимации можно воспользоваться параметром `wxanimate_framerate`:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:600
+#: ../../info/wxmaxima.md:631
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2370,7 +2447,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:602
+#: ../../info/wxmaxima.md:633
 msgid ""
 "The animation functions use _Maxima_’s `makelist` command and therefore "
 "share the pitfall that the slider variable’s value is substituted into the "
@@ -2383,7 +2460,7 @@ msgstr ""
 "выражении. Поэтому приведённый далее пример вызовет появление ошибки:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:612
+#: ../../info/wxmaxima.md:643
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2407,7 +2484,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:614
+#: ../../info/wxmaxima.md:645
 msgid ""
 "If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
 "works fine instead:"
@@ -2416,7 +2493,7 @@ msgstr ""
 "построение графиков работает прекрасно:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:627
+#: ../../info/wxmaxima.md:658
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2446,12 +2523,12 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:629
+#: ../../info/wxmaxima.md:660
 msgid "### Opening multiple plots in contemporaneous windows"
 msgstr "### Одновременное открытие нескольких графиков в нескольких окнах"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:631
+#: ../../info/wxmaxima.md:662
 msgid ""
 "While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups "
 "that support it) sometimes comes in handily. The following example comes "
@@ -2462,26 +2539,26 @@ msgstr ""
 "письма, которое Mario Rodriguez отправил в рассылку _Maxima_:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:634
+#: ../../info/wxmaxima.md:665
 msgid "```maxima load(draw);"
 msgstr "```maxima load(draw);"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:637
+#: ../../info/wxmaxima.md:668
 msgid ""
 "/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
 msgstr ""
 "/* Парабола в окне #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:640
+#: ../../info/wxmaxima.md:671
 msgid ""
 "/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
 msgstr ""
 "/* Парабола в окне #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:644
+#: ../../info/wxmaxima.md:675
 msgid ""
 "/* Paraboloid in window #3 */ "
 "draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```"
@@ -2490,7 +2567,7 @@ msgstr ""
 "draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:646
+#: ../../info/wxmaxima.md:677
 msgid ""
 "Plotting multiple plots in the same window is possible, too (the same is "
 "possible in command line Maxima with the standard `draw()` command):"
@@ -2500,7 +2577,7 @@ msgstr ""
 "`draw()`):"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:657
+#: ../../info/wxmaxima.md:688
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2526,12 +2603,12 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:659
+#: ../../info/wxmaxima.md:690
 msgid "### The \"Plot using draw\" side pane"
 msgstr "### Боковая панель «График с помощью Draw»"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:661
+#: ../../info/wxmaxima.md:692
 msgid ""
 "The \"Plot using draw\" sidebar hides a simple code generator that allows "
 "generating scenes that make use of some of the flexibility of the _draw_ "
@@ -2542,12 +2619,12 @@ msgstr ""
 "_draw_, поставляемого с _Maxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:663
+#: ../../info/wxmaxima.md:694
 msgid "#### 2D"
 msgstr "#### Двухмерный график"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:665
+#: ../../info/wxmaxima.md:696
 msgid ""
 "Generates the skeleton of a `draw()` command that draws a 2D scene. This "
 "scene later has to be filled with commands that generate the scene’s "
@@ -2559,7 +2636,7 @@ msgstr ""
 "наполнение, например, с помощью кнопок в строках под кнопкой «2D»."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:667
+#: ../../info/wxmaxima.md:698
 msgid ""
 "One helpful feature of the 2D button is that it allows to set up the scene "
 "as an animation in which a variable (by default it is _t_) has a different "
@@ -2572,12 +2649,12 @@ msgstr ""
 "график, чем те же самые данные в неподвижной трёхмерной сцене."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:669
+#: ../../info/wxmaxima.md:700
 msgid "#### 3D"
 msgstr "#### Трёхмерный график"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:671
+#: ../../info/wxmaxima.md:702
 msgid ""
 "Generates the skeleton of a `draw()` command that draws a 3D scene. If "
 "neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D "
@@ -2589,12 +2666,12 @@ msgstr ""
 "команду."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:673
+#: ../../info/wxmaxima.md:704
 msgid "#### Expression"
 msgstr "#### Выражение"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:675
+#: ../../info/wxmaxima.md:706
 msgid ""
 "Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or "
 "`x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is "
@@ -2607,12 +2684,12 @@ msgstr ""
 "сцена может быть заполнена любым количеством графиков."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:677
+#: ../../info/wxmaxima.md:708
 msgid "#### Implicit plot"
 msgstr "#### График неявной функции"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:679
+#: ../../info/wxmaxima.md:710
 msgid ""
 "Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or "
 "`x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command "
@@ -2625,12 +2702,12 @@ msgstr ""
 "draw отсутствует, то будет создана двухмерная сцена."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:681
+#: ../../info/wxmaxima.md:712
 msgid "#### Parametric plot"
 msgstr "#### График параметрической функции"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:683
+#: ../../info/wxmaxima.md:714
 msgid ""
 "Steps a variable from a lower limit to an upper limit and uses two "
 "expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in "
@@ -2643,12 +2720,12 @@ msgstr ""
 "draw."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:685
+#: ../../info/wxmaxima.md:716
 msgid "#### Points"
 msgstr "#### Точки"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:687
+#: ../../info/wxmaxima.md:718
 msgid ""
 "Draws many points that can optionally be joined. The coordinates of the "
 "points are taken from a list of lists, a 2D array or one list or array for "
@@ -2659,32 +2736,32 @@ msgstr ""
 "одного списка или массива для каждой оси."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:689
+#: ../../info/wxmaxima.md:720
 msgid "#### Diagram title"
 msgstr "#### Заголовок диаграммы"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:691
+#: ../../info/wxmaxima.md:722
 msgid "Draws a title on the upper end of the diagram,"
 msgstr "Рисует заголовок в верхней части диаграммы."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:693
+#: ../../info/wxmaxima.md:724
 msgid "#### Axis"
 msgstr "#### Ось"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:695
+#: ../../info/wxmaxima.md:726
 msgid "Sets up the axis."
 msgstr "Задаёт ось."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:697
+#: ../../info/wxmaxima.md:728
 msgid "#### Contour"
 msgstr "#### Контур"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:699
+#: ../../info/wxmaxima.md:730
 msgid ""
 "(Only for 3D plots): Adds contour lines similar to the ones one can find in "
 "a map of a mountain to the plot commands that follow in the current `draw()` "
@@ -2699,12 +2776,12 @@ msgstr ""
 "оставляя на графике только контуры."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:701
+#: ../../info/wxmaxima.md:732
 msgid "#### Plot name"
 msgstr "#### Название графика"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:703
+#: ../../info/wxmaxima.md:734
 msgid ""
 "Adds a legend entry showing the next plot’s name to the legend of the "
 "diagram. An empty name disables generating legend entries for the following "
@@ -2715,12 +2792,12 @@ msgstr ""
 "графиков."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:705
+#: ../../info/wxmaxima.md:736
 msgid "#### Line colour"
 msgstr "#### Цвет линии"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:707
+#: ../../info/wxmaxima.md:738
 msgid ""
 "Sets the line colour for the following plots the current draw command "
 "contains."
@@ -2729,12 +2806,12 @@ msgstr ""
 "команды draw."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:709
+#: ../../info/wxmaxima.md:740
 msgid "#### Fill colour"
 msgstr "#### Цвет заливки"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:711
+#: ../../info/wxmaxima.md:742
 msgid ""
 "Sets the fill colour for the following plots the current draw command "
 "contains."
@@ -2743,22 +2820,22 @@ msgstr ""
 "draw."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:713
+#: ../../info/wxmaxima.md:744
 msgid "#### Grid"
 msgstr "#### Сетка"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:715
+#: ../../info/wxmaxima.md:746
 msgid "Pops up a wizard that allows to set up grid lines."
 msgstr "Выводит мастер, позволяющий задать линии сетки."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:717
+#: ../../info/wxmaxima.md:748
 msgid "#### Accuracy"
 msgstr "#### Точность"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:719
+#: ../../info/wxmaxima.md:750
 msgid ""
 "Allows to select an adequate point in the speed vs. accuracy tradeoff that "
 "is part of any plot program."
@@ -2768,12 +2845,12 @@ msgstr ""
 "графиков."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:721
+#: ../../info/wxmaxima.md:752
 msgid "### Modify font and font size for plots"
 msgstr "### Изменение шрифта и размера шрифта для графиков"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:723
+#: ../../info/wxmaxima.md:754
 msgid ""
 "Especially when you use a high resolution display, the default font size "
 "might be very small. For the `draw`-based commands, you can set the font / "
@@ -2785,7 +2862,7 @@ msgstr ""
 "как `font=...`, `font_size=...`, например:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:730
+#: ../../info/wxmaxima.md:761
 #, no-wrap
 msgid ""
 "~~~maxima\n"
@@ -2803,7 +2880,7 @@ msgstr ""
 "~~~\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:732
+#: ../../info/wxmaxima.md:763
 msgid ""
 "For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts "
 "can be set using the `gnuplot_preamble` command, e.g.:"
@@ -2813,7 +2890,7 @@ msgstr ""
 "например:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:737
+#: ../../info/wxmaxima.md:768
 #, no-wrap
 msgid ""
 "~~~maxima\n"
@@ -2827,7 +2904,7 @@ msgstr ""
 "~~~\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:739
+#: ../../info/wxmaxima.md:770
 msgid ""
 "This sets the font for the numbers to Arial with size 30, the size for the "
 "xlabel and ylabel font to 20 (with the default font)."
@@ -2836,7 +2913,7 @@ msgstr ""
 "Размер шрифта для xlabel и ylabel будет равен 20 (со шрифтом по умолчанию)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:742
+#: ../../info/wxmaxima.md:773
 msgid ""
 "Read the Maxima and Gnuplot documentation for further information.  Note: "
 "Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue "
@@ -2848,12 +2925,12 @@ msgstr ""
 "wxMaxima-developers/wxmaxima/issues/1966)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:744
+#: ../../info/wxmaxima.md:775
 msgid "## Embedding graphics"
 msgstr "## Встраивание графики"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:746
+#: ../../info/wxmaxima.md:777
 msgid ""
 "If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
 "project can be done as easily as per drag-and-drop. But sometimes (for "
@@ -2866,17 +2943,17 @@ msgstr ""
 "задать загрузку файла изображения после проведения вычислений:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:750
+#: ../../info/wxmaxima.md:781
 msgid "```maxima show_image(\"man.png\"); ```"
 msgstr "```maxima show_image(\"man.png\"); ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:752
+#: ../../info/wxmaxima.md:783
 msgid "## Startup files"
 msgstr "## Файлы запуска"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:754
+#: ../../info/wxmaxima.md:785
 msgid ""
 "The config dialogue of _wxMaxima_ offers to edit two files with commands "
 "that are executed on startup:"
@@ -2885,7 +2962,7 @@ msgstr ""
 "командами, которые выполняются при запуске:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
+#: ../../info/wxmaxima.md:788
 msgid ""
 "A file that contains commands that are executed on starting up _Maxima_: "
 "`maxima-init.mac`"
@@ -2894,7 +2971,7 @@ msgstr ""
 "init.mac`."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
+#: ../../info/wxmaxima.md:788
 msgid ""
 "one file of additional commands that are executed if _wxMaxima_ is starting "
 "_Maxima_: `wxmaxima-init.mac`"
@@ -2903,7 +2980,7 @@ msgstr ""
 "запускает _Maxima_: `wxmaxima-init.mac`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:759
+#: ../../info/wxmaxima.md:790
 msgid ""
 "For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add "
 "`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` "
@@ -2914,7 +2991,7 @@ msgstr ""
 "gnuplot/bin/gnuplot` или любой другой путь)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:761
+#: ../../info/wxmaxima.md:792
 msgid ""
 "These files are in the Maxima user directory (usually `%USERPROFILE%/maxima` "
 "in Windows, `$HOME/.maxima` otherwise). The location can be found out with "
@@ -2925,12 +3002,12 @@ msgstr ""
 "выяснить с помощью команды: `maxima_userdir;`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:763
+#: ../../info/wxmaxima.md:794
 msgid "## Special variables wx..."
 msgstr "## Специальные переменные wx…"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxsubscripts` tells _Maxima_ if it should convert variable names that "
 "contain an underscore (`R_150` or the like) into subscripted variables. See "
@@ -2944,7 +3021,7 @@ msgstr ""
 "`wxdeclare_subscript`."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxfilename`: This variable contains the name of the file currently opened "
 "in _wxMaxima_."
@@ -2953,7 +3030,7 @@ msgstr ""
 "открыт в _wxMaxima_."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxdirname`: This variable contains the name the directory, in which the "
 "file currently opened in _wxMaxima_ is."
@@ -2962,7 +3039,7 @@ msgstr ""
 "текущий открытый в _wxMaxima_ файл."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_’s pngcairo "
 "terminal that provides more line styles and a better overall graphics "
@@ -2973,12 +3050,12 @@ msgstr ""
 "линий и обеспечивает лучшее качество графики в целом."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxplot_size` defines the resolution of embedded plots."
 msgstr "`wxplot_size` определяет разрешение встроенных графиков."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
 "_Maxima_’s working directory to the directory of the current file. This "
@@ -2996,7 +3073,7 @@ msgstr ""
 "диалоге настройки."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxanimate_framerate`: The number of frames per second the following "
 "animations have to be played back with."
@@ -3005,31 +3082,31 @@ msgstr ""
 "воспроизводить следующие анимации."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxanimate_autoplay`: Automatically play animations by default?"
 msgstr ""
 "`wxanimate_autoplay`: следует ли автоматически воспроизводить анимации по "
 "умолчанию."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
 msgstr "`wxmaximaversion`: возвращает номер версии _wxMaxima_."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
 msgstr ""
 "`wxwidgetsversion`: возвращает версию wxWidgets, которую использует "
 "_wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:776
+#: ../../info/wxmaxima.md:807
 msgid "## Pretty-printing 2D output"
 msgstr "## Структурный вывод двухмерных данных"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:778
+#: ../../info/wxmaxima.md:809
 msgid ""
 "The function `table_form()` displays a 2D list in a form that is more "
 "readable than the output from _Maxima_’s default output routine. The input "
@@ -3045,7 +3122,7 @@ msgstr ""
 "же таблицы вместе с сообщением «done»."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:787
+#: ../../info/wxmaxima.md:818
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -3067,7 +3144,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:789
+#: ../../info/wxmaxima.md:820
 msgid ""
 "As the next example shows, the lists that are assembled by the `table_form` "
 "command can be created before the command is executed."
@@ -3076,7 +3153,7 @@ msgstr ""
 "`table_form`, могут создаваться до выполнения команды."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:791
+#: ../../info/wxmaxima.md:822
 msgid ""
 "![A third table example](./MatrixTableExample.png)"
 "{ id=img_MatrixTableExample }"
@@ -3085,7 +3162,7 @@ msgstr ""
 "{ id=img_MatrixTableExample }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:793
+#: ../../info/wxmaxima.md:824
 msgid ""
 "Also, because a matrix is a list of lists, matrices can be converted to "
 "tables in a similar fashion."
@@ -3094,7 +3171,7 @@ msgstr ""
 "образом преобразовываться в таблицы."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:795
+#: ../../info/wxmaxima.md:826
 msgid ""
 "![Another table_form example](./SecondTableExample.png)"
 "{ id=img_SecondTableExample }"
@@ -3103,28 +3180,56 @@ msgstr ""
 "{ id=img_SecondTableExample }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:797
+#: ../../info/wxmaxima.md:828
 msgid ""
 "The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that "
 "allows for more flexible formatting of matrices in wxMaxima:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:803
+#: ../../info/wxmaxima.md:830
 #, no-wrap
+msgid "**`wx_matrix( <matrix>, [options] )`**\n"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
 msgid ""
-"**`wx_matrix( <matrix>, [options] )`**\n"
-"- **`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data.\n"
-"- **`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels.\n"
-"- **`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels.\n"
-"- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`.\n"
+"**`lines=true`**: Draws internal separator lines between the cells. This is "
+"required to visually separate headings from data."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`rownames=true`**: Tells wxMaxima that the first column of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`colnames=true`**: Tells wxMaxima that the first row of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
+"around the matrix. Supported styles are: `round` `()`, `square` `[]`, "
+"`angled` `<>`, `straight` `||`, or `none`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:809
+#: ../../info/wxmaxima.md:837
+msgid "Example:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:842
 #, no-wrap
 msgid ""
-"Example:\n"
 "```maxima\n"
 "wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
 "          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
@@ -3132,12 +3237,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:811
+#: ../../info/wxmaxima.md:844
 msgid "## Bug reporting"
 msgstr "## Отчёты об ошибках"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:813
+#: ../../info/wxmaxima.md:846
 msgid ""
 "_WxMaxima_ provides a few functions that gather bug reporting information "
 "about the current system:"
@@ -3146,7 +3251,7 @@ msgstr ""
 "текущей системе для формирования отчёта об ошибках:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:816
+#: ../../info/wxmaxima.md:849
 msgid ""
 "`wxbuild_info()` gathers information about the currently running version of "
 "_wxMaxima_"
@@ -3155,17 +3260,17 @@ msgstr ""
 "_wxMaxima_."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:816
+#: ../../info/wxmaxima.md:849
 msgid "`wxbug_report()` tells how and where to file bugs"
 msgstr "`wxbug_report()` определяет, как и куда отправлять отчёты об ошибках."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:819
+#: ../../info/wxmaxima.md:851
 msgid "## Marking output being drawn in red"
 msgstr "## Выделение вывода красным цветом"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:822
+#: ../../info/wxmaxima.md:854
 msgid ""
 "_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a "
 "red foreground, if the second argument to the command is the text "
@@ -3176,19 +3281,19 @@ msgstr ""
 "`highlight`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:824
+#: ../../info/wxmaxima.md:856
 msgid "## Output rendering."
 msgstr "## Визуализация вывода"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:826
+#: ../../info/wxmaxima.md:858
 msgid "With `set_display()` one can set, how wxMaxima will render the output."
 msgstr ""
 "`set_display()` позволяет указать, как wxMaxima следует визуализировать "
 "вывод."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:828
+#: ../../info/wxmaxima.md:860
 msgid ""
 "`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima "
 "using an (machine readable) XML-dialect (can be seen in the \"Raw XML "
@@ -3202,7 +3307,7 @@ msgstr ""
 "матрицы, знаки квадратного корня, дроби и так далее."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:831
+#: ../../info/wxmaxima.md:863
 msgid ""
 "<!--- Currently that does not work as it should, the line with the output "
 "label is shifted right (issue: #2006) --> `set_display('ascii)` causes "
@@ -3213,7 +3318,7 @@ msgstr ""
 "формулы как в командной строке Maxima, то есть в виде символов ASCII."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:833
+#: ../../info/wxmaxima.md:865
 msgid ""
 "`set_display('none)` causes 'one-line' ASCII results - the same as the "
 "command line Maxima command `display2d:false;` does."
@@ -3222,12 +3327,12 @@ msgstr ""
 "делает то же самое, что и команда `display2d:false;` командной строки Maxima."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:867
 msgid "# Help menu"
 msgstr "# Меню справки"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:837
+#: ../../info/wxmaxima.md:869
 msgid ""
 "WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, "
 "tips, some example worksheets and in command line Maxima included demos (the "
@@ -3238,21 +3343,21 @@ msgstr ""
 "демонстрационным примерам в командной строке Maxima (команда `demo()`)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:839
+#: ../../info/wxmaxima.md:871
 msgid "Please notice, that the demos write:"
 msgstr "Обратите внимание на вывод демонстрационных примеров:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:843
+#: ../../info/wxmaxima.md:875
 msgid ""
 "~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the "
 "demonstration.  ~~~"
 msgstr ""
-"~~~text При появлении приглашения в виде ’_’ введите ’;’ и нажмите <enter> для "
-"продолжения демонстрации.  ~~~"
+"~~~text При появлении приглашения в виде ’_’ введите ’;’ и нажмите <enter> "
+"для продолжения демонстрации.  ~~~"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:845
+#: ../../info/wxmaxima.md:877
 msgid ""
 "That is valid for command-line Maxima, however in wxMaxima by default it is "
 "necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</"
@@ -3263,7 +3368,7 @@ msgstr ""
 "kbd>+<kbd>ENTER</kbd>"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:847
+#: ../../info/wxmaxima.md:879
 msgid ""
 "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending "
 "commands to Maxima\" menu.)"
@@ -3272,17 +3377,17 @@ msgstr ""
 "клавиш для отправки команд в Maxima».)"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:851
+#: ../../info/wxmaxima.md:883
 msgid "# Troubleshooting"
 msgstr "# Устранение неполадок"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:853
+#: ../../info/wxmaxima.md:885
 msgid "## Cannot connect to _Maxima_"
 msgstr "## Не удаётся установить соединение с _Maxima_"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:855
+#: ../../info/wxmaxima.md:887
 msgid ""
 "Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ "
 "(providing the easy-to-use user interface) are separate programs that "
@@ -3310,7 +3415,7 @@ msgstr ""
 "программы sbcl, gcl, ccl, lisp.exe или подобные им."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:857
+#: ../../info/wxmaxima.md:889
 msgid ""
 "On Unix computers another possible reason would be that the loopback network "
 "that provides network connections between two programs in the same computer "
@@ -3321,12 +3426,12 @@ msgstr ""
 "двумя программами на одном компьютере."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:859
+#: ../../info/wxmaxima.md:891
 msgid "## How to save data from a broken .wxmx file"
 msgstr "## Как сохранить данные из повреждённого файла .wxmx"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:861
+#: ../../info/wxmaxima.md:893
 msgid ""
 "Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ "
 "doesn’t turn on compression, so the contents of `.wxmx` files can be viewed "
@@ -3337,7 +3442,7 @@ msgstr ""
 "файлов `.wxmx` можно просматривать в текстовом редакторе."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:863
+#: ../../info/wxmaxima.md:895
 msgid ""
 "If the zip signature at the end of the file is still intact after renaming a "
 "broken `.wxmx` file to `.zip` most operating systems will provide a way to "
@@ -3357,7 +3462,7 @@ msgstr ""
 "полезным."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:865
+#: ../../info/wxmaxima.md:897
 msgid ""
 "And even if there isn’t such a file: The `.wxmx` file is a container format "
 "and the XML portion is stored uncompressed. It it is possible to rename the "
@@ -3375,7 +3480,7 @@ msgstr ""
 "двоичный код)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:867
+#: ../../info/wxmaxima.md:899
 msgid ""
 "If a text file containing only these contents (e.g. copy and paste this text "
 "into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know "
@@ -3386,7 +3491,7 @@ msgstr ""
 "_wxMaxima_ сможет восстановить текст из этого документа."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:869
+#: ../../info/wxmaxima.md:901
 msgid ""
 "## I want some debug info to be displayed on the screen before my command "
 "has finished"
@@ -3394,7 +3499,7 @@ msgstr ""
 "## Как вывести отладочную информацию на экран до завершения работы команды"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:871
+#: ../../info/wxmaxima.md:903
 msgid ""
 "Normally _wxMaxima_ waits for the whole 2D formula to be transferred before "
 "it begins to typeset. This saves time for making many attempts to typeset a "
@@ -3409,7 +3514,7 @@ msgstr ""
 "информации без ожидания завершения выполнения текущей команды _Maxima_:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:881
+#: ../../info/wxmaxima.md:913
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -3433,21 +3538,21 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:883
+#: ../../info/wxmaxima.md:915
 msgid "Alternatively one can look for the `wxstatusbar()` command above."
 msgstr ""
 "Альтернативный вариант —  воспользоваться командой `wxstatusbar()` (её "
 "описание приводилось выше)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:885
+#: ../../info/wxmaxima.md:917
 msgid "## Plotting only shows a closed empty envelope with an error message"
 msgstr ""
 "## Функция построения графика показывает только закрытый пустой конверт с "
 "сообщением об ошибке"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:887
+#: ../../info/wxmaxima.md:919
 msgid ""
 "This means that _wxMaxima_ could not read the file _Maxima_ that was "
 "supposed to instruct _Gnuplot_ to create."
@@ -3456,12 +3561,12 @@ msgstr ""
 "быть создан _Gnuplot_ по инструкции от _Maxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:889
+#: ../../info/wxmaxima.md:921
 msgid "Possible reasons for this error are:"
 msgstr "Возможные причины ошибки:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 msgid ""
 "The plotting command is part of a third-party package like `implicit_plot` "
 "but this package was not loaded by _Maxima_’s `load()` command before trying "
@@ -3472,7 +3577,7 @@ msgstr ""
 "_Maxima_ перед попыткой построить график."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 msgid ""
 "_Maxima_ tried to do something the currently installed version of _Gnuplot_ "
 "isn’t able to understand. In this case, a file ending in `.gnuplot` located "
@@ -3487,7 +3592,7 @@ msgstr ""
 "содержимое этого файла помогает при отладке."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 msgid ""
 "Gnuplot was instructed to use the pngCairo library that provides "
 "antialiasing and additional line styles, but it was not compiled to support "
@@ -3503,17 +3608,17 @@ msgstr ""
 "«true» в _Maxima_."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 msgid "Gnuplot didn’t output a valid `.png` file."
 msgstr "Вывод Gnuplot — некорректный файл `.png`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:896
+#: ../../info/wxmaxima.md:928
 msgid "## Plotting an animation results in “error: undefined variable”"
 msgstr "## При создании анимации выводится ошибка «error: undefined variable»"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:898
+#: ../../info/wxmaxima.md:930
 msgid ""
 "The value of the slider variable by default is only substituted into the "
 "expression that is to be plotted if it is visible there. Using a `subst` "
@@ -3530,14 +3635,14 @@ msgstr ""
 "есть соответствующий пример."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:900
+#: ../../info/wxmaxima.md:932
 msgid "## I lost cell content and undo doesn’t remember"
 msgstr ""
 "## Содержимое поля потеряно, и отмена действия не может помочь в его "
 "восстановлении"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:902
+#: ../../info/wxmaxima.md:934
 msgid ""
 "There are separate undo functions for cell operations and for changes inside "
 "of cells so chances are low that this ever happens. If it does there are "
@@ -3549,7 +3654,7 @@ msgstr ""
 "восстановления данных:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid ""
 "_WxMaxima_ actually has two undo features: The global undo buffer that is "
 "active if no cell is selected and a per-cell undo buffer that is active if "
@@ -3562,7 +3667,7 @@ msgstr ""
 "функциями, чтобы увидеть, можно ли ещё получить доступ к старому значению."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid ""
 "If you still have a way to find out what label _Maxima_ has assigned to the "
 "cell just type in the cell’s label and its contents will reappear."
@@ -3571,7 +3676,7 @@ msgstr ""
 "эту метку, чтобы содержимое поля появилось вновь."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid ""
 "If you don’t: Don’t panic. In the “View” menu there is a way to show a "
 "history pane that shows all _Maxima_ commands that have been issued recently."
@@ -3580,26 +3685,26 @@ msgstr ""
 "показаны все недавно отданные команды _Maxima_."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid "If nothing else helps _Maxima_ contains a replay feature:"
 msgstr ""
 "Если больше ничего не помогло, в _Maxima_ есть функция повторного "
 "воспроизведения:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:911
+#: ../../info/wxmaxima.md:943
 msgid "```maxima playback(); ```"
 msgstr "```maxima playback(); ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:913
+#: ../../info/wxmaxima.md:945
 msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
 msgstr ""
 "## _WxMaxima_ запускается с выводом сообщения «Процесс Maxima неожиданно "
 "завершился.»"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:915
+#: ../../info/wxmaxima.md:947
 msgid ""
 "One possible reason is that _Maxima_ cannot be found in the location that is "
 "set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore "
@@ -3612,12 +3717,12 @@ msgstr ""
 "решается указанием пути к рабочему исполняемому файлу _Maxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:917
+#: ../../info/wxmaxima.md:949
 msgid "## Maxima is forever calculating and not responding to input"
 msgstr "## Maxima слишком долго выполняет вычисление и не отвечает на ввод"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:919
+#: ../../info/wxmaxima.md:951
 msgid ""
 "It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ "
 "has finished calculating and therefore never gets informed it can send new "
@@ -3630,12 +3735,12 @@ msgstr ""
 "evaluation” может помочь повторно синхронизировать эти две программы."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:921
+#: ../../info/wxmaxima.md:953
 msgid "## My SBCL-based _Maxima_ runs out of memory"
 msgstr "## При работе _Maxima_ на основе SBCL заканчивается свободная память"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:923
+#: ../../info/wxmaxima.md:955
 msgid ""
 "The Lisp compiler SBCL by default comes with a memory limit that allows it "
 "to run even on low-end computers. When compiling a big software package like "
@@ -3657,7 +3762,7 @@ msgstr ""
 "зарезервировать более 1280 мегабайт, необходимых для компилирования Lapack."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:925
+#: ../../info/wxmaxima.md:957
 msgid ""
 "One way to provide _Maxima_ (and thus SBCL) with command line parameters is "
 "the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration "
@@ -3668,17 +3773,17 @@ msgstr ""
 "диалоговом окне настройки параметров конфигурации _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:927
+#: ../../info/wxmaxima.md:959
 msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
 msgstr "![Память sbcl](./sbclMemory.png){ id=img_sbclMemory }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:929
+#: ../../info/wxmaxima.md:961
 msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
 msgstr "## Иногда ввод бывает медленным/игнорирует нажатия клавиш в Ubuntu"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:931
+#: ../../info/wxmaxima.md:963
 msgid ""
 "Installing the package `ibus-gtk` should resolve this issue. See ([https://"
 "bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://"
@@ -3690,14 +3795,14 @@ msgstr ""
 "wxwidgets3.0/+bug/1421558))."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:933
+#: ../../info/wxmaxima.md:965
 msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
 msgstr ""
 "## _WxMaxima_ зависает, когда _Maxima_ обрабатывает греческие символы или "
 "умляуты"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:935
+#: ../../info/wxmaxima.md:967
 msgid ""
 "If your _Maxima_ is based on SBCL the following lines have to be added to "
 "your `.sbclrc`:"
@@ -3706,12 +3811,12 @@ msgstr ""
 "необходимо добавить следующие строки:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:971
 msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
 msgstr "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:941
+#: ../../info/wxmaxima.md:973
 msgid ""
 "The folder where this file has to be placed is system- and installation-"
 "specific. But any SBCL-based _Maxima_ that already has evaluated a cell in "
@@ -3724,17 +3829,17 @@ msgstr ""
 "после получения следующей команды:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:945
+#: ../../info/wxmaxima.md:977
 msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
 msgstr "```maxima :lisp (sb-impl::userinit-pathname)  ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:947
+#: ../../info/wxmaxima.md:979
 msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
 msgstr "## Примечание касательно Wayland (свежие дистрибутивы Linux/BSD)"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:950
+#: ../../info/wxmaxima.md:982
 msgid ""
 "There seem to be issues with the Wayland Display Server and wxWidgets.  "
 "WxMaxima may be affected, e.g. that sidebars are not moveable."
@@ -3744,7 +3849,7 @@ msgstr ""
 "перемещать боковые панели)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:954
+#: ../../info/wxmaxima.md:986
 msgid ""
 "You can either disable Wayland and use X11 instead (globally)  or just tell, "
 "that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
@@ -3754,22 +3859,54 @@ msgstr ""
 "System, установкой параметра: `GDK_BACKEND=x11`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:956
+#: ../../info/wxmaxima.md:988
 msgid "E.g. start wxMaxima with:"
 msgstr "Например, запустить wxMaxima с параметром:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:958
+#: ../../info/wxmaxima.md:990
 msgid "`GDK_BACKEND=x11 wxmaxima`"
 msgstr "`GDK_BACKEND=x11 wxmaxima`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:960
+#: ../../info/wxmaxima.md:992
+msgid "## The menu bar disappears on KDE Plasma"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:997
+msgid ""
+"On some KDE Plasma installations the global menu bar disappears when "
+"clicked.  As this is a bug in the global menu proxy, the only way to avoid "
+"it is to tell that wxMaxima should use its own menu bar instead of the "
+"global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1001
+msgid ""
+"Starting with version 26.05.0, wxMaxima attempts to set this variable "
+"automatically if it detects an affected system (KDE, Unity, or Ubuntu with "
+"older wxWidgets versions)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1003
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1005
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1007
 msgid "## Why is the integrated manual browser not offered on my Windows PC?"
 msgstr "## Почему встроенный браузер руководства отсутствует на ПК с Windows?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:963
+#: ../../info/wxmaxima.md:1010
 msgid ""
 "Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or "
 "Microsoft’s webview2 isn’t installed."
@@ -3778,12 +3915,12 @@ msgstr ""
 "Microsoft, либо компонент webview2 от Microsoft не был установлен."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:965
+#: ../../info/wxmaxima.md:1012
 msgid "## Why is the external manual browser not working on my Linux box?"
 msgstr "## Почему внешний браузер руководства не работает в Linux?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:971
+#: ../../info/wxmaxima.md:1018
 msgid ""
 "The HTML browser might be a snap, flatpack or appimage version. All of these "
 "typically cannot access files that are installed on your local system. "
@@ -3801,7 +3938,7 @@ msgstr ""
 "получить доступ к онлайн-руководству не получается."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:973
+#: ../../info/wxmaxima.md:1020
 msgid ""
 "## Can I make _wxMaxima_ output both image files and embedded plots at once?"
 msgstr ""
@@ -3809,7 +3946,7 @@ msgstr ""
 "и встроенных в документ графиков?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:975
+#: ../../info/wxmaxima.md:1022
 msgid ""
 "The worksheet embeds `.png files. _WxMaxima_ allows the user to specify "
 "where they should be generated:"
@@ -3818,7 +3955,7 @@ msgstr ""
 "указать, где они должны генерироваться:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:982
+#: ../../info/wxmaxima.md:1029
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -3836,7 +3973,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:984
+#: ../../info/wxmaxima.md:1031
 msgid ""
 "If a different format is to be used, it is easier to generate the images and "
 "then import them into the worksheet again:"
@@ -3845,7 +3982,7 @@ msgstr ""
 "изображения, а затем снова импортировать их в рабочий лист:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1003
+#: ../../info/wxmaxima.md:1050
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -3887,7 +4024,7 @@ msgstr ""
 "    pngdraw(name,gr2d(contents));\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1008
+#: ../../info/wxmaxima.md:1055
 #, no-wrap
 msgid ""
 "pngdraw2d(\"Test\",\n"
@@ -3901,17 +4038,17 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1010
+#: ../../info/wxmaxima.md:1057
 msgid "## Can I set the aspect ratio of an embedded plot?"
 msgstr "## Как задать соотношение сторон встроенного графика?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1012
+#: ../../info/wxmaxima.md:1059
 msgid "Use the variable `wxplot_size`:"
 msgstr "С помощью переменной `wxplot_size`:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1018
+#: ../../info/wxmaxima.md:1065
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -3927,7 +4064,7 @@ msgstr ""
 "```\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1020
+#: ../../info/wxmaxima.md:1067
 msgid ""
 "## After upgrading to MacOS 13.1 plot and/or draw commands output error "
 "messages like"
@@ -3936,7 +4073,7 @@ msgstr ""
 "сообщения об ошибках, например:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1027
+#: ../../info/wxmaxima.md:1074
 msgid ""
 "```text 1 HIToolbox 0x00007ff80cd91726 "
 "_ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox "
@@ -3949,7 +4086,7 @@ msgstr ""
 "0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1029
+#: ../../info/wxmaxima.md:1076
 msgid ""
 "This might be an issue with the operating system. Disable the hiding of the "
 "menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the "
@@ -3962,12 +4099,12 @@ msgstr ""
 "wxMaxima #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1031
+#: ../../info/wxmaxima.md:1078
 msgid "## Logging"
 msgstr "## Журналирование"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1035
+#: ../../info/wxmaxima.md:1082
 msgid ""
 "Log messages might be helpful to debug problems. WxMaxima can log many "
 "events. Most log entries will be helpful for developers, especially in case "
@@ -3985,7 +4122,7 @@ msgstr ""
 "-> Переключить окно журнала»."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1037
+#: ../../info/wxmaxima.md:1084
 msgid ""
 "Messages are not 'lost', if the log window is not shown, if you select to "
 "show the log window later, you will see past log messages (if you did not "
@@ -3996,7 +4133,7 @@ msgstr ""
 "сообщения журнала (если они не были очищены пользователем)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1039
+#: ../../info/wxmaxima.md:1086
 msgid ""
 "Such messages may be helpful, when you create bug reports (or trying to find "
 "a bug by yourself)."
@@ -4005,7 +4142,7 @@ msgstr ""
 "самостоятельном поиске ошибок)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1042
+#: ../../info/wxmaxima.md:1089
 msgid ""
 "Log messages can (additionally) be printed to STDERR, when using the command "
 "line option \"--logtostderr\". On Windows a separate text console will be "
@@ -4017,17 +4154,17 @@ msgstr ""
 "интерфейсом пользователя не подключён стандартный ввод/вывод."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1046
+#: ../../info/wxmaxima.md:1093
 msgid "# FAQ"
 msgstr "# Вопросы и ответы"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1048
+#: ../../info/wxmaxima.md:1095
 msgid "## Is there a way to make more text fit on a LaTeX page?"
 msgstr "## Есть ли возможность поместить больше текста на страницу LaTeX?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1050
+#: ../../info/wxmaxima.md:1097
 msgid ""
 "Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to "
 "specify the size of the borders."
@@ -4036,7 +4173,7 @@ msgstr ""
 "geometry), который позволяет указать размеры границ."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1052
+#: ../../info/wxmaxima.md:1099
 msgid ""
 "You can add the following line to the LaTeX preamble (for example by using "
 "the respective field in the config dialogue (\"Export\"->\"Additional lines "
@@ -4048,19 +4185,19 @@ msgstr ""
 "1 см):"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1056
+#: ../../info/wxmaxima.md:1103
 msgid ""
 "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
 msgstr ""
 "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1058
+#: ../../info/wxmaxima.md:1105
 msgid "## Is there a dark mode?"
 msgstr "## Имеется ли тёмная тема?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1060
+#: ../../info/wxmaxima.md:1107
 msgid ""
 "If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if "
 "the rest of the operating system is. The worksheet itself is by default "
@@ -4076,14 +4213,14 @@ msgstr ""
 "рабочий лист из тёмного в светлый и обратно."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1062
+#: ../../info/wxmaxima.md:1109
 msgid ""
 "## _WxMaxima_ sometimes hangs for several seconds once in the first minute"
 msgstr ""
 "## _WxMaxima_ иногда зависает на несколько секунд в течение первой минуты"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1064
+#: ../../info/wxmaxima.md:1111
 msgid ""
 "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-"
 "manual to background tasks, which normally goes totally unnoticed. At the "
@@ -4097,7 +4234,7 @@ msgstr ""
 "продолжением работы."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1066
+#: ../../info/wxmaxima.md:1113
 msgid ""
 "## Especially when testing new locale settings, a message box \"locale "
 "’xx_YY’ can not be set\" occurs"
@@ -4106,12 +4243,12 @@ msgstr ""
 "’xx_YY’ can not be set»"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1068
+#: ../../info/wxmaxima.md:1115
 msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
 msgstr "![Предупреждение локали](./locale-warning.png){ id=img_locale_warning}"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1072
+#: ../../info/wxmaxima.md:1119
 msgid ""
 "(The same problem can occur with other applications too). The translations "
 "seem okay after you click on ’OK’. WxMaxima does not only use its own "
@@ -4123,7 +4260,7 @@ msgstr ""
 "wxWidgets."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1075
+#: ../../info/wxmaxima.md:1122
 msgid ""
 "These locales maybe not present in the system. On Ubuntu/Debian systems they "
 "can be generated using: `dpkg-reconfigure locales`"
@@ -4132,7 +4269,7 @@ msgstr ""
 "можно сгенерировать с помощью команды `dpkg-reconfigure locales`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1077
+#: ../../info/wxmaxima.md:1124
 msgid ""
 "## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
 msgstr ""
@@ -4140,7 +4277,7 @@ msgstr ""
 "и так далее?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1079
+#: ../../info/wxmaxima.md:1126
 msgid ""
 "You can find these symbols in the Unicode sidebar (search for ’double-struck "
 "capital’). But the selected font must also support these symbols. If they do "
@@ -4151,7 +4288,7 @@ msgstr ""
 "Выберите другой шрифт, если символы отображаются неправильно."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1081
+#: ../../info/wxmaxima.md:1128
 msgid ""
 "## How can a Maxima script determine, if it is running under wxMaxima or "
 "command line Maxima?"
@@ -4160,7 +4297,7 @@ msgstr ""
 "управлением wxMaxima или командной строки Maxima?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1083
+#: ../../info/wxmaxima.md:1130
 msgid ""
 "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to "
 "`wxmaxima`. The Maxima variable `maxima_frontend_version` contains the "
@@ -4171,7 +4308,7 @@ msgstr ""
 "`maxima_frontend_version` в этом случае содержит версию wxMaxima."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1085
+#: ../../info/wxmaxima.md:1132
 msgid ""
 "If no frontend is used (you are using command line Maxima), these variables "
 "are `false`."
@@ -4180,12 +4317,12 @@ msgstr ""
 "строке Maxima), то эти переменные имеют значение `false`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1087
+#: ../../info/wxmaxima.md:1134
 msgid "## Help! I can not save my document!"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1089
+#: ../../info/wxmaxima.md:1136
 msgid ""
 "If saving as wxmx file does not work, try saving the document as wxm file "
 "(and vice versa). And you can also try to remove all output (Menu Cell-"
@@ -4194,12 +4331,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1093
+#: ../../info/wxmaxima.md:1140
 msgid "# Command-line arguments"
 msgstr "# Аргументы командной строки"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1095
+#: ../../info/wxmaxima.md:1142
 msgid ""
 "Usually you can start programs with a graphical user interface just by "
 "clicking on a desktop icon or desktop menu entry. WxMaxima - if started from "
@@ -4211,17 +4348,17 @@ msgstr ""
 "использовать некоторые аргументы командной строки."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-v` or `--version`: Output the version information"
 msgstr "`-v` или `--version`: вывести информацию о версии."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-h` or `--help`: Output a short help text"
 msgstr "`-h` или `--help`: вывести краткую справочную информацию."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid ""
 "`-o` or `--open=<str>`: Open the filename given as an argument to this "
 "command-line switch"
@@ -4230,12 +4367,12 @@ msgstr ""
 "ключу командной строки."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-e` or `--eval`: Evaluate the file after opening it."
 msgstr "`-e` или `--eval`: выполнить вычисление файла после его открытия."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid ""
 "`-b` or `--batch`: If the command-line opens a file all cells in this file "
 "are evaluated and the file is saved afterward. This is for example useful if "
@@ -4255,7 +4392,7 @@ msgstr ""
 "полное отсутствие не всегда возможно."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, no-wrap
 msgid ""
 "- `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
@@ -4281,7 +4418,7 @@ msgstr ""
 "- `--wxmathml-lisp=<str>`:   расположение wxMathML.lisp (если необходимо использовать не встроенный файл; предназначено, главным образом, для разработчиков).\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1113
+#: ../../info/wxmaxima.md:1160
 msgid ""
 "Instead of a minus, some operating systems might use a dash in front of the "
 "command-line switches."
@@ -4290,12 +4427,12 @@ msgstr ""
 "строки может использоваться тире."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1117
+#: ../../info/wxmaxima.md:1164
 msgid "# About the program, contributing to wxMaxima"
 msgstr "# О программе, участие в разработке wxMaxima"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1119
+#: ../../info/wxmaxima.md:1166
 msgid ""
 "wxMaxima is mainly developed using the programming language C++ using the "
 "[wxWidgets framework](https://www.wxwidgets.org), as build system we use "
@@ -4314,7 +4451,7 @@ msgstr ""
 "желании внести вклад в разработку проекта wxMaxima с открытым исходным кодом."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1121
+#: ../../info/wxmaxima.md:1168
 msgid ""
 "But not only programmers are necessary! You can also contribute to wxMaxima, "
 "if you help to improve the documentation, find and report bugs (and maybe "
@@ -4333,13 +4470,13 @@ msgstr ""
 "locales))."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1123
+#: ../../info/wxmaxima.md:1170
 msgid "Or answer questions of other users in the discussion forum."
 msgstr ""
 "Также можно отвечать на вопросы других пользователей на дискуссионном форуме."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1125
+#: ../../info/wxmaxima.md:1172
 msgid ""
 "The source code of wxMaxima is documented using Doxygen [here](https://"
 "wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
@@ -4348,7 +4485,7 @@ msgstr ""
 "wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1127
+#: ../../info/wxmaxima.md:1174
 msgid ""
 "The program is nearly self-contained, so except for system libraries (and "
 "the wxWidgets library), no external dependencies (like graphic files or the "
@@ -4361,7 +4498,7 @@ msgstr ""
 "(файл `wxmathML.lisp`); эти файлы включены в исполняемый файл)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1128
+#: ../../info/wxmaxima.md:1175
 msgid ""
 "If you are a developer, you might want to try out a modified `wxmathML.lisp`-"
 "file without recompiling everything, one can use the command line option `--"

--- a/locales/manual/tr.po
+++ b/locales/manual/tr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tr\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-20 10:30+0200\n"
+"POT-Creation-Date: 2026-07-30 11:38+0200\n"
 "PO-Revision-Date: 2020-06-17 23:13+0300\n"
 "Last-Translator: Tufan Şirin <tsirin@turgutozal.edu.tr>\n"
 "Language-Team: Tufan Şirin <tsirin@turgutozal.edu.tr>\n"
@@ -55,9 +55,9 @@ msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 msgstr "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:426
-#: ../../info/wxmaxima.md:848 ../../info/wxmaxima.md:1043
-#: ../../info/wxmaxima.md:1090 ../../info/wxmaxima.md:1114
+#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:425
+#: ../../info/wxmaxima.md:880 ../../info/wxmaxima.md:1090
+#: ../../info/wxmaxima.md:1137 ../../info/wxmaxima.md:1161
 #, no-wrap
 msgid "______________________________________________________________________\n"
 msgstr ""
@@ -1088,14 +1088,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:224
+#: ../../info/wxmaxima.md:223
 #, fuzzy
 #| msgid "### Side Panes"
 msgid "### Side Panes"
 msgstr "### Kenar Panelleri"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:226
+#: ../../info/wxmaxima.md:225
 #, fuzzy
 #| msgid ""
 #| "Shortcuts to the most important _Maxima_ commands or things like a table "
@@ -1120,12 +1120,12 @@ msgstr ""
 "kullanarak Yunanca harflerin girilmesine izin veren bölmelerdir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:228
+#: ../../info/wxmaxima.md:227
 msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
 msgstr "![Farklı Kenar Panelleri Örneği](./SidePanes.png){ id=img_SidePanes }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:231
+#: ../../info/wxmaxima.md:230
 msgid ""
 "In the \"table of contents\" side pane, one can increase or decrease a "
 "heading by just clicking on the heading with the right mouse button and "
@@ -1133,21 +1133,21 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:233
+#: ../../info/wxmaxima.md:232
 msgid ""
 "![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-"
 "headings.png){ id=Sidepane-TOC-convert-headings }"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:235
+#: ../../info/wxmaxima.md:234
 #, fuzzy
 #| msgid "### MathML output"
 msgid "### MathML output"
 msgstr "### MathML çıktısı"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:237
+#: ../../info/wxmaxima.md:236
 #, fuzzy
 #| msgid ""
 #| "Several word processors and similar programs either recognize MathML "
@@ -1169,14 +1169,14 @@ msgstr ""
 "_wxMaxima_, sağ tıklama menüsünde çeşitli girişler sunar."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:239
+#: ../../info/wxmaxima.md:238
 #, fuzzy
 #| msgid "### Markdown support"
 msgid "### Markdown support"
 msgstr "### İşaretleme Desteği"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:241
+#: ../../info/wxmaxima.md:240
 #, fuzzy
 #| msgid ""
 #| "_wxMaxima_ offers a set of standard markdown conventions that don't "
@@ -1190,7 +1190,7 @@ msgstr ""
 "kuralı sunar. Bu unsurlardan biri mermi (tarzındaki) listeleridir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:251
+#: ../../info/wxmaxima.md:250
 #, fuzzy, no-wrap
 #| msgid ""
 #| "~~~~\n"
@@ -1224,7 +1224,7 @@ msgstr ""
 "~~~~\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:253
+#: ../../info/wxmaxima.md:252
 #, fuzzy
 #| msgid ""
 #| "_wxMaxima_ will recognize text starting with `>` chars as block quotes:"
@@ -1232,7 +1232,7 @@ msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
 msgstr "_ wxMaxima _, `> char 'dan başlayan metni blok tırnak olarak tanır:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:261
+#: ../../info/wxmaxima.md:260
 #, fuzzy
 #| msgid ""
 #| "~~~~ Ordinary text > quote quote quote quote > quote quote quote quote > "
@@ -1245,7 +1245,7 @@ msgstr ""
 "quote quote quote Düz Metin ~~~~"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:263
+#: ../../info/wxmaxima.md:262
 #, fuzzy
 #| msgid ""
 #| "_wxMaxima_'s TeX and html output will also recognize `=>` and replace it "
@@ -1258,14 +1258,14 @@ msgstr ""
 "unicode işareti koyuyor:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:267
+#: ../../info/wxmaxima.md:266
 #, fuzzy
 #| msgid "~~~~ cogito => sum.  ~~~~"
 msgid "```text cogito => sum.  ```"
 msgstr "~~~~ cogito => sum.  ~~~~"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:269
+#: ../../info/wxmaxima.md:268
 #, fuzzy
 #| msgid ""
 #| "Other symbols the html and TeX export will recognize are `<=` and `>=` "
@@ -1284,14 +1284,14 @@ msgstr ""
 "tanınır."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:271
+#: ../../info/wxmaxima.md:270
 #, fuzzy
 #| msgid "### Hotkeys"
 msgid "### Hotkeys"
 msgstr "### Kısayol Tuşları"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:273
+#: ../../info/wxmaxima.md:272
 msgid ""
 "Most hotkeys can be found in the text of the respective menus. Since they "
 "are actually taken from the menu text and thus can be customized by the "
@@ -1306,7 +1306,7 @@ msgstr ""
 "adları menülerde belgelenmemiştir:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 msgid ""
 "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
 msgstr ""
@@ -1314,7 +1314,7 @@ msgstr ""
 "hücreyi siler."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 #, fuzzy
 #| msgid ""
 #| "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete "
@@ -1327,20 +1327,20 @@ msgstr ""
 "hücreyi siler."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
 msgstr ""
 "<kbd> SHIFT </kbd> + <kbd> SPACE </kbd>, boşluk bırakmayan bir boşluk ekler."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:279
+#: ../../info/wxmaxima.md:278
 #, fuzzy
 #| msgid "### Raw TeX in the TeX export"
 msgid "### Raw TeX in the TeX export"
 msgstr "### TeX dışa aktarımında ham TeX"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:281
+#: ../../info/wxmaxima.md:280
 msgid ""
 "If a text cell begins with `TeX:` the TeX export contains the literal text "
 "that follows the `TeX:` marker. Using this feature allows the entry of TeX "
@@ -1351,14 +1351,14 @@ msgstr ""
 "kitabına TeX işaretlemesinin girilmesini sağlar."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:283
+#: ../../info/wxmaxima.md:282
 #, fuzzy
 #| msgid "## File Formats"
 msgid "## File Formats"
 msgstr "## Dosya formatları"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:285
+#: ../../info/wxmaxima.md:284
 msgid ""
 "The material that is developed in a _wxMaxima_ session can be stored for "
 "later use in any of three ways:"
@@ -1367,14 +1367,14 @@ msgstr ""
 "yoldan biriyle saklanabilir:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:287
+#: ../../info/wxmaxima.md:286
 #, fuzzy
 #| msgid "### .mac"
 msgid "### .mac"
 msgstr "### .mac"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:289
+#: ../../info/wxmaxima.md:288
 #, fuzzy
 #| msgid ""
 #| ".mac files are ordinary text files that contain _Maxima_ commands. They "
@@ -1390,7 +1390,7 @@ msgstr ""
 "kullanılarak okunabilirler."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:292
+#: ../../info/wxmaxima.md:291
 msgid ""
 "One example is shown below. `Quadratic.mac` defines a function and afterward "
 "generates a plot with `wxdraw2d()`.  Afterward the contents of the file "
@@ -1398,14 +1398,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:294
+#: ../../info/wxmaxima.md:293
 #, fuzzy
 #| msgid "![Batch image](./BatchImage.png){ id=img_BatchImage }"
 msgid "![Loading a file with `batch()`](./BatchImage.png){ id=img_BatchImage }"
 msgstr "![Batch image](./BatchImage.png){ id=img_BatchImage }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:296
+#: ../../info/wxmaxima.md:295
 msgid ""
 "Attention: Although the file `Quadratic.mac` has a usual _Maxima_ extension "
 "(`.mac`), it can only be read by _wxMaxima_, since the command `wxdraw2d()` "
@@ -1414,7 +1414,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:298
+#: ../../info/wxmaxima.md:297
 #, fuzzy
 #| msgid ""
 #| "You can be use `.mac` files for writing own library of macros. But since "
@@ -1430,14 +1430,14 @@ msgstr ""
 "oturumu olarak okunamazlar."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:300
+#: ../../info/wxmaxima.md:299
 #, fuzzy
 #| msgid "### .wxm"
 msgid "### .wxm"
 msgstr "### .wxm"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:303
+#: ../../info/wxmaxima.md:302
 #, fuzzy
 #| msgid ""
 #| ".wxm files contains the worksheet except _Maxima_'s output. On Maxima "
@@ -1461,7 +1461,7 @@ msgstr ""
 "olmaması kaçınılmazdır."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:305
+#: ../../info/wxmaxima.md:304
 #, fuzzy
 #| msgid ""
 #| ".wxm files contains the worksheet except _Maxima_'s output. On Maxima "
@@ -1481,39 +1481,39 @@ msgstr ""
 "olmaması kaçınılmazdır."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:307
+#: ../../info/wxmaxima.md:306
 #, fuzzy
 #| msgid "## File Formats"
 msgid "#### File format of wxm files"
 msgstr "## Dosya formatları"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:309
+#: ../../info/wxmaxima.md:308
 msgid ""
 "This is just a plain text file (you can open it with a text editor), "
 "containing the cell contents as some special Maxima comments."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:311
+#: ../../info/wxmaxima.md:310
 msgid "It starts with the following comment:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:316
+#: ../../info/wxmaxima.md:315
 msgid ""
 "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* "
 "[ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:318
+#: ../../info/wxmaxima.md:317
 msgid ""
 "And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:324
+#: ../../info/wxmaxima.md:323
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1524,14 +1524,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:326
+#: ../../info/wxmaxima.md:325
 msgid ""
 "or (in a Math cell the input is of course *not* commented out (the output is "
 "not saved in a `wxm` file)):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:333
+#: ../../info/wxmaxima.md:332
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1543,14 +1543,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:335
+#: ../../info/wxmaxima.md:334
 msgid ""
 "Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the "
 "image type as first line):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:342
+#: ../../info/wxmaxima.md:341
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1562,12 +1562,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:344
+#: ../../info/wxmaxima.md:343
 msgid "A page break is just one line containing:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:348
+#: ../../info/wxmaxima.md:347
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1576,12 +1576,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:350
+#: ../../info/wxmaxima.md:349
 msgid "And folded cells marked by:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:356
+#: ../../info/wxmaxima.md:355
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1592,14 +1592,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:358
+#: ../../info/wxmaxima.md:357
 #, fuzzy
 #| msgid "### .wxmx"
 msgid "### .wxmx"
 msgstr "### .wxmx"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:360
+#: ../../info/wxmaxima.md:359
 #, fuzzy
 #| msgid ""
 #| "This xml-based file format saves the complete worksheet including things "
@@ -1612,14 +1612,14 @@ msgstr ""
 "şeyleri içeren tüm çalışma sayfasını kaydeder. Tercih edilen dosya biçimidir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:362
+#: ../../info/wxmaxima.md:361
 #, fuzzy
 #| msgid "## File Formats"
 msgid "#### File format of wxmx files"
 msgstr "## Dosya formatları"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:365
+#: ../../info/wxmaxima.md:364
 msgid ""
 "A `wxmx`-file seems to be a binary format, but one can handle it with tools, "
 "which are included in your OS. It is a zip file, one can decompress it with "
@@ -1631,39 +1631,39 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:367
+#: ../../info/wxmaxima.md:366
 msgid "It does contain the following files:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-"
 "wxmathml`"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`format.txt`: a short description about wxMaxima and the wxmx file format"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima "
 "session and included images."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`content.xml`: a XML document, which contains the various cells of your "
 "document in XML format."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:374
+#: ../../info/wxmaxima.md:373
 msgid ""
 "So, if something goes wrong, you can unzip a wxMaxima document (maybe rename "
 "it before to a `zip`-file), maybe make changes in the `content.xml` file "
@@ -1673,14 +1673,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:376
+#: ../../info/wxmaxima.md:375
 #, fuzzy
 #| msgid "## Configuration options"
 msgid "## Configuration options"
 msgstr "## Yapılandırma Seçenekleri"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:378
+#: ../../info/wxmaxima.md:377
 msgid ""
 "For some common configuration variables _wxMaxima_ offers two ways of "
 "configuring:"
@@ -1689,7 +1689,7 @@ msgstr ""
 "yöntemi sunar:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
+#: ../../info/wxmaxima.md:380
 msgid ""
 "The configuration dialog box below lets you change their default values for "
 "the current and subsequent sessions."
@@ -1698,7 +1698,7 @@ msgstr ""
 "varsayılan değerlerini değiştirmenizi sağlar."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
+#: ../../info/wxmaxima.md:380
 #, fuzzy
 #| msgid ""
 #| "Also, the values for most configuration variables can be changed for the "
@@ -1714,7 +1714,7 @@ msgstr ""
 "yazılmasıyla değiştirilebilir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:383
+#: ../../info/wxmaxima.md:382
 msgid ""
 "![wxMaxima configuration 1](./wxMaxima_configuration_001.png)"
 "{ id=img_wxMaxima_configuration_001 }"
@@ -1723,14 +1723,14 @@ msgstr ""
 "{ id=img_wxMaxima_configuration_001 }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:385
+#: ../../info/wxmaxima.md:384
 #, fuzzy
 #| msgid "### Default animation framerate"
 msgid "### Default animation framerate"
 msgstr "Varsayılan animasyon kare hızı"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:387
+#: ../../info/wxmaxima.md:386
 msgid ""
 "The animation framerate that is used for new animations is kept in the "
 "variable `wxanimate_framerate`. The initial value this variable will contain "
@@ -1741,14 +1741,14 @@ msgstr ""
 "ilk değer, yapılandırma iletişim kutusu kullanılarak değiştirilebilir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:389
+#: ../../info/wxmaxima.md:388
 #, fuzzy
 #| msgid "### Default plot size for new _maxima_ sessions"
 msgid "### Default plot size for new _maxima_ sessions"
 msgstr "Yeni 'maxima' oturumları için varsayılan çizim boyutu"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:391
+#: ../../info/wxmaxima.md:390
 #, fuzzy
 #| msgid ""
 #| "After the next start plots embedded into the worksheet will be created "
@@ -1762,7 +1762,7 @@ msgstr ""
 "oluşturulacaktır."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:393
+#: ../../info/wxmaxima.md:392
 #, fuzzy
 #| msgid ""
 #| "In order to set the plot size of a single graph only use the following "
@@ -1775,7 +1775,7 @@ msgstr ""
 "yalnızca bir komut için ayarlayan aşağıdaki gösterimi kullanabilirsiniz:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:402
+#: ../../info/wxmaxima.md:401
 #, fuzzy, no-wrap
 #| msgid "    wxdraw2d( explicit(x^2,x,-5,5)), wxplot_size=[480,480]$\n"
 msgid ""
@@ -1790,19 +1790,19 @@ msgid ""
 msgstr "    wxdraw2d( explicit(x^2,x,-5,5)), wxplot_size=[480,480]$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:404
+#: ../../info/wxmaxima.md:403
 #, fuzzy
 #| msgid "### Match parenthesis in text controls"
 msgid "### Match parenthesis in text controls"
 msgstr "### Metin denetimlerinde parantezleri eşleştir"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:406
+#: ../../info/wxmaxima.md:405
 msgid "This option enables two things:"
 msgstr "Bu seçenek iki şeyi etkinleştirir:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
+#: ../../info/wxmaxima.md:408
 #, fuzzy
 #| msgid ""
 #| "If an opening parenthesis, bracket or double quote is entered _wxMaxima_ "
@@ -1815,7 +1815,7 @@ msgstr ""
 "arkasından bir kapanış ekler."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
+#: ../../info/wxmaxima.md:408
 msgid ""
 "If text is selected if any of these keys is pressed the selected text will "
 "be put between the matched signs."
@@ -1824,14 +1824,14 @@ msgstr ""
 "eşleşen işaretlerin arasına yerleştirilir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:411
+#: ../../info/wxmaxima.md:410
 #, fuzzy
 #| msgid "### Don't save the worksheet automatically"
 msgid "### Don’t save the worksheet automatically"
 msgstr "Çalışma sayfasını otomatik olarak kaydetme"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:413
+#: ../../info/wxmaxima.md:412
 #, fuzzy
 #| msgid ""
 #| "If this option is set the file the worksheet is in is overwritten only on "
@@ -1847,7 +1847,7 @@ msgstr ""
 "geçici dizinde yakın zamanda yedek bir kopya bulunmaya devam eder."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:415
+#: ../../info/wxmaxima.md:414
 #, fuzzy
 #| msgid ""
 #| "If this option isn't set wxMaxima behaves more like a modern cellphone "
@@ -1859,26 +1859,26 @@ msgstr ""
 "davranır:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
+#: ../../info/wxmaxima.md:417
 msgid "Files are saved automatically on exit"
 msgstr "Dosyalar çıkışta otomatik olarak kaydedilir"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
+#: ../../info/wxmaxima.md:417
 #, fuzzy
 #| msgid "And the file will automatically be saved every 3 minutes."
 msgid "And the file will automatically be saved every 3 minutes."
 msgstr "Ve dosya her 3 dakikada bir otomatik olarak kaydedilecektir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:420
+#: ../../info/wxmaxima.md:419
 #, fuzzy
 #| msgid "### Where is the configuration saved?"
 msgid "### Where is the configuration saved?"
 msgstr "### Yapılandırma nereye kaydedilir?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:423
+#: ../../info/wxmaxima.md:422
 #, fuzzy
 #| msgid ""
 #| "If you are using Unix/Linux, the configuration information will be saved "
@@ -1909,7 +1909,7 @@ msgstr ""
 "başladığından, “.wxMaxima` veya“ .config` gizlenecektir)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:425
+#: ../../info/wxmaxima.md:424
 #, fuzzy
 #| msgid ""
 #| "If you are using Windows, the configuration will be stored in the "
@@ -1925,7 +1925,7 @@ msgstr ""
 "`HKEY_CURRENT_USER \\ Software \\ wxMaxima`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:429
+#: ../../info/wxmaxima.md:428
 #, fuzzy
 #| msgid ""
 #| "Extensions to _Maxima_\n"
@@ -1936,7 +1936,7 @@ msgstr ""
 "======================\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:431
+#: ../../info/wxmaxima.md:430
 #, fuzzy
 #| msgid ""
 #| "_wxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
@@ -1964,34 +1964,34 @@ msgstr ""
 "geliştirmesinin bazı yollarını ele almaktadır. burada açıklanmıştır."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:433
+#: ../../info/wxmaxima.md:432
 #, fuzzy
 #| msgid "## Subscripted variables"
 msgid "## Subscripted variables"
 msgstr "## Alt indisli değişkenler"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:435
+#: ../../info/wxmaxima.md:434
 msgid ""
 "`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript "
 "variable names:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:437
+#: ../../info/wxmaxima.md:436
 msgid ""
 "If it is `false`, the functionality is off, wxMaxima will not autosubscript "
 "part of variable names after an underscore."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:439
+#: ../../info/wxmaxima.md:438
 msgid ""
 "If it is set to `'all`, everything after an underscore will be subscripted."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:441
+#: ../../info/wxmaxima.md:440
 #, fuzzy
 #| msgid ""
 #| "if `wxsubscripts` is set to true variable names of the format `x_y` are "
@@ -2004,26 +2004,26 @@ msgstr ""
 "bir alt simge kullanılarak görüntülenir, eğer"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
+#: ../../info/wxmaxima.md:443
 #, fuzzy
 #| msgid "`y` is a single letter"
 msgid "Either `x` or `y` is a single letter or"
 msgstr "\"y\" tek bir harftir"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
+#: ../../info/wxmaxima.md:443
 msgid "`y` is an integer (can include more than one character)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:446
+#: ../../info/wxmaxima.md:445
 msgid ""
 "![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png)"
 "{ id=img_wxsubscripts }"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:448
+#: ../../info/wxmaxima.md:447
 #, fuzzy
 #| msgid ""
 #| "If the variable name doesn’t match these requirements it can still be "
@@ -2047,19 +2047,19 @@ msgstr ""
 "`wxdeclare_subscript (değişken_adı, yanlış);`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:450
+#: ../../info/wxmaxima.md:449
 msgid "You can use the menu \"View->Autosubscript\" to set these values."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:452
+#: ../../info/wxmaxima.md:451
 #, fuzzy
 #| msgid "## User feedback in the statusbar"
 msgid "## User feedback in the status bar"
 msgstr "## Durum çubuğundaki kullanıcı geri bildirimi"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:454
+#: ../../info/wxmaxima.md:453
 #, fuzzy
 #| msgid ""
 #| "Long-running commands can provide user-feedback in the status bar. This "
@@ -2087,7 +2087,7 @@ msgstr ""
 "değerlendirilmeden bırakılır."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:465
+#: ../../info/wxmaxima.md:464
 #, fuzzy, no-wrap
 #| msgid ""
 #| "    for i:1 thru 10 do (\n"
@@ -2120,14 +2120,91 @@ msgstr ""
 "    )$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:467
+#: ../../info/wxmaxima.md:466
+msgid "## Exporting the worksheet from within Maxima"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:468
+msgid ""
+"The command `wxworksheettohtml()` exports the current worksheet to an HTML "
+"file from within a running _Maxima_ session, which is convenient for "
+"scripted or batch export. Like `wxstatusbar()` it is safe to use in code "
+"that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present "
+"the command is simply left unevaluated."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:473
+msgid ""
+"```maxima wxworksheettohtml(\"report.html\")$ "
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:475
+msgid ""
+"A relative file name is interpreted relative to _Maxima_’s working "
+"directory. The optional keyword options are:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:480
+#, no-wrap
+msgid ""
+"| option   | values                                          | meaning                                             |\n"
+"| -------- | ----------------------------------------------- | --------------------------------------------------- |\n"
+"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |\n"
+"| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:482
+msgid ""
+"The `flavor` values match the equation formats offered by the graphical "
+"**File → Export** dialog: `mathml` produces a self-contained page that needs "
+"no internet connection, `mathjax` adds a MathJaX fall-back for browsers that "
+"still lack MathML, and `svg`/`bitmap` render every equation to an image."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:484
+msgid ""
+"The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file "
+"the same way:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:489
+msgid ""
+"```maxima wxworksheettotex(\"report.tex\")$ wxworksheettotex(\"report.tex\", "
+"documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:494
+#, no-wrap
+msgid ""
+"| option                 | meaning                                                              |\n"
+"| ---------------------- | -------------------------------------------------------------------- |\n"
+"| `documentclass`        | overrides the LaTeX `\\documentclass` (e.g. `\"article\"`, `\"report\"`)  |\n"
+"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:496
+msgid "Support for `wxworksheettopdf()` is planned."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:498
 #, fuzzy
 #| msgid "## Plotting"
 msgid "## Plotting"
 msgstr "##Grafik çizmek"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:469
+#: ../../info/wxmaxima.md:500
 msgid ""
 "Plotting (having fundamentally to do with graphics) is a place where a "
 "graphical user interface will have to provide some extensions to the "
@@ -2138,14 +2215,14 @@ msgstr ""
 "yerdir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:471
+#: ../../info/wxmaxima.md:502
 #, fuzzy
 #| msgid "### Embedding a plot into the work sheet"
 msgid "### Embedding a plot into the worksheet"
 msgstr "### Bir taslağı çalışma sayfasına gömme"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:473
+#: ../../info/wxmaxima.md:504
 #, fuzzy
 #| msgid ""
 #| "_Maxima_ normally instructs the external program gnuplot to open a "
@@ -2172,12 +2249,12 @@ msgstr ""
 "\"histogram\" a karşılık gelir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:475
+#: ../../info/wxmaxima.md:506
 msgid "The following plotting functions have wx-counterparts:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:489
+#: ../../info/wxmaxima.md:520
 #, no-wrap
 msgid ""
 "| wxMaxima’s plot function | Maxima’s plot function                                                                          |\n"
@@ -2196,14 +2273,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:491
+#: ../../info/wxmaxima.md:522
 msgid ""
 "If a `wxm`-file is read by (console) Maxima, these functions are ignored "
 "(and printed as output, as other unknown functions in Maxima)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:493
+#: ../../info/wxmaxima.md:524
 msgid ""
 "If you got problems with one of these functions, please check, if the "
 "problem exists in the the Maxima function too (e.g. you got an error with "
@@ -2215,14 +2292,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:495
+#: ../../info/wxmaxima.md:526
 #, fuzzy
 #| msgid "### Making embedded plots bigger or smaller"
 msgid "### Making embedded plots bigger or smaller"
 msgstr "### Gömülü grafikleri daha büyük veya daha küçük yapma"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:497
+#: ../../info/wxmaxima.md:528
 #, fuzzy
 #| msgid ""
 #| "As noted above, the configure dialog provides a way to change the default "
@@ -2245,7 +2322,7 @@ msgstr ""
 "kullanılabilir:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:507
+#: ../../info/wxmaxima.md:538
 #, fuzzy, no-wrap
 #| msgid ""
 #| "    wxplot_size:[1200,800]$\n"
@@ -2275,7 +2352,7 @@ msgstr ""
 "    )$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:509
+#: ../../info/wxmaxima.md:540
 #, fuzzy
 #| msgid ""
 #| "If the size of only one plot is to be changed _Maxima_ provides a "
@@ -2290,7 +2367,7 @@ msgstr ""
 "hücre için bir özniteliği değiştirmek için standart bir yol sağlar."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:518
+#: ../../info/wxmaxima.md:549
 #, fuzzy, no-wrap
 #| msgid ""
 #| "     wxdraw2d(\n"
@@ -2317,7 +2394,7 @@ msgstr ""
 "     ),wxplot_size=[1600,800]$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:520
+#: ../../info/wxmaxima.md:551
 msgid ""
 "Setting the size of embedded plot with `wxplot_size` works for embedded "
 "plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` "
@@ -2326,14 +2403,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:522
+#: ../../info/wxmaxima.md:553
 #, fuzzy
 #| msgid "### Better quality plots"
 msgid "### Better quality plots"
 msgstr "### Daha kaliteli grafik çizimleri"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:524
+#: ../../info/wxmaxima.md:555
 #, fuzzy
 #| msgid ""
 #| "Gnuplot doesn’t seem to provide a portable way of determining whether it "
@@ -2361,14 +2438,14 @@ msgstr ""
 "ayarlanırsa, sonuç grafik yerine hata mesajları olur."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:526
+#: ../../info/wxmaxima.md:557
 #, fuzzy
 #| msgid "### Opening embedded plots in interactive gnuplot windows"
 msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
 msgstr "### İnteraktif gnuplot pencerelerinde gömülü grafikleri açma"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:528
+#: ../../info/wxmaxima.md:559
 #, fuzzy
 #| msgid ""
 #| "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
@@ -2387,14 +2464,14 @@ msgstr ""
 "etkileşimli bir gnuplot penceresinde çizimin açılmasını sağlayan menü sunar."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:530
+#: ../../info/wxmaxima.md:561
 #, fuzzy
 #| msgid "### Opening gnuplot's command console in `plot` windows"
 msgid "### Opening Gnuplot’s command console in `plot` windows"
 msgstr "### gnuplot'un komut konsolunu `plot` pencerelerinde açma"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:533
+#: ../../info/wxmaxima.md:564
 #, fuzzy
 #| msgid ""
 #| "On MS Windows, if in _Maxima_'s variable `gnuplot_command` \"gnuplot\" is "
@@ -2417,14 +2494,14 @@ msgstr ""
 "odağını kısa bir süre \"çalmasına\" neden olur."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:535
+#: ../../info/wxmaxima.md:566
 #, fuzzy
 #| msgid "### Embedding animations into the spreadsheet"
 msgid "### Embedding animations into the spreadsheet"
 msgstr "### Animasyonları düz bir sayfaya gömme"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:537
+#: ../../info/wxmaxima.md:568
 #, fuzzy
 #| msgid ""
 #| "3D diagrams tend to make it hard to read quantitative data. A viable "
@@ -2448,7 +2525,7 @@ msgstr ""
 "izin verir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:539
+#: ../../info/wxmaxima.md:570
 msgid ""
 "The first two arguments for `with_slider_draw` are the name of the variable "
 "that is stepped between the plots and a list of the values of these "
@@ -2460,7 +2537,7 @@ msgstr ""
 "argümanlar \"wxdraw2d\" için sıradan argümanlardır:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:550
+#: ../../info/wxmaxima.md:581
 #, fuzzy, no-wrap
 #| msgid ""
 #| "    with_slider_draw(\n"
@@ -2493,7 +2570,7 @@ msgstr ""
 "    );\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:552
+#: ../../info/wxmaxima.md:583
 msgid ""
 "The same functionality for 3D plots is accessible as `with_slider_draw3d`, "
 "which allows for rotating 3d plots:"
@@ -2502,7 +2579,7 @@ msgstr ""
 "with_slider_draw3d` ile erişilebilir:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:569
+#: ../../info/wxmaxima.md:600
 #, fuzzy, no-wrap
 #| msgid ""
 #| "    wxanimate_autoplay:true;\n"
@@ -2553,7 +2630,7 @@ msgstr ""
 "    )$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:571
+#: ../../info/wxmaxima.md:602
 #, fuzzy
 #| msgid ""
 #| "If the general shape of the plot is what matters it might suffice to move "
@@ -2568,7 +2645,7 @@ msgstr ""
 "çizimi biraz hareket ettirmek yeterli olabilir:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:588
+#: ../../info/wxmaxima.md:619
 #, fuzzy, no-wrap
 #| msgid ""
 #| "    wxanimate_autoplay:true;\n"
@@ -2619,7 +2696,7 @@ msgstr ""
 "    )$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:590
+#: ../../info/wxmaxima.md:621
 #, fuzzy
 #| msgid ""
 #| "For those more familiar with `plot` than with `draw` there is a second "
@@ -2632,19 +2709,19 @@ msgstr ""
 "vardır:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
+#: ../../info/wxmaxima.md:624
 #, fuzzy
 #| msgid "`with_slider` and"
 msgid "`with_slider` and"
 msgstr "`with_slider` ve"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
+#: ../../info/wxmaxima.md:624
 msgid "`wxanimate`."
 msgstr "`wxanimate`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:595
+#: ../../info/wxmaxima.md:626
 #, fuzzy
 #| msgid ""
 #| "Normally the animations are played back or exported with the frame rate "
@@ -2660,7 +2737,7 @@ msgstr ""
 "ayarlamak için `wxanimate_framerate 'değişkeni kullanılabilir:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:600
+#: ../../info/wxmaxima.md:631
 #, fuzzy, no-wrap
 #| msgid ""
 #| "    wxanimate(a, 10,\n"
@@ -2675,7 +2752,7 @@ msgstr ""
 "        sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:602
+#: ../../info/wxmaxima.md:633
 #, fuzzy
 #| msgid ""
 #| "The animation functions use _maxima_'s `makelist` command and therefore "
@@ -2694,7 +2771,7 @@ msgstr ""
 "nedenle aşağıdaki örnek başarısız olacaktır:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:612
+#: ../../info/wxmaxima.md:643
 #, fuzzy, no-wrap
 #| msgid ""
 #| "    f:sin(a*x);\n"
@@ -2724,7 +2801,7 @@ msgstr ""
 "    )$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:614
+#: ../../info/wxmaxima.md:645
 #, fuzzy
 #| msgid ""
 #| "If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
@@ -2737,7 +2814,7 @@ msgstr ""
 "değer grafiği işe yarar:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:627
+#: ../../info/wxmaxima.md:658
 #, fuzzy, no-wrap
 #| msgid ""
 #| "    f:sin(a*x);\n"
@@ -2776,14 +2853,14 @@ msgstr ""
 "    )$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:629
+#: ../../info/wxmaxima.md:660
 #, fuzzy
 #| msgid "### Opening multiple plots in contemporaneous windows"
 msgid "### Opening multiple plots in contemporaneous windows"
 msgstr "### Eşzamanlı olmayan pencerelerde birden fazla çizim açma"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:631
+#: ../../info/wxmaxima.md:662
 #, fuzzy
 #| msgid ""
 #| "While not being a provided by _wxMaxima_ this feature of _Maxima_ (on "
@@ -2799,14 +2876,14 @@ msgstr ""
 "Mario Rodriguez'in _Maxima_ posta listesine bir gönderiden geliyor:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:634
+#: ../../info/wxmaxima.md:665
 #, fuzzy
 #| msgid "    load(draw);\n"
 msgid "```maxima load(draw);"
 msgstr "    load(draw);\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:637
+#: ../../info/wxmaxima.md:668
 #, fuzzy
 #| msgid ""
 #| "    /* Parabola in window #1 */\n"
@@ -2818,7 +2895,7 @@ msgstr ""
 "    draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:640
+#: ../../info/wxmaxima.md:671
 #, fuzzy
 #| msgid ""
 #| "    /* Parabola in window #2 */\n"
@@ -2830,7 +2907,7 @@ msgstr ""
 "    draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:644
+#: ../../info/wxmaxima.md:675
 #, fuzzy
 #| msgid ""
 #| "    /* Paraboloid in window #3 */\n"
@@ -2843,14 +2920,14 @@ msgstr ""
 "    draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:646
+#: ../../info/wxmaxima.md:677
 msgid ""
 "Plotting multiple plots in the same window is possible, too (the same is "
 "possible in command line Maxima with the standard `draw()` command):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:657
+#: ../../info/wxmaxima.md:688
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2866,7 +2943,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:659
+#: ../../info/wxmaxima.md:690
 #, fuzzy
 #| msgid "### The \"Plot using draw\" sidepane"
 msgid "### The \"Plot using draw\" side pane"
@@ -2874,7 +2951,7 @@ msgstr ""
 "Draw  kullanarak grafik çiz### \"draw komutu ile grafik çizme'' yan paneli"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:661
+#: ../../info/wxmaxima.md:692
 #, fuzzy
 #| msgid ""
 #| "The \"Plot using draw\" sidebar hides a simple code generator that allows "
@@ -2890,12 +2967,12 @@ msgstr ""
 "basit bir kod oluşturucuyu gizler."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:663
+#: ../../info/wxmaxima.md:694
 msgid "#### 2D"
 msgstr "#### 2B"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:665
+#: ../../info/wxmaxima.md:696
 #, fuzzy
 #| msgid ""
 #| "Generates the skeleton of a `draw()` command that draws a 2D scene. This "
@@ -2913,7 +2990,7 @@ msgstr ""
 "kullanarak, sahnenin içeriğini oluşturan komutlarla doldurulmalıdır."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:667
+#: ../../info/wxmaxima.md:698
 #, fuzzy
 #| msgid ""
 #| "One helpful feature of the 2D button is that it allows to setup the scene "
@@ -2932,12 +3009,12 @@ msgstr ""
 "veriden daha kolay yorumlamaya izin verir hareketsiz 3D bir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:669
+#: ../../info/wxmaxima.md:700
 msgid "#### 3D"
 msgstr "#### 3B"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:671
+#: ../../info/wxmaxima.md:702
 #, fuzzy
 #| msgid ""
 #| "Generates the skeleton of a `draw()` command that draws a 3D scene. If "
@@ -2953,14 +3030,14 @@ msgstr ""
 "bir 2B sahne ayarlayın."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:673
+#: ../../info/wxmaxima.md:704
 #, fuzzy
 #| msgid "#### Expression"
 msgid "#### Expression"
 msgstr "#### İfade"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:675
+#: ../../info/wxmaxima.md:706
 msgid ""
 "Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or "
 "`x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is "
@@ -2973,14 +3050,14 @@ msgstr ""
 "ile doldurulabilir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:677
+#: ../../info/wxmaxima.md:708
 #, fuzzy
 #| msgid "#### Implicit plot"
 msgid "#### Implicit plot"
 msgstr "#### Kapalı çizim"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:679
+#: ../../info/wxmaxima.md:710
 msgid ""
 "Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or "
 "`x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command "
@@ -2993,14 +3070,14 @@ msgstr ""
 "oluşturulur."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:681
+#: ../../info/wxmaxima.md:712
 #, fuzzy
 #| msgid "#### Parametric plot"
 msgid "#### Parametric plot"
 msgstr "#### Parametrik Grafik çizimi"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:683
+#: ../../info/wxmaxima.md:714
 msgid ""
 "Steps a variable from a lower limit to an upper limit and uses two "
 "expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in "
@@ -3012,14 +3089,14 @@ msgstr ""
 "(t)` gibi iki ifade kullanır geçerli çizim komutuna konan eğri."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:685
+#: ../../info/wxmaxima.md:716
 #, fuzzy
 #| msgid "#### Points"
 msgid "#### Points"
 msgstr "#### Noktalar"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:687
+#: ../../info/wxmaxima.md:718
 msgid ""
 "Draws many points that can optionally be joined. The coordinates of the "
 "points are taken from a list of lists, a 2D array or one list or array for "
@@ -3030,38 +3107,38 @@ msgstr ""
 "listeden veya diziden alınır."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:689
+#: ../../info/wxmaxima.md:720
 #, fuzzy
 #| msgid "#### Diagram title"
 msgid "#### Diagram title"
 msgstr "#### Diyagram başlığı"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:691
+#: ../../info/wxmaxima.md:722
 msgid "Draws a title on the upper end of the diagram,"
 msgstr "Diyagramın üst ucuna bir başlık çizer,"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:693
+#: ../../info/wxmaxima.md:724
 #, fuzzy
 #| msgid "#### 2D"
 msgid "#### Axis"
 msgstr "#### 2B"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:695
+#: ../../info/wxmaxima.md:726
 msgid "Sets up the axis."
 msgstr "Ekseni ayarlar."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:697
+#: ../../info/wxmaxima.md:728
 #, fuzzy
 #| msgid "#### Contour"
 msgid "#### Contour"
 msgstr "#### Eşyükselti eğrisi"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:699
+#: ../../info/wxmaxima.md:730
 #, fuzzy
 #| msgid ""
 #| "(Only for 3D plots): Adds contour lines similar to the ones one can find "
@@ -3082,14 +3159,14 @@ msgstr ""
 "tamamen atlayarak sadece kontur grafiğini göstermeyi sağlar."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:701
+#: ../../info/wxmaxima.md:732
 #, fuzzy
 #| msgid "#### Plot name"
 msgid "#### Plot name"
 msgstr "#### Çizim Adı"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:703
+#: ../../info/wxmaxima.md:734
 #, fuzzy
 #| msgid ""
 #| "Adds a legend entry showing the next plot's name to the legend of the "
@@ -3105,14 +3182,14 @@ msgstr ""
 "oluşturulmasını devre dışı bırakır."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:705
+#: ../../info/wxmaxima.md:736
 #, fuzzy
 #| msgid "#### Line color"
 msgid "#### Line colour"
 msgstr "#### Çizgi Rengi"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:707
+#: ../../info/wxmaxima.md:738
 #, fuzzy
 #| msgid ""
 #| "Sets the line color for the following plots the current draw command "
@@ -3125,14 +3202,14 @@ msgstr ""
 "ayarlar."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:709
+#: ../../info/wxmaxima.md:740
 #, fuzzy
 #| msgid "#### Fill color"
 msgid "#### Fill colour"
 msgstr "#### Renk doldur"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:711
+#: ../../info/wxmaxima.md:742
 #, fuzzy
 #| msgid ""
 #| "Sets the fill color for the following plots the current draw command "
@@ -3145,26 +3222,26 @@ msgstr ""
 "ayarlar."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:713
+#: ../../info/wxmaxima.md:744
 #, fuzzy
 #| msgid "#### 2D"
 msgid "#### Grid"
 msgstr "#### 2B"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:715
+#: ../../info/wxmaxima.md:746
 msgid "Pops up a wizard that allows to set up grid lines."
 msgstr "Izgara çizgilerini ayarlamaya izin veren bir sihirbaz açar."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:717
+#: ../../info/wxmaxima.md:748
 #, fuzzy
 #| msgid "#### Accuracy"
 msgid "#### Accuracy"
 msgstr "#### Doğruluk"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:719
+#: ../../info/wxmaxima.md:750
 msgid ""
 "Allows to select an adequate point in the speed vs. accuracy tradeoff that "
 "is part of any plot program."
@@ -3173,12 +3250,12 @@ msgstr ""
 "yeterli bir noktanın seçilmesini sağlar."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:721
+#: ../../info/wxmaxima.md:752
 msgid "### Modify font and font size for plots"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:723
+#: ../../info/wxmaxima.md:754
 msgid ""
 "Especially when you use a high resolution display, the default font size "
 "might be very small. For the `draw`-based commands, you can set the font / "
@@ -3186,7 +3263,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:730
+#: ../../info/wxmaxima.md:761
 #, fuzzy, no-wrap
 #| msgid ""
 #| "pngdraw2d(\"Test\",\n"
@@ -3207,14 +3284,14 @@ msgstr ""
 "~~~~\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:732
+#: ../../info/wxmaxima.md:763
 msgid ""
 "For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts "
 "can be set using the `gnuplot_preamble` command, e.g.:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:737
+#: ../../info/wxmaxima.md:768
 #, no-wrap
 msgid ""
 "~~~maxima\n"
@@ -3224,14 +3301,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:739
+#: ../../info/wxmaxima.md:770
 msgid ""
 "This sets the font for the numbers to Arial with size 30, the size for the "
 "xlabel and ylabel font to 20 (with the default font)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:742
+#: ../../info/wxmaxima.md:773
 msgid ""
 "Read the Maxima and Gnuplot documentation for further information.  Note: "
 "Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue "
@@ -3239,14 +3316,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:744
+#: ../../info/wxmaxima.md:775
 #, fuzzy
 #| msgid "## Embedding graphics"
 msgid "## Embedding graphics"
 msgstr "## Grafikleri gömme"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:746
+#: ../../info/wxmaxima.md:777
 #, fuzzy
 #| msgid ""
 #| "if the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
@@ -3265,21 +3342,21 @@ msgstr ""
 "değerlendirme sırasında yüklemesini söylemek daha iyidir:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:750
+#: ../../info/wxmaxima.md:781
 #, fuzzy
 #| msgid "    show_image(\"man.png\");\n"
 msgid "```maxima show_image(\"man.png\"); ```"
 msgstr "    show_image(\"man.png\");\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:752
+#: ../../info/wxmaxima.md:783
 #, fuzzy
 #| msgid "## Startup files"
 msgid "## Startup files"
 msgstr "## Başlangıç dosyaları"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:754
+#: ../../info/wxmaxima.md:785
 msgid ""
 "The config dialogue of _wxMaxima_ offers to edit two files with commands "
 "that are executed on startup:"
@@ -3288,7 +3365,7 @@ msgstr ""
 "iki dosyayı düzenlemeyi önerir:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
+#: ../../info/wxmaxima.md:788
 #, fuzzy
 #| msgid ""
 #| "A file that contains commands that are executed on starting up _Maxima_: "
@@ -3301,7 +3378,7 @@ msgstr ""
 "içeren bir dosya"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
+#: ../../info/wxmaxima.md:788
 #, fuzzy
 #| msgid ""
 #| "A file that contains commands that are executed on starting up _Maxima_: "
@@ -3314,7 +3391,7 @@ msgstr ""
 "içeren bir dosya"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:759
+#: ../../info/wxmaxima.md:790
 msgid ""
 "For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add "
 "`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` "
@@ -3322,7 +3399,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:761
+#: ../../info/wxmaxima.md:792
 #, fuzzy
 #| msgid ""
 #| "These files are in the Maxima user directory, usually `.maxima/` in the "
@@ -3337,14 +3414,14 @@ msgstr ""
 "dizinindeki `.maxima /`, konum şu komutla bulunabilir: `maxima_userdir;`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:763
+#: ../../info/wxmaxima.md:794
 #, fuzzy
 #| msgid "## Special variables wx..."
 msgid "## Special variables wx..."
 msgstr "## Özel değişkenler wx ..."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxsubscripts` tells _Maxima_ if it should convert variable names that "
 "contain an underscore (`R_150` or the like) into subscripted variables. See "
@@ -3357,7 +3434,7 @@ msgstr ""
 "`wxdeclare_subscript'e bakınız."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxfilename`: This variable contains the name of the file currently opened "
 "in _wxMaxima_."
@@ -3366,7 +3443,7 @@ msgstr ""
 "adını içerir."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, fuzzy
 #| msgid ""
 #| "`wxfilename`: This variable contains the name of the file currently "
@@ -3379,7 +3456,7 @@ msgstr ""
 "adını içerir."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, fuzzy
 #| msgid ""
 #| "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _gnuplot_’s "
@@ -3395,12 +3472,12 @@ msgstr ""
 "çalışıp çalışmadığını söyler."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxplot_size` defines the resolution of embedded plots."
 msgstr "\"wxplot_size`, katıştırılmış grafiklerin çözünürlüğünü tanımlar."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, fuzzy
 #| msgid ""
 #| "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
@@ -3425,7 +3502,7 @@ msgstr ""
 "\"false\" olarak ayarlanabilir."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxanimate_framerate`: The number of frames per second the following "
 "animations have to be played back with."
@@ -3434,31 +3511,31 @@ msgstr ""
 "başına kare sayısı."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxanimate_autoplay`: Automatically play animations by default?"
 msgstr ""
 "\"wxanimate_autoplay`: Animasyonlar varsayılan olarak otomatik olarak "
 "oynatılsın mı?"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:776
+#: ../../info/wxmaxima.md:807
 #, fuzzy
 #| msgid "## Pretty-printing 2D output"
 msgid "## Pretty-printing 2D output"
 msgstr "## Güzel-baskı 2D çıktı"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:778
+#: ../../info/wxmaxima.md:809
 #, fuzzy
 #| msgid ""
 #| "The function `table_form()` displays a 2D list in a form that is more "
@@ -3481,7 +3558,7 @@ msgstr ""
 "birlikte aynı tabloda sonuçlanır."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:787
+#: ../../info/wxmaxima.md:818
 #, fuzzy, no-wrap
 #| msgid ""
 #| "    table_form(\n"
@@ -3508,7 +3585,7 @@ msgstr ""
 "    )$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:789
+#: ../../info/wxmaxima.md:820
 msgid ""
 "As the next example shows, the lists that are assembled by the `table_form` "
 "command can be created before the command is executed."
@@ -3517,7 +3594,7 @@ msgstr ""
 "listeler komut yürütülmeden önce oluşturulabilir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:791
+#: ../../info/wxmaxima.md:822
 msgid ""
 "![A third table example](./MatrixTableExample.png)"
 "{ id=img_MatrixTableExample }"
@@ -3526,7 +3603,7 @@ msgstr ""
 "{ id=img_MatrisTabloÖrneği }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:793
+#: ../../info/wxmaxima.md:824
 msgid ""
 "Also, because a matrix is a list of lists, matrices can be converted to "
 "tables in a similar fashion."
@@ -3535,7 +3612,7 @@ msgstr ""
 "tablolara dönüştürülebilir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:795
+#: ../../info/wxmaxima.md:826
 msgid ""
 "![Another table_form example](./SecondTableExample.png)"
 "{ id=img_SecondTableExample }"
@@ -3544,28 +3621,58 @@ msgstr ""
 "{ id=img_İkinciTabloÖrneği }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:797
+#: ../../info/wxmaxima.md:828
 msgid ""
 "The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that "
 "allows for more flexible formatting of matrices in wxMaxima:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:803
+#: ../../info/wxmaxima.md:830
 #, no-wrap
+msgid "**`wx_matrix( <matrix>, [options] )`**\n"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
 msgid ""
-"**`wx_matrix( <matrix>, [options] )`**\n"
-"- **`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data.\n"
-"- **`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels.\n"
-"- **`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels.\n"
-"- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`.\n"
+"**`lines=true`**: Draws internal separator lines between the cells. This is "
+"required to visually separate headings from data."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`rownames=true`**: Tells wxMaxima that the first column of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`colnames=true`**: Tells wxMaxima that the first row of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
+"around the matrix. Supported styles are: `round` `()`, `square` `[]`, "
+"`angled` `<>`, `straight` `||`, or `none`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:809
+#: ../../info/wxmaxima.md:837
+#, fuzzy
+#| msgid "One Example:"
+msgid "Example:"
+msgstr "Bir Örnek:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:842
 #, no-wrap
 msgid ""
-"Example:\n"
 "```maxima\n"
 "wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
 "          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
@@ -3573,14 +3680,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:811
+#: ../../info/wxmaxima.md:844
 #, fuzzy
 #| msgid "## Bug reporting"
 msgid "## Bug reporting"
 msgstr "## Hata Raporlama"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:813
+#: ../../info/wxmaxima.md:846
 #, fuzzy
 #| msgid ""
 #| "_wxMaxima_ provides a few functions that gather bug reporting information "
@@ -3593,7 +3700,7 @@ msgstr ""
 "işlev sunar:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:816
+#: ../../info/wxmaxima.md:849
 #, fuzzy
 #| msgid ""
 #| "`wxbuild_info()` gathers information about the currently running version "
@@ -3605,19 +3712,19 @@ msgstr ""
 "`wxbuild_info ()` şu anda çalışan _wxMaxima_ sürümü hakkında bilgi toplar"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:816
+#: ../../info/wxmaxima.md:849
 msgid "`wxbug_report()` tells how and where to file bugs"
 msgstr "`wxbug_report ()`, hataların nasıl ve nerede dosyalanacağını söyler"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:819
+#: ../../info/wxmaxima.md:851
 #, fuzzy
 #| msgid "## Marking output being drawn in red"
 msgid "## Marking output being drawn in red"
 msgstr "## İşaretleme çıktısı kırmızıyla çizilir"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:822
+#: ../../info/wxmaxima.md:854
 #, fuzzy
 #| msgid ""
 #| "_Maxima_'s `box()` command causes _wxMaxima_ to print its argument with a "
@@ -3631,17 +3738,17 @@ msgstr ""
 "yazdırmasına neden olur."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:824
+#: ../../info/wxmaxima.md:856
 msgid "## Output rendering."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:826
+#: ../../info/wxmaxima.md:858
 msgid "With `set_display()` one can set, how wxMaxima will render the output."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:828
+#: ../../info/wxmaxima.md:860
 msgid ""
 "`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima "
 "using an (machine readable) XML-dialect (can be seen in the \"Raw XML "
@@ -3650,7 +3757,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:831
+#: ../../info/wxmaxima.md:863
 msgid ""
 "<!--- Currently that does not work as it should, the line with the output "
 "label is shifted right (issue: #2006) --> `set_display('ascii)` causes "
@@ -3658,19 +3765,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:833
+#: ../../info/wxmaxima.md:865
 msgid ""
 "`set_display('none)` causes 'one-line' ASCII results - the same as the "
 "command line Maxima command `display2d:false;` does."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:867
 msgid "# Help menu"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:837
+#: ../../info/wxmaxima.md:869
 msgid ""
 "WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, "
 "tips, some example worksheets and in command line Maxima included demos (the "
@@ -3678,19 +3785,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:839
+#: ../../info/wxmaxima.md:871
 msgid "Please notice, that the demos write:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:843
+#: ../../info/wxmaxima.md:875
 msgid ""
 "~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the "
 "demonstration.  ~~~"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:845
+#: ../../info/wxmaxima.md:877
 msgid ""
 "That is valid for command-line Maxima, however in wxMaxima by default it is "
 "necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</"
@@ -3698,14 +3805,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:847
+#: ../../info/wxmaxima.md:879
 msgid ""
 "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending "
 "commands to Maxima\" menu.)"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:851
+#: ../../info/wxmaxima.md:883
 #, fuzzy
 #| msgid ""
 #| "Troubleshooting\n"
@@ -3716,14 +3823,14 @@ msgstr ""
 "===============\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:853
+#: ../../info/wxmaxima.md:885
 #, fuzzy
 #| msgid "## Cannot connect to _Maxima_"
 msgid "## Cannot connect to _Maxima_"
 msgstr "## _Maxima_ 'ya bağlanılamıyor"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:855
+#: ../../info/wxmaxima.md:887
 #, fuzzy
 #| msgid ""
 #| "Since _Maxima_ (the program that does the actual mathematics) and "
@@ -3765,7 +3872,7 @@ msgstr ""
 "lisp.exe veya benzer adlardır."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:857
+#: ../../info/wxmaxima.md:889
 #, fuzzy
 #| msgid ""
 #| "On Un\\*x computers another possible reason would be that the loopback "
@@ -3781,14 +3888,14 @@ msgstr ""
 "yapılandırılmamış olması olabilir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:859
+#: ../../info/wxmaxima.md:891
 #, fuzzy
 #| msgid "## How to save data from a broken .wxmx file"
 msgid "## How to save data from a broken .wxmx file"
 msgstr "## Bozuk bir .wxmx dosyasından veri nasıl kaydedilir"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:861
+#: ../../info/wxmaxima.md:893
 #, fuzzy
 #| msgid ""
 #| "Internally most modern xml-based formats are ordinary zip-files. wxMaxima "
@@ -3804,7 +3911,7 @@ msgstr ""
 "görüntülenebilir hale getiren sıkıştırmayı açmaz."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:863
+#: ../../info/wxmaxima.md:895
 #, fuzzy
 #| msgid ""
 #| "If the zip signature at the end of the file is still intact after "
@@ -3841,7 +3948,7 @@ msgstr ""
 "bölümünü kurtarmak için bir metin düzenleyicisi kullanmak mümkündür."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:865
+#: ../../info/wxmaxima.md:897
 msgid ""
 "And even if there isn’t such a file: The `.wxmx` file is a container format "
 "and the XML portion is stored uncompressed. It it is possible to rename the "
@@ -3852,7 +3959,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:867
+#: ../../info/wxmaxima.md:899
 #, fuzzy
 #| msgid ""
 #| "If the text file containing this contents is saved as a file ending "
@@ -3867,7 +3974,7 @@ msgstr ""
 "olarak kaydedilirse, belgenin metnini ondan nasıl kurtaracağını bilir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:869
+#: ../../info/wxmaxima.md:901
 #, fuzzy
 #| msgid ""
 #| "## I want some debug info to be displayed on the screen before my command "
@@ -3880,7 +3987,7 @@ msgstr ""
 "istiyorum"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:871
+#: ../../info/wxmaxima.md:903
 msgid ""
 "Normally _wxMaxima_ waits for the whole 2D formula to be transferred before "
 "it begins to typeset. This saves time for making many attempts to typeset a "
@@ -3895,7 +4002,7 @@ msgstr ""
 "sağlayacak bir 'disp` komutu vardır:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:881
+#: ../../info/wxmaxima.md:913
 #, fuzzy, no-wrap
 #| msgid ""
 #| "    for i:1 thru 10 do (\n"
@@ -3925,19 +4032,19 @@ msgstr ""
 "    )$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:883
+#: ../../info/wxmaxima.md:915
 msgid "Alternatively one can look for the `wxstatusbar()` command above."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:885
+#: ../../info/wxmaxima.md:917
 #, fuzzy
 #| msgid "## Plotting only shows a closed empty envelope with an error message"
 msgid "## Plotting only shows a closed empty envelope with an error message"
 msgstr "## Çizim yalnızca hata mesajı içeren kapalı bir boş zarf gösteriyor"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:887
+#: ../../info/wxmaxima.md:919
 #, fuzzy
 #| msgid ""
 #| "This means that _wxMaxima_ could not read the file _Maxima_ that was "
@@ -3950,12 +4057,12 @@ msgstr ""
 "_Maxima_ dosyasını okuyamadığı anlamına gelir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:889
+#: ../../info/wxmaxima.md:921
 msgid "Possible reasons for this error are:"
 msgstr "Bu hatanın olası nedenleri:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, fuzzy
 #| msgid ""
 #| "The plotting command is part of a third-party package like "
@@ -3971,7 +4078,7 @@ msgstr ""
 "tarafından yüklenmedi."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, fuzzy
 #| msgid ""
 #| "_Maxima_ tried to do something the currently installed version of gnuplot "
@@ -3992,7 +4099,7 @@ msgstr ""
 "nedenle, bu dosyanın içeriği çoğu zaman sorunu ayıklarken faydalıdır."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, fuzzy
 #| msgid ""
 #| "Gnuplot was instructed to use the pngcairo library that provides "
@@ -4014,21 +4121,21 @@ msgstr ""
 "`wxplot_pngcairo` değerini true olarak ayarlamayın."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, fuzzy
 #| msgid "Gnuplot didn’t output a valid .png file."
 msgid "Gnuplot didn’t output a valid `.png` file."
 msgstr "Gnuplot geçerli bir .png dosyası vermedi."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:896
+#: ../../info/wxmaxima.md:928
 #, fuzzy
 #| msgid "## Plotting an animation results in “error: undefined variable”"
 msgid "## Plotting an animation results in “error: undefined variable”"
 msgstr "## Bir animasyonun çizilmesi “hata: tanımsız değişken” ile sonuçlanır"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:898
+#: ../../info/wxmaxima.md:930
 #, fuzzy
 #| msgid ""
 #| "The value of the slider variable by default is only substituted into the "
@@ -4049,14 +4156,14 @@ msgstr ""
 "gerekir) bu sorunu çözer."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:900
+#: ../../info/wxmaxima.md:932
 #, fuzzy
 #| msgid "## I lost a cell contents and undo doesn’t remember"
 msgid "## I lost cell content and undo doesn’t remember"
 msgstr "## Bir hücre içeriğini kaybettim ve geri almayı hatırlamıyorum"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:902
+#: ../../info/wxmaxima.md:934
 msgid ""
 "There are separate undo functions for cell operations and for changes inside "
 "of cells so chances are low that this ever happens. If it does there are "
@@ -4067,7 +4174,7 @@ msgstr ""
 "verileri kurtarmak için birkaç yöntem vardır:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 #, fuzzy
 #| msgid ""
 #| "_wxMaxima_ actually has two undo features: The global undo buffer that is "
@@ -4087,7 +4194,7 @@ msgstr ""
 "kullanmaya değer."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 #, fuzzy
 #| msgid ""
 #| "If you still have a way to find out what label _Maxima_ has assigned to "
@@ -4101,7 +4208,7 @@ msgstr ""
 "görünür."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 #, fuzzy
 #| msgid ""
 #| "If you don’t: Don’t panic. In the “View” menu there is a way to show a "
@@ -4115,18 +4222,18 @@ msgstr ""
 "_Maxima_ komutlarını gösteren bir geçmiş bölmesi göstermenin bir yolu vardır."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid "If nothing else helps _Maxima_ contains a replay feature:"
 msgstr ""
 "Başka bir şey yardımcı olmazsa _Maxima_ bir yeniden oynatma özelliği içerir:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:911
+#: ../../info/wxmaxima.md:943
 msgid "```maxima playback(); ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:913
+#: ../../info/wxmaxima.md:945
 #, fuzzy
 #| msgid ""
 #| "## _wxMaxima_ starts up with the message “Maxima process terminated.”"
@@ -4134,7 +4241,7 @@ msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”
 msgstr "## _ wxMaxima _ “Maxima işlemi sonlandırıldı” mesajı ile başlar."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:915
+#: ../../info/wxmaxima.md:947
 #, fuzzy
 #| msgid ""
 #| "One possible reason is that _Maxima_ cannot be found in the location that "
@@ -4153,14 +4260,14 @@ msgstr ""
 "sorunu gidermelidir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:917
+#: ../../info/wxmaxima.md:949
 #, fuzzy
 #| msgid "## Maxima is forever calculating and not responding to input"
 msgid "## Maxima is forever calculating and not responding to input"
 msgstr "## Maxima sonsuza kadar hesaplıyor ve girdiye yanıt vermiyor"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:919
+#: ../../info/wxmaxima.md:951
 #, fuzzy
 #| msgid ""
 #| "It is theoretically possible that _wxMaxima_ doesn’t realize that "
@@ -4179,14 +4286,14 @@ msgstr ""
 "edebilir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:921
+#: ../../info/wxmaxima.md:953
 #, fuzzy
 #| msgid "## My SBCL-based _Maxima_ runs out of memory"
 msgid "## My SBCL-based _Maxima_ runs out of memory"
 msgstr "## SBCL tabanlı _Maxima_'ımın belleği yetersiz"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:923
+#: ../../info/wxmaxima.md:955
 #, fuzzy
 #| msgid ""
 #| "The Lisp compiler SBCL by default comes with a memory limit that allows "
@@ -4219,7 +4326,7 @@ msgstr ""
 "kullanma talimatı verilebilir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:925
+#: ../../info/wxmaxima.md:957
 #, fuzzy
 #| msgid ""
 #| "One way to provide _Maxima_ (and thus SBCL) with command line parameters "
@@ -4235,19 +4342,19 @@ msgstr ""
 "parametreler\" alanıdır."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:927
+#: ../../info/wxmaxima.md:959
 msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
 msgstr "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:929
+#: ../../info/wxmaxima.md:961
 #, fuzzy
 #| msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
 msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
 msgstr "## Girdi bazen Ubuntu'daki anahtarları yavaş / yok sayılıyor"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:931
+#: ../../info/wxmaxima.md:963
 msgid ""
 "Installing the package `ibus-gtk` should resolve this issue. See ([https://"
 "bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://"
@@ -4258,7 +4365,7 @@ msgstr ""
 "bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/ 1421558))."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:933
+#: ../../info/wxmaxima.md:965
 #, fuzzy
 #| msgid ""
 #| "## _wxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
@@ -4267,7 +4374,7 @@ msgstr ""
 "## _wxMaxima_, _Maxima_ Yunan karakterlerini veya Umlauts'u işlediğinde durur"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:935
+#: ../../info/wxmaxima.md:967
 msgid ""
 "If your _Maxima_ is based on SBCL the following lines have to be added to "
 "your `.sbclrc`:"
@@ -4276,14 +4383,14 @@ msgstr ""
 "eklenmesi gerekir:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:971
 #, fuzzy
 #| msgid "    (setf sb-impl::*default-external-format* :utf-8)\n"
 msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
 msgstr "    (setf sb-impl::*default-external-format* :utf-8)\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:941
+#: ../../info/wxmaxima.md:973
 #, fuzzy
 #| msgid ""
 #| "The folder this file has to be placed in is system- and installation-"
@@ -4302,60 +4409,92 @@ msgstr ""
 "memnuniyetle söyleyecektir:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:945
+#: ../../info/wxmaxima.md:977
 #, fuzzy
 #| msgid "    :lisp (sb-impl::userinit-pathname)\n"
 msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
 msgstr "    :lisp (sb-impl::userinit-pathname)\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:947
+#: ../../info/wxmaxima.md:979
 msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:950
+#: ../../info/wxmaxima.md:982
 msgid ""
 "There seem to be issues with the Wayland Display Server and wxWidgets.  "
 "WxMaxima may be affected, e.g. that sidebars are not moveable."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:954
+#: ../../info/wxmaxima.md:986
 msgid ""
 "You can either disable Wayland and use X11 instead (globally)  or just tell, "
 "that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:956
+#: ../../info/wxmaxima.md:988
 msgid "E.g. start wxMaxima with:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:958
+#: ../../info/wxmaxima.md:990
 msgid "`GDK_BACKEND=x11 wxmaxima`"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:960
+#: ../../info/wxmaxima.md:992
+msgid "## The menu bar disappears on KDE Plasma"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:997
+msgid ""
+"On some KDE Plasma installations the global menu bar disappears when "
+"clicked.  As this is a bug in the global menu proxy, the only way to avoid "
+"it is to tell that wxMaxima should use its own menu bar instead of the "
+"global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1001
+msgid ""
+"Starting with version 26.05.0, wxMaxima attempts to set this variable "
+"automatically if it detects an affected system (KDE, Unity, or Ubuntu with "
+"older wxWidgets versions)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1003
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1005
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1007
 msgid "## Why is the integrated manual browser not offered on my Windows PC?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:963
+#: ../../info/wxmaxima.md:1010
 msgid ""
 "Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or "
 "Microsoft’s webview2 isn’t installed."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:965
+#: ../../info/wxmaxima.md:1012
 msgid "## Why is the external manual browser not working on my Linux box?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:971
+#: ../../info/wxmaxima.md:1018
 msgid ""
 "The HTML browser might be a snap, flatpack or appimage version. All of these "
 "typically cannot access files that are installed on your local system. "
@@ -4366,7 +4505,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:973
+#: ../../info/wxmaxima.md:1020
 #, fuzzy
 #| msgid ""
 #| "### Can I make _wxMaxima_ output both image files and embedded plots at "
@@ -4378,7 +4517,7 @@ msgstr ""
 "grafikler yapabilir miyim?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:975
+#: ../../info/wxmaxima.md:1022
 #, fuzzy
 #| msgid ""
 #| "The worksheet embeds .png files. wxMaxima allows the user to specify "
@@ -4391,7 +4530,7 @@ msgstr ""
 "üretilmesi gerektiğini belirtmesini sağlar:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:982
+#: ../../info/wxmaxima.md:1029
 #, fuzzy, no-wrap
 #| msgid ""
 #| "~~~~\n"
@@ -4416,7 +4555,7 @@ msgstr ""
 "~~~~\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:984
+#: ../../info/wxmaxima.md:1031
 #, fuzzy
 #| msgid ""
 #| "If a different format is to be used it is easier to generate the images "
@@ -4429,7 +4568,7 @@ msgstr ""
 "çalışma sayfasına almak daha kolaydır:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1003
+#: ../../info/wxmaxima.md:1050
 #, fuzzy, no-wrap
 #| msgid ""
 #| "~~~~\n"
@@ -4490,7 +4629,7 @@ msgstr ""
 "    pngdraw(name,gr2d(contents));\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1008
+#: ../../info/wxmaxima.md:1055
 #, fuzzy, no-wrap
 #| msgid ""
 #| "pngdraw2d(\"Test\",\n"
@@ -4509,19 +4648,19 @@ msgstr ""
 "~~~~\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1010
+#: ../../info/wxmaxima.md:1057
 #, fuzzy
 #| msgid "### Can I set the aspect ratio of a plot?"
 msgid "## Can I set the aspect ratio of an embedded plot?"
 msgstr "### Bir grafiğin en boy oranını ayarlayabilir miyim?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1012
+#: ../../info/wxmaxima.md:1059
 msgid "Use the variable `wxplot_size`:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1018
+#: ../../info/wxmaxima.md:1065
 #, fuzzy, no-wrap
 #| msgid ""
 #| "     wxdraw2d(\n"
@@ -4541,14 +4680,14 @@ msgstr ""
 "     ),wxplot_size=[1000,1000];\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1020
+#: ../../info/wxmaxima.md:1067
 msgid ""
 "## After upgrading to MacOS 13.1 plot and/or draw commands output error "
 "messages like"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1027
+#: ../../info/wxmaxima.md:1074
 msgid ""
 "```text 1 HIToolbox 0x00007ff80cd91726 "
 "_ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox "
@@ -4557,7 +4696,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1029
+#: ../../info/wxmaxima.md:1076
 msgid ""
 "This might be an issue with the operating system. Disable the hiding of the "
 "menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the "
@@ -4566,12 +4705,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1031
+#: ../../info/wxmaxima.md:1078
 msgid "## Logging"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1035
+#: ../../info/wxmaxima.md:1082
 msgid ""
 "Log messages might be helpful to debug problems. WxMaxima can log many "
 "events. Most log entries will be helpful for developers, especially in case "
@@ -4582,7 +4721,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1037
+#: ../../info/wxmaxima.md:1084
 msgid ""
 "Messages are not 'lost', if the log window is not shown, if you select to "
 "show the log window later, you will see past log messages (if you did not "
@@ -4590,14 +4729,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1039
+#: ../../info/wxmaxima.md:1086
 msgid ""
 "Such messages may be helpful, when you create bug reports (or trying to find "
 "a bug by yourself)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1042
+#: ../../info/wxmaxima.md:1089
 msgid ""
 "Log messages can (additionally) be printed to STDERR, when using the command "
 "line option \"--logtostderr\". On Windows a separate text console will be "
@@ -4605,12 +4744,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1046
+#: ../../info/wxmaxima.md:1093
 msgid "# FAQ"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1048
+#: ../../info/wxmaxima.md:1095
 #, fuzzy
 #| msgid "## Is there a way to make more text fit on a pdfLaTeX page?"
 msgid "## Is there a way to make more text fit on a LaTeX page?"
@@ -4618,14 +4757,14 @@ msgstr ""
 "## Bir pdfLaTeX sayfasına daha fazla metin sığdırmanın bir yolu var mı?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1050
+#: ../../info/wxmaxima.md:1097
 msgid ""
 "Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to "
 "specify the size of the borders."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1052
+#: ../../info/wxmaxima.md:1099
 #, fuzzy
 #| msgid ""
 #| "There is: Just add the following lines to the LaTeX preamble (for example "
@@ -4641,7 +4780,7 @@ msgstr ""
 "\"TeX başlangıç eki için ek satırlar\"):"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1056
+#: ../../info/wxmaxima.md:1103
 #, fuzzy
 #| msgid "    \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
 msgid ""
@@ -4649,14 +4788,14 @@ msgid ""
 msgstr "    \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1058
+#: ../../info/wxmaxima.md:1105
 #, fuzzy
 #| msgid "## Is there a dark mode?"
 msgid "## Is there a dark mode?"
 msgstr "## Koyu bir mod var mı?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1060
+#: ../../info/wxmaxima.md:1107
 #, fuzzy
 #| msgid ""
 #| "If wxWidgets is new enough wxMaxima will automatically be in dark mode if "
@@ -4680,7 +4819,7 @@ msgstr ""
 "Çalışma sayfası parlaklığını görüntüle / tersine çevir '' menü girişi vardır."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1062
+#: ../../info/wxmaxima.md:1109
 #, fuzzy
 #| msgid ""
 #| "## wxMaxima sometimes hangs for a several seconds once in the first minute"
@@ -4689,7 +4828,7 @@ msgid ""
 msgstr "## wxMaxima bazen ilk dakikada bir kaç saniye takılır"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1064
+#: ../../info/wxmaxima.md:1111
 #, fuzzy
 #| msgid ""
 #| "wxMaxima delegates some big tasks like parsing maxima's >1000-page-manual "
@@ -4709,19 +4848,19 @@ msgstr ""
 "gerekebilir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1066
+#: ../../info/wxmaxima.md:1113
 msgid ""
 "## Especially when testing new locale settings, a message box \"locale "
 "’xx_YY’ can not be set\" occurs"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1068
+#: ../../info/wxmaxima.md:1115
 msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1072
+#: ../../info/wxmaxima.md:1119
 msgid ""
 "(The same problem can occur with other applications too). The translations "
 "seem okay after you click on ’OK’. WxMaxima does not only use its own "
@@ -4729,20 +4868,20 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1075
+#: ../../info/wxmaxima.md:1122
 msgid ""
 "These locales maybe not present in the system. On Ubuntu/Debian systems they "
 "can be generated using: `dpkg-reconfigure locales`"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1077
+#: ../../info/wxmaxima.md:1124
 msgid ""
 "## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1079
+#: ../../info/wxmaxima.md:1126
 msgid ""
 "You can find these symbols in the Unicode sidebar (search for ’double-struck "
 "capital’). But the selected font must also support these symbols. If they do "
@@ -4750,14 +4889,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1081
+#: ../../info/wxmaxima.md:1128
 msgid ""
 "## How can a Maxima script determine, if it is running under wxMaxima or "
 "command line Maxima?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1083
+#: ../../info/wxmaxima.md:1130
 msgid ""
 "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to "
 "`wxmaxima`. The Maxima variable `maxima_frontend_version` contains the "
@@ -4765,19 +4904,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1085
+#: ../../info/wxmaxima.md:1132
 msgid ""
 "If no frontend is used (you are using command line Maxima), these variables "
 "are `false`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1087
+#: ../../info/wxmaxima.md:1134
 msgid "## Help! I can not save my document!"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1089
+#: ../../info/wxmaxima.md:1136
 msgid ""
 "If saving as wxmx file does not work, try saving the document as wxm file "
 "(and vice versa). And you can also try to remove all output (Menu Cell-"
@@ -4786,7 +4925,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1093
+#: ../../info/wxmaxima.md:1140
 #, fuzzy
 #| msgid ""
 #| "Command-line arguments\n"
@@ -4797,7 +4936,7 @@ msgstr ""
 "======================\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1095
+#: ../../info/wxmaxima.md:1142
 msgid ""
 "Usually you can start programs with a graphical user interface just by "
 "clicking on a desktop icon or desktop menu entry. WxMaxima - if started from "
@@ -4805,17 +4944,17 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-v` or `--version`: Output the version information"
 msgstr "`-v` veya` --version`: Sürüm bilgisini çıktılar"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-h` or `--help`: Output a short help text"
 msgstr "`-h` veya` --help`: Kısa bir yardım metni çıkarır"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, fuzzy
 #| msgid ""
 #| "`-o` or `--open=<str>`: Open the filename given as argument to this "
@@ -4828,12 +4967,12 @@ msgstr ""
 "olarak verilen dosya adını açın"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-e` or `--eval`: Evaluate the file after opening it."
 msgstr "`-e` veya` --eval`: Dosyayı açtıktan sonra değerlendirin."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, fuzzy
 #| msgid ""
 #| "`-b` or `--batch`: If the command-line opens a file all cells in this "
@@ -4861,7 +5000,7 @@ msgstr ""
 "her zaman garanti edilemez."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, fuzzy, no-wrap
 #| msgid ""
 #| "* `--logtostdout`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
@@ -4894,7 +5033,7 @@ msgstr ""
 "* `-m` or `--maxima=<str>`:    _maxima_ ikili dosyasının konumunu belirtmenize izin verir\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1113
+#: ../../info/wxmaxima.md:1160
 #, fuzzy
 #| msgid ""
 #| "Instead of a minus some operating systems might use a dash in front of "
@@ -4907,12 +5046,12 @@ msgstr ""
 "tire kullanabilir."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1117
+#: ../../info/wxmaxima.md:1164
 msgid "# About the program, contributing to wxMaxima"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1119
+#: ../../info/wxmaxima.md:1166
 msgid ""
 "wxMaxima is mainly developed using the programming language C++ using the "
 "[wxWidgets framework](https://www.wxwidgets.org), as build system we use "
@@ -4924,7 +5063,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1121
+#: ../../info/wxmaxima.md:1168
 msgid ""
 "But not only programmers are necessary! You can also contribute to wxMaxima, "
 "if you help to improve the documentation, find and report bugs (and maybe "
@@ -4935,19 +5074,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1123
+#: ../../info/wxmaxima.md:1170
 msgid "Or answer questions of other users in the discussion forum."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1125
+#: ../../info/wxmaxima.md:1172
 msgid ""
 "The source code of wxMaxima is documented using Doxygen [here](https://"
 "wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1127
+#: ../../info/wxmaxima.md:1174
 msgid ""
 "The program is nearly self-contained, so except for system libraries (and "
 "the wxWidgets library), no external dependencies (like graphic files or the "
@@ -4956,7 +5095,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1128
+#: ../../info/wxmaxima.md:1175
 msgid ""
 "If you are a developer, you might want to try out a modified `wxmathML.lisp`-"
 "file without recompiling everything, one can use the command line option `--"
@@ -5103,9 +5242,6 @@ msgstr ""
 
 #~ msgid "a title, section or a subsection."
 #~ msgstr "bir başlık, bölüm yada bir alt bölüm."
-
-#~ msgid "One Example:"
-#~ msgstr "Bir Örnek:"
 
 #~ msgid ""
 #~ "A .mac file named Quadratic.mac was created. It consists of two commands: "

--- a/locales/manual/uk.po
+++ b/locales/manual/uk.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-05-20 10:30+0200\n"
+"POT-Creation-Date: 2026-07-30 11:38+0200\n"
 "PO-Revision-Date: 2023-10-04 23:58+0300\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <kde-i18n-uk@kde.org>\n"
@@ -53,9 +53,9 @@ msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 msgstr "![Логотип wxMaxima](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:426
-#: ../../info/wxmaxima.md:848 ../../info/wxmaxima.md:1043
-#: ../../info/wxmaxima.md:1090 ../../info/wxmaxima.md:1114
+#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:425
+#: ../../info/wxmaxima.md:880 ../../info/wxmaxima.md:1090
+#: ../../info/wxmaxima.md:1137 ../../info/wxmaxima.md:1161
 #, no-wrap
 msgid "______________________________________________________________________\n"
 msgstr ""
@@ -1199,14 +1199,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:224
+#: ../../info/wxmaxima.md:223
 #, fuzzy
 #| msgid "Side Panes"
 msgid "### Side Panes"
 msgstr "Бічні панелі"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:226
+#: ../../info/wxmaxima.md:225
 msgid ""
 "Shortcuts to the most important _Maxima_ commands, things like a table of "
 "contents, windows with debug messages or a history of the last issued "
@@ -1223,12 +1223,12 @@ msgstr ""
 "грецьких літер за допомогою вказівника миші."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:228
+#: ../../info/wxmaxima.md:227
 msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
 msgstr "![Приклад різних бічних панелей](./SidePanes.png){ id=img_SidePanes }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:231
+#: ../../info/wxmaxima.md:230
 msgid ""
 "In the \"table of contents\" side pane, one can increase or decrease a "
 "heading by just clicking on the heading with the right mouse button and "
@@ -1239,7 +1239,7 @@ msgstr ""
 "наступний більший або менший рівень заголовка."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:233
+#: ../../info/wxmaxima.md:232
 msgid ""
 "![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-"
 "headings.png){ id=Sidepane-TOC-convert-headings }"
@@ -1249,14 +1249,14 @@ msgstr ""
 "headings }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:235
+#: ../../info/wxmaxima.md:234
 #, fuzzy
 #| msgid "MathML output"
 msgid "### MathML output"
 msgstr "Виведення коду MathML"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:237
+#: ../../info/wxmaxima.md:236
 #, fuzzy
 #| msgid ""
 #| "Several word processors and similar programs either recognize [MathML]"
@@ -1281,14 +1281,14 @@ msgstr ""
 "контекстному меню."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:239
+#: ../../info/wxmaxima.md:238
 #, fuzzy
 #| msgid "Markdown support"
 msgid "### Markdown support"
 msgstr "Підтримка Markdown"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:241
+#: ../../info/wxmaxima.md:240
 #, fuzzy
 #| msgid ""
 #| "_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/"
@@ -1304,7 +1304,7 @@ msgstr ""
 "позначенням. Одним із елементів розмітки є невпорядковані списки."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:251
+#: ../../info/wxmaxima.md:250
 #, fuzzy, no-wrap
 #| msgid ""
 #| "Ordinary text\n"
@@ -1334,7 +1334,7 @@ msgstr ""
 "Звичайний текст\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:253
+#: ../../info/wxmaxima.md:252
 #, fuzzy
 #| msgid ""
 #| "_WxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
@@ -1344,7 +1344,7 @@ msgstr ""
 "блоками цитат:\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:261
+#: ../../info/wxmaxima.md:260
 #, fuzzy
 #| msgid ""
 #| "Ordinary text\n"
@@ -1363,7 +1363,7 @@ msgstr ""
 "Звичайний текст\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:263
+#: ../../info/wxmaxima.md:262
 #, fuzzy
 #| msgid ""
 #| "_WxMaxima_'s TeX and HTML output will also recognize `=>` and replace it "
@@ -1376,14 +1376,14 @@ msgstr ""
 "замінює на відповідний символ Юнікод:\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:267
+#: ../../info/wxmaxima.md:266
 #, fuzzy
 #| msgid "cogito => sum.\n"
 msgid "```text cogito => sum.  ```"
 msgstr "cogito => sum.\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:269
+#: ../../info/wxmaxima.md:268
 #, fuzzy
 #| msgid ""
 #| "Other symbols the HTML and TeX export will recognize are `<=` and `>=` "
@@ -1402,14 +1402,14 @@ msgstr ""
 "TeX передбачено також підтримку перетворення `<<` і `>>`.\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:271
+#: ../../info/wxmaxima.md:270
 #, fuzzy
 #| msgid "Hotkeys"
 msgid "### Hotkeys"
 msgstr "Клавіатурні скорочення"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:273
+#: ../../info/wxmaxima.md:272
 msgid ""
 "Most hotkeys can be found in the text of the respective menus. Since they "
 "are actually taken from the menu text and thus can be customized by the "
@@ -1424,7 +1424,7 @@ msgstr ""
 "скорочень все ж не документовано у меню:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 msgid ""
 "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
 msgstr ""
@@ -1432,7 +1432,7 @@ msgstr ""
 "комірки."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 #, fuzzy
 #| msgid ""
 #| "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete "
@@ -1445,19 +1445,19 @@ msgstr ""
 "комірки."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
 msgstr "<kbd>SHIFT</kbd>+<kbd>ПРОБІЛ</kbd> вставляє нерозривний пробіл."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:279
+#: ../../info/wxmaxima.md:278
 #, fuzzy
 #| msgid "Raw TeX in the TeX export"
 msgid "### Raw TeX in the TeX export"
 msgstr "Код TeX у експортованому TeX"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:281
+#: ../../info/wxmaxima.md:280
 msgid ""
 "If a text cell begins with `TeX:` the TeX export contains the literal text "
 "that follows the `TeX:` marker. Using this feature allows the entry of TeX "
@@ -1469,14 +1469,14 @@ msgstr ""
 "книзі _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:283
+#: ../../info/wxmaxima.md:282
 #, fuzzy
 #| msgid "File Formats"
 msgid "## File Formats"
 msgstr "Формати файлів"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:285
+#: ../../info/wxmaxima.md:284
 msgid ""
 "The material that is developed in a _wxMaxima_ session can be stored for "
 "later use in any of three ways:"
@@ -1485,14 +1485,14 @@ msgstr ""
 "збережено для наступного використання у три способи:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:287
+#: ../../info/wxmaxima.md:286
 #, fuzzy
 #| msgid ".mac"
 msgid "### .mac"
 msgstr ".mac"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:289
+#: ../../info/wxmaxima.md:288
 #, fuzzy
 #| msgid ""
 #| "`.mac` files are ordinary text files that contain _Maxima_ commands. They "
@@ -1508,7 +1508,7 @@ msgstr ""
 "пункту меню «Файл/Пакетний файл»."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:292
+#: ../../info/wxmaxima.md:291
 msgid ""
 "One example is shown below. `Quadratic.mac` defines a function and afterward "
 "generates a plot with `wxdraw2d()`.  Afterward the contents of the file "
@@ -1519,7 +1519,7 @@ msgstr ""
 "файла `Quadratic.mac` і виконано обчислення нової визначеної функції `f()`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:294
+#: ../../info/wxmaxima.md:293
 #, fuzzy
 #| msgid ""
 #| "![Loading a `.mac` file with `batch()`](./BatchImage.png)"
@@ -1530,7 +1530,7 @@ msgstr ""
 "{ id=img_BatchImage }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:296
+#: ../../info/wxmaxima.md:295
 #, fuzzy
 #| msgid ""
 #| "Attention: Although the file `Quadratic.mac` has a usual _Maxima_ "
@@ -1547,7 +1547,7 @@ msgstr ""
 "команда `wxdraw2d()` є wxMaxima-розширенням до _Maxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:298
+#: ../../info/wxmaxima.md:297
 #, fuzzy
 #| msgid ""
 #| "You can be use `.mac` files for writing your own library of macros. But "
@@ -1563,14 +1563,14 @@ msgstr ""
 "не можна читати як сеанс _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:300
+#: ../../info/wxmaxima.md:299
 #, fuzzy
 #| msgid ".wxm"
 msgid "### .wxm"
 msgstr ".wxm"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:303
+#: ../../info/wxmaxima.md:302
 #, fuzzy
 #| msgid ""
 #| ".wxm files contain the worksheet except for _Maxima_'s output. On Maxima "
@@ -1594,7 +1594,7 @@ msgstr ""
 "є зворотно сумісними із застарілими версіями _wxMaxima_.\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:305
+#: ../../info/wxmaxima.md:304
 #, fuzzy
 #| msgid ""
 #| ".wxm files contain the worksheet except for _Maxima_'s output. On Maxima "
@@ -1614,39 +1614,39 @@ msgstr ""
 "є зворотно сумісними із застарілими версіями _wxMaxima_.\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:307
+#: ../../info/wxmaxima.md:306
 #, fuzzy
 #| msgid "File Formats"
 msgid "#### File format of wxm files"
 msgstr "Формати файлів"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:309
+#: ../../info/wxmaxima.md:308
 msgid ""
 "This is just a plain text file (you can open it with a text editor), "
 "containing the cell contents as some special Maxima comments."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:311
+#: ../../info/wxmaxima.md:310
 msgid "It starts with the following comment:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:316
+#: ../../info/wxmaxima.md:315
 msgid ""
 "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* "
 "[ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:318
+#: ../../info/wxmaxima.md:317
 msgid ""
 "And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:324
+#: ../../info/wxmaxima.md:323
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1657,14 +1657,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:326
+#: ../../info/wxmaxima.md:325
 msgid ""
 "or (in a Math cell the input is of course *not* commented out (the output is "
 "not saved in a `wxm` file)):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:333
+#: ../../info/wxmaxima.md:332
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1676,14 +1676,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:335
+#: ../../info/wxmaxima.md:334
 msgid ""
 "Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the "
 "image type as first line):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:342
+#: ../../info/wxmaxima.md:341
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1695,12 +1695,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:344
+#: ../../info/wxmaxima.md:343
 msgid "A page break is just one line containing:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:348
+#: ../../info/wxmaxima.md:347
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1709,12 +1709,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:350
+#: ../../info/wxmaxima.md:349
 msgid "And folded cells marked by:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:356
+#: ../../info/wxmaxima.md:355
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1725,14 +1725,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:358
+#: ../../info/wxmaxima.md:357
 #, fuzzy
 #| msgid ".wxmx"
 msgid "### .wxmx"
 msgstr ".wxmx"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:360
+#: ../../info/wxmaxima.md:359
 msgid ""
 "This XML-based file format saves the complete worksheet including things "
 "like the zoom factor and the watchlist. It is the preferred file format."
@@ -1742,14 +1742,14 @@ msgstr ""
 "є рекомендованим."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:362
+#: ../../info/wxmaxima.md:361
 #, fuzzy
 #| msgid "File Formats"
 msgid "#### File format of wxmx files"
 msgstr "Формати файлів"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:365
+#: ../../info/wxmaxima.md:364
 msgid ""
 "A `wxmx`-file seems to be a binary format, but one can handle it with tools, "
 "which are included in your OS. It is a zip file, one can decompress it with "
@@ -1761,39 +1761,39 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:367
+#: ../../info/wxmaxima.md:366
 msgid "It does contain the following files:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-"
 "wxmathml`"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`format.txt`: a short description about wxMaxima and the wxmx file format"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima "
 "session and included images."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`content.xml`: a XML document, which contains the various cells of your "
 "document in XML format."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:374
+#: ../../info/wxmaxima.md:373
 msgid ""
 "So, if something goes wrong, you can unzip a wxMaxima document (maybe rename "
 "it before to a `zip`-file), maybe make changes in the `content.xml` file "
@@ -1803,14 +1803,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:376
+#: ../../info/wxmaxima.md:375
 #, fuzzy
 #| msgid "Configuration options"
 msgid "## Configuration options"
 msgstr "Параметри налаштування"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:378
+#: ../../info/wxmaxima.md:377
 msgid ""
 "For some common configuration variables _wxMaxima_ offers two ways of "
 "configuring:"
@@ -1819,7 +1819,7 @@ msgstr ""
 "налаштовування:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
+#: ../../info/wxmaxima.md:380
 msgid ""
 "The configuration dialog box below lets you change their default values for "
 "the current and subsequent sessions."
@@ -1829,7 +1829,7 @@ msgstr ""
 "програми."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
+#: ../../info/wxmaxima.md:380
 #, fuzzy
 #| msgid ""
 #| "Also, the values for most configuration variables can be changed for the "
@@ -1845,7 +1845,7 @@ msgstr ""
 "показано нижче."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:383
+#: ../../info/wxmaxima.md:382
 msgid ""
 "![wxMaxima configuration 1](./wxMaxima_configuration_001.png)"
 "{ id=img_wxMaxima_configuration_001 }"
@@ -1854,14 +1854,14 @@ msgstr ""
 "{ id=img_wxMaxima_configuration_001 }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:385
+#: ../../info/wxmaxima.md:384
 #, fuzzy
 #| msgid "Default animation framerate"
 msgid "### Default animation framerate"
 msgstr "Типова частота кадрів анімації"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:387
+#: ../../info/wxmaxima.md:386
 msgid ""
 "The animation framerate that is used for new animations is kept in the "
 "variable `wxanimate_framerate`. The initial value this variable will contain "
@@ -1873,14 +1873,14 @@ msgstr ""
 "допомогою діалогового вікна налаштовування."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:389
+#: ../../info/wxmaxima.md:388
 #, fuzzy
 #| msgid "Default plot size for new _maxima_ sessions"
 msgid "### Default plot size for new _maxima_ sessions"
 msgstr "Типовий розмір креслення для нових сеансів _maxima_"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:391
+#: ../../info/wxmaxima.md:390
 #, fuzzy
 #| msgid ""
 #| "After the next start, plots embedded into the worksheet will be created "
@@ -1894,7 +1894,7 @@ msgstr ""
 "_maxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:393
+#: ../../info/wxmaxima.md:392
 #, fuzzy
 #| msgid ""
 #| "In order to set the plot size of a single graph only use the following "
@@ -1908,7 +1908,7 @@ msgstr ""
 "команди:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:402
+#: ../../info/wxmaxima.md:401
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxdraw2d(\n"
@@ -1935,19 +1935,19 @@ msgstr ""
 "), wxplot_size=[480,480]$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:404
+#: ../../info/wxmaxima.md:403
 #, fuzzy
 #| msgid "Match parenthesis in text controls"
 msgid "### Match parenthesis in text controls"
 msgstr "Перевіряти баланс дужок у тексті"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:406
+#: ../../info/wxmaxima.md:405
 msgid "This option enables two things:"
 msgstr "За допомогою цього пункту можна увімкнути дві речі:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
+#: ../../info/wxmaxima.md:408
 #, fuzzy
 #| msgid ""
 #| "If an opening parenthesis, bracket, or double quote is entered _wxMaxima_ "
@@ -1961,7 +1961,7 @@ msgstr ""
 "нею."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
+#: ../../info/wxmaxima.md:408
 msgid ""
 "If text is selected if any of these keys is pressed the selected text will "
 "be put between the matched signs."
@@ -1970,14 +1970,14 @@ msgstr ""
 "тексту, цей текст буде вставлено між відповідними символами."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:411
+#: ../../info/wxmaxima.md:410
 #, fuzzy
 #| msgid "Don't save the worksheet automatically"
 msgid "### Don’t save the worksheet automatically"
 msgstr "Не зберігати робочий аркуш автоматично"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:413
+#: ../../info/wxmaxima.md:412
 msgid ""
 "If this option is set, the file where the worksheet is will be overwritten "
 "only the request of the user. In case of a crash/power loss/... a recent "
@@ -1989,7 +1989,7 @@ msgstr ""
 "копія."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:415
+#: ../../info/wxmaxima.md:414
 #, fuzzy
 #| msgid ""
 #| "If this option isn't set _wxMaxima_ behaves more like a modern cellphone "
@@ -2001,26 +2001,26 @@ msgstr ""
 "програми для мобільних телефонів:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
+#: ../../info/wxmaxima.md:417
 msgid "Files are saved automatically on exit"
 msgstr "Файли автоматично зберігаються під час виходу з програми"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
+#: ../../info/wxmaxima.md:417
 #, fuzzy
 #| msgid "And the file will automatically be saved every 3 minutes."
 msgid "And the file will automatically be saved every 3 minutes."
 msgstr "І файл буде автоматично збережено кожні 3 хвилини."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:420
+#: ../../info/wxmaxima.md:419
 #, fuzzy
 #| msgid "Where is the configuration saved?"
 msgid "### Where is the configuration saved?"
 msgstr "Де зберігаються налаштування?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:423
+#: ../../info/wxmaxima.md:422
 #, fuzzy
 #| msgid ""
 #| "If you are using Unix/Linux, the configuration information will be saved "
@@ -2054,7 +2054,7 @@ msgstr ""
 "каталог`.config` є прихованими).\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:425
+#: ../../info/wxmaxima.md:424
 msgid ""
 "If you are using Windows, the configuration will be stored in the registry. "
 "You will find the entries for _wxMaxima_ at the following position in the "
@@ -2064,14 +2064,14 @@ msgstr ""
 "_wxMaxima_ можна знайти у цій гілці: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:429
+#: ../../info/wxmaxima.md:428
 #, fuzzy
 #| msgid "Extensions to _Maxima_"
 msgid "# Extensions to _Maxima_"
 msgstr "Розширення _Maxima_"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:431
+#: ../../info/wxmaxima.md:430
 #, fuzzy
 #| msgid ""
 #| "_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
@@ -2099,14 +2099,14 @@ msgstr ""
 "способи, у які _wxMaxima_ удосконалює включення графіки до сеансу."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:433
+#: ../../info/wxmaxima.md:432
 #, fuzzy
 #| msgid "Subscripted variables"
 msgid "## Subscripted variables"
 msgstr "Змінні із індексами"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:435
+#: ../../info/wxmaxima.md:434
 msgid ""
 "`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript "
 "variable names:"
@@ -2115,7 +2115,7 @@ msgstr ""
 "нижніх індексів у назвах змінних (і як вона це робитиме):"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:437
+#: ../../info/wxmaxima.md:436
 msgid ""
 "If it is `false`, the functionality is off, wxMaxima will not autosubscript "
 "part of variable names after an underscore."
@@ -2125,7 +2125,7 @@ msgstr ""
 "символу підкреслення."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:439
+#: ../../info/wxmaxima.md:438
 #, fuzzy
 #| msgid ""
 #| "If it is set to `'all`, everything after an underscore will be "
@@ -2137,7 +2137,7 @@ msgstr ""
 "перетворено на нижній індекс."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:441
+#: ../../info/wxmaxima.md:440
 msgid ""
 "If it is set to `true` variable names of the format `x_y` are displayed "
 "using a subscript if"
@@ -2146,19 +2146,19 @@ msgstr ""
 "`x_y` буде показано як літеру із нижнім індексом, якщо"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
+#: ../../info/wxmaxima.md:443
 msgid "Either `x` or `y` is a single letter or"
 msgstr "`x` або `y` є одинарною літерою або"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
+#: ../../info/wxmaxima.md:443
 #, fuzzy
 #| msgid "`y` is an integer (can include more than one character)."
 msgid "`y` is an integer (can include more than one character)."
 msgstr "`y` є цілим числом (може складатися з декількох символів)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:446
+#: ../../info/wxmaxima.md:445
 msgid ""
 "![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png)"
 "{ id=img_wxsubscripts }"
@@ -2167,7 +2167,7 @@ msgstr ""
 "wxsubscripts.png){ id=img_wxsubscripts }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:448
+#: ../../info/wxmaxima.md:447
 #, fuzzy
 #| msgid ""
 #| "If the variable name doesn’t match these requirements, it can still be "
@@ -2192,7 +2192,7 @@ msgstr ""
 "команди: `wxdeclare_subscript(назва_змінної,false);`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:450
+#: ../../info/wxmaxima.md:449
 #, fuzzy
 #| msgid "You can use the menu \"View->Autosubscript\" to set these values.\n"
 msgid "You can use the menu \"View->Autosubscript\" to set these values."
@@ -2201,14 +2201,14 @@ msgstr ""
 ">Автоматичне переведення у нижній індекс».\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:452
+#: ../../info/wxmaxima.md:451
 #, fuzzy
 #| msgid "User feedback in the status bar"
 msgid "## User feedback in the status bar"
 msgstr "Візуальний супровід дій користувача у смужці стану"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:454
+#: ../../info/wxmaxima.md:453
 #, fuzzy
 #| msgid ""
 #| "Long-running commands can provide user feedback in the status bar. This "
@@ -2237,7 +2237,7 @@ msgstr ""
 "просто не оброблятиметься."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:465
+#: ../../info/wxmaxima.md:464
 #, fuzzy, no-wrap
 #| msgid ""
 #| "for i:1 thru 10 do (\n"
@@ -2270,14 +2270,91 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:467
+#: ../../info/wxmaxima.md:466
+msgid "## Exporting the worksheet from within Maxima"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:468
+msgid ""
+"The command `wxworksheettohtml()` exports the current worksheet to an HTML "
+"file from within a running _Maxima_ session, which is convenient for "
+"scripted or batch export. Like `wxstatusbar()` it is safe to use in code "
+"that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present "
+"the command is simply left unevaluated."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:473
+msgid ""
+"```maxima wxworksheettohtml(\"report.html\")$ "
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:475
+msgid ""
+"A relative file name is interpreted relative to _Maxima_’s working "
+"directory. The optional keyword options are:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:480
+#, no-wrap
+msgid ""
+"| option   | values                                          | meaning                                             |\n"
+"| -------- | ----------------------------------------------- | --------------------------------------------------- |\n"
+"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |\n"
+"| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:482
+msgid ""
+"The `flavor` values match the equation formats offered by the graphical "
+"**File → Export** dialog: `mathml` produces a self-contained page that needs "
+"no internet connection, `mathjax` adds a MathJaX fall-back for browsers that "
+"still lack MathML, and `svg`/`bitmap` render every equation to an image."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:484
+msgid ""
+"The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file "
+"the same way:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:489
+msgid ""
+"```maxima wxworksheettotex(\"report.tex\")$ wxworksheettotex(\"report.tex\", "
+"documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:494
+#, no-wrap
+msgid ""
+"| option                 | meaning                                                              |\n"
+"| ---------------------- | -------------------------------------------------------------------- |\n"
+"| `documentclass`        | overrides the LaTeX `\\documentclass` (e.g. `\"article\"`, `\"report\"`)  |\n"
+"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:496
+msgid "Support for `wxworksheettopdf()` is planned."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:498
 #, fuzzy
 #| msgid "Plotting"
 msgid "## Plotting"
 msgstr "Креслення"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:469
+#: ../../info/wxmaxima.md:500
 msgid ""
 "Plotting (having fundamentally to do with graphics) is a place where a "
 "graphical user interface will have to provide some extensions to the "
@@ -2288,14 +2365,14 @@ msgstr ""
 "оригінальної програми."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:471
+#: ../../info/wxmaxima.md:502
 #, fuzzy
 #| msgid "Embedding a plot into the worksheet"
 msgid "### Embedding a plot into the worksheet"
 msgstr "Вбудовування креслення до робочого аркуша"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:473
+#: ../../info/wxmaxima.md:504
 #, fuzzy
 #| msgid ""
 #| "_Maxima_ normally instructs the external program _gnuplot_ to open a "
@@ -2323,12 +2400,12 @@ msgstr ""
 "`draw`, а команда `wxhistogram` — команді `histogram`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:475
+#: ../../info/wxmaxima.md:506
 msgid "The following plotting functions have wx-counterparts:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:489
+#: ../../info/wxmaxima.md:520
 #, no-wrap
 msgid ""
 "| wxMaxima’s plot function | Maxima’s plot function                                                                          |\n"
@@ -2347,14 +2424,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:491
+#: ../../info/wxmaxima.md:522
 msgid ""
 "If a `wxm`-file is read by (console) Maxima, these functions are ignored "
 "(and printed as output, as other unknown functions in Maxima)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:493
+#: ../../info/wxmaxima.md:524
 msgid ""
 "If you got problems with one of these functions, please check, if the "
 "problem exists in the the Maxima function too (e.g. you got an error with "
@@ -2366,14 +2443,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:495
+#: ../../info/wxmaxima.md:526
 #, fuzzy
 #| msgid "Making embedded plots bigger or smaller"
 msgid "### Making embedded plots bigger or smaller"
 msgstr "Збільшення або зменшення вбудованих креслень"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:497
+#: ../../info/wxmaxima.md:528
 msgid ""
 "As noted above, the configure dialog provides a way to change the default "
 "size plots created which sets the starting value of `wxplot_size`. The "
@@ -2389,7 +2466,7 @@ msgstr ""
 "наступних креслень:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:507
+#: ../../info/wxmaxima.md:538
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxplot_size:[1200,800]$\n"
@@ -2419,7 +2496,7 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:509
+#: ../../info/wxmaxima.md:540
 msgid ""
 "If the size of only one plot is to be changed _Maxima_ provides a canonical "
 "way to change an attribute only for the current cell. In this usage the "
@@ -2432,7 +2509,7 @@ msgstr ""
 "значення2], яка не є частиною команди wxdraw2d."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:518
+#: ../../info/wxmaxima.md:549
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxdraw2d(\n"
@@ -2459,7 +2536,7 @@ msgstr ""
 "),wxplot_size=[1600,800]$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:520
+#: ../../info/wxmaxima.md:551
 msgid ""
 "Setting the size of embedded plot with `wxplot_size` works for embedded "
 "plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` "
@@ -2472,14 +2549,14 @@ msgstr ""
 "які використовують команди `with_slider_draw` і `wxanimate`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:522
+#: ../../info/wxmaxima.md:553
 #, fuzzy
 #| msgid "Better quality plots"
 msgid "### Better quality plots"
 msgstr "Креслення кращої якості"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:524
+#: ../../info/wxmaxima.md:555
 #, fuzzy
 #| msgid ""
 #| "_Gnuplot_ doesn’t seem to provide a portable way of determining whether "
@@ -2509,14 +2586,14 @@ msgstr ""
 "графіка."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:526
+#: ../../info/wxmaxima.md:557
 #, fuzzy
 #| msgid "Opening embedded plots in interactive _gnuplot_ windows"
 msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
 msgstr "Відкриття вбудованих креслень в інтерактивних вікнах _gnuplot_"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:528
+#: ../../info/wxmaxima.md:559
 #, fuzzy
 #| msgid ""
 #| "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
@@ -2537,14 +2614,14 @@ msgstr ""
 "інтерактивному вікні _gnuplot_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:530
+#: ../../info/wxmaxima.md:561
 #, fuzzy
 #| msgid "Opening gnuplot's command console in `plot` windows"
 msgid "### Opening Gnuplot’s command console in `plot` windows"
 msgstr "Відкриття консолі команд gnuplot у вікнах `plot`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:533
+#: ../../info/wxmaxima.md:564
 #, fuzzy
 #| msgid ""
 #| "On MS Windows, if in _Maxima_'s variable `gnuplot_command` \"gnuplot\" is "
@@ -2567,14 +2644,14 @@ msgstr ""
 "фокусування клавіатури кожного разу, коли готується креслення."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:535
+#: ../../info/wxmaxima.md:566
 #, fuzzy
 #| msgid "Embedding animations into the spreadsheet"
 msgid "### Embedding animations into the spreadsheet"
 msgstr "Вбудовування анімацій до робочого аркуша"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:537
+#: ../../info/wxmaxima.md:568
 msgid ""
 "3D diagrams tend to make it hard to read quantitative data. A viable "
 "alternative might be to assign the 3rd parameter to the mouse wheel. The "
@@ -2589,7 +2666,7 @@ msgstr ""
 "_WxMaxima_ надає змогу експортувати анімацію у форматі анімації gif."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:539
+#: ../../info/wxmaxima.md:570
 msgid ""
 "The first two arguments for `with_slider_draw` are the name of the variable "
 "that is stepped between the plots and a list of the values of these "
@@ -2601,7 +2678,7 @@ msgstr ""
 "аргументами є звичайні аргументи `wxdraw2d`:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:550
+#: ../../info/wxmaxima.md:581
 #, fuzzy, no-wrap
 #| msgid ""
 #| "with_slider_draw(\n"
@@ -2634,7 +2711,7 @@ msgstr ""
 ");\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:552
+#: ../../info/wxmaxima.md:583
 msgid ""
 "The same functionality for 3D plots is accessible as `with_slider_draw3d`, "
 "which allows for rotating 3d plots:"
@@ -2644,7 +2721,7 @@ msgstr ""
 "просторові креслення:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:569
+#: ../../info/wxmaxima.md:600
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxanimate_autoplay:true;\n"
@@ -2695,7 +2772,7 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:571
+#: ../../info/wxmaxima.md:602
 msgid ""
 "If the general shape of the plot is what matters it might suffice to move "
 "the plot just a little bit in order to make its 3D nature available to the "
@@ -2706,7 +2783,7 @@ msgstr ""
 "зрозумілою:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:588
+#: ../../info/wxmaxima.md:619
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxanimate_autoplay:true;\n"
@@ -2757,7 +2834,7 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:590
+#: ../../info/wxmaxima.md:621
 msgid ""
 "For those more familiar with `plot` than with `draw`, there is a second set "
 "of functions:"
@@ -2765,19 +2842,19 @@ msgstr ""
 "Для тих, хто знайомий більше з `plot`, аніж з `draw`, другий набір функцій:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
+#: ../../info/wxmaxima.md:624
 #, fuzzy
 #| msgid "`with_slider` and"
 msgid "`with_slider` and"
 msgstr "`with_slider` і"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
+#: ../../info/wxmaxima.md:624
 msgid "`wxanimate`."
 msgstr "`wxanimate`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:595
+#: ../../info/wxmaxima.md:626
 msgid ""
 "Normally the animations are played back or exported with the frame rate "
 "chosen in the configuration of _wxMaxima_. To set the speed at an individual "
@@ -2789,7 +2866,7 @@ msgstr ""
 "`wxanimate_framerate`:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:600
+#: ../../info/wxmaxima.md:631
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxanimate(a, 10,\n"
@@ -2804,7 +2881,7 @@ msgstr ""
 "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:602
+#: ../../info/wxmaxima.md:633
 #, fuzzy
 #| msgid ""
 #| "The animation functions use _Maxima_'s `makelist` command and therefore "
@@ -2822,7 +2899,7 @@ msgstr ""
 "змінна є безпосередньо видимою у виразі. Тому такий приклад не працюватиме:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:612
+#: ../../info/wxmaxima.md:643
 #, fuzzy, no-wrap
 #| msgid ""
 #| "f:sin(a*x);\n"
@@ -2852,7 +2929,7 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:614
+#: ../../info/wxmaxima.md:645
 #, fuzzy
 #| msgid ""
 #| "If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
@@ -2865,7 +2942,7 @@ msgstr ""
 "працюватиме як слід:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:627
+#: ../../info/wxmaxima.md:658
 #, fuzzy, no-wrap
 #| msgid ""
 #| "f:sin(a*x);\n"
@@ -2904,14 +2981,14 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:629
+#: ../../info/wxmaxima.md:660
 #, fuzzy
 #| msgid "Opening multiple plots in contemporaneous windows"
 msgid "### Opening multiple plots in contemporaneous windows"
 msgstr "Відкриття декількох креслень у вікнах одночасно"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:631
+#: ../../info/wxmaxima.md:662
 msgid ""
 "While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups "
 "that support it) sometimes comes in handily. The following example comes "
@@ -2923,14 +3000,14 @@ msgstr ""
 "листування _Maxima_:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:634
+#: ../../info/wxmaxima.md:665
 #, fuzzy
 #| msgid "~~~maxima load(draw);"
 msgid "```maxima load(draw);"
 msgstr "~~~maxima load(draw);"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:637
+#: ../../info/wxmaxima.md:668
 #, fuzzy
 #| msgid ""
 #| "/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
@@ -2940,7 +3017,7 @@ msgstr ""
 "    /* Парабола у вікні 1 */ draw1d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:640
+#: ../../info/wxmaxima.md:671
 #, fuzzy
 #| msgid ""
 #| "/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
@@ -2950,7 +3027,7 @@ msgstr ""
 "/* Парабола у вікні 2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:644
+#: ../../info/wxmaxima.md:675
 #, fuzzy
 #| msgid ""
 #| "/* Paraboloid in window #3 */ "
@@ -2963,14 +3040,14 @@ msgstr ""
 "draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ~~~"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:646
+#: ../../info/wxmaxima.md:677
 msgid ""
 "Plotting multiple plots in the same window is possible, too (the same is "
 "possible in command line Maxima with the standard `draw()` command):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:657
+#: ../../info/wxmaxima.md:688
 #, fuzzy, no-wrap
 #| msgid ""
 #| "\twxdraw(\n"
@@ -3003,14 +3080,14 @@ msgstr ""
 "\t );\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:659
+#: ../../info/wxmaxima.md:690
 #, fuzzy
 #| msgid "The \"Plot using draw\" side pane"
 msgid "### The \"Plot using draw\" side pane"
 msgstr "Бічна панель «Накреслити за допомогою Draw»"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:661
+#: ../../info/wxmaxima.md:692
 msgid ""
 "The \"Plot using draw\" sidebar hides a simple code generator that allows "
 "generating scenes that make use of some of the flexibility of the _draw_ "
@@ -3021,12 +3098,12 @@ msgstr ""
 "_draw_, з яким постачається _maxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:663
+#: ../../info/wxmaxima.md:694
 msgid "#### 2D"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:665
+#: ../../info/wxmaxima.md:696
 #, fuzzy
 #| msgid ""
 #| "Generates the skeleton of a `draw()` command that draws a 2D scene. This "
@@ -3044,7 +3121,7 @@ msgstr ""
 "наприклад, за допомогою кнопок у рядках під кнопкою «Плоский»."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:667
+#: ../../info/wxmaxima.md:698
 msgid ""
 "One helpful feature of the 2D button is that it allows to set up the scene "
 "as an animation in which a variable (by default it is _t_) has a different "
@@ -3058,12 +3135,12 @@ msgstr ""
 "просторового креслення."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:669
+#: ../../info/wxmaxima.md:700
 msgid "#### 3D"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:671
+#: ../../info/wxmaxima.md:702
 msgid ""
 "Generates the skeleton of a `draw()` command that draws a 3D scene. If "
 "neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D "
@@ -3074,14 +3151,14 @@ msgstr ""
 "налаштовуватимуть двовимірну сцену, яка містить команду, яку створює кнопка."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:673
+#: ../../info/wxmaxima.md:704
 #, fuzzy
 #| msgid "Expression"
 msgid "#### Expression"
 msgstr "Вираз"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:675
+#: ../../info/wxmaxima.md:706
 msgid ""
 "Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or "
 "`x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is "
@@ -3094,14 +3171,14 @@ msgstr ""
 "заповнити довільною кількістю креслень."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:677
+#: ../../info/wxmaxima.md:708
 #, fuzzy
 #| msgid "Implicit plot"
 msgid "#### Implicit plot"
 msgstr "Графік неявної функції"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:679
+#: ../../info/wxmaxima.md:710
 msgid ""
 "Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or "
 "`x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command "
@@ -3114,14 +3191,14 @@ msgstr ""
 "виявлено не буде, буде створено плоску сцену із кресленням."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:681
+#: ../../info/wxmaxima.md:712
 #, fuzzy
 #| msgid "Parametric plot"
 msgid "#### Parametric plot"
 msgstr "Графік параметричної функції"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:683
+#: ../../info/wxmaxima.md:714
 msgid ""
 "Steps a variable from a lower limit to an upper limit and uses two "
 "expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in "
@@ -3134,14 +3211,14 @@ msgstr ""
 "передано до поточної команди draw."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:685
+#: ../../info/wxmaxima.md:716
 #, fuzzy
 #| msgid "Points"
 msgid "#### Points"
 msgstr "Точки"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:687
+#: ../../info/wxmaxima.md:718
 msgid ""
 "Draws many points that can optionally be joined. The coordinates of the "
 "points are taken from a list of lists, a 2D array or one list or array for "
@@ -3151,38 +3228,38 @@ msgstr ""
 "зі списку списків, двовимірного масиву або списку масивів для кожної з осей."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:689
+#: ../../info/wxmaxima.md:720
 #, fuzzy
 #| msgid "Diagram title"
 msgid "#### Diagram title"
 msgstr "Заголовок діаграми"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:691
+#: ../../info/wxmaxima.md:722
 msgid "Draws a title on the upper end of the diagram,"
 msgstr "Малює заголовок у верхній частині діаграми,"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:693
+#: ../../info/wxmaxima.md:724
 #, fuzzy
 #| msgid "Axis"
 msgid "#### Axis"
 msgstr "Вісь"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:695
+#: ../../info/wxmaxima.md:726
 msgid "Sets up the axis."
 msgstr "Налаштовує вісі."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:697
+#: ../../info/wxmaxima.md:728
 #, fuzzy
 #| msgid "Contour"
 msgid "#### Contour"
 msgstr "Контур"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:699
+#: ../../info/wxmaxima.md:730
 msgid ""
 "(Only for 3D plots): Adds contour lines similar to the ones one can find in "
 "a map of a mountain to the plot commands that follow in the current `draw()` "
@@ -3197,14 +3274,14 @@ msgstr ""
 "контурне креслення."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:701
+#: ../../info/wxmaxima.md:732
 #, fuzzy
 #| msgid "Plot name"
 msgid "#### Plot name"
 msgstr "Назва графіка"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:703
+#: ../../info/wxmaxima.md:734
 #, fuzzy
 #| msgid ""
 #| "Adds a legend entry showing the next plot's name to the legend of the "
@@ -3220,14 +3297,14 @@ msgstr ""
 "умовних позначень для наступних креслень."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:705
+#: ../../info/wxmaxima.md:736
 #, fuzzy
 #| msgid "Line colour"
 msgid "#### Line colour"
 msgstr "Колір лінії"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:707
+#: ../../info/wxmaxima.md:738
 msgid ""
 "Sets the line colour for the following plots the current draw command "
 "contains."
@@ -3235,14 +3312,14 @@ msgstr ""
 "Встановлює колір лінії для наступних креслень у поточній команді малювання."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:709
+#: ../../info/wxmaxima.md:740
 #, fuzzy
 #| msgid "Fill colour"
 msgid "#### Fill colour"
 msgstr "Колір заповнення"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:711
+#: ../../info/wxmaxima.md:742
 msgid ""
 "Sets the fill colour for the following plots the current draw command "
 "contains."
@@ -3251,27 +3328,27 @@ msgstr ""
 "малювання."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:713
+#: ../../info/wxmaxima.md:744
 #, fuzzy
 #| msgid "Grid"
 msgid "#### Grid"
 msgstr "Сітка"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:715
+#: ../../info/wxmaxima.md:746
 msgid "Pops up a wizard that allows to set up grid lines."
 msgstr ""
 "Відкриває допоміжне вікно, за допомогою якого можна налаштувати лінії сітки."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:717
+#: ../../info/wxmaxima.md:748
 #, fuzzy
 #| msgid "Accuracy"
 msgid "#### Accuracy"
 msgstr "Точність"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:719
+#: ../../info/wxmaxima.md:750
 msgid ""
 "Allows to select an adequate point in the speed vs. accuracy tradeoff that "
 "is part of any plot program."
@@ -3280,12 +3357,12 @@ msgstr ""
 "точність?», яке є частиною будь-якої програми для креслення."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:721
+#: ../../info/wxmaxima.md:752
 msgid "### Modify font and font size for plots"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:723
+#: ../../info/wxmaxima.md:754
 msgid ""
 "Especially when you use a high resolution display, the default font size "
 "might be very small. For the `draw`-based commands, you can set the font / "
@@ -3293,7 +3370,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:730
+#: ../../info/wxmaxima.md:761
 #, fuzzy, no-wrap
 #| msgid ""
 #| "pngdraw2d(\"Test\",\n"
@@ -3315,14 +3392,14 @@ msgstr ""
 "~~~\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:732
+#: ../../info/wxmaxima.md:763
 msgid ""
 "For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts "
 "can be set using the `gnuplot_preamble` command, e.g.:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:737
+#: ../../info/wxmaxima.md:768
 #, no-wrap
 msgid ""
 "~~~maxima\n"
@@ -3332,14 +3409,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:739
+#: ../../info/wxmaxima.md:770
 msgid ""
 "This sets the font for the numbers to Arial with size 30, the size for the "
 "xlabel and ylabel font to 20 (with the default font)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:742
+#: ../../info/wxmaxima.md:773
 msgid ""
 "Read the Maxima and Gnuplot documentation for further information.  Note: "
 "Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue "
@@ -3347,14 +3424,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:744
+#: ../../info/wxmaxima.md:775
 #, fuzzy
 #| msgid "Embedding graphics"
 msgid "## Embedding graphics"
 msgstr "Вбудовування графіків"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:746
+#: ../../info/wxmaxima.md:777
 #, fuzzy
 #| msgid ""
 #| "If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
@@ -3374,21 +3451,21 @@ msgstr ""
 "команд:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:750
+#: ../../info/wxmaxima.md:781
 #, fuzzy
 #| msgid "show_image(\"man.png\");\n"
 msgid "```maxima show_image(\"man.png\"); ```"
 msgstr "show_image(\"man.png\");\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:752
+#: ../../info/wxmaxima.md:783
 #, fuzzy
 #| msgid "Startup files"
 msgid "## Startup files"
 msgstr "Файли запуску"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:754
+#: ../../info/wxmaxima.md:785
 msgid ""
 "The config dialogue of _wxMaxima_ offers to edit two files with commands "
 "that are executed on startup:"
@@ -3398,7 +3475,7 @@ msgstr ""
 "програми:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
+#: ../../info/wxmaxima.md:788
 msgid ""
 "A file that contains commands that are executed on starting up _Maxima_: "
 "`maxima-init.mac`"
@@ -3407,7 +3484,7 @@ msgstr ""
 "`maxima-init.mac`"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
+#: ../../info/wxmaxima.md:788
 #, fuzzy
 #| msgid ""
 #| "A file that contains commands that are executed on starting up _Maxima_: "
@@ -3420,7 +3497,7 @@ msgstr ""
 "`maxima-init.mac`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:759
+#: ../../info/wxmaxima.md:790
 msgid ""
 "For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add "
 "`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` "
@@ -3428,7 +3505,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:761
+#: ../../info/wxmaxima.md:792
 #, fuzzy
 #| msgid ""
 #| "These files are in the Maxima user directory (usually `maxima` in "
@@ -3446,14 +3523,14 @@ msgstr ""
 "`maxima_userdir;`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:763
+#: ../../info/wxmaxima.md:794
 #, fuzzy
 #| msgid "Special variables wx..."
 msgid "## Special variables wx..."
 msgstr "Спеціальні змінні wx..."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxsubscripts` tells _Maxima_ if it should convert variable names that "
 "contain an underscore (`R_150` or the like) into subscripted variables. See "
@@ -3466,7 +3543,7 @@ msgstr ""
 "які саме назви змінних буде перетворено автоматично."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxfilename`: This variable contains the name of the file currently opened "
 "in _wxMaxima_."
@@ -3475,7 +3552,7 @@ msgstr ""
 "_wxMaxima_."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxdirname`: This variable contains the name the directory, in which the "
 "file currently opened in _wxMaxima_ is."
@@ -3484,7 +3561,7 @@ msgstr ""
 "поточний відкритий _wxMaxima_ файл."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, fuzzy
 #| msgid ""
 #| "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _gnuplot_’s "
@@ -3500,12 +3577,12 @@ msgstr ""
 "ліній та кращої якості зображення."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxplot_size` defines the resolution of embedded plots."
 msgstr "`wxplot_size` визначає роздільну здатність для вбудованих креслень."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, fuzzy
 #| msgid ""
 #| "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
@@ -3531,7 +3608,7 @@ msgstr ""
 "діалоговому вікні налаштовування."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxanimate_framerate`: The number of frames per second the following "
 "animations have to be played back with."
@@ -3540,30 +3617,30 @@ msgstr ""
 "відтворюватимуться наступі анімації."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxanimate_autoplay`: Automatically play animations by default?"
 msgstr "`wxanimate_autoplay`: типово автоматично відтворювати анімації?"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
 msgstr "`wxmaximaversion`: повертає номер версії _wxMaxima_."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
 msgstr ""
 "`wxwidgetsversion`: повертає версію wxWidgets, яку використано у _wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:776
+#: ../../info/wxmaxima.md:807
 #, fuzzy
 #| msgid "Pretty-printing 2D output"
 msgid "## Pretty-printing 2D output"
 msgstr "Структурний друк двовимірних даних"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:778
+#: ../../info/wxmaxima.md:809
 #, fuzzy
 #| msgid ""
 #| "The function `table_form()` displays a 2D list in a form that is more "
@@ -3587,7 +3664,7 @@ msgstr ""
 "самої таблиці разом із інструкцією «done»."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:787
+#: ../../info/wxmaxima.md:818
 #, fuzzy, no-wrap
 #| msgid ""
 #| "table_form(\n"
@@ -3614,7 +3691,7 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:789
+#: ../../info/wxmaxima.md:820
 msgid ""
 "As the next example shows, the lists that are assembled by the `table_form` "
 "command can be created before the command is executed."
@@ -3623,7 +3700,7 @@ msgstr ""
 "можна створювати до виконання команди."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:791
+#: ../../info/wxmaxima.md:822
 msgid ""
 "![A third table example](./MatrixTableExample.png)"
 "{ id=img_MatrixTableExample }"
@@ -3632,7 +3709,7 @@ msgstr ""
 "{ id=img_MatrixTableExample }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:793
+#: ../../info/wxmaxima.md:824
 msgid ""
 "Also, because a matrix is a list of lists, matrices can be converted to "
 "tables in a similar fashion."
@@ -3641,7 +3718,7 @@ msgstr ""
 "таблиці у подібний же спосіб."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:795
+#: ../../info/wxmaxima.md:826
 msgid ""
 "![Another table_form example](./SecondTableExample.png)"
 "{ id=img_SecondTableExample }"
@@ -3650,28 +3727,58 @@ msgstr ""
 "{ id=img_SecondTableExample }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:797
+#: ../../info/wxmaxima.md:828
 msgid ""
 "The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that "
 "allows for more flexible formatting of matrices in wxMaxima:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:803
+#: ../../info/wxmaxima.md:830
 #, no-wrap
+msgid "**`wx_matrix( <matrix>, [options] )`**\n"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
 msgid ""
-"**`wx_matrix( <matrix>, [options] )`**\n"
-"- **`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data.\n"
-"- **`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels.\n"
-"- **`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels.\n"
-"- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`.\n"
+"**`lines=true`**: Draws internal separator lines between the cells. This is "
+"required to visually separate headings from data."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`rownames=true`**: Tells wxMaxima that the first column of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`colnames=true`**: Tells wxMaxima that the first row of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
+"around the matrix. Supported styles are: `round` `()`, `square` `[]`, "
+"`angled` `<>`, `straight` `||`, or `none`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:809
+#: ../../info/wxmaxima.md:837
+#, fuzzy
+#| msgid "One Example:"
+msgid "Example:"
+msgstr "Один приклад:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:842
 #, no-wrap
 msgid ""
-"Example:\n"
 "```maxima\n"
 "wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
 "          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
@@ -3679,14 +3786,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:811
+#: ../../info/wxmaxima.md:844
 #, fuzzy
 #| msgid "Bug reporting"
 msgid "## Bug reporting"
 msgstr "Звітування про вади"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:813
+#: ../../info/wxmaxima.md:846
 msgid ""
 "_WxMaxima_ provides a few functions that gather bug reporting information "
 "about the current system:"
@@ -3695,7 +3802,7 @@ msgstr ""
 "системи для звітування щодо вад:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:816
+#: ../../info/wxmaxima.md:849
 #, fuzzy
 #| msgid ""
 #| "`wxbuild_info()` gathers information about the currently running version "
@@ -3707,20 +3814,20 @@ msgstr ""
 "`wxbuild_info()` збирає відомості щодо поточної запущеної версії _wxMaxima_"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:816
+#: ../../info/wxmaxima.md:849
 msgid "`wxbug_report()` tells how and where to file bugs"
 msgstr ""
 "`wxbug_report()` надає відомості щодо того, як і де слід повідомляти про вади"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:819
+#: ../../info/wxmaxima.md:851
 #, fuzzy
 #| msgid "Marking output being drawn in red"
 msgid "## Marking output being drawn in red"
 msgstr "Як зробити так, щоб виведені дані було показано червоним кольором?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:822
+#: ../../info/wxmaxima.md:854
 #, fuzzy
 #| msgid ""
 #| "_Maxima_'s `box()` command causes _wxMaxima_ to print its argument with a "
@@ -3736,17 +3843,17 @@ msgstr ""
 "`highlight`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:824
+#: ../../info/wxmaxima.md:856
 msgid "## Output rendering."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:826
+#: ../../info/wxmaxima.md:858
 msgid "With `set_display()` one can set, how wxMaxima will render the output."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:828
+#: ../../info/wxmaxima.md:860
 msgid ""
 "`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima "
 "using an (machine readable) XML-dialect (can be seen in the \"Raw XML "
@@ -3755,7 +3862,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:831
+#: ../../info/wxmaxima.md:863
 msgid ""
 "<!--- Currently that does not work as it should, the line with the output "
 "label is shifted right (issue: #2006) --> `set_display('ascii)` causes "
@@ -3763,19 +3870,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:833
+#: ../../info/wxmaxima.md:865
 msgid ""
 "`set_display('none)` causes 'one-line' ASCII results - the same as the "
 "command line Maxima command `display2d:false;` does."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:867
 msgid "# Help menu"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:837
+#: ../../info/wxmaxima.md:869
 msgid ""
 "WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, "
 "tips, some example worksheets and in command line Maxima included demos (the "
@@ -3783,19 +3890,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:839
+#: ../../info/wxmaxima.md:871
 msgid "Please notice, that the demos write:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:843
+#: ../../info/wxmaxima.md:875
 msgid ""
 "~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the "
 "demonstration.  ~~~"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:845
+#: ../../info/wxmaxima.md:877
 msgid ""
 "That is valid for command-line Maxima, however in wxMaxima by default it is "
 "necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</"
@@ -3803,28 +3910,28 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:847
+#: ../../info/wxmaxima.md:879
 msgid ""
 "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending "
 "commands to Maxima\" menu.)"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:851
+#: ../../info/wxmaxima.md:883
 #, fuzzy
 #| msgid "Troubleshooting"
 msgid "# Troubleshooting"
 msgstr "Вирішення проблем"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:853
+#: ../../info/wxmaxima.md:885
 #, fuzzy
 #| msgid "Cannot connect to _Maxima_"
 msgid "## Cannot connect to _Maxima_"
 msgstr "Не вдається з'єднатися із _Maxima_"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:855
+#: ../../info/wxmaxima.md:887
 #, fuzzy
 #| msgid ""
 #| "Since _Maxima_ (the program that does the actual mathematics) and "
@@ -3866,7 +3973,7 @@ msgstr ""
 "мережі, можуть бути sbcl, gcl, ccl, lisp.exe або щось подібне."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:857
+#: ../../info/wxmaxima.md:889
 #, fuzzy
 #| msgid ""
 #| "On Unix computers another possible reason would be that the loopback "
@@ -3882,14 +3989,14 @@ msgstr ""
 "комп'ютері, не налаштовано належним чином."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:859
+#: ../../info/wxmaxima.md:891
 #, fuzzy
 #| msgid "How to save data from a broken .wxmx file"
 msgid "## How to save data from a broken .wxmx file"
 msgstr "Як зберегти дані із пошкодженого файла .wxmx"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:861
+#: ../../info/wxmaxima.md:893
 #, fuzzy
 #| msgid ""
 #| "Internally most modern XML-based formats are ordinary zip files. "
@@ -3905,7 +4012,7 @@ msgstr ""
 "`.wxmx` придатним до перекладу у будь-якому текстовому редакторі."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:863
+#: ../../info/wxmaxima.md:895
 #, fuzzy
 #| msgid ""
 #| "If the zip signature at the end of the file is still intact after "
@@ -3935,7 +4042,7 @@ msgstr ""
 "відновленні даних."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:865
+#: ../../info/wxmaxima.md:897
 #, fuzzy
 #| msgid ""
 #| "And even if there isn’t such a file: The `.wxmx` file is a container "
@@ -3962,7 +4069,7 @@ msgstr ""
 "ви побачите непридатні до читання двійкові дані).\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:867
+#: ../../info/wxmaxima.md:899
 msgid ""
 "If a text file containing only these contents (e.g. copy and paste this text "
 "into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know "
@@ -3973,7 +4080,7 @@ msgstr ""
 "_wxMaxima_ відомий спосіб відновлення тексту документа з цього файла."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:869
+#: ../../info/wxmaxima.md:901
 #, fuzzy
 #| msgid ""
 #| "I want some debug info to be displayed on the screen before my command "
@@ -3986,7 +4093,7 @@ msgstr ""
 "свою роботу"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:871
+#: ../../info/wxmaxima.md:903
 msgid ""
 "Normally _wxMaxima_ waits for the whole 2D formula to be transferred before "
 "it begins to typeset. This saves time for making many attempts to typeset a "
@@ -4001,7 +4108,7 @@ msgstr ""
 "завершення поточної команди _Maxima_:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:881
+#: ../../info/wxmaxima.md:913
 #, fuzzy, no-wrap
 #| msgid ""
 #| "for i:1 thru 10 do (\n"
@@ -4031,12 +4138,12 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:883
+#: ../../info/wxmaxima.md:915
 msgid "Alternatively one can look for the `wxstatusbar()` command above."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:885
+#: ../../info/wxmaxima.md:917
 #, fuzzy
 #| msgid "Plotting only shows a closed empty envelope with an error message"
 msgid "## Plotting only shows a closed empty envelope with an error message"
@@ -4045,7 +4152,7 @@ msgstr ""
 "помилку"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:887
+#: ../../info/wxmaxima.md:919
 #, fuzzy
 #| msgid ""
 #| "This means that _wxMaxima_ could not read the file _Maxima_ that was "
@@ -4058,12 +4165,12 @@ msgstr ""
 "наказати створити _gnuplot_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:889
+#: ../../info/wxmaxima.md:921
 msgid "Possible reasons for this error are:"
 msgstr "Можливими причинами цієї помилки є такі:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, fuzzy
 #| msgid ""
 #| "The plotting command is part of a third-party package like "
@@ -4079,7 +4186,7 @@ msgstr ""
 "команду було передано на виконання."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, fuzzy
 #| msgid ""
 #| "_Maxima_ tried to do something the currently installed version of "
@@ -4102,7 +4209,7 @@ msgstr ""
 "корисним для діагностування проблеми."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, fuzzy
 #| msgid ""
 #| "Gnuplot was instructed to use the pngCairo library that provides "
@@ -4125,14 +4232,14 @@ msgstr ""
 "значення true з коду _Maxima_."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, fuzzy
 #| msgid "Gnuplot didn’t output a valid `.png` file."
 msgid "Gnuplot didn’t output a valid `.png` file."
 msgstr "Gnuplot не вивів коректного файла `.png`."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:896
+#: ../../info/wxmaxima.md:928
 #, fuzzy
 #| msgid "Plotting an animation results in “error: undefined variable”"
 msgid "## Plotting an animation results in “error: undefined variable”"
@@ -4141,7 +4248,7 @@ msgstr ""
 "змінна»"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:898
+#: ../../info/wxmaxima.md:930
 msgid ""
 "The value of the slider variable by default is only substituted into the "
 "expression that is to be plotted if it is visible there. Using a `subst` "
@@ -4157,14 +4264,14 @@ msgstr ""
 "(#embedding-animations-into-the-spreadsheet) наведено приклад."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:900
+#: ../../info/wxmaxima.md:932
 #, fuzzy
 #| msgid "I lost cell content and undo doesn’t remember"
 msgid "## I lost cell content and undo doesn’t remember"
 msgstr "Втрачено вміст комірок і скасовування дій не допомагає"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:902
+#: ../../info/wxmaxima.md:934
 msgid ""
 "There are separate undo functions for cell operations and for changes inside "
 "of cells so chances are low that this ever happens. If it does there are "
@@ -4175,7 +4282,7 @@ msgstr ""
 "таке все ж сталося, існує декілька способів відновити дані:"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid ""
 "_WxMaxima_ actually has two undo features: The global undo buffer that is "
 "active if no cell is selected and a per-cell undo buffer that is active if "
@@ -4189,7 +4296,7 @@ msgstr ""
 "дістатися потрібного вам попереднього значення."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 #, fuzzy
 #| msgid ""
 #| "If you still have a way to find out what label _Maxima_ has assigned to "
@@ -4202,7 +4309,7 @@ msgstr ""
 "введіть до комірки цю мітку, і програма покаже її вміст."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 #, fuzzy
 #| msgid ""
 #| "If you don’t: Don’t panic. In the “View” menu there is a way to show a "
@@ -4217,19 +4324,19 @@ msgstr ""
 "нещодавно віддано."
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid "If nothing else helps _Maxima_ contains a replay feature:"
 msgstr ""
 "Якщо ніщо інше не допомагає, у _Maxima_ є функція для відтворення усіх "
 "команд:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:911
+#: ../../info/wxmaxima.md:943
 msgid "```maxima playback(); ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:913
+#: ../../info/wxmaxima.md:945
 #, fuzzy
 #| msgid "_WxMaxima_ starts up with the message “Maxima process terminated.”"
 msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
@@ -4238,7 +4345,7 @@ msgstr ""
 "роботу.»"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:915
+#: ../../info/wxmaxima.md:947
 #, fuzzy
 #| msgid ""
 #| "One possible reason is that _Maxima_ cannot be found in the location that "
@@ -4257,14 +4364,14 @@ msgstr ""
 "коректного виконуваного файла _Maxima_ має виправити цю проблему."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:917
+#: ../../info/wxmaxima.md:949
 #, fuzzy
 #| msgid "Maxima is forever calculating and not responding to input"
 msgid "## Maxima is forever calculating and not responding to input"
 msgstr "Maxima висне при обчислення і не відповідає на команди"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:919
+#: ../../info/wxmaxima.md:951
 #, fuzzy
 #| msgid ""
 #| "It is theoretically possible that _wxMaxima_ doesn’t realize that "
@@ -4283,14 +4390,14 @@ msgstr ""
 "обчислення може відновити синхронізацію між двома програмами."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:921
+#: ../../info/wxmaxima.md:953
 #, fuzzy
 #| msgid "My SBCL-based _Maxima_ runs out of memory"
 msgid "## My SBCL-based _Maxima_ runs out of memory"
 msgstr "Версії _Maxima_ на основі SBCL не вистачає оперативної пам'яті"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:923
+#: ../../info/wxmaxima.md:955
 msgid ""
 "The Lisp compiler SBCL by default comes with a memory limit that allows it "
 "to run even on low-end computers. When compiling a big software package like "
@@ -4313,7 +4420,7 @@ msgstr ""
 "достатньо для збирання lapack."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:925
+#: ../../info/wxmaxima.md:957
 #, fuzzy
 #| msgid ""
 #| "One way to provide _Maxima_ (and thus SBCL) with command line parameters "
@@ -4329,12 +4436,12 @@ msgstr ""
 "_wxMaxima_."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:927
+#: ../../info/wxmaxima.md:959
 msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
 msgstr "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:929
+#: ../../info/wxmaxima.md:961
 #, fuzzy
 #| msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
 msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
@@ -4342,7 +4449,7 @@ msgstr ""
 "При введенні даних програма уповільнюється або пропускає символи в Ubuntu"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:931
+#: ../../info/wxmaxima.md:963
 msgid ""
 "Installing the package `ibus-gtk` should resolve this issue. See ([https://"
 "bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://"
@@ -4354,7 +4461,7 @@ msgstr ""
 "1421558))."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:933
+#: ../../info/wxmaxima.md:965
 #, fuzzy
 #| msgid "_WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
 msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
@@ -4363,7 +4470,7 @@ msgstr ""
 "умляути"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:935
+#: ../../info/wxmaxima.md:967
 msgid ""
 "If your _Maxima_ is based on SBCL the following lines have to be added to "
 "your `.sbclrc`:"
@@ -4372,14 +4479,14 @@ msgstr ""
 "`.sbclrc`:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:971
 #, fuzzy
 #| msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
 msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
 msgstr "(setf sb-impl::*default-external-format* :utf-8)\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:941
+#: ../../info/wxmaxima.md:973
 msgid ""
 "The folder where this file has to be placed is system- and installation-"
 "specific. But any SBCL-based _Maxima_ that already has evaluated a cell in "
@@ -4392,60 +4499,92 @@ msgstr ""
 "повідомить, де його можна знайти, у відповідь на таку команду:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:945
+#: ../../info/wxmaxima.md:977
 #, fuzzy
 #| msgid "    :lisp (sb-impl::userinit-pathname)\n"
 msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
 msgstr "    :lisp (sb-impl::userinit-pathname)\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:947
+#: ../../info/wxmaxima.md:979
 msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:950
+#: ../../info/wxmaxima.md:982
 msgid ""
 "There seem to be issues with the Wayland Display Server and wxWidgets.  "
 "WxMaxima may be affected, e.g. that sidebars are not moveable."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:954
+#: ../../info/wxmaxima.md:986
 msgid ""
 "You can either disable Wayland and use X11 instead (globally)  or just tell, "
 "that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:956
+#: ../../info/wxmaxima.md:988
 msgid "E.g. start wxMaxima with:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:958
+#: ../../info/wxmaxima.md:990
 msgid "`GDK_BACKEND=x11 wxmaxima`"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:960
+#: ../../info/wxmaxima.md:992
+msgid "## The menu bar disappears on KDE Plasma"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:997
+msgid ""
+"On some KDE Plasma installations the global menu bar disappears when "
+"clicked.  As this is a bug in the global menu proxy, the only way to avoid "
+"it is to tell that wxMaxima should use its own menu bar instead of the "
+"global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1001
+msgid ""
+"Starting with version 26.05.0, wxMaxima attempts to set this variable "
+"automatically if it detects an affected system (KDE, Unity, or Ubuntu with "
+"older wxWidgets versions)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1003
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1005
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1007
 msgid "## Why is the integrated manual browser not offered on my Windows PC?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:963
+#: ../../info/wxmaxima.md:1010
 msgid ""
 "Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or "
 "Microsoft’s webview2 isn’t installed."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:965
+#: ../../info/wxmaxima.md:1012
 msgid "## Why is the external manual browser not working on my Linux box?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:971
+#: ../../info/wxmaxima.md:1018
 msgid ""
 "The HTML browser might be a snap, flatpack or appimage version. All of these "
 "typically cannot access files that are installed on your local system. "
@@ -4456,7 +4595,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:973
+#: ../../info/wxmaxima.md:1020
 #, fuzzy
 #| msgid ""
 #| "Can I make _wxMaxima_ output both image files and embedded plots at once?"
@@ -4467,7 +4606,7 @@ msgstr ""
 "зображень і до вбудованих до аркуша креслень?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:975
+#: ../../info/wxmaxima.md:1022
 #, fuzzy
 #| msgid ""
 #| "The worksheet embeds .png files. _WxMaxima_ allows the user to specify "
@@ -4480,7 +4619,7 @@ msgstr ""
 "вказати, де має бути створено ці файли:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:982
+#: ../../info/wxmaxima.md:1029
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxdraw2d(\n"
@@ -4501,7 +4640,7 @@ msgstr ""
 ");\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:984
+#: ../../info/wxmaxima.md:1031
 msgid ""
 "If a different format is to be used, it is easier to generate the images and "
 "then import them into the worksheet again:"
@@ -4510,7 +4649,7 @@ msgstr ""
 "зображення окремо, а потім імпортувати їх до робочого аркуша:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1003
+#: ../../info/wxmaxima.md:1050
 #, fuzzy, no-wrap
 #| msgid ""
 #| "load(\"draw\");\n"
@@ -4577,7 +4716,7 @@ msgstr ""
 ");\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1008
+#: ../../info/wxmaxima.md:1055
 #, fuzzy, no-wrap
 #| msgid ""
 #| "pngdraw2d(\"Test\",\n"
@@ -4597,19 +4736,19 @@ msgstr ""
 "~~~\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1010
+#: ../../info/wxmaxima.md:1057
 #, fuzzy
 #| msgid "Can I set the aspect ratio of a plot?"
 msgid "## Can I set the aspect ratio of an embedded plot?"
 msgstr "Чи можна встановити співвідношення розмірів зображення креслення?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1012
+#: ../../info/wxmaxima.md:1059
 msgid "Use the variable `wxplot_size`:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1018
+#: ../../info/wxmaxima.md:1065
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxdraw2d(\n"
@@ -4629,7 +4768,7 @@ msgstr ""
 "),wxplot_size=[1000,1000];\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1020
+#: ../../info/wxmaxima.md:1067
 #, fuzzy
 #| msgid ""
 #| "After upgrading to MacOS 13.1 plot and/or draw commands output error "
@@ -4642,7 +4781,7 @@ msgstr ""
 "програма виводить повідомлення про помилки, подібні до таких:"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1027
+#: ../../info/wxmaxima.md:1074
 #, fuzzy
 #| msgid ""
 #| "\n"
@@ -4666,7 +4805,7 @@ msgstr ""
 "...\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1029
+#: ../../info/wxmaxima.md:1076
 #, fuzzy
 #| msgid ""
 #| "This might be an issue with the operating system. Disable the hiding of "
@@ -4685,12 +4824,12 @@ msgstr ""
 "wxmaxima/issues/1746) for more information.\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1031
+#: ../../info/wxmaxima.md:1078
 msgid "## Logging"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1035
+#: ../../info/wxmaxima.md:1082
 msgid ""
 "Log messages might be helpful to debug problems. WxMaxima can log many "
 "events. Most log entries will be helpful for developers, especially in case "
@@ -4701,7 +4840,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1037
+#: ../../info/wxmaxima.md:1084
 msgid ""
 "Messages are not 'lost', if the log window is not shown, if you select to "
 "show the log window later, you will see past log messages (if you did not "
@@ -4709,14 +4848,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1039
+#: ../../info/wxmaxima.md:1086
 msgid ""
 "Such messages may be helpful, when you create bug reports (or trying to find "
 "a bug by yourself)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1042
+#: ../../info/wxmaxima.md:1089
 msgid ""
 "Log messages can (additionally) be printed to STDERR, when using the command "
 "line option \"--logtostderr\". On Windows a separate text console will be "
@@ -4724,19 +4863,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1046
+#: ../../info/wxmaxima.md:1093
 msgid "# FAQ"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1048
+#: ../../info/wxmaxima.md:1095
 #, fuzzy
 #| msgid "Is there a way to make more text fit on a LaTeX page?"
 msgid "## Is there a way to make more text fit on a LaTeX page?"
 msgstr "Чи є якийсь спосіб умістити більше тексту на сторінку LaTeX?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1050
+#: ../../info/wxmaxima.md:1097
 msgid ""
 "Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to "
 "specify the size of the borders."
@@ -4745,7 +4884,7 @@ msgstr ""
 "geometry) для визначення розмірів полів."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1052
+#: ../../info/wxmaxima.md:1099
 #, fuzzy
 #| msgid ""
 #| "You can add the following line to the LaTeX preamble (for example by "
@@ -4761,7 +4900,7 @@ msgstr ""
 "рядки до преамбули TeX») для встановлення розміру полів у 1 см):\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1056
+#: ../../info/wxmaxima.md:1103
 #, fuzzy
 #| msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
 msgid ""
@@ -4769,14 +4908,14 @@ msgid ""
 msgstr "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1058
+#: ../../info/wxmaxima.md:1105
 #, fuzzy
 #| msgid "Is there a dark mode?"
 msgid "## Is there a dark mode?"
 msgstr "Чи передбачено у програмі «темний» режим?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1060
+#: ../../info/wxmaxima.md:1107
 msgid ""
 "If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if "
 "the rest of the operating system is. The worksheet itself is by default "
@@ -4792,7 +4931,7 @@ msgstr ""
 "з темного на світлий, і навпаки."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1062
+#: ../../info/wxmaxima.md:1109
 #, fuzzy
 #| msgid ""
 #| "_WxMaxima_ sometimes hangs for several seconds once in the first minute"
@@ -4802,7 +4941,7 @@ msgstr ""
 "_wxMaxima_ іноді повисає на декілька секунд під час першої хвилини роботи"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1064
+#: ../../info/wxmaxima.md:1111
 #, fuzzy
 #| msgid ""
 #| "_WxMaxima_ delegates some big tasks like parsing _Maxima_'s >1000-page-"
@@ -4823,7 +4962,7 @@ msgstr ""
 "знадобитися декілька секунд для відновлення нормальної роботи.\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1066
+#: ../../info/wxmaxima.md:1113
 #, fuzzy
 #| msgid ""
 #| "Especially when testing new locale settings, a message box \"locale "
@@ -4836,13 +4975,13 @@ msgstr ""
 "під час тестування параметрів нової локалі"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1068
+#: ../../info/wxmaxima.md:1115
 msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
 msgstr ""
 "![Попередження про локаль](./locale-warning.png){ id=img_locale_warning}"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1072
+#: ../../info/wxmaxima.md:1119
 #, fuzzy
 #| msgid ""
 #| "(The same problem can occur with other applications too). The "
@@ -4859,7 +4998,7 @@ msgstr ""
 "переклади, але і переклади з бібліотеки wxWidgets."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1075
+#: ../../info/wxmaxima.md:1122
 msgid ""
 "These locales maybe not present in the system. On Ubuntu/Debian systems they "
 "can be generated using: `dpkg-reconfigure locales`"
@@ -4868,7 +5007,7 @@ msgstr ""
 "створити за допомогою такої команди: `dpkg-reconfigure locales`"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1077
+#: ../../info/wxmaxima.md:1124
 #, fuzzy
 #| msgid ""
 #| "How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
@@ -4879,7 +5018,7 @@ msgstr ""
 "тощо?"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1079
+#: ../../info/wxmaxima.md:1126
 #, fuzzy
 #| msgid ""
 #| "You can find these symbols in the Unicode sidebar (search for 'double-"
@@ -4896,14 +5035,14 @@ msgstr ""
 "інший шрифт."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1081
+#: ../../info/wxmaxima.md:1128
 msgid ""
 "## How can a Maxima script determine, if it is running under wxMaxima or "
 "command line Maxima?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1083
+#: ../../info/wxmaxima.md:1130
 msgid ""
 "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to "
 "`wxmaxima`. The Maxima variable `maxima_frontend_version` contains the "
@@ -4911,19 +5050,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1085
+#: ../../info/wxmaxima.md:1132
 msgid ""
 "If no frontend is used (you are using command line Maxima), these variables "
 "are `false`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1087
+#: ../../info/wxmaxima.md:1134
 msgid "## Help! I can not save my document!"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1089
+#: ../../info/wxmaxima.md:1136
 msgid ""
 "If saving as wxmx file does not work, try saving the document as wxm file "
 "(and vice versa). And you can also try to remove all output (Menu Cell-"
@@ -4932,14 +5071,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1093
+#: ../../info/wxmaxima.md:1140
 #, fuzzy
 #| msgid "Command-line arguments"
 msgid "# Command-line arguments"
 msgstr "Параметри командного рядка"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1095
+#: ../../info/wxmaxima.md:1142
 msgid ""
 "Usually you can start programs with a graphical user interface just by "
 "clicking on a desktop icon or desktop menu entry. WxMaxima - if started from "
@@ -4947,17 +5086,17 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-v` or `--version`: Output the version information"
 msgstr "`-v` або `--version`: вивести дані щодо версії програми"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-h` or `--help`: Output a short help text"
 msgstr "`-h` або `--help`: вивести короткий довідковий текст"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid ""
 "`-o` or `--open=<str>`: Open the filename given as an argument to this "
 "command-line switch"
@@ -4966,12 +5105,12 @@ msgstr ""
 "параметра командного рядка"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-e` or `--eval`: Evaluate the file after opening it."
 msgstr "`-e` або `--eval`: обробити файл після його відкриття"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid ""
 "`-b` or `--batch`: If the command-line opens a file all cells in this file "
 "are evaluated and the file is saved afterward. This is for example useful if "
@@ -4991,7 +5130,7 @@ msgstr ""
 "далеко не завжди."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, fuzzy, no-wrap
 #| msgid ""
 #| "* `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
@@ -5028,7 +5167,7 @@ msgstr ""
 "* `--wxmathml-lisp=<str>`:   розташування wxMathML.lisp (якщо слід використовувати відмінний від вбудованого, в основному, для розробників).\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1113
+#: ../../info/wxmaxima.md:1160
 msgid ""
 "Instead of a minus, some operating systems might use a dash in front of the "
 "command-line switches."
@@ -5037,14 +5176,14 @@ msgstr ""
 "командного рядка використовується тире."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1117
+#: ../../info/wxmaxima.md:1164
 #, fuzzy
 #| msgid "About the program, contributing to wxMaxima"
 msgid "# About the program, contributing to wxMaxima"
 msgstr "Про програму, участь у розробці wxMaxima"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1119
+#: ../../info/wxmaxima.md:1166
 #, fuzzy
 #| msgid ""
 #| "wxMaxima is mainly developed using the program language C++ using the "
@@ -5070,7 +5209,7 @@ msgstr ""
 "і хочете допомогти і удосконалити проєкт з відкрити кодом wxMaxima."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1121
+#: ../../info/wxmaxima.md:1168
 msgid ""
 "But not only programmers are necessary! You can also contribute to wxMaxima, "
 "if you help to improve the documentation, find and report bugs (and maybe "
@@ -5081,12 +5220,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1123
+#: ../../info/wxmaxima.md:1170
 msgid "Or answer questions of other users in the discussion forum."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1125
+#: ../../info/wxmaxima.md:1172
 msgid ""
 "The source code of wxMaxima is documented using Doxygen [here](https://"
 "wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
@@ -5095,7 +5234,7 @@ msgstr ""
 "(https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1127
+#: ../../info/wxmaxima.md:1174
 msgid ""
 "The program is nearly self-contained, so except for system libraries (and "
 "the wxWidgets library), no external dependencies (like graphic files or the "
@@ -5108,7 +5247,7 @@ msgstr ""
 "включено до виконуваного файла програми."
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1128
+#: ../../info/wxmaxima.md:1175
 #, fuzzy
 #| msgid ""
 #| "If you are a developer, you might want to try out a modified "
@@ -5278,9 +5417,6 @@ msgstr ""
 
 #~ msgid "a title, section or a subsection."
 #~ msgstr "заголовок, розділ або підрозділ."
-
-#~ msgid "One Example:"
-#~ msgstr "Один приклад:"
 
 #~ msgid ""
 #~ "A .mac file named Quadratic.mac was created. It consists of two commands: "

--- a/locales/manual/wxmaxima.md.pot
+++ b/locales/manual/wxmaxima.md.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-20 10:30+0200\n"
+"POT-Creation-Date: 2026-07-30 11:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,9 +37,9 @@ msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:426
-#: ../../info/wxmaxima.md:848 ../../info/wxmaxima.md:1043
-#: ../../info/wxmaxima.md:1090 ../../info/wxmaxima.md:1114
+#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:425
+#: ../../info/wxmaxima.md:880 ../../info/wxmaxima.md:1090
+#: ../../info/wxmaxima.md:1137 ../../info/wxmaxima.md:1161
 #, no-wrap
 msgid "______________________________________________________________________\n"
 msgstr ""
@@ -709,12 +709,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:224
+#: ../../info/wxmaxima.md:223
 msgid "### Side Panes"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:226
+#: ../../info/wxmaxima.md:225
 msgid ""
 "Shortcuts to the most important _Maxima_ commands, things like a table of "
 "contents, windows with debug messages or a history of the last issued "
@@ -725,12 +725,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:228
+#: ../../info/wxmaxima.md:227
 msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:231
+#: ../../info/wxmaxima.md:230
 msgid ""
 "In the \"table of contents\" side pane, one can increase or decrease a "
 "heading by just clicking on the heading with the right mouse button and "
@@ -738,7 +738,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:233
+#: ../../info/wxmaxima.md:232
 msgid ""
 "![Increase or decrease headings in the TOC side "
 "pane](./Sidepane-TOC-convert-headings.png){ id=Sidepane-TOC-convert-headings "
@@ -746,12 +746,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:235
+#: ../../info/wxmaxima.md:234
 msgid "### MathML output"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:237
+#: ../../info/wxmaxima.md:236
 msgid ""
 "Several word processors and similar programs either recognize "
 "[MathML](https://www.w3.org/Math/) input and automatically insert it as an "
@@ -762,12 +762,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:239
+#: ../../info/wxmaxima.md:238
 msgid "### Markdown support"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:241
+#: ../../info/wxmaxima.md:240
 msgid ""
 "_WxMaxima_ offers a set of standard "
 "[Markdown](https://en.wikipedia.org/wiki/Markdown) conventions that don’t "
@@ -775,10 +775,10 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:251
+#: ../../info/wxmaxima.md:250
 #, no-wrap
 msgid ""
-"```\n"
+"```text\n"
 "Ordinary text\n"
 " * One item, indentation level 1\n"
 " * Another item at indentation level 1\n"
@@ -790,31 +790,31 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:253
+#: ../../info/wxmaxima.md:252
 msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:261
+#: ../../info/wxmaxima.md:260
 msgid ""
-"``` Ordinary text > quote quote quote quote > quote quote quote quote > "
+"```text Ordinary text > quote quote quote quote > quote quote quote quote > "
 "quote quote quote quote Ordinary text ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:263
+#: ../../info/wxmaxima.md:262
 msgid ""
 "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by "
 "the corresponding Unicode sign:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:267
-msgid "``` cogito => sum.  ```"
+#: ../../info/wxmaxima.md:266
+msgid "```text cogito => sum.  ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:269
+#: ../../info/wxmaxima.md:268
 msgid ""
 "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for "
 "comparisons, a double-pointed double arrow (`<=>`), single-headed arrows "
@@ -823,12 +823,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:271
+#: ../../info/wxmaxima.md:270
 msgid "### Hotkeys"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:273
+#: ../../info/wxmaxima.md:272
 msgid ""
 "Most hotkeys can be found in the text of the respective menus. Since they "
 "are actually taken from the menu text and thus can be customized by the "
@@ -838,13 +838,13 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 #, markdown-text
 msgid "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 #, markdown-text
 msgid ""
 "<kbd>CTRL</kbd>+<kbd>TAB</kbd> or "
@@ -853,18 +853,18 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 #, markdown-text
 msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:279
+#: ../../info/wxmaxima.md:278
 msgid "### Raw TeX in the TeX export"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:281
+#: ../../info/wxmaxima.md:280
 msgid ""
 "If a text cell begins with `TeX:` the TeX export contains the literal text "
 "that follows the `TeX:` marker. Using this feature allows the entry of TeX "
@@ -872,24 +872,24 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:283
+#: ../../info/wxmaxima.md:282
 msgid "## File Formats"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:285
+#: ../../info/wxmaxima.md:284
 msgid ""
 "The material that is developed in a _wxMaxima_ session can be stored for "
 "later use in any of three ways:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:287
+#: ../../info/wxmaxima.md:286
 msgid "### .mac"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:289
+#: ../../info/wxmaxima.md:288
 msgid ""
 "`.mac` files are ordinary text files that contain _Maxima_ commands. They "
 "can be read using _Maxima_’s `batch()` or `load()` command or _wxMaxima_’s "
@@ -897,7 +897,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:292
+#: ../../info/wxmaxima.md:291
 msgid ""
 "One example is shown below. `Quadratic.mac` defines a function and afterward "
 "generates a plot with `wxdraw2d()`.  Afterward the contents of the file "
@@ -905,12 +905,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:294
+#: ../../info/wxmaxima.md:293
 msgid "![Loading a file with `batch()`](./BatchImage.png){ id=img_BatchImage }"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:296
+#: ../../info/wxmaxima.md:295
 msgid ""
 "Attention: Although the file `Quadratic.mac` has a usual _Maxima_ extension "
 "(`.mac`), it can only be read by _wxMaxima_, since the command `wxdraw2d()` "
@@ -919,7 +919,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:298
+#: ../../info/wxmaxima.md:297
 msgid ""
 "You can be use `.mac` files for writing your own library of macros. But "
 "since they don’t contain enough structural information they cannot be read "
@@ -927,12 +927,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:300
+#: ../../info/wxmaxima.md:299
 msgid "### .wxm"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:303
+#: ../../info/wxmaxima.md:302
 msgid ""
 "`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima "
 "versions >5.38 they can be read using _Maxima_’s `load()` function just as "
@@ -944,7 +944,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:305
+#: ../../info/wxmaxima.md:304
 msgid ""
 "With this plain-text format, it sometimes is unavoidable that worksheets "
 "that use new features are not downwards-compatible with older versions of "
@@ -952,39 +952,39 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:307
+#: ../../info/wxmaxima.md:306
 msgid "#### File format of wxm files"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:309
+#: ../../info/wxmaxima.md:308
 msgid ""
 "This is just a plain text file (you can open it with a text editor), "
 "containing the cell contents as some special Maxima comments."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:311
+#: ../../info/wxmaxima.md:310
 msgid "It starts with the following comment:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:316
+#: ../../info/wxmaxima.md:315
 msgid ""
-"``` /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [ "
+"```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [ "
 "Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:318
+#: ../../info/wxmaxima.md:317
 msgid "And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:324
+#: ../../info/wxmaxima.md:323
 #, no-wrap
 msgid ""
-"```\n"
+"```maxima\n"
 "/* [wxMaxima: section start ]\n"
 "Title of the section\n"
 "   [wxMaxima: section end   ] */\n"
@@ -992,17 +992,17 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:326
+#: ../../info/wxmaxima.md:325
 msgid ""
 "or (in a Math cell the input is of course *not* commented out (the output is "
 "not saved in a `wxm` file)):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:333
+#: ../../info/wxmaxima.md:332
 #, no-wrap
 msgid ""
-"```\n"
+"```maxima\n"
 "/* [wxMaxima: input   start ] */\n"
 "f(x):=x^2+1$\n"
 "f(2);\n"
@@ -1011,17 +1011,17 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:335
+#: ../../info/wxmaxima.md:334
 msgid ""
 "Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the "
 "image type as first line):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:342
+#: ../../info/wxmaxima.md:341
 #, no-wrap
 msgid ""
-"```\n"
+"```maxima\n"
 "/* [wxMaxima: image   start ]\n"
 "jpg\n"
 "[very chaotic looking character sequence]\n"
@@ -1030,29 +1030,29 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:344
+#: ../../info/wxmaxima.md:343
 msgid "A page break is just one line containing:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:348
+#: ../../info/wxmaxima.md:347
 #, no-wrap
 msgid ""
-"```\n"
+"```maxima\n"
 "/* [wxMaxima: page break    ] */\n"
 "```\n"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:350
+#: ../../info/wxmaxima.md:349
 msgid "And folded cells marked by:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:356
+#: ../../info/wxmaxima.md:355
 #, no-wrap
 msgid ""
-"```\n"
+"```maxima\n"
 "/* [wxMaxima: fold    start ] */\n"
 "...\n"
 "/* [wxMaxima: fold    end   ] */\n"
@@ -1060,24 +1060,24 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:358
+#: ../../info/wxmaxima.md:357
 msgid "### .wxmx"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:360
+#: ../../info/wxmaxima.md:359
 msgid ""
 "This XML-based file format saves the complete worksheet including things "
 "like the zoom factor and the watchlist. It is the preferred file format."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:362
+#: ../../info/wxmaxima.md:361
 msgid "#### File format of wxmx files"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:365
+#: ../../info/wxmaxima.md:364
 msgid ""
 "A `wxmx`-file seems to be a binary format, but one can handle it with tools, "
 "which are included in your OS. It is a zip file, one can decompress it with "
@@ -1089,12 +1089,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:367
+#: ../../info/wxmaxima.md:366
 msgid "It does contain the following files:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 #, markdown-text
 msgid ""
 "`mimetype`: this file does contain the mimetype of wxMaxima files: "
@@ -1102,13 +1102,13 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 #, markdown-text
 msgid "`format.txt`: a short description about wxMaxima and the wxmx file format"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 #, markdown-text
 msgid ""
 "Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima "
@@ -1116,7 +1116,7 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 #, markdown-text
 msgid ""
 "`content.xml`: a XML document, which contains the various cells of your "
@@ -1124,7 +1124,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:374
+#: ../../info/wxmaxima.md:373
 msgid ""
 "So, if something goes wrong, you can unzip a wxMaxima document (maybe rename "
 "it before to a `zip`-file), maybe make changes in the `content.xml` file "
@@ -1134,19 +1134,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:376
+#: ../../info/wxmaxima.md:375
 msgid "## Configuration options"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:378
+#: ../../info/wxmaxima.md:377
 msgid ""
 "For some common configuration variables _wxMaxima_ offers two ways of "
 "configuring:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
+#: ../../info/wxmaxima.md:380
 #, markdown-text
 msgid ""
 "The configuration dialog box below lets you change their default values for "
@@ -1154,7 +1154,7 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
+#: ../../info/wxmaxima.md:380
 #, markdown-text
 msgid ""
 "Also, the values for most configuration variables can be changed for the "
@@ -1163,19 +1163,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:383
+#: ../../info/wxmaxima.md:382
 msgid ""
 "![wxMaxima configuration 1](./wxMaxima_configuration_001.png){ "
 "id=img_wxMaxima_configuration_001 }"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:385
+#: ../../info/wxmaxima.md:384
 msgid "### Default animation framerate"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:387
+#: ../../info/wxmaxima.md:386
 msgid ""
 "The animation framerate that is used for new animations is kept in the "
 "variable `wxanimate_framerate`. The initial value this variable will contain "
@@ -1183,26 +1183,26 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:389
+#: ../../info/wxmaxima.md:388
 msgid "### Default plot size for new _maxima_ sessions"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:391
+#: ../../info/wxmaxima.md:390
 msgid ""
 "After the next start, plots embedded into the worksheet will be created with "
 "this size if the value of `wxplot_size` isn’t changed by _maxima_."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:393
+#: ../../info/wxmaxima.md:392
 msgid ""
 "In order to set the plot size of a single graph only use the following "
 "notation can be used that sets a variable’s value for one command only:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:402
+#: ../../info/wxmaxima.md:401
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1216,17 +1216,17 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:404
+#: ../../info/wxmaxima.md:403
 msgid "### Match parenthesis in text controls"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:406
+#: ../../info/wxmaxima.md:405
 msgid "This option enables two things:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
+#: ../../info/wxmaxima.md:408
 #, markdown-text
 msgid ""
 "If an opening parenthesis, bracket, or double quote is entered _wxMaxima_ "
@@ -1234,7 +1234,7 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
+#: ../../info/wxmaxima.md:408
 #, markdown-text
 msgid ""
 "If text is selected if any of these keys is pressed the selected text will "
@@ -1242,12 +1242,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:411
+#: ../../info/wxmaxima.md:410
 msgid "### Don’t save the worksheet automatically"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:413
+#: ../../info/wxmaxima.md:412
 msgid ""
 "If this option is set, the file where the worksheet is will be overwritten "
 "only the request of the user. In case of a crash/power loss/... a recent "
@@ -1255,31 +1255,31 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:415
+#: ../../info/wxmaxima.md:414
 msgid ""
 "If this option isn’t set _wxMaxima_ behaves more like a modern cellphone "
 "app:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
+#: ../../info/wxmaxima.md:417
 #, markdown-text
 msgid "Files are saved automatically on exit"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
+#: ../../info/wxmaxima.md:417
 #, markdown-text
 msgid "And the file will automatically be saved every 3 minutes."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:420
+#: ../../info/wxmaxima.md:419
 msgid "### Where is the configuration saved?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:423
+#: ../../info/wxmaxima.md:422
 msgid ""
 "If you are using Unix/Linux, the configuration information will be saved in "
 "a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< "
@@ -1293,7 +1293,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:425
+#: ../../info/wxmaxima.md:424
 msgid ""
 "If you are using Windows, the configuration will be stored in the "
 "registry. You will find the entries for _wxMaxima_ at the following position "
@@ -1301,12 +1301,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:429
+#: ../../info/wxmaxima.md:428
 msgid "# Extensions to _Maxima_"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:431
+#: ../../info/wxmaxima.md:430
 msgid ""
 "_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
 "its main purpose is to pass along commands to _Maxima_ and to report the "
@@ -1318,57 +1318,57 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:433
+#: ../../info/wxmaxima.md:432
 msgid "## Subscripted variables"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:435
+#: ../../info/wxmaxima.md:434
 msgid ""
 "`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript "
 "variable names:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:437
+#: ../../info/wxmaxima.md:436
 msgid ""
 "If it is `false`, the functionality is off, wxMaxima will not autosubscript "
 "part of variable names after an underscore."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:439
+#: ../../info/wxmaxima.md:438
 msgid "If it is set to `'all`, everything after an underscore will be subscripted."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:441
+#: ../../info/wxmaxima.md:440
 msgid ""
 "If it is set to `true` variable names of the format `x_y` are displayed "
 "using a subscript if"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
+#: ../../info/wxmaxima.md:443
 #, markdown-text
 msgid "Either `x` or `y` is a single letter or"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
+#: ../../info/wxmaxima.md:443
 #, markdown-text
 msgid "`y` is an integer (can include more than one character)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:446
+#: ../../info/wxmaxima.md:445
 msgid ""
 "![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png){ "
 "id=img_wxsubscripts }"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:448
+#: ../../info/wxmaxima.md:447
 msgid ""
 "If the variable name doesn’t match these requirements, it can still be "
 "declared as \"to be subscripted\" using the command "
@@ -1379,17 +1379,17 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:450
+#: ../../info/wxmaxima.md:449
 msgid "You can use the menu \"View->Autosubscript\" to set these values."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:452
+#: ../../info/wxmaxima.md:451
 msgid "## User feedback in the status bar"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:454
+#: ../../info/wxmaxima.md:453
 msgid ""
 "Long-running commands can provide user feedback in the status bar. This user "
 "feedback is replaced by any new feedback that is placed there (allowing to "
@@ -1401,7 +1401,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:465
+#: ../../info/wxmaxima.md:464
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1417,12 +1417,97 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:467
+#: ../../info/wxmaxima.md:466
+msgid "## Exporting the worksheet from within Maxima"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:468
+msgid ""
+"The command `wxworksheettohtml()` exports the current worksheet to an HTML "
+"file from within a running _Maxima_ session, which is convenient for "
+"scripted or batch export. Like `wxstatusbar()` it is safe to use in code "
+"that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present "
+"the command is simply left unevaluated."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:473
+msgid ""
+"```maxima wxworksheettohtml(\"report.html\")$ "
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:475
+msgid ""
+"A relative file name is interpreted relative to _Maxima_’s working "
+"directory. The optional keyword options are:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:480
+#, no-wrap
+msgid ""
+"| option   | values                                          | meaning                                             "
+"|\n"
+"| -------- | ----------------------------------------------- | "
+"--------------------------------------------------- |\n"
+"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the "
+"equations are rendered in the exported page |\n"
+"| `wxmx`   | `false` (default), `true`                       | embed a "
+"downloadable `.wxmx` copy of the session    |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:482
+msgid ""
+"The `flavor` values match the equation formats offered by the graphical "
+"**File → Export** dialog: `mathml` produces a self-contained page that needs "
+"no internet connection, `mathjax` adds a MathJaX fall-back for browsers that "
+"still lack MathML, and `svg`/`bitmap` render every equation to an image."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:484
+msgid ""
+"The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file "
+"the same way:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:489
+msgid ""
+"```maxima wxworksheettotex(\"report.tex\")$ wxworksheettotex(\"report.tex\", "
+"documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:494
+#, no-wrap
+msgid ""
+"| option                 | meaning                                                              "
+"|\n"
+"| ---------------------- | "
+"-------------------------------------------------------------------- |\n"
+"| `documentclass`        | overrides the LaTeX `\\documentclass` "
+"(e.g. `\"article\"`, `\"report\"`)  |\n"
+"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        "
+"|\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:496
+msgid "Support for `wxworksheettopdf()` is planned."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:498
 msgid "## Plotting"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:469
+#: ../../info/wxmaxima.md:500
 msgid ""
 "Plotting (having fundamentally to do with graphics) is a place where a "
 "graphical user interface will have to provide some extensions to the "
@@ -1430,12 +1515,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:471
+#: ../../info/wxmaxima.md:502
 msgid "### Embedding a plot into the worksheet"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:473
+#: ../../info/wxmaxima.md:504
 msgid ""
 "_Maxima_ normally instructs the external program _Gnuplot_ to open a "
 "separate window for every diagram it creates. Since many times it is "
@@ -1445,12 +1530,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:475
+#: ../../info/wxmaxima.md:506
 msgid "The following plotting functions have wx-counterparts:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:489
+#: ../../info/wxmaxima.md:520
 #, no-wrap
 msgid ""
 "| wxMaxima’s plot function | Maxima’s plot function                                                                          "
@@ -1494,14 +1579,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:491
+#: ../../info/wxmaxima.md:522
 msgid ""
 "If a `wxm`-file is read by (console) Maxima, these functions are ignored "
 "(and printed as output, as other unknown functions in Maxima)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:493
+#: ../../info/wxmaxima.md:524
 msgid ""
 "If you got problems with one of these functions, please check, if the "
 "problem exists in the the Maxima function too (e.g. you got an error with "
@@ -1513,12 +1598,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:495
+#: ../../info/wxmaxima.md:526
 msgid "### Making embedded plots bigger or smaller"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:497
+#: ../../info/wxmaxima.md:528
 msgid ""
 "As noted above, the configure dialog provides a way to change the default "
 "size plots created which sets the starting value of `wxplot_size`. The "
@@ -1528,7 +1613,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:507
+#: ../../info/wxmaxima.md:538
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1543,7 +1628,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:509
+#: ../../info/wxmaxima.md:540
 msgid ""
 "If the size of only one plot is to be changed _Maxima_ provides a canonical "
 "way to change an attribute only for the current cell. In this usage the "
@@ -1552,7 +1637,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:518
+#: ../../info/wxmaxima.md:549
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1566,7 +1651,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:520
+#: ../../info/wxmaxima.md:551
 msgid ""
 "Setting the size of embedded plot with `wxplot_size` works for embedded "
 "plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` "
@@ -1575,12 +1660,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:522
+#: ../../info/wxmaxima.md:553
 msgid "### Better quality plots"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:524
+#: ../../info/wxmaxima.md:555
 msgid ""
 "_Gnuplot_ doesn’t seem to provide a portable way of determining whether it "
 "supports the high-quality bitmap output that the Cairo library provides. On "
@@ -1592,12 +1677,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:526
+#: ../../info/wxmaxima.md:557
 msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:528
+#: ../../info/wxmaxima.md:559
 msgid ""
 "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
 "`wxplot3d` isn’t supported by this feature) and the file size of the "
@@ -1607,12 +1692,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:530
+#: ../../info/wxmaxima.md:561
 msgid "### Opening Gnuplot’s command console in `plot` windows"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:533
+#: ../../info/wxmaxima.md:564
 msgid ""
 "On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and "
 "`wgnuplot.exe`.  You can configure, which command should be used using the "
@@ -1623,12 +1708,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:535
+#: ../../info/wxmaxima.md:566
 msgid "### Embedding animations into the spreadsheet"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:537
+#: ../../info/wxmaxima.md:568
 msgid ""
 "3D diagrams tend to make it hard to read quantitative data. A viable "
 "alternative might be to assign the 3rd parameter to the mouse wheel. The "
@@ -1639,7 +1724,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:539
+#: ../../info/wxmaxima.md:570
 msgid ""
 "The first two arguments for `with_slider_draw` are the name of the variable "
 "that is stepped between the plots and a list of the values of these "
@@ -1648,7 +1733,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:550
+#: ../../info/wxmaxima.md:581
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1664,14 +1749,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:552
+#: ../../info/wxmaxima.md:583
 msgid ""
 "The same functionality for 3D plots is accessible as `with_slider_draw3d`, "
 "which allows for rotating 3d plots:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:569
+#: ../../info/wxmaxima.md:600
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1693,7 +1778,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:571
+#: ../../info/wxmaxima.md:602
 msgid ""
 "If the general shape of the plot is what matters it might suffice to move "
 "the plot just a little bit in order to make its 3D nature available to the "
@@ -1701,7 +1786,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:588
+#: ../../info/wxmaxima.md:619
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1723,26 +1808,26 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:590
+#: ../../info/wxmaxima.md:621
 msgid ""
 "For those more familiar with `plot` than with `draw`, there is a second set "
 "of functions:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
+#: ../../info/wxmaxima.md:624
 #, markdown-text
 msgid "`with_slider` and"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
+#: ../../info/wxmaxima.md:624
 #, markdown-text
 msgid "`wxanimate`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:595
+#: ../../info/wxmaxima.md:626
 msgid ""
 "Normally the animations are played back or exported with the frame rate "
 "chosen in the configuration of _wxMaxima_. To set the speed at an individual "
@@ -1750,7 +1835,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:600
+#: ../../info/wxmaxima.md:631
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1760,7 +1845,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:602
+#: ../../info/wxmaxima.md:633
 msgid ""
 "The animation functions use _Maxima_’s `makelist` command and therefore "
 "share the pitfall that the slider variable’s value is substituted into the "
@@ -1769,7 +1854,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:612
+#: ../../info/wxmaxima.md:643
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1784,14 +1869,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:614
+#: ../../info/wxmaxima.md:645
 msgid ""
 "If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
 "works fine instead:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:627
+#: ../../info/wxmaxima.md:658
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1809,12 +1894,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:629
+#: ../../info/wxmaxima.md:660
 msgid "### Opening multiple plots in contemporaneous windows"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:631
+#: ../../info/wxmaxima.md:662
 msgid ""
 "While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups "
 "that support it) sometimes comes in handily. The following example comes "
@@ -1822,36 +1907,36 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:634
+#: ../../info/wxmaxima.md:665
 msgid "```maxima load(draw);"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:637
+#: ../../info/wxmaxima.md:668
 msgid "/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:640
+#: ../../info/wxmaxima.md:671
 msgid "/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:644
+#: ../../info/wxmaxima.md:675
 msgid ""
 "/* Paraboloid in window #3 */ "
 "draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:646
+#: ../../info/wxmaxima.md:677
 msgid ""
 "Plotting multiple plots in the same window is possible, too (the same is "
 "possible in command line Maxima with the standard `draw()` command):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:657
+#: ../../info/wxmaxima.md:688
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1867,12 +1952,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:659
+#: ../../info/wxmaxima.md:690
 msgid "### The \"Plot using draw\" side pane"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:661
+#: ../../info/wxmaxima.md:692
 msgid ""
 "The \"Plot using draw\" sidebar hides a simple code generator that allows "
 "generating scenes that make use of some of the flexibility of the _draw_ "
@@ -1880,12 +1965,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:663
+#: ../../info/wxmaxima.md:694
 msgid "#### 2D"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:665
+#: ../../info/wxmaxima.md:696
 msgid ""
 "Generates the skeleton of a `draw()` command that draws a 2D scene. This "
 "scene later has to be filled with commands that generate the scene’s "
@@ -1894,7 +1979,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:667
+#: ../../info/wxmaxima.md:698
 msgid ""
 "One helpful feature of the 2D button is that it allows to set up the scene "
 "as an animation in which a variable (by default it is _t_) has a different "
@@ -1903,12 +1988,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:669
+#: ../../info/wxmaxima.md:700
 msgid "#### 3D"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:671
+#: ../../info/wxmaxima.md:702
 msgid ""
 "Generates the skeleton of a `draw()` command that draws a 3D scene. If "
 "neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D "
@@ -1916,12 +2001,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:673
+#: ../../info/wxmaxima.md:704
 msgid "#### Expression"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:675
+#: ../../info/wxmaxima.md:706
 msgid ""
 "Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or "
 "`x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is "
@@ -1930,12 +2015,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:677
+#: ../../info/wxmaxima.md:708
 msgid "#### Implicit plot"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:679
+#: ../../info/wxmaxima.md:710
 msgid ""
 "Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or "
 "`x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command "
@@ -1944,12 +2029,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:681
+#: ../../info/wxmaxima.md:712
 msgid "#### Parametric plot"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:683
+#: ../../info/wxmaxima.md:714
 msgid ""
 "Steps a variable from a lower limit to an upper limit and uses two "
 "expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in "
@@ -1958,12 +2043,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:685
+#: ../../info/wxmaxima.md:716
 msgid "#### Points"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:687
+#: ../../info/wxmaxima.md:718
 msgid ""
 "Draws many points that can optionally be joined. The coordinates of the "
 "points are taken from a list of lists, a 2D array or one list or array for "
@@ -1971,32 +2056,32 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:689
+#: ../../info/wxmaxima.md:720
 msgid "#### Diagram title"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:691
+#: ../../info/wxmaxima.md:722
 msgid "Draws a title on the upper end of the diagram,"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:693
+#: ../../info/wxmaxima.md:724
 msgid "#### Axis"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:695
+#: ../../info/wxmaxima.md:726
 msgid "Sets up the axis."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:697
+#: ../../info/wxmaxima.md:728
 msgid "#### Contour"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:699
+#: ../../info/wxmaxima.md:730
 msgid ""
 "(Only for 3D plots): Adds contour lines similar to the ones one can find in "
 "a map of a mountain to the plot commands that follow in the current `draw()` "
@@ -2006,12 +2091,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:701
+#: ../../info/wxmaxima.md:732
 msgid "#### Plot name"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:703
+#: ../../info/wxmaxima.md:734
 msgid ""
 "Adds a legend entry showing the next plot’s name to the legend of the "
 "diagram. An empty name disables generating legend entries for the following "
@@ -2019,58 +2104,58 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:705
+#: ../../info/wxmaxima.md:736
 msgid "#### Line colour"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:707
+#: ../../info/wxmaxima.md:738
 msgid ""
 "Sets the line colour for the following plots the current draw command "
 "contains."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:709
+#: ../../info/wxmaxima.md:740
 msgid "#### Fill colour"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:711
+#: ../../info/wxmaxima.md:742
 msgid ""
 "Sets the fill colour for the following plots the current draw command "
 "contains."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:713
+#: ../../info/wxmaxima.md:744
 msgid "#### Grid"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:715
+#: ../../info/wxmaxima.md:746
 msgid "Pops up a wizard that allows to set up grid lines."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:717
+#: ../../info/wxmaxima.md:748
 msgid "#### Accuracy"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:719
+#: ../../info/wxmaxima.md:750
 msgid ""
 "Allows to select an adequate point in the speed vs. accuracy tradeoff that "
 "is part of any plot program."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:721
+#: ../../info/wxmaxima.md:752
 msgid "### Modify font and font size for plots"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:723
+#: ../../info/wxmaxima.md:754
 msgid ""
 "Especially when you use a high resolution display, the default font size "
 "might be very small. For the `draw`-based commands, you can set the font / "
@@ -2078,7 +2163,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:730
+#: ../../info/wxmaxima.md:761
 #, no-wrap
 msgid ""
 "~~~maxima\n"
@@ -2090,14 +2175,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:732
+#: ../../info/wxmaxima.md:763
 msgid ""
 "For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts "
 "can be set using the `gnuplot_preamble` command, e.g.:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:737
+#: ../../info/wxmaxima.md:768
 #, no-wrap
 msgid ""
 "~~~maxima\n"
@@ -2108,14 +2193,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:739
+#: ../../info/wxmaxima.md:770
 msgid ""
 "This sets the font for the numbers to Arial with size 30, the size for the "
 "xlabel and ylabel font to 20 (with the default font)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:742
+#: ../../info/wxmaxima.md:773
 msgid ""
 "Read the Maxima and Gnuplot documentation for further information.  Note: "
 "Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue "
@@ -2123,12 +2208,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:744
+#: ../../info/wxmaxima.md:775
 msgid "## Embedding graphics"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:746
+#: ../../info/wxmaxima.md:777
 msgid ""
 "If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
 "project can be done as easily as per drag-and-drop. But sometimes (for "
@@ -2137,24 +2222,24 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:750
+#: ../../info/wxmaxima.md:781
 msgid "```maxima show_image(\"man.png\"); ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:752
+#: ../../info/wxmaxima.md:783
 msgid "## Startup files"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:754
+#: ../../info/wxmaxima.md:785
 msgid ""
 "The config dialogue of _wxMaxima_ offers to edit two files with commands "
 "that are executed on startup:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
+#: ../../info/wxmaxima.md:788
 #, markdown-text
 msgid ""
 "A file that contains commands that are executed on starting up _Maxima_: "
@@ -2162,7 +2247,7 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
+#: ../../info/wxmaxima.md:788
 #, markdown-text
 msgid ""
 "one file of additional commands that are executed if _wxMaxima_ is starting "
@@ -2170,7 +2255,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:759
+#: ../../info/wxmaxima.md:790
 msgid ""
 "For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add "
 "`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` "
@@ -2178,7 +2263,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:761
+#: ../../info/wxmaxima.md:792
 msgid ""
 "These files are in the Maxima user directory (usually `%USERPROFILE%/maxima` "
 "in Windows, `$HOME/.maxima` otherwise). The location can be found out with "
@@ -2186,12 +2271,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:763
+#: ../../info/wxmaxima.md:794
 msgid "## Special variables wx..."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, markdown-text
 msgid ""
 "`wxsubscripts` tells _Maxima_ if it should convert variable names that "
@@ -2201,7 +2286,7 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, markdown-text
 msgid ""
 "`wxfilename`: This variable contains the name of the file currently opened "
@@ -2209,7 +2294,7 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, markdown-text
 msgid ""
 "`wxdirname`: This variable contains the name the directory, in which the "
@@ -2217,7 +2302,7 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, markdown-text
 msgid ""
 "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_’s pngcairo "
@@ -2226,13 +2311,13 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, markdown-text
 msgid "`wxplot_size` defines the resolution of embedded plots."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, markdown-text
 msgid ""
 "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
@@ -2244,7 +2329,7 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, markdown-text
 msgid ""
 "`wxanimate_framerate`: The number of frames per second the following "
@@ -2252,30 +2337,30 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, markdown-text
 msgid "`wxanimate_autoplay`: Automatically play animations by default?"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, markdown-text
 msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, markdown-text
 msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:776
+#: ../../info/wxmaxima.md:807
 msgid "## Pretty-printing 2D output"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:778
+#: ../../info/wxmaxima.md:809
 msgid ""
 "The function `table_form()` displays a 2D list in a form that is more "
 "readable than the output from _Maxima_’s default output routine. The input "
@@ -2285,7 +2370,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:787
+#: ../../info/wxmaxima.md:818
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2299,81 +2384,108 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:789
+#: ../../info/wxmaxima.md:820
 msgid ""
 "As the next example shows, the lists that are assembled by the `table_form` "
 "command can be created before the command is executed."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:791
+#: ../../info/wxmaxima.md:822
 msgid ""
 "![A third table example](./MatrixTableExample.png){ "
 "id=img_MatrixTableExample }"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:793
+#: ../../info/wxmaxima.md:824
 msgid ""
 "Also, because a matrix is a list of lists, matrices can be converted to "
 "tables in a similar fashion."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:795
+#: ../../info/wxmaxima.md:826
 msgid ""
 "![Another table_form example](./SecondTableExample.png){ "
 "id=img_SecondTableExample }"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:797
+#: ../../info/wxmaxima.md:828
 msgid ""
 "The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that "
 "allows for more flexible formatting of matrices in wxMaxima:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:803
+#: ../../info/wxmaxima.md:830
 #, no-wrap
+msgid "**`wx_matrix( <matrix>, [options] )`**\n"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+#, markdown-text
 msgid ""
-"**`wx_matrix( <matrix>, [options] )`**\n"
-"- **`lines=true`**: Draws internal separator lines between the cells. This "
-"is required to visually separate headings from data.\n"
-"- **`rownames=true`**: Tells wxMaxima that the first column of the matrix "
-"contains labels.\n"
-"- **`colnames=true`**: Tells wxMaxima that the first row of the matrix "
-"contains labels.\n"
-"- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
+"**`lines=true`**: Draws internal separator lines between the cells. This is "
+"required to visually separate headings from data."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+#, markdown-text
+msgid ""
+"**`rownames=true`**: Tells wxMaxima that the first column of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+#, markdown-text
+msgid ""
+"**`colnames=true`**: Tells wxMaxima that the first row of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+#, markdown-text
+msgid ""
+"**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
 "around the matrix. Supported styles are: `round` `()`, `square` `[]`, "
-"`angled` `<>`, `straight` `||`, or `none`.\n"
+"`angled` `<>`, `straight` `||`, or `none`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:809
+#: ../../info/wxmaxima.md:837
+msgid "Example:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:842
 #, no-wrap
 msgid ""
-"Example:\n"
 "```maxima\n"
-"wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]), \n"
+"wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
 "          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
 "```\n"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:811
+#: ../../info/wxmaxima.md:844
 msgid "## Bug reporting"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:813
+#: ../../info/wxmaxima.md:846
 msgid ""
 "_WxMaxima_ provides a few functions that gather bug reporting information "
 "about the current system:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:816
+#: ../../info/wxmaxima.md:849
 #, markdown-text
 msgid ""
 "`wxbuild_info()` gathers information about the currently running version of "
@@ -2381,18 +2493,18 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:816
+#: ../../info/wxmaxima.md:849
 #, markdown-text
 msgid "`wxbug_report()` tells how and where to file bugs"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:819
+#: ../../info/wxmaxima.md:851
 msgid "## Marking output being drawn in red"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:822
+#: ../../info/wxmaxima.md:854
 msgid ""
 "_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a "
 "red foreground, if the second argument to the command is the text "
@@ -2400,17 +2512,17 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:824
+#: ../../info/wxmaxima.md:856
 msgid "## Output rendering."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:826
+#: ../../info/wxmaxima.md:858
 msgid "With `set_display()` one can set, how wxMaxima will render the output."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:828
+#: ../../info/wxmaxima.md:860
 msgid ""
 "`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima "
 "using an (machine readable) XML-dialect (can be seen in the \"Raw XML "
@@ -2419,7 +2531,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:831
+#: ../../info/wxmaxima.md:863
 msgid ""
 "<!--- Currently that does not work as it should, the line with the output "
 "label is shifted right (issue: #2006) --> `set_display('ascii)` causes "
@@ -2427,19 +2539,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:833
+#: ../../info/wxmaxima.md:865
 msgid ""
 "`set_display('none)` causes 'one-line' ASCII results - the same as the "
 "command line Maxima command `display2d:false;` does."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:867
 msgid "# Help menu"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:837
+#: ../../info/wxmaxima.md:869
 msgid ""
 "WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, "
 "tips, some example worksheets and in command line Maxima included demos (the "
@@ -2447,19 +2559,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:839
+#: ../../info/wxmaxima.md:871
 msgid "Please notice, that the demos write:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:843
+#: ../../info/wxmaxima.md:875
 msgid ""
-"~~~ At the ’_’ prompt, type ’;’ and <enter> to proceed with the "
+"~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the "
 "demonstration.  ~~~"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:845
+#: ../../info/wxmaxima.md:877
 msgid ""
 "That is valid for command-line Maxima, however in wxMaxima by default it is "
 "necessary to continue the demonstration with: "
@@ -2467,24 +2579,24 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:847
+#: ../../info/wxmaxima.md:879
 msgid ""
 "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending "
 "commands to Maxima\" menu.)"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:851
+#: ../../info/wxmaxima.md:883
 msgid "# Troubleshooting"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:853
+#: ../../info/wxmaxima.md:885
 msgid "## Cannot connect to _Maxima_"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:855
+#: ../../info/wxmaxima.md:887
 msgid ""
 "Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ "
 "(providing the easy-to-use user interface) are separate programs that "
@@ -2501,7 +2613,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:857
+#: ../../info/wxmaxima.md:889
 msgid ""
 "On Unix computers another possible reason would be that the loopback network "
 "that provides network connections between two programs in the same computer "
@@ -2509,12 +2621,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:859
+#: ../../info/wxmaxima.md:891
 msgid "## How to save data from a broken .wxmx file"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:861
+#: ../../info/wxmaxima.md:893
 msgid ""
 "Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ "
 "doesn’t turn on compression, so the contents of `.wxmx` files can be viewed "
@@ -2522,7 +2634,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:863
+#: ../../info/wxmaxima.md:895
 msgid ""
 "If the zip signature at the end of the file is still intact after renaming a "
 "broken `.wxmx` file to `.zip` most operating systems will provide a way to "
@@ -2534,7 +2646,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:865
+#: ../../info/wxmaxima.md:897
 msgid ""
 "And even if there isn’t such a file: The `.wxmx` file is a container format "
 "and the XML portion is stored uncompressed. It it is possible to rename the "
@@ -2545,7 +2657,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:867
+#: ../../info/wxmaxima.md:899
 msgid ""
 "If a text file containing only these contents (e.g. copy and paste this text "
 "into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know "
@@ -2553,14 +2665,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:869
+#: ../../info/wxmaxima.md:901
 msgid ""
 "## I want some debug info to be displayed on the screen before my command "
 "has finished"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:871
+#: ../../info/wxmaxima.md:903
 msgid ""
 "Normally _wxMaxima_ waits for the whole 2D formula to be transferred before "
 "it begins to typeset. This saves time for making many attempts to typeset a "
@@ -2570,7 +2682,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:881
+#: ../../info/wxmaxima.md:913
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2585,29 +2697,29 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:883
+#: ../../info/wxmaxima.md:915
 msgid "Alternatively one can look for the `wxstatusbar()` command above."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:885
+#: ../../info/wxmaxima.md:917
 msgid "## Plotting only shows a closed empty envelope with an error message"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:887
+#: ../../info/wxmaxima.md:919
 msgid ""
 "This means that _wxMaxima_ could not read the file _Maxima_ that was "
 "supposed to instruct _Gnuplot_ to create."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:889
+#: ../../info/wxmaxima.md:921
 msgid "Possible reasons for this error are:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, markdown-text
 msgid ""
 "The plotting command is part of a third-party package like `implicit_plot` "
@@ -2616,7 +2728,7 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, markdown-text
 msgid ""
 "_Maxima_ tried to do something the currently installed version of _Gnuplot_ "
@@ -2627,7 +2739,7 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, markdown-text
 msgid ""
 "Gnuplot was instructed to use the pngCairo library that provides "
@@ -2638,18 +2750,18 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, markdown-text
 msgid "Gnuplot didn’t output a valid `.png` file."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:896
+#: ../../info/wxmaxima.md:928
 msgid "## Plotting an animation results in “error: undefined variable”"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:898
+#: ../../info/wxmaxima.md:930
 msgid ""
 "The value of the slider variable by default is only substituted into the "
 "expression that is to be plotted if it is visible there. Using a `subst` "
@@ -2660,12 +2772,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:900
+#: ../../info/wxmaxima.md:932
 msgid "## I lost cell content and undo doesn’t remember"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:902
+#: ../../info/wxmaxima.md:934
 msgid ""
 "There are separate undo functions for cell operations and for changes inside "
 "of cells so chances are low that this ever happens. If it does there are "
@@ -2673,7 +2785,7 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 #, markdown-text
 msgid ""
 "_WxMaxima_ actually has two undo features: The global undo buffer that is "
@@ -2683,7 +2795,7 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 #, markdown-text
 msgid ""
 "If you still have a way to find out what label _Maxima_ has assigned to the "
@@ -2691,7 +2803,7 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 #, markdown-text
 msgid ""
 "If you don’t: Don’t panic. In the “View” menu there is a way to show a "
@@ -2700,23 +2812,23 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 #, markdown-text
 msgid "If nothing else helps _Maxima_ contains a replay feature:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:911
+#: ../../info/wxmaxima.md:943
 msgid "```maxima playback(); ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:913
+#: ../../info/wxmaxima.md:945
 msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:915
+#: ../../info/wxmaxima.md:947
 msgid ""
 "One possible reason is that _Maxima_ cannot be found in the location that is "
 "set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore "
@@ -2725,12 +2837,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:917
+#: ../../info/wxmaxima.md:949
 msgid "## Maxima is forever calculating and not responding to input"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:919
+#: ../../info/wxmaxima.md:951
 msgid ""
 "It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ "
 "has finished calculating and therefore never gets informed it can send new "
@@ -2739,12 +2851,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:921
+#: ../../info/wxmaxima.md:953
 msgid "## My SBCL-based _Maxima_ runs out of memory"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:923
+#: ../../info/wxmaxima.md:955
 msgid ""
 "The Lisp compiler SBCL by default comes with a memory limit that allows it "
 "to run even on low-end computers. When compiling a big software package like "
@@ -2757,7 +2869,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:925
+#: ../../info/wxmaxima.md:957
 msgid ""
 "One way to provide _Maxima_ (and thus SBCL) with command line parameters is "
 "the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration "
@@ -2765,17 +2877,17 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:927
+#: ../../info/wxmaxima.md:959
 msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:929
+#: ../../info/wxmaxima.md:961
 msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:931
+#: ../../info/wxmaxima.md:963
 msgid ""
 "Installing the package `ibus-gtk` should resolve this issue. See "
 "([https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) "
@@ -2783,24 +2895,24 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:933
+#: ../../info/wxmaxima.md:965
 msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:935
+#: ../../info/wxmaxima.md:967
 msgid ""
 "If your _Maxima_ is based on SBCL the following lines have to be added to "
 "your `.sbclrc`:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:971
 msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:941
+#: ../../info/wxmaxima.md:973
 msgid ""
 "The folder where this file has to be placed is system- and "
 "installation-specific. But any SBCL-based _Maxima_ that already has "
@@ -2809,58 +2921,90 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:945
-msgid "``` :lisp (sb-impl::userinit-pathname)  ```"
+#: ../../info/wxmaxima.md:977
+msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:947
+#: ../../info/wxmaxima.md:979
 msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:950
+#: ../../info/wxmaxima.md:982
 msgid ""
 "There seem to be issues with the Wayland Display Server and wxWidgets.  "
 "WxMaxima may be affected, e.g. that sidebars are not moveable."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:954
+#: ../../info/wxmaxima.md:986
 msgid ""
 "You can either disable Wayland and use X11 instead (globally)  or just tell, "
 "that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:956
+#: ../../info/wxmaxima.md:988
 msgid "E.g. start wxMaxima with:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:958
+#: ../../info/wxmaxima.md:990
 msgid "`GDK_BACKEND=x11 wxmaxima`"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:960
+#: ../../info/wxmaxima.md:992
+msgid "## The menu bar disappears on KDE Plasma"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:997
+msgid ""
+"On some KDE Plasma installations the global menu bar disappears when "
+"clicked.  As this is a bug in the global menu proxy, the only way to avoid "
+"it is to tell that wxMaxima should use its own menu bar instead of the "
+"global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1001
+msgid ""
+"Starting with version 26.05.0, wxMaxima attempts to set this variable "
+"automatically if it detects an affected system (KDE, Unity, or Ubuntu with "
+"older wxWidgets versions)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1003
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1005
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1007
 msgid "## Why is the integrated manual browser not offered on my Windows PC?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:963
+#: ../../info/wxmaxima.md:1010
 msgid ""
 "Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or "
 "Microsoft’s webview2 isn’t installed."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:965
+#: ../../info/wxmaxima.md:1012
 msgid "## Why is the external manual browser not working on my Linux box?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:971
+#: ../../info/wxmaxima.md:1018
 msgid ""
 "The HTML browser might be a snap, flatpack or appimage version. All of these "
 "typically cannot access files that are installed on your local "
@@ -2871,19 +3015,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:973
+#: ../../info/wxmaxima.md:1020
 msgid "## Can I make _wxMaxima_ output both image files and embedded plots at once?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:975
+#: ../../info/wxmaxima.md:1022
 msgid ""
 "The worksheet embeds `.png files. _WxMaxima_ allows the user to specify "
 "where they should be generated:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:982
+#: ../../info/wxmaxima.md:1029
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2895,14 +3039,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:984
+#: ../../info/wxmaxima.md:1031
 msgid ""
 "If a different format is to be used, it is easier to generate the images and "
 "then import them into the worksheet again:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1003
+#: ../../info/wxmaxima.md:1050
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2926,7 +3070,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1008
+#: ../../info/wxmaxima.md:1055
 #, no-wrap
 msgid ""
 "pngdraw2d(\"Test\",\n"
@@ -2936,17 +3080,17 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1010
+#: ../../info/wxmaxima.md:1057
 msgid "## Can I set the aspect ratio of an embedded plot?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1012
+#: ../../info/wxmaxima.md:1059
 msgid "Use the variable `wxplot_size`:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1018
+#: ../../info/wxmaxima.md:1065
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -2957,23 +3101,23 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1020
+#: ../../info/wxmaxima.md:1067
 msgid ""
 "## After upgrading to MacOS 13.1 plot and/or draw commands output error "
 "messages like"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1027
+#: ../../info/wxmaxima.md:1074
 msgid ""
-"``` 1 HIToolbox 0x00007ff80cd91726 "
+"```text 1 HIToolbox 0x00007ff80cd91726 "
 "_ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox "
 "0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox "
 "0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1029
+#: ../../info/wxmaxima.md:1076
 msgid ""
 "This might be an issue with the operating system. Disable the hiding of the "
 "menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the "
@@ -2983,12 +3127,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1031
+#: ../../info/wxmaxima.md:1078
 msgid "## Logging"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1035
+#: ../../info/wxmaxima.md:1082
 msgid ""
 "Log messages might be helpful to debug problems. WxMaxima can log many "
 "events. Most log entries will be helpful for developers, especially in case "
@@ -2999,7 +3143,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1037
+#: ../../info/wxmaxima.md:1084
 msgid ""
 "Messages are not 'lost', if the log window is not shown, if you select to "
 "show the log window later, you will see past log messages (if you did not "
@@ -3007,14 +3151,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1039
+#: ../../info/wxmaxima.md:1086
 msgid ""
 "Such messages may be helpful, when you create bug reports (or trying to find "
 "a bug by yourself)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1042
+#: ../../info/wxmaxima.md:1089
 msgid ""
 "Log messages can (additionally) be printed to STDERR, when using the command "
 "line option \"--logtostderr\". On Windows a separate text console will be "
@@ -3023,24 +3167,24 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1046
+#: ../../info/wxmaxima.md:1093
 msgid "# FAQ"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1048
+#: ../../info/wxmaxima.md:1095
 msgid "## Is there a way to make more text fit on a LaTeX page?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1050
+#: ../../info/wxmaxima.md:1097
 msgid ""
 "Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to "
 "specify the size of the borders."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1052
+#: ../../info/wxmaxima.md:1099
 msgid ""
 "You can add the following line to the LaTeX preamble (for example by using "
 "the respective field in the config dialogue (\"Export\"->\"Additional lines "
@@ -3048,17 +3192,17 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1056
+#: ../../info/wxmaxima.md:1103
 msgid "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1058
+#: ../../info/wxmaxima.md:1105
 msgid "## Is there a dark mode?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1060
+#: ../../info/wxmaxima.md:1107
 msgid ""
 "If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if "
 "the rest of the operating system is. The worksheet itself is by default "
@@ -3069,12 +3213,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1062
+#: ../../info/wxmaxima.md:1109
 msgid "## _WxMaxima_ sometimes hangs for several seconds once in the first minute"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1064
+#: ../../info/wxmaxima.md:1111
 msgid ""
 "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s "
 ">1000-page-manual to background tasks, which normally goes totally "
@@ -3084,19 +3228,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1066
+#: ../../info/wxmaxima.md:1113
 msgid ""
 "## Especially when testing new locale settings, a message box \"locale "
 "’xx_YY’ can not be set\" occurs"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1068
+#: ../../info/wxmaxima.md:1115
 msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1072
+#: ../../info/wxmaxima.md:1119
 msgid ""
 "(The same problem can occur with other applications too). The translations "
 "seem okay after you click on ’OK’. WxMaxima does not only use its own "
@@ -3104,19 +3248,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1075
+#: ../../info/wxmaxima.md:1122
 msgid ""
 "These locales maybe not present in the system. On Ubuntu/Debian systems they "
 "can be generated using: `dpkg-reconfigure locales`"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1077
+#: ../../info/wxmaxima.md:1124
 msgid "## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1079
+#: ../../info/wxmaxima.md:1126
 msgid ""
 "You can find these symbols in the Unicode sidebar (search for ’double-struck "
 "capital’). But the selected font must also support these symbols. If they do "
@@ -3124,14 +3268,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1081
+#: ../../info/wxmaxima.md:1128
 msgid ""
 "## How can a Maxima script determine, if it is running under wxMaxima or "
 "command line Maxima?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1083
+#: ../../info/wxmaxima.md:1130
 msgid ""
 "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to "
 "`wxmaxima`. The Maxima variable `maxima_frontend_version` contains the "
@@ -3139,19 +3283,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1085
+#: ../../info/wxmaxima.md:1132
 msgid ""
 "If no frontend is used (you are using command line Maxima), these variables "
 "are `false`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1087
+#: ../../info/wxmaxima.md:1134
 msgid "## Help! I can not save my document!"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1089
+#: ../../info/wxmaxima.md:1136
 msgid ""
 "If saving as wxmx file does not work, try saving the document as wxm file "
 "(and vice versa). And you can also try to remove all output (Menu "
@@ -3160,12 +3304,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1093
+#: ../../info/wxmaxima.md:1140
 msgid "# Command-line arguments"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1095
+#: ../../info/wxmaxima.md:1142
 msgid ""
 "Usually you can start programs with a graphical user interface just by "
 "clicking on a desktop icon or desktop menu entry. WxMaxima - if started from "
@@ -3173,19 +3317,19 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, markdown-text
 msgid "`-v` or `--version`: Output the version information"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, markdown-text
 msgid "`-h` or `--help`: Output a short help text"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, markdown-text
 msgid ""
 "`-o` or `--open=<str>`: Open the filename given as an argument to this "
@@ -3193,13 +3337,13 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, markdown-text
 msgid "`-e` or `--eval`: Evaluate the file after opening it."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, markdown-text
 msgid ""
 "`-b` or `--batch`: If the command-line opens a file all cells in this file "
@@ -3212,7 +3356,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, no-wrap
 msgid ""
 "- `--logtostderr`:                 Log all \"debug messages\" sidebar "
@@ -3235,19 +3379,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1113
+#: ../../info/wxmaxima.md:1160
 msgid ""
 "Instead of a minus, some operating systems might use a dash in front of the "
 "command-line switches."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1117
+#: ../../info/wxmaxima.md:1164
 msgid "# About the program, contributing to wxMaxima"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1119
+#: ../../info/wxmaxima.md:1166
 msgid ""
 "wxMaxima is mainly developed using the programming language C++ using the "
 "[wxWidgets framework](https://www.wxwidgets.org), as build system we use "
@@ -3259,7 +3403,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1121
+#: ../../info/wxmaxima.md:1168
 msgid ""
 "But not only programmers are necessary! You can also contribute to wxMaxima, "
 "if you help to improve the documentation, find and report bugs (and maybe "
@@ -3270,19 +3414,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1123
+#: ../../info/wxmaxima.md:1170
 msgid "Or answer questions of other users in the discussion forum."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1125
+#: ../../info/wxmaxima.md:1172
 msgid ""
 "The source code of wxMaxima is documented using Doxygen "
 "[here](https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1127
+#: ../../info/wxmaxima.md:1174
 msgid ""
 "The program is nearly self-contained, so except for system libraries (and "
 "the wxWidgets library), no external dependencies (like graphic files or the "
@@ -3291,7 +3435,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1128
+#: ../../info/wxmaxima.md:1175
 msgid ""
 "If you are a developer, you might want to try out a modified "
 "`wxmathML.lisp`-file without recompiling everything, one can use the command "

--- a/locales/manual/zh_CN.po
+++ b/locales/manual/zh_CN.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: wxMaxima-manual\n"
-"POT-Creation-Date: 2026-05-20 10:30+0200\n"
+"POT-Creation-Date: 2026-07-30 11:38+0200\n"
 "PO-Revision-Date: 2021-01-05 21:54+0800\n"
 "Last-Translator: Liu Rong <rong.liu@mail.bnu.edu.cn>\n"
 "Language-Team: rong.liu@mail.bnu.edu.cn\n"
@@ -50,9 +50,9 @@ msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 msgstr "![wxMaxima 的 logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:426
-#: ../../info/wxmaxima.md:848 ../../info/wxmaxima.md:1043
-#: ../../info/wxmaxima.md:1090 ../../info/wxmaxima.md:1114
+#: ../../info/wxmaxima.md:7 ../../info/wxmaxima.md:425
+#: ../../info/wxmaxima.md:880 ../../info/wxmaxima.md:1090
+#: ../../info/wxmaxima.md:1137 ../../info/wxmaxima.md:1161
 #, no-wrap
 msgid "______________________________________________________________________\n"
 msgstr ""
@@ -1123,14 +1123,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:224
+#: ../../info/wxmaxima.md:223
 #, fuzzy
 #| msgid "Side Panes"
 msgid "### Side Panes"
 msgstr "侧边栏"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:226
+#: ../../info/wxmaxima.md:225
 #, fuzzy
 #| msgid ""
 #| "Shortcuts to the most important _Maxima_ commands or things like a table "
@@ -1152,12 +1152,12 @@ msgstr ""
 "wxMaxima 窗口内部或外部。其中一个常用的是可用鼠标点选输入希腊字母的侧边栏。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:228
+#: ../../info/wxmaxima.md:227
 msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
 msgstr "![各种类型的侧边栏](./SidePanes.png){ id=img_SidePanes }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:231
+#: ../../info/wxmaxima.md:230
 msgid ""
 "In the \"table of contents\" side pane, one can increase or decrease a "
 "heading by just clicking on the heading with the right mouse button and "
@@ -1165,21 +1165,21 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:233
+#: ../../info/wxmaxima.md:232
 msgid ""
 "![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-"
 "headings.png){ id=Sidepane-TOC-convert-headings }"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:235
+#: ../../info/wxmaxima.md:234
 #, fuzzy
 #| msgid "MathML output"
 msgid "### MathML output"
 msgstr "MathML 输出"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:237
+#: ../../info/wxmaxima.md:236
 #, fuzzy
 #| msgid ""
 #| "Several word processors and similar programs either recognize MathML "
@@ -1200,14 +1200,14 @@ msgstr ""
 "方法。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:239
+#: ../../info/wxmaxima.md:238
 #, fuzzy
 #| msgid "Markdown support"
 msgid "### Markdown support"
 msgstr "标记语言（Markdown）支持"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:241
+#: ../../info/wxmaxima.md:240
 #, fuzzy
 #| msgid ""
 #| "_wxMaxima_ offers a set of standard markdown conventions that don't "
@@ -1221,7 +1221,7 @@ msgstr ""
 "冲突。其中一个支持是项目符号列表。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:251
+#: ../../info/wxmaxima.md:250
 #, fuzzy, no-wrap
 #| msgid ""
 #| "Ordinary text\n"
@@ -1251,7 +1251,7 @@ msgstr ""
 "普通文本\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:253
+#: ../../info/wxmaxima.md:252
 #, fuzzy
 #| msgid ""
 #| "_wxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
@@ -1259,7 +1259,7 @@ msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
 msgstr "wxMaxima 也能将以 `>` 字符开头的文本识别为引用块：\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:261
+#: ../../info/wxmaxima.md:260
 #, fuzzy
 #| msgid ""
 #| "Ordinary text\n"
@@ -1278,7 +1278,7 @@ msgstr ""
 "普通文本\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:263
+#: ../../info/wxmaxima.md:262
 #, fuzzy
 #| msgid ""
 #| "_wxMaxima_'s TeX and HTML output will also recognize `=>` and replace it "
@@ -1291,14 +1291,14 @@ msgstr ""
 "号：\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:267
+#: ../../info/wxmaxima.md:266
 #, fuzzy
 #| msgid "cogito => sum.\n"
 msgid "```text cogito => sum.  ```"
 msgstr "cogito => sum.\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:269
+#: ../../info/wxmaxima.md:268
 #, fuzzy
 #| msgid ""
 #| "Other symbols the HTML and TeX export will recognize are `<=` and `>=` "
@@ -1316,14 +1316,14 @@ msgstr ""
 "别 `<<` 和 `>>`。\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:271
+#: ../../info/wxmaxima.md:270
 #, fuzzy
 #| msgid "Hotkeys"
 msgid "### Hotkeys"
 msgstr "快捷键"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:273
+#: ../../info/wxmaxima.md:272
 msgid ""
 "Most hotkeys can be found in the text of the respective menus. Since they "
 "are actually taken from the menu text and thus can be customized by the "
@@ -1336,13 +1336,13 @@ msgstr ""
 "这里记录它们。但是，一些快捷键或其别名并没有记录在菜单中："
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 msgid ""
 "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
 msgstr "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> 删除一个单元格。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 #, fuzzy
 #| msgid ""
 #| "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete "
@@ -1353,19 +1353,19 @@ msgid ""
 msgstr "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> 删除一个单元格。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:277
+#: ../../info/wxmaxima.md:276
 msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
 msgstr "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> 插入一个不可断行的空格。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:279
+#: ../../info/wxmaxima.md:278
 #, fuzzy
 #| msgid "Raw TeX in the TeX export"
 msgid "### Raw TeX in the TeX export"
 msgstr "导出 TeX 时的原始 TeX 代码"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:281
+#: ../../info/wxmaxima.md:280
 msgid ""
 "If a text cell begins with `TeX:` the TeX export contains the literal text "
 "that follows the `TeX:` marker. Using this feature allows the entry of TeX "
@@ -1375,28 +1375,28 @@ msgstr ""
 "本。使用此功能可以在 wxMaxima 工作簿中输入 TeX 代码。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:283
+#: ../../info/wxmaxima.md:282
 #, fuzzy
 #| msgid "File Formats"
 msgid "## File Formats"
 msgstr "文件格式"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:285
+#: ../../info/wxmaxima.md:284
 msgid ""
 "The material that is developed in a _wxMaxima_ session can be stored for "
 "later use in any of three ways:"
 msgstr "在 wxMaxima 中输入的内容可以存为以下三种文件格式之一，以供以后使用："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:287
+#: ../../info/wxmaxima.md:286
 #, fuzzy
 #| msgid ".mac"
 msgid "### .mac"
 msgstr ".mac"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:289
+#: ../../info/wxmaxima.md:288
 #, fuzzy
 #| msgid ""
 #| ".mac files are ordinary text files that contain _Maxima_ commands. They "
@@ -1411,7 +1411,7 @@ msgstr ""
 "令或 wxMaxima 的\"文件->批处理\"（File->Batch）菜单项来读取它们。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:292
+#: ../../info/wxmaxima.md:291
 msgid ""
 "One example is shown below. `Quadratic.mac` defines a function and afterward "
 "generates a plot with `wxdraw2d()`.  Afterward the contents of the file "
@@ -1419,14 +1419,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:294
+#: ../../info/wxmaxima.md:293
 #, fuzzy
 #| msgid "![Batch image](./BatchImage.png){ id=img_BatchImage }"
 msgid "![Loading a file with `batch()`](./BatchImage.png){ id=img_BatchImage }"
 msgstr "![批处理](./BatchImage.png){ id=img_BatchImage }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:296
+#: ../../info/wxmaxima.md:295
 msgid ""
 "Attention: Although the file `Quadratic.mac` has a usual _Maxima_ extension "
 "(`.mac`), it can only be read by _wxMaxima_, since the command `wxdraw2d()` "
@@ -1435,7 +1435,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:298
+#: ../../info/wxmaxima.md:297
 #, fuzzy
 #| msgid ""
 #| "You can be use `.mac` files for writing your own library of macros. But "
@@ -1450,14 +1450,14 @@ msgstr ""
 "息，因此不能作为一个 wxMaxima 工作簿来读取。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:300
+#: ../../info/wxmaxima.md:299
 #, fuzzy
 #| msgid ".wxm"
 msgid "### .wxm"
 msgstr ".wxm"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:303
+#: ../../info/wxmaxima.md:302
 #, fuzzy
 #| msgid ""
 #| ".wxm files contain the worksheet except _Maxima_'s output. On Maxima "
@@ -1479,7 +1479,7 @@ msgstr ""
 "文本格式，使用含新功能的工作簿时会不可避免地与旧版本的 wxMaxima 不兼容。\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:305
+#: ../../info/wxmaxima.md:304
 #, fuzzy
 #| msgid ""
 #| ".wxm files contain the worksheet except _Maxima_'s output. On Maxima "
@@ -1497,39 +1497,39 @@ msgstr ""
 "文本格式，使用含新功能的工作簿时会不可避免地与旧版本的 wxMaxima 不兼容。\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:307
+#: ../../info/wxmaxima.md:306
 #, fuzzy
 #| msgid "File Formats"
 msgid "#### File format of wxm files"
 msgstr "文件格式"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:309
+#: ../../info/wxmaxima.md:308
 msgid ""
 "This is just a plain text file (you can open it with a text editor), "
 "containing the cell contents as some special Maxima comments."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:311
+#: ../../info/wxmaxima.md:310
 msgid "It starts with the following comment:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:316
+#: ../../info/wxmaxima.md:315
 msgid ""
 "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* "
 "[ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:318
+#: ../../info/wxmaxima.md:317
 msgid ""
 "And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:324
+#: ../../info/wxmaxima.md:323
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1540,14 +1540,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:326
+#: ../../info/wxmaxima.md:325
 msgid ""
 "or (in a Math cell the input is of course *not* commented out (the output is "
 "not saved in a `wxm` file)):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:333
+#: ../../info/wxmaxima.md:332
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1559,14 +1559,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:335
+#: ../../info/wxmaxima.md:334
 msgid ""
 "Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the "
 "image type as first line):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:342
+#: ../../info/wxmaxima.md:341
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1578,12 +1578,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:344
+#: ../../info/wxmaxima.md:343
 msgid "A page break is just one line containing:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:348
+#: ../../info/wxmaxima.md:347
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1592,12 +1592,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:350
+#: ../../info/wxmaxima.md:349
 msgid "And folded cells marked by:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:356
+#: ../../info/wxmaxima.md:355
 #, no-wrap
 msgid ""
 "```maxima\n"
@@ -1608,14 +1608,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:358
+#: ../../info/wxmaxima.md:357
 #, fuzzy
 #| msgid ".wxmx"
 msgid "### .wxmx"
 msgstr ".wxmx"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:360
+#: ../../info/wxmaxima.md:359
 msgid ""
 "This XML-based file format saves the complete worksheet including things "
 "like the zoom factor and the watchlist. It is the preferred file format."
@@ -1624,14 +1624,14 @@ msgstr ""
 "它是首选的文件格式。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:362
+#: ../../info/wxmaxima.md:361
 #, fuzzy
 #| msgid "File Formats"
 msgid "#### File format of wxmx files"
 msgstr "文件格式"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:365
+#: ../../info/wxmaxima.md:364
 msgid ""
 "A `wxmx`-file seems to be a binary format, but one can handle it with tools, "
 "which are included in your OS. It is a zip file, one can decompress it with "
@@ -1643,39 +1643,39 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:367
+#: ../../info/wxmaxima.md:366
 msgid "It does contain the following files:"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-"
 "wxmathml`"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`format.txt`: a short description about wxMaxima and the wxmx file format"
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima "
 "session and included images."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:372
+#: ../../info/wxmaxima.md:371
 msgid ""
 "`content.xml`: a XML document, which contains the various cells of your "
 "document in XML format."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:374
+#: ../../info/wxmaxima.md:373
 msgid ""
 "So, if something goes wrong, you can unzip a wxMaxima document (maybe rename "
 "it before to a `zip`-file), maybe make changes in the `content.xml` file "
@@ -1685,28 +1685,28 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:376
+#: ../../info/wxmaxima.md:375
 #, fuzzy
 #| msgid "Configuration options"
 msgid "## Configuration options"
 msgstr "设置选项"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:378
+#: ../../info/wxmaxima.md:377
 msgid ""
 "For some common configuration variables _wxMaxima_ offers two ways of "
 "configuring:"
 msgstr "对于一些常见的可设置变量，wxMaxima提供了两种设置方法："
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
+#: ../../info/wxmaxima.md:380
 msgid ""
 "The configuration dialog box below lets you change their default values for "
 "the current and subsequent sessions."
 msgstr "下面的设置对话框允许用户更改当前和后续会话的默认值。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:381
+#: ../../info/wxmaxima.md:380
 #, fuzzy
 #| msgid ""
 #| "Also, the values for most configuration variables can be changed for the "
@@ -1721,7 +1721,7 @@ msgstr ""
 "续说明。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:383
+#: ../../info/wxmaxima.md:382
 msgid ""
 "![wxMaxima configuration 1](./wxMaxima_configuration_001.png)"
 "{ id=img_wxMaxima_configuration_001 }"
@@ -1730,14 +1730,14 @@ msgstr ""
 "{ id=img_wxMaxima_configuration_001 }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:385
+#: ../../info/wxmaxima.md:384
 #, fuzzy
 #| msgid "Default animation framerate"
 msgid "### Default animation framerate"
 msgstr "默认动图帧率"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:387
+#: ../../info/wxmaxima.md:386
 msgid ""
 "The animation framerate that is used for new animations is kept in the "
 "variable `wxanimate_framerate`. The initial value this variable will contain "
@@ -1747,14 +1747,14 @@ msgstr ""
 "改此变量在新工作簿中的初始值。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:389
+#: ../../info/wxmaxima.md:388
 #, fuzzy
 #| msgid "Default plot size for new _maxima_ sessions"
 msgid "### Default plot size for new _maxima_ sessions"
 msgstr "新 Maxima 会话的默认绘图尺寸"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:391
+#: ../../info/wxmaxima.md:390
 #, fuzzy
 #| msgid ""
 #| "After the next start plots embedded into the worksheet will be created "
@@ -1766,7 +1766,7 @@ msgstr ""
 "如果 `wxplot_size` 的值没有被 Maxima 更改，则使用此大小创建绘图并嵌入工作簿。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:393
+#: ../../info/wxmaxima.md:392
 #, fuzzy
 #| msgid ""
 #| "In order to set the plot size of a single graph only use the following "
@@ -1777,7 +1777,7 @@ msgid ""
 msgstr "为了仅对单个绘图命令设置绘制图形的大小，可以使用以下代码："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:402
+#: ../../info/wxmaxima.md:401
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxdraw2d( \n"
@@ -1804,19 +1804,19 @@ msgstr ""
 "), wxplot_size=[480,480]$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:404
+#: ../../info/wxmaxima.md:403
 #, fuzzy
 #| msgid "Match parenthesis in text controls"
 msgid "### Match parenthesis in text controls"
 msgstr "在文本中匹配括号"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:406
+#: ../../info/wxmaxima.md:405
 msgid "This option enables two things:"
 msgstr "该选项使以下两个功能生效："
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
+#: ../../info/wxmaxima.md:408
 #, fuzzy
 #| msgid ""
 #| "If an opening parenthesis, bracket or double quote is entered _wxMaxima_ "
@@ -1829,7 +1829,7 @@ msgstr ""
 "号、右方括号或右双引号。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:409
+#: ../../info/wxmaxima.md:408
 msgid ""
 "If text is selected if any of these keys is pressed the selected text will "
 "be put between the matched signs."
@@ -1838,14 +1838,14 @@ msgstr ""
 "之间。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:411
+#: ../../info/wxmaxima.md:410
 #, fuzzy
 #| msgid "Don't save the worksheet automatically"
 msgid "### Don’t save the worksheet automatically"
 msgstr "不自动保存工作簿"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:413
+#: ../../info/wxmaxima.md:412
 #, fuzzy
 #| msgid ""
 #| "If this option is set the file the worksheet is in is overwritten only on "
@@ -1860,7 +1860,7 @@ msgstr ""
 "撞、断电等突发情况，临时目录（temp）中仍保留了一个最近的备份文件。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:415
+#: ../../info/wxmaxima.md:414
 #, fuzzy
 #| msgid ""
 #| "If this option isn't set _wxMaxima_ behaves more like a modern cellphone "
@@ -1870,26 +1870,26 @@ msgid ""
 msgstr "如果未设置此选项，则 wxMaxima 的行为更像现代手机软件："
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
+#: ../../info/wxmaxima.md:417
 msgid "Files are saved automatically on exit"
 msgstr "文件在退出时被自动保存；"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:418
+#: ../../info/wxmaxima.md:417
 #, fuzzy
 #| msgid "And the file will automatically be saved every 3 minutes."
 msgid "And the file will automatically be saved every 3 minutes."
 msgstr "每 3 分钟文件被自动保存一次；"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:420
+#: ../../info/wxmaxima.md:419
 #, fuzzy
 #| msgid "Where is the configuration saved?"
 msgid "### Where is the configuration saved?"
 msgstr "设置信息保存的位置"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:423
+#: ../../info/wxmaxima.md:422
 #, fuzzy
 #| msgid ""
 #| "If you are using Unix/Linux, the configuration information will be saved "
@@ -1920,7 +1920,7 @@ msgstr ""
 "（由于文件名以点“.”开头，文件 `.wxMaxima` 或 `.config` 将被隐藏）。\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:425
+#: ../../info/wxmaxima.md:424
 msgid ""
 "If you are using Windows, the configuration will be stored in the registry. "
 "You will find the entries for _wxMaxima_ at the following position in the "
@@ -1930,14 +1930,14 @@ msgstr ""
 "到 wxMaxima 的相关条目：`HKEY_CURRENT_USER\\Software\\wxMaxima`。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:429
+#: ../../info/wxmaxima.md:428
 #, fuzzy
 #| msgid "Extensions to _Maxima_"
 msgid "# Extensions to _Maxima_"
 msgstr "对 Maxima 功能的扩充"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:431
+#: ../../info/wxmaxima.md:430
 #, fuzzy
 #| msgid ""
 #| "_wxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
@@ -1962,34 +1962,34 @@ msgstr ""
 "论另外一些增强功能，以及在工作簿中包含图形的方法。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:433
+#: ../../info/wxmaxima.md:432
 #, fuzzy
 #| msgid "Subscripted variables"
 msgid "## Subscripted variables"
 msgstr "为变量添加下标"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:435
+#: ../../info/wxmaxima.md:434
 msgid ""
 "`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript "
 "variable names:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:437
+#: ../../info/wxmaxima.md:436
 msgid ""
 "If it is `false`, the functionality is off, wxMaxima will not autosubscript "
 "part of variable names after an underscore."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:439
+#: ../../info/wxmaxima.md:438
 msgid ""
 "If it is set to `'all`, everything after an underscore will be subscripted."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:441
+#: ../../info/wxmaxima.md:440
 #, fuzzy
 #| msgid ""
 #| "if `wxsubscripts` is set to true variable names of the format `x_y` are "
@@ -2002,26 +2002,26 @@ msgstr ""
 "`x_y` 的变量名："
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
+#: ../../info/wxmaxima.md:443
 #, fuzzy
 #| msgid "`y` is a single letter"
 msgid "Either `x` or `y` is a single letter or"
 msgstr "`y` 是一个字母；"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:444
+#: ../../info/wxmaxima.md:443
 msgid "`y` is an integer (can include more than one character)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:446
+#: ../../info/wxmaxima.md:445
 msgid ""
 "![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png)"
 "{ id=img_wxsubscripts }"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:448
+#: ../../info/wxmaxima.md:447
 #, fuzzy
 #| msgid ""
 #| "If the variable name doesn’t match these requirements it can still be "
@@ -2045,19 +2045,19 @@ msgstr ""
 "`wxdeclare_subscript(variable_name,false);`。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:450
+#: ../../info/wxmaxima.md:449
 msgid "You can use the menu \"View->Autosubscript\" to set these values."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:452
+#: ../../info/wxmaxima.md:451
 #, fuzzy
 #| msgid "User feedback in the status bar"
 msgid "## User feedback in the status bar"
 msgstr "在状态栏中提供反馈信息"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:454
+#: ../../info/wxmaxima.md:453
 #, fuzzy
 #| msgid ""
 #| "Long-running commands can provide user-feedback in the status bar. This "
@@ -2083,7 +2083,7 @@ msgstr ""
 "wxMaxima，那么命令 `wxstatusbar()` 也不会被执行。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:465
+#: ../../info/wxmaxima.md:464
 #, fuzzy, no-wrap
 #| msgid ""
 #| "for i:1 thru 10 do (\n"
@@ -2115,14 +2115,91 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:467
+#: ../../info/wxmaxima.md:466
+msgid "## Exporting the worksheet from within Maxima"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:468
+msgid ""
+"The command `wxworksheettohtml()` exports the current worksheet to an HTML "
+"file from within a running _Maxima_ session, which is convenient for "
+"scripted or batch export. Like `wxstatusbar()` it is safe to use in code "
+"that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present "
+"the command is simply left unevaluated."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:473
+msgid ""
+"```maxima wxworksheettohtml(\"report.html\")$ "
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:475
+msgid ""
+"A relative file name is interpreted relative to _Maxima_’s working "
+"directory. The optional keyword options are:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:480
+#, no-wrap
+msgid ""
+"| option   | values                                          | meaning                                             |\n"
+"| -------- | ----------------------------------------------- | --------------------------------------------------- |\n"
+"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |\n"
+"| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:482
+msgid ""
+"The `flavor` values match the equation formats offered by the graphical "
+"**File → Export** dialog: `mathml` produces a self-contained page that needs "
+"no internet connection, `mathjax` adds a MathJaX fall-back for browsers that "
+"still lack MathML, and `svg`/`bitmap` render every equation to an image."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:484
+msgid ""
+"The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file "
+"the same way:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:489
+msgid ""
+"```maxima wxworksheettotex(\"report.tex\")$ wxworksheettotex(\"report.tex\", "
+"documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$ ```"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:494
+#, no-wrap
+msgid ""
+"| option                 | meaning                                                              |\n"
+"| ---------------------- | -------------------------------------------------------------------- |\n"
+"| `documentclass`        | overrides the LaTeX `\\documentclass` (e.g. `\"article\"`, `\"report\"`)  |\n"
+"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:496
+msgid "Support for `wxworksheettopdf()` is planned."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:498
 #, fuzzy
 #| msgid "Plotting"
 msgid "## Plotting"
 msgstr "绘图"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:469
+#: ../../info/wxmaxima.md:500
 msgid ""
 "Plotting (having fundamentally to do with graphics) is a place where a "
 "graphical user interface will have to provide some extensions to the "
@@ -2132,14 +2209,14 @@ msgstr ""
 "扩充内容。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:471
+#: ../../info/wxmaxima.md:502
 #, fuzzy
 #| msgid "Embedding a plot into the work sheet"
 msgid "### Embedding a plot into the worksheet"
 msgstr "将绘制的图形嵌入工作簿"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:473
+#: ../../info/wxmaxima.md:504
 #, fuzzy
 #| msgid ""
 #| "_Maxima_ normally instructs the external program _gnuplot_ to open a "
@@ -2164,12 +2241,12 @@ msgstr ""
 "`draw`，`wxhistogram` 对应于 `histogram`。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:475
+#: ../../info/wxmaxima.md:506
 msgid "The following plotting functions have wx-counterparts:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:489
+#: ../../info/wxmaxima.md:520
 #, no-wrap
 msgid ""
 "| wxMaxima’s plot function | Maxima’s plot function                                                                          |\n"
@@ -2188,14 +2265,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:491
+#: ../../info/wxmaxima.md:522
 msgid ""
 "If a `wxm`-file is read by (console) Maxima, these functions are ignored "
 "(and printed as output, as other unknown functions in Maxima)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:493
+#: ../../info/wxmaxima.md:524
 msgid ""
 "If you got problems with one of these functions, please check, if the "
 "problem exists in the the Maxima function too (e.g. you got an error with "
@@ -2207,14 +2284,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:495
+#: ../../info/wxmaxima.md:526
 #, fuzzy
 #| msgid "Making embedded plots bigger or smaller"
 msgid "### Making embedded plots bigger or smaller"
 msgstr "设置嵌入图形的大小"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:497
+#: ../../info/wxmaxima.md:528
 #, fuzzy
 #| msgid ""
 #| "As noted above, the configure dialog provides a way to change the default "
@@ -2234,7 +2311,7 @@ msgstr ""
 "位）。可以查询该变量，或以如下方式设置所绘制图片的大小："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:507
+#: ../../info/wxmaxima.md:538
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxplot_size:[1200,800]$\n"
@@ -2264,7 +2341,7 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:509
+#: ../../info/wxmaxima.md:540
 msgid ""
 "If the size of only one plot is to be changed _Maxima_ provides a canonical "
 "way to change an attribute only for the current cell. In this usage the "
@@ -2276,7 +2353,7 @@ msgstr ""
 "尾，而不是作为该命令的一部分："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:518
+#: ../../info/wxmaxima.md:549
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxdraw2d(\n"
@@ -2303,7 +2380,7 @@ msgstr ""
 "),wxplot_size=[1600,800]$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:520
+#: ../../info/wxmaxima.md:551
 msgid ""
 "Setting the size of embedded plot with `wxplot_size` works for embedded "
 "plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` "
@@ -2312,14 +2389,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:522
+#: ../../info/wxmaxima.md:553
 #, fuzzy
 #| msgid "Better quality plots"
 msgid "### Better quality plots"
 msgstr "更好的绘图质量"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:524
+#: ../../info/wxmaxima.md:555
 #, fuzzy
 #| msgid ""
 #| "_Gnuplot_ doesn’t seem to provide a portable way of determining whether "
@@ -2345,14 +2422,14 @@ msgstr ""
 "息。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:526
+#: ../../info/wxmaxima.md:557
 #, fuzzy
 #| msgid "Opening embedded plots in interactive _gnuplot_ windows"
 msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
 msgstr "在交互式 gnuplot 窗口中打开嵌入的绘图"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:528
+#: ../../info/wxmaxima.md:559
 #, fuzzy
 #| msgid ""
 #| "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
@@ -2371,14 +2448,14 @@ msgstr ""
 "式的 gnuplot 窗口中打开绘制的图形。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:530
+#: ../../info/wxmaxima.md:561
 #, fuzzy
 #| msgid "Opening gnuplot's command console in `plot` windows"
 msgid "### Opening Gnuplot’s command console in `plot` windows"
 msgstr "在绘图窗口中打开 gnuplot 控制台"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:533
+#: ../../info/wxmaxima.md:564
 #, fuzzy
 #| msgid ""
 #| "On MS Windows, if in _Maxima_'s variable `gnuplot_command` \"gnuplot\" is "
@@ -2399,14 +2476,14 @@ msgstr ""
 "命令。但是，启用此功能会使得每次绘图时 gnuplot 短时间内独占键盘。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:535
+#: ../../info/wxmaxima.md:566
 #, fuzzy
 #| msgid "Embedding animations into the spreadsheet"
 msgid "### Embedding animations into the spreadsheet"
 msgstr "在工作簿中嵌入动图"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:537
+#: ../../info/wxmaxima.md:568
 #, fuzzy
 #| msgid ""
 #| "3D diagrams tend to make it hard to read quantitative data. A viable "
@@ -2428,7 +2505,7 @@ msgstr ""
 "这些图片之间切换。wxMaxima 支持将此动图导出为 gif 格式的图片。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:539
+#: ../../info/wxmaxima.md:570
 msgid ""
 "The first two arguments for `with_slider_draw` are the name of the variable "
 "that is stepped between the plots and a list of the values of these "
@@ -2439,7 +2516,7 @@ msgstr ""
 "下来的参数与 `wxdraw2d` 命令的参数相同："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:550
+#: ../../info/wxmaxima.md:581
 #, fuzzy, no-wrap
 #| msgid ""
 #| "with_slider_draw(\n"
@@ -2472,7 +2549,7 @@ msgstr ""
 ");\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:552
+#: ../../info/wxmaxima.md:583
 msgid ""
 "The same functionality for 3D plots is accessible as `with_slider_draw3d`, "
 "which allows for rotating 3d plots:"
@@ -2481,7 +2558,7 @@ msgstr ""
 "维图形："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:569
+#: ../../info/wxmaxima.md:600
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxanimate_autoplay:true;\n"
@@ -2532,7 +2609,7 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:571
+#: ../../info/wxmaxima.md:602
 msgid ""
 "If the general shape of the plot is what matters it might suffice to move "
 "the plot just a little bit in order to make its 3D nature available to the "
@@ -2542,7 +2619,7 @@ msgstr ""
 "征："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:588
+#: ../../info/wxmaxima.md:619
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxanimate_autoplay:true;\n"
@@ -2593,7 +2670,7 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:590
+#: ../../info/wxmaxima.md:621
 #, fuzzy
 #| msgid ""
 #| "For those more familiar with `plot` than with `draw` there is a second "
@@ -2604,19 +2681,19 @@ msgid ""
 msgstr "对于更熟悉 `plot` 而不是 `draw` 的用户来说，还有一组函数："
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
+#: ../../info/wxmaxima.md:624
 #, fuzzy
 #| msgid "`with_slider` and"
 msgid "`with_slider` and"
 msgstr "`with_slider`；"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:593
+#: ../../info/wxmaxima.md:624
 msgid "`wxanimate`."
 msgstr "`wxanimate`。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:595
+#: ../../info/wxmaxima.md:626
 #, fuzzy
 #| msgid ""
 #| "Normally the animations are played back or exported with the frame rate "
@@ -2631,7 +2708,7 @@ msgstr ""
 "可以修改变量 `wxanimate_framerate`："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:600
+#: ../../info/wxmaxima.md:631
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxanimate(a, 10,\n"
@@ -2646,7 +2723,7 @@ msgstr ""
 "     wxanimate_framerate=6$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:602
+#: ../../info/wxmaxima.md:633
 #, fuzzy
 #| msgid ""
 #| "The animation functions use _Maxima_'s `makelist` command and therefore "
@@ -2664,7 +2741,7 @@ msgstr ""
 "示错误信息："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:612
+#: ../../info/wxmaxima.md:643
 #, fuzzy, no-wrap
 #| msgid ""
 #| "f:sin(a*x);\n"
@@ -2694,7 +2771,7 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:614
+#: ../../info/wxmaxima.md:645
 #, fuzzy
 #| msgid ""
 #| "If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
@@ -2706,7 +2783,7 @@ msgstr ""
 "如果修改为明确要求 Maxima 代入滑块变量的值，则修改后的代码可用于绘制动图："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:627
+#: ../../info/wxmaxima.md:658
 #, fuzzy, no-wrap
 #| msgid ""
 #| "f:sin(a*x);\n"
@@ -2745,14 +2822,14 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:629
+#: ../../info/wxmaxima.md:660
 #, fuzzy
 #| msgid "Opening multiple plots in contemporaneous windows"
 msgid "### Opening multiple plots in contemporaneous windows"
 msgstr "同时打开多个绘图窗口"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:631
+#: ../../info/wxmaxima.md:662
 #, fuzzy
 #| msgid ""
 #| "While not being a provided by _wxMaxima_ this feature of _Maxima_ (on "
@@ -2768,38 +2845,38 @@ msgstr ""
 "一篇帖子："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:634
+#: ../../info/wxmaxima.md:665
 msgid "```maxima load(draw);"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:637
+#: ../../info/wxmaxima.md:668
 msgid ""
 "/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:640
+#: ../../info/wxmaxima.md:671
 msgid ""
 "/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:644
+#: ../../info/wxmaxima.md:675
 msgid ""
 "/* Paraboloid in window #3 */ "
 "draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:646
+#: ../../info/wxmaxima.md:677
 msgid ""
 "Plotting multiple plots in the same window is possible, too (the same is "
 "possible in command line Maxima with the standard `draw()` command):"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:657
+#: ../../info/wxmaxima.md:688
 #, fuzzy, no-wrap
 #| msgid ""
 #| "\twxdraw(\n"
@@ -2832,14 +2909,14 @@ msgstr ""
 "\t );\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:659
+#: ../../info/wxmaxima.md:690
 #, fuzzy
 #| msgid "The \"Plot using draw\" side pane"
 msgid "### The \"Plot using draw\" side pane"
 msgstr "“用 draw 函数绘图”侧边栏"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:661
+#: ../../info/wxmaxima.md:692
 #, fuzzy
 #| msgid ""
 #| "The \"Plot using draw\" sidebar hides a simple code generator that allows "
@@ -2854,12 +2931,12 @@ msgstr ""
 "draw 程序包方便灵活地生成一些图形绘制命令模板。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:663
+#: ../../info/wxmaxima.md:694
 msgid "#### 2D"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:665
+#: ../../info/wxmaxima.md:696
 #, fuzzy
 #| msgid ""
 #| "Generates the skeleton of a `draw()` command that draws a 2D scene. This "
@@ -2876,7 +2953,7 @@ msgstr ""
 "模板，例如利用“二维图形”按钮下方的其他按钮导入绘图命令。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:667
+#: ../../info/wxmaxima.md:698
 #, fuzzy
 #| msgid ""
 #| "One helpful feature of the 2D button is that it allows to setup the scene "
@@ -2894,12 +2971,12 @@ msgstr ""
 "形中的相同数据更容易理解。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:669
+#: ../../info/wxmaxima.md:700
 msgid "#### 3D"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:671
+#: ../../info/wxmaxima.md:702
 #, fuzzy
 #| msgid ""
 #| "Generates the skeleton of a `draw()` command that draws a 3D scene. If "
@@ -2914,14 +2991,14 @@ msgstr ""
 "能，则所有其他按钮都将自动提前调用上一功能中的绘制二维图形模板。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:673
+#: ../../info/wxmaxima.md:704
 #, fuzzy
 #| msgid "Expression"
 msgid "#### Expression"
 msgstr "表达式"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:675
+#: ../../info/wxmaxima.md:706
 msgid ""
 "Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or "
 "`x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is "
@@ -2933,14 +3010,14 @@ msgstr ""
 "令，将调用绘制二维图形的模板。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:677
+#: ../../info/wxmaxima.md:708
 #, fuzzy
 #| msgid "Implicit plot"
 msgid "#### Implicit plot"
 msgstr "隐式图形"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:679
+#: ../../info/wxmaxima.md:710
 msgid ""
 "Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or "
 "`x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command "
@@ -2952,14 +3029,14 @@ msgstr ""
 "绘制二维图形的模板。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:681
+#: ../../info/wxmaxima.md:712
 #, fuzzy
 #| msgid "Parametric plot"
 msgid "#### Parametric plot"
 msgstr "参数式图形"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:683
+#: ../../info/wxmaxima.md:714
 msgid ""
 "Steps a variable from a lower limit to an upper limit and uses two "
 "expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in "
@@ -2971,14 +3048,14 @@ msgstr ""
 "第三个表达式生成竖坐标 z）。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:685
+#: ../../info/wxmaxima.md:716
 #, fuzzy
 #| msgid "Points"
 msgid "#### Points"
 msgstr "点"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:687
+#: ../../info/wxmaxima.md:718
 msgid ""
 "Draws many points that can optionally be joined. The coordinates of the "
 "points are taken from a list of lists, a 2D array or one list or array for "
@@ -2988,38 +3065,38 @@ msgstr ""
 "个轴指定的一个列表或数组。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:689
+#: ../../info/wxmaxima.md:720
 #, fuzzy
 #| msgid "Diagram title"
 msgid "#### Diagram title"
 msgstr "图形标题"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:691
+#: ../../info/wxmaxima.md:722
 msgid "Draws a title on the upper end of the diagram,"
 msgstr "在图形上方绘制标题。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:693
+#: ../../info/wxmaxima.md:724
 #, fuzzy
 #| msgid "Axis"
 msgid "#### Axis"
 msgstr "坐标轴"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:695
+#: ../../info/wxmaxima.md:726
 msgid "Sets up the axis."
 msgstr "设置坐标轴。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:697
+#: ../../info/wxmaxima.md:728
 #, fuzzy
 #| msgid "Contour"
 msgid "#### Contour"
 msgstr "等高线"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:699
+#: ../../info/wxmaxima.md:730
 #, fuzzy
 #| msgid ""
 #| "(Only for 3D plots): Adds contour lines similar to the ones one can find "
@@ -3039,14 +3116,14 @@ msgstr ""
 "示等高线。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:701
+#: ../../info/wxmaxima.md:732
 #, fuzzy
 #| msgid "Plot name"
 msgid "#### Plot name"
 msgstr "图形名称"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:703
+#: ../../info/wxmaxima.md:734
 #, fuzzy
 #| msgid ""
 #| "Adds a legend entry showing the next plot's name to the legend of the "
@@ -3060,66 +3137,66 @@ msgstr ""
 "在图例中增加下一个图形对应的图例项。空名称将阻止为下一个图形生成图例项。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:705
+#: ../../info/wxmaxima.md:736
 #, fuzzy
 #| msgid "Line colour"
 msgid "#### Line colour"
 msgstr "线条颜色"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:707
+#: ../../info/wxmaxima.md:738
 msgid ""
 "Sets the line colour for the following plots the current draw command "
 "contains."
 msgstr "为当前 `draw()` 命令所绘图形设置线条颜色。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:709
+#: ../../info/wxmaxima.md:740
 #, fuzzy
 #| msgid "Fill colour"
 msgid "#### Fill colour"
 msgstr "填充颜色"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:711
+#: ../../info/wxmaxima.md:742
 msgid ""
 "Sets the fill colour for the following plots the current draw command "
 "contains."
 msgstr "为当前 `draw()` 命令所绘图形设置填充颜色。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:713
+#: ../../info/wxmaxima.md:744
 #, fuzzy
 #| msgid "Grid"
 msgid "#### Grid"
 msgstr "网格"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:715
+#: ../../info/wxmaxima.md:746
 msgid "Pops up a wizard that allows to set up grid lines."
 msgstr "弹出设置网格线的向导。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:717
+#: ../../info/wxmaxima.md:748
 #, fuzzy
 #| msgid "Accuracy"
 msgid "#### Accuracy"
 msgstr "精度"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:719
+#: ../../info/wxmaxima.md:750
 msgid ""
 "Allows to select an adequate point in the speed vs. accuracy tradeoff that "
 "is part of any plot program."
 msgstr "允许选择适当数目的点，以兼顾速度与精度（任何绘图程序都会权衡两者）。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:721
+#: ../../info/wxmaxima.md:752
 msgid "### Modify font and font size for plots"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:723
+#: ../../info/wxmaxima.md:754
 msgid ""
 "Especially when you use a high resolution display, the default font size "
 "might be very small. For the `draw`-based commands, you can set the font / "
@@ -3127,7 +3204,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:730
+#: ../../info/wxmaxima.md:761
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxdraw2d(\n"
@@ -3148,14 +3225,14 @@ msgstr ""
 ");\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:732
+#: ../../info/wxmaxima.md:763
 msgid ""
 "For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts "
 "can be set using the `gnuplot_preamble` command, e.g.:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:737
+#: ../../info/wxmaxima.md:768
 #, no-wrap
 msgid ""
 "~~~maxima\n"
@@ -3165,14 +3242,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:739
+#: ../../info/wxmaxima.md:770
 msgid ""
 "This sets the font for the numbers to Arial with size 30, the size for the "
 "xlabel and ylabel font to 20 (with the default font)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:742
+#: ../../info/wxmaxima.md:773
 msgid ""
 "Read the Maxima and Gnuplot documentation for further information.  Note: "
 "Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue "
@@ -3180,14 +3257,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:744
+#: ../../info/wxmaxima.md:775
 #, fuzzy
 #| msgid "Embedding graphics"
 msgid "## Embedding graphics"
 msgstr "嵌入图片"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:746
+#: ../../info/wxmaxima.md:777
 #, fuzzy
 #| msgid ""
 #| "If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
@@ -3204,21 +3281,21 @@ msgstr ""
 "但有时（例如某个图像的内容可能在稍后发生更改）最好指明在计算时加载图像："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:750
+#: ../../info/wxmaxima.md:781
 #, fuzzy
 #| msgid "show_image(\"man.png\");\n"
 msgid "```maxima show_image(\"man.png\"); ```"
 msgstr "show_image(\"man.png\");\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:752
+#: ../../info/wxmaxima.md:783
 #, fuzzy
 #| msgid "Startup files"
 msgid "## Startup files"
 msgstr "启动时读取的文件"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:754
+#: ../../info/wxmaxima.md:785
 msgid ""
 "The config dialogue of _wxMaxima_ offers to edit two files with commands "
 "that are executed on startup:"
@@ -3226,14 +3303,14 @@ msgstr ""
 "在 wxMaxima 的设置对话框中可以编辑两个文件的命令，这些命令在启动时被执行："
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
+#: ../../info/wxmaxima.md:788
 msgid ""
 "A file that contains commands that are executed on starting up _Maxima_: "
 "`maxima-init.mac`"
 msgstr "文件 `maxima-init.mac` 中包含每次启动 Maxima 时被执行的命令；"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:757
+#: ../../info/wxmaxima.md:788
 #, fuzzy
 #| msgid ""
 #| "A file that contains commands that are executed on starting up _Maxima_: "
@@ -3244,7 +3321,7 @@ msgid ""
 msgstr "文件 `maxima-init.mac` 中包含每次启动 Maxima 时被执行的命令；"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:759
+#: ../../info/wxmaxima.md:790
 msgid ""
 "For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add "
 "`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` "
@@ -3252,7 +3329,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:761
+#: ../../info/wxmaxima.md:792
 #, fuzzy
 #| msgid ""
 #| "These files are in the Maxima user directory (usually `maxima` in "
@@ -3269,14 +3346,14 @@ msgstr ""
 "该目录。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:763
+#: ../../info/wxmaxima.md:794
 #, fuzzy
 #| msgid "Special variables wx..."
 msgid "## Special variables wx..."
 msgstr "以 wx 开头的特殊变量"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxsubscripts` tells _Maxima_ if it should convert variable names that "
 "contain an underscore (`R_150` or the like) into subscripted variables. See "
@@ -3288,14 +3365,14 @@ msgstr ""
 "`wxdeclare_subscript`。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxfilename`: This variable contains the name of the file currently opened "
 "in _wxMaxima_."
 msgstr "`wxfilename`：此变量包含当前在 wxMaxima 中打开的文件的名称。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, fuzzy
 #| msgid ""
 #| "`wxfilename`: This variable contains the name of the file currently "
@@ -3306,7 +3383,7 @@ msgid ""
 msgstr "`wxfilename`：此变量包含当前在 wxMaxima 中打开的文件的名称。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, fuzzy
 #| msgid ""
 #| "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _gnuplot_’s "
@@ -3321,12 +3398,12 @@ msgstr ""
 "供更多的线条样式和更好的整体图形质量。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxplot_size` defines the resolution of embedded plots."
 msgstr "`wxplot_size`：定义嵌入绘图的分辨率。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 #, fuzzy
 #| msgid ""
 #| "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
@@ -3349,36 +3426,36 @@ msgstr ""
 "以在设置对话框中将其设置为 `false`。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid ""
 "`wxanimate_framerate`: The number of frames per second the following "
 "animations have to be played back with."
 msgstr "`wxanimate_framerate`：下一个动图回放的帧率。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxanimate_autoplay`: Automatically play animations by default?"
 msgstr "`wxanimate_autoplay`：是否在默认情况下自动播放动图。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:774
+#: ../../info/wxmaxima.md:805
 msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:776
+#: ../../info/wxmaxima.md:807
 #, fuzzy
 #| msgid "Pretty-printing 2D output"
 msgid "## Pretty-printing 2D output"
 msgstr "输出美观的二维公式"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:778
+#: ../../info/wxmaxima.md:809
 #, fuzzy
 #| msgid ""
 #| "The function `table_form()` displays a 2D list in a form that is more "
@@ -3399,7 +3476,7 @@ msgstr ""
 "`$` 结尾也会显示输出。以分号 `;` 结束命令时，除了得到列表，还会有“done”语句。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:787
+#: ../../info/wxmaxima.md:818
 #, fuzzy, no-wrap
 #| msgid ""
 #| "table_form(\n"
@@ -3426,7 +3503,7 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:789
+#: ../../info/wxmaxima.md:820
 msgid ""
 "As the next example shows, the lists that are assembled by the `table_form` "
 "command can be created before the command is executed."
@@ -3434,7 +3511,7 @@ msgstr ""
 "正如下一个例子所示，可以在执行 `table_form` 命令之前创建需要显示的列表。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:791
+#: ../../info/wxmaxima.md:822
 msgid ""
 "![A third table example](./MatrixTableExample.png)"
 "{ id=img_MatrixTableExample }"
@@ -3442,14 +3519,14 @@ msgstr ""
 "![一个三行表的例子](./MatrixTableExample.png){ id=img_MatrixTableExample }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:793
+#: ../../info/wxmaxima.md:824
 msgid ""
 "Also, because a matrix is a list of lists, matrices can be converted to "
 "tables in a similar fashion."
 msgstr "此外，由于矩阵是含列表的列表，它也可以用类似的方式转换为表格。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:795
+#: ../../info/wxmaxima.md:826
 msgid ""
 "![Another table_form example](./SecondTableExample.png)"
 "{ id=img_SecondTableExample }"
@@ -3458,28 +3535,58 @@ msgstr ""
 "{ id=img_SecondTableExample }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:797
+#: ../../info/wxmaxima.md:828
 msgid ""
 "The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that "
 "allows for more flexible formatting of matrices in wxMaxima:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:803
+#: ../../info/wxmaxima.md:830
 #, no-wrap
+msgid "**`wx_matrix( <matrix>, [options] )`**\n"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
 msgid ""
-"**`wx_matrix( <matrix>, [options] )`**\n"
-"- **`lines=true`**: Draws internal separator lines between the cells. This is required to visually separate headings from data.\n"
-"- **`rownames=true`**: Tells wxMaxima that the first column of the matrix contains labels.\n"
-"- **`colnames=true`**: Tells wxMaxima that the first row of the matrix contains labels.\n"
-"- **`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw around the matrix. Supported styles are: `round` `()`, `square` `[]`, `angled` `<>`, `straight` `||`, or `none`.\n"
+"**`lines=true`**: Draws internal separator lines between the cells. This is "
+"required to visually separate headings from data."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`rownames=true`**: Tells wxMaxima that the first column of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`colnames=true`**: Tells wxMaxima that the first row of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:835
+msgid ""
+"**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
+"around the matrix. Supported styles are: `round` `()`, `square` `[]`, "
+"`angled` `<>`, `straight` `||`, or `none`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:809
+#: ../../info/wxmaxima.md:837
+#, fuzzy
+#| msgid "One Example:"
+msgid "Example:"
+msgstr "例如："
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:842
 #, no-wrap
 msgid ""
-"Example:\n"
 "```maxima\n"
 "wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
 "          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
@@ -3487,14 +3594,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:811
+#: ../../info/wxmaxima.md:844
 #, fuzzy
 #| msgid "Bug reporting"
 msgid "## Bug reporting"
 msgstr "错误（bug）报告"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:813
+#: ../../info/wxmaxima.md:846
 #, fuzzy
 #| msgid ""
 #| "_wxMaxima_ provides a few functions that gather bug reporting information "
@@ -3505,7 +3612,7 @@ msgid ""
 msgstr "wxMaxima 提供了一些函数，用于收集当前系统的错误报告信息："
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:816
+#: ../../info/wxmaxima.md:849
 #, fuzzy
 #| msgid ""
 #| "`wxbuild_info()` gathers information about the currently running version "
@@ -3516,19 +3623,19 @@ msgid ""
 msgstr "`wxbuild_info()` 收集当前运行的 wxMaxima 的版本信息；"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:816
+#: ../../info/wxmaxima.md:849
 msgid "`wxbug_report()` tells how and where to file bugs"
 msgstr "`wxbug_report()` 说明如何以及在何处提交错误报告。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:819
+#: ../../info/wxmaxima.md:851
 #, fuzzy
 #| msgid "Marking output being drawn in red"
 msgid "## Marking output being drawn in red"
 msgstr "让输出显示为红色"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:822
+#: ../../info/wxmaxima.md:854
 #, fuzzy
 #| msgid ""
 #| "_Maxima_'s `box()` command causes _wxMaxima_ to print its argument with a "
@@ -3540,17 +3647,17 @@ msgid ""
 msgstr "Maxima 的 `box()` 命令使 wxMaxima 以红色输出其参数。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:824
+#: ../../info/wxmaxima.md:856
 msgid "## Output rendering."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:826
+#: ../../info/wxmaxima.md:858
 msgid "With `set_display()` one can set, how wxMaxima will render the output."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:828
+#: ../../info/wxmaxima.md:860
 msgid ""
 "`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima "
 "using an (machine readable) XML-dialect (can be seen in the \"Raw XML "
@@ -3559,7 +3666,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:831
+#: ../../info/wxmaxima.md:863
 msgid ""
 "<!--- Currently that does not work as it should, the line with the output "
 "label is shifted right (issue: #2006) --> `set_display('ascii)` causes "
@@ -3567,19 +3674,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:833
+#: ../../info/wxmaxima.md:865
 msgid ""
 "`set_display('none)` causes 'one-line' ASCII results - the same as the "
 "command line Maxima command `display2d:false;` does."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:835
+#: ../../info/wxmaxima.md:867
 msgid "# Help menu"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:837
+#: ../../info/wxmaxima.md:869
 msgid ""
 "WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, "
 "tips, some example worksheets and in command line Maxima included demos (the "
@@ -3587,19 +3694,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:839
+#: ../../info/wxmaxima.md:871
 msgid "Please notice, that the demos write:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:843
+#: ../../info/wxmaxima.md:875
 msgid ""
 "~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the "
 "demonstration.  ~~~"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:845
+#: ../../info/wxmaxima.md:877
 msgid ""
 "That is valid for command-line Maxima, however in wxMaxima by default it is "
 "necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</"
@@ -3607,28 +3714,28 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:847
+#: ../../info/wxmaxima.md:879
 msgid ""
 "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending "
 "commands to Maxima\" menu.)"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:851
+#: ../../info/wxmaxima.md:883
 #, fuzzy
 #| msgid "Troubleshooting"
 msgid "# Troubleshooting"
 msgstr "疑难解答"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:853
+#: ../../info/wxmaxima.md:885
 #, fuzzy
 #| msgid "Cannot connect to _Maxima_"
 msgid "## Cannot connect to _Maxima_"
 msgstr "无法连接到 Maxima"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:855
+#: ../../info/wxmaxima.md:887
 #, fuzzy
 #| msgid ""
 #| "Since _Maxima_ (the program that does the actual mathematics) and "
@@ -3666,7 +3773,7 @@ msgstr ""
 "似的名字。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:857
+#: ../../info/wxmaxima.md:889
 #, fuzzy
 #| msgid ""
 #| "On Un\\*x computers another possible reason would be that the loopback "
@@ -3681,14 +3788,14 @@ msgstr ""
 "接的环回（loopback）网络配置不正确。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:859
+#: ../../info/wxmaxima.md:891
 #, fuzzy
 #| msgid "How to save data from a broken .wxmx file"
 msgid "## How to save data from a broken .wxmx file"
 msgstr "从损坏的 .wxmx 文件中取回信息的方法"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:861
+#: ../../info/wxmaxima.md:893
 #, fuzzy
 #| msgid ""
 #| "Internally most modern XML-based formats are ordinary zip-files. "
@@ -3703,7 +3810,7 @@ msgstr ""
 "启用压缩，因此可以在任何文本编辑器中查看 `.wxmx` 文件的内容。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:863
+#: ../../info/wxmaxima.md:895
 #, fuzzy
 #| msgid ""
 #| "If the zip signature at the end of the file is still intact after "
@@ -3730,7 +3837,7 @@ msgstr ""
 "所帮助。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:865
+#: ../../info/wxmaxima.md:897
 #, fuzzy
 #| msgid ""
 #| "And even if there isn’t such a file: The `.wxmx` file is a container "
@@ -3754,7 +3861,7 @@ msgstr ""
 "（在 XML 部分的前后，可在文本编辑器中看到一些不可读的二进制内容）。\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:867
+#: ../../info/wxmaxima.md:899
 #, fuzzy
 #| msgid ""
 #| "If a text file containing only this contents (e.g. copy and paste this "
@@ -3769,7 +3876,7 @@ msgstr ""
 "以 `.xml` 结尾的文件，则 wxMaxima 可以从中恢复原始文档的文本。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:869
+#: ../../info/wxmaxima.md:901
 #, fuzzy
 #| msgid ""
 #| "I want some debug info to be displayed on the screen before my command "
@@ -3780,7 +3887,7 @@ msgid ""
 msgstr "在命令完成前显示一些调试信息"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:871
+#: ../../info/wxmaxima.md:903
 msgid ""
 "Normally _wxMaxima_ waits for the whole 2D formula to be transferred before "
 "it begins to typeset. This saves time for making many attempts to typeset a "
@@ -3793,7 +3900,7 @@ msgstr ""
 "令完成："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:881
+#: ../../info/wxmaxima.md:913
 #, fuzzy, no-wrap
 #| msgid ""
 #| "for i:1 thru 10 do (\n"
@@ -3822,19 +3929,19 @@ msgstr ""
 ")$\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:883
+#: ../../info/wxmaxima.md:915
 msgid "Alternatively one can look for the `wxstatusbar()` command above."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:885
+#: ../../info/wxmaxima.md:917
 #, fuzzy
 #| msgid "Plotting only shows a closed empty envelope with an error message"
 msgid "## Plotting only shows a closed empty envelope with an error message"
 msgstr "绘图结果是空的绘图框和错误信息"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:887
+#: ../../info/wxmaxima.md:919
 #, fuzzy
 #| msgid ""
 #| "This means that _wxMaxima_ could not read the file _Maxima_ that was "
@@ -3845,12 +3952,12 @@ msgid ""
 msgstr "这意味着 wxMaxima 无法读取由 Maxima 指示 gnuplot 创建的文件。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:889
+#: ../../info/wxmaxima.md:921
 msgid "Possible reasons for this error are:"
 msgstr "这个错误的可能原因如下："
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, fuzzy
 #| msgid ""
 #| "The plotting command is part of a third-party package like "
@@ -3865,7 +3972,7 @@ msgstr ""
 "调用 Maxima 的 `load()` 命令加载此包。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, fuzzy
 #| msgid ""
 #| "_Maxima_ tried to do something the currently installed version of "
@@ -3886,7 +3993,7 @@ msgstr ""
 "gnuplot 的指令。在调试问题时，此文件的内容在大多数情况下都是有帮助的。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, fuzzy
 #| msgid ""
 #| "Gnuplot was instructed to use the pngcairo library that provides "
@@ -3906,21 +4013,21 @@ msgstr ""
 "图”复选框，并且不要在 Maxima 中将 `wxplot_pngcairo` 设置为true。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:894
+#: ../../info/wxmaxima.md:926
 #, fuzzy
 #| msgid "Gnuplot didn’t output a valid `.png` file."
 msgid "Gnuplot didn’t output a valid `.png` file."
 msgstr "Gnuplot 没有生成有效的 .png 文件。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:896
+#: ../../info/wxmaxima.md:928
 #, fuzzy
 #| msgid "Plotting an animation results in “error: undefined variable”"
 msgid "## Plotting an animation results in “error: undefined variable”"
 msgstr "绘制动图时得到“error: undefined variable（错误：未定义的变量）”"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:898
+#: ../../info/wxmaxima.md:930
 #, fuzzy
 #| msgid ""
 #| "The value of the slider variable by default is only substituted into the "
@@ -3943,14 +4050,14 @@ msgstr ""
 "一个例子。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:900
+#: ../../info/wxmaxima.md:932
 #, fuzzy
 #| msgid "I lost a cell contents and undo doesn’t remember"
 msgid "## I lost cell content and undo doesn’t remember"
 msgstr "删除了一个单元格，而撤销操作不起作用"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:902
+#: ../../info/wxmaxima.md:934
 msgid ""
 "There are separate undo functions for cell operations and for changes inside "
 "of cells so chances are low that this ever happens. If it does there are "
@@ -3960,7 +4067,7 @@ msgstr ""
 "很低。如果确实是这样，有如下方法可以恢复数据："
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 #, fuzzy
 #| msgid ""
 #| "_wxMaxima_ actually has two undo features: The global undo buffer that is "
@@ -3977,7 +4084,7 @@ msgstr ""
 "果光标在单元格内）。可以尝试使用这两个撤消选项，以查看是否可以恢复内容。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 #, fuzzy
 #| msgid ""
 #| "If you still have a way to find out what label _Maxima_ has assigned to "
@@ -3990,7 +4097,7 @@ msgstr ""
 "重新出现。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 #, fuzzy
 #| msgid ""
 #| "If you don’t: Don’t panic. In the “View” menu there is a way to show a "
@@ -4004,17 +4111,17 @@ msgstr ""
 "栏，其中显示了最近使用的所有 Maxima 命令。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:907
+#: ../../info/wxmaxima.md:939
 msgid "If nothing else helps _Maxima_ contains a replay feature:"
 msgstr "如果以上都没有帮助，可以调用 Maxima 的回放功能："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:911
+#: ../../info/wxmaxima.md:943
 msgid "```maxima playback(); ```"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:913
+#: ../../info/wxmaxima.md:945
 #, fuzzy
 #| msgid "_wxMaxima_ starts up with the message “Maxima process terminated.”"
 msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
@@ -4022,7 +4129,7 @@ msgstr ""
 "wxMaxima 启动时显示信息“Maxima process terminated（Maxima 进程已终止）。”"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:915
+#: ../../info/wxmaxima.md:947
 #, fuzzy
 #| msgid ""
 #| "One possible reason is that _Maxima_ cannot be found in the location that "
@@ -4040,14 +4147,14 @@ msgstr ""
 "该可以解决此问题。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:917
+#: ../../info/wxmaxima.md:949
 #, fuzzy
 #| msgid "Maxima is forever calculating and not responding to input"
 msgid "## Maxima is forever calculating and not responding to input"
 msgstr "Maxima 永远在计算中而不响应输入"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:919
+#: ../../info/wxmaxima.md:951
 #, fuzzy
 #| msgid ""
 #| "It is theoretically possible that _wxMaxima_ doesn’t realize that "
@@ -4065,14 +4172,14 @@ msgstr ""
 "程序同步。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:921
+#: ../../info/wxmaxima.md:953
 #, fuzzy
 #| msgid "My SBCL-based _Maxima_ runs out of memory"
 msgid "## My SBCL-based _Maxima_ runs out of memory"
 msgstr "基于 SBCL 的 Maxima 耗尽内存"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:923
+#: ../../info/wxmaxima.md:955
 #, fuzzy
 #| msgid ""
 #| "The Lisp compiler SBCL by default comes with a memory limit that allows "
@@ -4102,7 +4209,7 @@ msgstr ""
 "编译 Lapack 所需的约 1280 兆字节）。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:925
+#: ../../info/wxmaxima.md:957
 #, fuzzy
 #| msgid ""
 #| "One way to provide _Maxima_ (and thus SBCL) with command line parameters "
@@ -4117,19 +4224,19 @@ msgstr ""
 "的“额外的 Maxima 参数（Additional parameters for Maxima）”字段。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:927
+#: ../../info/wxmaxima.md:959
 msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
 msgstr "![SBCL 内存](./sbclMemory.png){ id=img_sbclMemory }"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:929
+#: ../../info/wxmaxima.md:961
 #, fuzzy
 #| msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
 msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
 msgstr "在 Ubuntu 系统上，有时输入无响应或响应迟缓"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:931
+#: ../../info/wxmaxima.md:963
 msgid ""
 "Installing the package `ibus-gtk` should resolve this issue. See ([https://"
 "bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://"
@@ -4140,28 +4247,28 @@ msgstr ""
 "+source/wxwidgets3.0/+bug/1421558)。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:933
+#: ../../info/wxmaxima.md:965
 #, fuzzy
 #| msgid "_wxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
 msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
 msgstr "wxMaxima 在处理希腊字符或元音变音符时停止"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:935
+#: ../../info/wxmaxima.md:967
 msgid ""
 "If your _Maxima_ is based on SBCL the following lines have to be added to "
 "your `.sbclrc`:"
 msgstr "如果所使用的 Maxima 基于SBCL，则必须将以下行添加到 `.sbclrc` 文件中："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:939
+#: ../../info/wxmaxima.md:971
 #, fuzzy
 #| msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
 msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
 msgstr "(setf sb-impl::*default-external-format* :utf-8)\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:941
+#: ../../info/wxmaxima.md:973
 #, fuzzy
 #| msgid ""
 #| "The folder this file has to be placed in is system- and installation-"
@@ -4178,60 +4285,92 @@ msgstr ""
 "中计算了一个单元格，那么在获得如下命令后，都会显示该文件的位置："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:945
+#: ../../info/wxmaxima.md:977
 #, fuzzy
 #| msgid "    :lisp (sb-impl::userinit-pathname)\n"
 msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
 msgstr "    :lisp (sb-impl::userinit-pathname)\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:947
+#: ../../info/wxmaxima.md:979
 msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:950
+#: ../../info/wxmaxima.md:982
 msgid ""
 "There seem to be issues with the Wayland Display Server and wxWidgets.  "
 "WxMaxima may be affected, e.g. that sidebars are not moveable."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:954
+#: ../../info/wxmaxima.md:986
 msgid ""
 "You can either disable Wayland and use X11 instead (globally)  or just tell, "
 "that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:956
+#: ../../info/wxmaxima.md:988
 msgid "E.g. start wxMaxima with:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:958
+#: ../../info/wxmaxima.md:990
 msgid "`GDK_BACKEND=x11 wxmaxima`"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:960
+#: ../../info/wxmaxima.md:992
+msgid "## The menu bar disappears on KDE Plasma"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:997
+msgid ""
+"On some KDE Plasma installations the global menu bar disappears when "
+"clicked.  As this is a bug in the global menu proxy, the only way to avoid "
+"it is to tell that wxMaxima should use its own menu bar instead of the "
+"global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1001
+msgid ""
+"Starting with version 26.05.0, wxMaxima attempts to set this variable "
+"automatically if it detects an affected system (KDE, Unity, or Ubuntu with "
+"older wxWidgets versions)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1003
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1005
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1007
 msgid "## Why is the integrated manual browser not offered on my Windows PC?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:963
+#: ../../info/wxmaxima.md:1010
 msgid ""
 "Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or "
 "Microsoft’s webview2 isn’t installed."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:965
+#: ../../info/wxmaxima.md:1012
 msgid "## Why is the external manual browser not working on my Linux box?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:971
+#: ../../info/wxmaxima.md:1018
 msgid ""
 "The HTML browser might be a snap, flatpack or appimage version. All of these "
 "typically cannot access files that are installed on your local system. "
@@ -4242,7 +4381,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:973
+#: ../../info/wxmaxima.md:1020
 #, fuzzy
 #| msgid ""
 #| "Can I make _wxMaxima_ output both image files and embedded plots at once?"
@@ -4251,7 +4390,7 @@ msgid ""
 msgstr "是否可以同时输出和嵌入绘图文件？"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:975
+#: ../../info/wxmaxima.md:1022
 #, fuzzy
 #| msgid ""
 #| "The worksheet embeds .png files. _wxMaxima_ allows the user to specify "
@@ -4262,7 +4401,7 @@ msgid ""
 msgstr "工作簿可嵌入 `.png` 文件。wxMaxima 允许用户指定它们的生成位置："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:982
+#: ../../info/wxmaxima.md:1029
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxdraw2d(\n"
@@ -4283,7 +4422,7 @@ msgstr ""
 ");\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:984
+#: ../../info/wxmaxima.md:1031
 #, fuzzy
 #| msgid ""
 #| "If a different format is to be used it is easier to generate the images "
@@ -4294,7 +4433,7 @@ msgid ""
 msgstr "如果要使用不同的格式，则可以先生成图像，然后再将其导入工作簿："
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1003
+#: ../../info/wxmaxima.md:1050
 #, fuzzy, no-wrap
 #| msgid ""
 #| "load(\"draw\");\n"
@@ -4361,7 +4500,7 @@ msgstr ""
 ");\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1008
+#: ../../info/wxmaxima.md:1055
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxdraw2d(\n"
@@ -4380,19 +4519,19 @@ msgstr ""
 ");\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1010
+#: ../../info/wxmaxima.md:1057
 #, fuzzy
 #| msgid "Can I set the aspect ratio of a plot?"
 msgid "## Can I set the aspect ratio of an embedded plot?"
 msgstr "是否可以指定绘制图形的相对比例？"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1012
+#: ../../info/wxmaxima.md:1059
 msgid "Use the variable `wxplot_size`:"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1018
+#: ../../info/wxmaxima.md:1065
 #, fuzzy, no-wrap
 #| msgid ""
 #| "wxdraw2d(\n"
@@ -4412,14 +4551,14 @@ msgstr ""
 "),wxplot_size=[1000,1000];\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1020
+#: ../../info/wxmaxima.md:1067
 msgid ""
 "## After upgrading to MacOS 13.1 plot and/or draw commands output error "
 "messages like"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1027
+#: ../../info/wxmaxima.md:1074
 msgid ""
 "```text 1 HIToolbox 0x00007ff80cd91726 "
 "_ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox "
@@ -4428,7 +4567,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1029
+#: ../../info/wxmaxima.md:1076
 msgid ""
 "This might be an issue with the operating system. Disable the hiding of the "
 "menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the "
@@ -4437,12 +4576,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1031
+#: ../../info/wxmaxima.md:1078
 msgid "## Logging"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1035
+#: ../../info/wxmaxima.md:1082
 msgid ""
 "Log messages might be helpful to debug problems. WxMaxima can log many "
 "events. Most log entries will be helpful for developers, especially in case "
@@ -4453,7 +4592,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1037
+#: ../../info/wxmaxima.md:1084
 msgid ""
 "Messages are not 'lost', if the log window is not shown, if you select to "
 "show the log window later, you will see past log messages (if you did not "
@@ -4461,14 +4600,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1039
+#: ../../info/wxmaxima.md:1086
 msgid ""
 "Such messages may be helpful, when you create bug reports (or trying to find "
 "a bug by yourself)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1042
+#: ../../info/wxmaxima.md:1089
 msgid ""
 "Log messages can (additionally) be printed to STDERR, when using the command "
 "line option \"--logtostderr\". On Windows a separate text console will be "
@@ -4476,26 +4615,26 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1046
+#: ../../info/wxmaxima.md:1093
 msgid "# FAQ"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1048
+#: ../../info/wxmaxima.md:1095
 #, fuzzy
 #| msgid "Is there a way to make more text fit on a LaTeX page?"
 msgid "## Is there a way to make more text fit on a LaTeX page?"
 msgstr "有没有办法在 LaTeX 页面中显示更多的文字？"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1050
+#: ../../info/wxmaxima.md:1097
 msgid ""
 "Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to "
 "specify the size of the borders."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1052
+#: ../../info/wxmaxima.md:1099
 #, fuzzy
 #| msgid ""
 #| "There is: Just add the following lines to the LaTeX preamble (for example "
@@ -4511,7 +4650,7 @@ msgstr ""
 "TeX preamble））：\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1056
+#: ../../info/wxmaxima.md:1103
 #, fuzzy
 #| msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
 msgid ""
@@ -4519,14 +4658,14 @@ msgid ""
 msgstr "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1058
+#: ../../info/wxmaxima.md:1105
 #, fuzzy
 #| msgid "Is there a dark mode?"
 msgid "## Is there a dark mode?"
 msgstr "是否有深色模式？"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1060
+#: ../../info/wxmaxima.md:1107
 #, fuzzy
 #| msgid ""
 #| "If wxWidgets is new enough _wxMaxima_ will automatically be in dark mode "
@@ -4547,7 +4686,7 @@ msgstr ""
 "“查看->反转工作簿亮度”，可以快速将工作簿在浅色模式和深色模式中转换。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1062
+#: ../../info/wxmaxima.md:1109
 #, fuzzy
 #| msgid ""
 #| "_wxMaxima_ sometimes hangs for a several seconds once in the first minute"
@@ -4556,7 +4695,7 @@ msgid ""
 msgstr "wxMaxima 有时在启动后的一段时间内无响应"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1064
+#: ../../info/wxmaxima.md:1111
 #, fuzzy
 #| msgid ""
 #| "_wxMaxima_ delegates some big tasks like parsing _Maxima_'s >1000-page-"
@@ -4575,19 +4714,19 @@ msgstr ""
 "才能继续工作。\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1066
+#: ../../info/wxmaxima.md:1113
 msgid ""
 "## Especially when testing new locale settings, a message box \"locale "
 "’xx_YY’ can not be set\" occurs"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1068
+#: ../../info/wxmaxima.md:1115
 msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1072
+#: ../../info/wxmaxima.md:1119
 msgid ""
 "(The same problem can occur with other applications too). The translations "
 "seem okay after you click on ’OK’. WxMaxima does not only use its own "
@@ -4595,20 +4734,20 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1075
+#: ../../info/wxmaxima.md:1122
 msgid ""
 "These locales maybe not present in the system. On Ubuntu/Debian systems they "
 "can be generated using: `dpkg-reconfigure locales`"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1077
+#: ../../info/wxmaxima.md:1124
 msgid ""
 "## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1079
+#: ../../info/wxmaxima.md:1126
 msgid ""
 "You can find these symbols in the Unicode sidebar (search for ’double-struck "
 "capital’). But the selected font must also support these symbols. If they do "
@@ -4616,14 +4755,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1081
+#: ../../info/wxmaxima.md:1128
 msgid ""
 "## How can a Maxima script determine, if it is running under wxMaxima or "
 "command line Maxima?"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1083
+#: ../../info/wxmaxima.md:1130
 msgid ""
 "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to "
 "`wxmaxima`. The Maxima variable `maxima_frontend_version` contains the "
@@ -4631,19 +4770,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1085
+#: ../../info/wxmaxima.md:1132
 msgid ""
 "If no frontend is used (you are using command line Maxima), these variables "
 "are `false`."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1087
+#: ../../info/wxmaxima.md:1134
 msgid "## Help! I can not save my document!"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1089
+#: ../../info/wxmaxima.md:1136
 msgid ""
 "If saving as wxmx file does not work, try saving the document as wxm file "
 "(and vice versa). And you can also try to remove all output (Menu Cell-"
@@ -4652,14 +4791,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1093
+#: ../../info/wxmaxima.md:1140
 #, fuzzy
 #| msgid "Command-line arguments"
 msgid "# Command-line arguments"
 msgstr "命令行参数"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1095
+#: ../../info/wxmaxima.md:1142
 msgid ""
 "Usually you can start programs with a graphical user interface just by "
 "clicking on a desktop icon or desktop menu entry. WxMaxima - if started from "
@@ -4667,17 +4806,17 @@ msgid ""
 msgstr ""
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-v` or `--version`: Output the version information"
 msgstr "`-v` 或 `--version`：输出版本信息。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-h` or `--help`: Output a short help text"
 msgstr "`-h` 或 `--help`: 输出简短的帮助文本。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, fuzzy
 #| msgid ""
 #| "`-o` or `--open=<str>`: Open the filename given as argument to this "
@@ -4688,12 +4827,12 @@ msgid ""
 msgstr "`-o` 或 `--open=<str>`：打开作为此命令行参数的文件名。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 msgid "`-e` or `--eval`: Evaluate the file after opening it."
 msgstr "`-e` 或 `--eval`：打开文件后对公式单元格求值。"
 
 #. type: Bullet: '- '
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, fuzzy
 #| msgid ""
 #| "`-b` or `--batch`: If the command-line opens a file all cells in this "
@@ -4719,7 +4858,7 @@ msgstr ""
 "完全无交互的批处理。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1111
+#: ../../info/wxmaxima.md:1158
 #, fuzzy, no-wrap
 #| msgid ""
 #| "* `--logtostdout`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
@@ -4755,7 +4894,7 @@ msgstr ""
 "\n"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1113
+#: ../../info/wxmaxima.md:1160
 #, fuzzy
 #| msgid ""
 #| "Instead of a minus some operating systems might use a dash in front of "
@@ -4766,12 +4905,12 @@ msgid ""
 msgstr "一些操作系统可能在命令行选项前面使用连字符（-，dash），而不是减号。"
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1117
+#: ../../info/wxmaxima.md:1164
 msgid "# About the program, contributing to wxMaxima"
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1119
+#: ../../info/wxmaxima.md:1166
 msgid ""
 "wxMaxima is mainly developed using the programming language C++ using the "
 "[wxWidgets framework](https://www.wxwidgets.org), as build system we use "
@@ -4783,7 +4922,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1121
+#: ../../info/wxmaxima.md:1168
 msgid ""
 "But not only programmers are necessary! You can also contribute to wxMaxima, "
 "if you help to improve the documentation, find and report bugs (and maybe "
@@ -4794,19 +4933,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1123
+#: ../../info/wxmaxima.md:1170
 msgid "Or answer questions of other users in the discussion forum."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1125
+#: ../../info/wxmaxima.md:1172
 msgid ""
 "The source code of wxMaxima is documented using Doxygen [here](https://"
 "wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1127
+#: ../../info/wxmaxima.md:1174
 msgid ""
 "The program is nearly self-contained, so except for system libraries (and "
 "the wxWidgets library), no external dependencies (like graphic files or the "
@@ -4815,7 +4954,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../../info/wxmaxima.md:1128
+#: ../../info/wxmaxima.md:1175
 msgid ""
 "If you are a developer, you might want to try out a modified `wxmathML.lisp`-"
 "file without recompiling everything, one can use the command line option `--"
@@ -4974,9 +5113,6 @@ msgstr ""
 
 #~ msgid "a title, section or a subsection."
 #~ msgstr "文档标题、节标题或小节标题等。"
-
-#~ msgid "One Example:"
-#~ msgstr "例如："
 
 #~ msgid ""
 #~ "A .mac file named Quadratic.mac was created. It consists of two commands: "


### PR DESCRIPTION
Pure generated output -- `ninja update-locale-manual-in-source`, i.e. po4a, with no
hand edits. The English `info/wxmaxima.md` is untouched.

The manual sections added by #2149, #2154 and #2155 (the `wxworksheettohtml` and
`wxworksheettotex` commands) were never propagated, so the eight translated
manuals had been drifting for several releases; the code-block languages from
#2159 hadn't reached them either. This catches all of it up in one place, instead
of letting feature branches carry generated files.

## Effect on the manuals: purely additive

A word-level comparison of all eight, before and after, finds **zero** words
present in the old version and missing from the new:

```text
wxmaxima.de.md     words only in the OLD version: 0
wxmaxima.es.md     words only in the OLD version: 0
wxmaxima.fr.md     words only in the OLD version: 0
...                (all eight: 0)
```

Each gains the fence languages -- with its own translated text intact, e.g. French
keeps `Texte ordinaire` -- plus the new, as yet untranslated, English sections.
Every catalogue still passes `msgfmt -c`.

## Two statistics changes worth explaining

**Every language gains ~19 untranslated entries.** Those are the new sections. All
eight catalogues now hold po4a's full **428** entries.

**French goes from 410 translated to 340 translated + 64 fuzzy**, and its `.po` is
rewritten wholesale, because it had only 410 entries and was structurally stale.
This is a **bookkeeping correction, not a regression**: had po4a really been using
those 64 translations, the French manual would have lost 64 blocks of French -- and
it lost nothing at all. Their msgids no longer matched the manual, so the output
already showed English there while `msgfmt` went on counting them as translated.
The French text is preserved in the file and now only needs a translator's
confirmation to come back into use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XPDxkWgQan8Qbb89drnjz
