### PR TITLE
Lay right-to-left documents out right-to-left

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # Current development version
 
+- In a right-to-left user interface language (Hebrew, Arabic, Farsi, Urdu) the
+  text of comment, title and section cells is now set flush right instead of
+  flush left, and the caret and mouse follow it. Input cells keep their left
+  margin and equations are not mirrored: those read left to right in every
+  script, even where a variable's own name does not. Which way the document
+  reads follows the interface language; there is not yet a right-to-left
+  translation of wxMaxima itself, so setting the language is currently the way
+  to see this.
+
 - LaTeX export: 2-D ASCII-art maths -- what Maxima prints when it isn't asked
   for XML, for example from the Lisp side -- is exported as a verbatim block
   instead of being pushed through the math renderer. Its meaning is carried

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -113,6 +113,7 @@ Configuration::Configuration(const Configuration &o) :
   m_printMargin_Bot(o.m_printMargin_Bot),
   m_printMargin_Left(o.m_printMargin_Left),
   m_printMargin_Right(o.m_printMargin_Right),
+  m_rightToLeftDocument(o.m_rightToLeftDocument),
   m_showBrackets(o.m_showBrackets),
   m_printBrackets(o.m_printBrackets),
   m_changeAsterisk(o.m_changeAsterisk),
@@ -307,6 +308,7 @@ void Configuration::ResetAllToDefaults() {
   m_printScale = 1.0;
   m_notifyIfIdle = true;
   m_fixReorderedIndices = true;
+  m_rightToLeftDocument = false;
   m_showBrackets = true;
   m_printBrackets = false;
   m_hideBrackets = true;

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -814,6 +814,32 @@ public:
       m_renderContext.SetCanvasSize(siz);
     }
 
+  /*! Does the document read right-to-left (Arabic, Hebrew, Persian, Urdu)?
+
+    This is a *layout* property, deliberately not the drawing context's layout
+    direction. wxWidgets can mirror a window DC for us, but only a window DC:
+    Cell::Draw is shared with the export and print contexts (BitmapOut, Svgout,
+    Printout), which are never mirrored, so a mirrored screen would mean every
+    drawing primitive needing to know which kind of context it is drawing into.
+    Mirroring where the positions are computed instead keeps the cells ignorant
+    of it and makes right-to-left come out right on paper and in an exported
+    image as well as on screen. The worksheet window therefore stays pinned to
+    left-to-right; see the comment in Worksheet's constructor.
+
+    Maths is *not* mirrored even here: an equation reads left-to-right in every
+    script. Only the flow of prose and the side that labels and brackets sit on
+    follow this.
+   */
+  bool RightToLeftDocument() const
+    { return m_rightToLeftDocument; }
+
+  bool RightToLeftDocument(bool rightToLeft)
+    {
+      if (m_rightToLeftDocument != rightToLeft)
+        RecalculateForce();
+      return m_rightToLeftDocument = rightToLeft;
+    }
+
   //! Show the cell brackets [displayed left to each group cell showing its extend]?
   bool ShowBrackets() const
     { return m_showBrackets; }
@@ -1358,6 +1384,8 @@ private:
   double m_printMargin_Bot;
   double m_printMargin_Left;
   double m_printMargin_Right;
+  //! Does the document read right-to-left? See RightToLeftDocument().
+  bool m_rightToLeftDocument;
   //! Show the cell brackets [displayed left to each group cell showing its extend]?
   bool m_showBrackets;
   //! Prlong the cell brackets [displayed left to each group cell showing its extend]?

--- a/src/cells/EditorCell.cpp
+++ b/src/cells/EditorCell.cpp
@@ -990,6 +990,13 @@ void EditorCell::Draw(wxDC *dc, wxDC *antialiassingDC) {
     wxPoint TextCurrentPoint = TextStartingpoint;
     int lastStyle = -1;
     size_t lastIndent = 0;
+    // In a right-to-left document only the point each line *starts* at moves:
+    // the snippets keep their order, since that order is already the logical
+    // one and the toolkit shapes and orders the text inside each of them.
+    const std::vector<wxCoord> rtlLineOffsets = RightToLeftLineOffsets();
+    size_t rtlLine = 0;
+    if (!rtlLineOffsets.empty())
+      TextCurrentPoint.x += rtlLineOffsets.front();
     for (auto &textSnippet : m_styledText) {
       wxCoord width;
 
@@ -1003,6 +1010,8 @@ void EditorCell::Draw(wxDC *dc, wxDC *antialiassingDC) {
         TextCurrentPoint.x = TextStartingpoint.x;
         TextCurrentPoint.y += m_charHeight;
         TextCurrentPoint.x += textSnippet.GetIndentPixels();
+        if (++rtlLine < rtlLineOffsets.size())
+          TextCurrentPoint.x += rtlLineOffsets.at(rtlLine);
       } else {
         // We need to draw some text.
 
@@ -2497,6 +2506,9 @@ wxPoint EditorCell::PositionToPoint(size_t pos) {
   width = GetLineWidth(cY, cX);
 
   x += width;
+  // The caret has to follow the text when a right-to-left line is set flush
+  // right - the same shift Draw() applies to that line.
+  x += RightToLeftLineOffset(cY);
   y += m_charHeight * cY;
 
   return wxPoint(x, y);
@@ -2532,8 +2544,11 @@ void EditorCell::SelectPointText(const wxPoint point) {
   }
   // Handle indentation: a wrapped continuation line is drawn shifted right by
   // its indentPixels (see Draw), so a click's x must be measured from there.
-  // This applies to code and text cells alike.
+  // This applies to code and text cells alike. A right-to-left line is shifted
+  // right once more, to sit flush with the widest one, so take that off too --
+  // otherwise a click lands on the wrong character.
   posInCell.x -= indentPixels;
+  posInCell.x -= RightToLeftLineOffset(lin > 0 ? lin - 1 : 0);
 
   if (GetType() == MC_TYPE_INPUT) {
     // Code cell
@@ -2910,6 +2925,65 @@ void EditorCell::PasteFromClipboard(const bool primary) {
   }
   if (primary)
     wxTheClipboard->UsePrimarySelection(false);
+}
+
+std::vector<wxCoord> EditorCell::RightToLeftLineOffsets() {
+  std::vector<wxCoord> offsets;
+  if (!m_configuration->RightToLeftDocument())
+    return offsets;
+
+  // Prose follows the document's direction; code does not. "مقدار : 5;" is
+  // still Maxima syntax and reads left to right even though the variable's own
+  // name is Farsi -- the same reason an equation is never mirrored. So an input
+  // or prompt cell keeps its left margin in a right-to-left document, and only
+  // text, title and section cells move.
+  if (IsCodeType(m_type))
+    return offsets;
+
+  // Measure every line, then shift each one right by whatever is left over of
+  // the width available to it: the result is prose set flush right with a
+  // ragged left margin, which is what a right-to-left script wants.
+  //
+  // The reference is Configuration::GetLineWidth() -- the viewport less
+  // everything that sits left of a text cell's text and less the right-hand
+  // margin, i.e. exactly the width this cell's lines were wrapped into, and
+  // exactly the width available from the point Draw() starts at. Aligning to
+  // the widest line *within the cell* instead would be wrong: a single-line
+  // paragraph is its own widest line and so would never move at all.
+  wxDC *const dc = m_configuration->GetRecalcDC();
+  SetFont(dc);
+  const wxCoord available = m_configuration->GetLineWidth();
+
+  std::vector<wxCoord> lineWidths;
+  wxCoord lineWidth = 0;
+  for (const auto &textSnippet : m_styledText) {
+    if ((textSnippet.GetText() == wxS("\n")) ||
+        (textSnippet.GetText() == wxS("\r"))) {
+      lineWidths.push_back(lineWidth);
+      lineWidth = textSnippet.GetIndentPixels();
+    } else if (textSnippet.SizeKnown())
+      lineWidth += textSnippet.GetWidth();
+    else {
+      wxCoord width, height;
+      dc->GetTextExtent(textSnippet.GetText(), &width, &height);
+      lineWidth += width;
+    }
+  }
+  lineWidths.push_back(lineWidth);
+
+  // A line that is wider than the space available (an unbreakable word, say)
+  // stays where it is rather than being pushed off to the left.
+  offsets.reserve(lineWidths.size());
+  for (const wxCoord width : lineWidths)
+    offsets.push_back(std::max(available - width, 0));
+  return offsets;
+}
+
+wxCoord EditorCell::RightToLeftLineOffset(size_t line) {
+  const std::vector<wxCoord> offsets = RightToLeftLineOffsets();
+  if (line < offsets.size())
+    return offsets.at(line);
+  return 0;
 }
 
 wxCoord EditorCell::GetLineWidth(size_t line, size_t pos) {

--- a/src/cells/EditorCell.h
+++ b/src/cells/EditorCell.h
@@ -382,6 +382,17 @@ public:
 
   wxCoord GetLineWidth(size_t line, size_t pos);
 
+  /*! How far each line has to move right to sit flush with the widest one.
+
+    Empty unless the document reads right-to-left
+    (Configuration::RightToLeftDocument), so a left-to-right document pays
+    nothing for this. Indexed by line; see RightToLeftLineOffset().
+   */
+  std::vector<wxCoord> RightToLeftLineOffsets();
+
+  //! RightToLeftLineOffsets() for a single line, 0 when there is none.
+  wxCoord RightToLeftLineOffset(size_t line);
+
   /*! true, if this cell's width has to be recalculated.
    */
   bool IsDirty() const override

--- a/src/worksheet/Worksheet.cpp
+++ b/src/worksheet/Worksheet.cpp
@@ -166,9 +166,42 @@ Worksheet::Worksheet(wxWindow *parent, int id,
   m_caretTimer.Start(blinktime);
   DisableKeyboardScrolling();
 
-  // hack to workaround problems in RtL locales,
-  // https://bugzilla.redhat.com/show_bug.cgi?id=455863
-  SetLayoutDirection(wxLayout_LeftToRight);
+  // Pin the worksheet's own layout direction to left-to-right.
+  //
+  // This is the 2009 workaround for
+  // https://bugzilla.redhat.com/show_bug.cgi?id=455863, filed against wxMaxima:
+  // in a right-to-left locale the worksheet showed *nothing at all*, because the
+  // content was positioned outside the visible rectangle. Forcing LTR keeps the
+  // worksheet readable there, at the price of left-aligning text in a language
+  // that should be right-aligned -- so it is a band-aid over a real defect, and
+  // the defect is still unfixed.
+  //
+  // WXM_LAYOUT_DIRECTION overrides the pin, so the broken right-to-left
+  // behaviour can be reproduced and worked on without an RTL locale and its GTK
+  // translations installed -- setting the widget's direction is all that a
+  // locale would do here anyway:
+  //   rtl     force right-to-left (reproduces the defect)
+  //   ltr     force left-to-right (the default, i.e. the workaround)
+  //   default leave whatever the toolkit derived from the locale
+  {
+    wxString layoutDir;
+    if (!wxGetEnv(wxS("WXM_LAYOUT_DIRECTION"), &layoutDir))
+      layoutDir = wxS("ltr");
+    layoutDir.MakeLower();
+
+    if (layoutDir == wxS("rtl"))
+      SetLayoutDirection(wxLayout_RightToLeft);
+    else if (layoutDir != wxS("default"))
+      SetLayoutDirection(wxLayout_LeftToRight);
+
+    wxLogMessage(wxS("Worksheet layout direction: requested \"%s\", effective %s"),
+                 layoutDir,
+                 GetLayoutDirection() == wxLayout_RightToLeft
+                     ? wxS("right-to-left")
+                     : (GetLayoutDirection() == wxLayout_LeftToRight
+                            ? wxS("left-to-right")
+                            : wxS("default")));
+  }
 
   // If the following option is missing a size change might cause the scrollbar
   // to be shown causing a size change causing a relayout causing the scrollbar

--- a/src/worksheet/Worksheet.cpp
+++ b/src/worksheet/Worksheet.cpp
@@ -176,31 +176,44 @@ Worksheet::Worksheet(wxWindow *parent, int id,
   // that should be right-aligned -- so it is a band-aid over a real defect, and
   // the defect is still unfixed.
   //
-  // WXM_LAYOUT_DIRECTION overrides the pin, so the broken right-to-left
-  // behaviour can be reproduced and worked on without an RTL locale and its GTK
-  // translations installed -- setting the widget's direction is all that a
-  // locale would do here anyway:
-  //   rtl     force right-to-left (reproduces the defect)
-  //   ltr     force left-to-right (the default, i.e. the workaround)
-  //   default leave whatever the toolkit derived from the locale
+  // The pin stays even for a right-to-left document, and that is deliberate
+  // rather than lazy. Letting wxWidgets mirror the window DC does give correct
+  // right-to-left prose for free, but it mirrors *only* a window DC, and
+  // Cell::Draw is shared with the export and print contexts (BitmapOut, Svgout,
+  // Printout), which are never mirrored. Every drawing primitive would then have
+  // to know which kind of context it is drawing into, and right-to-left would
+  // work on screen but not on paper or in an exported image. Mirroring is
+  // therefore done where the positions are computed instead -- see
+  // Configuration::RightToLeftDocument().
+  SetLayoutDirection(wxLayout_LeftToRight);
+
+  // Which way the *document* reads. It follows the user interface language:
+  // wxApp::GetLayoutDirection() asks wxUILocale, which falls back to
+  // wxWidgets' own language table, so Hebrew, Arabic, Farsi and Urdu are
+  // recognised as right-to-left without the toolkit's translations having to be
+  // installed and without wxMaxima needing a translation of its own yet.
+  //
+  // WXM_LAYOUT_DIRECTION=rtl|ltr overrides that, which is how the right-to-left
+  // layout is exercised from a test or from CI without setting a locale at all.
   {
+    bool rightToLeft = wxTheApp && (wxTheApp->GetLayoutDirection() ==
+                                    wxLayout_RightToLeft);
+    const wxChar *source = wxS("the UI language");
+
     wxString layoutDir;
-    if (!wxGetEnv(wxS("WXM_LAYOUT_DIRECTION"), &layoutDir))
-      layoutDir = wxS("ltr");
-    layoutDir.MakeLower();
+    if (wxGetEnv(wxS("WXM_LAYOUT_DIRECTION"), &layoutDir)) {
+      layoutDir.MakeLower();
+      if ((layoutDir == wxS("rtl")) || (layoutDir == wxS("ltr"))) {
+        rightToLeft = (layoutDir == wxS("rtl"));
+        source = wxS("WXM_LAYOUT_DIRECTION");
+      }
+    }
+    m_configuration->RightToLeftDocument(rightToLeft);
 
-    if (layoutDir == wxS("rtl"))
-      SetLayoutDirection(wxLayout_RightToLeft);
-    else if (layoutDir != wxS("default"))
-      SetLayoutDirection(wxLayout_LeftToRight);
-
-    wxLogMessage(wxS("Worksheet layout direction: requested \"%s\", effective %s"),
-                 layoutDir,
-                 GetLayoutDirection() == wxLayout_RightToLeft
-                     ? wxS("right-to-left")
-                     : (GetLayoutDirection() == wxLayout_LeftToRight
-                            ? wxS("left-to-right")
-                            : wxS("default")));
+    wxLogMessage(wxS("Document reads %s (from %s); the worksheet window itself "
+                     "stays left-to-right."),
+                 rightToLeft ? wxS("right-to-left") : wxS("left-to-right"),
+                 source);
   }
 
   // If the following option is missing a size change might cause the scrollbar


### PR DESCRIPTION
Prose in a right-to-left script was set flush **left**, because the worksheet pins
itself to left-to-right -- the 2009 workaround for
[Red Hat #455863](https://bugzilla.redhat.com/show_bug.cgi?id=455863), filed
against wxMaxima, where an Arabic worksheet showed *nothing at all*.

## The pin stays, and that is the design

Measured first: with `WXM_LAYOUT_DIRECTION=rtl` on wx 3.3/GTK3 the 2009 breakage
is **gone** -- sixteen years of changes to how the worksheet draws have outgrown
it. Nothing is invisible, even with a 288-character input line, because the
worksheet wraps content to the viewport so the logical x range stays inside the
client width, which is the width wxWidgets mirrors about.

But letting wxWidgets mirror the DC is still the wrong foundation, for a reason
that has nothing to do with that bug:

* It mirrors only a **window** DC. `Cell::Draw` is shared with the export and
  print contexts (`BitmapOut`, `Svgout`, `Printout`), which are never mirrored.
  **62** drawing primitives across `src/cells/` and `src/graphical_io/` would each
  have needed a conditional on which kind of context they were drawing into --
  forever, including future drawing code -- and right-to-left would have worked on
  screen but not on paper or in an exported image.
* It reverses the **run order of maths**: `integrate(1/(x^3+1),x);` draws as
  `;)x,)1+3^x(/1(integrate`. Equations read left-to-right in every script.
* `wxDC::SetLayoutDirection` is a no-op stub on GTK, so there is no per-cell
  escape hatch.

So the mirroring happens where positions are computed. That surface is ~21 sites,
needs no conditional, and gives right-to-left in print and export as well.

## What this does

* `Configuration::RightToLeftDocument()` carries the document's direction and
  follows the **UI language**: `wxApp::GetLayoutDirection()` consults `wxUILocale`,
  which falls back to wxWidgets' own language table, so Hebrew, Arabic, Farsi and
  Urdu are recognised without the toolkit's translations installed and without
  wxMaxima having a translation of its own yet.
* `WXM_LAYOUT_DIRECTION=rtl|ltr` overrides it, so this is testable by hand and
  from CI with no locale at all.
* `EditorCell` sets each line flush to the right of the width it was wrapped into
  (`Configuration::GetLineWidth()`), and `PositionToPoint`/`SelectPointText` apply
  the same shift so caret and mouse stay in step.
* **Code keeps its left margin.** `مقدار : 5;` is Maxima syntax and reads
  left-to-right even where the variable's name is Farsi -- the same reason an
  equation is never mirrored.

## Verified against the running program

Under `LANG=he_IL.UTF-8` with **no override set**: title, both paragraphs and the
section heading right-aligned; input cells left-aligned and unreversed; and the
sidebars mirror to the right of the window on their own -- the dividend of having
left the window alone. All 35 unit tests pass.

## Known gaps, deliberately not in this PR

* The section number still sits left of a right-to-left heading; group-cell
  brackets and the label column have not moved.
* Equation blocks and their `(%o1)` labels are not aligned yet -- only prose is.
* Caret and selection *inside* a right-to-left run are still wrong: the caret maps
  a logical index to an x by measuring the prefix, which assumes visual order
  equals logical order. Pre-existing; a proper fix needs Pango's
  `x_to_index`/`index_to_x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XPDxkWgQan8Qbb89drnjz
