### PR TITLE
Start GUI tests through the headless wrapper instead of their own Xvfb

### DIFF
--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -118,7 +118,8 @@ add_test(MaximaProtocol test_MaximaProtocol)
 add_executable(test_MenuHelpString
     test_MenuHelpString.cpp ${CMAKE_SOURCE_DIR}/src/MenuHelpString.cpp ${WXM_TEST_SETUP})
 target_link_libraries(test_MenuHelpString PRIVATE ${wxWidgets_LIBRARIES})
-add_test(MenuHelpString test_MenuHelpString)
+add_test(NAME MenuHelpString
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_MenuHelpString>")
 
 # Guards the Greek/symbol sidebars' Buttonwrapsizer (a wxWrapSizer subclass that
 # uses the protected m_availSize -- fragile across wx versions, broke wrapping on
@@ -127,7 +128,8 @@ add_executable(test_ButtonWrapSizer
     test_ButtonWrapSizer.cpp ${CMAKE_SOURCE_DIR}/src/sidebars/ButtonWrapSizer.cpp
     ${WXM_TEST_SETUP})
 target_link_libraries(test_ButtonWrapSizer PRIVATE ${wxWidgets_LIBRARIES})
-add_test(ButtonWrapSizer test_ButtonWrapSizer)
+add_test(NAME ButtonWrapSizer
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_ButtonWrapSizer>")
 
 # Layout/recalculation regression test. Unlike the tests above (which stub out
 # GroupCell via TestStubs.cpp), this links the real application code through the
@@ -140,7 +142,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_GroupCellLayout PUBLIC cxx_std_20)
     target_link_libraries(test_GroupCellLayout PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(GroupCellLayout test_GroupCellLayout)
+    add_test(NAME GroupCellLayout
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_GroupCellLayout>")
 
     # Drives the full layout pipeline (RequestRecalculation ->
     # RecalculateIfNeeded -> virtual size pushed to a mock view) with real
@@ -152,7 +155,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_WorksheetLayout PUBLIC cxx_std_20)
     target_link_libraries(test_WorksheetLayout PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(WorksheetLayout test_WorksheetLayout)
+    add_test(NAME WorksheetLayout
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_WorksheetLayout>")
 
     # Line-wrapping inside EditorCells: soft breaks must be derived layout
     # state that never alters or leaks out of the cell's content, for the
@@ -163,7 +167,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_EditorCellWrapping PUBLIC cxx_std_20)
     target_link_libraries(test_EditorCellWrapping PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(EditorCellWrapping test_EditorCellWrapping)
+    add_test(NAME EditorCellWrapping
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_EditorCellWrapping>")
 
     # What the caret does inside bidirectional text: a position in a Hebrew word
     # has to map to a point in the word's *drawn* order, which is the reverse of
@@ -194,7 +199,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_Accessibility PUBLIC cxx_std_20)
     target_link_libraries(test_Accessibility PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(Accessibility test_Accessibility)
+    add_test(NAME Accessibility
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_Accessibility>")
 
     # Guards everything a .wxm file (= the copy-to-clipboard path) can hold --
     # images in several formats, every text cell type, code cell answers and the
@@ -205,7 +211,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_WXMRoundtrip PUBLIC cxx_std_20)
     target_link_libraries(test_WXMRoundtrip PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(WXMRoundtrip test_WXMRoundtrip)
+    add_test(NAME WXMRoundtrip
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_WXMRoundtrip>")
 
     # Round-trip guard for the .wxmx content.xml (the MathML-like math format):
     # parsing a content.xml into a cell tree and serialising it back must be a
@@ -218,7 +225,8 @@ if(TARGET wxmTestApp)
         WXM_CORPUS_DIR="${CMAKE_SOURCE_DIR}/test/fuzz/corpus_mathparser")
     target_link_libraries(test_WXMXRoundtrip PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(WXMXRoundtrip test_WXMXRoundtrip)
+    add_test(NAME WXMXRoundtrip
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_WXMXRoundtrip>")
 
     # Safety net for extracting the export/serialization cluster out of
     # Worksheet: loads the real math corpus plus sentinel cells into a live
@@ -235,7 +243,8 @@ if(TARGET wxmTestApp)
         WXM_TESTFILES_DIR="${CMAKE_SOURCE_DIR}/test/automatic_test_files")
     target_link_libraries(test_WorksheetExport PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(WorksheetExport test_WorksheetExport)
+    add_test(NAME WorksheetExport
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_WorksheetExport>")
 
     # Safety net for the multi-format clipboard / drag-export payload: builds
     # the real Copy()/CopyCells() data objects over a live document and pins
@@ -249,7 +258,8 @@ if(TARGET wxmTestApp)
         WXM_CORPUS_DIR="${CMAKE_SOURCE_DIR}/test/fuzz/corpus_mathparser")
     target_link_libraries(test_WorksheetClipboard PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(WorksheetClipboard test_WorksheetClipboard)
+    add_test(NAME WorksheetClipboard
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_WorksheetClipboard>")
 
     # Pins the right-click context menu (WorksheetContextMenu, extracted from
     # Worksheet::OnMouseRightDown): drives the main right-click states on a
@@ -260,7 +270,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_WorksheetContextMenu PUBLIC cxx_std_20)
     target_link_libraries(test_WorksheetContextMenu PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(WorksheetContextMenu test_WorksheetContextMenu)
+    add_test(NAME WorksheetContextMenu
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_WorksheetContextMenu>")
 
     # Pins the worksheet's two-cursor model (h-caret between cells XOR editor
     # cursor inside a cell; neither while cells are selected) ahead of the
@@ -271,7 +282,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_WorksheetCursor PUBLIC cxx_std_20)
     target_link_libraries(test_WorksheetCursor PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(WorksheetCursor test_WorksheetCursor)
+    add_test(NAME WorksheetCursor
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_WorksheetCursor>")
 
     # Pins the worksheet's find/replace behavior (wrap-around group loop,
     # prompt/editor/output order, start-from-cursor skip rules) ahead of the
@@ -282,7 +294,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_WorksheetFind PUBLIC cxx_std_20)
     target_link_libraries(test_WorksheetFind PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(WorksheetFind test_WorksheetFind)
+    add_test(NAME WorksheetFind
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_WorksheetFind>")
 
     # Pins the "add cells to the evaluation queue" behavior (which visible code
     # cells each Add*ToEvaluationQueue enqueues, and where the h-caret lands)
@@ -293,7 +306,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_WorksheetEvalQueue PUBLIC cxx_std_20)
     target_link_libraries(test_WorksheetEvalQueue PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(WorksheetEvalQueue test_WorksheetEvalQueue)
+    add_test(NAME WorksheetEvalQueue
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_WorksheetEvalQueue>")
 
     # Command-level behavior of the EvaluationQueue: how a cell's input is split
     # into the commands sent to maxima one at a time, and how lisp/maxima mode
@@ -305,7 +319,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_EvalQueueCommands PUBLIC cxx_std_20)
     target_link_libraries(test_EvalQueueCommands PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(EvalQueueCommands test_EvalQueueCommands)
+    add_test(NAME EvalQueueCommands
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_EvalQueueCommands>")
 
     # Hardening/fuzz test for EditorCell's text-editing core: drives the real
     # key-event paths and checks the cursor/selection invariants after every op.
@@ -315,7 +330,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_EditorCellInvariants PUBLIC cxx_std_20)
     target_link_libraries(test_EditorCellInvariants PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(EditorCellInvariants test_EditorCellInvariants)
+    add_test(NAME EditorCellInvariants
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_EditorCellInvariants>")
 
     # The directory-scanning half of the bash-like file-name completion:
     # openr()/load()/demo() file arguments complete against the directory the
@@ -326,7 +342,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_Autocomplete PUBLIC cxx_std_20)
     target_link_libraries(test_Autocomplete PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(Autocomplete test_Autocomplete)
+    add_test(NAME Autocomplete
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_Autocomplete>")
 
     # Layout idempotency invariants: after zoom / canvas-size changes, the
     # converged layout must equal a fresh layout of the same content - catches
@@ -338,7 +355,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_LayoutInvariants PUBLIC cxx_std_20)
     target_link_libraries(test_LayoutInvariants PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(LayoutInvariants test_LayoutInvariants)
+    add_test(NAME LayoutInvariants
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_LayoutInvariants>")
 
     # Round-trip test for the mechanical scalar settings: guards that
     # ReadConfig() and the settings-write side share one key<->member table
@@ -350,7 +368,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_ConfigRoundtrip PUBLIC cxx_std_20)
     target_link_libraries(test_ConfigRoundtrip PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(ConfigRoundtrip test_ConfigRoundtrip)
+    add_test(NAME ConfigRoundtrip
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_ConfigRoundtrip>")
 
     # Round-trip test for the worksheet styles: guards that ReadStyles() and
     # WriteStyles() share one TextStyle -> config-key mapping so styles can never
@@ -361,7 +380,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_StyleConfigRoundtrip PUBLIC cxx_std_20)
     target_link_libraries(test_StyleConfigRoundtrip PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(StyleConfigRoundtrip test_StyleConfigRoundtrip)
+    add_test(NAME StyleConfigRoundtrip
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_StyleConfigRoundtrip>")
 
     # Direct parser test for MaximaManual's help anchors: batch mode no longer
     # compiles anchors (interactive-only), so they need their own regression net.
@@ -371,7 +391,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_ManualAnchors PUBLIC cxx_std_20)
     target_link_libraries(test_ManualAnchors PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(ManualAnchors test_ManualAnchors)
+    add_test(NAME ManualAnchors
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_ManualAnchors>")
 
     # Regression test for the cell-tree undo/redo (TreeUndo_*); the safety net for
     # extracting that subsystem out of the Worksheet god class.
@@ -381,7 +402,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_TreeUndo PUBLIC cxx_std_20)
     target_link_libraries(test_TreeUndo PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(TreeUndo test_TreeUndo)
+    add_test(NAME TreeUndo
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_TreeUndo>")
 
     # Drives a real GreekSidebar to guard its line wrapping: when too small to show
     # every letter it must grow its virtual height so the wrapped rows stay
@@ -392,7 +414,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_GreekSidebar PUBLIC cxx_std_20)
     target_link_libraries(test_GreekSidebar PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(GreekSidebar test_GreekSidebar)
+    add_test(NAME GreekSidebar
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_GreekSidebar>")
 
     # Drives a real BTextCtrl to guard the last-active-text-control tracking
     # (which text control the sidebars' symbol buttons type into). It was a raw
@@ -405,7 +428,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_LastActiveTextCtrl PUBLIC cxx_std_20)
     target_link_libraries(test_LastActiveTextCtrl PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(LastActiveTextCtrl test_LastActiveTextCtrl)
+    add_test(NAME LastActiveTextCtrl
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_LastActiveTextCtrl>")
 
     # Guards the declarative variable-to-menu-items table (MaximaMenuSync) that
     # keeps menu check marks in sync with the option variables Maxima reports -
@@ -417,7 +441,8 @@ if(TARGET wxmTestApp)
     target_compile_features(test_MaximaMenuSync PUBLIC cxx_std_20)
     target_link_libraries(test_MaximaMenuSync PRIVATE
         ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-    add_test(MaximaMenuSync test_MaximaMenuSync)
+    add_test(NAME MaximaMenuSync
+        COMMAND "${WXM_TEST_WRAPPER}" "$<TARGET_FILE:test_MaximaMenuSync>")
 endif()
 
 # Same watchdog timeout the parent directory applies to its tests: keep a hung

--- a/test/unit_tests/test_Accessibility.cpp
+++ b/test/unit_tests/test_Accessibility.cpp
@@ -56,7 +56,6 @@
 
 #include <cstdlib>
 #ifndef _WIN32
-#include <unistd.h> // sleep(), used only by the POSIX EnsureDisplay() path
 #endif
 
 #define CATCH_CONFIG_RUNNER
@@ -69,17 +68,6 @@ Configuration *g_cfg = nullptr;
 Worksheet *g_ws = nullptr;
 wxFrame *g_frame = nullptr;
 } // namespace
-
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
 
 // Runs everywhere (even with accessibility compiled out) so Catch always has a
 // test case and gross construction breakage is still caught.
@@ -188,7 +176,6 @@ wxDECLARE_APP(TestApp);
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_Autocomplete.cpp
+++ b/test/unit_tests/test_Autocomplete.cpp
@@ -58,17 +58,6 @@ Configuration *g_cfg = nullptr;
 wxString g_baseDir;
 } // namespace
 
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 // Runs before Catch2's session, so failures abort instead of REQUIREing.
 static void Touch(const wxString &path) {
   wxFFile file(path, wxS("w"));
@@ -206,7 +195,6 @@ wxDECLARE_APP(TestApp);
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_ButtonWrapSizer.cpp
+++ b/test/unit_tests/test_ButtonWrapSizer.cpp
@@ -53,17 +53,6 @@ public:
 };
 wxDECLARE_APP(TestApp);
 
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 // Fills a panel with n buttons inside a Buttonwrapsizer, sizes it to the given
 // width and lays it out. The buttons are the caller's to inspect afterwards.
 static std::vector<wxWindow *> LayOutButtons(wxFrame *frame, int n, int width) {
@@ -184,7 +173,6 @@ SCENARIO("Buttonwrapsizer::HeightForWidth needs more height at a narrower width"
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_ConfigRoundtrip.cpp
+++ b/test/unit_tests/test_ConfigRoundtrip.cpp
@@ -48,7 +48,6 @@
 #include <type_traits>
 #include <variant>
 #ifndef _WIN32
-#include <unistd.h> // sleep(), used only by the POSIX EnsureDisplay() path
 #endif
 
 #define CATCH_CONFIG_RUNNER
@@ -171,20 +170,8 @@ public:
 };
 wxDECLARE_APP(TestApp);
 
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_EditorCellInvariants.cpp
+++ b/test/unit_tests/test_EditorCellInvariants.cpp
@@ -62,7 +62,6 @@
 #include <random>
 #include <stdexcept>
 #ifndef _WIN32
-#include <unistd.h> // sleep(), used only by the POSIX EnsureDisplay() path
 #endif
 
 #define CATCH_CONFIG_RUNNER
@@ -81,19 +80,6 @@ Worksheet *g_ws = nullptr;
 
 // wxGTK routes font/DC work through GTK, which needs an X display. When run via
 // ctest the headless wrapper provides one; when run directly we start our own.
-static void EnsureDisplay() {
-#ifndef _WIN32
-  // Windows runners have a real desktop session, so this is a no-op there
-  // (and Xvfb/setenv/sleep are POSIX-only anyway).
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 // A fresh, active code/text GroupCell whose editor we drive. The GroupCell is
 // owned by the returned unique_ptr; the editor it lends out lives as long as it.
 static EditorCell *ActiveEditor(std::unique_ptr<GroupCell> &owner,
@@ -413,7 +399,6 @@ static void ThrowingAssertHandler(const wxString &file, int line,
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_EditorCellWrapping.cpp
+++ b/test/unit_tests/test_EditorCellWrapping.cpp
@@ -51,7 +51,6 @@
 #include <memory>
 #include <vector>
 #ifndef _WIN32
-#include <unistd.h> // sleep(), used only by the POSIX EnsureDisplay() path
 #endif
 
 #define CATCH_CONFIG_RUNNER
@@ -68,19 +67,6 @@ Configuration *g_cfg = nullptr;
 
 // wxGTK routes font/DC work through GTK, which needs an X display. When run via
 // ctest the headless wrapper provides one; when run directly we start our own.
-static void EnsureDisplay() {
-#ifndef _WIN32
-  // Windows runners have a real desktop session, so this is a no-op there
-  // (and Xvfb/setenv/sleep are POSIX-only anyway).
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 namespace {
 
 //! Saves the auto-wrap mode and canvas size; restores both on scope exit.
@@ -665,7 +651,6 @@ wxDECLARE_APP(TestApp);
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_EvalQueueCommands.cpp
+++ b/test/unit_tests/test_EvalQueueCommands.cpp
@@ -70,17 +70,6 @@ Worksheet *g_ws = nullptr;
 wxFrame *g_frame = nullptr;
 } // namespace
 
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 //! Owns the code cells a scenario builds (kept alive for the queue's CellPtrs).
 static GroupCell *MakeCodeCell(const wxString &code) {
   auto group = std::make_unique<GroupCell>(g_cfg, GC_TYPE_CODE, code);
@@ -286,7 +275,6 @@ wxDECLARE_APP(TestApp);
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_GreekSidebar.cpp
+++ b/test/unit_tests/test_GreekSidebar.cpp
@@ -64,17 +64,6 @@ public:
 };
 wxDECLARE_APP(TestApp);
 
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 SCENARIO("A too-small statistics sidebar keeps its buttons reachable by scrolling") {
   // Same bug family as the Greek sidebar: a Buttonwrapsizer's own min height
   // is a deliberately-small rearrangeable minimum, so without pinning it the
@@ -115,7 +104,6 @@ SCENARIO("A too-small Greek sidebar keeps its wrapped rows reachable by scrollin
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_GroupCellLayout.cpp
+++ b/test/unit_tests/test_GroupCellLayout.cpp
@@ -57,7 +57,6 @@
 
 #include <cstdlib>
 #ifndef _WIN32
-#include <unistd.h> // sleep(), used only by the POSIX EnsureDisplay() path
 #endif
 
 #define CATCH_CONFIG_RUNNER
@@ -76,19 +75,6 @@ Worksheet *g_ws = nullptr;
 
 // wxGTK routes font/DC work through GTK, which needs an X display. When run via
 // ctest the headless wrapper provides one; when run directly we start our own.
-static void EnsureDisplay() {
-#ifndef _WIN32
-  // Windows runners have a real desktop session, so this is a no-op there
-  // (and Xvfb/setenv/sleep are POSIX-only anyway).
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 // Builds a code GroupCell (prompt label + input EditorCell) holding "text" and
 // lays it out, returning its total height.
 static int CodeGroupHeight(const wxString &text) {
@@ -473,7 +459,6 @@ wxDECLARE_APP(TestApp);
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_LastActiveTextCtrl.cpp
+++ b/test/unit_tests/test_LastActiveTextCtrl.cpp
@@ -62,17 +62,6 @@ public:
 };
 wxDECLARE_APP(TestApp);
 
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 //! Deliver the focus event BTextCtrl::OnFocus is bound to.
 static void FocusByEvent(BTextCtrl *ctrl) {
   wxFocusEvent focus(wxEVT_SET_FOCUS, ctrl->GetId());
@@ -117,7 +106,6 @@ SCENARIO("A destroyed text control cannot stay the symbol target") {
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_LayoutInvariants.cpp
+++ b/test/unit_tests/test_LayoutInvariants.cpp
@@ -53,7 +53,6 @@
 #include <cstdlib>
 #include <vector>
 #ifndef _WIN32
-#include <unistd.h> // sleep(), used only by the POSIX EnsureDisplay() path
 #endif
 
 #define CATCH_CONFIG_RUNNER
@@ -65,17 +64,6 @@ wxMemoryDC *g_dc = nullptr;
 Configuration *g_cfg = nullptr;
 Worksheet *g_ws = nullptr;
 } // namespace
-
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
 
 // Maxima output (via wxMathML.lisp) for
 //   f_aa\,bb\+cc[ff]=[min=11.1111*10^3,...,Fail=0.00111*10^3*"ppm"];
@@ -417,7 +405,6 @@ wxDECLARE_APP(TestApp);
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_ManualAnchors.cpp
+++ b/test/unit_tests/test_ManualAnchors.cpp
@@ -44,7 +44,6 @@
 
 #include <cstdlib>
 #ifndef _WIN32
-#include <unistd.h> // sleep(), used only by the POSIX EnsureDisplay() path
 #endif
 
 #define CATCH_CONFIG_RUNNER
@@ -113,22 +112,8 @@ wxDECLARE_APP(TestApp);
 
 // wxGTK routes regex/file work that needs no display, but Configuration still
 // pulls in GTK; mirror the other unit tests and make sure a display exists.
-static void EnsureDisplay() {
-#ifndef _WIN32
-  // Windows runners have a real desktop session, so this is a no-op there
-  // (and Xvfb/setenv/sleep are POSIX-only anyway).
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_MaximaMenuSync.cpp
+++ b/test/unit_tests/test_MaximaMenuSync.cpp
@@ -58,17 +58,6 @@ public:
 };
 wxDECLARE_APP(TestApp);
 
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 //! Build one menu per table row, holding real items with the row's menu ids.
 static wxMenuBar *MenuBarFromTable() {
   wxMenuBar *menubar = new wxMenuBar;
@@ -206,7 +195,6 @@ SCENARIO("Variables without a table row are reported as unhandled") {
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_MenuHelpString.cpp
+++ b/test/unit_tests/test_MenuHelpString.cpp
@@ -46,7 +46,6 @@
 #include <cstdlib>
 #include <stdexcept>
 #ifndef _WIN32
-#include <unistd.h> // sleep(), used only by the POSIX EnsureDisplay() path
 #endif
 
 #define CATCH_CONFIG_RUNNER
@@ -122,20 +121,8 @@ public:
 wxDECLARE_APP(TestApp);
 
 // wxGTK routes menu/GUI object creation through GTK, which needs an X display.
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_StyleConfigRoundtrip.cpp
+++ b/test/unit_tests/test_StyleConfigRoundtrip.cpp
@@ -49,7 +49,6 @@
 #include <cstdint>
 #include <cstdlib>
 #ifndef _WIN32
-#include <unistd.h> // sleep(), used only by the POSIX EnsureDisplay() path
 #endif
 
 #define CATCH_CONFIG_RUNNER
@@ -132,22 +131,8 @@ wxDECLARE_APP(TestApp);
 
 // wxGTK routes color/font work through GTK, which needs an X display. When run
 // via ctest the headless wrapper provides one; when run directly we start ours.
-static void EnsureDisplay() {
-#ifndef _WIN32
-  // Windows runners have a real desktop session, so this is a no-op there
-  // (and Xvfb/setenv/sleep are POSIX-only anyway).
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_TreeUndo.cpp
+++ b/test/unit_tests/test_TreeUndo.cpp
@@ -329,20 +329,8 @@ public:
 };
 wxDECLARE_APP(TestApp);
 
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_WXMRoundtrip.cpp
+++ b/test/unit_tests/test_WXMRoundtrip.cpp
@@ -68,17 +68,6 @@ Worksheet *g_ws = nullptr;
 wxFrame *g_frame = nullptr;
 } // namespace
 
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 // Builds a small image and encodes it to the given format's bytes.
 static wxMemoryBuffer EncodeImage(wxBitmapType type) {
   wxImage img(12, 8);
@@ -443,7 +432,6 @@ wxDECLARE_APP(TestApp);
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_WXMXRoundtrip.cpp
+++ b/test/unit_tests/test_WXMXRoundtrip.cpp
@@ -70,17 +70,6 @@ Worksheet *g_ws = nullptr;
 wxFrame *g_frame = nullptr;
 } // namespace
 
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 // Parses a whole content.xml document into a cell tree and serialises the tree
 // back to the content.xml cell markup (without the <wxMaximaDocument> wrapper).
 static wxString ParseSerialize(const wxString &documentXml) {
@@ -232,7 +221,6 @@ wxDECLARE_APP(TestApp);
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_WorksheetClipboard.cpp
+++ b/test/unit_tests/test_WorksheetClipboard.cpp
@@ -80,17 +80,6 @@ Worksheet *g_ws = nullptr;
 wxFrame *g_frame = nullptr;
 } // namespace
 
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 static wxString ReadTextFile(const wxString &path) {
   wxFFile f(path, wxS("rb"));
   REQUIRE(f.IsOpened());
@@ -295,7 +284,6 @@ wxDECLARE_APP(TestApp);
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_WorksheetContextMenu.cpp
+++ b/test/unit_tests/test_WorksheetContextMenu.cpp
@@ -62,17 +62,6 @@ Worksheet *g_ws = nullptr;
 wxFrame *g_frame = nullptr;
 } // namespace
 
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 //! Does the menu (including submenus) contain an item whose label starts so?
 static bool HasItem(const wxMenu &menu, const wxString &labelStart) {
   for (size_t i = 0; i < menu.GetMenuItemCount(); ++i) {
@@ -205,7 +194,6 @@ wxDECLARE_APP(TestApp);
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_WorksheetCursor.cpp
+++ b/test/unit_tests/test_WorksheetCursor.cpp
@@ -58,17 +58,6 @@ Worksheet *g_ws = nullptr;
 wxFrame *g_frame = nullptr;
 } // namespace
 
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 //! A fresh three-cell document; returns the first cell.
 static GroupCell *BuildDocument() {
   g_ws->ClearDocument();
@@ -202,7 +191,6 @@ wxDECLARE_APP(TestApp);
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_WorksheetEvalQueue.cpp
+++ b/test/unit_tests/test_WorksheetEvalQueue.cpp
@@ -59,17 +59,6 @@ Worksheet *g_ws = nullptr;
 wxFrame *g_frame = nullptr;
 } // namespace
 
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 //! Append a group of the given type (with a text output) after \p after.
 static GroupCell *AppendGroup(GroupType type, const wxString &code,
                               GroupCell *after) {
@@ -283,7 +272,6 @@ wxDECLARE_APP(TestApp);
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_WorksheetExport.cpp
+++ b/test/unit_tests/test_WorksheetExport.cpp
@@ -90,17 +90,6 @@ wxString g_outputRoot;
 bool g_keepOutput = false;
 } // namespace
 
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 static wxString ReadTextFile(const wxString &path) {
   wxFFile f(path, wxS("rb"));
   REQUIRE(f.IsOpened());
@@ -769,7 +758,6 @@ wxDECLARE_APP(TestApp);
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_WorksheetFind.cpp
+++ b/test/unit_tests/test_WorksheetFind.cpp
@@ -58,17 +58,6 @@ Worksheet *g_ws = nullptr;
 wxFrame *g_frame = nullptr;
 } // namespace
 
-static void EnsureDisplay() {
-#ifndef _WIN32
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 //! A code group with the given input and a one-cell text output.
 static GroupCell *AppendCodeGroup(const wxString &code,
                                   const wxString &outputText,
@@ -346,7 +335,6 @@ wxDECLARE_APP(TestApp);
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();

--- a/test/unit_tests/test_WorksheetLayout.cpp
+++ b/test/unit_tests/test_WorksheetLayout.cpp
@@ -47,7 +47,6 @@
 #include <cstdlib>
 #include <memory>
 #ifndef _WIN32
-#include <unistd.h> // sleep(), used only by the POSIX EnsureDisplay() path
 #endif
 
 #define CATCH_CONFIG_RUNNER
@@ -64,19 +63,6 @@ Configuration *g_cfg = nullptr;
 
 // wxGTK routes font/DC work through GTK, which needs an X display. When run via
 // ctest the headless wrapper provides one; when run directly we start our own.
-static void EnsureDisplay() {
-#ifndef _WIN32
-  // Windows runners have a real desktop session, so this is a no-op there
-  // (and Xvfb/setenv/sleep are POSIX-only anyway).
-  if (getenv("DISPLAY") || getenv("WAYLAND_DISPLAY"))
-    return;
-  if (system("Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &") == 0) {
-    setenv("DISPLAY", ":99", 1);
-    sleep(1);
-  }
-#endif
-}
-
 namespace {
 //! Records everything the engine pushes to the window; injects a client size.
 class MockView : public WorksheetView {
@@ -471,7 +457,6 @@ wxDECLARE_APP(TestApp);
 
 int main(int argc, char **argv) {
   wxLog::EnableLogging(false);
-  EnsureDisplay();
   wxApp::SetInstance(new TestApp());
   wxEntryStart(argc, argv);
   wxTheApp->CallOnInit();


### PR DESCRIPTION
Follows #2168, where flawfinder flagged the new test for calling `system()` to
start an Xvfb. It was right to, and the pattern was already in twenty-five other
tests.

Each carried a copy of the same `EnsureDisplay()`: `system()` an Xvfb onto a
hardcoded `:99`, `sleep(1)`, hope. The `system()` call is the least of it:

* two tests running at once want the same `:99`;
* nothing kills the server, so debugging a test by running it directly leaves one
  behind;
* a fixed sleep stands in for waiting until the display answers;
* and because it returns early whenever any `DISPLAY` is set, a "headless" test
  run on a desktop machine quietly **opens windows on the developer's screen** —
  which is how a stray assert dialog from a background test once turned up on
  Gunter's.

## The tree has had a proper runner all along

`run_headless.sh`, written into the build directory by `test/CMakeLists.txt`,
tries a headless Weston, then `xvfb-run -a`, then an Xvfb on the first free
display between `:100` and `:200`; waits for it with `xdpyinfo`; kills what it
started through a trap; and refuses to fall back to the desktop.

**Nothing invoked it.** The three places it appears are the ones that define,
write and `chmod` it.

## What changes

The twenty-five copies are gone and those tests run through the wrapper — **347
lines deleted, 50 added**.

The ten tests that need no display keep starting directly. They were checked one
by one: all ten pass with `DISPLAY` and `WAYLAND_DISPLAY` unset, so giving them a
display server each would be pure cost.

## Verification

The whole suite with **no display in the environment at all**, which the old
arrangement could not do:

```text
100% tests passed, 0 tests failed out of 36
real  0m50.6s      (against 46s for the previous xvfb-run-the-whole-suite run)
```

The documented `xvfb-run -a ctest` invocation still works, and neither leaves an
Xvfb process or a stale `/tmp/.X*-lock` behind.

`test/fuzz/fuzz_init.h` still starts its own display; oss-fuzz doesn't run through
ctest, so that's a separate question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XPDxkWgQan8Qbb89drnjz
