### PR TITLE
Stop asking Weston to run the tests, since it never did

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,13 +38,19 @@ trap \"rm -rf $XDG_RUNTIME_DIR\" EXIT
 unset DISPLAY
 unset WAYLAND_DISPLAY
 
-# 2. Try Weston (Wayland)
-if command -v weston >/dev/null 2>&1; then
-    export GDK_BACKEND=wayland
-    echo \"Attempting headless Weston...\" >&2
-    # Use exec to ensure signals from ctest reach the process and it's dead on timeout
-    exec weston --backend=headless -- \"$@\"
-fi
+# 2. Weston is deliberately not used.
+#
+# This used to try \"weston --backend=headless -- <test>\" first. Weston 13
+# answers that with \"fatal: unhandled option: --\" and runs nothing, so every
+# test on a machine that has weston installed failed in a hundredth of a second.
+# It went unnoticed for as long as nothing invoked this wrapper; the moment the
+# unit tests were moved onto it, every GUI test on the Ubuntu CI - which has
+# weston - broke, while this machine, which does not, saw nothing.
+#
+# X11 under Xvfb is what wxMaxima is actually tested against, so that is what
+# this uses. Should Wayland coverage ever be wanted it needs a working
+# invocation - weston started in the background, WAYLAND_DISPLAY exported, the
+# client run separately - and a CI job that proves it.
 
 # 3. Try xvfb-run (X11)
 if command -v xvfb-run >/dev/null 2>&1; then


### PR DESCRIPTION
**Fixes the Ubuntu CI**, broken by #2169.

The headless wrapper tried `weston --backend=headless -- <test>` before anything
else. Weston 13 answers that with

```text
fatal: unhandled option: --
fatal: unhandled option: /home/runner/.../test_EditorCellBidi
```

runs nothing, and exits. So on any machine that *has* weston, every test going
through the wrapper failed in a hundredth of a second — 26 of them on
`compile_latest_and_test`.

## Why it went unnoticed

Nothing invoked the wrapper until #2169 moved the unit tests onto it, so that line
had never executed. And **this development machine has no weston**, so every local
run took the `xvfb-run` path and passed. No amount of running the suite here would
have shown it; only a machine with weston installed could.

## The fix

X11 under Xvfb is what wxMaxima is actually tested against, so the wrapper goes
straight to it.

The weston attempt is **removed rather than repaired**. A corrected invocation —
weston in the background, `WAYLAND_DISPLAY` exported, the client run separately —
would be exactly as untested as the one being removed, and this isn't the change
in which to discover that. What it would take is written where the attempt used to
be, so the option stays open.

## Verification

Checked the way CI sees it rather than the way this machine does: with a `weston`
on `PATH` that fails exactly as the real one does, the wrapper ignores it and
**36 of 36 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XPDxkWgQan8Qbb89drnjz
