### PR TITLE
Mirror a group cell's labels and bracket in a right-to-left document

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,12 +2,14 @@
 
 - In a right-to-left user interface language (Hebrew, Arabic, Farsi, Urdu) the
   text of comment, title and section cells is now set flush right instead of
-  flush left, and the caret and mouse follow it. Input cells keep their left
-  margin and equations are not mirrored: those read left to right in every
-  script, even where a variable's own name does not. Which way the document
-  reads follows the interface language; there is not yet a right-to-left
-  translation of wxMaxima itself, so setting the language is currently the way
-  to see this.
+  flush left, and the caret and mouse follow it. The furniture of the page
+  follows: labels such as `(%i1)`, a section's number, the cell bracket and its
+  fold button all move to the right-hand side, and the text starts at the left
+  edge instead. Input cells keep their left margin and equations are not
+  mirrored: those read left to right in every script, even where a variable's
+  own name does not. Which way the document reads follows the interface
+  language; there is not yet a right-to-left translation of wxMaxima itself, so
+  setting the language is currently the way to see this.
 
 - LaTeX export: 2-D ASCII-art maths -- what Maxima prints when it isn't asked
   for XML, for example from the Lisp side -- is exported as a verbatim block

--- a/src/cells/GroupCell.cpp
+++ b/src/cells/GroupCell.cpp
@@ -497,13 +497,9 @@ void GroupCell::RecalculateInput() const {
   m_currentPoint.x = m_configuration->GetIndent();
 
   if (m_inputLabel)
-    m_inputLabel->SetCurrentPoint(m_currentPoint);
-  if (GetEditable()) {
-    wxPoint in = GetCurrentPoint();
-
-    in.x += GetInputIndent();
-    GetEditable()->SetCurrentPoint(in);
-  }
+    m_inputLabel->SetCurrentPoint(CalculateLabelPosition());
+  if (GetEditable())
+    GetEditable()->SetCurrentPoint(CalculateInputPosition());
 
   // special case
   if (m_groupType == GC_TYPE_PAGEBREAK) {
@@ -696,7 +692,41 @@ bool GroupCell::Reposition() const {
   return false;
 }
 
+/*! The x just past the right edge of a cell's content column.
+
+  Deliberately the same for every cell, so that the gutter and the label column
+  of a right-to-left document line up into straight columns the way they do on
+  the left in a left-to-right one. Configuration::GetLineWidth() is the width
+  the text is wrapped into and the label column is what GroupCell puts in front
+  of it, so the two together are the content's width.
+ */
+wxCoord GroupCell::ContentColumnRight() const {
+  return m_configuration->GetIndent() + m_configuration->GetLineWidth() +
+    Scale_Px(m_configuration->GetLabelWidth()) + MC_TEXT_PADDING;
+}
+
+wxCoord GroupCell::BracketColumnLeft() const {
+  if (m_configuration->RightToLeftDocument())
+    return ContentColumnRight();
+  return m_configuration->GetIndent() - m_configuration->GetCellBracketWidth();
+}
+
+wxPoint GroupCell::CalculateLabelPosition() const {
+  if (m_configuration->RightToLeftDocument()) {
+    wxCoord labelWidth = 0;
+    if (m_inputLabel && (m_inputLabel->GetWidth() >= 0))
+      labelWidth = m_inputLabel->GetWidth();
+    return wxPoint(ContentColumnRight() - labelWidth,
+                   m_currentPoint.y);
+  }
+  return m_currentPoint;
+}
+
 wxPoint GroupCell::CalculateInputPosition() const {
+  // In a right-to-left document the label sits to the right of the text, so the
+  // text starts at the cell's own x rather than a label's width further in.
+  if (m_configuration->RightToLeftDocument())
+    return wxPoint(m_currentPoint.x, m_currentPoint.y);
   return wxPoint(m_currentPoint.x + GetInputIndent(), m_currentPoint.y);
 }
 
@@ -776,7 +806,7 @@ void GroupCell::SetCurrentPoint(wxPoint point) const {
   
   // 1. Position Input Label (%i1)
   if (m_inputLabel)
-    m_inputLabel->SetCurrentPointList(m_currentPoint);
+    m_inputLabel->SetCurrentPointList(CalculateLabelPosition());
 
   // 2. Position Editor (the code area)
   EditorCell *editor = GetEditable();
@@ -877,8 +907,7 @@ wxCoord GroupCell::GetCenterList() const {
 wxRect GroupCell::GetBracketRect() const {
   // Keep this in sync with the rectangle DrawBracket() clears and paints.
   const wxRect rect = GetRect();
-  return wxRect(m_configuration->GetIndent() -
-                    m_configuration->GetCellBracketWidth(),
+  return wxRect(BracketColumnLeft(),
                 rect.GetTop() - 2, m_configuration->GetCellBracketWidth(),
                 rect.GetHeight() + 5);
 }
@@ -942,8 +971,7 @@ void GroupCell::DrawBracket(wxDC *dc, wxDC *antialiassingDC) {
     }
   }
   wxRect rect = GetRect();
-  rect = wxRect(m_configuration->GetIndent() -
-                m_configuration->GetCellBracketWidth(),
+  rect = wxRect(BracketColumnLeft(),
                 rect.GetTop() - 2, m_configuration->GetCellBracketWidth(),
                 rect.GetHeight() + 5);
   if (m_configuration->InUpdateRegion(rect))
@@ -968,7 +996,7 @@ void GroupCell::DrawBracket(wxDC *dc, wxDC *antialiassingDC) {
                                                    m_configuration->GetDefaultLineWidth(), wxPENSTYLE_SOLID)));
       }
     wxRect bracketRect = wxRect(
-                                m_configuration->GetIndent() - m_configuration->GetCellBracketWidth(),
+                                BracketColumnLeft(),
                                 rect.GetTop() - 2, m_configuration->GetCellBracketWidth(),
                                 rect.GetHeight() + 5);
     if (m_configuration->InUpdateRegion(bracketRect))
@@ -1045,7 +1073,11 @@ void GroupCell::DrawBracket(wxDC *dc, wxDC *antialiassingDC) {
 }
 
 wxRect GroupCell::HideRect() const {
-  return wxRect(m_currentPoint.x - m_configuration->GetCellBracketWidth() -
+  // The fold toggle sits at the top of the bracket, so it follows the bracket
+  // to the other side of the page in a right-to-left document. Worksheet's
+  // click handling asks this same rectangle, so the toggle stays where it
+  // looks like it is.
+  return wxRect(BracketColumnLeft() -
                 m_configuration->GetDefaultLineWidth() / 2,
                 m_currentPoint.y - m_center -
                 m_configuration->GetDefaultLineWidth() / 2,

--- a/src/cells/GroupCell.h
+++ b/src/cells/GroupCell.h
@@ -225,6 +225,28 @@ public:
 
   wxRect HideRect() const;
 
+  /*! The left edge of the gutter column the cell bracket is drawn in.
+
+    The bracket marks a cell's extent from the outside of the page: to the left
+    of the content in a left-to-right document, and to the right of it in a
+    right-to-left one. Everything that draws or hit-tests the bracket asks here,
+    so the picture and the mouse cannot drift apart -- which is the failure mode
+    that makes mirrored user interfaces feel broken.
+   */
+  wxCoord BracketColumnLeft() const;
+
+  //! The x just past the right edge of the content column. See the definition.
+  wxCoord ContentColumnRight() const;
+
+  /*! Where this group cell's label (the "(%i1)", or a section's number) goes.
+
+    Beside the text on the outside of the page: left of it in a left-to-right
+    document, right of it in a right-to-left one. The text column starts at the
+    cell's own x in a right-to-left document, since the label no longer precedes
+    it -- see CalculateInputPosition().
+   */
+  wxPoint CalculateLabelPosition() const;
+
   // raw manipulation of GC (should be protected)
   void SetInput(std::unique_ptr<Cell> &&input);
 


### PR DESCRIPTION
Stacked on #2164 — review that one first.

The text of a right-to-left document was already set flush right, but the
furniture around it was not: the `(%i1)` label and a section's number still sat to
the *left* of the text, and the cell bracket and its fold button in the gutter
left of that. A page with its margin notes on the wrong side reads as broken
however well the prose is aligned.

## What moves

The label goes on the outside of the page — left of the text in a left-to-right
document, right of it in a right-to-left one — and the text correspondingly starts
at the cell's own x instead of a label's width further in. The bracket and fold
button follow it.

## Why it's two accessors and not sixteen edits

`BracketColumnLeft()` and `CalculateLabelPosition()` are single definitions, and
that is what makes this safe rather than merely mirrored:

**`HideRect()` is both the fold button's drawn rectangle and the rectangle
`Worksheet.cpp:1244` hit-tests against.** With one definition the button cannot be
drawn in one place and clickable in another. Letting the picture and the mouse
drift apart is exactly the failure mode that ruled out mirroring the drawing
context in #2164, so reintroducing it here would have been careless.

Three open-coded copies of the bracket's x disappear in the process, and so does
`RecalculateInput()`'s hand-rolled duplicate of the arrange pass's positioning —
the recalculate and arrange paths now can't disagree about where a label goes.

Both accessors anchor on `ContentColumnRight()`, deliberately identical for every
cell so the mirrored gutter and label column line up into straight columns the way
their left-hand counterparts do, rather than jittering with each cell's label
width.

## Verified against the running program

Under `LANG=he_IL.UTF-8`: the section number and input prompts sit to the right,
code starts at the left edge. The default left-to-right layout is unchanged, down
to the indentation of the input cells. All 35 unit tests pass.

Still not addressed, as in #2164: equation blocks and their `(%o1)` labels, and
bidi caret/selection *inside* a right-to-left run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XPDxkWgQan8Qbb89drnjz
