### PR TITLE
Highlight the characters a right-to-left selection actually selects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,8 +12,9 @@
   text actually is -- it used to be placed at the mirror image of its position,
   so putting the cursor in front of a Hebrew word showed it at the word's far
   end -- and the arrow keys move it the way it is drawn rather than the way the
-  text is stored. Which way the document reads follows the interface
-  language; there is not yet a right-to-left translation of wxMaxima itself, so
+  text is stored, and selecting inside it highlights the characters that are
+  selected rather than the ones after them. Which way the document reads follows
+  the interface language; there is not yet a right-to-left translation of wxMaxima itself, so
   setting the language is currently the way to see this.
 
 - LaTeX export: 2-D ASCII-art maths -- what Maxima prints when it isn't asked

--- a/src/cells/EditorCell.cpp
+++ b/src/cells/EditorCell.cpp
@@ -797,6 +797,21 @@ wxString EditorCell::ToHTML() const {
   return retval;
 }
 
+wxCoord EditorCell::SelectionRunLeft(size_t runStart, size_t runEnd,
+                                     wxCoord runStartX, wxCoord runWidth) {
+  size_t column, line;
+  PositionToXY(runStart, &column, &line);
+  if (!LineIsRightToLeft(line) || LineIsMixedDirection(line))
+    return runStartX;
+
+  // The run reads right to left, so runStart sits at its right edge: the left
+  // edge is one run-width further left. Deriving it from runStartX rather than
+  // from PositionToPoint(runEnd) keeps the rectangle exactly as wide as the
+  // text it covers, even where the two differ by a rounding.
+  (void)runEnd;
+  return runStartX - runWidth;
+}
+
 void EditorCell::MarkSelection(wxDC *dc, size_t start, size_t end, TextStyle style) {
   if (start > m_text.Length())
     start = m_text.Length();
@@ -834,6 +849,14 @@ void EditorCell::MarkSelection(wxDC *dc, size_t start, size_t end, TextStyle sty
         .GetWidth();
     if (pos == lineStart) // empty line
       selectionWidth = 0;
+
+    // On a right-to-left line the selected run is drawn from its *end*
+    // leftwards, so the first selected character is at the run's right edge and
+    // the rectangle has to start at the last one instead. Taking
+    // PositionToPoint(lineStart) as the left edge there would highlight the
+    // text that follows the selection rather than the selection itself.
+    point.x = SelectionRunLeft(lineStart, pos, point.x, selectionWidth);
+
     wxRect rect;
 #if defined(__WXOSX__)
     rect = GetRect(); // rectangle representing the cell

--- a/src/cells/EditorCell.h
+++ b/src/cells/EditorCell.h
@@ -412,6 +412,18 @@ public:
   //! How many characters the given display line holds, excluding its newline.
   size_t LineLength(size_t line);
 
+  /*! The left edge of the rectangle covering the run [runStart, runEnd).
+
+    \param runStartX where PositionToPoint() puts runStart
+    \param runWidth  how wide the run's text is
+
+    The same for both directions except in one respect: on a right-to-left line
+    the run is drawn from its end leftwards, so runStart marks its *right* edge
+    and the rectangle begins a run-width further left.
+   */
+  wxCoord SelectionRunLeft(size_t runStart, size_t runEnd, wxCoord runStartX,
+                           wxCoord runWidth);
+
   /*! How far each line has to move right to sit flush with the widest one.
 
     Empty unless the document reads right-to-left

--- a/test/unit_tests/test_EditorCellBidi.cpp
+++ b/test/unit_tests/test_EditorCellBidi.cpp
@@ -173,6 +173,48 @@ SCENARIO("The arrow keys move the caret the way it is drawn") {
   }
 }
 
+SCENARIO("A selection covers the characters it selects") {
+  // The rectangle MarkSelection() draws for a run: its left edge, and its width.
+  // Selecting positions [2,5) must cover exactly the glyphs of those three
+  // characters - the same span of screen in either script, just reached from
+  // the other end.
+  const size_t from = 2, to = 5;
+
+  GIVEN("a left-to-right word") {
+    auto group = MakeCell(kLatin);
+    EditorCell *editor = group->GetEditable();
+    REQUIRE(editor != nullptr);
+
+    THEN("the rectangle starts where the first selected character is") {
+      const wxCoord startX = editor->PositionToPoint(from).x;
+      const wxCoord endX = editor->PositionToPoint(to).x;
+      const wxCoord width = endX - startX;
+      REQUIRE(width > 0);
+      REQUIRE(editor->SelectionRunLeft(from, to, startX, width) == startX);
+    }
+  }
+
+  GIVEN("a right-to-left word") {
+    auto group = MakeCell(kHebrew);
+    EditorCell *editor = group->GetEditable();
+    REQUIRE(editor != nullptr);
+
+    THEN("the rectangle starts at the *last* selected character instead") {
+      const wxCoord startX = editor->PositionToPoint(from).x;
+      const wxCoord endX = editor->PositionToPoint(to).x;
+      // Reading right to left, a later position is further left.
+      REQUIRE(endX < startX);
+      const wxCoord width = startX - endX;
+
+      const wxCoord left = editor->SelectionRunLeft(from, to, startX, width);
+      // Taking the run's start as the left edge would have highlighted the text
+      // *after* the selection; the rectangle has to sit over the glyphs.
+      REQUIRE(left == endX);
+      REQUIRE(left + width == startX);
+    }
+  }
+}
+
 class TestApp : public wxApp {
 public:
   bool OnInit() override { return true; }


### PR DESCRIPTION
The other half of #2168, and I should say so plainly: **that PR moved this
breakage rather than removing it.**

`MarkSelection()` takes `PositionToPoint(lineStart)` as the left edge of its
rectangle and extends it rightwards by the width of the selected text. Making
`PositionToPoint()` correct for right-to-left text made that assumption wrong: on
such a line the *first* selected character sits at the run's **right** edge, so
the highlight landed on the text following the selection. Before #2168 both were
wrong and cancelled out.

## The fix

`SelectionRunLeft()` starts the rectangle a run-width further left where the line
reads right to left — where the run's last character is drawn. It derives that
from the run's own start and width rather than from `PositionToPoint(runEnd)`, so
the rectangle stays exactly as wide as the text it covers even if the two
disagree by a rounding.

Mixed-direction lines are excluded by the same predicate as the caret and keep
their previous behaviour.

## The test was checked to bite

It asserts the rectangle covers the selected glyphs in both scripts, reached from
opposite ends. With the fix removed it fails on precisely that assertion
(`37 assertions, 1 failed`) and passes again once restored.

Doing that check caught a trap worth recording: my first attempt at breaking the
code didn't compile under `-Werror` (unused parameter), so the test ran against a
**stale binary** and reported everything passing — which would have "confirmed" a
vacuous test.

36 of 36 tests pass, with no display in the environment.

Still open in the bidi work: lines that genuinely mix scripts (they need the real
algorithm, and are deliberately left alone), and the unexplained token-order
effect in code lines whose first strong character is right-to-left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XPDxkWgQan8Qbb89drnjz
