### PR TITLE
Set results against the right edge in a right-to-left document

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,9 +3,10 @@
 - In a right-to-left user interface language (Hebrew, Arabic, Farsi, Urdu) the
   text of comment, title and section cells is now set flush right instead of
   flush left, and the caret and mouse follow it. The furniture of the page
-  follows: labels such as `(%i1)`, a section's number, the cell bracket and its
-  fold button all move to the right-hand side, and the text starts at the left
-  edge instead. Input cells keep their left margin and equations are not
+  follows: labels such as `(%i1)` and `(%o1)`, a section's number, the cell
+  bracket and its fold button all move to the right-hand side, results are set
+  against the right edge of the page, and the text starts at the left edge
+  instead. Input cells keep their left margin and equations are not
   mirrored: those read left to right in every script, even where a variable's
   own name does not. Which way the document reads follows the interface
   language; there is not yet a right-to-left translation of wxMaxima itself, so

--- a/src/cells/GroupCell.cpp
+++ b/src/cells/GroupCell.cpp
@@ -758,6 +758,30 @@ wxCoord GroupCell::GetInputIndent() const {
  * - Mathematical indentation (aligning results with the input area).
  * - Coordinate accumulation (drop and center list).
  */
+bool GroupCell::IsOutputLabel(const Cell &cell) {
+  return (cell.GetTextStyle() == TS_LABEL) ||
+    (cell.GetTextStyle() == TS_USERLABEL);
+}
+
+std::vector<GroupCell::OutputLineWidths>
+GroupCell::MeasureOutputLines(Cell *displayed) {
+  std::vector<OutputLineWidths> lines;
+  bool isFirst = true;
+  for (const Cell &tmp : OnDrawList(displayed)) {
+    if (isFirst || tmp.BreakLineHere())
+      lines.emplace_back();
+    OutputLineWidths &line = lines.back();
+    // Only a *leading* run of labels counts as the label: a string that happens
+    // to be styled like one further along the line belongs to the equation.
+    if (IsOutputLabel(tmp) && (line.rest == 0))
+      line.label += tmp.GetWidth();
+    else
+      line.rest += tmp.GetWidth();
+    isFirst = false;
+  }
+  return lines;
+}
+
 void GroupCell::UpdateOutputPositions() const {
   Cell *const displayed = DisplayedOutput();
   if (displayed && !IsHidden()) {
@@ -770,8 +794,28 @@ void GroupCell::UpdateOutputPositions() const {
     // (m_outputRect is mutable - no const_cast needed).
     m_outputRect.SetPosition(in);
 
+    // A right-to-left document sets each result against the right-hand edge of
+    // the content column, with its "(%o1)" in the label column to the right of
+    // that -- the mirror of the left-to-right layout, and of what the input
+    // half of the cell already does. The equation's *contents* are not
+    // mirrored: an equation reads left to right in every script.
+    //
+    // Placing a line therefore needs its widths before the first cell of it is
+    // placed, which one pass over the draw list works out. The label is what
+    // starts a line, so its width and the rest's are counted separately.
+    const bool rightToLeft = m_configuration->RightToLeftDocument();
+    const wxCoord labelColumnLeft =
+      ContentColumnRight() - Scale_Px(m_configuration->GetLabelWidth()) -
+      MC_TEXT_PADDING;
+    std::vector<OutputLineWidths> lineWidths;
+    if (rightToLeft)
+      lineWidths = MeasureOutputLines(displayed);
+
     bool isFirst = true;
     int drop = 0;
+    std::size_t lineIndex = 0;
+    bool inLabelColumn = false;
+    wxCoord equationStart = 0;
     for (Cell &tmp : OnDrawList(displayed)) {
       if (isFirst || tmp.BreakLineHere()) {
         if (!isFirst) {
@@ -779,18 +823,37 @@ void GroupCell::UpdateOutputPositions() const {
           in.y += m_configuration->GetInterEquationSkip();
           if (tmp.HasBigSkip())
             in.y += MC_LINE_SKIP;
+          if (rightToLeft)
+            lineIndex++;
         }
 
         // Apply horizontal indentation
-        in.x = m_currentPoint.x + tmp.GetLineIndent();
-        
+        if (rightToLeft && (lineIndex < lineWidths.size())) {
+          const OutputLineWidths &line = lineWidths.at(lineIndex);
+          equationStart = labelColumnLeft - line.rest;
+          // The label sits in its own column on the right; everything after it
+          // is set flush against the left of that column.
+          inLabelColumn = (line.label > 0);
+          in.x = inLabelColumn ? ContentColumnRight() - line.label
+            : equationStart;
+        } else
+          in.x = m_currentPoint.x + tmp.GetLineIndent();
+
         // Accumulate vertical height based on previous line's drop and current line's center
         in.y += drop + tmp.GetCenterList();
         drop = tmp.GetMaxDrop();
       }
+
+      // Leaving the label column means jumping back to where the equation
+      // itself starts, since the two are not adjacent in a mirrored layout.
+      if (inLabelColumn && !IsOutputLabel(tmp)) {
+        in.x = equationStart;
+        inLabelColumn = false;
+      }
+
       // Recursively position the cell and its children
       tmp.SetCurrentPoint(in);
-      
+
       // Advance horizontally
       in.x += tmp.GetWidth();
       isFirst = false;

--- a/src/cells/GroupCell.h
+++ b/src/cells/GroupCell.h
@@ -32,6 +32,7 @@
 
 #include <utility>
 #include <memory>
+#include <vector>
 #include "Cell.h"
 #include "EditorCell.h"
 #include <unordered_map>
@@ -237,6 +238,22 @@ public:
 
   //! The x just past the right edge of the content column. See the definition.
   wxCoord ContentColumnRight() const;
+
+  //! The widths of one line of output, split at the label that starts it.
+  struct OutputLineWidths {
+    wxCoord label = 0;
+    wxCoord rest = 0;
+  };
+
+  //! Is this output cell one of the labels that start a line, like "(%o1)"?
+  static bool IsOutputLabel(const Cell &cell);
+
+  /*! The width of every line of output, so a line can be placed before it is walked.
+
+    Only needed to set output flush right in a right-to-left document, where a
+    line's starting x depends on how wide the whole line turns out to be.
+   */
+  static std::vector<OutputLineWidths> MeasureOutputLines(Cell *displayed);
 
   /*! Where this group cell's label (the "(%i1)", or a section's number) goes.
 


### PR DESCRIPTION
Follows #2164 and #2165. The last part of the worksheet still reading
left-to-right was the **output**: results stayed at the left indent with their
`(%o1)` in front of them, even though the input above had already moved its label
to the right-hand column.

A result is now set against the right edge of the content column with its label in
the column to the right of that — the mirror of the left-to-right layout, and the
same arrangement the input half already uses. **The equation's own contents are
untouched**: an equation reads left to right in every script, so only where the
line begins changes, never the order within it.

## Why there's a measuring pass

Placing a mirrored line needs its width *before* its first cell is placed, which
the existing single pass can't give. `MeasureOutputLines()` works the widths out
first, counting the label and the rest of the line **separately** — because a
mirrored line puts them in two places that aren't adjacent: the label in its
column at the far right, the equation flush against the left of that column.

Only a *leading* run of labels counts as the label; a string that happens to be
styled like one further along the line belongs to the equation.

Both columns derive from `ContentColumnRight()` (added in #2165), so results line
up with the input labels and the bracket above them instead of each computing its
own idea of the right-hand edge.

## Verified against the running program

On `all-celltypes.wxmx`, which carries 63 stored labels: under `LANG=he_IL.UTF-8`
`(%o189)` sits in the right-hand column with its equation right-aligned beside it
and still reading left to right; the default layout is an exact mirror of it. All
35 unit tests pass.

With this, the visible half of right-to-left support is done: prose, page
furniture and results. What remains is bidi caret/selection *inside* a
right-to-left run, and the unexplained token-order effect in code lines whose
first strong character is right-to-left — both recorded rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XPDxkWgQan8Qbb89drnjz
