### PR TITLE
Give the unit tests a manifest, so Windows loads ComCtl32 v6

### DIFF
--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -17,6 +17,15 @@ include_directories(
 # test until ctest's watchdog kills it. Compiles to nothing off Windows.
 set(WXM_TEST_SETUP "${CMAKE_CURRENT_SOURCE_DIR}/wxm_test_setup.cpp")
 
+# On Windows the tests also need an application manifest, or the loader binds
+# COMCTL32 to the legacy 5.82 assembly, which lacks the window-subclassing
+# entry points wx's GUI code imports, and refuses to start the executable at
+# all. See wxm_test_manifest.rc for the full story. Cygwin builds no PE
+# resources, and wxmaxima.exe gets the same manifest from src/wxmaxima.rc.
+if(WIN32 AND NOT CYGWIN)
+    list(APPEND WXM_TEST_SETUP "${CMAKE_CURRENT_SOURCE_DIR}/wxm_test_manifest.rc")
+endif()
+
 if(MINGW)
     # Statically link the GCC/C++/winpthread runtimes into the test executables.
     # Otherwise each exe depends on libstdc++-6.dll, libgcc_s_seh-1.dll and

--- a/test/unit_tests/wxm_test_manifest.rc
+++ b/test/unit_tests/wxm_test_manifest.rc
@@ -1,0 +1,22 @@
+// An application manifest for the unit-test executables.
+//
+// Without one, Windows binds COMCTL32.dll to the legacy 5.82 side-by-side
+// assembly. That version predates the window-subclassing API, so it exports
+// neither SetWindowSubclass nor RemoveWindowSubclass nor DefSubclassProc --
+// all three of which wxWidgets' GUI code imports. The loader then rejects the
+// executable outright with STATUS_ENTRYPOINT_NOT_FOUND (exit code 0xc0000139)
+// before main() is reached, which under ctest looks like a test failing in a
+// hundredth of a second with no output at all.
+//
+// Only the tests that pull in wx's GUI code were affected, since they are the
+// ones that import COMCTL32; a test that does not, such as test_AFontSize,
+// passed throughout. wxmaxima.exe itself was never affected because
+// src/wxmaxima.rc gives it this same manifest.
+//
+// wx's own resource script carries a manifest that asks for ComCtl32 v6, so
+// including it is all that is needed. wxUSE_DPI_AWARE_MANIFEST matches
+// src/wxmaxima.rc, so the tests run under the same DPI regime as the
+// application they test.
+#define wxUSE_DPI_AWARE_MANIFEST 2
+
+#include "wx/msw/wx.rc"


### PR DESCRIPTION
Since 2026-07-30 the Windows-on-Arm job has failed three tests — `CellPtr`,
`SqrtCell`, `ImgCell` — with exit code **`0xc0000139`**
(`STATUS_ENTRYPOINT_NOT_FOUND`), each in under a tenth of a second. The loader was
rejecting the executables before `main()`.

The diagnostics step from #2162 found it on its first firing.

## Root cause

The failing executables import `COMCTL32` and the passing one doesn't, every DLL
resolves, and `COMCTL32` resolves to:

```text
C:/Windows/WinSxS/arm64_..._common-controls_..._5.82.26100.8521_.../COMCTL32.dll
```

**Version 5.82** — the legacy one. The import table then asks that library for:

```text
SetWindowSubclass   RemoveWindowSubclass   DefSubclassProc
```

which **only ComCtl32 v6 exports**. Windows hands out 5.82 to any executable that
doesn't carry a manifest asking for v6, so the loader can't bind them and refuses
to start the process.

That explains the shape of the failure exactly:

* only the tests linking wx's GUI code import `COMCTL32`, so only those three
  failed, while `test_AFontSize` passed throughout;
* `wxmaxima.exe` was never affected, because `src/wxmaxima.rc` already gives it
  this manifest.

So it is **our** bug, not the runner's: the test executables have simply never had
a manifest, and something in the toolchain recently began importing the
subclassing API. (It also means my earlier "this is environmental" read was only
half right — the trigger was external, the defect ours.)

## The fix

The tests get the same manifest the application has, by including wx's own
resource script. It goes into the source list shared by *every* test executable,
so a test added later cannot forget it, and only on Windows outside Cygwin, which
builds no PE resources.

## Verification

As far as is possible without a Windows-on-Arm machine: configure and build are
unaffected on Linux and all 35 unit tests pass there. The Windows jobs on this PR
are the real check — `Compile using CLANGARM64` should go green, and if it does
the diagnostics step will simply not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XPDxkWgQan8Qbb89drnjz
