### PR TITLE
Fix misaligned ASCII-art 2D math by wrapping blocks in explicit tags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,35 @@ tried without rebuilding.
     thread-safety of logging from that thread at all remains unverified --
     treat any such tracing as temporary/debug-only, never ship it).
 
+- **ASCII-art 2D display (`set_display('ascii)`) and `*alt-display2d*`:**
+  when `$display2d` is on, Maxima's evaluator checks the special variable
+  `*alt-display2d*` before printing a result: if it's a function symbol,
+  that function is called *instead of* Maxima's own stock printer (this is
+  how `mydispla` in `wxMathML.lisp` produces the normal `<mth>`/XML output);
+  if it's `nil`, Maxima falls through to its own built-in ASCII-art printer,
+  which pads a result's lines with literal spaces so a multi-line fraction/
+  matrix/etc. lines up correctly under the `(%oN)` label -- but that padding
+  assumes every line, including the label, ends up rendered in one uniform
+  monospace font. `wxMathML.lisp`'s `wx-ascii-displa` wraps that stock
+  printer in `<wxxml-asciimath>`/`</wxxml-asciimath>` markers *without*
+  reimplementing it: it dynamically rebinds `*alt-display2d*` to `nil` for
+  just the duration of `(displa x)`, which re-enters Maxima's own dispatch
+  and this time takes the stock ASCII path (confirmed live: this is
+  correctly reentrant-safe through Maxima's own recursive sub-expression
+  `displa` calls, e.g. matrix rows, since they run inside the same dynamic
+  extent). `Maxima::ProcessData()` only fires the corresponding
+  `XML_ASCIIMATH` event once it has seen the *complete* matching closing
+  tag, so `MaximaResponseReader::ReadAsciiMath()` always receives one whole
+  block in one piece and can render all of it in one uniform style --
+  before this, `ReadMiscText()` guessed a chunk's style from whether it
+  happened to start with `"(%"`, and since chunks are split by socket/timer
+  batching (not by where Maxima's actual output boundaries are), a block's
+  label line could land in a separate batch than its neighbors and get
+  misclassified into a different (proportional) font, breaking the
+  alignment Maxima's padding assumed -- root-caused with a raw
+  `:lisp-quiet (with-input-from-string ...)` / socket-level reproduction
+  (see the debugging technique note above) before the fix, not guessed.
+
 ### File Formats
 
 - **`.wxmx`** -- a ZIP archive holding `content.xml` (the MathML-like XML) plus

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # Current development version
 
+- Fixed misaligned ASCII-art 2D math (`set_display('ascii)`): the top/bottom
+  lines of a fraction, matrix, etc. are padded by Maxima on the assumption
+  that every line -- including the `(%oN)` label line -- renders in the same
+  monospace font. wxMaxima used to guess which lines belonged to the same
+  block from their *content* alone (whether a chunk of already-batched
+  socket data happened to start with `(%`), and since that batching is
+  timing-dependent rather than tied to Maxima's actual output boundaries,
+  the label line could land in a separate read from its neighbors and get
+  misclassified into a different, proportional font -- breaking the visual
+  alignment even though Maxima's own whitespace padding was correct.
+  `wxMathML.lisp` now wraps each complete ASCII-art block in explicit
+  `<wxxml-asciimath>`/`</wxxml-asciimath>` markers (reusing Maxima's own
+  stock ASCII printer via a `*alt-display2d*` hook, not reimplementing it),
+  so wxMaxima always renders a whole block in one uniform monospace style
+  instead of guessing per chunk.
+
 - `--batch`/`--exit-on-error` now actually halts when Maxima asks an
   interactive question it cannot auto-answer, instead of hanging forever:
   the process logs the question and exits with an error status, matching

--- a/src/Maxima.cpp
+++ b/src/Maxima.cpp
@@ -62,6 +62,7 @@ Maxima::Maxima(wxSocketBase *socket, Configuration *config) :
           m_knownTags[wxS("mth")] = XML_MATHS;
           m_knownTags[wxS("math")] = XML_MATHS;
           m_knownTags[wxS("wxxml-key")] = XML_WXXML_KEY;
+          m_knownTags[wxS("wxxml-asciimath")] = XML_ASCIIMATH;
         }
   }
   wxASSERT(socket);

--- a/src/Maxima.h
+++ b/src/Maxima.h
@@ -123,6 +123,8 @@ public:
     XML_MATHS,
     XML_TOOLONGMATHS,
     XML_WXXML_KEY,
+    //! Maxima has sent one complete block of ASCII-art 2D display output.
+    XML_ASCIIMATH,
     //! Maxima has disconnected (possibly because the process had died).
     DISCONNECTED,
     //! A write to Maxima is still ongoing. We use this event to keep the traffic indicator alive.

--- a/src/MaximaProcessManager.cpp
+++ b/src/MaximaProcessManager.cpp
@@ -771,6 +771,11 @@ void MaximaProcessManager::MaximaEvent(wxThreadEvent &event) {
     break;
   case Maxima::XML_WXXML_KEY: // TODO: Should the key be outside the SuppressOutput?
     break;
+  case Maxima::XML_ASCIIMATH:
+    m_wxMaxima.m_responseReader.ReadStdErr();
+    m_wxMaxima.m_statusBar->NetworkStatus(StatusBar::receive);
+    m_wxMaxima.m_responseReader.ReadAsciiMath(event.GetString());
+    break;
   case Maxima::READ_PENDING:
     m_wxMaxima.m_responseReader.ReadStdErr();
     m_wxMaxima.m_statusBar->NetworkStatus(StatusBar::receive);

--- a/src/MaximaResponseReader.cpp
+++ b/src/MaximaResponseReader.cpp
@@ -362,6 +362,26 @@ void MaximaResponseReader::ReadSuppressedOutput(const wxString &data) {
   });
 }
 
+void MaximaResponseReader::ReadAsciiMath(const wxString &data) {
+  if(!m_wxMaxima.GetWorksheet())
+    return;
+
+  // Maxima::ProcessData only fires this event once it has a complete
+  // <wxxml-asciimath>...</wxxml-asciimath> tag (see the class comment
+  // there), so the whole block - however many socket reads it took to
+  // arrive - is always classified and rendered as one uniform monospace
+  // unit here, unlike ReadMiscText()'s per-chunk "does this text start with
+  // (%" guess.
+  static const wxString startTag = wxS("<wxxml-asciimath>");
+  static const wxString endTag = wxS("</wxxml-asciimath>");
+  wxASSERT(data.StartsWith(startTag) && data.EndsWith(endTag));
+  wxString content = data.SubString(startTag.Length(),
+                                    data.Length() - endTag.Length() - 1);
+
+  m_wxMaxima.GetWorksheet()->SetCurrentTextCell(nullptr);
+  m_wxMaxima.m_outputAppender.DoRawConsoleAppend(content, MC_TYPE_ASCIIMATHS);
+}
+
 void MaximaResponseReader::ReadPrompt(const wxString &data) {
   m_wxMaxima.m_evalOnStartup = false;
   if(!m_wxMaxima.GetWorksheet())

--- a/src/MaximaResponseReader.h
+++ b/src/MaximaResponseReader.h
@@ -95,6 +95,11 @@ public:
   //! authentication handshake (the <wxxml-key> exchange).
   void ReadSuppressedOutput(const wxString &data);
 
+  //! Handles one complete <wxxml-asciimath>...</wxxml-asciimath> block:
+  //! Maxima's stock ASCII-art 2D display, always rendered as one uniform
+  //! monospace block instead of ReadMiscText()'s per-chunk font guess.
+  void ReadAsciiMath(const wxString &data);
+
   //! Handles a new input/question prompt: advances the evaluation queue or
   //! surfaces the question, and tracks Maxima's lisp/maxima mode.
   void ReadPrompt(const wxString &data);

--- a/src/wxMathML.lisp
+++ b/src/wxMathML.lisp
@@ -1547,6 +1547,31 @@ Submit bug reports by following the 'New issue' link on that page."))
 ;; Default to use wxMaxima's 2d XML display
 (setf *alt-display2d* 'mydispla)
 
+;; Wraps Maxima's own stock ASCII-art 2D display (the one *alt-display2d*
+;; would otherwise bypass) in <wxxml-asciimath>...</wxxml-asciimath>
+;; markers, without reimplementing any of its formatting. Maxima pads the
+;; lines above/below the label line assuming every line is later rendered
+;; in one uniform monospace font; wxMaxima used to guess which physical
+;; lines belonged to that same block from their *content* alone (whether a
+;; line of already-batched socket data happened to start with "(%") - since
+;; batching is timing-dependent, not tied to Maxima's actual block
+;; boundaries, a block's label line could land in a different socket read
+;; than its neighbors and get misclassified into a different (proportional)
+;; font, breaking the alignment Maxima's whitespace padding assumed. Explicit
+;; markers make the block boundaries unambiguous instead of guessed.
+;; Rebinding *alt-display2d* to nil for the (displa x) call - rather than
+;; calling some lower-level stock-printer function directly - re-enters
+;; Maxima's own dispatch and picks up its stock ASCII path, since nil is
+;; exactly what tells that dispatch not to redirect to an alternate printer;
+;; this also stays correct through any of Maxima's own recursive
+;; sub-expression displa calls (matrix rows, etc.), because they run inside
+;; the same dynamic extent.
+(defun wx-ascii-displa (x)
+  (format t "~%<wxxml-asciimath>")
+  (let ((*alt-display2d* nil))
+    (displa x))
+  (format t "</wxxml-asciimath>~%"))
+
 ;; Allow the user to switch between display schemes.
 (defun $set_display (tp)
   (cond
@@ -1554,7 +1579,7 @@ Submit bug reports by following the 'New issue' link on that page."))
      (setq $display2d nil))
     ((eq tp '$ascii)
      (setq $display2d t)
-     (setf *alt-display2d* nil))
+     (setf *alt-display2d* 'wx-ascii-displa))
     ((eq tp '$xml)
      (setq $display2d t)
      (setf *alt-display2d* 'mydispla))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -222,6 +222,17 @@ add_test(
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/automatic_test_files
     COMMAND wxmaxima --debug --logtostderr --pipe --batch --exit-on-error lisp_mode.wxm)
 
+# set_display('ascii): wx-ascii-displa wraps Maxima's own stock ASCII-art
+# printer in <wxxml-asciimath> markers instead of reimplementing it. The
+# worksheet is self-checking (results are compared against the same
+# expressions evaluated in the default XML display mode); with
+# --exit-on-error a wrong value, an error, or a hang in the lisp hook fails
+# the test.
+add_test(
+    NAME asciiDisplay
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/automatic_test_files
+    COMMAND wxmaxima --debug --logtostderr --pipe --batch --exit-on-error asciiDisplay.wxm)
+
 # Smoke test for the side-by-side diff viewer (wxmxdiff / --diff): it has no
 # other test and has broken silently when surrounding code changed. Loads two
 # .wxmx files in diff mode and fails on a crash or assertion.

--- a/test/automatic_test_files/asciiDisplay.wxm
+++ b/test/automatic_test_files/asciiDisplay.wxm
@@ -1,0 +1,45 @@
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 26.07.1-dev ] */
+/* [wxMaxima: comment start ]
+Regression test for set_display('ascii): wxMathML.lisp's wx-ascii-displa
+wraps Maxima's own stock ASCII-art 2D printer in
+<wxxml-asciimath>/</wxxml-asciimath> markers (by dynamically rebinding
+*alt-display2d* to nil for one (displa x) call) instead of disabling the
+hook outright, so wxMaxima can always render a whole block in one uniform
+monospace style. This is self-checking: each result is compared against
+the value computed while still in the default XML display mode, and mode
+switches themselves are also checked, so a broken wx-ascii-displa (wrong
+value, an error, or a hang) fails the test.
+   [wxMaxima: comment end   ] */
+/* [wxMaxima: input   start ] */
+ar1: sin(a/b)$
+mr1: matrix([1,2],[3,4]) . matrix([5,6],[7,8])$
+nr1: 6*7$
+/* [wxMaxima: input   end   ] */
+/* [wxMaxima: input   start ] */
+if set_display('ascii) # 'ascii then error("FAIL: set_display('ascii) did not report switching to ascii display")$
+/* [wxMaxima: input   end   ] */
+/* [wxMaxima: input   start ] */
+ar2: sin(a/b)$
+mr2: matrix([1,2],[3,4]) . matrix([5,6],[7,8])$
+nr2: 6*7$
+sin(a/b);
+matrix([1,2],[3,4]) . matrix([5,6],[7,8]);
+6*7;
+/* [wxMaxima: input   end   ] */
+/* [wxMaxima: input   start ] */
+if ar1 # ar2 then error("FAIL: a fraction's value changed across set_display('ascii)")$
+if mr1 # mr2 then error("FAIL: a matrix product's value changed across set_display('ascii)")$
+if nr1 # nr2 then error("FAIL: a plain number's value changed across set_display('ascii)")$
+/* [wxMaxima: input   end   ] */
+/* [wxMaxima: input   start ] */
+if set_display('xml) # 'xml then error("FAIL: set_display('xml) did not report switching back to xml display")$
+if 6*7 # 42 then error("FAIL: normal Maxima evaluation is broken after an ascii-display round-trip")$
+/* [wxMaxima: input   end   ] */
+/* [wxMaxima: input   start ] */
+"ascii-display round-trip test passed"$
+/* Maxima can't load/batch files which end with a comment! */
+/* [wxMaxima: input   end   ] */
+
+/* Old versions of Maxima abort on loading files that end in a comment. */
+"Created with wxMaxima 26.07.1-dev"$


### PR DESCRIPTION
set_display('ascii) makes Maxima pad a multi-line result's lines (a fraction, matrix, etc.) assuming every line - including the (%oN) label
- renders in one uniform monospace font. wxMaxima classified each incoming chunk of raw text as monospace or proportional by checking whether that chunk's content happened to start with "(%", but chunks are split by socket/timer batching rather than by Maxima's actual output boundaries, so a block's label line could land in a separate read from its neighbors and get misclassified into the wrong font, breaking the alignment.

wxMathML.lisp now wraps Maxima's own stock ASCII printer in <wxxml-asciimath>/</wxxml-asciimath> markers via a *alt-display2d* hook (wx-ascii-displa), reusing the stock printer rather than reimplementing it. Maxima::ProcessData() only fires the new XML_ASCIIMATH event once the whole tag is complete, so ReadAsciiMath() always renders one whole block in one uniform style.


Claude-Session: https://claude.ai/code/session_01UDdgx8DR7G9w9B5hBZAo9R