### PR TITLE
Offer Hebrew and Arabic, seeded rather than translated

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Current development version
 
+- Hebrew and Arabic can now be chosen as the interface language. Both are only
+  seeded, not translated: they cover the thirty menu and dialog words that mean
+  the same in every desktop application and leave the rest in English. What they
+  do give is a way to run wxMaxima right-to-left without changing the system
+  locale, and a starting point for anyone who wants to take one of these
+  languages on -- the entries were not written or reviewed by a speaker, and are
+  meant to be overwritten.
+
 - In a right-to-left user interface language (Hebrew, Arabic, Farsi, Urdu) the
   text of comment, title and section cells is now set flush right instead of
   flush left, and the caret and mouse follow it. The furniture of the page

--- a/locales/wxMaxima/ar.po
+++ b/locales/wxMaxima/ar.po
@@ -1,0 +1,162 @@
+# Partial Arabic translation of wxMaxima.
+#
+# A seed rather than a translation: it covers only the couple of dozen menu and
+# dialog words that mean the same in every desktop application, and leaves the
+# other ~1875 strings to fall back to English. It exists so that wxMaxima can be
+# run right-to-left at all, and so that whoever takes this language on has
+# somewhere to start rather than an empty file.
+#
+# These entries were not written by a Arabic speaker and have not been reviewed
+# by one. They are the standard renderings used across desktop environments, but
+# where a language admits more than one form - imperative against gerund for menu
+# verbs, say - the choice here is a guess at the most common one. Corrections are
+# welcome and should simply overwrite what is here.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wxMaxima\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 12:00+0200\n"
+"PO-Revision-Date: 2026-07-31 12:00+0200\n"
+"Last-Translator: unreviewed seed, see the note above\n"
+"Language-Team: none yet\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n\n"
+
+
+#: ../../src/main.cpp:439
+msgid "File"
+msgstr "ملف"
+
+#: ../../src/wxMaximaFrame.cpp:836
+msgid "View"
+msgstr "عرض"
+
+#: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
+msgid "Help"
+msgstr "مساعدة"
+
+#: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593 ../../src/wxMaxima.cpp:6074
+msgid "Open"
+msgstr "فتح"
+
+#: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
+msgid "Save"
+msgstr "حفظ"
+
+#: ../../src/wxMaxima.cpp:11203
+msgid "Cancel"
+msgstr "إلغاء"
+
+#: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
+msgid "OK"
+msgstr "موافق"
+
+#: ../../src/ToolBar.cpp:209 ../../src/Worksheet.cpp:1290
+#: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
+#: ../../src/Worksheet.cpp:1684
+msgid "Copy"
+msgstr "نسخ"
+
+#: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
+#: ../../src/Worksheet.cpp:1685
+msgid "Paste"
+msgstr "لصق"
+
+#: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
+msgid "Cut"
+msgstr "قص"
+
+#: ../../src/ToolBar.cpp:191
+msgid "Undo"
+msgstr "تراجع"
+
+#: ../../src/ToolBar.cpp:192
+msgid "Redo"
+msgstr "إعادة"
+
+#: ../../src/ToolBar.cpp:184
+msgid "Print"
+msgstr "طباعة"
+
+#: ../../src/ToolBar.cpp:174
+msgid "New"
+msgstr "جديد"
+
+#: ../../src/main.cpp:438
+msgid "Exit"
+msgstr "خروج"
+
+#: ../../src/wxMaximaFrame.cpp:1550
+msgid "No"
+msgstr "لا"
+
+#: ../../src/ToolBar.cpp:222
+msgid "Find"
+msgstr "بحث"
+
+#: ../../src/wxMaximaFrame.cpp:1963
+msgid "About"
+msgstr "حول"
+
+#: ../../src/ToolBar.cpp:199
+msgid "Options"
+msgstr "خيارات"
+
+#: ../../src/main.cpp:437
+msgid "Preferences"
+msgstr "تفضيلات"
+
+#: ../../src/wxMaximaFrame.cpp:314
+msgid "Insert"
+msgstr "إدراج"
+
+#: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
+#: ../../src/wxMaximaFrame.cpp:673
+msgid "Select all"
+msgstr "تحديد الكل"
+
+#: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
+#: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
+#: ../../src/WXMXformat.cpp:332 ../../src/WXMXformat.cpp:362
+#: ../../src/wxMaxima.cpp:3020 ../../src/wxMaxima.cpp:4163
+#: ../../src/wxMaxima.cpp:4222 ../../src/wxMaxima.cpp:4231
+#: ../../src/wxMaxima.cpp:4491 ../../src/wxMaxima.cpp:4502
+#: ../../src/wxMaxima.cpp:4605 ../../src/wxMaxima.cpp:4634
+#: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
+#: ../../src/wxMaxima.cpp:11166
+msgid "Error"
+msgstr "خطأ"
+
+#: ../../src/MathParser.cpp:1229 ../../src/wxMaxima.cpp:3296
+#: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
+#: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
+msgid "Warning"
+msgstr "تحذير"
+
+#: ../../src/wxMaximaFrame.cpp:626
+msgid "&File"
+msgstr "&ملف"
+
+#: ../../src/wxMaximaFrame.cpp:689
+msgid "&Edit"
+msgstr "&تحرير"
+
+#: ../../src/wxMaximaFrame.cpp:1968
+msgid "&Help"
+msgstr "&مساعدة"
+
+#: ../../src/wxMaximaFrame.cpp:1780
+msgid "&Plot"
+msgstr "&رسم"
+
+#: ../../src/wxMaximaFrame.cpp:1870
+msgid "&Numeric"
+msgstr "&عددي"
+
+#: ../../src/wxMaximaFrame.cpp:1763
+msgid "&List"
+msgstr "&قائمة"

--- a/locales/wxMaxima/he.po
+++ b/locales/wxMaxima/he.po
@@ -1,0 +1,162 @@
+# Partial Hebrew translation of wxMaxima.
+#
+# A seed rather than a translation: it covers only the couple of dozen menu and
+# dialog words that mean the same in every desktop application, and leaves the
+# other ~1875 strings to fall back to English. It exists so that wxMaxima can be
+# run right-to-left at all, and so that whoever takes this language on has
+# somewhere to start rather than an empty file.
+#
+# These entries were not written by a Hebrew speaker and have not been reviewed
+# by one. They are the standard renderings used across desktop environments, but
+# where a language admits more than one form - imperative against gerund for menu
+# verbs, say - the choice here is a guess at the most common one. Corrections are
+# welcome and should simply overwrite what is here.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wxMaxima\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 12:00+0200\n"
+"PO-Revision-Date: 2026-07-31 12:00+0200\n"
+"Last-Translator: unreviewed seed, see the note above\n"
+"Language-Team: none yet\n"
+"Language: he\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n\n"
+
+
+#: ../../src/main.cpp:439
+msgid "File"
+msgstr "קובץ"
+
+#: ../../src/wxMaximaFrame.cpp:836
+msgid "View"
+msgstr "תצוגה"
+
+#: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
+msgid "Help"
+msgstr "עזרה"
+
+#: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593 ../../src/wxMaxima.cpp:6074
+msgid "Open"
+msgstr "פתח"
+
+#: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
+msgid "Save"
+msgstr "שמור"
+
+#: ../../src/wxMaxima.cpp:11203
+msgid "Cancel"
+msgstr "ביטול"
+
+#: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
+msgid "OK"
+msgstr "אישור"
+
+#: ../../src/ToolBar.cpp:209 ../../src/Worksheet.cpp:1290
+#: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
+#: ../../src/Worksheet.cpp:1684
+msgid "Copy"
+msgstr "העתק"
+
+#: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
+#: ../../src/Worksheet.cpp:1685
+msgid "Paste"
+msgstr "הדבק"
+
+#: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
+msgid "Cut"
+msgstr "גזור"
+
+#: ../../src/ToolBar.cpp:191
+msgid "Undo"
+msgstr "בטל"
+
+#: ../../src/ToolBar.cpp:192
+msgid "Redo"
+msgstr "בצע שוב"
+
+#: ../../src/ToolBar.cpp:184
+msgid "Print"
+msgstr "הדפס"
+
+#: ../../src/ToolBar.cpp:174
+msgid "New"
+msgstr "חדש"
+
+#: ../../src/main.cpp:438
+msgid "Exit"
+msgstr "יציאה"
+
+#: ../../src/wxMaximaFrame.cpp:1550
+msgid "No"
+msgstr "לא"
+
+#: ../../src/ToolBar.cpp:222
+msgid "Find"
+msgstr "חפש"
+
+#: ../../src/wxMaximaFrame.cpp:1963
+msgid "About"
+msgstr "אודות"
+
+#: ../../src/ToolBar.cpp:199
+msgid "Options"
+msgstr "אפשרויות"
+
+#: ../../src/main.cpp:437
+msgid "Preferences"
+msgstr "העדפות"
+
+#: ../../src/wxMaximaFrame.cpp:314
+msgid "Insert"
+msgstr "הוסף"
+
+#: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
+#: ../../src/wxMaximaFrame.cpp:673
+msgid "Select all"
+msgstr "בחר הכל"
+
+#: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
+#: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
+#: ../../src/WXMXformat.cpp:332 ../../src/WXMXformat.cpp:362
+#: ../../src/wxMaxima.cpp:3020 ../../src/wxMaxima.cpp:4163
+#: ../../src/wxMaxima.cpp:4222 ../../src/wxMaxima.cpp:4231
+#: ../../src/wxMaxima.cpp:4491 ../../src/wxMaxima.cpp:4502
+#: ../../src/wxMaxima.cpp:4605 ../../src/wxMaxima.cpp:4634
+#: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
+#: ../../src/wxMaxima.cpp:11166
+msgid "Error"
+msgstr "שגיאה"
+
+#: ../../src/MathParser.cpp:1229 ../../src/wxMaxima.cpp:3296
+#: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
+#: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
+msgid "Warning"
+msgstr "אזהרה"
+
+#: ../../src/wxMaximaFrame.cpp:626
+msgid "&File"
+msgstr "&קובץ"
+
+#: ../../src/wxMaximaFrame.cpp:689
+msgid "&Edit"
+msgstr "&עריכה"
+
+#: ../../src/wxMaximaFrame.cpp:1968
+msgid "&Help"
+msgstr "&עזרה"
+
+#: ../../src/wxMaximaFrame.cpp:1780
+msgid "&Plot"
+msgstr "&תרשים"
+
+#: ../../src/wxMaximaFrame.cpp:1870
+msgid "&Numeric"
+msgstr "&מספרי"
+
+#: ../../src/wxMaximaFrame.cpp:1763
+msgid "&List"
+msgstr "&רשימה"

--- a/src/dialogs/ConfigDialogue.cpp
+++ b/src/dialogs/ConfigDialogue.cpp
@@ -181,6 +181,7 @@ ConfigDialogue::ConfigDialogue(wxWindow *parent)
       "processes. Allows more than one gcl-compiled maxima to run at the "
       "same time, but might provoke crashes.");
   m_languages[_("(Use default language)")] = wxLANGUAGE_DEFAULT;
+  m_languages[_("Arabic")] = wxLANGUAGE_ARABIC;
   m_languages[_("Catalan")] = wxLANGUAGE_CATALAN;
   m_languages[_("Chinese (Simplified)")] = wxLANGUAGE_CHINESE_SIMPLIFIED;
   m_languages[_("Chinese (traditional)")] = wxLANGUAGE_CHINESE_TRADITIONAL;
@@ -192,6 +193,7 @@ ConfigDialogue::ConfigDialogue(wxWindow *parent)
   m_languages[_("Galician")] = wxLANGUAGE_GALICIAN;
   m_languages[_("German")] = wxLANGUAGE_GERMAN;
   m_languages[_("Greek")] = wxLANGUAGE_GREEK;
+  m_languages[_("Hebrew")] = wxLANGUAGE_HEBREW;
   m_languages[_("Hungarian")] = wxLANGUAGE_HUNGARIAN;
   m_languages[_("Italian")] = wxLANGUAGE_ITALIAN;
   m_languages[_("Japanese")] = wxLANGUAGE_JAPANESE;


### PR DESCRIPTION
Right-to-left layout has worked since the interface language could ask for it —
but only a user whose whole system already ran in Hebrew or Arabic could reach it.
The language list offers exactly those languages wxMaxima has a catalogue for, and
there was none for either.

Both now have one: the **30** menu and dialog words that mean the same in every
desktop application — File, View, Help, Open, Save, Cancel, Copy, Paste, Error,
Warning and the like — with the other ~1870 strings falling back to English. A
partially translated interface is a normal thing; one that cannot be reached at
all is not.

## These are seeds, and say so

They were **not written or reviewed by a speaker** of either language. So:

* `Last-Translator` records that rather than naming anyone, and `Language-Team`
  says there is none yet;
* a note at the top invites whoever takes the language on to simply overwrite
  what is here;
* the words are the standard renderings across desktop environments, but where a
  language admits more than one form — Hebrew menu verbs are imperative on
  Windows, gerunds on GNOME — the choice is consistent and flagged as a guess.

Hebrew and Arabic are added **together**, deliberately. **Farsi is left out**:
even "File" has two live variants there (فایل, پرونده), which is exactly the
uncertainty this was meant to avoid.

## Verified

Both pass `msgfmt -c` and neither has an accelerator mismatch, so the
`check-translations` gate from #2161 is satisfied. 36 of 36 unit tests pass.

Checked on screen under `LANG=he_IL.UTF-8`: six of the thirteen menus read Hebrew,
right to left — קובץ, עריכה, תצוגה … רשימה, תרשים, מספרי, עזרה.

## What cost a second pass

The words on the menu bar are `&File` and `&Edit`, **not** `File` and `Edit` — the
plain forms are used elsewhere in the program. Translating only the plain ones
left the menu bar almost entirely English. The catalogue statistics looked
identical either way; only the screenshot showed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XPDxkWgQan8Qbb89drnjz
