### PR TITLE
Announce Crowdin translations in README, fix un-scrollable config dialog tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ tried without rebuilding.
   3. `BreakLines_List()`: Final line wrapping.
 - **High-DPI / wxBitmapBundle:** Use `wxBitmapBundle` for SVG rendering.
 - **Windows Focus Management:** Use `CallAfter` for focus transitions (e.g., `m_searchText->SetFocus()`) to prevent the worksheet from "stealing" focus back.
+- **ConfigDialogue Tabs Must Scroll:** Every tab panel in `src/dialogs/ConfigDialogue.cpp` is a `wxScrolled<wxPanel>` with `SetScrollRate(5 * GetContentScaleFactor(), 5 * GetContentScaleFactor())` and `SetMinSize(wxSize(GetContentScaleFactor() * mMinPanelWidth, GetContentScaleFactor() * mMinPanelHeight))`. Without this, a tab's natural size (which grows with font size/DPI/translation length) can make the whole dialog taller than a hi-DPI screen with no way to reach what's cut off. When adding a new tab, copy this pattern (see `CreateWorksheetPanel()`) rather than a plain `wxPanel`.
 - **Constructor Initialization:** Order initialization lists to match header declaration order to prevent `-Wreorder` warnings.
 
 ## Performance & Documentation Mandates

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # Current development version
 
+- wxMaxima's translations can now also be contributed online via
+  <https://crowdin.com/project/wxmaxima-gui>, in addition to editing the
+  `.po` files in `locales/` directly.
+
+- The "Revert to defaults" tab of the configuration dialogue is scrollable
+  again, like every other tab. It had been left as a plain, non-scrolling
+  panel, so on a screen too short to show it in full there was no way to
+  reach the buttons below the fold.
+
 - The LaTeX export can carry the worksheet inside the PDF. With "Export
   contains the .wxmx file" set -- the same preference the HTML export already
   used to offer the session as a download -- the exported document embeds the

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ contributions are always welcome.
 
 The wxMaxima Team
 
+## Translations
+
+WxMaxima is translated by volunteers, and help with translations is always
+welcome, whether that means improving an existing translation or adding a
+new language. Translations can be contributed in either of two ways:
+
+- Directly, by editing the `.po` files in the `locales/` subdirectory
+  (see `locales/README.md` for details), or
+- Online, without needing any of the source code, via our project on
+  Crowdin: <https://crowdin.com/project/wxmaxima-gui>
+
 ## Note concerning Wayland (recent Linux/BSD distributions)
 
 There seem to be issues with the Wayland Display Server and wxWidgets.

--- a/src/dialogs/ConfigDialogue.cpp
+++ b/src/dialogs/ConfigDialogue.cpp
@@ -938,11 +938,11 @@ wxWindow *ConfigDialogue::CreateWorksheetPanel() {
 }
 
 wxWindow *ConfigDialogue::CreateRevertToDefaultsPanel() {
-  wxPanel *panel = new wxPanel(m_notebook, wxID_ANY);
-  // panel->SetScrollRate(5 * GetContentScaleFactor(),
-  //                      5 * GetContentScaleFactor());
-  // panel->SetMinSize(wxSize(GetContentScaleFactor() * mMinPanelWidth,
-  //                          GetContentScaleFactor() * mMinPanelHeight));
+  wxScrolled<wxPanel> *panel = new wxScrolled<wxPanel>(m_notebook, wxID_ANY);
+  panel->SetScrollRate(5 * GetContentScaleFactor(),
+                       5 * GetContentScaleFactor());
+  panel->SetMinSize(wxSize(GetContentScaleFactor() * mMinPanelWidth,
+                           GetContentScaleFactor() * mMinPanelHeight));
 
   wxBoxSizer *vsizer = new wxBoxSizer(wxVERTICAL);
   // WrappingStaticText *helpText1 = new WrappingStaticText(


### PR DESCRIPTION
- README: point contributors at both the .po files under locales/ and the
  Crowdin project (https://crowdin.com/project/wxmaxima-gui) for translating
  wxMaxima.
- ConfigDialogue: the "Revert to defaults" tab was left as a plain wxPanel
  with its SetScrollRate/SetMinSize calls commented out, unlike every other
  tab. On a screen too short for the dialog this made part of the tab
  unreachable, since it was the one tab that couldn't scroll.
- AGENTS.md: note the wxScrolled<wxPanel> convention every ConfigDialogue tab
  needs, so a future tab doesn't reintroduce the same gap.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDdgx8DR7G9w9B5hBZAo9R