### PR TITLE
Put the caret where right-to-left text actually is

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,11 @@
   against the right edge of the page, and the text starts at the left edge
   instead. Input cells keep their left margin and equations are not
   mirrored: those read left to right in every script, even where a variable's
-  own name does not. Which way the document reads follows the interface
+  own name does not. Inside right-to-left text the caret is drawn where that
+  text actually is -- it used to be placed at the mirror image of its position,
+  so putting the cursor in front of a Hebrew word showed it at the word's far
+  end -- and the arrow keys move it the way it is drawn rather than the way the
+  text is stored. Which way the document reads follows the interface
   language; there is not yet a right-to-left translation of wxMaxima itself, so
   setting the language is currently the way to see this.
 

--- a/src/cells/EditorCell.cpp
+++ b/src/cells/EditorCell.cpp
@@ -1549,6 +1549,21 @@ bool EditorCell::HandleSpecialKey(wxKeyEvent &event) {
     return true;
   }
 
+  // The arrow keys move the caret by what the user sees, not by what is stored.
+  // In a right-to-left line the two disagree: the text is drawn in the reverse
+  // of its stored order, so stepping *forward* through it moves the caret to the
+  // *left* on screen. Pressing Left there therefore has to do what Right does to
+  // the stored text, and the other way round -- otherwise the caret walks the
+  // wrong way and the key that looks like it should undo the last movement
+  // repeats it. Only lines that are wholly one direction are handled; see
+  // LineIsRightToLeft().
+  if ((event.GetKeyCode() == WXK_LEFT) || (event.GetKeyCode() == WXK_RIGHT)) {
+    size_t cursorColumn, cursorLine;
+    PositionToXY(CursorPosition(), &cursorColumn, &cursorLine);
+    if (LineIsRightToLeft(cursorLine) && !LineIsMixedDirection(cursorLine))
+      event.m_keyCode = (event.GetKeyCode() == WXK_LEFT) ? WXK_RIGHT : WXK_LEFT;
+  }
+
   switch (event.GetKeyCode()) {
   case WXK_LEFT:
     {
@@ -2505,7 +2520,17 @@ wxPoint EditorCell::PositionToPoint(size_t pos) {
 
   width = GetLineWidth(cY, cX);
 
-  x += width;
+  // A right-to-left line is drawn in the reverse of the order it is stored in,
+  // so the text before a position is drawn *after* it: the caret belongs that
+  // far in from the line's right end rather than from its left. Mirroring the
+  // measurement is exact as long as the line is wholly one direction, which is
+  // the case LineIsRightToLeft() answers for; a line genuinely mixing scripts
+  // needs the real bidirectional algorithm and is left as it was.
+  if (LineIsRightToLeft(cY) && !LineIsMixedDirection(cY))
+    x += GetLineWidth(cY, LineLength(cY)) - width;
+  else
+    x += width;
+
   // The caret has to follow the text when a right-to-left line is set flush
   // right - the same shift Draw() applies to that line.
   x += RightToLeftLineOffset(cY);
@@ -2984,6 +3009,67 @@ wxCoord EditorCell::RightToLeftLineOffset(size_t line) {
   if (line < offsets.size())
     return offsets.at(line);
   return 0;
+}
+
+bool EditorCell::IsStrongRightToLeft(wxUniChar c) {
+  const auto u = static_cast<wxUint32>(c);
+  return
+    // Hebrew, and the alphabetic presentation forms that follow it
+    ((u >= 0x0590) && (u <= 0x05FF)) || ((u >= 0xFB1D) && (u <= 0xFB4F)) ||
+    // Arabic, including the Farsi and Urdu letters, plus its supplements
+    ((u >= 0x0600) && (u <= 0x06FF)) || ((u >= 0x0750) && (u <= 0x077F)) ||
+    ((u >= 0x08A0) && (u <= 0x08FF)) ||
+    // Arabic presentation forms A and B
+    ((u >= 0xFB50) && (u <= 0xFDFF)) || ((u >= 0xFE70) && (u <= 0xFEFF)) ||
+    // Syriac, Thaana, N'Ko, Samaritan, Mandaic
+    ((u >= 0x0700) && (u <= 0x074F)) || ((u >= 0x0780) && (u <= 0x07BF)) ||
+    ((u >= 0x07C0) && (u <= 0x07FF)) || ((u >= 0x0800) && (u <= 0x083F)) ||
+    ((u >= 0x0840) && (u <= 0x085F));
+}
+
+bool EditorCell::IsStrongLeftToRight(wxUniChar c) {
+  // Everything a Latin, Greek or Cyrillic script writes with, which is as much
+  // as this needs to tell apart from the right-to-left blocks above. Digits are
+  // deliberately not here: they take their direction from their surroundings.
+  return wxIsalpha(c) && !IsStrongRightToLeft(c);
+}
+
+bool EditorCell::LineIsRightToLeft(size_t line) {
+  const size_t start = XYToPosition(0, line);
+  for (size_t pos = start; pos < m_text.Length(); pos++) {
+    const wxUniChar c = m_text.at(pos);
+    if (c == wxS('\n'))
+      break;
+    if (IsStrongRightToLeft(c))
+      return true;
+    if (IsStrongLeftToRight(c))
+      return false;
+  }
+  // Nothing strong either way: follow the document.
+  return m_configuration->RightToLeftDocument();
+}
+
+size_t EditorCell::LineLength(size_t line) {
+  const size_t start = XYToPosition(0, line);
+  size_t length = 0;
+  while ((start + length < m_text.Length()) &&
+         (m_text.at(start + length) != wxS('\n')))
+    length++;
+  return length;
+}
+
+bool EditorCell::LineIsMixedDirection(size_t line) {
+  const size_t start = XYToPosition(0, line);
+  bool sawRightToLeft = false;
+  bool sawLeftToRight = false;
+  for (size_t pos = start; pos < m_text.Length(); pos++) {
+    const wxUniChar c = m_text.at(pos);
+    if (c == wxS('\n'))
+      break;
+    sawRightToLeft = sawRightToLeft || IsStrongRightToLeft(c);
+    sawLeftToRight = sawLeftToRight || IsStrongLeftToRight(c);
+  }
+  return sawRightToLeft && sawLeftToRight;
 }
 
 wxCoord EditorCell::GetLineWidth(size_t line, size_t pos) {

--- a/src/cells/EditorCell.h
+++ b/src/cells/EditorCell.h
@@ -382,6 +382,36 @@ public:
 
   wxCoord GetLineWidth(size_t line, size_t pos);
 
+  /*! Is this character a strong right-to-left one (Hebrew, Arabic, Farsi, ...)?
+
+    "Strong" in the sense of the Unicode bidirectional algorithm: a character
+    that carries a direction of its own, as opposed to a digit, a space or
+    punctuation, which take theirs from what surrounds them.
+   */
+  static bool IsStrongRightToLeft(wxUniChar c);
+
+  //! Is this character a strong left-to-right one?
+  static bool IsStrongLeftToRight(wxUniChar c);
+
+  /*! Is the given display line written right to left?
+
+    Decided by its first strong character, which is the rule the Unicode
+    bidirectional algorithm uses for a paragraph. A line with no strong
+    character at all - digits and punctuation only - follows the document.
+
+    Only lines that are wholly one direction are handled: for those the caret's
+    position is the mirror of what measuring the text before it gives, which is
+    exact and needs no reordering. A line that genuinely mixes the two scripts
+    would need the real algorithm and is left as it was.
+   */
+  bool LineIsRightToLeft(size_t line);
+
+  //! Does this line mix strong characters of both directions?
+  bool LineIsMixedDirection(size_t line);
+
+  //! How many characters the given display line holds, excluding its newline.
+  size_t LineLength(size_t line);
+
   /*! How far each line has to move right to sit flush with the widest one.
 
     Empty unless the document reads right-to-left

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -165,6 +165,17 @@ if(TARGET wxmTestApp)
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
     add_test(EditorCellWrapping test_EditorCellWrapping)
 
+    # What the caret does inside bidirectional text: a position in a Hebrew word
+    # has to map to a point in the word's *drawn* order, which is the reverse of
+    # the order it is stored in.
+    add_executable(test_EditorCellBidi
+        test_EditorCellBidi.cpp groupcell_test_stubs.cpp ${WXM_TEST_SETUP}
+        $<TARGET_OBJECTS:wxmTestApp>)
+    target_compile_features(test_EditorCellBidi PUBLIC cxx_std_20)
+    target_link_libraries(test_EditorCellBidi PRIVATE
+        ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+    add_test(EditorCellBidi test_EditorCellBidi)
+
     # Logic-level regression tests for the custom wxAccessible classes (worksheet
     # and toolbar). They only assert where wxUSE_ACCESSIBILITY is set (the Windows
     # CI); elsewhere they compile out to a harness sanity check. This catches the

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -174,7 +174,14 @@ if(TARGET wxmTestApp)
     target_compile_features(test_EditorCellBidi PUBLIC cxx_std_20)
     target_link_libraries(test_EditorCellBidi PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(EditorCellBidi test_EditorCellBidi)
+    # Started through the headless wrapper rather than spawning an Xvfb of its
+    # own, as the other GUI tests still do. The wrapper picks a free display
+    # instead of a fixed :99 two tests can collide on, kills the server it
+    # started, waits for it to be ready rather than sleeping, and refuses to
+    # fall back to the developer's own desktop. It also keeps a system() call
+    # out of the test, which is what flawfinder rightly objects to.
+    add_test(NAME EditorCellBidi
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_EditorCellBidi>")
 
     # Logic-level regression tests for the custom wxAccessible classes (worksheet
     # and toolbar). They only assert where wxUSE_ACCESSIBILITY is set (the Windows

--- a/test/unit_tests/test_EditorCellBidi.cpp
+++ b/test/unit_tests/test_EditorCellBidi.cpp
@@ -34,17 +34,13 @@
   it exists.
 
   Windowless: a real GroupCell/EditorCell against a memory-DC Configuration, in
-  the manner of test_EditorCellWrapping.
+  the manner of test_EditorCellWrapping. The display comes from the run_headless
+  wrapper ctest starts this through, so there is no Xvfb wrangling here.
 */
 
 #include <wx/wx.h>
 #include <wx/bitmap.h>
 #include <wx/dcmemory.h>
-
-#include <cstdlib>
-#ifndef _WIN32
-#include <unistd.h>
-#endif
 
 #include <vector>
 
@@ -61,17 +57,6 @@ wxBitmap *g_bmp = nullptr;
 wxMemoryDC *g_dc = nullptr;
 Configuration *g_cfg = nullptr;
 } // namespace
-
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
 
 namespace {
 
@@ -196,7 +181,6 @@ wxDECLARE_APP(TestApp);
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_EditorCellBidi.cpp
+++ b/test/unit_tests/test_EditorCellBidi.cpp
@@ -1,0 +1,218 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+//
+//  Copyright (C) 2026 Gunter Königsmann <wxMaxima@physikbuch.de>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+/*! \file
+  What the caret does inside bidirectional text.
+
+  EditorCell maps a caret position (an index into the content) to a point by
+  measuring how wide the text before it is - PositionToPoint(). That is only
+  correct while the text is drawn in the same order it is stored. In a
+  right-to-left script it is not: the first character of a Hebrew word is drawn
+  at its *right* end, so a caret one character in belongs near the right of the
+  word and not, as the measurement says, one character's width from its left.
+
+  These scenarios measure the mapping rather than assume it, for a left-to-right
+  string as the control and a right-to-left one as the subject. They are written
+  to describe what the caret *should* do, so they document the gap for as long as
+  it exists.
+
+  Windowless: a real GroupCell/EditorCell against a memory-DC Configuration, in
+  the manner of test_EditorCellWrapping.
+*/
+
+#include <wx/wx.h>
+#include <wx/bitmap.h>
+#include <wx/dcmemory.h>
+
+#include <cstdlib>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+#include <vector>
+
+#include "CellPointers.h"
+#include "Configuration.h"
+#include "cells/EditorCell.h"
+#include "cells/GroupCell.h"
+
+#define CATCH_CONFIG_RUNNER
+#include <catch2/catch.hpp>
+
+namespace {
+wxBitmap *g_bmp = nullptr;
+wxMemoryDC *g_dc = nullptr;
+Configuration *g_cfg = nullptr;
+} // namespace
+
+static void EnsureDisplay() {
+#ifndef _WIN32
+  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
+    return;
+  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
+    setenv("DISPLAY", ":99", 1);
+    sleep(1);
+  }
+#endif
+}
+
+namespace {
+
+//! Hebrew, so every letter is a strong right-to-left character.
+const wxString kHebrew = wxS("שלוםעולם");
+//! The left-to-right control, same number of characters.
+const wxString kLatin = wxS("abcdefgh");
+
+//! The caret's x for every position in the text, cell-relative.
+std::vector<wxCoord> CaretXs(EditorCell *editor, const wxString &text) {
+  std::vector<wxCoord> xs;
+  for (size_t i = 0; i <= text.Length(); i++)
+    xs.push_back(editor->PositionToPoint(i).x - editor->GetCurrentPoint().x);
+  return xs;
+}
+
+//! Builds a text cell holding \p text and lays it out.
+std::unique_ptr<GroupCell> MakeCell(const wxString &text) {
+  auto group = std::make_unique<GroupCell>(g_cfg, GC_TYPE_TEXT, text);
+  group->Recalculate();
+  return group;
+}
+
+} // namespace
+
+SCENARIO("The caret follows the text it is placed in") {
+  GIVEN("a left-to-right word") {
+    auto group = MakeCell(kLatin);
+    EditorCell *editor = group->GetEditable();
+    REQUIRE(editor != nullptr);
+    const std::vector<wxCoord> xs = CaretXs(editor, kLatin);
+
+    THEN("it advances rightwards, one character at a time") {
+      // The control: for Latin, stored order is drawn order, so each further
+      // position is further right. If this fails the harness is wrong, not the
+      // bidi handling.
+      for (size_t i = 1; i < xs.size(); i++)
+        REQUIRE(xs.at(i) >= xs.at(i - 1));
+      REQUIRE(xs.back() > xs.front());
+    }
+  }
+
+  GIVEN("a right-to-left word") {
+    auto group = MakeCell(kHebrew);
+    EditorCell *editor = group->GetEditable();
+    REQUIRE(editor != nullptr);
+    const std::vector<wxCoord> xs = CaretXs(editor, kHebrew);
+
+    THEN("the caret before the first letter is at the word's right end") {
+      // The first stored character is drawn rightmost, so a caret in front of
+      // it belongs at the right edge of the word - not at its left edge, which
+      // is where measuring the (empty) text before it puts it.
+      INFO("caret x per position: " << [&xs] {
+          std::string s;
+          for (const wxCoord x : xs)
+            s += std::to_string(x) + " ";
+          return s;
+        }());
+      REQUIRE(xs.front() > xs.back());
+    }
+
+    THEN("it advances leftwards as the position grows") {
+      for (size_t i = 1; i < xs.size(); i++)
+        REQUIRE(xs.at(i) <= xs.at(i - 1));
+    }
+  }
+}
+
+namespace {
+
+//! Sends one arrow key to the cell and returns where the caret ended up.
+size_t PressArrow(EditorCell *editor, int keyCode, size_t from) {
+  editor->CursorPosition(from);
+  wxKeyEvent event(wxEVT_KEY_DOWN);
+  event.m_keyCode = keyCode;
+  editor->ProcessEvent(event);
+  return editor->CursorPosition();
+}
+
+} // namespace
+
+SCENARIO("The arrow keys move the caret the way it is drawn") {
+  GIVEN("a left-to-right word") {
+    auto group = MakeCell(kLatin);
+    EditorCell *editor = group->GetEditable();
+    REQUIRE(editor != nullptr);
+
+    THEN("Right advances through the text and Left goes back") {
+      REQUIRE(PressArrow(editor, WXK_RIGHT, 3) == 4);
+      REQUIRE(PressArrow(editor, WXK_LEFT, 3) == 2);
+    }
+  }
+
+  GIVEN("a right-to-left word") {
+    auto group = MakeCell(kHebrew);
+    EditorCell *editor = group->GetEditable();
+    REQUIRE(editor != nullptr);
+
+    THEN("Left advances through the text, because that is rightwards on screen") {
+      // The text is drawn in the reverse of its stored order, so moving the
+      // caret leftwards on screen means stepping forward through the content.
+      REQUIRE(PressArrow(editor, WXK_LEFT, 3) == 4);
+      REQUIRE(PressArrow(editor, WXK_RIGHT, 3) == 2);
+    }
+
+    THEN("the caret keeps moving the same way on screen as the key repeats") {
+      // The real complaint a user would make: pressing one arrow twice must not
+      // move the caret back where it started.
+      const size_t once = PressArrow(editor, WXK_LEFT, 2);
+      const size_t twice = PressArrow(editor, WXK_LEFT, once);
+      REQUIRE(twice != 2);
+      REQUIRE(editor->PositionToPoint(twice).x < editor->PositionToPoint(2).x);
+    }
+  }
+}
+
+class TestApp : public wxApp {
+public:
+  bool OnInit() override { return true; }
+};
+wxDECLARE_APP(TestApp);
+
+int main(int argc, char **argv) {
+  wxLog::EnableLogging(false);
+  EnsureDisplay();
+  wxApp::SetInstance(new TestApp());
+  wxEntryStart(argc, argv);
+  wxTheApp->CallOnInit();
+
+  g_bmp = new wxBitmap(400, 400);
+  g_dc = new wxMemoryDC();
+  g_dc->SelectObject(*g_bmp);
+  g_cfg = new Configuration(g_dc);
+  g_cfg->SetZoomFactor(1.0);
+  static DocumentCellPointers documentPointers;
+  static ViewCellPointers viewPointers(nullptr);
+  g_cfg->SetDocumentCellPointers(&documentPointers);
+  g_cfg->SetViewCellPointers(&viewPointers);
+
+  const int result = Catch::Session().run(argc, argv);
+
+  wxEntryCleanup();
+  return result;
+}


### PR DESCRIPTION
`EditorCell` turns a caret position into a point by measuring how wide the text
*before* it is. That is only right while the text is drawn in the order it is
stored — and a right-to-left script is drawn in the reverse of it. So the caret
landed at the mirror image of where it belonged: put the cursor in front of a
Hebrew word and it appeared at the word's far end.

**Measured, not assumed.** For the eight-letter Hebrew word the caret's x ran:

```text
position:  0   1   2   3   4   5   6   7   8
x:         0  12  20  25  36  45  50  58  69
```

Increasing left to right, exactly as if the text were Latin.

## The fix

For a line that is wholly one direction, mirroring the measurement isn't an
approximation, it's exact: the text before a position is drawn *after* it, so the
caret sits that far in from the line's right end rather than its left.

* `LineIsRightToLeft()` decides by the line's first strong character — the rule
  the Unicode algorithm uses for a paragraph.
* `LineIsMixedDirection()` holds back any line that genuinely mixes scripts.
  Those need the real bidirectional algorithm and are left **exactly as they
  were**, rather than made differently wrong.

The arrow keys follow. They moved through the stored text, so in right-to-left
text pressing Right walked the caret *leftwards* across the screen, and the key
that looked like it should undo a movement repeated it instead. They now move the
caret the way it is drawn.

## The test earned its keep immediately

`test_EditorCellBidi` measures all of this against a real cell, with a Latin
string as the control so a harness fault can't be mistaken for a bidi one.

It caught a real mistake: `XYToPosition()` numbers display lines **from zero**,
and my first attempt asked it for `line + 1`. Every lookup ran off the end of a
single-line text, found no strong character, and fell back to the document's
direction — so the change built, ran, and did nothing whatsoever. Without the
probe I would have shipped a no-op.

36 unit tests pass (35 + the new one).

## Not addressed, and deliberately not papered over

Selecting inside right-to-left text, and lines that mix scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XPDxkWgQan8Qbb89drnjz
