### PR TITLE
Carry the worksheet inside the exported PDF

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Current development version
 
+- The LaTeX export can carry the worksheet inside the PDF. With "Export
+  contains the .wxmx file" set -- the same preference the HTML export already
+  used to offer the session as a download -- the exported document embeds the
+  .wxmx as a file attachment, so the PDF and the session that produced it cannot
+  become separated. `wxworksheettotex("f.tex", wxmx=true)` does the same from
+  within Maxima, matching `wxworksheettohtml`.
+
 - Hebrew and Arabic can now be chosen as the interface language. Both are only
   seeded, not translated: they cover the thirty menu and dialog words that mean
   the same in every desktop application and leave the rest in English. What they

--- a/src/MaximaResponseReader.cpp
+++ b/src/MaximaResponseReader.cpp
@@ -109,7 +109,8 @@ void MaximaResponseReader::ReadWorksheetExport(const wxXmlDocument &xmldoc) {
   if (type == wxS("html"))
     m_wxMaxima.ExportWorksheetToHtml(file, flavor, wxmx);
   else if (type == wxS("tex"))
-    m_wxMaxima.ExportWorksheetToTex(file, documentclass, documentclassOptions);
+    m_wxMaxima.ExportWorksheetToTex(file, documentclass, documentclassOptions,
+                                    wxmx);
   else
     m_wxMaxima.m_outputAppender.DoRawConsoleAppend(
       wxString::Format(

--- a/src/worksheet/Worksheet.cpp
+++ b/src/worksheet/Worksheet.cpp
@@ -3701,7 +3701,8 @@ void Worksheet::CodeCellVisibilityChanged() {
 bool Worksheet::ExportToTeX(const wxString &file) {
   // Show a busy cursor as long as we export.
   wxBusyCursor crs;
-  return WorksheetExport::ExportToTeX(GetTree(), m_configuration, file);
+  return WorksheetExport::ExportToTeX(GetTree(), m_configuration, file,
+                                      &GetViewCellPointers(), GetHCaret());
 }
 
 void Worksheet::LoadSymbols() { m_autocomplete.LoadSymbols(); }

--- a/src/worksheet/WorksheetExport.cpp
+++ b/src/worksheet/WorksheetExport.cpp
@@ -715,6 +715,14 @@ void WriteTeXPreamble(wxTextOutputStream &output, Configuration *configuration) 
   // that plays in PDF viewers supporting it (and shows the first frame in the
   // rest).
   output << wxS("\\usepackage{animate}\n");
+
+  // Carries the worksheet itself inside the PDF as a file attachment, so the
+  // document and the session that produced it cannot be separated. attachfile2
+  // rather than attachfile: the older package fails under LuaLaTeX, while this
+  // one works on pdfTeX, LuaTeX and XeTeX alike. Only loaded when there is
+  // something to attach, so nobody needs the package otherwise.
+  if (configuration->ExportContainsWXMX())
+    output << wxS("\\usepackage{attachfile2}\n");
   // We want to color the labels and text cells. The following line adds the
   // necessary logic for this to TeX.
   output << wxS("\\usepackage{color}\n");
@@ -780,7 +788,9 @@ void WriteTeXPreamble(wxTextOutputStream &output, Configuration *configuration) 
 } // namespace
 
 bool WorksheetExport::ExportToTeX(GroupCell *tree, Configuration *configuration,
-                                  const wxString &file) {
+                                  const wxString &file,
+                                  ViewCellPointers *cellPointers,
+                                  GroupCell *hCaret) {
   wxString imgDir;
   wxString path, filename, ext;
 
@@ -804,6 +814,20 @@ bool WorksheetExport::ExportToTeX(GroupCell *tree, Configuration *configuration,
   for (auto &tmp : OnList(tree)) {
     wxString s = tmp.ToTeX(imgDir, filename, &imgCounter);
     output << s << wxS("\n");
+  }
+
+  // The worksheet itself, embedded in the PDF the way the HTML export offers it
+  // for download. It is written beside the .tex, since that is what the LaTeX
+  // run has to find, and named after it.
+  if (configuration->ExportContainsWXMX()) {
+    const wxString wxmxFile = path + wxS("/") + filename + wxS(".wxmx");
+    std::vector<wxString> noVariables;
+    if (Format::ExportToWXMX(tree, wxmxFile, configuration, cellPointers,
+                             noVariables, hCaret))
+      output << wxS("\n\\attachfile[mimetype=application/zip,")
+             << wxS("description={The wxMaxima session this document was made "
+                    "from}]{")
+             << filename << wxS(".wxmx}\n");
   }
 
   //

--- a/src/worksheet/WorksheetExport.h
+++ b/src/worksheet/WorksheetExport.h
@@ -77,7 +77,8 @@ wxSize CopyToFile(const wxString &file, Cell *start, Cell *end, bool asData,
 
 //! Export the tree to a LaTeX document; images go to a <name>_img directory.
 bool ExportToTeX(GroupCell *tree, Configuration *configuration,
-                 const wxString &file);
+                 const wxString &file, ViewCellPointers *cellPointers,
+                 GroupCell *hCaret);
 
 /*! Serialize the tree as .wxm (wxm = true) or .mac lines into output.
 

--- a/src/wxMathML.lisp
+++ b/src/wxMathML.lisp
@@ -210,9 +210,11 @@
 (defun $wxworksheettohtml (filename &rest opts)
   (wxexport-emit "html" filename opts))
 
-;; wxworksheettotex("file.tex" [, documentclass=..., documentclassoptions=...])
+;; wxworksheettotex("file.tex" [, documentclass=..., documentclassoptions=...,
+;;                    wxmx=...])
 ;;   documentclass         overrides the LaTeX \documentclass (e.g. "report")
 ;;   documentclassoptions  overrides its options (e.g. "12pt,a4paper")
+;;   wxmx = true           embeds the session in the PDF as a file attachment
 (defun $wxworksheettotex (filename &rest opts)
   (wxexport-emit "tex" filename opts))
 

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -2097,7 +2097,8 @@ void wxMaxima::ExportWorksheetToHtml(const wxString &filename,
 
 void wxMaxima::ExportWorksheetToTex(const wxString &filename,
                                     const wxString &documentclass,
-                                    const wxString &documentclassOptions) {
+                                    const wxString &documentclassOptions,
+                                    bool embedWorksheet) {
   if (!GetWorksheet())
     return;
 
@@ -2106,6 +2107,8 @@ void wxMaxima::ExportWorksheetToTex(const wxString &filename,
   Configuration *const cfg = GetWorksheet()->GetConfig();
   const wxString oldClass = cfg->Documentclass();
   const wxString oldOptions = cfg->DocumentclassOptions();
+  const bool oldEmbed = cfg->ExportContainsWXMX();
+  cfg->ExportContainsWXMX(embedWorksheet);
   if (!documentclass.IsEmpty())
     cfg->Documentclass(documentclass);
   if (!documentclassOptions.IsEmpty())
@@ -2120,6 +2123,7 @@ void wxMaxima::ExportWorksheetToTex(const wxString &filename,
 
   cfg->Documentclass(oldClass);
   cfg->DocumentclassOptions(oldOptions);
+  cfg->ExportContainsWXMX(oldEmbed);
 
   if (ok) {
     StatusExportFinished();

--- a/src/wxMaxima.h
+++ b/src/wxMaxima.h
@@ -394,7 +394,8 @@ protected:
   */
   void ExportWorksheetToTex(const wxString &filename,
                             const wxString &documentclass,
-                            const wxString &documentclassOptions);
+                            const wxString &documentclassOptions,
+                            bool embedWorksheet);
 #ifdef __WXMSW__
   //! Register wxMaxima's own path as the .wxmx diff tool for TortoiseSVN/Git.
   void RegisterWxmxDiffTool();

--- a/test/unit_tests/test_WorksheetExport.cpp
+++ b/test/unit_tests/test_WorksheetExport.cpp
@@ -592,6 +592,39 @@ SCENARIO("TeX export succeeds, is deterministic and contains the document") {
     REQUIRE_FALSE(tex.Contains(wxS("\\tag{%o11}")));
   }
 
+  THEN("the worksheet itself is carried inside the PDF") {
+    // The .tex only says \attachfile; whether anything actually reaches the
+    // PDF is decided by the LaTeX run, so this asks the finished PDF rather
+    // than the source. Skipped where the tools are absent, like the compile
+    // check below.
+    const bool wanted = g_cfg->ExportContainsWXMX();
+    g_cfg->ExportContainsWXMX(true);
+    const wxString dir = MakeExportDir(wxS("tex_attach"));
+    REQUIRE(g_ws->ExportToTeX(dir + wxS("/doc.tex")));
+    g_cfg->ExportContainsWXMX(wanted);
+
+    // The worksheet is written beside the .tex, which is where LaTeX looks.
+    REQUIRE(wxFileExists(dir + wxS("/doc.wxmx")));
+
+    const wxString tex = ReadTextFile(dir + wxS("/doc.tex"));
+    REQUIRE(tex.Contains(wxS("\\usepackage{attachfile2}")));
+    REQUIRE(tex.Contains(wxS("\\attachfile")));
+
+    RequireTexCompiles(dir + wxS("/doc.tex"), wxS("pdflatex"));
+    const wxString pdf = dir + wxS("/out_pdflatex.pdf");
+    if (wxFileExists(pdf)) {
+      wxArrayString out, err;
+      if (wxExecute(wxS("pdfdetach -list \"") + pdf + wxS("\""), out, err,
+                    wxEXEC_SYNC) == 0) {
+        wxString listing;
+        for (const auto &line : out)
+          listing += line + wxS("\n");
+        INFO(listing.ToStdString());
+        REQUIRE(listing.Contains(wxS("doc.wxmx")));
+      }
+    }
+  }
+
   THEN("the exported LaTeX compiles under both engine families") {
     // pdfTeX (inputenc path) and a Unicode engine (fontspec + unicode-math
     // path); each is skipped if that binary isn't installed.


### PR DESCRIPTION
The HTML export has long been able to put a copy of the session beside the page
and link to it. The LaTeX export could not — and a PDF is exactly the format where
the two are most likely to be separated, because it gets mailed around on its own.

With `Configuration::ExportContainsWXMX` set — the same preference the HTML export
already reads — the `.wxmx` is written beside the `.tex` and embedded in the PDF as
a file attachment. `wxworksheettotex("f.tex", wxmx=true)` does the same from within
Maxima, matching `wxworksheettohtml`; the Lisp side already passed the option
through untouched, only the C++ was dropping it.

## Why attachfile2

`attachfile` builds under pdfTeX and XeTeX but dies under LuaLaTeX with an
undefined control sequence, and this preamble has to work under all three.
`attachfile2` works everywhere. Both were tried against all three engines **before
any C++ was written**, which is how the requirement was settled rather than
guessed. It is loaded only when there is something to attach, so nobody needs the
package otherwise.

## The test asks the PDF, not the .tex

Whether anything is really embedded is decided by the LaTeX run, not by the
markup, so the test checks the finished document:

```text
$ pdfdetach -list out_pdflatex.pdf
1 embedded files
1: doc.wxmx
```

and extracting it yields a worksheet whose `content.xml` opens as one. Skipped
where the tools are absent, like the compile check beside it.

36 of 36 unit tests pass.

## Note on the wider "port the HTML options to LaTeX" idea

Only this one ported. `HTMLequationFormat` (mathml/mathjax/svg/bitmap) has no
LaTeX meaning — LaTeX typesets maths natively — and `Documentclass` /
`DocumentclassOptions` / `TexPreamble` already exist on the LaTeX side. So the
option surfaces are now as aligned as they sensibly get.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XPDxkWgQan8Qbb89drnjz
