### PR TITLE
Fix a critical po4a data-destruction bug and #2047's manual wrapping bug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,28 +199,137 @@ tried without rebuilding.
 
 ### Translations (`locales/`)
 
-- **One combined `.po` per language, in `locales/wxMaxima/`:** it covers both
-  wxMaxima's own UI strings (`xgettext`-extracted from `src/**/*.cpp`/`*.h`)
-  and the manual's prose (`po4a`-extracted from `info/wxmaxima.md`), merged
-  into a single catalog -- a translator only needs one file per language.
-  `locales/wxMaxima/wxMaxima.pot`, the template both `msgmerge` and Crowdin
-  work against, is regenerated as the union of a fresh source scan and
-  `locales/manual/wxmaxima.md.pot` (`msgcat --use-first`, preferring
-  `wxMaxima.pot`'s own header) by the `update-locale` CMake target -- so this
-  stays merged on every future update instead of re-diverging into two
-  catalogs again. `locales/manual/wxmaxima.md.pot` itself still exists (it's
-  `po4a`'s own intermediate template, scoped to just the manual's msgids) but
-  there is no more `locales/manual/*.po`: `po4a.cfg`'s `$lang:` path points at
-  `locales/wxMaxima/$lang.po` instead, and `po4a` looks up each of its own
-  (manual-only) msgids there, ignoring the UI-only entries it has no
-  matching source line for.
-- **Don't run this sandbox's `po4a` (0.69) against real translated content.**
-  See `CheckPo4aVersion.cmake`'s corruption warning above -- verifying a
-  change to the translation *pipeline* (`po4a.cfg.in`, the CMake wiring) is
-  fine without running `po4a` itself; regenerating actual `.po`/`.md` output
-  needs a real `po4a` >= 0.70, which wasn't reachable from this sandbox
-  (`apt` only has 0.69; Debian's package archive and po4a's own GitHub
-  releases were both unreachable through this sandbox's proxy).
+- **One combined `.po` per language, in `locales/wxMaxima/`, is the file a
+  translator edits.** It covers both wxMaxima's own UI strings
+  (`xgettext`-extracted from `src/**/*.cpp`/`*.h`) and the manual's prose
+  (`po4a`-extracted from `info/wxmaxima.md`). `locales/wxMaxima/wxMaxima.pot`,
+  the template both `msgmerge` and Crowdin work against, is regenerated as
+  the union of a fresh source scan and `locales/manual/wxmaxima.md.pot`
+  (`msgcat --use-first`, preferring `wxMaxima.pot`'s own header) by the
+  `update-locale` CMake target.
+- **`po4a` must never be pointed at `locales/wxMaxima/<lang>.po` directly.**
+  It looks like the obvious way to keep the manual's translations inside the
+  combined file (`po4a.cfg`'s `$lang:` path *was* set to
+  `locales/wxMaxima/$lang.po` at one point), but `po4a` doesn't treat a `.po`
+  file as something to add/update entries in - it treats it as *its own*,
+  and **rewrites it wholesale to contain only the entries it itself
+  extracted from `info/wxmaxima.md`, silently discarding everything else**.
+  Confirmed live: a language with 1000 translated UI strings and 69
+  translated manual strings dropped to 69 (the UI strings gone) after one
+  `po4a` run against the combined file - and this shipped merged to `main`
+  before being caught. `po4a` therefore keeps writing its own
+  `locales/manual/<lang>.po` (`po4a.cfg`'s `$lang:` path), exactly as before
+  the two catalogs were combined; `locales/wxMaxima/CMakeLists.txt`'s
+  `${LANG}_po` target runs `merge_manual_po.cmake` (`msgcat --use-first`) to
+  fold `locales/manual/<lang>.po` into `locales/wxMaxima/<lang>.po` *before*
+  `msgmerge`, every time - that script is the only place allowed to write
+  manual content into the combined file. `locales/manual/*.po` only exists
+  for the languages that actually have a manual translation (not the full
+  `locales/wxMaxima/*.po` language list) - `info/CMakeLists.txt` expects a
+  matching `info/wxmaxima.<lang>.md` to already exist for every language
+  `po4a.cfg`'s language list names, and doesn't create a fresh empty one, so
+  don't widen that language list to languages that have no manual
+  translation yet without also handling that.
+- **`po4a.cfg`'s manual `[type: text]` line needs `opt:"-o markdown"`
+  explicitly** - `Locale::Po4a::Text`'s own default for that option is `1`,
+  but that default does not take effect through `[type: text]`'s normal
+  invocation; confirmed live by extracting the same heading with and without
+  an explicit `-o markdown`. Without it, every markdown structural element
+  (`##` headings, list items, ...) is extracted as generic wrapped "Plain
+  text" instead of being recognized as its own no-wrap markdown construct,
+  which is what caused #2047: a translated heading long enough to wrap got a
+  literal newline inserted mid-heading when `po4a` wrote it back out,
+  turning the second half into a normal paragraph in the rendered manual.
+  The tempting broader fix, `opt:"-o neverwrap"` (disables wrapping
+  entirely), is a trap: it doesn't just change *output* wrapping, it changes
+  how `po4a` *segments source paragraphs into msgids* (each source line
+  becomes a literal embedded `\n` in the msgid instead of the paragraph
+  being one reflowed string) - confirmed live it turns 293 cleanly-matched
+  German translations into 2 clean matches + 328 fuzzy, i.e. it invalidates
+  the translation of nearly every multi-line paragraph in the whole manual,
+  for a bug that's specifically about headings. `-o markdown` alone fixes
+  the reported bug (headings/lists become their own no-wrap entries) with a
+  much smaller, semantically-justified cost: only headings, list items and
+  fenced code blocks need re-confirming as fuzzy (e.g. 293 clean -> 183
+  clean + 156 fuzzy for German - about 89 of those are headings whose old
+  msgstr still has the now-redundant leading `## ` baked in, since `po4a`
+  auto-prepends it from the `Title ##` type instead of storing it in the
+  translated text; the rest are fenced-code-block delimiters `po4a` now
+  reconstructs itself instead of storing literally, plus a handful of
+  entries that were already fuzzy for unrelated reasons - real source-text
+  edits, not a `markdown` side effect), not full paragraphs. **The old
+  translation text is not deleted** (`.po` keeps the fuzzy msgstr plus the
+  previous msgid in a `#|` comment) **but it stops appearing in the
+  generated manual** until a translator re-confirms it - `po4a-translate`
+  skips fuzzy entries by default the same way `msgfmt` does for a compiled
+  `.mo`, falling back to the untranslated English source. Don't describe
+  this fix as lossless to a translator without that caveat: a previously
+  fully-translated heading really does render in English again in
+  `info/wxmaxima.<lang>.md` until someone reviews the (mostly mechanical:
+  strip the leading `#+ `) fuzzy diff. Fixing the wrapping bug and keeping
+  every translation rendering are in tension - there's no `po4a` option that
+  gets both, since the whole point of `-o markdown` is to change what a
+  heading's msgid *is*.
+- **`locales/wxMaxima/CMakeLists.txt`'s `${LANG}_po` target needs
+  `wxMaxima.pot` in its own `DEPENDS`, not just as a plain path string
+  inside a `COMMAND` argument.** `add_custom_command(OUTPUT wxMaxima.pot
+  ...)` only creates a file-level build rule; a *different* custom command
+  (or target) that merely references that output path in a shell argument
+  gets no ordering guarantee from it. Confirmed live: after fixing the
+  manual's extraction to `-o markdown`, `make update-locale` kept producing
+  stale results (matching the pre-fix fuzzy/translated counts exactly)
+  because `wxMaxima.pot` itself hadn't been rebuilt - `${LANG}_po`'s
+  `PRE_BUILD` command still consumed yesterday's `wxMaxima.pot` on disk.
+  Fixed by declaring `DEPENDS ${LANG}.po wxMaxima.pot` on the
+  `add_custom_target(${LANG}_po ...)` line.
+- **Committing a `make update-locale` run's output means committing
+  *every* language's drift against the current C++ source, not just the
+  fix you're testing.** Running it live in this sandbox (to verify the two
+  bugs above) also picked up ~1100 real UI strings that exist in
+  `src/**/*.cpp`/`*.h` today but were missing from every committed
+  `locales/wxMaxima/*.po` and `wxMaxima.pot` (confirmed genuine, not a
+  sandbox artifact: `grep`-verified several, e.g. `Configuration.cpp`'s
+  `_("  Font cache hits: %ld")`, actually exist in the source at `HEAD` -
+  `xgettext` just hadn't been re-run against the source in a while before
+  `wxMaxima.pot` was last committed). That's real, legitimate drift, but
+  it's a separate concern from a `po4a`-pipeline bug fix - bundling ~1100
+  new untranslated strings across 24 languages into a bugfix commit buries
+  the actual fix and forces reviewers (translators included) to wade
+  through unrelated noise. After verifying a `po4a`/CMake fix works
+  end-to-end in the build directory, `git checkout --
+  locales/wxMaxima/*.po locales/wxMaxima/wxMaxima.pot` to drop that
+  incidental drift back to the committed state before committing, keeping
+  only the actual pipeline files (`po4a.cfg.in`, the `CMakeLists.txt`s,
+  `merge_manual_po.cmake`) plus whatever's scoped to the manual itself
+  (`locales/manual/*.po`, `locales/manual/wxmaxima.md.pot`,
+  `info/wxmaxima.<lang>.md`). The UI-string staleness is a legitimate
+  follow-up `make update-locale` run of its own, on its own commit.
+- **Don't run this sandbox's stock `po4a` (0.69) against real translated
+  content.** See `CheckPo4aVersion.cmake`'s corruption warning above --
+  verifying a change to the translation *pipeline*
+  (`po4a.cfg.in`/`merge_manual_po.cmake`/the CMake wiring) is fine without
+  running `po4a` itself, but regenerating actual `.po`/`.md` output needs a
+  real `po4a` >= 0.70. It wasn't reachable via any of apt (only has 0.69),
+  Debian's package archive, or po4a's own GitHub releases (both blocked by
+  this sandbox's proxy) - but a source tarball of a current release, fetched
+  outside the sandbox and handed to the agent as a file, runs perfectly well
+  unpacked with no install step beyond `PERL5LIB=<unpacked-dir>/lib`
+  pointing at its `Locale::Po4a::*` modules; the `po4a`/`po4a-updatepo`/
+  `po4a-translate`/etc. scripts at the tarball's top level need nothing else
+  to work standalone, e.g. `PERL5LIB=lib ./po4a --version`. Regenerating
+  translated content live and diffing it (`msgfmt --statistics` before/after
+  per language, matching translated-message counts) is how both bugs above
+  were actually caught, not guessed from reading `Locale::Po4a::Text`'s
+  source.
+- **`git clean -fd` after `git checkout --` on a directory wipes untracked
+  files in it too, including ones you meant to keep** (e.g. a new
+  `locales/manual/<lang>.po` restored from a scratch copy, or a brand new
+  `.cmake` helper script that was never committed yet) - it doesn't
+  distinguish "test-run droppings" from "uncommitted new work" by intent,
+  only by whether `git add` has seen the path yet. Prefer reverting only the
+  specific files that are actually wrong (or committing work-in-progress to
+  a scratch commit first) over a blanket `git checkout -- <dir> && git clean
+  -fd <dir>` once a directory has a mix of both kinds of changes in it.
 
 ## Conventions & Standards
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,26 @@
 # Current development version
 
+- Fixed a critical bug in the translation merge above: `po4a` treats the `.po`
+  file it is pointed at as its own and rewrites it wholesale on every run, so
+  pointing it directly at the combined `locales/wxMaxima/<lang>.po` (as the
+  merge originally did) silently deleted every UI translation the first time
+  `make update-locale-manual-in-source` ran with a real `po4a` >= 0.70 (a
+  language with 1000+ translated UI strings dropped to just its ~69 manual
+  translations). `po4a` now keeps writing its own `locales/manual/<lang>.po`
+  as before, and a new `merge_manual_po.cmake` step folds that into
+  `locales/wxMaxima/<lang>.po` before `msgmerge` runs, so translators still
+  only need to look in one file.
+- Fixed translated manual headings, lists and code blocks sometimes wrapping
+  incorrectly or losing their Markdown formatting after `po4a` translation
+  (#2047): `po4a`'s `[type: text]` mode needs `-o markdown` passed explicitly
+  to recognize Markdown structure -- its own default for that option does not
+  take effect through this invocation path. Existing translations of an
+  affected heading/list/code block are marked fuzzy (their translated text is
+  preserved in the `.po` file, but a fuzzy entry isn't used in the generated
+  manual until a translator re-confirms it, since the old translation's exact
+  wording no longer matches how `po4a` now segments that text) rather than
+  lost outright.
+
 - Translations: the manual's per-language translations now live merged into
   `locales/wxMaxima/*.po`, alongside wxMaxima's own UI strings, instead of a
   separate `locales/manual/*.po` per language -- so translating both only

--- a/info/wxmaxima.de.md
+++ b/info/wxmaxima.de.md
@@ -1,4 +1,4 @@
-# Das Handbuch von wxMaxima
+# The wxMaxima user manual
 
 WxMaxima ist ein graphisches Benutzerinterface (GUI) für das
 Computer-Algebrasystem Maxima. wxMaxima erlaubt die Nutzung aller Funktionen
@@ -10,9 +10,9 @@ beliebtesten graphischen Benutzerumgebung für Maxima gemacht haben.
 
 ______________________________________________________________________
 
-# Einführung in wxMaxima
+# Introduction to wxMaxima
 
-## _Maxima_ und wxMaxima
+## _Maxima_ and wxMaxima
 
 Im Open-Source-Bereich ist es üblich, große Systeme in kleine Projekte
 aufzuteilen, die jeweils klein genug sind, dass eine endliche Menge an
@@ -43,12 +43,7 @@ numerische Lösungen existieren.
 ![Maxima Screenshot, Kommandozeile](./maxima_screenshot.png){
 id=img_maxima_screenshot }
 
-Umfangreiche Dokumentation für Maxima ist [im Internet
-verfügbar](https://maxima.sourceforge.io/documentation.html). Teile davon
-sind auch im Hilfe-Menü von wxMaxima verfügbar. Ein Druck auf die
-Hilfe-Taste (auf den meisten Systemen ist dies die <kbd>F1</kbd>-Taste)
-springt automatisch zur Stelle im _Maxima_-Handbuch, wo das Kommando unter
-dem Cursor erklärt wird.
+Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.
 
 ### WxMaxima
 
@@ -67,7 +62,7 @@ werden, oder über das Hilfemenü.
 _wxMaxima_ lässt alle Berechnungen im Hintergrund durch das
 Kommandozeilen-Werkzeug _Maxima_ durchführen.
 
-## Grundlagen zum Arbeitsblatt
+## Workbook basics
 
 wxMaxima ist größtenteils selbsterklärend. [Diese
 Internetseite](https://wxMaxima-developers.github.io/wxmaxima/help.html)
@@ -75,7 +70,7 @@ bietet einige Beispiele an, wovon das "10-Minuten-Tutorial" besonders zu
 empfehlen ist. Dieses Handbuch beschreibt einige zusätzliche Aspekte von
 wxMaxima.
 
-### Der Arbeitsblatt-Ansatz
+### The workbook approach
 
 Eine der Sachen, die neue Benutzer oft verwirrt, ist, dass das Arbeitsblatt
 von wxMaxima in Zellen aufgeteilt ist, die nur auf Befehl vom Benutzer an
@@ -114,7 +109,7 @@ Untertitelzellen, Textzellen, Eingabe/Ausgabezellen und eine Bildzelle).
 
 ![Ein Beispiel verschiedener wxMaxima Zelltypen](./cell-example.png)
 
-### Zellen
+### Cells
 
 Das Arbeitsblatt ist in Zellen aufgeteilt. WxMaxima kennt die folgenden
 Zelltypen:
@@ -142,7 +137,7 @@ Maxima ignoriert */`.
 
 "`/*`" markiert den Beginn des Kommentars, "`*/`" das Ende.
 
-### Horizontale und vertikale Cursors
+### Horizontal and vertical cursors
 
 Wenn in einer Textverarbeitung versucht wird, einen Satz auszuwählen, wird
 diese versuchen, Beginn und Ende der Auswahl so zu verschieben, dass ganze
@@ -159,12 +154,7 @@ wechselt zwischen ihnen nach Bedarf:
   wird mit dem Mauszeiger oder den Cursortasten in einer Textzelle aktiviert
   und funktioniert ähnlich wie in einem Text-Editor.
 
-When you start wxMaxima, you will only see the blinking horizontal
-cursor. If you start typing, a math cell will be automatically created and
-the cursor will change to a regular vertical one (you will see a right arrow
-as "prompt", after the Math cell is evaluated
-(<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`,
-`(%o1)`).
+When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as "prompt", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).
 
 ![(Blinkender) Horizontaler Cursor nachdem wxMaxima gestartet
 wurde](./horizontal-cursor-only.png){ id=img_horizontal_cursor_only }
@@ -183,33 +173,19 @@ Zellen-Menüs).
 Zellen](./horizontal-cursor-between-cells.png){
 id=img_horizontal_cursor_between_cells }
 
-### Eingabezellen an_Maxima schicken
+### Sending cells to Maxima
 
-Die Befehle in einer Codezelle werden ausgeführt, sobald die
-<kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> oder
-<kbd>ENTER</kbd> Taste im Nummernblock gedrückt wird. Standardmässig nimmt
-_wxMaxima_ Befehle mit <kbd>CTRL+ENTER</kbd> oder <kbd>SHIFT+ENTER</kbd>
-entgegen, aber _wxMaxima_ kann auch konfiguriert werden, dass Befehle nach
-<kbd>ENTER</kbd> ausgeführt werden.
+The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.
 
-### Auto-Vervollständigung
+### Command autocompletion
 
-_WxMaxima_ versucht, automatisch die Namen von Befehlen oder Variablen zu
-vervollständigen, wenn der Menüpunkt (Zellen/Vervollständige Befehl)
-angewählt wird, oder die Tastenkombination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>
-gedrückt wird. Die automatische Vervollständigung erkennt oft den Kontext,
-in dem sie ausgeführt wird, und kann beispielsweise Dateinamen oder
-Einheiten für ezUnits vorschlagen.
+_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.
 
 ![ezUnits](./ezUnits.png){ id=img_ezUnits }
 
-Außer der Vervollständigung des Namens einer Datei, einer Einheit, eines
-Kommandos oder eines Variablennamens kann für viele Befehle eine Liste der
-erwarteten Argumente angezeigt werden. Hierfür muss einfach
-<kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> gedrückt werden, oder der
-entsprechende Menüeintrag gewählt (Zelle/Zeige Parameter).
+Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).
 
-#### Griechische Zeichen
+#### Greek characters
 
 Computer speichern Zeichen meist als 8-Bit-Werte, was maximal 256
 unterschiedliche Typen von Zeichen erlaubt. Die meisten Sprachen nutzen
@@ -330,25 +306,19 @@ einzugeben:
 
 You can also use the "Symbols"-sidebar to enter these Mathematical symbols.
 
-If a special symbol isn’t in the list, it is possible to input arbitrary
-Unicode characters by pressing <kbd>ESC</kbd> \[number of the character
-(hexadecimal)\] <kbd>ESC</kbd>. Additionally the "symbols" sidebar has a
-right-click menu that allow to display a list of all available Unicode
-symbols one can add to this toolbar or to the worksheet.
+If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \[number of the character (hexadecimal)\] <kbd>ESC</kbd>. Additionally the "symbols" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.
 
-<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> erzeugt daher ein `a`.
+<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.
 
 Viele der Unicode-Symbole (mit der Ausnahme der logischen Verknüpfungen)
 haben keine direkte Entsprechung in _Maxima_ und werden daher als normale
 Zeichen interpretiert. Falls _Maxima_ eine Lisp-Version verwendet, die
 Unicode nicht unterstützt, kann das eine Fehlermeldung verursachen.
 
-Es kann passieren, dass z.B. griechische Buchstaben oder mathematische
-Symbole in der ausgewählten Schriftart nicht vorhanden sind, dann können sie
-nicht dargestellt werden. Um das Problem zu lösen, bitte eine andere
-Schriftart wählen (Bearbeiten -> Einstellungen -> Stil).
+It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.
+To solve that problem, select other fonts (using: Edit -> Configure -> Style).
 
-### Unicode Ersetzung
+### Unicode replacement
 
 wxMaxima will replace several Unicode characters with their respective
 Maxima expressions, e.g. `²` with `^2`, `³` with `^3`, the square root sign
@@ -370,7 +340,7 @@ math input does not contain them; (b) if you save the document as
 changes will of course not work in command line Maxima); but they may occur,
 if you cut&paste a formula from another document.
 
-### Seitenleisten
+### Side Panes
 
 Die meisten _Maxima_-Befehle, ein Inhaltsverzeichnis, Debug-Meldungen oder
 die Liste der zuletzt verwendeten Befehle werden in Seitenleisten angeboten,
@@ -390,7 +360,7 @@ next higher or lower heading type.
 pane](./Sidepane-TOC-convert-headings.png){ id=Sidepane-TOC-convert-headings
 }
 
-### MathML-Ausgabe
+### MathML output
 
 Einige Textverarbeitungen verstehen entweder
 [MathML](https://www.w3.org/Math/) oder (wie LibreOffice) haben einen
@@ -398,7 +368,7 @@ Formeleditor, der die Option “importiere MathML aus der Zwischenablage”
 unterstützt. Andere unterstützen Mathematik im RTF-Format. _wxMaxima_ bietet
 daher einige entsprechende Optionen im Rechtsklick-Menü an. 
 
-### Markdown Unterstützung
+### Markdown support
 
 _WxMaxima_ unterstützt einige
 [Markdown](https://en.wikipedia.org/wiki/Markdown)-Kommandos, die nicht mit
@@ -406,31 +376,34 @@ Konstrukten kollidieren, die in mathematischen Formeln vorkommen. Eines
 dieser Elemente sind Aufzählungen:
 
 ```text
-Normaler Text
- * Ein eingerückter Aufzählungspunkt
- * Ein zweiter Aufzählungspunkt
-   * Eine Aufzählung in der Aufzählung
-   * Ein zweiter Aufzählungspunkt der Aufzählung in der Aufzählung
- * Ein Punkt in der äußeren Aufzählung
-Normaler text
+Ordinary text
+ * One item, indentation level 1
+ * Another item at indentation level 1
+   * An item at a second indentation level
+   * A second item at the second indentation level
+ * A third item at the first indentation level
+Ordinary text
 ```
 
-_WxMaxima_ erkennt Text, der mit einem `>` beginnt, als ein Zitat:
+_WxMaxima_ will recognize text starting with `>` chars as block quotes:
 
-```text Ordinary text > quote quote quote quote > quote quote quote quote >
-quote quote quote quote Ordinary text ```
+```text
+Ordinary text
+> quote quote quote quote
+> quote quote quote quote
+> quote quote quote quote
+Ordinary text
+```
 
-Die TeX- und HTML-Ausgabe von _WxMaxima_ erkennt auch `=>` und ersetzt es
-durch das entsprechende Unicode-Symbol:
+_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:
 
-```text cogito => sum. ```
+```text
+cogito => sum.
+```
 
-Andere Symbole, die vom HTML- und TeX-Export erkannt werden, sind `<=` und
-`>=` (Vergleichsoperatoren), ein Doppelpfeil (`<=>`), einfache Pfeile
-(`<->`, `->` und `<-`) und `+/-`. Die TeX-Ausgabe erkennt zusätzlich `<<`
-und `>>`.
+Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.
 
-### Tastenkürzel
+### Hotkeys
 
 Die meisten Tastenkürzel entstammen den Menüs, was bedeutet, dass sie mit
 diesen übersetzt werden können, falls die Tastatur der aktuellen Sprache
@@ -444,12 +417,12 @@ dies erforderlich macht. Nicht dort dokumentiert ist:
 - <kbd>SHIFT</kbd>+<kbd>SPACE</kbd> fügt ein nicht-umbrechbares Leerzeichen
   ein.
 
-### Direkte Eingabe von TeX-Befehlen im TeX-Export
+### Raw TeX in the TeX export
 
 Wenn eine Textzelle mit "TeX:" beginnt, wird der Rest ihres Inhalts bei der
 Konvertierung des Dokuments nach TeX unverändert ausgegeben.
 
-## Dateiformate
+## File Formats
 
 Das Arbeitsblatt kann auf verschiedene Weisen gespeichert werden:
 
@@ -478,27 +451,24 @@ rekonstruieren, enthalten sie aber nicht.
 
 ### .wxm
 
-`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima
-versions >5.38 they can be read using _Maxima_’s `load()` function just as
-.mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as
-the answer is written in the `.wxm` file (so that it can be suggested after
-loading), but that can Maxima not evaluate.  You can prevent Maxima from
-asking questions by using `assume()` to declare some properties, Maxima
-wants to know.
+`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.
+You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.
 
 With this plain-text format, it sometimes is unavoidable that worksheets
 that use new features are not downwards-compatible with older versions of
 _wxMaxima_.
 
-#### Dateiformat von wxm-Dateien
+#### File format of wxm files
 
 This is just a plain text file (you can open it with a text editor),
 containing the cell contents as some special Maxima comments.
 
 It starts with the following comment:
 
-```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
-Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```
+```maxima
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */
+```
 
 And then the cells follow, encoded as Maxima comments, e.g. a section cell:
 
@@ -548,7 +518,7 @@ Dieses XML basiertes Dateiformat enthält das gesamte Arbeitsblatt, inklusive
 Eigenschaften wie den Zoom-Faktor oder die Watchlist. Es ist das empfohlene
 Dateiformat für wxMaxima-Arbeitsblätter.
 
-#### Dateiformat von wxmx-Dateien
+#### File format of wxmx files
 
 A `wxmx`-file seems to be a binary format, but one can handle it with tools,
 which are included in your OS. It is a zip file, one can decompress it with
@@ -574,7 +544,7 @@ with a text editor, or replace an broken image, zip the files again,
 probably rename the `zip` to a `wxmx`-file - and you get another modified
 `wxmx`-file.
 
-## Konfigurations-Optionen
+## Configuration options
 
 Einige Variablen, über die Maxima konfiguriert wird, können auf zwei Arten
 eingestellt werden:
@@ -587,13 +557,13 @@ eingestellt werden:
 ![wxMaxima Konfiguration 1](./wxMaxima_configuration_001.png){
 id=img_wxMaxima_configuration_001 }
 
-### Die Standard-Bildwiederholrate bei Animationen
+### Default animation framerate
 
 Die Bildwiederholgeschwindigkeit für Animationen wird in der Variable
 `wxanimate_framerate` gespeichert. wxMaxima setzt sie auf den Wert aus dem
 Konfigurationsdialog, wenn ein neues _Maxima_ gestartet wird.
 
-### Standardgröße der Diagramme bei neuen _Maxima_ Sitzungen
+### Default plot size for new _maxima_ sessions
 
 Beim nächsten Start werden im Arbeitsblatt eingebettete Diagramme mit dieser
 Größe erstellt, wenn der Wert von `wxplot_size` nicht geändert wird.
@@ -605,12 +575,12 @@ werden:
 wxdraw2d(
    explicit(
        x^2,
-	   x,-5,5
+       x,-5,5
    )
 ), wxplot_size=[480,480]$
 ```
 
-### Automatisches Schließen von Klammern
+### Match parenthesis in text controls
 
 Diese Option schaltet zwei Funktionen ein:
 
@@ -620,7 +590,7 @@ Diese Option schaltet zwei Funktionen ein:
 - Markierter Text wird, wenn man eine geöffnete Klammer einzugeben versucht,
   automatisch in Klammern gesetzt.
 
-### Arbeitsblatt nicht automatisch speichern
+### Don’t save the worksheet automatically
 
 Wenn diese Option gewählt ist, wird das Arbeitsblatt nur überschrieben, wenn
 der Benutzer es speichert. Ein aktuelles Backup wird in diesem Fall im
@@ -632,24 +602,17 @@ Handy-App:
 - Dateien werden beim Schließen automatisch gespeichert
 - Und die Datei wird automatisch alle 3 Minuten gespeichert.
 
-### Wo wird die Konfiguration gespeichert?
+### Where is the configuration saved?
 
-Auf Linux/Unix-Rechnern wird die Konfiguration im Home-Verzeichnis in der
-Datei `.wxMaxima` gespeichert, oder (für wxWidgets >3.1.1) in
-`.config/wxMaxima.conf` (XDG-Standard). Die wxWidgets-Version kann über
-`wxbuild_info()` oder über das Hilfe->Über-Menü abgerufen
-werden. [wxWidgets](https://www.wxwidgets.org/) ist eine Bibliothek für
-graphische Benutzeroberflächen, die auf verschiedensten Betriebssystemen
-läuft und für das `wx` im Namen von wxMaxima verantwortlich ist.
-(Da der Dateiname mit einem Punkt beginnt, ist `.wxMaxima` oder `.config`
-eine versteckte Datei).
+If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).
+(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).
 
 Unter Windows wird die Konfiguration in der Registry unter
 `HKEY_CURRENT_USER\Software\wxMaxima` gespeichert.
 
 ______________________________________________________________________
 
-# Erweiterungen für _Maxima_
+# Extensions to _Maxima_
 
 _wxMaxima_'s Hauptaufgabe ist es, die Ein- und Ausgaben von Maxima graphisch
 darzustellen. An einigen Stellen fügt es jedoch Funktionalitäten zu _Maxima_
@@ -658,7 +621,7 @@ nach HTML und LaTeX exportiert werden können, wurde erwähnt. Dieser
 Abschnitt betrachtet einige Arten, wie _wxMaxima_ die Einbindung von
 Graphiken in ein Arbeitsblatt verbessert
 
-## Variablen mit tiefgestelltem Index
+## Subscripted variables
 
 `wxsubscripts` gibt an, wie (und ob) _wxMaxima_ Variablennamen automatisch
 tiefstellen wird:
@@ -684,10 +647,9 @@ deklariert werden mittels `wxdeclare_subscript(variablenname);` oder
 Rückgängig gemacht werden kann dies mittels
 `wxdeclare_subscript(variablenname,false);`
 
-Sie können das Menü "Anzeige->Automatisches Tiefstellen" verwenden, um diese
-Werte zu setzen.
+You can use the menu "View->Autosubscript" to set these values.
 
-## Meldungen in der Statusleiste
+## User feedback in the status bar
 
 Kommandos, die lange arbeiten, können Fortschrittsinformationen in die
 Statuszeile ausgeben. Diese Informationen überschreiben deren
@@ -698,15 +660,14 @@ hat, wird sie von Maxima einfach als undefinierte Funktion betrachtet und
 nicht weiter bearbeitet.
 
 ```maxima
-    for i:1 thru 10 do (
-        /* Gib dem User Bescheid, wie weit wir schon sind */
-        wxstatusbar(concat("Pass ",i)),
-        /* (sleep n) ist eine Lisp-Funktion, die mit einem */
-        /* "?" Zeichen vorher verwendet werden kann. */
-        /* Sie verzögert die Programmausführung für n Sekunden */
-        /* (in diesem Beispiel: für 3 Sekunden). */
-        ?sleep(3)
-    )$
+for i:1 thru 10 do (
+    /* Tell the user how far we got */
+    wxstatusbar(concat("Pass ",i)),
+    /* (sleep n) is a Lisp function, which can be used */
+    /* with the character "?" before. It delays the */
+    /* program execution (here: for 3 seconds) */
+    ?sleep(3)
+)$
 ```
 
 ## Exporting the worksheet from within Maxima
@@ -717,8 +678,10 @@ scripted or batch export. Like `wxstatusbar()` it is safe to use in code
 that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present
 the command is simply left unevaluated.
 
-```maxima wxworksheettohtml("report.html")$ wxworksheettohtml("report.html",
-flavor="svg", wxmx=true)$ ```
+```maxima
+wxworksheettohtml("report.html")$
+wxworksheettohtml("report.html", flavor="svg", wxmx=true)$
+```
 
 A relative file name is interpreted relative to _Maxima_’s working
 directory. The optional keyword options are:
@@ -736,8 +699,10 @@ still lack MathML, and `svg`/`bitmap` render every equation to an image.
 The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file
 the same way:
 
-```maxima wxworksheettotex("report.tex")$ wxworksheettotex("report.tex",
-documentclass="report", documentclassoptions="12pt,a4paper")$ ```
+```maxima
+wxworksheettotex("report.tex")$
+wxworksheettotex("report.tex", documentclass="report", documentclassoptions="12pt,a4paper")$
+```
 
 | option                 | meaning                                                              |
 | ---------------------- | -------------------------------------------------------------------- |
@@ -746,12 +711,12 @@ documentclass="report", documentclassoptions="12pt,a4paper")$ ```
 
 Support for `wxworksheettopdf()` is planned.
 
-## Diagramme
+## Plotting
 
 Diagramme haben per definitionem mit einer graphischen Benutzerumgebung zu
 tun, weswegen an dieser Stelle Erweiterungen von Maxima zu erwarten sind.
 
-### Diagramme in das Arbeitsblatt einbetten
+### Embedding a plot into the worksheet
 
 _Maxima_ weist normalerweise Gnuplot an, Diagramme in eigenen Fenstern
 darzustellen. Wenn dem entsprechenden `draw` oder `plot`-Kommando ein "wx"
@@ -784,7 +749,7 @@ is most likely a Maxima issue and should be reported in the [Maxima
 bugtracker](https://sourceforge.net/p/maxima/bugs/). Or maybe a Gnuplot
 issue.
 
-### Eingebettete Diagramme größer oder kleiner machen
+### Making embedded plots bigger or smaller
 
 Wie bereits beschrieben kann die Größe von Diagrammen mittels der Variable
 `wxplot_size` definiert werden. Die plot-Funktionen von _wxMaxima_ beachten
@@ -807,12 +772,12 @@ _Maxima_ dies für die aktuelle Zelle zu machen. In diesem Beispiel wird
 nicht Teil des `wxdraw2d` Befehls.
 
 ```maxima
-    wxdraw2d(
-        explicit(
-            sin(x),
-            x,1,10
-        )
-    ),wxplot_size=[1600,800]$
+wxdraw2d(
+    explicit(
+        sin(x),
+        x,1,10
+    )
+),wxplot_size=[1600,800]$
 ```
 
 Setting the size of embedded plot with `wxplot_size` works for embedded
@@ -820,7 +785,7 @@ plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot`
 commands and for embedded animations with `with_slider_draw` and `wxanimate`
 commands.
 
-### Hochqualitativere Diagramme
+### Better quality plots
 
 _Gnuplot_ doesn’t seem to provide a portable way of determining whether it
 supports the high-quality bitmap output that the Cairo library provides. On
@@ -830,7 +795,7 @@ from the configuration menu (that can be overridden by the variable
 styles. If `wxplot_pngCairo` is set without _Gnuplot_ supporting this the
 result will be error messages instead of graphics.
 
-### Öffnen eingebetteter Diagramme in interaktiven _Gnuplot_ Fenstern
+### Opening embedded plots in interactive _Gnuplot_ windows
 
 Wenn ein Diagramm mittels einem `wxdraw`-ähnlichen Befehl erstellt wurde
 (`wxplot2d` und `wxplot3d` werden hier nicht unterstützt) und die
@@ -838,7 +803,7 @@ Gnuplot-Datei nicht allzu lang ist, bietet _wxMaxima_ einen
 Rechts-Klick-Menüpunkt an, der das Diagramm in einem interaktiven
 Gnuplot-Fenster öffnet.
 
-### Öffnen der Gnuplot Kommandozeile in `plot` Fenstern
+### Opening Gnuplot’s command console in `plot` windows
 
 On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and
 `wgnuplot.exe`.  You can configure, which command should be used using the
@@ -847,7 +812,7 @@ window, where _gnuplot_ commands can be entered into, `gnuplot.exe` does not
 offer this possibility. Unfortunately, `wgnuplot.exe` causes _Gnuplot_ to
 "steal" the keyboard focus for a short time every time a plot is prepared.
 
-### Einbetten von Animationen in das Arbeitsblatt
+### Embedding animations into the spreadsheet
 
 Es ist meist schwer, aus 3D-Diagrammen quantitative Aussagen zu
 entnehmen. Eine Alternative ist es, den 3. Parameter auf das Mausrad zu
@@ -959,19 +924,23 @@ with_slider_draw(
 )$
 ```
 
-### Mehrere Diagramme gleichzeitig in Fenstern öffnen
+### Opening multiple plots in contemporaneous windows
 
 Strenggenommen kein Feature von _wxMaxima_. Aber Maxima erlaubt auf vielen
 Systemen das folgende Beispiel von Mario Rodriguez auszuführen:
 
-```maxima load(draw);
+```maxima
+load(draw);
 
-/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));
+/* Parabola in window #1 */
+draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));
 
-/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));
+/* Parabola in window #2 */
+draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));
 
 /* Paraboloid in window #3 */
-draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```
+draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));
+```
 
 Mehrere Diagramme in einem Fenster sind auch möglich (dies ist auch möglich
 in Kommandozeilen-Maxima mit dem Standard-`draw()`-Befehl:
@@ -987,7 +956,7 @@ wxdraw(
 );
 ```
 
-### Die "Plotte mittels Draw"-Seitenleiste
+### The "Plot using draw" side pane
 
 Die "Plotte mittels Draw"-Seitenleiste enthält einen Codegenerator, der es
 erlaubt, einen Teil der Flexibilität des _draw_-Pakets von _Maxima_ zu
@@ -1011,41 +980,41 @@ Generates the skeleton of a `draw()` command that draws a 3D scene. If
 neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D
 scene that contains the command the button generates.
 
-#### Ausdruck
+#### Expression
 
 Fügt den aktuellen `draw()`-Befehl den Plot einer Kurve wie `sin(x)`,
 `x*sin(x)` oder `x^2+2*x-4` hinzu. Besteht noch kein `draw()`-Befehl, wird
 automatisch eine 2D-Szene erzeugt. Jede Szene kann beliebig viele Plots
 beinhalten.
 
-#### Impliziter Plot
+#### Implicit plot
 
 Markiert alle Punkte, an denen eine Bedingung wie `y=sin(x)`, `y*sin(x)=3`
 oder `x^2+y^2=4` erfüllt ist und zeichnet diese Kurve in das aktuelle
 Diagramm ein. Gibt es kein aktuelles Diagramm, wird ein 2D-Diagramm erzeugt.
 
-#### Parametrischer Plot
+#### Parametric plot
 
 Bewegt eine Variable von einem Start- zu einem Endwert und verwendet
 getrennte Ausdrücke wie `t*sin(t)` und `t*cos(t)`, um die x-, die y- (und in
 3D-Diagrammen auch die z-) Koordinaten zu generieren.
 
-#### Punkte
+#### Points
 
 Zeichnet eine Reihe von Punkten, die optional miteinander verbunden
 werden. Die Koordinaten der Punkte können aus einer Liste von Listen, einem
 2-dimensionalen Array oder einer Liste oder einem Array pro Achse entnommen
 werden.
 
-#### Diagrammtitel
+#### Diagram title
 
 Bestimmt den Titel des Diagramms.
 
-#### Achsen
+#### Axis
 
 Die Einstellungen für die Achsen.
 
-#### Höhenlinien
+#### Contour
 
 (Only for 3D plots): Adds contour lines similar to the ones one can find in
 a map of a mountain to the plot commands that follow in the current `draw()`
@@ -1053,32 +1022,32 @@ command and/or to the ground plane of the diagram. Alternatively, this
 wizard allows skipping drawing the curves entirely only showing the contour
 plot.
 
-#### Name des Plots
+#### Plot name
 
 Fügt einen Eintrag zur Legende hinzu, der für die nächsten Objekte gilt. Ein
 leerer Name bedeutet, dass die nun folgenden Objekte keinen eigenen Eintrag
 erhalten.
 
-#### Linienfarbe
+#### Line colour
 
 Setzt die Linienfarbe für die nun folgenden Plots des aktuellen
 draw-Befehls.
 
-#### Füllfarbe
+#### Fill colour
 
 Setzt die Füllfarbe für die nun folgenden Objekte des aktuellen
 `draw`-Kommandos.
 
-#### Gitternetz
+#### Grid
 
 Ein Assistent, der die Gitterlinien einzustellen hilft.
 
-#### Genauigkeit
+#### Accuracy
 
 Erlaubt das Wählen zwischen Geschwindigkeit und Genauigkeit bei der
 Erstellung der folgenden Kurven.
 
-### Schrift und Schriftgröße for Plots ändern
+### Modify font and font size for plots
 
 Especially when you use a high resolution display, the default font size
 might be very small. For the `draw`-based commands, you can set the font /
@@ -1106,16 +1075,18 @@ Read the Maxima and Gnuplot documentation for further information.  Note:
 Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue
 1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966).
 
-## Einbetten von Bildern
+## Embedding graphics
 
 Das `.wxmx`-Dateiformat erlaubt es, Bilder per Drag-And-Drop
 einzubetten. Manchmal (z.B. wenn die Bildinhalte sich später während einer
 Sitzung ändern könnten) ist es besser, die Bilddatei während der Auswertung
 zu laden:
 
-```maxima show_image("man.png"); ```
+```maxima
+show_image("man.png");
+```
 
-## Startbefehle
+## Startup files
 
 Der Konfigurationsdialog von _wxMaxima_ bietet an, zwei Dateien mit
 _Maxima_-Befehlen zu bearbeiten:
@@ -1133,7 +1104,7 @@ These files are in the Maxima user directory (usually `%USERPROFILE%/maxima`
 in Windows, `$HOME/.maxima` otherwise). The location can be found out with
 the command: `maxima_userdir;`
 
-## Spezielle Variablen, die wxMaxima definiert
+## Special variables wx...
 
 - `wxsubscripts` informiert _Maxima_, welche Variablen mit Unterstrich
   (z.B. `R_150`) in Variablen mit Subscript konvertieren soll. Details
@@ -1157,8 +1128,22 @@ the command: `maxima_userdir;`
 - `wxmaximaversion`: Ergibt die Versionsnummer von _wxMaxima_.
 - `wxwidgetsversion`: Ergibt die Versionsnummer der verwendeten
   wxWidgets-Version.
+- `wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these
+  differ by maintainer, distribution and operating system:
+  - `wxdirs@userconfdir`: The directory the user's configuration is stored
+    in. Same directory as `maxima_userdir` (see above) - both point at the
+    same place, `wxdirs@userconfdir` is only useful if that is more
+    convenient to reach from a `.mac` file than the Maxima-side variable.
+  - `wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the
+    built-in autocompletion list, ...) is installed in.
+  - `wxdirs@helpdir`: The directory the offline copy of this manual is
+    installed in.
+  - `wxdirs@localedir`: The directory _wxMaxima_'s translation files are
+    installed in.
+  - `wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_
+    is configured to start.
 
-## 2D-Tabellen sauber ausgeben
+## Pretty-printing 2D output
 
 Die Funktion `table_form()` konvertiert 2D-Listen in eine lesbarere
 Tabellenform als _Maxima_ selbst. Die Eingabe ist eine Liste von einer oder
@@ -1209,7 +1194,7 @@ wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]),
           lines=true, rownames=true, colnames=true, parenstyle=square);
 ```
 
-## Fehler melden
+## Bug reporting
 
 _WxMaxima_ bietet einige Funktionen für das Melden von Fehlern an:
 
@@ -1217,7 +1202,7 @@ _WxMaxima_ bietet einige Funktionen für das Melden von Fehlern an:
   Version von _wxMaxima_
 - `wxbug_report()` sagt, wo und wie Fehler gemeldet werden können
 
-## Rotes Markieren von Formelteilen
+## Marking output being drawn in red
 
 _Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a
 red foreground, if the second argument to the command is the text
@@ -1232,14 +1217,13 @@ using an (machine readable) XML-dialect (can be seen in the "Raw XML
 sidebar") and outputs the resulting formulas nicely rendered, e.g. pretty
 Matrices, Square root signs, fractions, etc.
 
-<!--- Currently that does not work as it should, the line with the output
-label is shifted right (issue: #2006) --> `set_display('ascii)` causes
-wxMaxima to output formulas as in command line Maxima - as ASCII-Art.
+<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->
+`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.
 
 `set_display('none)` bewirkt  'einzeilige' ASCII Ausgaben - dasselbe was
 (Kommandozeilen-)Maxima mit `display2d:false;` macht.
 
-# Hilfemenü
+# Help menu
 
 WxMaxima’s help menu provides access to the Maxima and wxMaxima manual,
 tips, some example worksheets and in command line Maxima included demos (the
@@ -1247,21 +1231,19 @@ tips, some example worksheets and in command line Maxima included demos (the
 
 Please notice, that the demos write:
 
-~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the
-demonstration.  ~~~
+~~~text
+At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.
+~~~
 
-That is valid for command-line Maxima, however in wxMaxima by default it is
-necessary to continue the demonstration with:
-<kbd>CTRL</kbd>+<kbd>ENTER</kbd>
+That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>
 
-(That can be configured in the Configure->Worksheet->"Hotkeys for sending
-commands to Maxima" menu.)
+(That can be configured in the Configure->Worksheet->"Hotkeys for sending commands to Maxima" menu.)
 
 ______________________________________________________________________
 
-# Fehlersuche
+# Troubleshooting
 
-## Keine Verbindung zu _Maxima_ möglich
+## Cannot connect to _Maxima_
 
 Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_
 (providing the easy-to-use user interface) are separate programs that
@@ -1280,7 +1262,7 @@ Auf Unix/Linux-Rechnern kann ein weiterer Grund sein, dass das
 "loopback"-Netzwerkgerät (erlaubt Netzwerkverbindungen zwischen 2 Prorammen
 am selben Rechner) nicht korrekt eingestellt ist.
 
-## Wie repariere ich kaputte .wxmx-Dateien?
+## How to save data from a broken .wxmx file
 
 Die meisten modernen XML-basierten Formate sind von ihrem Inhalt her
 einfache .zip-Dateien. _wxMaxima_ schaltet bei ihnen die Kompression nicht
@@ -1294,19 +1276,13 @@ processor document. If the zip signature isn’t intact that does not need to
 be the end of the world: If _wxMaxima_ during saving detected that something
 went wrong there will be a `.wxmx~` file whose contents might help.
 
-And even if there isn’t such a file: The `.wxmx` file is a container format
-and the XML portion is stored uncompressed. It it is possible to rename the
-`.wxmx` file to a `.txt` file and to use a text editor to recover the XML
-portion of the file’s contents (it starts with `<?xml version="1.0"
-encoding="UTF-8"?>` and ends with `</wxMaximaDocument>`. Before and after
-that text you will see some unreadable binary contents in the text editor).
+And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version="1.0" encoding="UTF-8"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).
 
 Wird eine Textdatei mit diesem Text (z.B. indem er mit Copy+Paste in eine
 neue Datei eingefügt wird) als `.xml`-Datei gespeichert, weiß _wxMaxima_,
 wie man den Text-Teil des Dokuments rekonstruiert.
 
-## Ich will Statusmeldungen am Bildschirm ausgeben, während mein Befehl
-ausgeführt wird
+## I want some debug info to be displayed on the screen before my command has finished
 
 Normalerweise gibt _wxMaxima_ erst etwas aus, wenn die komplette Ausgabe
 steht. Das `disp`-Kommando wird hingegen sofort ausgeführt:
@@ -1314,18 +1290,16 @@ steht. Das `disp`-Kommando wird hingegen sofort ausgeführt:
 ```maxima
 for i:1 thru 10 do (
    disp(i),
-   /* (sleep n) ist eine Lisp-Funktion, die mit einem */
-   /* "?" Zeichen vorher verwendet werden kann. */
-   /* Sie verzögert die Programmausführung für n Sekunden */
-   /* (in diesem Beispiel: für 3 Sekunden). */
+   /* (sleep n) is a Lisp function, which can be used */
+   /* with the character "?" before. It delays the */
+   /* program execution (here: for 3 seconds) */
    ?sleep(3)
 )$
 ```
 
 Alternativ kann man sich das `wxstatusbar()`-Kommando oben ansehen.
 
-## Statt eines Diagramms wird ein Briefumschlag mit einer Fehlermeldung
-dargestellt
+## Plotting only shows a closed empty envelope with an error message
 
 _wxMaxima_ konnte die Datei, die _Maxima_ _Gnuplot_ instruiert hat, zu
 generieren, nicht lesen.
@@ -1347,7 +1321,7 @@ Mögliche Gründe für diesen Fehler sind:
   `wxplot_pngcairo` to true from _Maxima_.
 - Gnuplot hat keine gültige `.png`-Datei ausgegeben.
 
-## Animationen enden in "Error: Undefined Variable"
+## Plotting an animation results in “error: undefined variable”
 
 The value of the slider variable by default is only substituted into the
 expression that is to be plotted if it is visible there. Using a `subst`
@@ -1356,7 +1330,7 @@ resolves this problem. At the end of section [Embedding animations into the
 spreadsheet](#embedding-animations-into-the-spreadsheet), you can see an
 example.
 
-## Rückgängig-machen erinnert sich nicht an das, was ich brauche
+## I lost cell content and undo doesn’t remember
 
 Es gibt zwei Rückgängigmach- Funktionen, die beide die wichtige Information
 enthalten können:
@@ -1372,23 +1346,24 @@ enthalten können:
 - Wenn nichts anderes funktioniert, bietet Maxima die Möglichkeit an, alle
   bisherigen Befehle nochmals auszuführen:
 
-```maxima playback(); ```
+```maxima
+playback();
+```
 
-## _WxMaxima_ meldet gleich beim Hochfahren "Maxima hat sich beendet."
+## _WxMaxima_ starts up with the message “Maxima process terminated.”
 
 Ein möglicher Grund ist, dass Maxima nicht dort gefunden worden kann, wo
 dies in wxMaxima's Konfigurationsdialog angegeben ist. Korrektur des dort
 angegebenen Pfades zum Programm löst dieses Problem.
 
-## Maxima hört nicht auf zu rechnen und reagiert nicht auf Eingaben
+## Maxima is forever calculating and not responding to input
 
 Theoretisch kann es passieren, daß wxMaxima nicht erkennt, dass Maxima mit
 der Berechnung fertig ist und daher nie neue Befehle an Maxima sendet. In
 diesem Fall kann der Befehl 'Trigger Evaluation' die Synchronisation wieder
 herstellen.
 
-## _Maxima_ (mit SBCL compilliert) beschwert sich über einen Mangel an
-Speicher
+## My SBCL-based _Maxima_ runs out of memory
 
 The Lisp compiler SBCL by default comes with a memory limit that allows it
 to run even on low-end computers. When compiling a big software package like
@@ -1404,27 +1379,30 @@ _wxMaxima_'s Konfigurationsdialog eingegeben werden.
 
 ![SBCL Speicherkonfiguration](./sbclMemory.png){ id=img_sbclMemory }
 
-## Ubuntu: Die Tastatur ist langsam oder ignoriert einzelne Tasten
+## Input sometimes is sluggish/ignoring keys on Ubuntu
 
 Das Installieren von `ibus-gtk` behebt dieses Problem meist. Auf
 ([https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558))
 findet man genauere Angaben dazu.
 
-## _WxMaxima_ stoppt, wenn _Maxima_ griechische Buchstaben oder Umlaute
-verarbeitet
+## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts
 
 Wenn _Maxima_ mittels SBCL compiliert wurde, können die folgenden Befehle
 zur `.sbclrc` hinzugefügt werden:
 
-```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```
+```commonlisp
+(setf sb-impl::*default-external-format* :utf-8)
+```
 
 Wo diese Datei abgelegt werden muss, ist systemabhängig. Aber ein mit SBCL
 compiliertes Maxima kann durch den folgenden Befehl angewiesen werden, den
 Ort zu nennen:
 
-```maxima :lisp (sb-impl::userinit-pathname)  ```
+```maxima
+:lisp (sb-impl::userinit-pathname)
+```
 
-## Anmerkung bezüglich Wayland (aktuelle Linux/BSD Distributionen)
+## Note concerning Wayland (recent Linux/BSD distributions)
 
 There seem to be issues with the Wayland Display Server and wxWidgets.
 WxMaxima may be affected, e.g. that sidebars are not moveable.
@@ -1456,7 +1434,7 @@ If the automatic fix fails, you can manually start wxMaxima with:
 Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or
 Microsoft’s webview2 isn’t installed.
 
-## Warum funktioniert der externe Hilfebrowser nicht unter Linux?
+## Why is the external manual browser not working on my Linux box?
 
 The HTML browser might be a snap, flatpack or appimage version. All of these
 typically cannot access files that are installed on your local
@@ -1465,8 +1443,7 @@ snap, flatpack or something else that doesn’t give the host system access to
 its contents. A third reason might be that the maxima HTML manual isn’t
 installed and the online one cannot be accessed.
 
-### Kann _wxMaxima_ das eingebettete Diagramm gleich noch als Datei
-ausgeben?
+## Can I make _wxMaxima_ output both image files and embedded plots at once?
 
 Das Arbeitsblatt enthält png-Dateien. _WxMaxima_ erlaubt dem User anzugeben,
 wo sie generiert werden sollen:
@@ -1505,39 +1482,32 @@ pngdraw2d("Test",
 );
 ```
 
-Kann ich das Seitenverhältnis eines eingebetteten Plots angeben?
+## Can I set the aspect ratio of an embedded plot?
 
 Verwenden Sie die Variable `wxplot_size`:
 
 ```maxima
-     wxdraw2d(
-         proportional_axis=xy,
-         explicit(sin(x),x,1,10)
-     ),wxplot_size=[1000,1000];
+wxdraw2d(
+    explicit(sin(x),x,1,10)
+),wxplot_size=[1000,1000];
 ```
 
-### Nach dem Upgrade auf MacOS 13.1 geben Plot- oder Draw Befehle
-Fehlermeldungen aus, wie
+## After upgrading to MacOS 13.1 plot and/or draw commands output error messages like
 
-```text 1 HIToolbox 0x00007ff80cd91726
-_ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox
-0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox
-0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```
+```text
+1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102
+2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52
+3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408
+...
+```
 
-This might be an issue with the operating system. Disable the hiding of the
-menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the
-issue. See [wxMaxima issue
-#1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more
-information.
+This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.
 
-## Fehlerprotokollierung
+## Logging
 
-Log messages might be helpful to debug problems. WxMaxima can log many
-events. Most log entries will be helpful for developers, especially in case
-of problems or bugs. If you run a "Release"-Build, the log windows is not
-shown by default, if you run a development version, it is shown by default
-as a second window. You can enable and disable this window using the
-"View->Toggle log window" menu entry.
+Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a "Release"-Build,
+the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable
+this window using the "View->Toggle log window" menu entry.
 
 Messages are not 'lost', if the log window is not shown, if you select to
 show the log window later, you will see past log messages (if you did not
@@ -1555,20 +1525,19 @@ ______________________________________________________________________
 
 # FAQ
 
-## Gibt es eine Möglichkeit mehr Text auf eine LaTeX-Seite zu schreiben?
+## Is there a way to make more text fit on a LaTeX page?
 
 Ja. Verwenden Sie das [LaTeX Paket
 "geometry"](https://ctan.org/pkg/geometry) um die Größe der Ränder
 anzugeben.
 
-Ja, gibt es. Geben Sie einfach die folgenden Zeilen im LaTeX-Vorspann
-(z.B. indem sie das entsprechende Feld im Konfigurationsdialog
-("Exportieren"->"Zusätzliche Zeilen für die LaTeX preamble") angeben, um
-Ränder von 1cm zu setzen):
+You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue ("Export"->"Additional lines for the TeX preamble"), to set borders of 1cm):
 
-```latex \usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```
+```latex
+\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}
+```
 
-## Gibt es einen Dark Mode?
+## Is there a dark mode?
 
 If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if
 the rest of the operating system is. The worksheet itself is by default
@@ -1577,18 +1546,11 @@ otherwise. Alternatively, there is a `View/Invert worksheet brightness` menu
 entry that allows to quickly convert the worksheet from dark to bright and
 vice versa.
 
-## _WxMaxima_ hängt manchmal in der ersten Minute einmal für mehrere
-Sekunden
+## _WxMaxima_ sometimes hangs for several seconds once in the first minute
 
-WxMaxima lagert große Aufgaben, wie das Interpretieren des
->1000-Seiten-Handbuchs von Maxima an Hintergrundtasks aus. Solange die
-Ergebnisse dieser Tasks nicht benötigt werden, kann während dieser Zeit ganz
-normal weitergearbeitet werden. Wird aber eine Aktion ausgeführt, für die
-die Ergebnisse eines Tasks benötigt werden, muss _wxMaxima_ warten, bis
-dieser beendet ist.
+_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.
 
-## Speziell wenn man neue Spracheinstellungen testet, kann eine
-Nachrichtenbox "locale 'xx_YY' can not be set" angezeigt werden.
+## Especially when testing new locale settings, a message box "locale ’xx_YY’ can not be set" occurs
 
 ![Locale Warnung](./locale-warning.png){ id=img_locale_warning}
 
@@ -1601,15 +1563,13 @@ Diese Übersetzungen sind möglicherweise im System nicht vorhanden. Auf
 Ubuntu/Debian Linux-Systemen können sie mit `dpkg-reconfigure locales`
 erzeugt werden.
 
-## Wie kann man Symbole für reele Zahlen, ganze Zahlen (ℝ, ℕ),
-etc. verwenden?
+## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?
 
 You can find these symbols in the Unicode sidebar (search for ’double-struck
 capital’). But the selected font must also support these symbols. If they do
 not display properly, select another font.
 
-## Wie kann ein Maxima-Skript feststellen, ob es unter wxMaxima oder
-Kommandozeilen-Maxima läuft?
+## How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?
 
 Wenn wxMaxima verwendet wird, hat die Maxima-Variable `maxima_frontend` den
 Wert wxmaxima`. Die Maxima-Variable `maxima_frontend_version` enthält dann
@@ -1620,14 +1580,11 @@ dann haben diese Variablen den Wert `false`).
 
 ## Help! I can not save my document!
 
-If saving as wxmx file does not work, try saving the document as wxm file
-(and vice versa). And you can also try to remove all output (Menu
-Cell->Remove all output) and save that file, maybe some unexpected output
-causes issues during the save process.
+If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.
 
 ______________________________________________________________________
 
-# Kommandozeilen-Optionen
+# Command-line arguments
 
 Üblicherweise werden Programme mit einer graphischen Oberfläche einfach mit
 einem Mausklick auf ein Desktop-Icon oder einen Desktop-Menüeintrag
@@ -1662,7 +1619,7 @@ Schrägstrich statt eines Minuszeichens.
 
 ______________________________________________________________________
 
-# Über das Programm, zu wxMaxima beitragen
+# About the program, contributing to wxMaxima
 
 WxMaxima wird hauptsächlich in der Programmiersprache C++ entwickelt,
 verwendet das [wxWidgets framework](https://www.wxwidgets.org), als
@@ -1690,7 +1647,4 @@ der wxWidgets-Bibliothek) sind keine externen Abhängigkeiten (z.B. externe
 Graphiken oder der Lisp-Teil (die `wxMathML.lisp`-Datei) notwendig, diese
 Dateien sind alle in wxMaxima eingebaut.
 
-If you are a developer, you might want to try out a modified
-`wxmathML.lisp`-file without recompiling everything, one can use the command
-line option `--wxmathml-lisp=<str>` to use another Lisp file, not the
-included one.
+If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.

--- a/info/wxmaxima.es.md
+++ b/info/wxmaxima.es.md
@@ -1,4 +1,4 @@
-# El manual del usuario de wxMaxima
+# The wxMaxima user manual
 
 WxMaxima es un interfaz gráfico del usuario (IGU) para el sistema algebraico
 de computación _Maxima_ (CAS). WxMaxima le permite a uno utilizar todas las
@@ -11,9 +11,9 @@ más populares para _Maxima_.
 
 ______________________________________________________________________
 
-# Introducción a wxMaxima
+# Introduction to wxMaxima
 
-## _Maxima_ y wxMaxima
+## _Maxima_ and wxMaxima
 
 En el dominio de código abierto, los sistemas grandes están divididos
 normalmente en proyectos más pequeños que son más fáciles para manipular en
@@ -53,13 +53,7 @@ resueltos.
 ![Pantallazo de Maxima, línea intrucción](./maxima_screenshot.png){
 id=img_maxima_pantallazo }
 
-Documentación extensiva para _Maxima_ está [disponible en
-Internet](https://maxima.sourceforge.io/documentation.html).  Parte de esta
-documentación además está disponible en el menú de ayuda de wxMaxima.
-Pulsando la tecla Ayuda (en muchos sistemas la tecla <kbd>F1</kbd>) causa
-que la característica de contexto de ayuda distinguible de _wxMaxima_
-automáticamente vaya a la página del manual de _Maxima_ para la instrucción
-en el cursor.
+Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.
 
 ### WxMaxima
 
@@ -81,7 +75,7 @@ _wxMaxima_, así como a través del menú de ayuda.
 Los cálculos que son introducidos en _wxMaxima_ son realizados por la
 herramienta de línea de instrucciones de _Maxima_ en el segundo plano.
 
-## Cuaderno básico
+## Workbook basics
 
 Mucho de _wxMaxima_ son auto-explicativos, pero algunos detalles requieren
 atención.  [Este
@@ -93,7 +87,7 @@ uso de _wxMAxima_ para interactuar con _Maxima_.  Este manual se concentra
 en describir aspectos de _wxMaxima_ que no son como los evidentes y que tal
 vez no está cubierto dentro del material en línea.
 
-### La aproximación del cuaderno
+### The workbook approach
 
 Una de las muy pocas cosas que no están normalizadas en _wxMaxima_ es que se
 organiza los datos para _Maxima_ dentro de celdas que son evaluadas (la cual
@@ -139,7 +133,7 @@ sección, subsección, texto, E/S e imagen).
 
 ![Ejemplo de celdas wxMaxima](./cell-example.png){ id=img_cell-example }
 
-### Celdas
+### Cells
 
 La hoja de trabajo está organizada dentro de celdas.  wxmaxima conoce los
 tipos de celdas siguientes:
@@ -166,7 +160,7 @@ ignorado por Maxima */`
 
 "`/*`" marca el inicio del comentario, "`*/`" el final.
 
-### Cursores horizontales y verticales
+### Horizontal and vertical cursors
 
 Si el usuario intenta seccionar una oración completa, un procesador de
 palabras intentará extender la selección para iniciar y finalizar
@@ -183,12 +177,7 @@ entre ellos automáticamente cuando lo necesite:
   moving the cursor inside a cell using the mouse pointer or the cursor keys
   and works much like the cursor in a text editor.
 
-Cuando arranque wxMaxima, solo verá el cursor horizontal parpadeando. Si
-inicia al teclear, automáticamente será creada una celda matemática y el
-cursor cambiará a una vertical usual (verá una flecha derecha como
-"petición", tras ser evaluada la celda matemática
-(<kbd>CTRL</kbd>+<kbd>ENTRAR</kbd>), verá las etiquetas, p.ej. `(%i1)`,
-`(%o1)`).
+When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as "prompt", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).
 
 ![(parpadeando) cursor horizontal tras iniciar
 wxMaxima](./horizontal-cursor-only.png){ id=img_horizontal_cursor_only }
@@ -206,35 +195,19 @@ celda diferente utilizando el menú).
 celdas](./horizontal-cursor-between-cells.png){
 id=img_horizontal_cursor_between_cells }
 
-### Enviar celdas a “Maxima”
+### Sending cells to Maxima
 
-La instrucción dentro de una celda de código es ejecutada una vez pulsando
-<kbd>CTRL</kbd>+<kbd>ENTRAR</kbd>, <kbd>MAYÚS</kbd>+<kbd>ENTRAR</kbd> o la
-tecla <kbd>ENTRAR</kbd> en el teclado numérico. Lo predeterminado de
-_wxMaxima_ es introducir instrucciones cuando se introduzca
-<kbd>CTRL</kbd>+<kbd>ENTRAR</kbd> o <kbd>MAYÚS</kbd>+<kbd>ENTRAR</kbd>, pero
-_wxMaxima_ puede ser configurado para ejecutar instrucciones como respuesta
-al <kbd>ENTRAR</kbd>.
+The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.
 
-### Instrucción con auto-completado
+### Command autocompletion
 
-_WxMaxima_ contiene una característica de auto-completado que es disparada a
-través del menú (Celda/Palabra Completa) o alternativamente pulsando la
-combinación de teclas <kbd>CTRL</kbd>+<kbd>ESPACIO</kbd>.  El
-auto-completado distingue MAYÚS/minús.  Por ejemplo si está activado dentro
-de una especificación unitaria para ezUnits ofrecerá un listado de unidades
-aplicables.
+_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.
 
 ![ezUnits](./ezUnits.png){ id=img_ezUnits }
 
-Al lado de completar un nombre de archivo, un nombre de unidad o la
-instrucción actual o el nombre de variable, el auto-completado es capas de
-mostrar una plantilla para muchas de las instrucciones iniciando el tipo (y
-significado) de los parámetros que este programa espera. Para activar esta
-característica presione <kbd>MAYÚS</kbd>+<kbd>CTRL</kbd>+<kbd>ESPACIO</kbd>
-o seleccione el ítem del menú respectivo (Celda/Mostrar plantilla).
+Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).
 
-#### Caracteres griegos
+#### Greek characters
 
 Equipos tradicionalmente almacenados en valores 8-bit.  Esto permite para un
 máximo de 256 caracteres diferentes.  Todas las letras, números t y símbolos
@@ -357,15 +330,9 @@ adicionales:
 Puede utilizar también los «Símbolos» de la barra lateral para introducir
 estos símbolos matemáticos.
 
-Si un símbolo especial no está dentro del listado, es posible introducir
-caracteres Unicode arbitrarios pulsando <kbd>ESC</kbd> \[número del carácter
-(hexadecimal)\] <kbd>ESC</kbd>. Adicionalmente los "símbolos" de barra
-lateral tiene un menú de pulsación secundaria que permite representar un
-listado de todos los símbolos Unicode disponibles uno puede añadir a esta
-barra de herramientas o para la hoja de trabajo.
+If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \[number of the character (hexadecimal)\] <kbd>ESC</kbd>. Additionally the "symbols" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.
 
-<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> por tanto los
-resultados en una `a`.
+<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.
 
 Note que muchos de estos símbolos (notablemente excepciones son los símbolos
 lógicos) no tiene un significado especial dentro de _Maxima_ y por lo tanto
@@ -373,12 +340,10 @@ serán interpretados como caracteres ordinarios.  Si _Maxima_ está compilado
 utilizando un Lisp que no admite caracteres Unicode quizá cause un mensaje
 de error.
 
-Puede ser el caso que p.ej. caracteres griegos o símbolos matemáticos no
-estén incluidos dentro de la tipografía seleccionada, entonces puede no ser
-reproducibles.  Para resolver ese problema, seleccione otras tipografías
-(utilizando: Editar→Configurar→Estilo).
+It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.
+To solve that problem, select other fonts (using: Edit -> Configure -> Style).
 
-### Sustitución Unicode
+### Unicode replacement
 
 wxMaxima sustituirá varios caracteres Unicode por sus expresiones
 respectivas de Maxima, p.ej. "²" por "^2", "³" por "^3", el signo de raíz
@@ -401,7 +366,7 @@ math input does not contain them; (b) if you save the document as
 changes will of course not work in command line Maxima); but they may occur,
 if you cut&paste a formula from another document.
 
-### Paneles Laterales
+### Side Panes
 
 Enlaces para las instrucciones de _Maxima_ más importantes, cosas como un
 índice de contenido, ventanas con mensajes de depuración o un historial de
@@ -423,7 +388,7 @@ bajo.
 TOC](./Sidepane-TOC-convert-headings.png){ id=Sidepane-TOC-convert-headings
 }
 
-### Salida MathML
+### MathML output
 
 Varios procesadores de palabras y programas similares o bien reconocen
 entradas de [MathML](https://www.w3.org/Math/) y lo insertan automáticamente
@@ -433,7 +398,7 @@ portapapeles”.  Otros admiten matemáticas RTF.  _WxMaxima_ por lo tanto
 ofrece varios apuntes dentro del menú a través de la pulsación secundaria
 del menú.
 
-### Asistente Markdown
+### Markdown support
 
 _WxMaxima_ ofrece un conjunto de convenciones de
 [Markdown](https://es.wikipedia.org/wiki/Markdown) estándar que no colisione
@@ -441,32 +406,34 @@ con la notación matemática.  Una vez que estos elementos son listados de
 puntos.
 
 ```text
-Texto ordinario
- * Un ítem, nivel 1 de sangrado
- * Otro ítem en nivel 1 de sangrado
-   * Un ítem en un nivel de sangrado 2
-   * Un segundo ítem en el nivel 2 de sangrado
- * Un tercer ítem en el nivel 1 del sangrado
-Texto ordinario
+Ordinary text
+ * One item, indentation level 1
+ * Another item at indentation level 1
+   * An item at a second indentation level
+   * A second item at the second indentation level
+ * A third item at the first indentation level
+Ordinary text
 ```
 
-_WxMaxima_ reconocerá texto iniciando con los caracteres `>` como
-entrecomillado de bloque:
+_WxMaxima_ will recognize text starting with `>` chars as block quotes:
 
-```text Texto ordinario > comilla comilla comilla > comilla comilla comilla
-> comilla comilla comilla Texto ordinario ```
+```text
+Ordinary text
+> quote quote quote quote
+> quote quote quote quote
+> quote quote quote quote
+Ordinary text
+```
 
-Las salidas de TeX y HTML de _wxMaxima_ también reconocerán `=>` y lo
-reemplazarán por el signo correspondiente de Unicode:
+_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:
 
-```text cogito => sum.  ```
+```text
+cogito => sum.
+```
 
-Otros símbolos de exportación HTML y TeX reconocerán son `<=` y `>=` para
-comparaciones, una flecha doble doble-apuntada (`<=>`), flechas con cabecera
-única (`<->`, `->` y `<-`) y `+/-` como el signo respectivo.  Para salida
-TeX además son reconocidos `<<` y `>>`.
+Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.
 
-### Teclas rápidas
+### Hotkeys
 
 Muchas teclas resaltadas pueden ser encontradas dentro del texto de los
 respectivos menús.  Desde que son tomados actualmente desde el texto del
@@ -481,13 +448,13 @@ están documentadas dentro de los menús:
   auto-completion mechanism.
 - <kbd>MAYÚS</kbd>+<kbd>ESPACIO</kbd> introduce un espacio sin ruptura.
 
-## TeX crudo dentro de la exportación TeX
+### Raw TeX in the TeX export
 
 Si una celda de texto comienza con `TeX:` la exportación de TeX contiene el
 texto literal que continua el marcador `TeX:`.  Utilizando esta
 característica permite al apunte del marcado TeX sin el cuaderno _wxMaxima_.
 
-## Formatos de Archivos
+## File Formats
 
 El material desarrollado en una sesión _wxMaxima_ puede ser almacenado para
 un posterior uso en cualquiera de estas tras maneras:
@@ -517,19 +484,14 @@ pueden releer como una sesión _wxMaxima_.
 
 ### .wxm
 
-`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima
-versions >5.38 they can be read using _Maxima_’s `load()` function just as
-.mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as
-the answer is written in the `.wxm` file (so that it can be suggested after
-loading), but that can Maxima not evaluate.  You can prevent Maxima from
-asking questions by using `assume()` to declare some properties, Maxima
-wants to know.
+`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.
+You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.
 
 With this plain-text format, it sometimes is unavoidable that worksheets
 that use new features are not downwards-compatible with older versions of
 _wxMaxima_.
 
-#### Formato de archivo de archivos wxm
+#### File format of wxm files
 
 Esto es tan solo un archivo de texto simple (puede abrirlo con un editor de
 texto), conteniendo el contenido de celda como algunos comentarios Maxima
@@ -537,50 +499,52 @@ especial.
 
 Comienza con el siguiente comentario:
 
-```maxima /* [archivo de guion wxMaxima versión 1] [ ¡NO LO EDITE A MANO!
-]*/ /* [ Creado con wxMaxima versión 24.02.2_DevelopmentSnapshot ] */ ```
+```maxima
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */
+```
 
 Y entonces las celdas siguientes, codificados como comentarios Maxima,
 p.ej., una celda de sección:
 
 ```maxima
-/* [wxMaxima: inicio de sesión ]
-Título de la sección
-   [wxMaxima: final de sección   ] */
+/* [wxMaxima: section start ]
+Title of the section
+   [wxMaxima: section end   ] */
 ```
 
 o (en una celda matemática la entrada es por supuesto *no* comentada afuera
 (la salida no es guardada en un archivo `wxm`)):
 
 ```maxima
-/* [wxMaxima: entrada   inicio ] */
+/* [wxMaxima: input   start ] */
 f(x):=x^2+1$
 f(2);
-/* [wxMaxima: entrada   final   ] */
+/* [wxMaxima: input   end   ] */
 ```
 
 Imágenes están [codificadas en base64](https://es.wikipedia.org/wiki/Base64)
 con el tipo de imagen como primera línea):
 
 ```maxima
-/* [wxMaxima: imagen  inicio ]
+/* [wxMaxima: image   start ]
 jpg
-[vista de secuencia de caracteres muy caótica]
-   [wxMaxima: imagen  final  ] */
+[very chaotic looking character sequence]
+   [wxMaxima: image   end   ] */
 ```
 
 Un salto de página es tan solo una línea conteniendo:
 
 ```maxima
-/* [wxMaxima: salto de página    ] */
+/* [wxMaxima: page break    ] */
 ```
 
 Y las celdas encarpetadas marcadas por:
 
 ```maxima
-/* [wxMaxima: carpeta    inicio ] */
+/* [wxMaxima: fold    start ] */
 ...
-/* [wxMaxima: carpeta    final  ] */
+/* [wxMaxima: fold    end   ] */
 ```
 
 ### .wxmx
@@ -589,7 +553,7 @@ Este archivo cuyo formato está basado en XML guarda la hoja de trabajo
 completa incluyendo cosas como el factor de zoom y el listado de vigía.  Es
 el formato de archivo preferido.
 
-#### Formato de archivo de archivos wxm
+#### File format of wxmx files
 
 A `wxmx`-file seems to be a binary format, but one can handle it with tools,
 which are included in your OS. It is a zip file, one can decompress it with
@@ -615,7 +579,7 @@ with a text editor, or replace an broken image, zip the files again,
 probably rename the `zip` to a `wxmx`-file - and you get another modified
 `wxmx`-file.
 
-## Opciones de configuración
+## Configuration options
 
 Para algunas configuraciones comunes de variables _wxMaxima_ ofrecen dos
 maneras de configurarlas:
@@ -629,14 +593,14 @@ maneras de configurarlas:
 ![Configuración de wxMaxima 1](./wxMaxima_configuration_001.png){
 id=img_wxMaxima_configuration_001 }
 
-### Velocidad de cuadros de animación predeterminada
+### Default animation framerate
 
 La tasa del marco de animación que se utiliza para animaciones nuevas se
 conserva dentro de la variable `wxanimate_framerate`.  El valor inicial de
 esta variable contiene dentro una hoja de trabajo nueva que puede ser
 modificada utilizando el diálogo de configuración.
 
-### Tamaño de trama predet. para sesiones _maxima_ nuevas
+### Default plot size for new _maxima_ sessions
 
 Tras el siguiente inicio, tramas empotradas a la hoja del trabajo será
 creada con este tamaño si el valor de `wxplot_size` no es modificado por
@@ -650,12 +614,12 @@ valor de variable solamente para una sola instrucción:
 wxdraw2d(
    explicit(
        x^2,
-	   x,-5,5
+       x,-5,5
    )
 ), wxplot_size=[480,480]$
 ```
 
-### Coincide paréntesis en controles de texto
+### Match parenthesis in text controls
 
 Esta opción habilita dos cosas:
 
@@ -664,7 +628,7 @@ Esta opción habilita dos cosas:
 - Si el texto está seleccionad si cualquiera de estas teclas es pulsada el
   texto seleccionado será puedes entre los signos coincidan.
 
-### No guardar automáticamente la hoja de trabajo
+### Don’t save the worksheet automatically
 
 Si esta opción está puesta, el archivo donde la hoja de trabajo será
 sobrescrita solamente al solicitar el usuario.  En caso de un cuelgue/corte
@@ -677,18 +641,10 @@ telefónica moderna:
 - Ficheros son guardados automáticamente al salir
 - And the file will automatically be saved every 3 minutes.
 
-### ¿Donde está la configuración guardada?
+### Where is the configuration saved?
 
-Si está utilizando Unix/Linux, la información de la configuración será
-guardada dentro de un archivo `.wxMaxima` dentro de su directorio personal
-(si está utilizando wxWidgets < 3.1.1), o
-`.config/wxMaxima.conf`((XDG-Estandarizado) si wxWidgets ≥ 3.1.1).  Puede
-obtener la versión de wxWidgets desde la instrucción `wxbuild_info();` o
-para utilizar la opción del menú Ayuda→Acerca
-de. [wxWidgets](https://www.wxwidgets.org/) es la biblioteca IGU de
-plataforma cruzada lo cual es la base para _wxMaxima_ (por lo tanto el `wx`
-dentro del nombre).  (Cuando el nombre del archivo comience con un punto,
-`.wxmaxima` o `.config` estarán ocultos).
+If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).
+(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).
 
 Si está utilizando Windows, la configuración será almacenada dentro del
 registro.  Encontrará los apuntes para _wxMaxima_ en la posición siguiente
@@ -697,7 +653,7 @@ dentro del registro:
 
 ______________________________________________________________________
 
-# Extensiones para _Maxima_
+# Extensions to _Maxima_
 
 _WxMaxima_ es primariamente un interfaz gráfico de usuario para _Maxima_.
 Por lo tanto, su propósito principal es enviar órdenes a _Maxima_ y
@@ -707,7 +663,7 @@ _wxMaxima_ para generar informes exportando un contenido del cuaderno a HTML
 y LaTeX ha sido mencionado.  Esta sección considera algunas maneras que
 _wxMaxima_ mejora la inclusión de gráficos dentro de una sesión.
 
-## Variables subescritas
+## Subscripted variables
 
 Especificidades `wxsubscripts`, si (y como) _wxMaxima_ auto-suscribirá
 nombres de variable:
@@ -733,9 +689,9 @@ declarado como "para ser sub-guionado" utilizando la instrucción
 una variable como sub-guion puede ser revertido utilizando la instrucción
 siguiente: `wxdeclare_subscript(nombre_variable,false);`
 
-Puede utilizar el menú «Vista→Auto-subguion» para fijar estos valores.
+You can use the menu "View->Autosubscript" to set these values.
 
-## Comentario del usuario en la barra de estado
+## User feedback in the status bar
 
 Las instrucciones de ejecución largas pueden proporcionar al usuario su
 estado dentro de la barra de estado.  Esta comentario es sustituído por
@@ -748,11 +704,11 @@ presente la instrucción `wxstatusbar()` será tan solo dejada sin evaluar.
 
 ```maxima
 for i:1 thru 10 do (
-    /* Dice al usuario como de lejos obtuvo */
+    /* Tell the user how far we got */
     wxstatusbar(concat("Pass ",i)),
-    /* (sleep n) es una función Lisp, la cual puede utilizarse */
-    /* con el carácter "?" antes. Retarda el */
-    /* la ejecución del programa (aquí: para 3 segundos) */
+    /* (sleep n) is a Lisp function, which can be used */
+    /* with the character "?" before. It delays the */
+    /* program execution (here: for 3 seconds) */
     ?sleep(3)
 )$
 ```
@@ -765,8 +721,10 @@ scripted or batch export. Like `wxstatusbar()` it is safe to use in code
 that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present
 the command is simply left unevaluated.
 
-```maxima wxworksheettohtml("report.html")$ wxworksheettohtml("report.html",
-flavor="svg", wxmx=true)$ ```
+```maxima
+wxworksheettohtml("report.html")$
+wxworksheettohtml("report.html", flavor="svg", wxmx=true)$
+```
 
 A relative file name is interpreted relative to _Maxima_’s working
 directory. The optional keyword options are:
@@ -784,8 +742,10 @@ still lack MathML, and `svg`/`bitmap` render every equation to an image.
 The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file
 the same way:
 
-```maxima wxworksheettotex("report.tex")$ wxworksheettotex("report.tex",
-documentclass="report", documentclassoptions="12pt,a4paper")$ ```
+```maxima
+wxworksheettotex("report.tex")$
+wxworksheettotex("report.tex", documentclass="report", documentclassoptions="12pt,a4paper")$
+```
 
 | option                 | meaning                                                              |
 | ---------------------- | -------------------------------------------------------------------- |
@@ -794,13 +754,13 @@ documentclass="report", documentclassoptions="12pt,a4paper")$ ```
 
 Support for `wxworksheettopdf()` is planned.
 
-## Tramar
+## Plotting
 
 Tramar (teniendo fundamentalmente hacerlo con gráficas) es un lugar donde un
 interfaz gráfico del usuario tendrá para proporcionar algunas extensiones
 para el programa original.
 
-### Empotrar una trama dentro de la hoja de trabajo
+### Embedding a plot into the worksheet
 
 _Maxima_ normalmente instrumenta el programa _Gnuplot_ externo para abrir
 una ventana separada por cada diagrama que crea.  Debido a que muchas veces
@@ -837,7 +797,7 @@ is most likely a Maxima issue and should be reported in the [Maxima
 bugtracker](https://sourceforge.net/p/maxima/bugs/). Or maybe a Gnuplot
 issue.
 
-### Creación de tramas empotradas más mayores o menores
+### Making embedded plots bigger or smaller
 
 Tal como notó arriba, el dialogo de configuración proporciona una manera de
 modificar el tamaño de trama predeterminada lo cual fija el valor de inicio
@@ -875,7 +835,7 @@ trazos empotrados utilizando p.e. instrucciones `wxplot`, `wxdraw`,
 `wxcontour_plot` y `wximplicit_plot` y para animaciones empotradas con
 instrucciones `with_slider_draw` y `wxanimate`.
 
-## Tramas de mayor calidad
+### Better quality plots
 
 _Gnuplot_ parece no proporcionar una manera portable de determinar si admite
 bitmap de salida de calidad alta que la biblioteca Cairo proporciona. En los
@@ -886,7 +846,7 @@ y estilos de línea adicional. Si `wxplot_pngCairo` está establecido sin
 _Gnuplot_ admitiendo esto el resultado dará mensajes de error en vez de
 gráficos.
 
-### Abriendo tramados empotrados en ventanas _Gnuplot_ interactivas
+### Opening embedded plots in interactive _Gnuplot_ windows
 
 Si fue generada una trama utilizando las instrucciones de tipo `wxdraw`
 (`wxplot2d` y `wxplot3d` no son admitidas por esta característica) y el
@@ -894,7 +854,7 @@ tamaño del archivo del proyecto _Gnuplot_ subyacente no es una manera
 demasiado buena que _wxMaxima_ ofrezca un menú de pulsación secundaria que
 permita abrir el tramado dentro de una ventana interactiva de _Gnuplot_.
 
-### Abrir consola para instrucciones Gnuplot en las ventanas `tramado`
+### Opening Gnuplot’s command console in `plot` windows
 
 On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and
 `wgnuplot.exe`.  You can configure, which command should be used using the
@@ -903,7 +863,7 @@ window, where _gnuplot_ commands can be entered into, `gnuplot.exe` does not
 offer this possibility. Unfortunately, `wgnuplot.exe` causes _Gnuplot_ to
 "steal" the keyboard focus for a short time every time a plot is prepared.
 
-### Empotrar animaciones dentro de la hoja de cálculo
+### Embedding animations into the spreadsheet
 
 Diagramas 3D tienden hacerlo difícil para lectura de datos
 cuantitativos. Una alternativa viable sería asignar el 3er parámetro a la
@@ -1017,21 +977,25 @@ with_slider_draw(
 )$
 ```
 
-### Abrir múltiples tramas en ventanas contemporáneas
+### Opening multiple plots in contemporaneous windows
 
 Mientras no sean proporcionados por _wxMaxima_ esta característica de
 _Maxima_ (sobre configuraciones que la admitan) algunas veces vienen
 manualmente.  Los siguientes ejemplos vienen desde una carta desde Mario
 Rodríguez al listado de correo de _Maxima_:
 
-```maxima load(draw);
+```maxima
+load(draw);
 
-/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));
+/* Parabola in window #1 */
+draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));
 
-/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));
+/* Parabola in window #2 */
+draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));
 
 /* Paraboloid in window #3 */
-draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```
+draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));
+```
 
 Plotting multiple plots in the same window is possible, too (the same is
 possible in command line Maxima with the standard `draw()` command):
@@ -1047,7 +1011,7 @@ wxdraw(
 );
 ```
 
-### El panel lateral «Tramado utilizando dibujo»
+### The "Plot using draw" side pane
 
 La barra lateral «Tramado utilizando dibujo» oculta un generador de código
 simple que permite generar escenas que hagan uso de alguna de la
@@ -1072,34 +1036,34 @@ Genera el esqueleto de una instrucción `draw()` que dibuja una escena 3D.
 Si no está configurada ninguna escena 2D o 3D, todo de los otros botones
 configuran una escena 2D que contenga la instrucción que el botón genera.
 
-#### Expresión
+#### Expression
 
 Adjunta una trama común de una expresión como `sin(x)`, `x*sin(x)` o
 `x^2+2*x-4` para la instrucción `draw()` el cursor actualmente está dentro.
 Si no hay ninguna instrucción de dibujo en una escena 2D con la trama es
 generada.  Cada escena puede ser completada con cualquier número de tramas.
 
-#### Tramado implícito
+#### Implicit plot
 
 Intenta encontrar todos los puntos como una expresión `y=sin(x)`,
 `y*sin(x)=3` o `x^2+y^2=4` es verdadero y trama de la curva resultante
 dentro de la instrucción `draw()` el cursor actualmente está dentro.  Si no
 hay instrucción de dibujo en escena de 2D con el trama es generado.
 
-#### Trama paramétrica
+#### Parametric plot
 
 Para un paso de una variable desde un límite inferior a un límite superior y
 utiliza dos expresiones como `t*sin(t)` y `t*cos(t)` para generar
 coordenadas x, y (y en tramas 3D también z) de una curva que es puesta
 dentro de la instrucción de actual del dibujo.
 
-#### Puntos
+#### Points
 
 Dibuja muchos puntos que pueden ser unidos opcionalmente.  Las coordenadas
 de los puntos son tomados desde un listado de listas, una unimatriz 2D o un
 listado o unimatriz por cada eje.
 
-#### Título del diagrama
+#### Diagram title
 
 Dibuja un título sobre el final superior del diagrama,
 
@@ -1107,7 +1071,7 @@ Dibuja un título sobre el final superior del diagrama,
 
 Establece los ejes.
 
-#### Contorno
+#### Contour
 
 (Solo para tramas 3D): agrega líneas de contorno similares a los que puedan
 ser encontrados dentro de una asociación de una montaña a la trama de
@@ -1115,18 +1079,18 @@ instrucciones que continúe dentro de la instrucción ‘draw()’ actual y/o al
 plano de tierra del diagrama.  Alternativamente, este asistente permite
 descartar el dibujo de las curvas completamente.
 
-#### Nombre de trama
+#### Plot name
 
 Agrega un apunte para leyenda mostrando el nombre del siguiente tramado de
 la leyenda del diagrama. Un nombre vacío deshabilita generando apuntes de
 leyenda para las tramas siguientes.
 
-#### Color de línea
+#### Line colour
 
 Establece el color de línea para las tramas seguidas que contiene la
 instrucción de dibujo actual.
 
-#### Color de relleno
+#### Fill colour
 
 Establece un color de relleno para tramas seguidas que contiene la
 instrucción de dibujo actual.
@@ -1135,7 +1099,7 @@ instrucción de dibujo actual.
 
 Aparece un asistente que permite establecer las líneas de rejilla.
 
-#### Precisión
+#### Accuracy
 
 Permite seleccionar un punto adecuado dentro de la velocidad versus
 exactitud compensada que es parte de cualquier programa de trama.
@@ -1168,7 +1132,7 @@ Read the Maxima and Gnuplot documentation for further information.  Note:
 Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue
 1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966).
 
-## Gráficos empotrados
+## Embedding graphics
 
 Si el formato de archivo `.wxmx` está siendo utilizado empotrando archivos
 dentro de un proyecto _wxMaxima_ puede ser hecho como fácilmente como por
@@ -1176,9 +1140,11 @@ arrastrar-y-soltar.  Pero algunas veces (por ejemplo si el contenido de la
 imagen es modificado posteriormente sobre una sesión) es mejor decirle al
 archivo que cargue la imagen al evaluar:
 
-```maxima show_image("man.png"); ```
+```maxima
+show_image("man.png");
+```
 
-## Archivos de inicio
+## Startup files
 
 El diálogo de configuración de _wxMaxima_ ofrece editar dos archivos con
 instrucciones que son ejecutadas al inicializar:
@@ -1196,7 +1162,7 @@ These files are in the Maxima user directory (usually `%USERPROFILE%/maxima`
 in Windows, `$HOME/.maxima` otherwise). The location can be found out with
 the command: `maxima_userdir;`
 
-## Variables especiales wx...
+## Special variables wx...
 
 - ‘wxsubscripts’ le dice a _Maxima_ si debería convertir los nombres de
   variables que contengan un guión bajo (‘R_150’ o lo similar) en variables
@@ -1223,8 +1189,22 @@ the command: `maxima_userdir;`
   predeterminadamente?
 - `wxmaximaversion`: Returns the version number of _wxMaxima_.
 - `wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using.
+- `wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these
+  differ by maintainer, distribution and operating system:
+  - `wxdirs@userconfdir`: The directory the user's configuration is stored
+    in. Same directory as `maxima_userdir` (see above) - both point at the
+    same place, `wxdirs@userconfdir` is only useful if that is more
+    convenient to reach from a `.mac` file than the Maxima-side variable.
+  - `wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the
+    built-in autocompletion list, ...) is installed in.
+  - `wxdirs@helpdir`: The directory the offline copy of this manual is
+    installed in.
+  - `wxdirs@localedir`: The directory _wxMaxima_'s translation files are
+    installed in.
+  - `wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_
+    is configured to start.
 
-## Salida de 2D con impresión bonita
+## Pretty-printing 2D output
 
 La función `table_form()` representa un listado 2D dentro de un formulario
 que es más legible que la salida desde la rutina de salida predeterminada de
@@ -1278,7 +1258,7 @@ wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]),
           lines=true, rownames=true, colnames=true, parenstyle=square);
 ```
 
-## Comunicar fallo
+## Bug reporting
 
 _WxMaxima_ proporciona unas pocas funciones que obtenga información de
 comunicados de fallos acerca del sistema actual:
@@ -1287,7 +1267,7 @@ comunicados de fallos acerca del sistema actual:
   of _wxMaxima_
 - `wxbug_report()` informa cómo y donde archivar los gazapos
 
-## Marcar que la salida sea dibujada en rojo
+## Marking output being drawn in red
 
 La instrucción `box()` de _Maxima_ causa que _wxMaxima_ escriba su argumento
 con un fondo rojo, si el segundo argumento para la instrucción es el texto
@@ -1302,14 +1282,13 @@ using an (machine readable) XML-dialect (can be seen in the "Raw XML
 sidebar") and outputs the resulting formulas nicely rendered, e.g. pretty
 Matrices, Square root signs, fractions, etc.
 
-<!--- Currently that does not work as it should, the line with the output
-label is shifted right (issue: #2006) --> `set_display('ascii)` causes
-wxMaxima to output formulas as in command line Maxima - as ASCII-Art.
+<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->
+`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.
 
 `set_display('none)` causes 'one-line' ASCII results - the same as the
 command line Maxima command `display2d:false;` does.
 
-# Menú de ayuda
+# Help menu
 
 El menú de ayuda de wxMaxima proporciona acceso para el manual de Maxima y
 wxMaxima, consejos, algunos ejemplos de hojas de trabajo y en la línea de
@@ -1317,21 +1296,19 @@ instrucción de Maxima incluyó demos (la instrucción `demo()`).
 
 Infórmese, que las demos escriben:
 
-~~~text En la solicitud ’_’, teclee ’;’ y <entrar> para proceder con la
-demostración.  ~~~
+~~~text
+At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.
+~~~
 
-Eso es válido para línea de instrucciones de Maxima, sin embargo en wxMaxima
-por defecto es necesario continuar la demostración con:
-<kbd>CTRL</kbd>+<kbd>ENTRAR</kbd>
+That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>
 
-(Eso puede ser configurado en el menú Configurar→Hoja de trabajo→"Teclas
-directas para enviar instrucciones a Maxima".)
+(That can be configured in the Configure->Worksheet->"Hotkeys for sending commands to Maxima" menu.)
 
 ______________________________________________________________________
 
-# Solución de problemas
+# Troubleshooting
 
-## No se puede conectar a _Maxima_
+## Cannot connect to _Maxima_
 
 Desde _Maxima_ (el programa que hace las matemáticas actuales) y _wxMaxima_
 (proporcionando el interfaz de usuario de uso-fácil) con programas separados
@@ -1350,7 +1327,7 @@ En las máquinas Un\*x otra razón posible sería que la red del bucle
 invertido que proporciona conexiones de red entre dos programas dentro del
 mismo equipo no está configurado apropiadamente.
 
-## Cómo guardar datos desde un archivo .wxmx defectuoso
+## How to save data from a broken .wxmx file
 
 Internamente muchos formatos modernos basados en XML están normalmente en
 archivos zip. _WxMaxima_ no activa la compresión, por lo que el contenido de
@@ -1365,21 +1342,14 @@ procesamiento de texto.  Si la firma zip no está intacta que no necesita
 estar el final del mundo: si _wxMaxima_ al guardar ha detectado que algo es
 erróneo habrá un archivo `.wxmx~` cuyo contenido quizá ayude.
 
-E incluso si no hay un archivo: el archivo `.wxmx` es un formato de
-contenedor y la porción XML es almacenada sin comprimir.  Es posible
-renombrar el archivo `.wxmx` a un archivo `.txt` y utilizar un editor de
-texto para recuperar la porción XML del contenido del archivo (se inicia con
-`<?xml version="1.0" encoding="UTF-8"?>` y termina con
-`</wxMaximaDocument>`. Antes y después de ese texto verá algún contenido
-binario no legible dentro del editor del texto).
+And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version="1.0" encoding="UTF-8"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).
 
 Si un archivo de texto conteniendo solamente estos contenidos (p.ej. copiar
 y pegar este texto a un archivo nuevo) es guardado como un archivo
 terminando en `.xml`, _wxMaxima_ conocerá como recuperar el texto desde el
 documento.
 
-## Deseo algo del informe de depuración para ser desplegada sobre la
-pantalla antes de que mi instrucción haya finalizado
+## I want some debug info to be displayed on the screen before my command has finished
 
 Normalmente _wxMaxima_ espera a la fórmula 2D completa para ser transferida
 antes que comenzar a configurar el conjunto del tipo.  Esto guarda tiempo
@@ -1391,17 +1361,16 @@ instrucción de _Maxima_ finalice:
 ```maxima
 for i:1 thru 10 do (
    disp(i),
-   /* (sleep n) es una función de Lisp, la cual puede utilizarse */
-   /* con el carácter "?" antes.  Retrasa la ejecución del */
-   /* programa (aquí: por 3 segundos) */
+   /* (sleep n) is a Lisp function, which can be used */
+   /* with the character "?" before. It delays the */
+   /* program execution (here: for 3 seconds) */
    ?sleep(3)
 )$
 ```
 
 Alternativamente uno puede buscar la instrucción `wxstatusbar()` arriba.
 
-## El tramado solamente muestra una cobertura de sobre vacío cerrado con un
-mensaje de error
+## Plotting only shows a closed empty envelope with an error message
 
 Esto significa que _wxMaxima_ no pudo leer el archivo _Maxima_ que fue
 proporcionado a la instrucción _Gnuplot_ para crear.
@@ -1424,7 +1393,7 @@ Las posibles razones de este error son:
   establezca `wxplot_pngcairo` a cierto desde _Maxima_.
 - Gnuplot no saca un fichero «.png» válido.
 
-## Tramar una animación de resultados en «error: variable no definida»
+## Plotting an animation results in “error: undefined variable”
 
 El valor de la variable desplazada por defecto únicamente es sustituido
 dentro de la expresión que está para ser tramado si es visible ahí.
@@ -1434,7 +1403,7 @@ la sección [Animaciones empotradas a la hoja de
 cálculo](#embedding-animations-into-the-spreadsheet), puede consultar un
 ejemplo.
 
-## He perdido el contenido de una celda y al deshacer no lo recuerda
+## I lost cell content and undo doesn’t remember
 
 Hay funciones de deshacer separadas para operaciones de celdas y para
 modificaciones dentro de celdas tales que modifiquen son bajos que este a
@@ -1453,9 +1422,11 @@ veces ocurran.  Si no hay varios métodos para cubrir datos:
   emitidas recientemente.
 - Si nada más ayuda _Maxima_ contiene una característica de reproducción:
 
-```maxima playback(); ```
+```maxima
+playback();
+```
 
-## _WxMaxima_ arranca con el mensaje «Proceso de Maxima terminado.»
+## _WxMaxima_ starts up with the message “Maxima process terminated.”
 
 Una razón posible es que _Maxima_ no puede ser encontrada dentro de la
 localización que está fijada dentro de la etiqueta “Maxima” del diálogo de
@@ -1463,14 +1434,14 @@ configuración de _wxMaxima_ y por lo tanto no ejecutará nada.  Estableciendo
 la ruta a un _Maxima_ binario para el trabajo debería solucionar este
 problema.
 
-## ‘Maxima’ está calculando para siempre y no responde a la entrada
+## Maxima is forever calculating and not responding to input
 
 Es posible teóricamente que _wxMaxima_ no realiza que _Maxima_ ha finalizado
 el cálculo y por lo tanto nunca está informado que puede enviar datos nuevos
 a _Maxima_. Si esto es el caso “Disparar evaluación” tal vez re-sincronice
 los dos programas.
 
-## Mi _Maxima_ basada en SBCL se ejecuta fuera de la memoria
+## My SBCL-based _Maxima_ runs out of memory
 
 El compilador Lisp SBCL por defecto viene con un límite de memoria que lo
 permite ejecutar incluso en equipos de bajo nivel.  Cuando compile un
@@ -1489,27 +1460,31 @@ diálogo de configuración de _wxMaxima_.
 
 ![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }
 
-## Algunas veces las teclas de entrada son vagas/perezosas en Ubuntu
+## Input sometimes is sluggish/ignoring keys on Ubuntu
 
 La instalación del paquete «ibus-gtk» debería resolver este problema.  Vea
 [https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558))
 para los detalles.
 
-## _WxMaxima_ se detiene cuando _Maxima_ procesa caracteres griegos o ümlaut
+## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts
 
 Si su _Maxima_ está basado en SBCL las siguientes líneas tienen que ser
 agregadas a su `.sbclrc`:
 
-```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```
+```commonlisp
+(setf sb-impl::*default-external-format* :utf-8)
+```
 
 La carpeta donde este archivo tiene que colocarse es específico del sistema
 e instalación.  Pero cualquier _Maxima_ basada en SBCL que ya ha evaluado
 una celda dentro de la sesión actual felizmente dirá donde puede ser
 encontrada tras obtener la instrucción siguiente:
 
-```maxima :lisp (sb-impl::userinit-pathname)  ```
+```maxima
+:lisp (sb-impl::userinit-pathname)
+```
 
-## Nota concerniente a Wayland (distribuciones recientes de Linux/BSD)
+## Note concerning Wayland (recent Linux/BSD distributions)
 
 Parecen ser emitidos con el Servidor de Pantalla Wayland y wxWidgets.
 WxMaxima puede ser afectado, p.ej. esas barras laterales no son movibles.
@@ -1537,12 +1512,12 @@ If the automatic fix fails, you can manually start wxMaxima with:
 
 `UBUNTU_MENUPROXY=0 wxmaxima`
 
-### ¿Por qué no es ofrecido el explorador manual integrado en mi PC Windows?
+## Why is the integrated manual browser not offered on my Windows PC?
 
 O bien wxWidgets no fueron compilados con mantenimiento para webview2 o
 webview2 de Microsoft no está instalado.
 
-### ¿Por qué el explorador manual externo no funciona en mi caja Linux?
+## Why is the external manual browser not working on my Linux box?
 
 El explorador HTML quizá es una versión de «snap», «flatpack» o
 «appimage». Todo de estos típicamente no puede acceder archivos que son
@@ -1552,8 +1527,7 @@ proporciona el acceso al sistema hospedante para sus contenidos. Una tercera
 razón sería que el manual HTML de maxima no está instalado y la conexión por
 línea no puede ser accedida.
 
-### ¿Se puede crear la salida de _wxMaxima_ por ambos archivo de imagen y
-tramas empotradas a la vez?
+## Can I make _wxMaxima_ output both image files and embedded plots at once?
 
 La hoja de trabajo empotra archivos .png. _wxMaxima_ permite al usuario
 especificar donde serían generados:
@@ -1592,7 +1566,7 @@ pngdraw2d("Test",
 );
 ```
 
-### ¿Se puede establecer la proporción de aspecto de una trama?
+## Can I set the aspect ratio of an embedded plot?
 
 Use the variable `wxplot_size`:
 
@@ -1602,28 +1576,22 @@ wxdraw2d(
 ),wxplot_size=[1000,1000];
 ```
 
-### Tras mejorar a MacOS 13.1 los mensajes de error de salida para las
-instrucciones de trama y/o dibujos como
+## After upgrading to MacOS 13.1 plot and/or draw commands output error messages like
 
-```text 1 HIToolbox 0x00007ff80cd91726
-_ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox
-0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox
-0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```
+```text
+1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102
+2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52
+3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408
+...
+```
 
-Esto quizá sea un asunto con el sistema operativo. Desactive el oculto de la
-barra de menú (SystemSettings => Desktop & Dock => Menu Bar) tal vez
-resuelve el asunto.  Consulte [wxMaxima issue
-#1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) para más
-información.
+This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.
 
 ## Logging
 
-Log messages might be helpful to debug problems. WxMaxima can log many
-events. Most log entries will be helpful for developers, especially in case
-of problems or bugs. If you run a "Release"-Build, the log windows is not
-shown by default, if you run a development version, it is shown by default
-as a second window. You can enable and disable this window using the
-"View->Toggle log window" menu entry.
+Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a "Release"-Build,
+the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable
+this window using the "View->Toggle log window" menu entry.
 
 Messages are not 'lost', if the log window is not shown, if you select to
 show the log window later, you will see past log messages (if you did not
@@ -1641,18 +1609,18 @@ ______________________________________________________________________
 
 # FAQ
 
-## ¿Hay una manera de crear más texto que quepa en una página LaTeX?
+## Is there a way to make more text fit on a LaTeX page?
 
 Sí.  Utilice el [paquete "geometry" de LaTeX](https://ctan.org/pkg/geometry)
 para especificar el tamaño de los bordes.
 
-Puede agregar la línea siguiente al preámbulo LaTeX (por ejemplo utilizando
-el campo respectivo dentro del diálogo de configuración («Exportar» →
-«Líneas adicionales para el preámbulo TeX»), para fijar bordes de 1cm):
+You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue ("Export"->"Additional lines for the TeX preamble"), to set borders of 1cm):
 
-```latex \usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```
+```latex
+\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}
+```
 
-## ¿Hay un modo oscuro?
+## Is there a dark mode?
 
 Si wxWidgets es suficientemente nuevo _wxMaxima_ automáticamente estará en
 modo oscuro si el resto del sistema operativo también lo está.  La misma
@@ -1661,17 +1629,11 @@ puede ser configurado de otras maneras.  Alternativamente hay un apunte del
 menú para ‘Ver/Invertir brillo de la hoja de trabajo’ para convertir
 rápidamente la hoja de trabajo desde oscuro a claro y viceversa.
 
-## _WxMaxima_ algunas veces se cuelga durante varios segundos una vez en el
-primer minuto
+## _WxMaxima_ sometimes hangs for several seconds once in the first minute
 
-_WxMaxima_ delega algunas tareas grandes como interpretar el manual de
-página >1000 de _Maxima_ para tareas en segundo plano, lo cual normalmente
-va totalmente no comunicado.  En el momento que el resultado de dicha tarea
-es necesaria, es posible que _wxMaxima_ necesite esperar un par de segundos
-antes de poder continuar su trabajo.
+_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.
 
-## Especialmente cuando pruebe parámetros locales nuevos, sucede una caja
-con el mensaje "locale ’xx_YY’ no puede ser fijada"
+## Especially when testing new locale settings, a message box "locale ’xx_YY’ can not be set" occurs
 
 ![Aviso local](./locale-warning.png){ id=img_locale_warning}
 
@@ -1683,16 +1645,14 @@ trabajo de wxWidgets.
 Estos locales quizá no sean presente dentro del sistema. En sistemas
 Ubuntu/Debian pueden ser generados utilizando: `dpkg-reconfigure locales`
 
-## ¿Cómo puedo utilizar símbolos para números reales, naturales (ℝ, ℕ),
-etc.?
+## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?
 
 Puede encontrar estos símbolos en la barra lateral Unicode (busca
 ’doble-stuck capital’). Pero la tipografía seleccionada además debe mantener
 estos símbolos. Si no representan apropiadamente, seleccione otra
 tipografía.
 
-## ¿Cómo puede un guion Maxima determinar, si está ejecutándose bajo
-wxMaxima o línea de instrucción de Maxima?
+## How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?
 
 Si se utiliza wxMaxima, la variable `maxima_frontend` de Maxima está fijada
 a `wxmaxima`. La variable Maxima `maxima_frontend_version` contiene la
@@ -1703,14 +1663,11 @@ instrucción), estas variables son falsas.
 
 ## Help! I can not save my document!
 
-If saving as wxmx file does not work, try saving the document as wxm file
-(and vice versa). And you can also try to remove all output (Menu
-Cell->Remove all output) and save that file, maybe some unexpected output
-causes issues during the save process.
+If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.
 
 ______________________________________________________________________
 
-# Argumentos de línea de instrucción
+# Command-line arguments
 
 Usualmente puede iniciar programas con un interfaz gráfico de usuario tan
 solo pulsando en un icono de escritorio o apunte de menú del
@@ -1751,7 +1708,7 @@ breve al frente de los conmutadores de línea de instrucciones.
 
 ______________________________________________________________________
 
-# Sobre el programa, contribuyendo a wxMaxima
+# About the program, contributing to wxMaxima
 
 wxMaxima es principalmente desarrollado utilizando el lenguaje de
 programación C++ utilizando el [marco de trabajo
@@ -1780,7 +1737,4 @@ El programa es casi autónomo, por tanto excepto para bibliotecas del sistema
 gráficos o la parte Lisp (el archivo `wxmathML.lisp`) es necesario, se
 incluyen estos archivos dentro del ejecutable.
 
-Si es un desarrollador, quizá desea intentar un archivo modificado de
-`wxmathML.lisp` sin tener que recompilar todo, uno puede utilizar la opción
-de línea de instrucción `--wxmathml-lisp=<str>` para utilizar otro archivo
-Lisp, no el incluido.
+If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.

--- a/info/wxmaxima.fr.md
+++ b/info/wxmaxima.fr.md
@@ -1,4 +1,4 @@
-# Manuel de l'utilisateur de wxMaxima
+# The wxMaxima user manual
 
 WxMaxima is a graphical user interface (GUI) for the _Maxima_ computer
 algebra system (CAS). WxMaxima allows one to use all of _Maxima_’s
@@ -10,9 +10,9 @@ make wxMaxima one of the most popular GUIs for _Maxima_.
 
 ______________________________________________________________________
 
-# Présentation de wxMaxima
+# Introduction to wxMaxima
 
-## _Maxima_ et wxMaxima
+## _Maxima_ and wxMaxima
 
 In the open-source domain, big systems are normally split into smaller
 projects that are easier to handle for small groups of developers. For
@@ -53,12 +53,7 @@ qui ne peuvent pas être résolus de manière formelle.
 ![Copie d'écran Maxima, ligne de commande](./maxima_screenshot.png){
 id=img_maxima_screenshot }
 
-Extensive documentation for _Maxima_ is [available in the
-internet](https://maxima.sourceforge.io/documentation.html). Part of this
-documentation is also available in wxMaxima’s help menu. Pressing the Help
-key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s
-context-sensitive help feature to automatically jump to _Maxima_’s manual
-page for the command at the cursor.
+Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.
 
 ### WxMaxima
 
@@ -79,7 +74,7 @@ via the help menu.
 Les calculs saisis dans _wxMaxima_ sont exécutés en arrière-plan par l'outil
 en ligne de commande _Maxima_.
 
-## Notions de base d'un notebook
+## Workbook basics
 
 Much of _wxMaxima_ is self-explaining, but some details require
 attention. [This
@@ -91,7 +86,7 @@ use of _wxMaxima_ to interact with _Maxima_. This manual concentrates on
 describing aspects of _wxMaxima_ that are not likely to be self-evident and
 that might not be covered in the online material.
 
-### Fondamentaux du notebook
+### The workbook approach
 
 One of the very few things that are not standard in _wxMaxima_ is that it
 organizes the data for _Maxima_ into cells that are evaluated (which means:
@@ -138,7 +133,7 @@ d’entrée/sortie et cellules d’image).
 ![Exemple de cellules différentes de wxMaxima](./cell-example.png){
 id=img_cell-example }
 
-### Cellules
+### Cells
 
 Le notebook est organisé en cellules. WxMaxima distingue les types de
 cellules suivants  :
@@ -166,7 +161,7 @@ sera ignoré par Maxima */`
 
 "`/*`" indique le début du commentaire, "`*/`" la fin.
 
-### curseurs horizontaux et verticaux
+### Horizontal and vertical cursors
 
 Si l’utilisateur tente de sélectionner une phrase complète, un traitement de
 texte étendra automatiquement la sélection pour qu’elle commence et se
@@ -184,12 +179,7 @@ automatically when needed:
   pointeur de la souris ou des touches de direction, et fonctionne de
   manière similaire à celui d’un éditeur de texte.
 
-Quand vous lancez wxMaxima, vous ne verrez que le curseur horizontal
-clignotant. Si vous commencez à taper, une cellule mathématique sera
-automatiquement créée et le curseur deviendra un curseur vertical classique
-(vous verrez une flèche vers la droite comme "invite", et après avoir évalué
-la cellule mathématique (<kbd>CTRL</kbd>+<kbd>ENTRÉE</kbd>), les étiquettes
-apparaîtront, par exemple `(%i1)`, `(%o1)`.
+When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as "prompt", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).
 
 ![curseur horizontal (clignotant) après le démarrage de
 wxMaxima](./horizontal-cursor-only.png){ id=img_horizontal_cursor_only }
@@ -209,34 +199,19 @@ en utilisant le menu).
 cellules](./horizontal-cursor-between-cells.png){
 id=img_horizontal_cursor_between_cells }
 
-### Envoyer des cellules à Maxima
+### Sending cells to Maxima
 
-La commande dans une cellule de code est exécutée en appuyant une fois sur
-<kbd>CTRL</kbd>+<kbd>ENTRÉE</kbd>, <kbd>MAJ</kbd>+<kbd>ENTRÉE</kbd> ou la
-touche <kbd>ENTRÉE</kbd> du pavé numérique. Par défaut, _wxMaxima_ exécute
-les commandes lorsque <kbd>CTRL</kbd>+<kbd>ENTRÉE</kbd> ou
-<kbd>MAJ</kbd>+<kbd>ENTRÉE</kbd> est pressé, mais il est possible de
-configurer _wxMaxima_ pour qu’il exécute les commandes en réponse à la
-touche <kbd>ENTRÉE</kbd>.
+The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.
 
-### Complétion automatique des commandes
+### Command autocompletion
 
-_wxMaxima_ dispose d’une fonction de complétion automatique, accessible via
-le menu (Cellule/Compléter le mot) ou en appuyant sur la combinaison de
-touches <kbd>CTRL</kbd>+<kbd>ESPACE</kbd>. Cette complétion est sensible au
-contexte : par exemple, si elle est activée lors d'une spécification d’unité
-pour ezUnits, elle proposera une liste des unités applicables.
+_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.
 
 ![ezUnits](./ezUnits.png){ id=img_ezUnits }
 
-Outre la complétion des noms de fichiers, d’unités, de commandes ou de
-variables, la complétion automatique peut aussi afficher un modèle pour la
-plupart des commandes, indiquant le type (et la signification) des
-paramètres attendus par le programme. Pour activer cette fonctionnalité,
-appuyez sur <kbd>MAJ</kbd>+<kbd>CTRL</kbd>+<kbd>ESPACE</kbd> ou sélectionnez
-l’option correspondante dans le menu (Cellule/Afficher le modèle).
+Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).
 
-#### Caractères grecs
+#### Greek characters
 
 Traditionnellement, les ordinateurs stockaient les caractères sur 8 bits, ce
 qui permet un maximum de 256 caractères différents. Toutes les lettres,
@@ -287,7 +262,7 @@ method of entering Greek characters using the keyboard:
 Vous pouvez également utiliser la barre latérale « Lettres grecques » pour
 insérer les lettres grecques.
 
-##### Attention aux caractères similaires
+##### Attention: Lookalike characters
 
 Plusieurs lettres latines ressemblent aux lettres grecques, par exemple la
 lettre latine "A" et la lettre grecque "Alpha". Bien qu'elles aient la même
@@ -360,26 +335,19 @@ Touches à saisir | symbole mathématique                                     
 Vous pouvez aussi utiliser la barre latérale « Symboles » pour saisir ces
 symboles mathématiques.
 
-If a special symbol isn’t in the list, it is possible to input arbitrary
-Unicode characters by pressing <kbd>ESC</kbd> \[number of the character
-(hexadecimal)\] <kbd>ESC</kbd>. Additionally the "symbols" sidebar has a
-right-click menu that allow to display a list of all available Unicode
-symbols one can add to this toolbar or to the worksheet.
+If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \[number of the character (hexadecimal)\] <kbd>ESC</kbd>. Additionally the "symbols" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.
 
-<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd>  est une séquence qui
-produit un `a`.
+<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.
 
 Please note that most of these symbols (notable exceptions are the logic
 symbols) do not have a special meaning in _Maxima_ and therefore will be
 interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp
 that doesn’t support Unicode characters they might cause an error message.
 
-Il est possible que, par exemple, les caractères grecs ou les symboles
-mathématiques ne soient pas inclus dans la police sélectionnée et ne
-puissent donc pas s'afficher. Pour résoudre ce problème, choisissez une
-autre police (via : Édition -> Configurer -> Style).
+It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.
+To solve that problem, select other fonts (using: Edit -> Configure -> Style).
 
-### Remplacement de caractères Unicode
+### Unicode replacement
 
 wxMaxima will replace several Unicode characters with their respective
 Maxima expressions, e.g. `²` with `^2`, `³` with `^3`, the square root sign
@@ -403,7 +371,7 @@ par Maxima en ligne de commande, mais ces substitutions ne fonctionneront
 peuvent apparaître si vous copiez-collez une formule depuis un autre
 document.
 
-### Les panneaux latéraux
+### Side Panes
 
 Les raccourcis vers les commandes les plus importantes de _Maxima_, comme
 une table des matières, des fenêtres avec des messages de débogage ou un
@@ -425,7 +393,7 @@ inférieur.
 des Matières](./Sidepane-TOC-convert-headings.png){
 id=Sidepane-TOC-convert-headings }
 
-### Export MathML
+### MathML output
 
 Several word processors and similar programs either recognize
 [MathML](https://www.w3.org/Math/) input and automatically insert it as an
@@ -434,41 +402,41 @@ offers an “import MathML from clipboard” feature. Others support RTF
 maths. _WxMaxima_, therefore, offers several entries in the right-click
 menu.
 
-### Prise en charge de Markdown
+### Markdown support
 
 _WxMaxima_ offers a set of standard
 [Markdown](https://en.wikipedia.org/wiki/Markdown) conventions that don’t
 collide with mathematical notation. One of these elements is bullet lists.
 
 ```text
-Texte ordinaire
-* Un élément, niveau d'indentation 1
-* Un autre élément au niveau d'indentation 1
-  * Un élément au deuxième niveau d'indentation
-  * Un deuxième élément au deuxième niveau d'indentation
-* Un troisième élément au premier niveau d'indentation
-Texte ordinaire
+Ordinary text
+ * One item, indentation level 1
+ * Another item at indentation level 1
+   * An item at a second indentation level
+   * A second item at the second indentation level
+ * A third item at the first indentation level
+Ordinary text
 ```
 
-_WxMaxima_ reconnaîtra le texte commençant par le caractère `>` comme des
-blocs de citations  :
+_WxMaxima_ will recognize text starting with `>` chars as block quotes:
 
-```text Texte ordinaire > citation citation citation citation > citation
-citation citation citation > citation citation citation citation Texte
-ordinaire```
+```text
+Ordinary text
+> quote quote quote quote
+> quote quote quote quote
+> quote quote quote quote
+Ordinary text
+```
 
-_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by
-the corresponding Unicode sign:
+_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:
 
-```text cogito => sum.  ```
+```text
+cogito => sum.
+```
 
-D’autres symboles reconnus par les exports HTML et TeX sont `<=` et `>=`
-pour les comparaisons, une double flèche à double pointe (`<=>`), des
-flèches à une seule direction (`<->`, `->` et `<-`) ainsi que `+/-` pour le
-symbole correspondant. Pour la sortie TeX, les symboles `<<` et `>>` sont
-également reconnus.
+Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.
 
-### Raccourcis clavier
+### Hotkeys
 
 La plupart des raccourcis clavier peuvent être trouvés dans le texte des
 menus associés. Comme ils sont effectivement tirés du texte des menus, ils
@@ -484,13 +452,13 @@ raccourcis ne sont pas documentés dans les menus :
   saisie automatique.
 - <kbd>SHIFT</kbd>+<kbd>SPACE</kbd> insère un espace insécable.
 
-### TeX brut dans l'export TeX
+### Raw TeX in the TeX export
 
 Si une cellule de texte commence par `TeX:`, l'export TeX inclut le texte
 littéral qui suit le marqueur `TeX:`. Cette fonctionnalité permet d'insérer
 du code TeX directement dans le classeur _wxMaxima_.
 
-## Formats de fichiers
+## File Formats
 
 Le contenu développé lors d'une session _wxMaxima_ peut être enregistré pour
 une utilisation ultérieure de trois manières différentes :
@@ -521,19 +489,14 @@ back as a _wxMaxima_ session.
 
 ### .wxm
 
-`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima
-versions >5.38 they can be read using _Maxima_’s `load()` function just as
-.mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as
-the answer is written in the `.wxm` file (so that it can be suggested after
-loading), but that can Maxima not evaluate.  You can prevent Maxima from
-asking questions by using `assume()` to declare some properties, Maxima
-wants to know.
+`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.
+You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.
 
 Avec ce format en texte brut, il est parfois inévitable que les feuilles de
 calcul utilisant de nouvelles fonctionnalités ne soient pas rétrocompatibles
 avec les anciennes versions de _wxMaxima_.
 
-#### Format de fichier des fichiers wxm
+#### File format of wxm files
 
 Il s'agit simplement d'un fichier texte brut (vous pouvez l'ouvrir avec un
 éditeur de texte), contenant le contenu des cellules sous forme de
@@ -541,15 +504,17 @@ commentaires spéciaux Maxima.
 
 Cela commence par le commentaire suivant :
 
-```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
-Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```
+```maxima
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */
+```
 
 Puis les cellules suivent, encodées sous forme de commentaires Maxima, par
 exemple une cellule de section :
 
 ```maxima
 /* [wxMaxima: section start ]
-Titre de la section
+Title of the section
    [wxMaxima: section end   ] */
 ```
 
@@ -569,14 +534,14 @@ avec l'indication du type de l'image sur la première ligne):
 ```maxima
 /* [wxMaxima: image   start ]
 jpg
-[séquence de caractères très chaotique à première vue]
+[very chaotic looking character sequence]
    [wxMaxima: image   end   ] */
 ```
 
 Une saut de page est simplement une ligne contenant :
 
 ```maxima
-/* [wxMaxima: saut de page    ] */
+/* [wxMaxima: page break    ] */
 ```
 
 Et les cellules repliées sont marquées par :
@@ -593,7 +558,7 @@ Ce format de fichier basé sur le XML enregistre la feuille de travail
 complète, y compris des éléments comme le facteur de zoom et la liste de
 suivi du notebook. C'est le format de fichier recommandé.
 
-#### Format de fichier des fichiers wxmx
+#### File format of wxmx files
 
 Un fichier `wxmx` semble être un format binaire, mais on peut le gérer avec
 des outils inclus dans votre système d'exploitation. Il s'agit d'un fichier
@@ -621,7 +586,7 @@ modifier le fichier `content.xml` avec un éditeur de texte ou remplacer une
 image corrompue, recompresser les fichiers, probablement renommer le `.zip`
 en `.wxmx` — et vous obtiendrez un autre fichier `wxmx` modifié.
 
-## Options pour la configuration
+## Configuration options
 
 Pour certaines variables courantes liées à la configuration, _wxMaxima_
 propose deux méthodes de configuration :
@@ -635,15 +600,14 @@ propose deux méthodes de configuration :
 ![configuration 1 de wxMaxima](./wxMaxima_configuration_001.png){
 id=img_wxMaxima_configuration_001 }
 
-### Fréquence par défaut des images pour les animations
+### Default animation framerate
 
 La fréquence des images utilisée pour les nouvelles animations est stockée
 dans la variable `wxanimate_framerate`. La valeur initiale de cette variable
 dans un nouveau notebook peut être modifiée via la boîte de dialogue de
 configuration.
 
-### Dimensions par défaut des graphiques pour les nouvelles sessions de
-_maxima_
+### Default plot size for new _maxima_ sessions
 
 After the next start, plots embedded into the worksheet will be created with
 this size if the value of `wxplot_size` isn’t changed by _maxima_.
@@ -660,7 +624,7 @@ wxdraw2d(
 ), wxplot_size=[480,480]$
 ```
 
-### Correspondance des parenthèses dans les zones de texte
+### Match parenthesis in text controls
 
 Cette option active deux fonctionnalités :
 
@@ -670,7 +634,7 @@ Cette option active deux fonctionnalités :
 - Si du texte est sélectionné lorsque l’une de ces touches est enfoncée, le
   texte sélectionné est placé entre les signes correspondants appariés.
 
-### Ne pas enregistrer automatiquement le notebook
+### Don’t save the worksheet automatically
 
 Si cette option est activée, le fichier du notebook ne sera écrasé que sur
 demande de l'utilisateur. En cas de plantage, de coupure de courant ou autre
@@ -684,17 +648,10 @@ app:
   programme
 - Et le fichier sera automatiquement sauvegardé toutes les 3 minutes.
 
-### Où est enregistrée la configuration  ?
+### Where is the configuration saved?
 
-Si vous utilisez Unix/Linux, les informations de configuration sont
-enregistrées dans un fichier `.wxMaxima` de votre répertoire personnel (si
-vous utilisez wxWidgets < 3.1.1), ou dans `.config/wxMaxima.conf` (norme
-XDG, si wxWidgets >= 3.1.1 est utilisé). Vous pouvez connaître la version de
-wxWidgets avec la commande `wxbuild_info();` ou via le menu Aide → À
-propos. [wxWidgets](https://www.wxwidgets.org/) est la bibliothèque
-d'interface graphique multiplateforme sur laquelle repose _wxMaxima_ (d'où
-le `wx` dans le nom). (Ces fichiers ou dossiers, commençant par un point,
-`.wxMaxima` ou `.config`, sont donc des fichiers cachés).
+If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).
+(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).
 
 Si vous utilisez Windows, la configuration est stockée dans le
 registre. Vous trouverez les entrées pour _wxMaxima_ à l'emplacement suivant
@@ -702,7 +659,7 @@ du registre : `HKEY_CURRENT_USER\Software\wxMaxima`
 
 ______________________________________________________________________
 
-# Extensions pour _Maxima_
+# Extensions to _Maxima_
 
 _WxMaxima_ is primarily a graphical user interface for _Maxima_. As such,
 its main purpose is to pass along commands to _Maxima_ and to report the
@@ -712,7 +669,7 @@ exporting a workbook’s contents to HTML and LaTeX files has been
 mentioned. This section considers some ways that _wxMaxima_ enhances the
 inclusion of graphics in a session.
 
-## Variables en indice
+## Subscripted variables
 
 `wxsubscripts` définit si (et comment) _wxMaxima appliquera automatiquement
 des indices aux noms de variables :
@@ -740,10 +697,9 @@ declared as "to be subscripted" using the command
 variable as subscripted can be reverted using the following command:
 `wxdeclare_subscript(variable_name,false);`
 
-Vous pouvez utiliser le menu "Affichage->Mise en indice automatique" pour
-définir ces valeurs.
+You can use the menu "View->Autosubscript" to set these values.
 
-## Message utilisateur dans la barre d'état
+## User feedback in the status bar
 
 Long-running commands can provide user feedback in the status bar. This user
 feedback is replaced by any new feedback that is placed there (allowing to
@@ -755,11 +711,11 @@ just be left unevaluated.
 
 ```maxima
 for i:1 thru 10 do (
-    /* Informe l'utilisateur de l'avancement. */
+    /* Tell the user how far we got */
     wxstatusbar(concat("Pass ",i)),
-    /* (sleep n) est une fonction Lisp, qui peut être utilisée */
-    /* avec le caractère "?" avant. Cela retarde */
-    /* l'exécution du programme (dans ce cas : pour 3 secondes) */
+    /* (sleep n) is a Lisp function, which can be used */
+    /* with the character "?" before. It delays the */
+    /* program execution (here: for 3 seconds) */
     ?sleep(3)
 )$
 ```
@@ -772,8 +728,10 @@ scripted or batch export. Like `wxstatusbar()` it is safe to use in code
 that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present
 the command is simply left unevaluated.
 
-```maxima wxworksheettohtml("report.html")$ wxworksheettohtml("report.html",
-flavor="svg", wxmx=true)$ ```
+```maxima
+wxworksheettohtml("report.html")$
+wxworksheettohtml("report.html", flavor="svg", wxmx=true)$
+```
 
 A relative file name is interpreted relative to _Maxima_’s working
 directory. The optional keyword options are:
@@ -791,8 +749,10 @@ still lack MathML, and `svg`/`bitmap` render every equation to an image.
 The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file
 the same way:
 
-```maxima wxworksheettotex("report.tex")$ wxworksheettotex("report.tex",
-documentclass="report", documentclassoptions="12pt,a4paper")$ ```
+```maxima
+wxworksheettotex("report.tex")$
+wxworksheettotex("report.tex", documentclass="report", documentclassoptions="12pt,a4paper")$
+```
 
 | option                 | meaning                                                              |
 | ---------------------- | -------------------------------------------------------------------- |
@@ -801,13 +761,13 @@ documentclass="report", documentclassoptions="12pt,a4paper")$ ```
 
 Support for `wxworksheettopdf()` is planned.
 
-## Graphiques
+## Plotting
 
 La création de courbes (qui repose fondamentalement sur des éléments
 graphiques) est un domaine où une interface utilisateur graphique devra
 apporter certaines extensions au programme d'origine.
 
-### Intégrer un graphique dans le notebook
+### Embedding a plot into the worksheet
 
 _Maxima_ normally instructs the external program _Gnuplot_ to open a
 separate window for every diagram it creates. Since many times it is
@@ -845,7 +805,7 @@ probablement d'un problème de Maxima qui devrait être signalé dans le [suivi
 des bogues de Maxima](https://sourceforge.net/p/maxima/bugs/). Ou peut-être
 un problème de Gnuplot.
 
-### Agrandir ou diminuer les graphiques intégrés
+### Making embedded plots bigger or smaller
 
 Comme indiqué précédemment, la boîte de dialogue de configuration permet de
 modifier la taille par défaut des graphiques créés, en définissant la valeur
@@ -885,7 +845,7 @@ fonctionne pour les graphiques en ligne utilisant par exemple les commandes
 les animations intégrées avec les commandes `with_slider_draw` et
 `wxanimate`.
 
-### Des graphiques de meilleur qualité
+### Better quality plots
 
 _Gnuplot_ doesn’t seem to provide a portable way of determining whether it
 supports the high-quality bitmap output that the Cairo library provides. On
@@ -895,8 +855,7 @@ from the configuration menu (that can be overridden by the variable
 styles. If `wxplot_pngCairo` is set without _Gnuplot_ supporting this the
 result will be error messages instead of graphics.
 
-### Ouvrir les graphiques intégrés dans les fenêtres interactives de
-_Gnuplot_
+### Opening embedded plots in interactive _Gnuplot_ windows
 
 If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and
 `wxplot3d` isn’t supported by this feature) and the file size of the
@@ -904,7 +863,7 @@ underlying _Gnuplot_ project isn’t way too high _wxMaxima_ offers a
 right-click menu that allows to open the plot in an interactive _Gnuplot_
 window.
 
-### Ouvrir la console de commandes de Gnuplot dans les fenêtres `plot`
+### Opening Gnuplot’s command console in `plot` windows
 
 Sous MS Windows, il existe deux programmes Gnuplot : `gnuplot.exe` et
 `wgnuplot.exe`. Vous pouvez configurer lequel utiliser via le menu de
@@ -913,7 +872,7 @@ commandes _Gnuplot_ peuvent être saisies, ce que `gnuplot.exe` ne propose
 pas. Malheureusement, `wgnuplot.exe` provoque un bref "décrochage" du focus
 clavier à chaque génération d'un graphique.
 
-### Intégrer des animations dans le notebook
+### Embedding animations into the spreadsheet
 
 Les diagrammes en 3D impliquent souvent que la lecture des données
 quantitatives soit difficile. Une alternative intéressante consiste à
@@ -1000,7 +959,7 @@ share the pitfall that the slider variable’s value is substituted into the
 expression only if the variable is directly visible in the
 expression. Therefore the following example will fail:
 
-``maxima
+```maxima
 f:sin(a*x);
 with_slider_draw(
     a,makelist(i/2,i,1,10),
@@ -1008,6 +967,7 @@ with_slider_draw(
     grid=true,
     explicit(f,x,0,10)
 )$
+```
 
 If _Maxima_ is explicitly asked to substitute the slider’s value plotting
 works fine instead:
@@ -1025,23 +985,25 @@ with_slider_draw(
 )$
 ```
 
-### Ouvrir plusieurs graphiques dans des fenêtres de manière simultanée
+### Opening multiple plots in contemporaneous windows
 
 Cette fonctionnalité de _Maxima_ (sur les configurations qui la supportent),
 bien qu'elle ne soit pas disponible via  _wxMaxima_, s'avère parfois bien
 pratique. L'exemple suivant provient d'un message de Mario Rodriguez sur la
 _liste de diffusion de Maxima_ :
 
-```maxima load(draw);
+```maxima
+load(draw);
 
-/* Une parabole dans une fenêtre #1 */
+/* Parabola in window #1 */
 draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));
 
-/* Une parabole dans une fenêtre #2 */
+/* Parabola in window #2 */
 draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));
 
-/* Un paraboloide dans une fenêtre #3 */
-draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```
+/* Paraboloid in window #3 */
+draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));
+```
 
 Il est également possible de tracer plusieurs graphiques dans une même
 fenêtre (la même chose est réalisable avec la commande standard `draw()` de
@@ -1058,7 +1020,7 @@ wxdraw(
 );
 ```
 
-### Le panneau latéral "Graphiques avec draw"
+### The "Plot using draw" side pane
 
 Le panneau latéral "Graphiques avec draw" cache un générateur simple de code
 qui permet de créer des représentations graphiques exploitant une partie des
@@ -1090,14 +1052,14 @@ Ajoute un tracé standard d'une expression comme `sin(x)`, `x*sin(x)` ou
 aucune commande `draw()` n'existe, une scène 2D avec ce tracé est
 générée. Chaque scène peut contenir un nombre illimité de graphiques.
 
-#### Courbe définie de manière implicite
+#### Implicit plot
 
 Tente de trouver tous les points où une expression comme `y=sin(x)`,
 `y*sin(x)=3` ou `x^2+y^2=4` est vérifiée et trace la courbe résultante dans
 la commande `draw()` où se trouve le curseur. Si aucune commande `draw()`
 n'existe, une scène 2D avec ce tracé est générée.
 
-#### Courbe paramétrique
+#### Parametric plot
 
 Fait varier une variable entre une borne inférieure et une borne supérieure,
 puis utilise deux expressions comme `t*sin(t)` et `t*cos(t)` pour générer
@@ -1110,15 +1072,15 @@ Trace plusieurs points, éventuellement reliés entre eux. Les coordonnées des
 points peuvent provenir d'une liste de listes, d'un tableau 2D, ou d'une
 liste ou d'un tableau pour chaque axe.
 
-#### Titre du graphique
+#### Diagram title
 
 Ajoute un titre en haut du graphique,
 
-#### Axes
+#### Axis
 
 Configurer l'axe.
 
-#### Lignes de niveau
+#### Contour
 
 (Uniquement pour les tracés 3D) : Ajoute des lignes de niveau similaires à
 celles que l'on trouve sur une carte de montagne aux commandes du tracé qui
@@ -1126,32 +1088,32 @@ suivent dans la commande `draw()` actuelle et/ou au plan de base du
 graphique. Alternativement, cet assistant permet de sauter entièrement le
 tracé des courbes et d'afficher uniquement le tracé des lignes de niveau.
 
-#### Légende du graphique
+#### Plot name
 
 Adds a legend entry showing the next plot’s name to the legend of the
 diagram. An empty name disables generating legend entries for the following
 plots.
 
-#### Couleur de la ligne du tracé
+#### Line colour
 
 Définit la couleur de ligne pour les tracés suivants contenus dans la
 commande `draw()` actuelle.
 
-#### Couleur de remplissage
+#### Fill colour
 
 Définit la couleur de remplissage pour les tracés suivants contenus dans la
 commande `draw()` actuelle.
 
-#### Quadrillage
+#### Grid
 
 Ouvre un assistant permettant de configurer les lignes du quadrillage.
 
-#### Précision
+#### Accuracy
 
 Permet de choisir un compromis adapté entre vitesse et précision, inhérent à
 tout programme de tracé graphique.
 
-### Modifier la police et la taille de police pour les graphiques
+### Modify font and font size for plots
 
 Surtout lorsque vous utilisez un affichage haute résolution, la taille de
 police par défaut peut être très petite. Pour les commandes basées sur
@@ -1183,16 +1145,18 @@ d'informations. Remarque : Gnuplot semble rencontrer des problèmes avec les
 polices de grande taille, voir [wxMaxima issue
 1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966).
 
-## Graphiques intégrés
+## Embedding graphics
 
 If the `.wxmx` file format is being used embedding files in a _wxMaxima_
 project can be done as easily as per drag-and-drop. But sometimes (for
 example if an image’s contents might change later on in a session) it is
 better to tell the file to load the image on evaluation:
 
-```maxima show_image("man.png"); ```
+```maxima
+show_image("man.png");
+```
 
-## Fichiers au démarrage
+## Startup files
 
 La boîte de dialogue de configuration de _wxMaxima_ permet de modifier deux
 fichiers contenant des commandes exécutées au démarrage :
@@ -1211,7 +1175,7 @@ Ces fichiers se trouvent dans le répertoire utilisateur de Maxima
 sinon). Vous pouvez connaître leur emplacement avec la commande :
 `maxima_userdir;`
 
-## Variables spéciales wx...
+## Special variables wx...
 
 - `wxsubscripts` indique à _Maxima_ s'il doit convertir les noms de
   variables contenant un tiret bas (`R_150` ou similaire) en variables avec
@@ -1237,8 +1201,22 @@ sinon). Vous pouvez connaître leur emplacement avec la commande :
 - `wxmaximaversion` : Retourne le numéro de version de _wxMaxima_.
 - `wxwidgetsversion` : Retourne la version de wxWidgets utilisée par
   _wxMaxima_.
+- `wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these
+  differ by maintainer, distribution and operating system:
+  - `wxdirs@userconfdir`: The directory the user's configuration is stored
+    in. Same directory as `maxima_userdir` (see above) - both point at the
+    same place, `wxdirs@userconfdir` is only useful if that is more
+    convenient to reach from a `.mac` file than the Maxima-side variable.
+  - `wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the
+    built-in autocompletion list, ...) is installed in.
+  - `wxdirs@helpdir`: The directory the offline copy of this manual is
+    installed in.
+  - `wxdirs@localedir`: The directory _wxMaxima_'s translation files are
+    installed in.
+  - `wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_
+    is configured to start.
 
-## Affichage formaté en 2D
+## Pretty-printing 2D output
 
 The function `table_form()` displays a 2D list in a form that is more
 readable than the output from _Maxima_’s default output routine. The input
@@ -1289,7 +1267,7 @@ wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]),
           lines=true, rownames=true, colnames=true, parenstyle=square);
 ```
 
-## Signalement de bugs
+## Bug reporting
 
 _WxMaxima_ propose quelques fonctions qui collectent des informations utiles
 pour signaler un bug concernant le système actuel :
@@ -1298,13 +1276,13 @@ pour signaler un bug concernant le système actuel :
   d'exécution  de _wxMaxima_
 - `wxbug_report()` indique comment et où signaler les bogues
 
-## Ecrire le résultat de la sortie en rouge
+## Marking output being drawn in red
 
 _Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a
 red foreground, if the second argument to the command is the text
 `highlight`.
 
-## Rendu de la sortie.
+## Output rendering.
 
 Avec `set_display()`, on peut définir de quelle manière wxMaxima affichera
 la sortie.
@@ -1315,15 +1293,13 @@ barre latérale « XML brut ») et affiche les formules résultantes avec un
 visuel mathématique, par exemple des matrices bien délimitées et
 structurées, des signes de racine carrée, des fractions, etc.
 
-<!--- Actuellement, cela ne fonctionne pas comme prévu : la ligne avec
-l’étiquette de sortie est décalée vers la droite (problème : #2006) -->
-`set_display('ascii)` fait en sorte que wxMaxima affiche les formules comme
-dans Maxima en ligne de commande — en ASCII-Art.
+<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->
+`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.
 
 `set_display('none)` produit des résultats ASCII « sur une seule ligne » —
 comme le fait la commande de Maxima en ligne de commande `display2d:false;`.
 
-# Menu d'aide
+# Help menu
 
 WxMaxima’s help menu provides access to the Maxima and wxMaxima manual,
 tips, some example worksheets and in command line Maxima included demos (the
@@ -1331,21 +1307,19 @@ tips, some example worksheets and in command line Maxima included demos (the
 
 Veuillez noter que les exemples indiquent :
 
-~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the
-demonstration.  ~~~
+~~~text
+At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.
+~~~
 
-Cela est valable pour Maxima en ligne de commande, mais dans wxMaxima, par
-défaut, il est nécessaire de poursuivre la démonstration avec :
-<kbd>CTRL</kbd> + <kbd>ENTRÉE</kbd>
+That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>
 
-(Ce comportement peut être configuré dans le menu Configurer → Notebook →
-" Raccourcis pour envoyer des commandes à Maxima".)
+(That can be configured in the Configure->Worksheet->"Hotkeys for sending commands to Maxima" menu.)
 
 ______________________________________________________________________
 
-# Résolution des problèmes
+# Troubleshooting
 
-## Impossible de se connecter à _Maxima_
+## Cannot connect to _Maxima_
 
 Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_
 (providing the easy-to-use user interface) are separate programs that
@@ -1364,7 +1338,7 @@ On Unix computers another possible reason would be that the loopback network
 that provides network connections between two programs in the same computer
 isn’t properly configured.
 
-## Comment récupérer les données d’un fichier .wxmx corrompu
+## How to save data from a broken .wxmx file
 
 Internally most modern XML-based formats are ordinary zip files. _WxMaxima_
 doesn’t turn on compression, so the contents of `.wxmx` files can be viewed
@@ -1378,19 +1352,13 @@ processor document. If the zip signature isn’t intact that does not need to
 be the end of the world: If _wxMaxima_ during saving detected that something
 went wrong there will be a `.wxmx~` file whose contents might help.
 
-And even if there isn’t such a file: The `.wxmx` file is a container format
-and the XML portion is stored uncompressed. It it is possible to rename the
-`.wxmx` file to a `.txt` file and to use a text editor to recover the XML
-portion of the file’s contents (it starts with `<?xml version="1.0"
-encoding="UTF-8"?>` and ends with `</wxMaximaDocument>`. Before and after
-that text you will see some unreadable binary contents in the text editor).
+And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version="1.0" encoding="UTF-8"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).
 
 Si vous enregistrez un fichier texte contenant uniquement ce contenu (par
 exemple, en copiant et collant ce texte dans un nouveau fichier) avec une
 extension `.xml`, _wxMaxima_ saura comment récupérer le texte du document.
 
-## Je souhaite afficher des informations de débogage à l’écran avant que ma
-commande ne soit terminée
+## I want some debug info to be displayed on the screen before my command has finished
 
 Normalement, _wxMaxima_ attend que la formule 2D soit transférée en totalité
 avant de commencer la composition typographique. Cela permet d’économiser du
@@ -1399,7 +1367,7 @@ existe une commande `disp` qui affiche immédiatement des informations de
 débogage, sans attendre la fin de l’exécution de la commande _Maxima_ en
 cours :
 
-``maxima
+```maxima
 for i:1 thru 10 do (
    disp(i),
    /* (sleep n) is a Lisp function, which can be used */
@@ -1411,8 +1379,7 @@ for i:1 thru 10 do (
 
 Sinon, on peut utiliser la commande `wxstatusbar()` mentionnée ci-dessus.
 
-## La création d'un graphique n'affiche qu'une enveloppe vide encadrée avec
-un message d'erreur
+## Plotting only shows a closed empty envelope with an error message
 
 Cela signifie que _wxMaxima_ n'a pas pu lire le fichier généré par _Maxima_,
 qui était censé donner les instructions à _Gnuplot_ pour créer le graphique.
@@ -1435,7 +1402,7 @@ Les causes possibles de cette erreur sont :
   `wxplot_pngcairo` to true from _Maxima_.
 - Gnuplot n'a pas produit un fichier .png valide.
 
-## Le tracé d'une animation génère l'erreur "error: undefined variable"
+## Plotting an animation results in “error: undefined variable”
 
 Par défaut, la valeur du paramètre pour le curseur n'est substituée dans
 l'expression à tracer que si elle y est visible. L'utilisation d'une
@@ -1444,8 +1411,7 @@ tracer résout ce problème. À la fin de la section [Intégrer des animations
 dans le notebook](#embedding-animations-into-the-spreadsheet), vous pouvez
 voir un exemple.
 
-## J’ai perdu le contenu d’une cellule et la fonction Annuler ne le restaure
-pas
+## I lost cell content and undo doesn’t remember
 
 Il existe des fonctions Annuler distinctes pour les opérations sur les
 cellules et pour les modifications à l’intérieur des cellules, donc il est
@@ -1464,23 +1430,25 @@ permettent de récupérer les données :
   recently.
 - Si rien d’autre ne fonctionne, _Maxima_ contient une fonction de replay :
 
-```maxima playback(); ```
+```maxima
+playback();
+```
 
-## _WxMaxima_ démarre avec le message  Maxima process terminated
+## _WxMaxima_ starts up with the message “Maxima process terminated.”
 
 One possible reason is that _Maxima_ cannot be found in the location that is
 set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore
 won’t run at all. Setting the path to a working _Maxima_ binary should fix
 this problem.
 
-## Maxima calcule indéfiniment et ne répond plus aux commandes entrées
+## Maxima is forever calculating and not responding to input
 
 It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_
 has finished calculating and therefore never gets informed it can send new
 data to _Maxima_. If this is the case “Trigger evaluation” might
 resynchronize the two programs.
 
-## Mon _Maxima_ basé sur SBCL manque de mémoire
+## My SBCL-based _Maxima_ runs out of memory
 
 Le compilateur Lisp SBCL est configuré par défaut avec une limite de mémoire
 qui lui permet de fonctionner même sur des ordinateurs peu
@@ -1499,29 +1467,31 @@ dialogue.
 
 ![mémoire pour sbcl](./sbclMemory.png){ id=img_sbclMemory }
 
-## Sous Ubuntu, la saisie est parfois lente ou certaines touches sont
-ignorées
+## Input sometimes is sluggish/ignoring keys on Ubuntu
 
 L'installation du paquet 'ibus-gtk' devrait résoudre ce problème. Pour plus
 de détails, voir :
 [https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558).
 
-## _WxMaxima_ se fige lorsque _Maxima_ traite des caractères grecs ou des
-lettres accentuées (comme les umlauts)
+## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts
 
 Si votre _Maxima_ est basé sur SBCL, ajoutez les lignes suivantes à votre
 fichier `.sbclrc` :
 
-```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```
+```commonlisp
+(setf sb-impl::*default-external-format* :utf-8)
+```
 
 Le dossier où ce fichier doit être placé dépend du système et de
 l’installation. Cependant, toute version de _Maxima_ basée sur SBCL, ayant
 déjà évalué une cellule durant la session en cours, peut gentiment indiquer
 son emplacement après exécution de la commande suivante :
 
-```maxima :lisp (sb-impl::userinit-pathname)  ```
+```maxima
+:lisp (sb-impl::userinit-pathname)
+```
 
-## Remarque concernant Wayland (distributions Linux/BSD récentes)
+## Note concerning Wayland (recent Linux/BSD distributions)
 
 Il semble y avoir des problèmes de compatibilité entre le serveur
 d'affichage Wayland et wxWidgets. WxMaxima peut en être affecté, par exemple
@@ -1550,14 +1520,12 @@ If the automatic fix fails, you can manually start wxMaxima with:
 
 `UBUNTU_MENUPROXY=0 wxmaxima`
 
-## Pourquoi le navigateur pour le manuel intégré n’est-il pas disponible sur
-mon PC Windows ?
+## Why is the integrated manual browser not offered on my Windows PC?
 
 Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or
 Microsoft’s webview2 isn’t installed.
 
-## Pourquoi le navigateur pour le manuel externe ne fonctionne-t-il pas sur
-ma machine Linux ?
+## Why is the external manual browser not working on my Linux box?
 
 The HTML browser might be a snap, flatpack or appimage version. All of these
 typically cannot access files that are installed on your local
@@ -1566,8 +1534,7 @@ snap, flatpack or something else that doesn’t give the host system access to
 its contents. A third reason might be that the maxima HTML manual isn’t
 installed and the online one cannot be accessed.
 
-## Puis-je faire en sorte que _wxMaxima_ génère à la fois des fichiers image
-et des graphiques en ligne en même temps ?
+## Can I make _wxMaxima_ output both image files and embedded plots at once?
 
 Le notebook intègre les fichiers `.png`. _WxMaxima_ permet à l'utilisateur
 de spécifier où ces fichiers doivent être générés :
@@ -1606,8 +1573,7 @@ pngdraw2d("Test",
 );
 ```
 
-## Puis-je définir le rapport hauteur/largeur (aspect ratio) d’un graphique
-en ligne ?
+## Can I set the aspect ratio of an embedded plot?
 
 Utilisez la variable `wxplot_size` :
 
@@ -1617,30 +1583,22 @@ wxdraw2d(
 ),wxplot_size=[1000,1000];
 ```
 
-## Après la mise à niveau vers macOS 13.1, les commandes plot et/ou draw
-affichent des messages d'erreur du type
+## After upgrading to MacOS 13.1 plot and/or draw commands output error messages like
 
-```text 1 HIToolbox 0x00007ff80cd91726
-_ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox
-0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox
-0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```
+```text
+1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102
+2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52
+3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408
+...
+```
 
-Ce problème pourrait être lié au système d'exploitation. Désactiver le
-masquage automatique de la barre de menus (via Réglages Système => Bureau et
-Dock => Barre des menus) pourrait résoudre le problème. Pour plus
-d'informations, voir [l'issue wxMaxima
-#1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746).
+This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.
 
-## Journalisation
+## Logging
 
-Les messages du journal peuvent être utiles pour déboguer des
-problèmes. WxMaxima peut enregistrer de nombreux événements. La plupart des
-entrées du journal seront utiles aux développeurs, notamment en cas de
-problème ou de bogue. Si vous exécutez une version « Release », la fenêtre
-du journal n’est pas affichée par défaut ; si vous exécutez une version de
-développement, elle est affichée par défaut comme une seconde fenêtre. Vous
-pouvez activer ou désactiver cette fenêtre via le menu « Affichage ->
-Basculer la fenêtre du journal ».
+Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a "Release"-Build,
+the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable
+this window using the "View->Toggle log window" menu entry.
 
 Les messages ne sont pas « perdus » si la fenêtre du journal n’est pas
 affichée. Si vous choisissez d’afficher la fenêtre du journal plus tard,
@@ -1659,18 +1617,18 @@ ______________________________________________________________________
 
 # FAQ
 
-## Comment faire tenir plus de texte sur une page LaTeX ?
+## Is there a way to make more text fit on a LaTeX page?
 
 Oui. Utilisez le [package LaTeX "geometry"](https://ctan.org/pkg/geometry)
 pour définir la taille des marges.
 
-Vous pouvez ajouter la ligne suivante dans le préambule LaTeX (par exemple
-via le champ dédié dans la fenêtre de configuration : ("Export" → "Lignes
-supplémentaires pour le préambule TeX") pour régler les marges à 1 cm :
+You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue ("Export"->"Additional lines for the TeX preamble"), to set borders of 1cm):
 
-```latex \usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```
+```latex
+\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}
+```
 
-## Un mode sombre existe-t-il ?
+## Is there a dark mode?
 
 Si wxWidgets est suffisamment récent, _wxMaxima_ passera automatiquement en
 mode sombre si le système d'exploitation l'est également. Par défaut, la
@@ -1678,17 +1636,11 @@ feuille de travail a un fond clair, mais cela peut être personnalisé. Sinon,
 il existe une option 'Affichage/Inverser la luminosité de la feuille' qui
 permet de basculer rapidement entre un fond clair et un fond sombre.
 
-## _WxMaxima_ se fige parfois pendant plusieurs secondes lors de la première
-minute d'utilisation
+## _WxMaxima_ sometimes hangs for several seconds once in the first minute
 
-_WxMaxima_ delegates some big tasks like parsing _Maxima_’s
->1000-page-manual to background tasks, which normally goes totally
-unnoticed. At the moment the result of such a task is needed, though, it is
-possible that _wxMaxima_ needs to wait a couple of seconds before it can
-continue its work.
+_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.
 
-## Especially when testing new locale settings, a message box "locale
-’xx_YY’ can not be set" occurs
+## Especially when testing new locale settings, a message box "locale ’xx_YY’ can not be set" occurs
 
 ![Avertissement sur la langue locale](./locale-warning.png){
 id=img_locale_warning}
@@ -1707,8 +1659,7 @@ You can find these symbols in the Unicode sidebar (search for ’double-struck
 capital’). But the selected font must also support these symbols. If they do
 not display properly, select another font.
 
-## Comment un script Maxima peut-il déterminer s'il s'exécute sous wxMaxima
-ou en ligne de commande ?
+## How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?
 
 Si wxMaxima est utilisé, la variable Maxima `maxima_frontend` est définie
 sur `wxmaxima`. Dans ce cas, la variable Maxima `maxima_frontend_version`
@@ -1717,16 +1668,13 @@ contient la version de wxMaxima.
 Si aucun programme pour le frontend n'est utilisé (si vous utilisez Maxima
 en ligne de commande), ces variables valent `false`.
 
-## De l'aide ! Je ne peux pas sauvegarder mon document !
+## Help! I can not save my document!
 
-If saving as wxmx file does not work, try saving the document as wxm file
-(and vice versa). And you can also try to remove all output (Menu
-Cell->Remove all output) and save that file, maybe some unexpected output
-causes issues during the save process.
+If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.
 
 ______________________________________________________________________
 
-# Arguments en ligne de commande
+# Command-line arguments
 
 Généralement, les programmes dotés d'une interface graphique se lancent
 simplement en cliquant sur une icône ou une entrée de menu. WxMaxima,
@@ -1762,7 +1710,7 @@ d'un tiret court (-) devant les options en ligne de commande.
 
 ______________________________________________________________________
 
-# À propos du logiciel et des contributions à wxMaxima
+# About the program, contributing to wxMaxima
 
 wxMaxima est principalement développé en C++ avec le framework
 [wxWidgets](https://www.wxwidgets.org), et utilise
@@ -1789,7 +1737,4 @@ bibliothèque wxWidgets), il ne nécessite aucune dépendance externe (comme
 des fichiers graphiques ou le logiciel Lisp.   Les éléments comme le fichier
 ( `wxmathML.lisp`) sont intégrés directement dans l'exécutable.
 
-Si vous êtes développeur et que vous souhaitez tester une version modifiée
-du fichier `wxmathML.lisp`  sans tout recompiler, vous pouvez utiliser
-l'option en ligne de commande : `--wxmathml-lisp=<chemin>` pour spécifier un
-autre fichier Lisp à la place de celui intégré à la version actuelle.
+If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.

--- a/info/wxmaxima.it.md
+++ b/info/wxmaxima.it.md
@@ -1,4 +1,4 @@
-# Il manuale utente di wxMaxima {-}
+# The wxMaxima user manual
 
 wxMaxima è un'interfaccia utente grafica (GUI) per il sistema di algebra
 computazionale (CAS) _Maxima_. wxMaxima consente di utilizzare tutte le
@@ -11,9 +11,9 @@ popolari per _Maxima_.
 
 ______________________________________________________________________
 
-# Introduzione a wxMaxima
+# Introduction to wxMaxima
 
-## _Maxima_ e wxMaxima
+## _Maxima_ and wxMaxima
 
 Nel dominio open source, i grandi sistemi sono normalmente suddivisi in
 progetti più piccoli che sono più facili da gestire per piccoli gruppi di
@@ -55,14 +55,9 @@ possono essere risolti analiticamente.
 ![schermata di Maxima, riga di comando](./maxima_screenshot.png){
 id=img_maxima_screenshot }
 
-Ampia documentazione per _Maxima_ è [disponibile su Internet]
-(https://maxima.sourceforge.io/documentation.html). Parte di questa
-documentazione è disponibile anche nel menu di aiuto di wxMaxima. Premendo
-il tasto Guida (sulla maggior parte dei sistemi il tasto  <kbd>F1</kbd>), la
-funzione di guida sensibile al contesto di _wxMaxima_ passa automaticamente
-alla pagina di manuale di _Maxima_ per il comando sotto il cursore.
+Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.
 
-### wxMaxima
+### WxMaxima
 
 _wxMaxima_ è un'interfaccia utente grafica che fornisce flessibilità e tutte
 le funzionalità di _Maxima_. wxMaxima offre agli utenti una visualizzazione
@@ -82,7 +77,7 @@ tramite il menu della guida.
 I calcoli immessi in _wxMaxima_ vengono eseguiti dallo strumento della riga
 di comando _Maxima_ in background.
 
-## Nozioni di base sulle cartelle di lavoro
+## Workbook basics
 
 Gran parte di _wxMaxima_ si spiega da sé, ma alcuni dettagli richiedono
 attenzione. [Questo
@@ -95,7 +90,7 @@ _wxMaxima_ per interagire con _Maxima_. Questo manuale si concentra sulla
 descrizione degli aspetti di _wxMaxima_ che probabilmente non sono evidenti
 e che potrebbero non essere trattati nel materiale online.
 
-### L'approccio della cartella di lavoro
+### The workbook approach
 
 Una delle pochissime cose che non sono standard in _wxMaxima_ è che
 organizza i dati per _Maxima_ in celle che vengono elaborate (ovvero:
@@ -146,7 +141,7 @@ immagine).
 ![Esempio di celle wxMaxima diverse](./cell-example.png){
 id=img_cell-example }
 
-### Celle
+### Cells
 
 Il foglio di lavoro è organizzato in celle. wxMaxima riconosce i seguenti
 tipi di celle:
@@ -171,7 +166,7 @@ matematica come di seguito: `/* Questo commento verrà ignorato da Maxima */`
 
 "`/*`" marca l'inizio del commento, mentre "`*/`" la sua fine.
 
-### Cursori orizzontali e verticali
+### Horizontal and vertical cursors
 
 Se l'utente tenta di selezionare una frase completa, un elaboratore di testi
 tenterà di estendere la selezione per iniziare e terminare automaticamente
@@ -189,12 +184,7 @@ passerà da uno all'altro automaticamente alla bisogna:
   il puntatore del mouse o i tasti cursore e funziona in modo molto simile
   al cursore in un editor di testo.
 
-Quando si avvia wxMaxima, è visibile solo un cursore orizzontale
-lampeggiante. Se si inizia a digitare, viene creata automaticamente una
-cella matematica e il cursore diventa verticale (si vedrà una freccia destra
-come "prompt", dopo l'elaborazione della cella matematica
-(<kbd>CTRL+INVIO</kbd >), si noteranno, ad esempio, le etichette `(%i1)` e
-`(%o1)`).
+When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as "prompt", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).
 
 ![(blinking) cursore orizzontale dopo l'avvio di
 wxMaxima](./horizontal-cursor-only.png){ id=img_horizontal_cursor_only }
@@ -212,34 +202,19 @@ altro tipo di cella utilizzando il menu).
 celle](./horizontal-cursor-between-cells.png){
 id=img_horizontal_cursor_between_cells }
 
-### Invio delle celle a Maxima
+### Sending cells to Maxima
 
-Il comando in una cella di codice viene eseguito una volta premuti i tasti
-<kbd>CTRL</kbd>+<kbd>INVIO</kbd>, <kbd>MAIUSC</kbd>+<kbd>INVIO</kbd> o
-<kbd>INVIO</kbd> sulla tastiera. L'impostazione predefinita di _wxMaxima_
-prevede l'immissione di comandi quando viene inserito
-<kbd>CTRL</kbd>+<kbd>INVIO</kbd> o <kbd>MAIUSC</kbd>+<kbd>INVIO</kbd>, ma
-_wxMaxima_ può essere configurato per eseguire comandi in risposta anche a
-solo <kbd>INVIO</kbd>.
+The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.
 
-### Autocompletamento comandi
+### Command autocompletion
 
-_wxMaxima_ contiene una funzione di completamento automatico che viene
-attivata tramite il menu (Cella/Parola completa) o in alternativa premendo
-la combinazione di tasti <kbd>CTRL</kbd>+<kbd>SPAZIO</kbd>. Il completamento
-automatico è sensibile al contesto. Ad esempio, se attivato all'interno di
-una specifica di unità di ezUnits, offrirà un elenco di unità applicabili.
+_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.
 
 ![ezUnits](./ezUnits.png){ id=img_ezUnits }
 
-Oltre a completare un nome di file, un nome di unità o il nome del comando o
-della variabile corrente, l'autocompletamento è in grado di mostrare un
-modello per la maggior parte dei comandi indicando il tipo (e il
-significato) dei parametri che questo programma si aspetta. Per attivare
-questa funzione premere <kbd>MAIUSC</kbd>+<kbd>CTRL</kbd>+<kbd>SPAZIO</kbd>
-o selezionare la rispettiva voce di menu (Cella/Mostra modello).
+Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).
 
-#### Caratteri greci
+#### Greek characters
 
 I computer tradizionalmente memorizzavano i caratteri in valori a 8 bit. Ciò
 consente un massimo di 256 caratteri diversi. Tutte le lettere, i numeri e i
@@ -359,25 +334,17 @@ vari:
 
 You can also use the "Symbols"-sidebar to enter these Mathematical symbols.
 
-If a special symbol isn’t in the list, it is possible to input arbitrary
-Unicode characters by pressing <kbd>ESC</kbd> \[number of the character
-(hexadecimal)\] <kbd>ESC</kbd>. Additionally the "symbols" sidebar has a
-right-click menu that allow to display a list of all available Unicode
-symbols one can add to this toolbar or to the worksheet.
+If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \[number of the character (hexadecimal)\] <kbd>ESC</kbd>. Additionally the "symbols" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.
 
-<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an
-`a`.
+<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.
 
 Please note that most of these symbols (notable exceptions are the logic
 symbols) do not have a special meaning in _Maxima_ and therefore will be
 interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp
 that doesn’t support Unicode characters they might cause an error message.
 
-Potrebbe capitare che, ad es. caratteri greci o simboli matematici non siano
-stati inclusi nel font selezionato, e quindi non possano essere
-visualizzati.
-Per risolvere questo problema, provare a selezionare un altro font (tramite:
-Modifica -> Configura -> Stile).
+It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.
+To solve that problem, select other fonts (using: Edit -> Configure -> Style).
 
 ### Unicode replacement
 
@@ -401,7 +368,7 @@ math input does not contain them; (b) if you save the document as
 changes will of course not work in command line Maxima); but they may occur,
 if you cut&paste a formula from another document.
 
-### Pannelli laterali
+### Side Panes
 
 È possibile accedere più velocemente ai comandi _Maxima_ più importanti o a
 cose come il sommario, finestre con messaggi diagnostici o la cronologia
@@ -422,7 +389,7 @@ o inferiore.
 sommario](./Sidepane-TOC-convert-headings.png){
 id=Sidepane-TOC-convert-headings }
 
-### Uscita MathML
+### MathML output
 
 Several word processors and similar programs either recognize
 [MathML](https://www.w3.org/Math/) input and automatically insert it as an
@@ -431,37 +398,41 @@ offers an “import MathML from clipboard” feature. Others support RTF
 maths. _WxMaxima_, therefore, offers several entries in the right-click
 menu.
 
-### Supporto Markdown
+### Markdown support
 
 _WxMaxima_ offers a set of standard
 [Markdown](https://en.wikipedia.org/wiki/Markdown) conventions that don’t
 collide with mathematical notation. One of these elements is bullet lists.
 
-Testo normale
- * Un elemento, livello indentazione 1
- * Un altro elemento a livello indentazione 1
-   * Un elemento al secondo livello di indentazione
-   * Un secondo elemento al secondo livello di indentazione
- * Un terzo elemento al primo livello di indentazione
-Testo normale
+```text
+Ordinary text
+ * One item, indentation level 1
+ * Another item at indentation level 1
+   * An item at a second indentation level
+   * A second item at the second indentation level
+ * A third item at the first indentation level
+Ordinary text
+```
 
-_wxMaxima_ riconoscerà il testo che inizia con i caratteri `>` come
-virgolette di blocco:
+_WxMaxima_ will recognize text starting with `>` chars as block quotes:
 
-```text Ordinary text > quote quote quote quote > quote quote quote quote >
-quote quote quote quote Ordinary text ```
+```text
+Ordinary text
+> quote quote quote quote
+> quote quote quote quote
+> quote quote quote quote
+Ordinary text
+```
 
-Anche l'uscita TeX e HTML di _wxMaxima_ riconoscerà `=>` e lo sostituirà con
-il corrispondente simbolo Unicode:
+_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:
 
-```text cogito => sum.  ```
+```text
+cogito => sum.
+```
 
-Altri simboli che l'esportazione HTML e TeX riconoscerà sono `<=` e `>=` per
-i confronti, una doppia freccia a doppia punta (`<=>`), frecce a punta
-singola (`<->`, `-> ` e `<-`) e `+/-` come simbolo. Per l'uscita TeX sono
-riconosciuti anche `<<` e `>>`.
+Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.
 
-### Scorciatoie da tastiera
+### Hotkeys
 
 La maggior parte dei tasti di scelta rapida si trova nel testo dei
 rispettivi menu. Dal momento che sono effettivamente presi dal testo del
@@ -477,14 +448,14 @@ rapida, tuttavia, non sono documentati neanche nei menu:
   auto-completion mechanism.
 - <kbd>MAIUSC</kbd>+<kbd>SPAZIO</kbd> inserisce uno spazio non divisibile.
 
-### TeX grezzo nell'esportazione TeX
+### Raw TeX in the TeX export
 
 Se una cella di testo inizia con `TeX:`, l'esportazione TeX contiene il
 testo letterale che segue l'indicatore `TeX:`. L'utilizzo di questa funzione
 consente l'inserimento del marcatore TeX all'interno della cartella di
 lavoro _wxMaxima_.
 
-## Formati di file
+## File Formats
 
 Il materiale sviluppato in una sessione _wxMaxima_ può essere archiviato per
 un uso successivo in uno dei seguenti tre modi:
@@ -513,13 +484,8 @@ essere rilette come sessioni _wxMaxima_.
 
 ### .wxm
 
-`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima
-versions >5.38 they can be read using _Maxima_’s `load()` function just as
-.mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as
-the answer is written in the `.wxm` file (so that it can be suggested after
-loading), but that can Maxima not evaluate.  You can prevent Maxima from
-asking questions by using `assume()` to declare some properties, Maxima
-wants to know.
+`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.
+You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.
 
 With this plain-text format, it sometimes is unavoidable that worksheets
 that use new features are not downwards-compatible with older versions of
@@ -532,8 +498,10 @@ containing the cell contents as some special Maxima comments.
 
 It starts with the following comment:
 
-```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
-Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```
+```maxima
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */
+```
 
 And then the cells follow, encoded as Maxima comments, e.g. a section cell:
 
@@ -609,7 +577,7 @@ with a text editor, or replace an broken image, zip the files again,
 probably rename the `zip` to a `wxmx`-file - and you get another modified
 `wxmx`-file.
 
-## Opzioni di configurazione
+## Configuration options
 
 Per alcune variabili di configurazione comuni _wxMaxima_ offre due modalità
 di configurazione:
@@ -623,14 +591,14 @@ di configurazione:
 ![Configurazione wxMaxima 1](./wxMaxima_configuration_001.png){
 id=img_wxMaxima_configuration_001 }
 
-### Frequenza di quadro animazioni predefinita
+### Default animation framerate
 
 La frequenza di quadro dell'animazione usata per le nuove animazioni è
 conservata nella variabile `wxanimate_framerate`. Il valore iniziale che
 questa variabile conterrà in un nuovo foglio di lavoro può essere modificato
 utilizzando la finestra di configurazione.
 
-### Dimensione predefinita dei grafici per le nuove sessioni _maxima_
+### Default plot size for new _maxima_ sessions
 
 Al prossimo riavvio, i grafici incorporati nel foglio di lavoro verranno
 creati con questa dimensione se il valore di `wxplot_size` non viene
@@ -649,7 +617,7 @@ wxdraw2d(
 ), wxplot_size=[480,480]$
 ```
 
-### Abbina parentesi nei controlli di testo
+### Match parenthesis in text controls
 
 Questa opzione abilita due cose:
 
@@ -658,7 +626,7 @@ Questa opzione abilita due cose:
 - Se il testo è selezionato e viene premuto uno di questi tasti, questo
   verrà inserito in una coppia di segni corrispondenti.
 
-### Non salvare il foglio di lavoro automaticamente
+### Don’t save the worksheet automatically
 
 Se questa opzione è impostata, il file in cui si trova il foglio di lavoro
 verrà sovrascritto solo su richiesta dell'utente. Tuttavia, in caso di
@@ -671,17 +639,10 @@ moderna app per cellulari:
 - I file vengono salvati automaticamente all'uscita
 - E il file verrà automaticamente salvato ogni 3 minuti.
 
-### Dove viene salvata la configurazione?
+### Where is the configuration saved?
 
-If you are using Unix/Linux, the configuration information will be saved in
-a file `.wxMaxima` in your home directory (if you are using wxWidgets \<
-3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is
-used). You can retrieve the wxWidgets version from the command
-`wxbuild_info();` or by using the menu option
-Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform
-GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the
-name).  (Since the filename starts with a dot, `.wxMaxima` or `.config` will
-be hidden).
+If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).
+(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).
 
 Se si sta usando Windows, la configurazione verrà memorizzata nel registro
 di sistema. Le voci per _wxMaxima_ sono nella seguente posizione nel
@@ -689,7 +650,7 @@ registro: `HKEY_CURRENT_USER\Software\wxMaxima`
 
 ______________________________________________________________________
 
-# Estensioni a _Maxima_
+# Extensions to _Maxima_
 
 _wxMaxima_ è principalmente un'interfaccia utente grafica per _Maxima_. In
 quanto tale, il suo scopo principale è passare i comandi a _Maxima_ e
@@ -699,7 +660,7 @@ capacità di _wxMaxima_ di generare report esportando il contenuto di una
 cartella di lavoro in file HTML e LaTeX. Questa sezione descrive alcuni modi
 in cui _wxMaxima_ migliora l'inclusione della grafica in una sessione.
 
-## Variabili pedice
+## Subscripted variables
 
 `wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript
 variable names:
@@ -727,7 +688,7 @@ variabile pedice può essere ripristinata usando il seguente comando:
 
 You can use the menu "View->Autosubscript" to set these values.
 
-## Feedback utente nella barra di stato
+## User feedback in the status bar
 
 I comandi a esecuzione prolungata possono fornire feedback all'utente nella
 barra di stato. Questo feedback all'utente viene sostituito da qualsiasi
@@ -757,8 +718,10 @@ scripted or batch export. Like `wxstatusbar()` it is safe to use in code
 that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present
 the command is simply left unevaluated.
 
-```maxima wxworksheettohtml("report.html")$ wxworksheettohtml("report.html",
-flavor="svg", wxmx=true)$ ```
+```maxima
+wxworksheettohtml("report.html")$
+wxworksheettohtml("report.html", flavor="svg", wxmx=true)$
+```
 
 A relative file name is interpreted relative to _Maxima_’s working
 directory. The optional keyword options are:
@@ -776,8 +739,10 @@ still lack MathML, and `svg`/`bitmap` render every equation to an image.
 The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file
 the same way:
 
-```maxima wxworksheettotex("report.tex")$ wxworksheettotex("report.tex",
-documentclass="report", documentclassoptions="12pt,a4paper")$ ```
+```maxima
+wxworksheettotex("report.tex")$
+wxworksheettotex("report.tex", documentclass="report", documentclassoptions="12pt,a4paper")$
+```
 
 | option                 | meaning                                                              |
 | ---------------------- | -------------------------------------------------------------------- |
@@ -786,13 +751,13 @@ documentclass="report", documentclassoptions="12pt,a4paper")$ ```
 
 Support for `wxworksheettopdf()` is planned.
 
-## Diagrammi
+## Plotting
 
 Fare diagrammi (che ha fondamentalmente a che fare con la grafica) è un
 luogo in cui un'interfaccia utente grafica dovrà fornire alcune estensioni
 al programma originale.
 
-### Incorporare un diagramma nel foglio di lavoro
+### Embedding a plot into the worksheet
 
 _Maxima_ normally instructs the external program _Gnuplot_ to open a
 separate window for every diagram it creates. Since many times it is
@@ -827,7 +792,7 @@ is most likely a Maxima issue and should be reported in the [Maxima
 bugtracker](https://sourceforge.net/p/maxima/bugs/). Or maybe a Gnuplot
 issue.
 
-### Rendere i diagrammi incorporati più grandi o più piccoli
+### Making embedded plots bigger or smaller
 
 Come evidenziato sopra, la finestra di dialogo di configurazione fornisce un
 modo per modificare le dimensioni predefinite dei grafici creati impostando
@@ -852,19 +817,21 @@ corrente. Con questo metodo di utilizzo la specifica `wxplot_size = [value1,
 value2]` viene aggiunta al comando `wxdraw2d()` e non fa parte del comando
 `wxdraw2d`.
 
+```maxima
 wxdraw2d(
     explicit(
         sin(x),
         x,1,10
     )
 ),wxplot_size=[1600,800]$
+```
 
 Setting the size of embedded plot with `wxplot_size` works for embedded
 plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot`
 commands and for embedded animations with `with_slider_draw` and `wxanimate`
 commands.
 
-### Grafici di qualità superiore
+### Better quality plots
 
 _Gnuplot_ doesn’t seem to provide a portable way of determining whether it
 supports the high-quality bitmap output that the Cairo library provides. On
@@ -874,7 +841,7 @@ from the configuration menu (that can be overridden by the variable
 styles. If `wxplot_pngCairo` is set without _Gnuplot_ supporting this the
 result will be error messages instead of graphics.
 
-### Aprire grafici incorporati in finestre interattive _gnuplot_
+### Opening embedded plots in interactive _Gnuplot_ windows
 
 If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and
 `wxplot3d` isn’t supported by this feature) and the file size of the
@@ -882,7 +849,7 @@ underlying _Gnuplot_ project isn’t way too high _wxMaxima_ offers a
 right-click menu that allows to open the plot in an interactive _Gnuplot_
 window.
 
-### Apertura della console dei comandi di gnuplot in finestra `plot`
+### Opening Gnuplot’s command console in `plot` windows
 
 On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and
 `wgnuplot.exe`.  You can configure, which command should be used using the
@@ -891,7 +858,7 @@ window, where _gnuplot_ commands can be entered into, `gnuplot.exe` does not
 offer this possibility. Unfortunately, `wgnuplot.exe` causes _Gnuplot_ to
 "steal" the keyboard focus for a short time every time a plot is prepared.
 
-### Incorporamento di animazioni nel foglio di calcolo
+### Embedding animations into the spreadsheet
 
 I diagrammi 3D tendono a rendere difficile la lettura dei dati
 quantitativi. Una valida alternativa potrebbe essere quella di assegnare il
@@ -1003,20 +970,24 @@ with_slider_draw(
 )$
 ```
 
-### Apertura di più grafici in più finestre contemporaneamente
+### Opening multiple plots in contemporaneous windows
 
 Sebbene non sia fornita da _wxMaxima_, questa funzionalità di _Maxima_ (nei
 setup che la supportano) a volte è utile. L'esempio seguente viene da un
 post di Mario Rodriguez alla mailing list _Maxima_:
 
-```maxima load(draw);
+```maxima
+load(draw);
 
-/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));
+/* Parabola in window #1 */
+draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));
 
-/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));
+/* Parabola in window #2 */
+draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));
 
 /* Paraboloid in window #3 */
-draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```
+draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));
+```
 
 Plotting multiple plots in the same window is possible, too (the same is
 possible in command line Maxima with the standard `draw()` command):
@@ -1077,7 +1048,7 @@ expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in
 3D plots also z) coordinates of a curve that is put into the current draw
 command.
 
-#### Punti
+#### Points
 
 Draws many points that can optionally be joined. The coordinates of the
 points are taken from a list of lists, a 2D array or one list or array for
@@ -1087,7 +1058,7 @@ each axis.
 
 Draws a title on the upper end of the diagram,
 
-#### Assi
+#### Axis
 
 Sets up the axis.
 
@@ -1110,12 +1081,12 @@ plots.
 Sets the line colour for the following plots the current draw command
 contains.
 
-#### Colore riempimento
+#### Fill colour
 
 Sets the fill colour for the following plots the current draw command
 contains.
 
-#### Griglia
+#### Grid
 
 Pops up a wizard that allows to set up grid lines.
 
@@ -1159,7 +1130,9 @@ project can be done as easily as per drag-and-drop. But sometimes (for
 example if an image’s contents might change later on in a session) it is
 better to tell the file to load the image on evaluation:
 
-```maxima show_image("man.png"); ```
+```maxima
+show_image("man.png");
+```
 
 ## Startup files
 
@@ -1204,6 +1177,20 @@ the command: `maxima_userdir;`
 - `wxanimate_autoplay`: Automatically play animations by default?
 - `wxmaximaversion`: Returns the version number of _wxMaxima_.
 - `wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using.
+- `wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these
+  differ by maintainer, distribution and operating system:
+  - `wxdirs@userconfdir`: The directory the user's configuration is stored
+    in. Same directory as `maxima_userdir` (see above) - both point at the
+    same place, `wxdirs@userconfdir` is only useful if that is more
+    convenient to reach from a `.mac` file than the Maxima-side variable.
+  - `wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the
+    built-in autocompletion list, ...) is installed in.
+  - `wxdirs@helpdir`: The directory the offline copy of this manual is
+    installed in.
+  - `wxdirs@localedir`: The directory _wxMaxima_'s translation files are
+    installed in.
+  - `wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_
+    is configured to start.
 
 ## Pretty-printing 2D output
 
@@ -1280,9 +1267,8 @@ using an (machine readable) XML-dialect (can be seen in the "Raw XML
 sidebar") and outputs the resulting formulas nicely rendered, e.g. pretty
 Matrices, Square root signs, fractions, etc.
 
-<!--- Currently that does not work as it should, the line with the output
-label is shifted right (issue: #2006) --> `set_display('ascii)` causes
-wxMaxima to output formulas as in command line Maxima - as ASCII-Art.
+<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->
+`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.
 
 `set_display('none)` causes 'one-line' ASCII results - the same as the
 command line Maxima command `display2d:false;` does.
@@ -1295,21 +1281,19 @@ tips, some example worksheets and in command line Maxima included demos (the
 
 Please notice, that the demos write:
 
-~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the
-demonstration.  ~~~
+~~~text
+At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.
+~~~
 
-That is valid for command-line Maxima, however in wxMaxima by default it is
-necessary to continue the demonstration with:
-<kbd>CTRL</kbd>+<kbd>ENTER</kbd>
+That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>
 
-(That can be configured in the Configure->Worksheet->"Hotkeys for sending
-commands to Maxima" menu.)
+(That can be configured in the Configure->Worksheet->"Hotkeys for sending commands to Maxima" menu.)
 
 ______________________________________________________________________
 
-# Risoluzione dei problemi
+# Troubleshooting
 
-## Estensioni a _Maxima_
+## Cannot connect to _Maxima_
 
 Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_
 (providing the easy-to-use user interface) are separate programs that
@@ -1342,19 +1326,13 @@ processor document. If the zip signature isn’t intact that does not need to
 be the end of the world: If _wxMaxima_ during saving detected that something
 went wrong there will be a `.wxmx~` file whose contents might help.
 
-And even if there isn’t such a file: The `.wxmx` file is a container format
-and the XML portion is stored uncompressed. It it is possible to rename the
-`.wxmx` file to a `.txt` file and to use a text editor to recover the XML
-portion of the file’s contents (it starts with `<?xml version="1.0"
-encoding="UTF-8"?>` and ends with `</wxMaximaDocument>`. Before and after
-that text you will see some unreadable binary contents in the text editor).
+And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version="1.0" encoding="UTF-8"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).
 
 If a text file containing only these contents (e.g. copy and paste this text
 into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know
 how to recover the text from the document.
 
-## I want some debug info to be displayed on the screen before my command
-has finished
+## I want some debug info to be displayed on the screen before my command has finished
 
 Normally _wxMaxima_ waits for the whole 2D formula to be transferred before
 it begins to typeset. This saves time for making many attempts to typeset a
@@ -1423,7 +1401,9 @@ several methods to recover data:
   recently.
 - If nothing else helps _Maxima_ contains a replay feature:
 
-```maxima playback(); ```
+```maxima
+playback();
+```
 
 ## _WxMaxima_ starts up with the message “Maxima process terminated.”
 
@@ -1467,14 +1447,18 @@ for details.
 If your _Maxima_ is based on SBCL the following lines have to be added to
 your `.sbclrc`:
 
-```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```
+```commonlisp
+(setf sb-impl::*default-external-format* :utf-8)
+```
 
 The folder where this file has to be placed is system- and
 installation-specific. But any SBCL-based _Maxima_ that already has
 evaluated a cell in the current session will happily tell where it can be
 found after getting the following command:
 
-```maxima :lisp (sb-impl::userinit-pathname)  ```
+```maxima
+:lisp (sb-impl::userinit-pathname)
+```
 
 ## Note concerning Wayland (recent Linux/BSD distributions)
 
@@ -1566,28 +1550,22 @@ wxdraw2d(
 ),wxplot_size=[1000,1000];
 ```
 
-## After upgrading to MacOS 13.1 plot and/or draw commands output error
-messages like
+## After upgrading to MacOS 13.1 plot and/or draw commands output error messages like
 
-```text 1 HIToolbox 0x00007ff80cd91726
-_ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox
-0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox
-0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```
+```text
+1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102
+2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52
+3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408
+...
+```
 
-This might be an issue with the operating system. Disable the hiding of the
-menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the
-issue. See [wxMaxima issue
-#1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more
-information.
+This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.
 
 ## Logging
 
-Log messages might be helpful to debug problems. WxMaxima can log many
-events. Most log entries will be helpful for developers, especially in case
-of problems or bugs. If you run a "Release"-Build, the log windows is not
-shown by default, if you run a development version, it is shown by default
-as a second window. You can enable and disable this window using the
-"View->Toggle log window" menu entry.
+Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a "Release"-Build,
+the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable
+this window using the "View->Toggle log window" menu entry.
 
 Messages are not 'lost', if the log window is not shown, if you select to
 show the log window later, you will see past log messages (if you did not
@@ -1610,11 +1588,11 @@ ______________________________________________________________________
 Yes. Use the [LaTeX package "geometry"](https://ctan.org/pkg/geometry) to
 specify the size of the borders.
 
-You can add the following line to the LaTeX preamble (for example by using
-the respective field in the config dialogue ("Export"->"Additional lines for
-the TeX preamble"), to set borders of 1cm):
+You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue ("Export"->"Additional lines for the TeX preamble"), to set borders of 1cm):
 
-```latex \usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```
+```latex
+\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}
+```
 
 ## Is there a dark mode?
 
@@ -1627,14 +1605,9 @@ vice versa.
 
 ## _WxMaxima_ sometimes hangs for several seconds once in the first minute
 
-_WxMaxima_ delegates some big tasks like parsing _Maxima_’s
->1000-page-manual to background tasks, which normally goes totally
-unnoticed. At the moment the result of such a task is needed, though, it is
-possible that _wxMaxima_ needs to wait a couple of seconds before it can
-continue its work.
+_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.
 
-## Especially when testing new locale settings, a message box "locale
-’xx_YY’ can not be set" occurs
+## Especially when testing new locale settings, a message box "locale ’xx_YY’ can not be set" occurs
 
 ![Locale warning](./locale-warning.png){ id=img_locale_warning}
 
@@ -1651,8 +1624,7 @@ You can find these symbols in the Unicode sidebar (search for ’double-struck
 capital’). But the selected font must also support these symbols. If they do
 not display properly, select another font.
 
-## How can a Maxima script determine, if it is running under wxMaxima or
-command line Maxima?
+## How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?
 
 If wxMaxima is used, the Maxima variable `maxima_frontend` is set to
 `wxmaxima`. The Maxima variable `maxima_frontend_version` contains the
@@ -1663,14 +1635,11 @@ are `false`.
 
 ## Help! I can not save my document!
 
-If saving as wxmx file does not work, try saving the document as wxm file
-(and vice versa). And you can also try to remove all output (Menu
-Cell->Remove all output) and save that file, maybe some unexpected output
-causes issues during the save process.
+If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.
 
 ______________________________________________________________________
 
-# Argomenti della riga di comando
+# Command-line arguments
 
 Usually you can start programs with a graphical user interface just by
 clicking on a desktop icon or desktop menu entry. WxMaxima - if started from
@@ -1731,7 +1700,4 @@ the wxWidgets library), no external dependencies (like graphic files or the
 Lisp part (the `wxmathML.lisp`-file) is needed, these files are included in
 the executable.
 
-If you are a developer, you might want to try out a modified
-`wxmathML.lisp`-file without recompiling everything, one can use the command
-line option `--wxmathml-lisp=<str>` to use another Lisp file, not the
-included one.
+If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.

--- a/info/wxmaxima.ru.md
+++ b/info/wxmaxima.ru.md
@@ -1,4 +1,4 @@
-# Руководство пользователя wxMaxima
+# The wxMaxima user manual
 
 WxMaxima — графический интерфейс пользователя для системы компьютерной
 алгебры (СКА) _Maxima_. WxMaxima позволяет использовать все функции
@@ -11,9 +11,9 @@ _Maxima_. А также предоставляет ряд удобных мас�
 
 ______________________________________________________________________
 
-# Введение в wxMaxima
+# Introduction to wxMaxima
 
-## _Maxima_ и wxMaxima
+## _Maxima_ and wxMaxima
 
 В области открытого программного обеспечения большие системы обычно делятся
 на небольшие проекты, которые проще обслуживать небольшим группам
@@ -54,12 +54,7 @@ _Maxima_ является полноценной системой компьют
 ![Снимок экрана Maxima, командная строка](./maxima_screenshot.png){
 id=img_maxima_screenshot }
 
-Исчерпывающая документация _Maxima_ [доступна в сети
-Интернет](https://maxima.sourceforge.io/documentation.html). Часть этой
-документации также доступна в меню справки wxMaxima. При нажатии клавиши
-«Справка» (в большинстве систем эту функцию выполняет клавиша <kbd>F1</kbd>)
-контекстно-зависимая функция справки _wxMaxima_ автоматически переходит на
-страницу руководства _Maxima_ с описанием команды, заданной в поле ввода.
+Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.
 
 ### WxMaxima
 
@@ -81,7 +76,7 @@ _wxMaxima_, а также в меню справки программы.
 Введённые в _wxMaxima_ вычисления выполняются в фоновом режиме консольной
 программой _Maxima_.
 
-## Основная информация о рабочей книге
+## Workbook basics
 
 Большая часть интерфейса _wxMaxima_ интуитивно понятна, но некоторые детали
 требуют особенного внимания. [Этот
@@ -94,7 +89,7 @@ _wxMaxima_. Проработка некоторых из них (особенн�
 интуитивно понятны, и описание которых может отсутствовать в материалах,
 доступных онлайн.
 
-### Метод работы с использованием рабочих книг
+### The workbook approach
 
 Одним из незначительного числа нестандартных подходов, нашедших применение в
 _wxMaxima_, является организация данных для работы с _Maxima_ по полям,
@@ -139,7 +134,7 @@ _Maxima_ вывод также получает метку, начинающую
 ![Пример различных полей wxMaxima](./cell-example.png){ id=img_cell-example
 }
 
-### Поля
+### Cells
 
 Рабочий лист состоит из полей. WxMaxima оперирует следующими их типами:
 
@@ -164,7 +159,7 @@ _Maxima_ вывод также получает метку, начинающую
 
 «`/*`» указывает начало комментария, «`*/`» указывает его конец.
 
-### Горизонтальный и вертикальный курсоры
+### Horizontal and vertical cursors
 
 Если пользователь пытается выделить предложение полностью, текстовый
 процессор будет автоматически пытаться расширить выделение, чтобы оно
@@ -182,12 +177,7 @@ _wxMaxima_ переключается между ними автоматичес
   клавишами со стрелками и в работе очень напоминает курсор текстового
   редактора.
 
-После загрузки wxMaxima отображается только мигающий горизонтальный
-курсор. Если начать ввод, автоматически создаётся математическое поле и
-курсор принимает обычную вертикальную форму. Появится стрелка вправо —
-«запрос на ввод». После вычисления математического поля
-(<kbd>CTRL</kbd>+<kbd>ENTER</kbd>) будут показаны метки, например: `(%i1)`,
-`(%o1)`.
+When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as "prompt", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).
 
 ![(Мигающий) горизонтальный курсор после запуска
 wxMaxima](./horizontal-cursor-only.png){ id=img_horizontal_cursor_only }
@@ -204,32 +194,19 @@ wxMaxima](./horizontal-cursor-only.png){ id=img_horizontal_cursor_only }
 полями](./horizontal-cursor-between-cells.png){
 id=img_horizontal_cursor_between_cells }
 
-### Отправка полей в Maxima
+### Sending cells to Maxima
 
-Команда в поле кода исполняется однократно по нажатию сочетания клавиш
-<kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> или
-клавиши <kbd>ENTER</kbd> на клавиатуре. По умолчанию _wxMaxima_ вводит
-команды при нажатии <kbd>CTRL</kbd>+<kbd>ENTER</kbd> или
-<kbd>SHIFT</kbd>+<kbd>ENTER</kbd>, но после соответствующей настройки
-_wxMaxima_ будет выполнять команды по нажатию <kbd>ENTER</kbd>.
+The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.
 
-### Автодополнение команд
+### Command autocompletion
 
-_WxMaxima_ содержит функцию автодополнения, которая включается через меню
-(«Поле/Завершить слово») или по нажатию сочетания клавиш
-<kbd>CTRL</kbd>+<kbd>ПРОБЕЛ</kbd>. Автодополнение зависит от
-контекста. Например, при активации внутри спецификации модулей для ezUnits
-будет предлагаться список применимых модулей.
+_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.
 
 ![ezUnits](./ezUnits.png){ id=img_ezUnits }
 
-Помимо дополнения имени файла, имени модуля, текущей команды или имени
-переменной, автодополнение может отображать шаблон большинства команд с
-указанием типа (и значения) ожидаемых программой параметров. Для включения
-этой функции нажмите <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>ПРОБЕЛ</kbd> или
-выберите соответствующий пункт меню («Поле/Показать шаблон»).
+Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).
 
-#### Греческие символы
+#### Greek characters
 
 Компьютеры традиционно хранят символы в 8-разрядных значениях. Это позволяет
 создать набор из 256 различных символов. В такой набор можно включить все
@@ -276,7 +253,7 @@ _Maxima_ позволяет использовать Юникод, если её
 Для ввода греческих букв также можно воспользоваться боковой панелью
 «Греческие буквы».
 
-##### Внимание: похожие буквы
+##### Attention: Lookalike characters
 
 Несколько букв латиницы схожи с греческими буквами. Например, латинская «A»
 и греческая буква «Альфа». Однако, несмотря на кажущееся сходство, это два
@@ -347,15 +324,9 @@ _Maxima_ позволяет использовать Юникод, если её
 Для ввода математических символов также можно использовать боковую панель
 «Математические символы».
 
-Если специальный символ отсутствует в списке, то произвольный символ Юникода
-можно ввести нажатием <kbd>ESC</kbd> \[код символа (шестнадцатеричный)\]
-<kbd>ESC</kbd>. Кроме того, с помощью контекстного меню боковой панели
-«Математические символы» можно отобразить список всех доступных символов
-Юникода, которые можно добавить на эту панель или в рабочий лист.
+If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \[number of the character (hexadecimal)\] <kbd>ESC</kbd>. Additionally the "symbols" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.
 
-Таким образом комбинация
-<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> позволяет ввести символ
-«a».
+<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.
 
 Обратите внимание, что большая часть этих символов (заметным исключением
 являются логические символы) не имеют специального значения в _Maxima_ и
@@ -363,12 +334,10 @@ _Maxima_ позволяет использовать Юникод, если её
 в компиляторе Lisp, не имеющем поддержки символов Юникода, то при их
 использовании может быть выведено сообщение об ошибке.
 
-Также бывает, что греческие или математические символы отсутствуют в
-выбранном шрифте, из-за чего их отображение невозможно. Для решения этой
-проблемы необходимо выбрать другие шрифты (с помощью меню «Правка ->
-Настройка -> Стиль»).
+It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.
+To solve that problem, select other fonts (using: Edit -> Configure -> Style).
 
-### Замена символов Юникода
+### Unicode replacement
 
 wxMaxima заменяет некоторые символы Юникода на соответствующие выражения
 Maxima, например, `²` на `^2`, `³` на `^3`, знак квадратного корня на
@@ -390,7 +359,7 @@ wxMaxima заменит их соответствующими представл
 будут работать в командной строке Maxima); но они могут появиться при
 вырезании и вставке формулы из другого документа.
 
-### Боковые панели
+### Side Panes
 
 Наиболее важные команды _Maxima_, а также содержание, окна с отладочными
 сообщениями и журнал последних отданных команд доступны на соответствующих
@@ -408,7 +377,7 @@ wxMaxima заменит их соответствующими представл
 «Содержание»](./Sidepane-TOC-convert-headings.png){
 id=Sidepane-TOC-convert-headings}
 
-### Вывод MathML
+### MathML output
 
 Несколько текстовых процессоров и подобных им программ либо способны
 распознать ввод [MathML](https://www.w3.org/Math/) и автоматически вставить
@@ -417,7 +386,7 @@ id=Sidepane-TOC-convert-headings}
 обмена». Другие поддерживают RTF maths. Поэтому в контекстном меню
 _wxMaxima_ доступно несколько пунктов.
 
-### Поддержка Markdown
+### Markdown support
 
 _WxMaxima_ поддерживает стандартные элементы форматирования
 [Markdown](https://en.wikipedia.org/wiki/Markdown), которые не конфликтуют с
@@ -425,31 +394,34 @@ _WxMaxima_ поддерживает стандартные элементы фо
 списки.
 
 ```text
-Обычный текст
- * Один элемент, уровень отступа 1
- * Другой элемент с уровнем отступа 1
-   * Элемент на втором уровне отступа
-   * Второй элемент на втором уровне отступа
- * Третий элемент на первом уровне отступа
-Обычный текст
+Ordinary text
+ * One item, indentation level 1
+ * Another item at indentation level 1
+   * An item at a second indentation level
+   * A second item at the second indentation level
+ * A third item at the first indentation level
+Ordinary text
 ```
 
-_WxMaxima_ считает цитатой текст, начинающийся символом `>`:
+_WxMaxima_ will recognize text starting with `>` chars as block quotes:
 
-```text Обычный текст > цитата цитата цитата цитата > цитата цитата цитата
-цитата > цитата цитата цитата цитата Обычный текст ```
+```text
+Ordinary text
+> quote quote quote quote
+> quote quote quote quote
+> quote quote quote quote
+Ordinary text
+```
 
-Вывод _wxMaxima_ в формате TeX и HTML также распознаёт `=>` и заменяет его
-на соответствующий символ Юникода:
+_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:
 
-```text cogito => sum.  ```
+```text
+cogito => sum.
+```
 
-Другие символы, которые распознаются при экспорте в HTML и TeX: `<=` и `>=`
-для сравнений, двойная двухсторонняя стрелка (`<=>`), односторонние стрелки
-(`<->`, `->` и `<-`) и `+/-` в качестве соответствующего знака. Для вывода
-TeX также распознаются `<<` и `>>`.
+Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.
 
-### Сочетания клавиш
+### Hotkeys
 
 Большинство сочетаний клавиш можно найти в тексте соответствующих
 меню. Поскольку они фактически берутся из текста меню и могут быть
@@ -463,13 +435,13 @@ TeX также распознаются `<<` и `>>`.
   автодополнения.
 - <kbd>SHIFT</kbd>+<kbd>ПРОБЕЛ</kbd> вставляет неразрывный пробел.
 
-### Код TeX при экспорте в TeX
+### Raw TeX in the TeX export
 
 Если текстовое поле начинается с `TeX:` экспорт в TeX будет содержать
 дословный текст, который который следует за меткой `TeX:`. Эта функция
 позволяет вводить разметку TeX непосредственно в рабочую книгу _wxMaxima_.
 
-## Форматы файлов
+## File Formats
 
 Разрабатываемые в сеансе _wxMaxima_ материалы можно сохранять для
 дальнейшего использования одним из трёх способов:
@@ -498,34 +470,31 @@ Maxima проигнорирует неизвестную команду `wxdraw2
 
 ### .wxm
 
-`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima
-versions >5.38 they can be read using _Maxima_’s `load()` function just as
-.mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as
-the answer is written in the `.wxm` file (so that it can be suggested after
-loading), but that can Maxima not evaluate.  You can prevent Maxima from
-asking questions by using `assume()` to declare some properties, Maxima
-wants to know.
+`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.
+You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.
 
 With this plain-text format, it sometimes is unavoidable that worksheets
 that use new features are not downwards-compatible with older versions of
 _wxMaxima_.
 
-#### Формат файлов wxm
+#### File format of wxm files
 
 Это файл с обычным текстом (открывается в текстовом редакторе), в котором
 содержимое полей хранится в виде специальных комментариев Maxima.
 
 Файл начинается со следующего комментария:
 
-```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
-Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```
+```maxima
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */
+```
 
 Затем следуют поля, записанные в виде комментариев Maxima. Например, поле
 раздела:
 
 ```maxima
 /* [wxMaxima: section start ]
-Заголовок раздела
+Title of the section
    [wxMaxima: section end   ] */
 ```
 
@@ -545,7 +514,7 @@ f(2);
 ```maxima
 /* [wxMaxima: image   start ]
 jpg
-[кажущаяся беспорядочной последовательность символов]
+[very chaotic looking character sequence]
    [wxMaxima: image   end   ] */
 ```
 
@@ -569,7 +538,7 @@ jpg
 такие параметры, как масштаб отображения и список отслеживания. Это
 рекомендуемый формат.
 
-#### Формат файлов wxmx
+#### File format of wxmx files
 
 Файл `wxmx` похож на двоичный формат, но работать с ним можно с помощью
 базовых инструментов ОС. Это файл zip, который можно разархивировать с
@@ -595,7 +564,7 @@ wxMaxima (рекомендуется сначала переименовать �
 повреждённое изображение, снова добавить файлы в архив и заменить расширение
 `zip` на `wxmx` — и получаем отредактированный файл `wxmx`.
 
-## Параметры конфигурации
+## Configuration options
 
 Для некоторых общих переменных конфигурации _wxMaxima_ обеспечивает два вида
 настройки:
@@ -610,14 +579,14 @@ wxMaxima (рекомендуется сначала переименовать �
 ![Конфигурация wxMaxima 1](./wxMaxima_configuration_001.png){
 id=img_wxMaxima_configuration_001 }
 
-### Частота кадров анимации по умолчанию
+### Default animation framerate
 
 Значение частоты кадров анимации, использующееся при создании новых
 анимаций, хранится в переменной `wxanimate_framerate`. Начальное значение
 этой переменной, которое будет содержаться в новом рабочем листе, можно
 изменить в диалоговом окне настройки параметров конфигурации.
 
-### Размер графика по умолчанию для новых сеансов _Maxima_
+### Default plot size for new _maxima_ sessions
 
 Начиная со следующего запуска, указанный размер будет использоваться для
 создания графиков, встраиваемых в рабочий лист, если значение параметра
@@ -635,7 +604,7 @@ wxdraw2d(
 ), wxplot_size=[480,480]$
 ```
 
-### Проверять расстановку скобок в текстовом вводе
+### Match parenthesis in text controls
 
 Этот параметр активирует сразу две функции:
 
@@ -644,7 +613,7 @@ wxdraw2d(
 - При выделении текста, если нажать любую из этих клавиш, выделенный текст
   помещается между парой этих знаков.
 
-### Не сохранять рабочий лист автоматически
+### Don’t save the worksheet automatically
 
 При включении этого параметра файл с рабочим листом перезаписывается только
 по требованию пользователя. В случае сбоя/отключении питания/... свежая
@@ -656,17 +625,10 @@ wxdraw2d(
 - Файлы автоматически сохраняются при выходе.
 - Также файл автоматически сохраняется каждые 3 минуты.
 
-### Где сохраняется конфигурация параметров?
+### Where is the configuration saved?
 
-При использовании Unix/Linux параметры конфигурации сохраняются в домашнем
-каталоге в файле `.wxMaxima` (если используется wxWidgets \< 3.1.1) или в
-`.config/wxMaxima.conf` (XDG-Standard) (если используется wxWidgets >=
-3.1.1). Версию wxWidgets можно посмотреть с помощью команды
-`wxbuild_info();` или в меню «Справка -> О
-программе». [wxWidgets](https://www.wxwidgets.org/) — кросс-платформенная
-библиотека для построения графического интерфейса пользователя, на которой
-основан интерфейс _wxMaxima_ (отсюда `wx` в имени). (Поскольку имя файла
-начинается с точки, `.wxMaxima` или `.config` будут скрытыми файлами.)
+If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).
+(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).
 
 При использовании Windows параметры конфигурации будут храниться в
 реестре. Расположение записей _wxMaxima_ в реестре:
@@ -674,7 +636,7 @@ wxdraw2d(
 
 ______________________________________________________________________
 
-# Расширения _Maxima_
+# Extensions to _Maxima_
 
 _WxMaxima_ является прежде всего графическим интерфейсом пользователя для
 _Maxima_. В этом качестве её главной целью является передача команд _Maxima_
@@ -685,7 +647,7 @@ _wxMaxima_ позволяет дополнить функциональные в
 способы, которые _wxMaxima_ использует для усовершенствования использования
 графики в сеансе.
 
-## Переменные в нижнем индексе
+## Subscripted variables
 
 Параметр `wxsubscripts` указывает, будет ли (и как) _wxMaxima_ автоматически
 переводить в нижний индекс имена переменных:
@@ -713,10 +675,9 @@ wxsubscripts](./wxsubscripts.png){ id=img_wxsubscripts }
 переменной в качестве переведённой в нижний индекс можно отменить с помощью
 команды: `wxdeclare_subscript(variable_name,false);`
 
-Для установки этих значений можно воспользоваться меню «Вид -> Автоперевод в
-нижний индекс».
+You can use the menu "View->Autosubscript" to set these values.
 
-## Информация в строке состояния
+## User feedback in the status bar
 
 Работающие на протяжении длительного времени команды могут выводить
 информацию в строку состояния. Новая информация последовательно заменяет
@@ -729,11 +690,11 @@ _Maxima_ (а не _wxMaxima_): при отсутствии _wxMaxima_ коман
 
 ```maxima
 for i:1 thru 10 do (
-    /* Информирование о ходе выполнения */
+    /* Tell the user how far we got */
     wxstatusbar(concat("Pass ",i)),
-    /* (sleep n) — функция Lisp, которую можно вызывать */
-    /* путём предварения символом "?". Она откладывает */
-    /* выполнение программы (здесь: на 3 секунды) */
+    /* (sleep n) is a Lisp function, which can be used */
+    /* with the character "?" before. It delays the */
+    /* program execution (here: for 3 seconds) */
     ?sleep(3)
 )$
 ```
@@ -746,8 +707,10 @@ scripted or batch export. Like `wxstatusbar()` it is safe to use in code
 that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present
 the command is simply left unevaluated.
 
-```maxima wxworksheettohtml("report.html")$ wxworksheettohtml("report.html",
-flavor="svg", wxmx=true)$ ```
+```maxima
+wxworksheettohtml("report.html")$
+wxworksheettohtml("report.html", flavor="svg", wxmx=true)$
+```
 
 A relative file name is interpreted relative to _Maxima_’s working
 directory. The optional keyword options are:
@@ -765,8 +728,10 @@ still lack MathML, and `svg`/`bitmap` render every equation to an image.
 The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file
 the same way:
 
-```maxima wxworksheettotex("report.tex")$ wxworksheettotex("report.tex",
-documentclass="report", documentclassoptions="12pt,a4paper")$ ```
+```maxima
+wxworksheettotex("report.tex")$
+wxworksheettotex("report.tex", documentclass="report", documentclassoptions="12pt,a4paper")$
+```
 
 | option                 | meaning                                                              |
 | ---------------------- | -------------------------------------------------------------------- |
@@ -775,13 +740,13 @@ documentclass="report", documentclassoptions="12pt,a4paper")$ ```
 
 Support for `wxworksheettopdf()` is planned.
 
-## Построение графиков
+## Plotting
 
 Построение графиков (в основном в связи с графической системой)
 предполагает, что графический интерфейс пользователя предоставит ряд
 расширений для исходной программы.
 
-### Встраивание графика в рабочий лист
+### Embedding a plot into the worksheet
 
 Обычно _Maxima_ использует внешнюю программу _Gnuplot_, которая открывает
 отдельное окно для каждого создаваемого графика. Поскольку часто удобнее не
@@ -817,7 +782,7 @@ Support for `wxworksheettopdf()` is planned.
 Maxima](https://sourceforge.net/p/maxima/bugs/). Либо это может быть ошибкой
 Gnuplot.
 
-### Увеличение или уменьшение встроенных графиков
+### Making embedded plots bigger or smaller
 
 Как указано выше, диалоговое окно настройки конфигурации позволяет изменять
 размер по умолчанию для создаваемых графиков, устанавливая начальное
@@ -856,7 +821,7 @@ wxdraw2d(
 `wxdraw`, `wxcontour_plot` и `wximplicit_plot`, а также для встроенных
 анимаций при использовании команд `with_slider_draw` и `wxanimate`.
 
-### Улучшение качества графиков
+### Better quality plots
 
 По всей видимости в _Gnuplot_ не реализован универсальный способ определения
 наличия поддержки вывода растрового изображения в улучшенном качестве,
@@ -867,14 +832,14 @@ wxdraw2d(
 `wxplot_pngCairo` в системах без поддержки этой библиотеки в _Gnuplot_, то
 вместо графического изображения будут получены сообщения об ошибке.
 
-### Открытие встроенных графиков в интерактивных окнах _Gnuplot_
+### Opening embedded plots in interactive _Gnuplot_ windows
 
 Если график был создан с помощью команд типа `wxdraw` (`wxplot2d` и
 `wxplot3d` в этой функции не поддерживаются) и размер файла основного
 проекта _Gnuplot_ не слишком велик, то можно использовать контекстное меню
 _wxMaxima_, которое позволяет открыть график в интерактивном окне _Gnuplot_.
 
-### Открытие командной строки Gnuplot в окне `plot`
+### Opening Gnuplot’s command console in `plot` windows
 
 В MS Windows существует две программы Gnuplot: `gnuplot.exe` и
 `wgnuplot.exe`. Выбрать ту из них, которая будет использоваться, можно в
@@ -884,7 +849,7 @@ _wxMaxima_, которое позволяет открыть график в и�
 _Gnuplot_ на некоторое время «захватывать» фокус клавиатуры каждый раз при
 подготовке графика.
 
-### Встраивание анимаций в электронную таблицу
+### Embedding animations into the spreadsheet
 
 Трёхмерные графики затрудняют чтение количественных данных. В качестве
 возможной альтернативы можно назначить третий параметр колесу мыши. Команда
@@ -995,20 +960,24 @@ with_slider_draw(
 )$
 ```
 
-### Одновременное открытие нескольких графиков в нескольких окнах
+### Opening multiple plots in contemporaneous windows
 
 Эта функция _Maxima_ (в системах, которые её поддерживают) не реализована в
 _wxMaxima_, но иногда может быть очень удобной. Следующий пример взят из
 письма, которое Mario Rodriguez отправил в рассылку _Maxima_:
 
-```maxima load(draw);
+```maxima
+load(draw);
 
-/* Парабола в окне #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));
+/* Parabola in window #1 */
+draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));
 
-/* Парабола в окне #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));
+/* Parabola in window #2 */
+draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));
 
-/* Параболоид в окне #3 */
-draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```
+/* Paraboloid in window #3 */
+draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));
+```
 
 Также возможно создание нескольких графиков в одном окне (то же самое
 возможно в командной строке Maxima при использовании стандартной команды
@@ -1025,13 +994,13 @@ wxdraw(
 );
 ```
 
-### Боковая панель «График с помощью Draw»
+### The "Plot using draw" side pane
 
 Боковая панель «График с помощью Draw» работает как простой генератор кода,
 который позволяет создавать сцены, использующие гибкие возможности пакета
 _draw_, поставляемого с _Maxima_.
 
-#### Двухмерный график
+#### 2D
 
 Генерирует основную конструкцию команды `draw()`, которая рисует двухмерную
 сцену. Эту сцену далее необходимо заполнить командами, формирующими её
@@ -1042,49 +1011,49 @@ _draw_, поставляемого с _Maxima_.
 значение в каждом кадре: часто бывает проще понять анимированный двухмерный
 график, чем те же самые данные в неподвижной трёхмерной сцене.
 
-#### Трёхмерный график
+#### 3D
 
 Генерирует основную конструкцию команды `draw()`, которая рисует трёхмерную
 сцену. Если ни двухмерная, ни трёхмерная сцена не заданы, при нажатии всех
 остальных кнопок создаётся двухмерная сцена, содержащая генерируемую кнопкой
 команду.
 
-#### Выражение
+#### Expression
 
 Добавляет стандартный график выражения, подобного `sin(x)`, `x*sin(x)` или
 `x^2+2*x-4`, в команду `draw()`, в которой в данный момент находится
 курсор. Если команда draw отсутствует, то будет создана двухмерная
 сцена. Каждая сцена может быть заполнена любым количеством графиков.
 
-#### График неявной функции
+#### Implicit plot
 
 Пытается найти все точки, для которых истинны выражения, подобные
 `y=sin(x)`, `y*sin(x)=3` или `x^2+y^2=4`, и помещает итоговую кривую в
 команду `draw()`, в которой в данный момент находится курсор. Если команда
 draw отсутствует, то будет создана двухмерная сцена.
 
-#### График параметрической функции
+#### Parametric plot
 
 Проводит переменную по шагам от нижнего до верхнего предела с использованием
 двух выражений, подобных `t*sin(t)` и `t*cos(t)`, для генерации координат x,
 y (а в трёхмерных графиках ещё и z) для кривой, заданной в текущей команде
 draw.
 
-#### Точки
+#### Points
 
 Рисует несколько точек, которые при необходимости можно
 соединить. Координаты точек берутся из списка списков, двухмерного массива,
 либо из одного списка или массива для каждой оси.
 
-#### Заголовок диаграммы
+#### Diagram title
 
 Рисует заголовок в верхней части диаграммы.
 
-#### Ось
+#### Axis
 
 Задаёт ось.
 
-#### Контур
+#### Contour
 
 (Только для трёхмерных графиков): добавляет отображение контурных линий,
 подобных изображаемым на картах гор, в команды создания графиков, которые
@@ -1092,33 +1061,33 @@ draw.
 графика. Данный мастер также позволяет полностью исключить начертание
 кривых, оставляя на графике только контуры.
 
-#### Название графика
+#### Plot name
 
 Добавляет запись с отображением имени следующего графика к легенде
 диаграммы. Пустое имя отключает формирование записей легенды для последующих
 графиков.
 
-#### Цвет линии
+#### Line colour
 
 Задаёт цвет линии для последующих графиков, содержащихся в составе текущей
 команды draw.
 
-#### Цвет заливки
+#### Fill colour
 
 Задаёт цвет заливки для последующих графиков, передаваемых в составе команды
 draw.
 
-#### Сетка
+#### Grid
 
 Выводит мастер, позволяющий задать линии сетки.
 
-#### Точность
+#### Accuracy
 
 Позволяет выбрать приемлемое значение компромисса между скоростью и
 точностью, являющегося неотъемлемой частью любой программы формирования
 графиков.
 
-### Изменение шрифта и размера шрифта для графиков
+### Modify font and font size for plots
 
 Размер шрифта по умолчанию может оказаться слишком маленьким, особенно при
 использовании мониторов с высоким разрешением. Для команд на основе `draw`
@@ -1150,16 +1119,18 @@ wxplot2d(sin(x),[x,1,10],
 большого размера, смотрите [ошибку wxMaxima
 #1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966).
 
-## Встраивание графики
+## Embedding graphics
 
 При использовании формата файла `.wxmx` встраивание графики в проект
 _wxMaxima_ выполняется простым перетаскиванием. Но иногда (например, если
 содержимое изображения может измениться позднее во время сеанса) лучше
 задать загрузку файла изображения после проведения вычислений:
 
-```maxima show_image("man.png"); ```
+```maxima
+show_image("man.png");
+```
 
-## Файлы запуска
+## Startup files
 
 В диалоге настройки _wxMaxima_ можно внести изменения в два файла с
 командами, которые выполняются при запуске:
@@ -1177,7 +1148,7 @@ _wxMaxima_ выполняется простым перетаскиванием.
 `%USERPROFILE%/maxima`, в других ОС — `$HOME/.maxima`). Местоположение можно
 выяснить с помощью команды: `maxima_userdir;`
 
-## Специальные переменные wx…
+## Special variables wx...
 
 - `wxsubscripts` указывает _Maxima_, следует ли преобразовать имена
   переменных, которые содержат символ подчёркивания (`R_150` или аналог), в
@@ -1206,8 +1177,22 @@ _wxMaxima_ выполняется простым перетаскиванием.
 - `wxmaximaversion`: возвращает номер версии _wxMaxima_.
 - `wxwidgetsversion`: возвращает версию wxWidgets, которую использует
   _wxMaxima_.
+- `wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these
+  differ by maintainer, distribution and operating system:
+  - `wxdirs@userconfdir`: The directory the user's configuration is stored
+    in. Same directory as `maxima_userdir` (see above) - both point at the
+    same place, `wxdirs@userconfdir` is only useful if that is more
+    convenient to reach from a `.mac` file than the Maxima-side variable.
+  - `wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the
+    built-in autocompletion list, ...) is installed in.
+  - `wxdirs@helpdir`: The directory the offline copy of this manual is
+    installed in.
+  - `wxdirs@localedir`: The directory _wxMaxima_'s translation files are
+    installed in.
+  - `wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_
+    is configured to start.
 
-## Структурный вывод двухмерных данных
+## Pretty-printing 2D output
 
 Функция `table_form()` отображает двухмерный список в более удобочитаемой
 форме, нежели при стандартном выводе процедуры _Maxima_. Ввод осуществляется
@@ -1259,7 +1244,7 @@ wx_matrix(matrix(["Name", "Value"], ["X", 10], ["Y", 20]),
           lines=true, rownames=true, colnames=true, parenstyle=square);
 ```
 
-## Отчёты об ошибках
+## Bug reporting
 
 _WxMaxima_ предоставляет несколько функций, которые собирают информацию о
 текущей системе для формирования отчёта об ошибках:
@@ -1268,13 +1253,13 @@ _WxMaxima_ предоставляет несколько функций, кот�
   _wxMaxima_.
 - `wxbug_report()` определяет, как и куда отправлять отчёты об ошибках.
 
-## Выделение вывода красным цветом
+## Marking output being drawn in red
 
 Команда _Maxima_ `box()` вызывает вывод аргументов _wxMaxima_ с выделением
 красным цветом, если второй аргумент команды представляет собой текст
 `highlight`.
 
-## Визуализация вывода
+## Output rendering.
 
 `set_display()` позволяет указать, как wxMaxima следует визуализировать
 вывод.
@@ -1285,15 +1270,14 @@ wxMaxima с помощью (машиночитаемого) XML-диалекта
 получившиеся формулы в удобном для восприятия пользователем виде; например,
 матрицы, знаки квадратного корня, дроби и так далее.
 
-<!--- Сейчас не работает надлежащим образом; строка с меткой вывода сдвинута
-вправо (ошибка #2006) --> `set_display('ascii)` заставляет wxMaxima выводить
-формулы как в командной строке Maxima, то есть в виде символов ASCII.
+<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->
+`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.
 
 `set_display('none)` — «однострочные» выходные данные ASCII — эта команда
 делает то же самое, что и команда `display2d:false;` командной строки
 Maxima.
 
-# Меню справки
+# Help menu
 
 Меню справки wxMaxima предоставляет доступ к руководству, подсказкам и
 некоторым примерам рабочих листов Maxima и wxMaxima, а также к
@@ -1301,21 +1285,19 @@ Maxima.
 
 Обратите внимание на вывод демонстрационных примеров:
 
-~~~text При появлении приглашения в виде ’_’ введите ’;’ и нажмите <enter>
-для продолжения демонстрации.  ~~~
+~~~text
+At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.
+~~~
 
-Это работает в командной строке Maxima, но в wxMaxima для продолжения
-демонстрации необходимо использовать сочетание клавиш
-<kbd>CTRL</kbd>+<kbd>ENTER</kbd>
+That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>
 
-(Сочетание клавиш можно настроить в меню «Настройка -> Лист -> Комбинации
-клавиш для отправки команд в Maxima».)
+(That can be configured in the Configure->Worksheet->"Hotkeys for sending commands to Maxima" menu.)
 
 ______________________________________________________________________
 
-# Устранение неполадок
+# Troubleshooting
 
-## Не удаётся установить соединение с _Maxima_
+## Cannot connect to _Maxima_
 
 _Maxima_ (программа, которая фактически выполняет математические расчёты) и
 _wxMaxima_ (предоставляет удобный интерфейс пользователя) — отдельные
@@ -1333,7 +1315,7 @@ _wxMaxima_ (предоставляет удобный интерфейс пол�
 конфигурация закольцованной сети, обеспечивающей сетевое соединение между
 двумя программами на одном компьютере.
 
-## Как сохранить данные из повреждённого файла .wxmx
+## How to save data from a broken .wxmx file
 
 Большинство современных форматов на основе XML представляют собой обычные
 zip-файлы. _WxMaxima_ не использует функцию сжатия, поэтому содержимое
@@ -1348,19 +1330,13 @@ zip-файлы. _WxMaxima_ не использует функцию сжатия
 пошло не так, появится файл `.wxmx~`, содержимое которого может оказаться
 полезным.
 
-И даже если этого файла нет: формат файла `.wxmx` представляет собой
-контейнер, XML-содержимое в котором хранится без сжатия. Можно переименовать
-файл `.wxmx` в файл `.txt` и с помощью текстового редактора восстановить
-XML-содержимое файла (оно начинается со строки `<?xml version="1.0"
-encoding="UTF-8"?>` и завершается строкой `</wxMaximaDocument>`, а перед
-этим текстом и после него в текстовом редакторе располагается нечитаемый
-двоичный код).
+And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version="1.0" encoding="UTF-8"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).
 
 Если извлечь это содержимое (например, скопировать и вставить этот текст в
 новый файл) и сохранить полученный текстовый файл с расширением `.xml`, то
 _wxMaxima_ сможет восстановить текст из этого документа.
 
-## Как вывести отладочную информацию на экран до завершения работы команды
+## I want some debug info to be displayed on the screen before my command has finished
 
 Обычно _wxMaxima_ начинает вёрстку только после полной передачи двухмерной
 формулы. Это сделано, чтобы не тратить время на выполнение нескольких
@@ -1371,9 +1347,9 @@ _wxMaxima_ сможет восстановить текст из этого до
 ```maxima
 for i:1 thru 10 do (
    disp(i),
-   /* (sleep n) — функция Lisp, которую можно вызывать */
-   /* путём предварения символом "?". Она откладывает */
-   /* выполнение программы (здесь: на 3 секунды) */
+   /* (sleep n) is a Lisp function, which can be used */
+   /* with the character "?" before. It delays the */
+   /* program execution (here: for 3 seconds) */
    ?sleep(3)
 )$
 ```
@@ -1381,8 +1357,7 @@ for i:1 thru 10 do (
 Альтернативный вариант —  воспользоваться командой `wxstatusbar()` (её
 описание приводилось выше).
 
-## Функция построения графика показывает только закрытый пустой конверт с
-сообщением об ошибке
+## Plotting only shows a closed empty envelope with an error message
 
 Это означает, что _wxMaxima_ не удалось прочитать файл, который должен был
 быть создан _Gnuplot_ по инструкции от _Maxima_.
@@ -1405,7 +1380,7 @@ for i:1 thru 10 do (
   «true» в _Maxima_.
 - Вывод Gnuplot — некорректный файл `.png`.
 
-## При создании анимации выводится ошибка «error: undefined variable»
+## Plotting an animation results in “error: undefined variable”
 
 По умолчанию значение переменной ползунка подставляется в выражение только
 тогда, когда эта переменная непосредственно видима в выражении. Проблему
@@ -1414,8 +1389,7 @@ for i:1 thru 10 do (
 анимаций в электронную таблицу](#embedding-animations-into-the-spreadsheet)
 есть соответствующий пример.
 
-## Содержимое поля потеряно, и отмена действия не может помочь в его
-восстановлении
+## I lost cell content and undo doesn’t remember
 
 Операции с полями и действия по изменению их содержимого имеют свои
 отдельные функции отмены. Поэтому возникновение такой ситуации крайне
@@ -1433,24 +1407,25 @@ for i:1 thru 10 do (
 - Если больше ничего не помогло, в _Maxima_ есть функция повторного
   воспроизведения:
 
-```maxima playback(); ```
+```maxima
+playback();
+```
 
-## _WxMaxima_ запускается с выводом сообщения «Процесс Maxima неожиданно
-завершился.»
+## _WxMaxima_ starts up with the message “Maxima process terminated.”
 
 Одна из возможных причин — _Maxima_ не удалось найти в расположении, которое
 задано на вкладке «Maxima» диалогового окна параметров конфигурации
 _wxMaxima_, и поэтому программа не может запуститься в принципе. Проблема
 решается указанием пути к рабочему исполняемому файлу _Maxima_.
 
-## Maxima слишком долго выполняет вычисление и не отвечает на ввод
+## Maxima is forever calculating and not responding to input
 
 Теоретически возможно, что _wxMaxima_ не распознаёт, что _Maxima_ уже
 завершила вычисление, и поэтому не получает уведомление о том, что пора
 отправлять новые данные для _Maxima_. Если дело в этом, то “Trigger
 evaluation” может помочь повторно синхронизировать эти две программы.
 
-## При работе _Maxima_ на основе SBCL заканчивается свободная память
+## My SBCL-based _Maxima_ runs out of memory
 
 Компилятор Lisp SBCL по умолчанию поставляется с ограничением памяти,
 которое позволяет ему работать даже на очень слабых компьютерах. В процессе
@@ -1468,28 +1443,31 @@ evaluation” может помочь повторно синхронизиро�
 
 ![Память sbcl](./sbclMemory.png){ id=img_sbclMemory }
 
-## Иногда ввод бывает медленным/игнорирует нажатия клавиш в Ubuntu
+## Input sometimes is sluggish/ignoring keys on Ubuntu
 
 Установка пакета `ibus-gtk` должна решить этот вопрос. Более подробную
 информацию смотрите по адресу
 ([https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)).
 
-## _WxMaxima_ зависает, когда _Maxima_ обрабатывает греческие символы или
-умляуты
+## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts
 
 Если используемая версия _Maxima_ основана на SBCL, то в `.sbclrc`
 необходимо добавить следующие строки:
 
-```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```
+```commonlisp
+(setf sb-impl::*default-external-format* :utf-8)
+```
 
 Папка, в которой размещается этот файл, зависит от конкретной системы и
 установки. Но любая версия _Maxima_ на основе SBCL, в которой в текущем
 сеансе уже производилось вычисление поля, всегда укажет его местонахождение
 после получения следующей команды:
 
-```maxima :lisp (sb-impl::userinit-pathname)  ```
+```maxima
+:lisp (sb-impl::userinit-pathname)
+```
 
-## Примечание касательно Wayland (свежие дистрибутивы Linux/BSD)
+## Note concerning Wayland (recent Linux/BSD distributions)
 
 Возможны проблемы с работой протокола графического сервера Wayland и
 wxWidgets. Это может затронуть wxMaxima (например, будет невозможно
@@ -1518,12 +1496,12 @@ If the automatic fix fails, you can manually start wxMaxima with:
 
 `UBUNTU_MENUPROXY=0 wxmaxima`
 
-## Почему встроенный браузер руководства отсутствует на ПК с Windows?
+## Why is the integrated manual browser not offered on my Windows PC?
 
 Либо компиляция wxWidgets была выполнена без поддержки webview2 от
 Microsoft, либо компонент webview2 от Microsoft не был установлен.
 
-## Почему внешний браузер руководства не работает в Linux?
+## Why is the external manual browser not working on my Linux box?
 
 Браузер HTML может быть реализован в виде версии пакета snap, flatpack или
 appimage. Все они обычно не имеют доступа к файлам, установленным локально в
@@ -1533,15 +1511,14 @@ appimage. Все они обычно не имеют доступа к файл�
 может быть то, что HTML-руководство maxima не установлено локально, а
 получить доступ к онлайн-руководству не получается.
 
-## Можно ли сделать вывод _wxMaxima_ одновременно в виде файлов изображений
-и встроенных в документ графиков?
+## Can I make _wxMaxima_ output both image files and embedded plots at once?
 
 В рабочий лист встраиваются .png-файлы. _WxMaxima_ позволяет пользователю
 указать, где они должны генерироваться:
 
 ```maxima
 wxdraw2d(
-    file_name="test",  /* автоматически добавляется расширение .png */
+    file_name="test",  /* extension .png automatically added */
     explicit(sin(x),x,1,10)
 );
 ```
@@ -1573,7 +1550,7 @@ pngdraw2d("Test",
 );
 ```
 
-## Как задать соотношение сторон встроенного графика?
+## Can I set the aspect ratio of an embedded plot?
 
 С помощью переменной `wxplot_size`:
 
@@ -1583,29 +1560,22 @@ wxdraw2d(
 ),wxplot_size=[1000,1000];
 ```
 
-## После обновления до MacOS 13.1 команды plot и/или draw возвращают
-сообщения об ошибках, например:
+## After upgrading to MacOS 13.1 plot and/or draw commands output error messages like
 
-```text 1 HIToolbox 0x00007ff80cd91726
-_ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox
-0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox
-0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```
+```text
+1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102
+2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52
+3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408
+...
+```
 
-Эта ошибка может быть связана с операционной системой. Отключение скрытия
-строки меню (Системные настройки => Рабочий стол и Dock => Строка меню)
-может решить проблему. Более подробная информация доступна в [ошибке
-wxMaxima
-#1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746).
+This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.
 
-## Журналирование
+## Logging
 
-Сообщения журнала могут быть полезны при отладке. WxMaxima поддерживает
-журналирование широкого спектра событий. Большинство записей журнала
-пригодятся разработчикам, особенно при появлении проблем или внутренних
-ошибок. Если запущена сборка выпуска, журнал не отображается по
-умолчанию. Если же запущена сборка разработки, журнал по умолчанию
-отображается как второе окно. Это окно можно включать и отключать с помощью
-пункта меню «Вид -> Переключить окно журнала».
+Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a "Release"-Build,
+the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable
+this window using the "View->Toggle log window" menu entry.
 
 Сообщения не «теряются»; если окно журнала не показано, то при последующем
 включении его отображения будут доступны для просмотра также и прошлые
@@ -1621,22 +1591,21 @@ wxMaxima
 
 ______________________________________________________________________
 
-# Вопросы и ответы
+# FAQ
 
-## Есть ли возможность поместить больше текста на страницу LaTeX?
+## Is there a way to make more text fit on a LaTeX page?
 
 Да. Можно использовать [пакет LaTeX
 «geometry»](https://ctan.org/pkg/geometry), который позволяет указать
 размеры границ.
 
-Можно добавить следующую строку к преамбуле LaTeX (например, путём
-использования соответствующего поля в диалоге настройки («Экспорт ->
-Дополнительные строки для преамбулы TeX»), чтобы установить границы размером
-1 см):
+You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue ("Export"->"Additional lines for the TeX preamble"), to set borders of 1cm):
 
-```latex \usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```
+```latex
+\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}
+```
 
-## Имеется ли тёмная тема?
+## Is there a dark mode?
 
 Если версия wxWidgets достаточно свежая, то _wxMaxima_ автоматически
 использует тёмную тему, когда вся остальная операционная система настроена
@@ -1645,16 +1614,11 @@ ______________________________________________________________________
 «Вид/Инвертировать яркость рабочего листа», позволяющий быстро
 преобразовывать рабочий лист из тёмного в светлый и обратно.
 
-## _WxMaxima_ иногда зависает на несколько секунд в течение первой минуты
+## _WxMaxima_ sometimes hangs for several seconds once in the first minute
 
-_WxMaxima_ делегирует ряд больших задач, таких как обработка
->1000-страничного руководства _Maxima_, фоновым задачам, что обычно
-происходит абсолютно незаметно. Когда требуется получить результат
-выполнения такой задачи, _wxMaxima_ может понадобиться подождать пару секунд
-перед продолжением работы.
+_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.
 
-## Часто при тестировании новых настроек локали выводится сообщение «locale
-’xx_YY’ can not be set»
+## Especially when testing new locale settings, a message box "locale ’xx_YY’ can not be set" occurs
 
 ![Предупреждение локали](./locale-warning.png){ id=img_locale_warning}
 
@@ -1666,15 +1630,13 @@ wxWidgets.
 Указанные локали могут отсутствовать в системе. В системах Ubuntu/Debian их
 можно сгенерировать с помощью команды `dpkg-reconfigure locales`
 
-## Как использовать символы для вещественных чисел, натуральных чисел (ℝ, ℕ)
-и так далее?
+## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?
 
 Эти символы доступны на боковой панели «Юникод» (выполните поиск по
 ’double-struck capital’). Но такие символы должен поддерживать и выбранный
 шрифт. Выберите другой шрифт, если символы отображаются неправильно.
 
-## Каким образом сценарий Maxima может определить, работает ли он под
-управлением wxMaxima или командной строки Maxima?
+## How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?
 
 Если используется wxMaxima, то переменная Maxima `maxima_frontend`
 установлена в значение `wxmaxima`. Переменная Maxima
@@ -1685,14 +1647,11 @@ wxWidgets.
 
 ## Help! I can not save my document!
 
-If saving as wxmx file does not work, try saving the document as wxm file
-(and vice versa). And you can also try to remove all output (Menu
-Cell->Remove all output) and save that file, maybe some unexpected output
-causes issues during the save process.
+If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.
 
 ______________________________________________________________________
 
-# Аргументы командной строки
+# Command-line arguments
 
 Обычно программы с графическим интерфейсом пользователя можно запускать
 простым щелчком по значку на рабочем столе или пункту меню рабочего
@@ -1728,7 +1687,7 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
-# О программе, участие в разработке wxMaxima
+# About the program, contributing to wxMaxima
 
 wxMaxima написана большей частью на языке программирования C++ с
 использованием [платформы wxWidgets](https://www.wxwidgets.org), в качестве
@@ -1758,7 +1717,4 @@ wxMaxima на другие языки (для получения информа�
 внешних зависимостей (например, графических файлов или части на языке Lisp
 (файл `wxmathML.lisp`); эти файлы включены в исполняемый файл).
 
-Если вы разработчик, то вы можете поработать с изменённым файлом
-`wxmathML.lisp` без выполнения полной перекомпиляции. Указать другой файл
-Lisp (нестандартный файл) можно с помощью параметра командной строки
-`--wxmathml-lisp=<str>`.
+If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.

--- a/info/wxmaxima.tr.md
+++ b/info/wxmaxima.tr.md
@@ -50,12 +50,7 @@ sistemleri için bir dizi sayısal analiz yöntemi sunar.
 ![Maxima screenshot, command line](./maxima_screenshot.png){
 id=img_maxima_screenshot }
 
-Extensive documentation for _Maxima_ is [available in the
-internet](https://maxima.sourceforge.io/documentation.html). Part of this
-documentation is also available in wxMaxima’s help menu. Pressing the Help
-key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s
-context-sensitive help feature to automatically jump to _Maxima_’s manual
-page for the command at the cursor.
+Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.
 
 ### WxMaxima
 
@@ -175,12 +170,7 @@ automatically when needed:
   moving the cursor inside a cell using the mouse pointer or the cursor keys
   and works much like the cursor in a text editor.
 
-When you start wxMaxima, you will only see the blinking horizontal
-cursor. If you start typing, a math cell will be automatically created and
-the cursor will change to a regular vertical one (you will see a right arrow
-as "prompt", after the Math cell is evaluated
-(<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`,
-`(%o1)`).
+When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as "prompt", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).
 
 ![(blinking) horizontal cursor after wxMaxima
 start](./horizontal-cursor-only.png){ id=img_horizontal_cursor_only }
@@ -200,29 +190,15 @@ id=img_horizontal_cursor_between_cells }
 
 ### Sending cells to Maxima
 
-The command in a code cell is executed once by pressing
-<kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the
-<kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter
-commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or
-<kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be
-configured to execute commands in response to <kbd>ENTER</kbd>.
+The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.
 
 ### Command autocompletion
 
-_WxMaxima_ contains an autocompletion feature that is triggered via the menu
-(Cell/Complete Word) or alternatively by pressing the key combination
-<kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is
-context-sensitive. For example, if activated within a unit specification for
-ezUnits it will offer a list of applicable units.
+_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.
 
 ![ezUnits](./ezUnits.png){ id=img_ezUnits }
 
-Besides completing a file name, a unit name, or the current command or
-variable name, the autocompletion is able to show a template for most of the
-commands indicating the type (and meaning) of the parameters this program
-expects. To activate this feature press
-<kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective
-menu item (Cell/Show Template).
+Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).
 
 #### Greek characters
 
@@ -343,23 +319,17 @@ verir:
 
 You can also use the "Symbols"-sidebar to enter these Mathematical symbols.
 
-If a special symbol isn’t in the list, it is possible to input arbitrary
-Unicode characters by pressing <kbd>ESC</kbd> \[number of the character
-(hexadecimal)\] <kbd>ESC</kbd>. Additionally the "symbols" sidebar has a
-right-click menu that allow to display a list of all available Unicode
-symbols one can add to this toolbar or to the worksheet.
+If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \[number of the character (hexadecimal)\] <kbd>ESC</kbd>. Additionally the "symbols" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.
 
-<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an
-`a`.
+<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.
 
 Please note that most of these symbols (notable exceptions are the logic
 symbols) do not have a special meaning in _Maxima_ and therefore will be
 interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp
 that doesn’t support Unicode characters they might cause an error message.
 
-It may be the case that e.g. Greek characters or mathematical symbols are
-not included in the selected font, then they can not be displayed.  To solve
-that problem, select other fonts (using: Edit -> Configure -> Style).
+It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.
+To solve that problem, select other fonts (using: Edit -> Configure -> Style).
 
 ### Unicode replacement
 
@@ -429,18 +399,21 @@ Ordinary text
 
 _WxMaxima_ will recognize text starting with `>` chars as block quotes:
 
-```text Ordinary text > quote quote quote quote > quote quote quote quote >
-quote quote quote quote Ordinary text ```
+```text
+Ordinary text
+> quote quote quote quote
+> quote quote quote quote
+> quote quote quote quote
+Ordinary text
+```
 
-_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by
-the corresponding Unicode sign:
+_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:
 
-```text cogito => sum.  ```
+```text
+cogito => sum.
+```
 
-Other symbols the HTML and TeX export will recognize are `<=` and `>=` for
-comparisons, a double-pointed double arrow (`<=>`), single-headed arrows
-(`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also
-`<<` and `>>` are recognized.
+Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.
 
 ### Hotkeys
 
@@ -492,13 +465,8 @@ back as a _wxMaxima_ session.
 
 ### .wxm
 
-`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima
-versions >5.38 they can be read using _Maxima_’s `load()` function just as
-.mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as
-the answer is written in the `.wxm` file (so that it can be suggested after
-loading), but that can Maxima not evaluate.  You can prevent Maxima from
-asking questions by using `assume()` to declare some properties, Maxima
-wants to know.
+`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.
+You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.
 
 With this plain-text format, it sometimes is unavoidable that worksheets
 that use new features are not downwards-compatible with older versions of
@@ -511,8 +479,10 @@ containing the cell contents as some special Maxima comments.
 
 It starts with the following comment:
 
-```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
-Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```
+```maxima
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */
+```
 
 And then the cells follow, encoded as Maxima comments, e.g. a section cell:
 
@@ -647,15 +617,8 @@ app:
 
 ### Where is the configuration saved?
 
-If you are using Unix/Linux, the configuration information will be saved in
-a file `.wxMaxima` in your home directory (if you are using wxWidgets \<
-3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is
-used). You can retrieve the wxWidgets version from the command
-`wxbuild_info();` or by using the menu option
-Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform
-GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the
-name).  (Since the filename starts with a dot, `.wxMaxima` or `.config` will
-be hidden).
+If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).
+(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).
 
 If you are using Windows, the configuration will be stored in the
 registry. You will find the entries for _wxMaxima_ at the following position
@@ -730,8 +693,10 @@ scripted or batch export. Like `wxstatusbar()` it is safe to use in code
 that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present
 the command is simply left unevaluated.
 
-```maxima wxworksheettohtml("report.html")$ wxworksheettohtml("report.html",
-flavor="svg", wxmx=true)$ ```
+```maxima
+wxworksheettohtml("report.html")$
+wxworksheettohtml("report.html", flavor="svg", wxmx=true)$
+```
 
 A relative file name is interpreted relative to _Maxima_’s working
 directory. The optional keyword options are:
@@ -749,8 +714,10 @@ still lack MathML, and `svg`/`bitmap` render every equation to an image.
 The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file
 the same way:
 
-```maxima wxworksheettotex("report.tex")$ wxworksheettotex("report.tex",
-documentclass="report", documentclassoptions="12pt,a4paper")$ ```
+```maxima
+wxworksheettotex("report.tex")$
+wxworksheettotex("report.tex", documentclass="report", documentclassoptions="12pt,a4paper")$
+```
 
 | option                 | meaning                                                              |
 | ---------------------- | -------------------------------------------------------------------- |
@@ -981,14 +948,18 @@ While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups
 that support it) sometimes comes in handily. The following example comes
 from a post from Mario Rodriguez to the _Maxima_ mailing list:
 
-```maxima load(draw);
+```maxima
+load(draw);
 
-/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));
+/* Parabola in window #1 */
+draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));
 
-/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));
+/* Parabola in window #2 */
+draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));
 
 /* Paraboloid in window #3 */
-draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```
+draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));
+```
 
 Plotting multiple plots in the same window is possible, too (the same is
 possible in command line Maxima with the standard `draw()` command):
@@ -1010,7 +981,7 @@ The "Plot using draw" sidebar hides a simple code generator that allows
 generating scenes that make use of some of the flexibility of the _draw_
 package _maxima_ comes with.
 
-#### 2B
+#### 2D
 
 Generates the skeleton of a `draw()` command that draws a 2D scene. This
 scene later has to be filled with commands that generate the scene’s
@@ -1022,7 +993,7 @@ as an animation in which a variable (by default it is _t_) has a different
 value in each frame: Often a moving 2D plot allows easier interpretation
 than the same data in a non-moving 3D one.
 
-#### 3B
+#### 3D
 
 Generates the skeleton of a `draw()` command that draws a 3D scene. If
 neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D
@@ -1130,7 +1101,9 @@ project can be done as easily as per drag-and-drop. But sometimes (for
 example if an image’s contents might change later on in a session) it is
 better to tell the file to load the image on evaluation:
 
-```maxima show_image("man.png"); ```
+```maxima
+show_image("man.png");
+```
 
 ## Startup files
 
@@ -1176,6 +1149,20 @@ the command: `maxima_userdir;`
   oynatılsın mı?
 - `wxmaximaversion`: Returns the version number of _wxMaxima_.
 - `wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using.
+- `wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these
+  differ by maintainer, distribution and operating system:
+  - `wxdirs@userconfdir`: The directory the user's configuration is stored
+    in. Same directory as `maxima_userdir` (see above) - both point at the
+    same place, `wxdirs@userconfdir` is only useful if that is more
+    convenient to reach from a `.mac` file than the Maxima-side variable.
+  - `wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the
+    built-in autocompletion list, ...) is installed in.
+  - `wxdirs@helpdir`: The directory the offline copy of this manual is
+    installed in.
+  - `wxdirs@localedir`: The directory _wxMaxima_'s translation files are
+    installed in.
+  - `wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_
+    is configured to start.
 
 ## Pretty-printing 2D output
 
@@ -1252,9 +1239,8 @@ using an (machine readable) XML-dialect (can be seen in the "Raw XML
 sidebar") and outputs the resulting formulas nicely rendered, e.g. pretty
 Matrices, Square root signs, fractions, etc.
 
-<!--- Currently that does not work as it should, the line with the output
-label is shifted right (issue: #2006) --> `set_display('ascii)` causes
-wxMaxima to output formulas as in command line Maxima - as ASCII-Art.
+<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->
+`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.
 
 `set_display('none)` causes 'one-line' ASCII results - the same as the
 command line Maxima command `display2d:false;` does.
@@ -1267,15 +1253,13 @@ tips, some example worksheets and in command line Maxima included demos (the
 
 Please notice, that the demos write:
 
-~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the
-demonstration.  ~~~
+~~~text
+At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.
+~~~
 
-That is valid for command-line Maxima, however in wxMaxima by default it is
-necessary to continue the demonstration with:
-<kbd>CTRL</kbd>+<kbd>ENTER</kbd>
+That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>
 
-(That can be configured in the Configure->Worksheet->"Hotkeys for sending
-commands to Maxima" menu.)
+(That can be configured in the Configure->Worksheet->"Hotkeys for sending commands to Maxima" menu.)
 
 ______________________________________________________________________
 
@@ -1314,19 +1298,13 @@ processor document. If the zip signature isn’t intact that does not need to
 be the end of the world: If _wxMaxima_ during saving detected that something
 went wrong there will be a `.wxmx~` file whose contents might help.
 
-And even if there isn’t such a file: The `.wxmx` file is a container format
-and the XML portion is stored uncompressed. It it is possible to rename the
-`.wxmx` file to a `.txt` file and to use a text editor to recover the XML
-portion of the file’s contents (it starts with `<?xml version="1.0"
-encoding="UTF-8"?>` and ends with `</wxMaximaDocument>`. Before and after
-that text you will see some unreadable binary contents in the text editor).
+And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version="1.0" encoding="UTF-8"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).
 
 If a text file containing only these contents (e.g. copy and paste this text
 into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know
 how to recover the text from the document.
 
-## I want some debug info to be displayed on the screen before my command
-has finished
+## I want some debug info to be displayed on the screen before my command has finished
 
 Normalde _wxMaxima_, 2B formülün tamamının dizilmeye başlamadan önce
 aktarılmasını bekler. Bu, sadece kısmen tamamlanmış bir denklemi dizmek için
@@ -1396,7 +1374,9 @@ verileri kurtarmak için birkaç yöntem vardır:
 - Başka bir şey yardımcı olmazsa _Maxima_ bir yeniden oynatma özelliği
   içerir:
 
-```maxima playback(); ```
+```maxima
+playback();
+```
 
 ## _WxMaxima_ starts up with the message “Maxima process terminated.”
 
@@ -1442,14 +1422,18 @@ yetersiz(https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/
 _Maxima_'nız SBCL'ye dayanıyorsa, aşağıdaki satırların .sbclrc`inize
 eklenmesi gerekir:
 
-```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```
+```commonlisp
+(setf sb-impl::*default-external-format* :utf-8)
+```
 
 The folder where this file has to be placed is system- and
 installation-specific. But any SBCL-based _Maxima_ that already has
 evaluated a cell in the current session will happily tell where it can be
 found after getting the following command:
 
-```maxima :lisp (sb-impl::userinit-pathname)  ```
+```maxima
+:lisp (sb-impl::userinit-pathname)
+```
 
 ## Note concerning Wayland (recent Linux/BSD distributions)
 
@@ -1541,28 +1525,22 @@ wxdraw2d(
 ),wxplot_size=[1000,1000];
 ```
 
-## After upgrading to MacOS 13.1 plot and/or draw commands output error
-messages like
+## After upgrading to MacOS 13.1 plot and/or draw commands output error messages like
 
-```text 1 HIToolbox 0x00007ff80cd91726
-_ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox
-0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox
-0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```
+```text
+1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102
+2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52
+3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408
+...
+```
 
-This might be an issue with the operating system. Disable the hiding of the
-menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the
-issue. See [wxMaxima issue
-#1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more
-information.
+This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.
 
 ## Logging
 
-Log messages might be helpful to debug problems. WxMaxima can log many
-events. Most log entries will be helpful for developers, especially in case
-of problems or bugs. If you run a "Release"-Build, the log windows is not
-shown by default, if you run a development version, it is shown by default
-as a second window. You can enable and disable this window using the
-"View->Toggle log window" menu entry.
+Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a "Release"-Build,
+the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable
+this window using the "View->Toggle log window" menu entry.
 
 Messages are not 'lost', if the log window is not shown, if you select to
 show the log window later, you will see past log messages (if you did not
@@ -1585,11 +1563,11 @@ ______________________________________________________________________
 Yes. Use the [LaTeX package "geometry"](https://ctan.org/pkg/geometry) to
 specify the size of the borders.
 
-You can add the following line to the LaTeX preamble (for example by using
-the respective field in the config dialogue ("Export"->"Additional lines for
-the TeX preamble"), to set borders of 1cm):
+You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue ("Export"->"Additional lines for the TeX preamble"), to set borders of 1cm):
 
-```latex \usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```
+```latex
+\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}
+```
 
 ## Is there a dark mode?
 
@@ -1602,14 +1580,9 @@ vice versa.
 
 ## _WxMaxima_ sometimes hangs for several seconds once in the first minute
 
-_WxMaxima_ delegates some big tasks like parsing _Maxima_’s
->1000-page-manual to background tasks, which normally goes totally
-unnoticed. At the moment the result of such a task is needed, though, it is
-possible that _wxMaxima_ needs to wait a couple of seconds before it can
-continue its work.
+_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.
 
-## Especially when testing new locale settings, a message box "locale
-’xx_YY’ can not be set" occurs
+## Especially when testing new locale settings, a message box "locale ’xx_YY’ can not be set" occurs
 
 ![Locale warning](./locale-warning.png){ id=img_locale_warning}
 
@@ -1626,8 +1599,7 @@ You can find these symbols in the Unicode sidebar (search for ’double-struck
 capital’). But the selected font must also support these symbols. If they do
 not display properly, select another font.
 
-## How can a Maxima script determine, if it is running under wxMaxima or
-command line Maxima?
+## How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?
 
 If wxMaxima is used, the Maxima variable `maxima_frontend` is set to
 `wxmaxima`. The Maxima variable `maxima_frontend_version` contains the
@@ -1638,10 +1610,7 @@ are `false`.
 
 ## Help! I can not save my document!
 
-If saving as wxmx file does not work, try saving the document as wxm file
-(and vice versa). And you can also try to remove all output (Menu
-Cell->Remove all output) and save that file, maybe some unexpected output
-causes issues during the save process.
+If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.
 
 ______________________________________________________________________
 
@@ -1706,7 +1675,4 @@ the wxWidgets library), no external dependencies (like graphic files or the
 Lisp part (the `wxmathML.lisp`-file) is needed, these files are included in
 the executable.
 
-If you are a developer, you might want to try out a modified
-`wxmathML.lisp`-file without recompiling everything, one can use the command
-line option `--wxmathml-lisp=<str>` to use another Lisp file, not the
-included one.
+If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.

--- a/info/wxmaxima.uk.md
+++ b/info/wxmaxima.uk.md
@@ -51,12 +51,7 @@ _Maxima_ є повноцінною системою комп'ютерної ал
 ![Знімок вікна Maxima, командний рядок](./maxima_screenshot.png){
 id=img_maxima_screenshot }
 
-Extensive documentation for _Maxima_ is [available in the
-internet](https://maxima.sourceforge.io/documentation.html). Part of this
-documentation is also available in wxMaxima’s help menu. Pressing the Help
-key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s
-context-sensitive help feature to automatically jump to _Maxima_’s manual
-page for the command at the cursor.
+Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.
 
 ### WxMaxima
 
@@ -180,12 +175,7 @@ automatically when needed:
   moving the cursor inside a cell using the mouse pointer or the cursor keys
   and works much like the cursor in a text editor.
 
-When you start wxMaxima, you will only see the blinking horizontal
-cursor. If you start typing, a math cell will be automatically created and
-the cursor will change to a regular vertical one (you will see a right arrow
-as "prompt", after the Math cell is evaluated
-(<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`,
-`(%o1)`).
+When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as "prompt", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).
 
 ![Горизонтальний курсор після запуску
 wxMaxima](./horizontal-cursor-only.png){ id=img_horizontal_cursor_only }
@@ -205,29 +195,15 @@ id=img_horizontal_cursor_between_cells }
 
 ### Sending cells to Maxima
 
-The command in a code cell is executed once by pressing
-<kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the
-<kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter
-commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or
-<kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be
-configured to execute commands in response to <kbd>ENTER</kbd>.
+The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.
 
 ### Command autocompletion
 
-_WxMaxima_ contains an autocompletion feature that is triggered via the menu
-(Cell/Complete Word) or alternatively by pressing the key combination
-<kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is
-context-sensitive. For example, if activated within a unit specification for
-ezUnits it will offer a list of applicable units.
+_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.
 
 ![ezUnits](./ezUnits.png){ id=img_ezUnits }
 
-Besides completing a file name, a unit name, or the current command or
-variable name, the autocompletion is able to show a template for most of the
-commands indicating the type (and meaning) of the parameters this program
-expects. To activate this feature press
-<kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective
-menu item (Cell/Show Template).
+Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).
 
 #### Greek characters
 
@@ -346,23 +322,17 @@ menu).
 
 You can also use the "Symbols"-sidebar to enter these Mathematical symbols.
 
-If a special symbol isn’t in the list, it is possible to input arbitrary
-Unicode characters by pressing <kbd>ESC</kbd> \[number of the character
-(hexadecimal)\] <kbd>ESC</kbd>. Additionally the "symbols" sidebar has a
-right-click menu that allow to display a list of all available Unicode
-symbols one can add to this toolbar or to the worksheet.
+If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \[number of the character (hexadecimal)\] <kbd>ESC</kbd>. Additionally the "symbols" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.
 
-<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an
-`a`.
+<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.
 
 Please note that most of these symbols (notable exceptions are the logic
 symbols) do not have a special meaning in _Maxima_ and therefore will be
 interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp
 that doesn’t support Unicode characters they might cause an error message.
 
-It may be the case that e.g. Greek characters or mathematical symbols are
-not included in the selected font, then they can not be displayed.  To solve
-that problem, select other fonts (using: Edit -> Configure -> Style).
+It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.
+To solve that problem, select other fonts (using: Edit -> Configure -> Style).
 
 ### Unicode replacement
 
@@ -432,18 +402,21 @@ Ordinary text
 
 _WxMaxima_ will recognize text starting with `>` chars as block quotes:
 
-```text Ordinary text > quote quote quote quote > quote quote quote quote >
-quote quote quote quote Ordinary text ```
+```text
+Ordinary text
+> quote quote quote quote
+> quote quote quote quote
+> quote quote quote quote
+Ordinary text
+```
 
-_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by
-the corresponding Unicode sign:
+_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:
 
-```text cogito => sum.  ```
+```text
+cogito => sum.
+```
 
-Other symbols the HTML and TeX export will recognize are `<=` and `>=` for
-comparisons, a double-pointed double arrow (`<=>`), single-headed arrows
-(`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also
-`<<` and `>>` are recognized.
+Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.
 
 ### Hotkeys
 
@@ -495,13 +468,8 @@ back as a _wxMaxima_ session.
 
 ### .wxm
 
-`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima
-versions >5.38 they can be read using _Maxima_’s `load()` function just as
-.mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as
-the answer is written in the `.wxm` file (so that it can be suggested after
-loading), but that can Maxima not evaluate.  You can prevent Maxima from
-asking questions by using `assume()` to declare some properties, Maxima
-wants to know.
+`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.
+You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.
 
 With this plain-text format, it sometimes is unavoidable that worksheets
 that use new features are not downwards-compatible with older versions of
@@ -514,8 +482,10 @@ containing the cell contents as some special Maxima comments.
 
 It starts with the following comment:
 
-```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
-Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```
+```maxima
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */
+```
 
 And then the cells follow, encoded as Maxima comments, e.g. a section cell:
 
@@ -654,15 +624,8 @@ app:
 
 ### Where is the configuration saved?
 
-If you are using Unix/Linux, the configuration information will be saved in
-a file `.wxMaxima` in your home directory (if you are using wxWidgets \<
-3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is
-used). You can retrieve the wxWidgets version from the command
-`wxbuild_info();` or by using the menu option
-Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform
-GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the
-name).  (Since the filename starts with a dot, `.wxMaxima` or `.config` will
-be hidden).
+If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).
+(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).
 
 Якщо ви користуєтеся Windows, налаштування буде збережено у реєстрі. Записи
 _wxMaxima_ можна знайти у цій гілці: `HKEY_CURRENT_USER\Software\wxMaxima`
@@ -737,8 +700,10 @@ scripted or batch export. Like `wxstatusbar()` it is safe to use in code
 that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present
 the command is simply left unevaluated.
 
-```maxima wxworksheettohtml("report.html")$ wxworksheettohtml("report.html",
-flavor="svg", wxmx=true)$ ```
+```maxima
+wxworksheettohtml("report.html")$
+wxworksheettohtml("report.html", flavor="svg", wxmx=true)$
+```
 
 A relative file name is interpreted relative to _Maxima_’s working
 directory. The optional keyword options are:
@@ -756,8 +721,10 @@ still lack MathML, and `svg`/`bitmap` render every equation to an image.
 The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file
 the same way:
 
-```maxima wxworksheettotex("report.tex")$ wxworksheettotex("report.tex",
-documentclass="report", documentclassoptions="12pt,a4paper")$ ```
+```maxima
+wxworksheettotex("report.tex")$
+wxworksheettotex("report.tex", documentclass="report", documentclassoptions="12pt,a4paper")$
+```
 
 | option                 | meaning                                                              |
 | ---------------------- | -------------------------------------------------------------------- |
@@ -990,14 +957,18 @@ with_slider_draw(
 нижче приклад походить із допису Маріо Родрігеса (Mario Rodriguez) у списку
 листування _Maxima_:
 
-```maxima load(draw);
+```maxima
+load(draw);
 
-/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));
+/* Parabola in window #1 */
+draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));
 
-/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));
+/* Parabola in window #2 */
+draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));
 
 /* Paraboloid in window #3 */
-draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```
+draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));
+```
 
 Plotting multiple plots in the same window is possible, too (the same is
 possible in command line Maxima with the standard `draw()` command):
@@ -1139,7 +1110,9 @@ project can be done as easily as per drag-and-drop. But sometimes (for
 example if an image’s contents might change later on in a session) it is
 better to tell the file to load the image on evaluation:
 
-```maxima show_image("man.png"); ```
+```maxima
+show_image("man.png");
+```
 
 ## Startup files
 
@@ -1186,6 +1159,20 @@ the command: `maxima_userdir;`
 - `wxmaximaversion`: повертає номер версії _wxMaxima_.
 - `wxwidgetsversion`: повертає версію wxWidgets, яку використано у
   _wxMaxima_.
+- `wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these
+  differ by maintainer, distribution and operating system:
+  - `wxdirs@userconfdir`: The directory the user's configuration is stored
+    in. Same directory as `maxima_userdir` (see above) - both point at the
+    same place, `wxdirs@userconfdir` is only useful if that is more
+    convenient to reach from a `.mac` file than the Maxima-side variable.
+  - `wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the
+    built-in autocompletion list, ...) is installed in.
+  - `wxdirs@helpdir`: The directory the offline copy of this manual is
+    installed in.
+  - `wxdirs@localedir`: The directory _wxMaxima_'s translation files are
+    installed in.
+  - `wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_
+    is configured to start.
 
 ## Pretty-printing 2D output
 
@@ -1263,9 +1250,8 @@ using an (machine readable) XML-dialect (can be seen in the "Raw XML
 sidebar") and outputs the resulting formulas nicely rendered, e.g. pretty
 Matrices, Square root signs, fractions, etc.
 
-<!--- Currently that does not work as it should, the line with the output
-label is shifted right (issue: #2006) --> `set_display('ascii)` causes
-wxMaxima to output formulas as in command line Maxima - as ASCII-Art.
+<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->
+`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.
 
 `set_display('none)` causes 'one-line' ASCII results - the same as the
 command line Maxima command `display2d:false;` does.
@@ -1278,15 +1264,13 @@ tips, some example worksheets and in command line Maxima included demos (the
 
 Please notice, that the demos write:
 
-~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the
-demonstration.  ~~~
+~~~text
+At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.
+~~~
 
-That is valid for command-line Maxima, however in wxMaxima by default it is
-necessary to continue the demonstration with:
-<kbd>CTRL</kbd>+<kbd>ENTER</kbd>
+That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>
 
-(That can be configured in the Configure->Worksheet->"Hotkeys for sending
-commands to Maxima" menu.)
+(That can be configured in the Configure->Worksheet->"Hotkeys for sending commands to Maxima" menu.)
 
 ______________________________________________________________________
 
@@ -1325,19 +1309,13 @@ processor document. If the zip signature isn’t intact that does not need to
 be the end of the world: If _wxMaxima_ during saving detected that something
 went wrong there will be a `.wxmx~` file whose contents might help.
 
-And even if there isn’t such a file: The `.wxmx` file is a container format
-and the XML portion is stored uncompressed. It it is possible to rename the
-`.wxmx` file to a `.txt` file and to use a text editor to recover the XML
-portion of the file’s contents (it starts with `<?xml version="1.0"
-encoding="UTF-8"?>` and ends with `</wxMaximaDocument>`. Before and after
-that text you will see some unreadable binary contents in the text editor).
+And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version="1.0" encoding="UTF-8"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).
 
 Якщо текстовий файл, що містить ці дані (наприклад скопійовані і вставлені
 як текст до звичайного файла), збережено як файл із суфіксом назви .xml,
 _wxMaxima_ відомий спосіб відновлення тексту документа з цього файла.
 
-## I want some debug info to be displayed on the screen before my command
-has finished
+## I want some debug info to be displayed on the screen before my command has finished
 
 Зазвичай, _wxMaxima_ очікує, доки буде передано усю двовимірну формулу, перш
 ніж починає виводити дані. Таким чином заощаджується час, який могло б бути
@@ -1407,7 +1385,9 @@ supposed to instruct _Gnuplot_ to create.
 - Якщо ніщо інше не допомагає, у _Maxima_ є функція для відтворення усіх
   команд:
 
-```maxima playback(); ```
+```maxima
+playback();
+```
 
 ## _WxMaxima_ starts up with the message “Maxima process terminated.”
 
@@ -1453,14 +1433,18 @@ dialogue.
 Якщо вашу _Maxima_ засновано на SBCL, слід додати такі рядки до вашого файла
 `.sbclrc`:
 
-```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```
+```commonlisp
+(setf sb-impl::*default-external-format* :utf-8)
+```
 
 Тека, у якій має бути розташовано цей файл залежить від системи та способу
 встановлення. Втім, будь-яка _Maxima_ на основі SBCL, яка вже виконала
 обчислення у якійсь комірці протягом поточного сеансу, без проблем
 повідомить, де його можна знайти, у відповідь на таку команду:
 
-```maxima :lisp (sb-impl::userinit-pathname)  ```
+```maxima
+:lisp (sb-impl::userinit-pathname)
+```
 
 ## Note concerning Wayland (recent Linux/BSD distributions)
 
@@ -1552,28 +1536,22 @@ wxdraw2d(
 ),wxplot_size=[1000,1000];
 ```
 
-## After upgrading to MacOS 13.1 plot and/or draw commands output error
-messages like
+## After upgrading to MacOS 13.1 plot and/or draw commands output error messages like
 
-```text 1 HIToolbox 0x00007ff80cd91726
-_ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox
-0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox
-0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```
+```text
+1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102
+2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52
+3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408
+...
+```
 
-This might be an issue with the operating system. Disable the hiding of the
-menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the
-issue. See [wxMaxima issue
-#1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more
-information.
+This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.
 
 ## Logging
 
-Log messages might be helpful to debug problems. WxMaxima can log many
-events. Most log entries will be helpful for developers, especially in case
-of problems or bugs. If you run a "Release"-Build, the log windows is not
-shown by default, if you run a development version, it is shown by default
-as a second window. You can enable and disable this window using the
-"View->Toggle log window" menu entry.
+Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a "Release"-Build,
+the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable
+this window using the "View->Toggle log window" menu entry.
 
 Messages are not 'lost', if the log window is not shown, if you select to
 show the log window later, you will see past log messages (if you did not
@@ -1596,11 +1574,11 @@ ______________________________________________________________________
 Так. Скористайтеся [пакунком LaTeX
 «geometry»](https://ctan.org/pkg/geometry) для визначення розмірів полів.
 
-You can add the following line to the LaTeX preamble (for example by using
-the respective field in the config dialogue ("Export"->"Additional lines for
-the TeX preamble"), to set borders of 1cm):
+You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue ("Export"->"Additional lines for the TeX preamble"), to set borders of 1cm):
 
-```latex \usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```
+```latex
+\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}
+```
 
 ## Is there a dark mode?
 
@@ -1613,14 +1591,9 @@ the TeX preamble"), to set borders of 1cm):
 
 ## _WxMaxima_ sometimes hangs for several seconds once in the first minute
 
-_WxMaxima_ delegates some big tasks like parsing _Maxima_’s
->1000-page-manual to background tasks, which normally goes totally
-unnoticed. At the moment the result of such a task is needed, though, it is
-possible that _wxMaxima_ needs to wait a couple of seconds before it can
-continue its work.
+_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.
 
-## Especially when testing new locale settings, a message box "locale
-’xx_YY’ can not be set" occurs
+## Especially when testing new locale settings, a message box "locale ’xx_YY’ can not be set" occurs
 
 ![Попередження про локаль](./locale-warning.png){ id=img_locale_warning}
 
@@ -1637,8 +1610,7 @@ You can find these symbols in the Unicode sidebar (search for ’double-struck
 capital’). But the selected font must also support these symbols. If they do
 not display properly, select another font.
 
-## How can a Maxima script determine, if it is running under wxMaxima or
-command line Maxima?
+## How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?
 
 If wxMaxima is used, the Maxima variable `maxima_frontend` is set to
 `wxmaxima`. The Maxima variable `maxima_frontend_version` contains the
@@ -1649,10 +1621,7 @@ are `false`.
 
 ## Help! I can not save my document!
 
-If saving as wxmx file does not work, try saving the document as wxm file
-(and vice versa). And you can also try to remove all output (Menu
-Cell->Remove all output) and save that file, maybe some unexpected output
-causes issues during the save process.
+If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.
 
 ______________________________________________________________________
 
@@ -1718,7 +1687,4 @@ Or answer questions of other users in the discussion forum.
 файлів або частини Lisp (файла `wxmathML.lisp`) не потрібно, ці файли
 включено до виконуваного файла програми.
 
-If you are a developer, you might want to try out a modified
-`wxmathML.lisp`-file without recompiling everything, one can use the command
-line option `--wxmathml-lisp=<str>` to use another Lisp file, not the
-included one.
+If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.

--- a/info/wxmaxima.zh_CN.md
+++ b/info/wxmaxima.zh_CN.md
@@ -42,12 +42,7 @@ Maxima 是一个功能齐全的计算机代数系统（CAS）。CAS
 
 ![Maxima 截图，命令行](./maxima_screenshot.png){ id=img_maxima_screenshot }
 
-Extensive documentation for _Maxima_ is [available in the
-internet](https://maxima.sourceforge.io/documentation.html). Part of this
-documentation is also available in wxMaxima’s help menu. Pressing the Help
-key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s
-context-sensitive help feature to automatically jump to _Maxima_’s manual
-page for the command at the cursor.
+Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.
 
 ### WxMaxima
 
@@ -154,12 +149,7 @@ automatically when needed:
   moving the cursor inside a cell using the mouse pointer or the cursor keys
   and works much like the cursor in a text editor.
 
-When you start wxMaxima, you will only see the blinking horizontal
-cursor. If you start typing, a math cell will be automatically created and
-the cursor will change to a regular vertical one (you will see a right arrow
-as "prompt", after the Math cell is evaluated
-(<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`,
-`(%o1)`).
+When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as "prompt", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).
 
 ![(blinking) horizontal cursor after wxMaxima
 start](./horizontal-cursor-only.png){ id=img_horizontal_cursor_only }
@@ -179,29 +169,15 @@ id=img_horizontal_cursor_between_cells }
 
 ### Sending cells to Maxima
 
-The command in a code cell is executed once by pressing
-<kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the
-<kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter
-commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or
-<kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be
-configured to execute commands in response to <kbd>ENTER</kbd>.
+The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.
 
 ### Command autocompletion
 
-_WxMaxima_ contains an autocompletion feature that is triggered via the menu
-(Cell/Complete Word) or alternatively by pressing the key combination
-<kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is
-context-sensitive. For example, if activated within a unit specification for
-ezUnits it will offer a list of applicable units.
+_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.
 
 ![ezUnits](./ezUnits.png){ id=img_ezUnits }
 
-Besides completing a file name, a unit name, or the current command or
-variable name, the autocompletion is able to show a template for most of the
-commands indicating the type (and meaning) of the parameters this program
-expects. To activate this feature press
-<kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective
-menu item (Cell/Show Template).
+Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).
 
 #### Greek characters
 
@@ -318,23 +294,17 @@ menu).
 
 You can also use the "Symbols"-sidebar to enter these Mathematical symbols.
 
-If a special symbol isn’t in the list, it is possible to input arbitrary
-Unicode characters by pressing <kbd>ESC</kbd> \[number of the character
-(hexadecimal)\] <kbd>ESC</kbd>. Additionally the "symbols" sidebar has a
-right-click menu that allow to display a list of all available Unicode
-symbols one can add to this toolbar or to the worksheet.
+If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \[number of the character (hexadecimal)\] <kbd>ESC</kbd>. Additionally the "symbols" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.
 
-<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an
-`a`.
+<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.
 
 Please note that most of these symbols (notable exceptions are the logic
 symbols) do not have a special meaning in _Maxima_ and therefore will be
 interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp
 that doesn’t support Unicode characters they might cause an error message.
 
-It may be the case that e.g. Greek characters or mathematical symbols are
-not included in the selected font, then they can not be displayed.  To solve
-that problem, select other fonts (using: Edit -> Configure -> Style).
+It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.
+To solve that problem, select other fonts (using: Edit -> Configure -> Style).
 
 ### Unicode replacement
 
@@ -404,18 +374,21 @@ Ordinary text
 
 _WxMaxima_ will recognize text starting with `>` chars as block quotes:
 
-```text Ordinary text > quote quote quote quote > quote quote quote quote >
-quote quote quote quote Ordinary text ```
+```text
+Ordinary text
+> quote quote quote quote
+> quote quote quote quote
+> quote quote quote quote
+Ordinary text
+```
 
-_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by
-the corresponding Unicode sign:
+_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:
 
-```text cogito => sum.  ```
+```text
+cogito => sum.
+```
 
-Other symbols the HTML and TeX export will recognize are `<=` and `>=` for
-comparisons, a double-pointed double arrow (`<=>`), single-headed arrows
-(`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also
-`<<` and `>>` are recognized.
+Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.
 
 ### Hotkeys
 
@@ -460,13 +433,8 @@ back as a _wxMaxima_ session.
 
 ### .wxm
 
-`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima
-versions >5.38 they can be read using _Maxima_’s `load()` function just as
-.mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as
-the answer is written in the `.wxm` file (so that it can be suggested after
-loading), but that can Maxima not evaluate.  You can prevent Maxima from
-asking questions by using `assume()` to declare some properties, Maxima
-wants to know.
+`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.
+You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.
 
 With this plain-text format, it sometimes is unavoidable that worksheets
 that use new features are not downwards-compatible with older versions of
@@ -479,8 +447,10 @@ containing the cell contents as some special Maxima comments.
 
 It starts with the following comment:
 
-```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [
-Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```
+```maxima
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */
+```
 
 And then the cells follow, encoded as Maxima comments, e.g. a section cell:
 
@@ -609,15 +579,8 @@ app:
 
 ### Where is the configuration saved?
 
-If you are using Unix/Linux, the configuration information will be saved in
-a file `.wxMaxima` in your home directory (if you are using wxWidgets \<
-3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is
-used). You can retrieve the wxWidgets version from the command
-`wxbuild_info();` or by using the menu option
-Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform
-GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the
-name).  (Since the filename starts with a dot, `.wxMaxima` or `.config` will
-be hidden).
+If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).
+(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).
 
 当使用 Windows 系统时，配置信息将存储在注册表中。在注册表中的以下位置可以找到 wxMaxima
 的相关条目：`HKEY_CURRENT_USER\Software\wxMaxima`。
@@ -691,8 +654,10 @@ scripted or batch export. Like `wxstatusbar()` it is safe to use in code
 that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present
 the command is simply left unevaluated.
 
-```maxima wxworksheettohtml("report.html")$ wxworksheettohtml("report.html",
-flavor="svg", wxmx=true)$ ```
+```maxima
+wxworksheettohtml("report.html")$
+wxworksheettohtml("report.html", flavor="svg", wxmx=true)$
+```
 
 A relative file name is interpreted relative to _Maxima_’s working
 directory. The optional keyword options are:
@@ -710,8 +675,10 @@ still lack MathML, and `svg`/`bitmap` render every equation to an image.
 The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file
 the same way:
 
-```maxima wxworksheettotex("report.tex")$ wxworksheettotex("report.tex",
-documentclass="report", documentclassoptions="12pt,a4paper")$ ```
+```maxima
+wxworksheettotex("report.tex")$
+wxworksheettotex("report.tex", documentclass="report", documentclassoptions="12pt,a4paper")$
+```
 
 | option                 | meaning                                                              |
 | ---------------------- | -------------------------------------------------------------------- |
@@ -933,14 +900,18 @@ While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups
 that support it) sometimes comes in handily. The following example comes
 from a post from Mario Rodriguez to the _Maxima_ mailing list:
 
-```maxima load(draw);
+```maxima
+load(draw);
 
-/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));
+/* Parabola in window #1 */
+draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));
 
-/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));
+/* Parabola in window #2 */
+draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));
 
 /* Paraboloid in window #3 */
-draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1)); ```
+draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));
+```
 
 Plotting multiple plots in the same window is possible, too (the same is
 possible in command line Maxima with the standard `draw()` command):
@@ -1072,7 +1043,9 @@ project can be done as easily as per drag-and-drop. But sometimes (for
 example if an image’s contents might change later on in a session) it is
 better to tell the file to load the image on evaluation:
 
-```maxima show_image("man.png"); ```
+```maxima
+show_image("man.png");
+```
 
 ## Startup files
 
@@ -1111,6 +1084,20 @@ the command: `maxima_userdir;`
 - `wxanimate_autoplay`：是否在默认情况下自动播放动图。
 - `wxmaximaversion`: Returns the version number of _wxMaxima_.
 - `wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using.
+- `wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these
+  differ by maintainer, distribution and operating system:
+  - `wxdirs@userconfdir`: The directory the user's configuration is stored
+    in. Same directory as `maxima_userdir` (see above) - both point at the
+    same place, `wxdirs@userconfdir` is only useful if that is more
+    convenient to reach from a `.mac` file than the Maxima-side variable.
+  - `wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the
+    built-in autocompletion list, ...) is installed in.
+  - `wxdirs@helpdir`: The directory the offline copy of this manual is
+    installed in.
+  - `wxdirs@localedir`: The directory _wxMaxima_'s translation files are
+    installed in.
+  - `wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_
+    is configured to start.
 
 ## Pretty-printing 2D output
 
@@ -1183,9 +1170,8 @@ using an (machine readable) XML-dialect (can be seen in the "Raw XML
 sidebar") and outputs the resulting formulas nicely rendered, e.g. pretty
 Matrices, Square root signs, fractions, etc.
 
-<!--- Currently that does not work as it should, the line with the output
-label is shifted right (issue: #2006) --> `set_display('ascii)` causes
-wxMaxima to output formulas as in command line Maxima - as ASCII-Art.
+<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->
+`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.
 
 `set_display('none)` causes 'one-line' ASCII results - the same as the
 command line Maxima command `display2d:false;` does.
@@ -1198,15 +1184,13 @@ tips, some example worksheets and in command line Maxima included demos (the
 
 Please notice, that the demos write:
 
-~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the
-demonstration.  ~~~
+~~~text
+At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.
+~~~
 
-That is valid for command-line Maxima, however in wxMaxima by default it is
-necessary to continue the demonstration with:
-<kbd>CTRL</kbd>+<kbd>ENTER</kbd>
+That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>
 
-(That can be configured in the Configure->Worksheet->"Hotkeys for sending
-commands to Maxima" menu.)
+(That can be configured in the Configure->Worksheet->"Hotkeys for sending commands to Maxima" menu.)
 
 ______________________________________________________________________
 
@@ -1245,19 +1229,13 @@ processor document. If the zip signature isn’t intact that does not need to
 be the end of the world: If _wxMaxima_ during saving detected that something
 went wrong there will be a `.wxmx~` file whose contents might help.
 
-And even if there isn’t such a file: The `.wxmx` file is a container format
-and the XML portion is stored uncompressed. It it is possible to rename the
-`.wxmx` file to a `.txt` file and to use a text editor to recover the XML
-portion of the file’s contents (it starts with `<?xml version="1.0"
-encoding="UTF-8"?>` and ends with `</wxMaximaDocument>`. Before and after
-that text you will see some unreadable binary contents in the text editor).
+And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version="1.0" encoding="UTF-8"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).
 
 If a text file containing only these contents (e.g. copy and paste this text
 into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know
 how to recover the text from the document.
 
-## I want some debug info to be displayed on the screen before my command
-has finished
+## I want some debug info to be displayed on the screen before my command has finished
 
 通常 wxMaxima 会等待最后的公式形成后才开始输出，这节省了多次尝试输出部分公式的时间。不过， `disp()`
 命令可以立即输出调试信息，而不必等待当前的 Maxima 命令完成：
@@ -1321,7 +1299,9 @@ example.
   recently.
 - 如果以上都没有帮助，可以调用 Maxima 的回放功能：
 
-```maxima playback(); ```
+```maxima
+playback();
+```
 
 ## _WxMaxima_ starts up with the message “Maxima process terminated.”
 
@@ -1363,14 +1343,18 @@ dialogue.
 
 如果所使用的 Maxima 基于SBCL，则必须将以下行添加到 `.sbclrc` 文件中：
 
-```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```
+```commonlisp
+(setf sb-impl::*default-external-format* :utf-8)
+```
 
 The folder where this file has to be placed is system- and
 installation-specific. But any SBCL-based _Maxima_ that already has
 evaluated a cell in the current session will happily tell where it can be
 found after getting the following command:
 
-```maxima :lisp (sb-impl::userinit-pathname)  ```
+```maxima
+:lisp (sb-impl::userinit-pathname)
+```
 
 ## Note concerning Wayland (recent Linux/BSD distributions)
 
@@ -1462,28 +1446,22 @@ wxdraw2d(
 ),wxplot_size=[1000,1000];
 ```
 
-## After upgrading to MacOS 13.1 plot and/or draw commands output error
-messages like
+## After upgrading to MacOS 13.1 plot and/or draw commands output error messages like
 
-```text 1 HIToolbox 0x00007ff80cd91726
-_ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox
-0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox
-0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```
+```text
+1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102
+2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52
+3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408
+...
+```
 
-This might be an issue with the operating system. Disable the hiding of the
-menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the
-issue. See [wxMaxima issue
-#1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more
-information.
+This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.
 
 ## Logging
 
-Log messages might be helpful to debug problems. WxMaxima can log many
-events. Most log entries will be helpful for developers, especially in case
-of problems or bugs. If you run a "Release"-Build, the log windows is not
-shown by default, if you run a development version, it is shown by default
-as a second window. You can enable and disable this window using the
-"View->Toggle log window" menu entry.
+Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a "Release"-Build,
+the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable
+this window using the "View->Toggle log window" menu entry.
 
 Messages are not 'lost', if the log window is not shown, if you select to
 show the log window later, you will see past log messages (if you did not
@@ -1506,11 +1484,11 @@ ______________________________________________________________________
 Yes. Use the [LaTeX package "geometry"](https://ctan.org/pkg/geometry) to
 specify the size of the borders.
 
-You can add the following line to the LaTeX preamble (for example by using
-the respective field in the config dialogue ("Export"->"Additional lines for
-the TeX preamble"), to set borders of 1cm):
+You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue ("Export"->"Additional lines for the TeX preamble"), to set borders of 1cm):
 
-```latex \usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```
+```latex
+\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}
+```
 
 ## Is there a dark mode?
 
@@ -1523,14 +1501,9 @@ vice versa.
 
 ## _WxMaxima_ sometimes hangs for several seconds once in the first minute
 
-_WxMaxima_ delegates some big tasks like parsing _Maxima_’s
->1000-page-manual to background tasks, which normally goes totally
-unnoticed. At the moment the result of such a task is needed, though, it is
-possible that _wxMaxima_ needs to wait a couple of seconds before it can
-continue its work.
+_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.
 
-## Especially when testing new locale settings, a message box "locale
-’xx_YY’ can not be set" occurs
+## Especially when testing new locale settings, a message box "locale ’xx_YY’ can not be set" occurs
 
 ![Locale warning](./locale-warning.png){ id=img_locale_warning}
 
@@ -1547,8 +1520,7 @@ You can find these symbols in the Unicode sidebar (search for ’double-struck
 capital’). But the selected font must also support these symbols. If they do
 not display properly, select another font.
 
-## How can a Maxima script determine, if it is running under wxMaxima or
-command line Maxima?
+## How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?
 
 If wxMaxima is used, the Maxima variable `maxima_frontend` is set to
 `wxmaxima`. The Maxima variable `maxima_frontend_version` contains the
@@ -1559,10 +1531,7 @@ are `false`.
 
 ## Help! I can not save my document!
 
-If saving as wxmx file does not work, try saving the document as wxm file
-(and vice versa). And you can also try to remove all output (Menu
-Cell->Remove all output) and save that file, maybe some unexpected output
-causes issues during the save process.
+If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.
 
 ______________________________________________________________________
 
@@ -1627,7 +1596,4 @@ the wxWidgets library), no external dependencies (like graphic files or the
 Lisp part (the `wxmathML.lisp`-file) is needed, these files are included in
 the executable.
 
-If you are a developer, you might want to try out a modified
-`wxmathML.lisp`-file without recompiling everything, one can use the command
-line option `--wxmathml-lisp=<str>` to use another Lisp file, not the
-included one.
+If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.

--- a/locales/README.md
+++ b/locales/README.md
@@ -15,12 +15,15 @@ current by `make update-locale-manual-in-source`, which needs `po4a` >= 0.70 -
 see `CheckPo4aVersion.cmake`) via `msgcat`. A translator therefore only has one
 file per language to work in for both the UI and the manual.
 
-`manual/wxmaxima.md.pot` still exists as po4a's own intermediate template (it
-extracts msgids purely from `info/wxmaxima.md`), but the manual's actual
-per-language translations now live in `wxMaxima/*.po` alongside the UI
-strings, not in a separate `manual/*.po` per language: po4a reads the manual's
-msgids out of the combined file when regenerating `info/wxmaxima.$lang.md`,
-simply ignoring the UI-only entries it has no source line for.
+`manual/*.po` still exists, one file per language that has a manual
+translation: po4a owns that file exclusively and rewrites it wholesale on
+every run (it does not just add/update entries - pointing it at a file that
+also held UI strings silently dropped all of them, confirmed live). Each
+`make update-locale` run folds `manual/<lang>.po`'s translations into
+`wxMaxima/<lang>.po` (`merge_manual_po.cmake`, via `msgcat`) *before*
+`msgmerge`, so a translator only has to look in `wxMaxima/<lang>.po` to find
+or edit the manual's translations, even though po4a's own working copy lives
+elsewhere.
 
 ## Translating wxMaxima to a new language
 

--- a/locales/manual/CMakeLists.txt
+++ b/locales/manual/CMakeLists.txt
@@ -3,10 +3,15 @@
 
 include(${CMAKE_SOURCE_DIR}/CheckPo4aVersion.cmake)
 
-# Translations of the manual now live merged into locales/wxMaxima/*.po
-# alongside the UI strings (see locales/README.md), so the language list
-# comes from there.
-file(GLOB LANGUAGES ${CMAKE_CURRENT_SOURCE_DIR}/../wxMaxima/*.po)
+# which languages are supported? info/CMakeLists.txt expects a translated
+# info/wxmaxima.<lang>.md to already exist for every language in this list
+# (it doesn't generate a fresh empty one), so this must stay scoped to the
+# languages that actually have a manual translation - not every language
+# locales/wxMaxima/*.po covers (most of which have no manual translation at
+# all yet, only UI strings). po4a keeps writing its own po file here (see
+# ../wxMaxima/merge_manual_po.cmake for why it can't write directly into the
+# combined locales/wxMaxima/*.po).
+file(GLOB LANGUAGES *.po)
 list(TRANSFORM LANGUAGES REPLACE ".*/(.*).po$" "\\1")
 string(REPLACE ";" " " LANGUAGES_SPACESEPARATED "${LANGUAGES}")
 file(RELATIVE_PATH WXMAXIMA_MD_RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_SOURCE_DIR}/info/wxmaxima.md")

--- a/locales/manual/de.po
+++ b/locales/manual/de.po
@@ -1,0 +1,4606 @@
+# translation of de.po to german
+# This file was written by Gunter Königsmann <wxMaxima@peterpall.de> in 2019.
+# This file is released to the public domain.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: wxmaxima-gui\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-04 07:28+0000\n"
+"PO-Revision-Date: 2026-08-02 11:43\n"
+"Last-Translator: \n"
+"Language-Team: German\n"
+"Language: de_DE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: wxmaxima-gui\n"
+"X-Crowdin-Project-ID: 917703\n"
+"X-Crowdin-Language: de\n"
+"X-Crowdin-File: /main/locales/wxMaxima/wxMaxima.pot\n"
+"X-Crowdin-File-ID: 8\n"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1
+#, fuzzy, no-wrap
+#| msgid "# The wxMaxima user manual"
+msgid "The wxMaxima user manual"
+msgstr "# Das Handbuch von wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:4
+msgid ""
+"WxMaxima is a graphical user interface (GUI) for the _Maxima_ computer "
+"algebra system (CAS). WxMaxima allows one to use all of _Maxima_’s "
+"functions. In addition, it provides convenient wizards for accessing the "
+"most commonly used features. This manual describes some of the features that "
+"make wxMaxima one of the most popular GUIs for _Maxima_."
+msgstr ""
+"WxMaxima ist ein graphisches Benutzerinterface (GUI) für das Computer-"
+"Algebrasystem Maxima. wxMaxima erlaubt die Nutzung aller Funktionen dieses "
+"Programms und bietet Assistenten für dessen wichtigste Funktionen an. Dieses "
+"Handbuch beschreibt die Features, die wxMaxima zu einer der beliebtesten "
+"graphischen Benutzerumgebung für Maxima gemacht haben."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:6
+msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
+msgstr "![wxMaxima Logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:9
+#, fuzzy, no-wrap
+#| msgid "# Introduction to wxMaxima"
+msgid "Introduction to wxMaxima"
+msgstr "# Einführung in wxMaxima"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:11
+#, fuzzy, no-wrap
+#| msgid "## _Maxima_ and wxMaxima"
+msgid "_Maxima_ and wxMaxima"
+msgstr "## _Maxima_ und wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:14
+msgid ""
+"In the open-source domain, big systems are normally split into smaller "
+"projects that are easier to handle for small groups of developers. For "
+"example a CD burner program will consist of a command-line tool that "
+"actually burns the CD and a graphical user interface that allows users to "
+"implement it without having to learn about all the command line switches and "
+"in fact without using the command line at all. One advantage of this "
+"approach is that the developing work that was invested into the command-line "
+"program can be shared by many programs: The same CD-burner command-line "
+"program can be used as a “send-to-CD”-plug-in for a file manager "
+"application, for the “burn to CD” function of a music player and as the CD "
+"writer for a DVD backup tool. Another advantage is that splitting one big "
+"task into smaller parts allows the developers to provide several user "
+"interfaces for the same program."
+msgstr ""
+"Im Open-Source-Bereich ist es üblich, große Systeme in kleine Projekte "
+"aufzuteilen, die jeweils klein genug sind, dass eine endliche Menge an "
+"Entwicklern ausreicht, um sie weiterzuentwickeln. Beispielsweise ist ein CD-"
+"Brennprogramm aus einem Kommandozeilentool zusammengesetzt, das die CDs "
+"brennt und eine graphische Benutzerumgebung, die dieses Tool bedient. Ein "
+"Vorteil dieses Ansatzes ist es, daß dasselbe Kommandozeilenprogramm von "
+"vielen Stellen aus genutzt werden: Das Brennprogramm, ein \"Sende an die "
+"CD\"-Knopf und beispielsweise ein Backup-Tool. Ein weiterer Vorteil ist es, "
+"dass auf diese Weise für eine Funktionalität mehrere Benutzerinterfaces "
+"angeboten werden können."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:16
+msgid ""
+"A computer algebra system (CAS) like _Maxima_ fits into this framework. A "
+"CAS can provide the logic behind an arbitrary precision calculator "
+"application or it can do automatic transforms of formulas in the background "
+"of a bigger system (e.g., [Sage](https://www.sagemath.org/)). Alternatively, "
+"it can be used directly as a free-standing system. _Maxima_ can be accessed "
+"via a command line. Often, however, an interface like _wxMaxima_ proves a "
+"more efficient way to access the software, especially for newcomers."
+msgstr ""
+"Ein Computer-Algebrasystem (CAS) wie _Maxima_ ist hervorragend für diesen "
+"Ansatz geeignet: Es kann die Logik hinter einem Taschenrechner liefern, der "
+"mit beliebig langen Zahlen hantieren kann, Formeln für ein größeres System, "
+"z.B. [Sage](https://www.sagemath.org/) umstellen. Alternativ kann es direkt "
+"verwendet werden. Dies kann von der Kommandozeile aus geschehen, oder von "
+"wxMaxima aus, das eine komfortablere Bedienung unterstützt."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:17
+#, fuzzy, no-wrap
+#| msgid "### _Maxima_"
+msgid "_Maxima_"
+msgstr "### _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:20
+msgid ""
+"_Maxima_ is a full-featured computer algebra system (CAS). A CAS is a "
+"program that can solve mathematical problems by rearranging formulas and "
+"finding a formula that solves the problem as opposed to just outputting the "
+"numeric value of the result. In other words, _Maxima_ can serve as a "
+"calculator that gives numerical representations of variables, and it can "
+"also provide analytical solutions. Furthermore, it offers a range of "
+"numerical methods of analysis for equations or systems of equations that "
+"cannot be solved analytically."
+msgstr ""
+"Maxima ist ein komplettes Computer-Algebrasystem (CAS): Ein Programm, das "
+"die Formel, nicht nur die Zahl sucht, die ein mathematisches Problem löst. "
+"Auch wenn es darauf  spezialisiert ist, mit Buchstaben zu rechnen, bietet es "
+"auch eine Menge an Funktionen, die Probleme lösen, für die nur numerische "
+"Lösungen existieren."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:22
+msgid ""
+"![Maxima screenshot, command line](./maxima_screenshot.png)"
+"{ id=img_maxima_screenshot }"
+msgstr ""
+"![Maxima Screenshot, Kommandozeile](./maxima_screenshot.png)"
+"{ id=img_maxima_screenshot }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:24
+#, fuzzy, no-wrap
+#| msgid "Extensive documentation for _Maxima_ is [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor."
+msgid "Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.\n"
+msgstr "Umfangreiche Dokumentation für Maxima ist [im Internet verfügbar](https://maxima.sourceforge.io/documentation.html). Teile davon sind auch im Hilfe-Menü von wxMaxima verfügbar. Ein Druck auf die Hilfe-Taste (auf den meisten Systemen ist dies die <kbd>F1</kbd>-Taste) springt automatisch zur Stelle im _Maxima_-Handbuch, wo das Kommando unter dem Cursor erklärt wird."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:25
+#, fuzzy, no-wrap
+#| msgid "### WxMaxima"
+msgid "WxMaxima"
+msgstr "### WxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:28
+msgid ""
+"_WxMaxima_ is a graphical user interface that provides the full "
+"functionality and flexibility of _Maxima_. WxMaxima offers users a graphical "
+"display and many features that make working with _Maxima_ easier. For "
+"example _wxMaxima_ allows one to export any cell’s contents (or, if that is "
+"needed, any part of a formula, as well) as text, as LaTeX or as MathML "
+"specification at a simple right-click. Indeed, an entire workbook can be "
+"exported, either as a HTML file or as a LaTeX file. Documentation for "
+"_wxMaxima_, including workbooks to illustrate aspects of its use, is online "
+"at the _wxMaxima_ [help site](https://wxMaxima-developers.github.io/wxmaxima/"
+"help.html), as well as via the help menu."
+msgstr ""
+"_wxMaxima_ ist ein graphisches Benutzer-Interface, das die komplette "
+"Funktionalität und Flexibilität von Maxima zu nutzen erlaubt. Zudem bietet "
+"es viele Funktionalitäten an, die die Verwendung von _Maxima_ einfacher "
+"gestalten. Beispielsweise kann es den Inhalt eines Arbeitsblattes, einer "
+"Zelle des Arbeitsblatts oder einen Teil einer Formel nach LaTeX, MathML oder "
+"in eine RTF-Formel für eine Textverarbeitung konvertieren. Dokumentation für "
+"wxMaxima kann [im Internet](https://wxMaxima-developers.github.io/wxmaxima/"
+"help.html) gefunden werden, oder über das Hilfemenü."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:30
+msgid "![wxMaxima window](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
+msgstr "![wxMaxima Fenster](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:32
+msgid ""
+"The calculations that are entered in _wxMaxima_ are performed by the "
+"_Maxima_ command-line tool in the background."
+msgstr ""
+"_wxMaxima_ lässt alle Berechnungen im Hintergrund durch das Kommandozeilen-"
+"Werkzeug _Maxima_ durchführen."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:33
+#, fuzzy, no-wrap
+#| msgid "## Workbook basics"
+msgid "Workbook basics"
+msgstr "## Grundlagen zum Arbeitsblatt"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:36
+msgid ""
+"Much of _wxMaxima_ is self-explaining, but some details require attention. "
+"[This site](https://wxMaxima-developers.github.io/wxmaxima/help.html) "
+"contains a number of workbooks that address various aspects of _wxMaxima_. "
+"Working through some of these (particularly the \"10 minute _(wx)Maxima_ "
+"tutorial\") will increase one’s familiarity with both the content of "
+"_Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. This manual "
+"concentrates on describing aspects of _wxMaxima_ that are not likely to be "
+"self-evident and that might not be covered in the online material."
+msgstr ""
+"wxMaxima ist größtenteils selbsterklärend. [Diese Internetseite](https://"
+"wxMaxima-developers.github.io/wxmaxima/help.html) bietet einige Beispiele "
+"an, wovon das \"10-Minuten-Tutorial\" besonders zu empfehlen ist. Dieses "
+"Handbuch beschreibt einige zusätzliche Aspekte von wxMaxima."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:37
+#, fuzzy, no-wrap
+#| msgid "### The workbook approach"
+msgid "The workbook approach"
+msgstr "### Der Arbeitsblatt-Ansatz"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:40
+msgid ""
+"One of the very few things that are not standard in _wxMaxima_ is that it "
+"organizes the data for _Maxima_ into cells that are evaluated (which means: "
+"sent to _Maxima_) only when the user requests this. When a cell is "
+"evaluated, all commands in that cell, and only that cell, are evaluated as a "
+"batch. (The preceding statement is not quite accurate: One can select a set "
+"of adjacent cells and evaluate them together. Also, one can instruct "
+"_Maxima_ to evaluate all cells in a workbook in one pass.) _WxMaxima_’s "
+"approach to submitting commands for execution might feel unfamiliar at the "
+"first sight. It does, however, drastically ease work with big documents "
+"(where the user does not want every change to automatically trigger a full "
+"re-evaluation of the whole document). Also, this approach is very handy for "
+"debugging."
+msgstr ""
+"Eine der Sachen, die neue Benutzer oft verwirrt, ist, dass das Arbeitsblatt "
+"von wxMaxima in Zellen aufgeteilt ist, die nur auf Befehl vom Benutzer an "
+"_Maxima_ gesendet werden. Wenn eine Zelle ausgewertet wird, werden alle "
+"Maxima-Befehle (nur) dieser Zelle als Batch-Befehle ausgewertet. Man kann "
+"auch mehrere Zellen auswählen und gleichzeitig auswählen. Oder das gesamte "
+"Arbeitsblatt auf einmal auswerten _WxMaxima_'s Ansatz für die Auswertung von "
+"Befehlen mag seltsam erscheinen. Es vereinfacht aber die Arbeit mit großen "
+"Dokumenten (wo man nicht jede Änderung eine komplette Neu-Evaluierung des "
+"ganzen Dokuments auslösen will. Ausserdem ist dieser Ansatz für die "
+"Fehlersuche praktisch."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:42
+msgid ""
+"If text is typed into _wxMaxima_ it automatically creates a new worksheet "
+"cell. The type of this cell can be selected in the toolbar. If a code cell "
+"is created the cell can be sent to _Maxima_, which causes the result of the "
+"calculation to be displayed below the code. A pair of such commands is shown "
+"below."
+msgstr ""
+"Wenn Text in _wxMaxima_ eingegeben wird, erzeugt er automatisch eine neue "
+"Zelle des Arbeitsblattes. Wenn dies eine Code-Zelle ist, kann ihr Inhalt an "
+"_Maxima_ gesendet werden und das Resultat dieser Aktion wird unter der Zelle "
+"angezeigt, wie unten abgebildet."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:44
+msgid "![Input/output cell](./InputCell.png){ id=img_InputCell }"
+msgstr "![Eingabe/Ausgabe Zelle](./InputCell.png){ id=img_InputCell }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:46
+msgid ""
+"On evaluation of an input cell’s contents the input cell _Maxima_ assigns a "
+"label to the input (by default shown in red and recognizable by the `%i`) by "
+"which it can be referenced later in the _wxMaxima_ session. The output that "
+"_Maxima_ generates also gets a label that begins with `%o` and by default is "
+"hidden, except if the user assigns the output a name. In this case by "
+"default the user-defined label is displayed. The `%o`-style label _Maxima_ "
+"auto-generates will also be accessible, though."
+msgstr ""
+"Wird eine Code-Zelle ausgewertet, weist ihr _Maxima_ eine Marke zu "
+"(standardmäßig ist diese in roter Schrift gehalten und beginnt mit einem "
+"`%i`), über das sie später wieder referenziert werden kann. Für die Ausgabe "
+"wird eine Marke generiert, die standardmäßig mit `%o` beginnt und nicht "
+"angezeigt wird, außer der Benutzer hat der Formel einen sprechenden Namen "
+"gegeben, der stattdessen angezeigt werden kann. Der `%o`-Label den Maxima "
+"automatisch erzeugt, ist trotzdem verwendbar."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:48
+msgid ""
+"Besides the input cells _wxMaxima_ allows for text cells for documentation, "
+"image cells, title cells, chapter cells and section cells. Every cell has "
+"its own undo buffer so debugging by changing the values of several cells and "
+"then gradually reverting the unneeded changes is rather easy. Furthermore "
+"the worksheet itself has a global undo buffer that can undo cell edits, adds "
+"and deletes."
+msgstr ""
+"Außer Code-Zellen kennt wxMaxima auch Textzellen und solche mit Bildern oder "
+"Überschriften. Jede Zelle hat ihren eigenen Speicher für das "
+"Rückgängigmachen von Aktionen, was sich oft als hilfreich erwiesen hat. "
+"Zudem besitzt, wie in fast allen Applikationen, das Arbeitsblatt einen "
+"eigenen Speicher für die Rückgängigmachen-Funktion."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:50
+msgid ""
+"The figure below shows different cell types (title cells, section cells, "
+"subsection cells, text cells, input/output cells and image cells)."
+msgstr ""
+"Die nun folgende Abbildung zeigt verschiedene Zelltypen (Titelzellen, "
+"Untertitelzellen, Textzellen, Eingabe/Ausgabezellen und eine Bildzelle)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:52
+msgid ""
+"![Example of different wxMaxima cells](./cell-example.png){ id=img_cell-"
+"example }"
+msgstr "![Ein Beispiel verschiedener wxMaxima Zelltypen](./cell-example.png)"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:53
+#, fuzzy, no-wrap
+#| msgid "### Cells"
+msgid "Cells"
+msgstr "### Zellen"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:56
+msgid ""
+"The worksheet is organized in cells. WxMaxima knows the following cell types:"
+msgstr ""
+"Das Arbeitsblatt ist in Zellen aufgeteilt. WxMaxima kennt die folgenden "
+"Zelltypen:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Math cells, containing one or more lines of _Maxima_ input."
+msgstr ""
+"Mathematik-Eingabezellen beinhalten eine oder mehrere Eingabe-Zeilen für "
+"_Maxima_"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Output of, or a question from, _Maxima_."
+msgstr "Ausgaben oder Fragen von _Maxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Image cells."
+msgstr "Bild-Zellen."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Text cells, that can for example be used for documentation."
+msgstr ""
+"Text-Zellen, die beispielsweise für Dokumentation verwendet werden können."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid ""
+"A title, section or a subsection. 6 levels of different headings are "
+"possible."
+msgstr ""
+"Ein Titel, Überschrift oder Unterüberschrift. 6 unterschiedliche "
+"Überschriftenebenen sind möglich."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Page breaks."
+msgstr "Seitenumbrüche."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:65
+msgid ""
+"The default behavior of _wxMaxima_ when text is entered is to automatically "
+"create a math cell. Cells of other types can be created using the Cell menu, "
+"using the hot keys shown in the menu or using the drop-down list in the "
+"toolbar. Once the non-math cell is created, whatever is typed into the file "
+"is interpreted as text."
+msgstr ""
+"Wenn Text eingegeben ist, erzeugt _wxMaxima_ normalerweise gleich eine Code-"
+"Zelle. Andere Zelltypen können über das \"Zellen\"-Menü, die dort "
+"dokumentierten Tastenkombinationen oder über die Werkzeugleiste erzeugt "
+"werden. Wenn eine nicht-mathematische Zelle (Überschrift, Text, etc.) "
+"erzeugt wurde, wird alles was eingetippt wird, als Text interpretiert."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:67
+msgid ""
+"A (C-style) [comment text](https://maxima.sourceforge.io/docs/manual/"
+"maxima_singlepage.html#Comments) can be part of a math cell as follows: `/* "
+"This comment will be ignored by Maxima */`"
+msgstr ""
+"Ein [Kommentar](https://maxima.sourceforge.io/docs/manual/maxima_singlepage."
+"html#Comments) (wie in der Programmiersprache C) kann als Teil einer "
+"Mathematik-Eingabezelle eingegeben werden: `/* Dieser Kommentar wird von "
+"Maxima ignoriert */`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:69
+msgid "\"`/*`\" marks the start of the comment, \"`*/`\" the end."
+msgstr "\"`/*`\" markiert den Beginn des Kommentars, \"`*/`\" das Ende."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:70
+#, fuzzy, no-wrap
+#| msgid "### Horizontal and vertical cursors"
+msgid "Horizontal and vertical cursors"
+msgstr "### Horizontale und vertikale Cursors"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:73
+msgid ""
+"If the user tries to select a complete sentence, a word processor will try "
+"to extend the selection to automatically begin and end with a word boundary. "
+"Likewise, if more than one cell is selected, _wxMaxima_ will extend the "
+"selection to whole cells."
+msgstr ""
+"Wenn in einer Textverarbeitung versucht wird, einen Satz auszuwählen, wird "
+"diese versuchen, Beginn und Ende der Auswahl so zu verschieben, dass ganze "
+"Wörter ausgewählt sind. _wxMaxima_ wird aus diesem Grund, wenn mehr als eine "
+"Zelle ausgewählt wird, die Auswahl auf ganze Zellen ausdehnen."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:75
+msgid ""
+"What isn’t standard is that _wxMaxima_ provides drag-and-drop flexibility by "
+"defining two types of cursors. _WxMaxima_ will switch between them "
+"automatically when needed:"
+msgstr ""
+"Was ungewöhnlich erscheinen kann ist, dass _wxMaxima_ alternativ einen "
+"vertikalen oder einen horizontalen Cursor darstellen kann. _wxMaxima_ "
+"wechselt zwischen ihnen nach Bedarf:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:78
+msgid ""
+"The cursor is drawn horizontally if it is moved in the space between two "
+"cells or by clicking there."
+msgstr ""
+"Der Cursor wird vertikal dargestellt wird, wenn er zwischen zwei Zellen zu "
+"liegen kommt."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:78
+msgid ""
+"A vertical cursor that works inside a cell. This cursor is activated by "
+"moving the cursor inside a cell using the mouse pointer or the cursor keys "
+"and works much like the cursor in a text editor."
+msgstr ""
+"Innerhalb einer Zelle wird der Cursor vertikal dargestellt. Der Cursor wird "
+"mit dem Mauszeiger oder den Cursortasten in einer Textzelle aktiviert und "
+"funktioniert ähnlich wie in einem Text-Editor."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:80
+#, no-wrap
+msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:82
+msgid ""
+"![(blinking) horizontal cursor after wxMaxima start](./horizontal-cursor-"
+"only.png){ id=img_horizontal_cursor_only }"
+msgstr ""
+"![(Blinkender) Horizontaler Cursor nachdem wxMaxima gestartet wurde](./"
+"horizontal-cursor-only.png){ id=img_horizontal_cursor_only }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:84
+msgid ""
+"You might want to create a different cell type (using the \"Cell\" menu), "
+"maybe a title cell or text cell, which describes, what will be done, when "
+"you start creating your worksheet."
+msgstr ""
+"Möglicherweise wollen Sie einen anderen Zelltyp erzeugen (im \"Zellen\" "
+"Menü), vielleicht eine Titelzelle oder Textzelle, die beschreibt, was das "
+"Arbeitsblatt machen wird, wenn Sie beginnen, ein Arbeitsblatt zu erstellen."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:86
+msgid ""
+"If you navigate between the different cells, you will also see the "
+"(blinking) horizontal cursor, where you can insert a cell into your "
+"worksheet (either a math cell, by just start typing your formula - or a "
+"different cell type using the menu)."
+msgstr ""
+"Wenn Sie zwischen den Zellen navigieren, sehen Sie den (blinkenden) "
+"horizontalen Cursor. An dieser Stelle können Sie eine Zelle einfügen - "
+"entweder eine mathematische Eingabezelle, indem einfach der Maxima-code "
+"eingegeben wird), oder eine andere Zelle (unter Verwendung des Zellen-Menüs)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:88
+msgid ""
+"![(blinking) horizontal cursor between cells](./horizontal-cursor-between-"
+"cells.png){ id=img_horizontal_cursor_between_cells }"
+msgstr ""
+"![(Blinkender) Horizontaler Cursor zwischen den Zellen](./horizontal-cursor-"
+"between-cells.png){ id=img_horizontal_cursor_between_cells }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:89
+#, fuzzy, no-wrap
+#| msgid "### Sending cells to Maxima"
+msgid "Sending cells to Maxima"
+msgstr "### Eingabezellen an_Maxima schicken"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:92
+#, fuzzy, no-wrap
+#| msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>."
+msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.\n"
+msgstr "Die Befehle in einer Codezelle werden ausgeführt, sobald die <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> oder <kbd>ENTER</kbd> Taste im Nummernblock gedrückt wird. Standardmässig nimmt _wxMaxima_ Befehle mit <kbd>CTRL+ENTER</kbd> oder <kbd>SHIFT+ENTER</kbd> entgegen, aber _wxMaxima_ kann auch konfiguriert werden, dass Befehle nach <kbd>ENTER</kbd> ausgeführt werden."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:93
+#, fuzzy, no-wrap
+#| msgid "### Command autocompletion"
+msgid "Command autocompletion"
+msgstr "### Auto-Vervollständigung"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:96
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units."
+msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.\n"
+msgstr "_WxMaxima_ versucht, automatisch die Namen von Befehlen oder Variablen zu vervollständigen, wenn der Menüpunkt (Zellen/Vervollständige Befehl) angewählt wird, oder die Tastenkombination <kbd>CTRL</kbd>+<kbd>SPACE</kbd> gedrückt wird. Die automatische Vervollständigung erkennt oft den Kontext, in dem sie ausgeführt wird, und kann beispielsweise Dateinamen oder Einheiten für ezUnits vorschlagen."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:98
+msgid "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
+msgstr "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:100
+#, fuzzy, no-wrap
+#| msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template)."
+msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).\n"
+msgstr "Außer der Vervollständigung des Namens einer Datei, einer Einheit, eines Kommandos oder eines Variablennamens kann für viele Befehle eine Liste der erwarteten Argumente angezeigt werden. Hierfür muss einfach <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> gedrückt werden, oder der entsprechende Menüeintrag gewählt (Zelle/Zeige Parameter)."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:101
+#, fuzzy, no-wrap
+#| msgid "#### Greek characters"
+msgid "Greek characters"
+msgstr "#### Griechische Zeichen"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:104
+msgid ""
+"Computers traditionally stored characters in 8-bit values. This allows for a "
+"maximum of 256 different characters. All letters, numbers, and control "
+"symbols (end of transmission, end of string, lines and edges for drawing "
+"rectangles for menus _etc_.) of nearly any given language can fit within "
+"that limit."
+msgstr ""
+"Computer speichern Zeichen meist als 8-Bit-Werte, was maximal 256 "
+"unterschiedliche Typen von Zeichen erlaubt. Die meisten Sprachen nutzen "
+"inklusive Steuerzeichen, Ziffern und ein paar Zeichen, aus denen Graphiken "
+"zusammengesetzt werden können, weniger als dies."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:106
+msgid ""
+"For most countries, the codepage of 256 characters that has been chosen does "
+"not include things like Greek letters, though, that are frequently used in "
+"mathematics. To overcome this type of limitation [Unicode](https://home."
+"unicode.org/) has been invented: An encoding that makes English text work "
+"like normal, but to use much more than 256 characters."
+msgstr ""
+"Für die Mehrzahl der Länder ist aus diesem Grund eine Codepage mit 256 "
+"Zeichen definiert worden, die allerdings in den meisten Ländern "
+"beispielsweise keine griechischen Buchstaben beinhaltet, die in der "
+"Mathematik oft verwendet werden. Um diese Begrenzung zu umgehen, wurde "
+"[Unicode](https://home.unicode.org/) entwickelt: Eine Zeichencodierung, die "
+"englischen Text wie gewohnt aussehen lässt, aber viel mehr als 256 Zeichen "
+"ermöglicht."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:108
+msgid ""
+"_Maxima_ allows Unicode if it was compiled using a Lisp compiler that either "
+"supports Unicode or that doesn’t care about the font encoding. As at least "
+"one of this pair of conditions is likely to be true. _WxMaxima_ provides a "
+"method of entering Greek characters using the keyboard:"
+msgstr ""
+"Wenn Maxima mit einem Lisp-Compiler generiert wurde, der Unicode unterstützt "
+"oder sich nicht darum kümmert, auf welche Weise Zeichen codiert werden, "
+"unterstützt es Unicode. Da meist eine dieser Bedingungen gegeben ist, bietet "
+"_WxMaxima_ eine Methode an, griechische Zeichen mit der Tastatur einzugeben:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:111
+msgid ""
+"A Greek letter can be entered by pressing the <kbd>ESC</kbd> key and then "
+"starting to type the Greek character’s name."
+msgstr ""
+"Ein griechischer Buchstabe kann eingegeben werden, indem erst auf die "
+"<kbd>ESC</kbd>-Taste gedrückt wird, und dann sein Name einzugeben begonnen "
+"wird."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:111
+msgid ""
+"Alternatively it can be entered by pressing <kbd>ESC</kbd>, one letter (or "
+"two for the Greek letter omicron) and <kbd>ESC</kbd> again. In this case the "
+"following letters are supported:"
+msgstr ""
+"Ebenso kann er eingegeben werden, indem <kbd>ESC</kbd> gedrückt wird, ein "
+"Buchstabe (bzw. zwei für den griechischen Buchstaben omicron) und dann "
+"erneut <kbd>ESC</kbd>. In diesem Fall werden die folgenden Zeichen "
+"unterstützt:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:130
+#, no-wrap
+msgid ""
+"| key | Greek letter | key | Greek letter | key | Greek letter |\n"
+"| :-: | :----------: | :-: | :----------: | :-: | :----------: |\n"
+"|  a  |    alpha     |  i  |     iota     |  r  |     rho      |\n"
+"|  b  |     beta     |  k  |    kappa     |  s  |    sigma     |\n"
+"|  g  |    gamma     |  l  |    lambda    |  t  |     tau      |\n"
+"|  d  |    delta     |  m  |      mu      |  u  |   upsilon    |\n"
+"|  e  |   epsilon    |  n  |      nu      |  f  |     phi      |\n"
+"|  z  |     zeta     |  x  |      xi      |  c  |     chi      |\n"
+"|  h  |     eta      | om  |   omicron    |  y  |     psi      |\n"
+"|  q  |    theta     |  p  |      pi      |  o  |    omega     |\n"
+"|  A  |    Alpha     |  I  |     Iota     |  R  |     Rho      |\n"
+"|  B  |     Beta     |  K  |    Kappa     |  S  |    Sigma     |\n"
+"|  G  |    Gamma     |  L  |    Lambda    |  T  |     Tau      |\n"
+"|  D  |    Delta     |  M  |      Mu      |  U  |   Upsilon    |\n"
+"|  E  |   Epsilon    |  N  |      Nu      |  P  |     Phi      |\n"
+"|  Z  |     Zeta     |  X  |      Xi      |  C  |     Chi      |\n"
+"|  H  |     Eta      | Om  |   Omicron    |  Y  |     Psi      |\n"
+"|  T  |    Theta     |  P  |      Pi      |  O  |    Omega     |\n"
+msgstr ""
+"| Zeichen | Griechischer Buchstabe | Zeichen |Griechischer Buchstabe | Zeichen | Griechischer Buchstabe |\n"
+"| :-----: | :--------------------: | :-----: | :-------------------: | :-----: | :--------------------: |\n"
+"|  a      |    alpha               |  i      |     iota              |  r      |     rho                |\n"
+"|  b      |     beta               |  k      |    kappa              |  s      |    sigma               |\n"
+"|  g      |    gamma               |  l      |    lambda             |  t      |     tau                |\n"
+"|  d      |    delta               |  m      |      mu               |  u      |   upsilon              |\n"
+"|  e      |   epsilon              |  n      |      nu               |  f      |     phi                |\n"
+"|  z      |     zeta               |  x      |      xi               |  c      |     chi                |\n"
+"|  h      |     eta                | om      |   omicron             |  y      |     psi                |\n"
+"|  q      |    theta               |  p      |      pi               |  o      |    omega               |\n"
+"|  A      |    Alpha               |  I      |     Iota              |  R      |     Rho                |\n"
+"|  B      |     Beta               |  K      |    Kappa              |  S      |    Sigma               |\n"
+"|  G      |    Gamma               |  L      |    Lambda             |  T      |     Tau                |\n"
+"|  D      |    Delta               |  M      |      Mu               |  U      |   Upsilon              |\n"
+"|  E      |   Epsilon              |  N      |      Nu               |  P      |     Phi                |\n"
+"|  Z      |     Zeta               |  X      |      Xi               |  C      |     Chi                |\n"
+"|  H      |     Eta                | Om      |   Omicron             |  Y      |     Psi                |\n"
+"|  T      |    Theta               |  P      |      Pi               |  O      |    Omega               |\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:132
+msgid ""
+"You can also use the \"Greek letters\"-sidebar to enter the Greek letters."
+msgstr ""
+
+#. type: Title #####
+#: ../../info/wxmaxima.md:133
+#, no-wrap
+msgid "Attention: Lookalike characters"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:138
+msgid ""
+"Several Latin letters look like the Greek letters, e.g. the Latin letter "
+"\"A\" and the Greek letter \"Alpha\". Although they look identical, they are "
+"two different Unicode characters, represented by different Unicode code "
+"points (numbers)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:143
+msgid ""
+"This might be problematic, if you assign a value to the variable A and later "
+"use the Greek letter Alpha to do something with this variable, especially on "
+"printouts.  For the Greek letter my (which is also used as prefix for micro) "
+"there are also two different Unicode code points."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:146
+msgid ""
+"The \"Greek letters\"-sidebar therefore has the option, that lookalike "
+"characters are not available (which can be changed using a right-click menu)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:148
+msgid ""
+"The same mechanism also allows to enter some miscellaneous mathematical "
+"symbols:"
+msgstr ""
+"Derselbe Mechanismus erlaubt es auch, einige andere mathematische Symbole "
+"einzugeben:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:199
+#, no-wrap
+msgid ""
+"| keys to enter  | mathematical symbol                                   |\n"
+"| -------------- | ----------------------------------------------------- |\n"
+"| hbar           | Planck constant: a h with a horizontal bar above it   |\n"
+"| Hbar           | a H with a horizontal bar above it                    |\n"
+"| 2              | squared                                               |\n"
+"| 3              | to the power of three                                 |\n"
+"| /2             | 1/2                                                   |\n"
+"| partial        | partial sign (the d of dx/dt)                         |\n"
+"| integral       | integral sign                                         |\n"
+"| sq             | square root                                           |\n"
+"| ii             | imaginary                                             |\n"
+"| ee             | element                                               |\n"
+"| in             | in                                                    |\n"
+"| impl implies   | implies                                               |\n"
+"| inf            | infinity                                              |\n"
+"| empty          | empty                                                 |\n"
+"| TB             | big triangle right                                    |\n"
+"| tb             | small triangle right                                  |\n"
+"| and            | and                                                   |\n"
+"| or             | or                                                    |\n"
+"| xor            | xor                                                   |\n"
+"| nand           | nand                                                  |\n"
+"| nor            | nor                                                   |\n"
+"| equiv          | equivalent to                                         |\n"
+"| not            | not                                                   |\n"
+"| union          | union                                                 |\n"
+"| inter          | intersection                                          |\n"
+"| subseteq       | subset or equal                                       |\n"
+"| subset         | subset                                                |\n"
+"| notsubseteq    | not subset or equal                                   |\n"
+"| notsubset      | not subset                                            |\n"
+"| approx         | approximately                                         |\n"
+"| propto         | proportional to                                       |\n"
+"| neq != /= or # | not equal to                                          |\n"
+"| +/- or pm      | a plus/minus sign                                     |\n"
+"| \\<= or leq     | equal or less than                                    |\n"
+"| >= or geq      | equal or greater than                                 |\n"
+"| \\<\\< or ll     | much less than                                        |\n"
+"| >> or gg       | much greater than                                     |\n"
+"| qed            | end of proof                                          |\n"
+"| nabla          | a nabla operator                                      |\n"
+"| sum            | sum sign                                              |\n"
+"| prod           | product sign                                          |\n"
+"| exists         | there exists sign                                     |\n"
+"| nexists        | there is no sign                                      |\n"
+"| parallel       | a parallel sign                                       |\n"
+"| perp           | a perpendicular sign                                  |\n"
+"| leadsto        | a leads to sign                                       |\n"
+"| ->             | a right arrow                                         |\n"
+"| -->            | a long right arrow                                    |\n"
+msgstr ""
+"| Zeicheneingabe | Mathematisches Symbol                                 |\n"
+"| -------------- | ----------------------------------------------------- |\n"
+"| hbar           | Planck constant: a h with a horizontal bar above it   |\n"
+"| Hbar           | a H with a horizontal bar above it                    |\n"
+"| 2              | squared                                               |\n"
+"| 3              | to the power of three                                 |\n"
+"| /2             | 1/2                                                   |\n"
+"| partial        | partial sign (the d of dx/dt)                         |\n"
+"| integral       | integral sign                                         |\n"
+"| sq             | square root                                           |\n"
+"| ii             | imaginary                                             |\n"
+"| ee             | element                                               |\n"
+"| in             | in                                                    |\n"
+"| impl implies   | implies                                               |\n"
+"| inf            | infinity                                              |\n"
+"| empty          | empty                                                 |\n"
+"| TB             | big triangle right                                    |\n"
+"| tb             | small triangle right                                  |\n"
+"| and            | and                                                   |\n"
+"| or             | or                                                    |\n"
+"| xor            | xor                                                   |\n"
+"| nand           | nand                                                  |\n"
+"| nor            | nor                                                   |\n"
+"| equiv          | equivalent to                                         |\n"
+"| not            | not                                                   |\n"
+"| union          | union                                                 |\n"
+"| inter          | intersection                                          |\n"
+"| subseteq       | subset or equal                                       |\n"
+"| subset         | subset                                                |\n"
+"| notsubseteq    | not subset or equal                                   |\n"
+"| notsubset      | not subset                                            |\n"
+"| approx         | approximately                                         |\n"
+"| propto         | proportional to                                       |\n"
+"| neq != /= or # | not equal to                                          |\n"
+"| +/- or pm      | a plus/minus sign                                     |\n"
+"| \\<= or leq     | equal or less than                                    |\n"
+"| >= or geq      | equal or greater than                                 |\n"
+"| \\<\\< or ll     | much less than                                        |\n"
+"| >> or gg       | much greater than                                     |\n"
+"| qed            | end of proof                                          |\n"
+"| nabla          | a nabla operator                                      |\n"
+"| sum            | sum sign                                              |\n"
+"| prod           | product sign                                          |\n"
+"| exists         | there exists sign                                     |\n"
+"| nexists        | there is no sign                                      |\n"
+"| parallel       | a parallel sign                                       |\n"
+"| perp           | a perpendicular sign                                  |\n"
+"| leadsto        | a leads to sign                                       |\n"
+"| ->             | a right arrow                                         |\n"
+"| -->            | a long right arrow                                    |\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:201
+msgid ""
+"You can also use the \"Symbols\"-sidebar to enter these Mathematical symbols."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:203
+#, fuzzy, no-wrap
+#| msgid "If a special symbol isn’t in the list it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> [number of the character (hexadecimal)] <kbd>ESC</kbd>.\n"
+msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.\n"
+msgstr "Wenn das gewünschte Zeichen auf diese Weise nicht erreichbar ist, können Zeichen auch als <kbd>ESC</kbd> (Nummer des Zeichens (hexadezimal)) <kbd>ESC</kbd> eingegeben werden.\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:205
+#, fuzzy, no-wrap
+#| msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`."
+msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.\n"
+msgstr "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> erzeugt daher ein `a`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:207
+msgid ""
+"Please note that most of these symbols (notable exceptions are the logic "
+"symbols) do not have a special meaning in _Maxima_ and therefore will be "
+"interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp "
+"that doesn’t support Unicode characters they might cause an error message."
+msgstr ""
+"Viele der Unicode-Symbole (mit der Ausnahme der logischen Verknüpfungen) "
+"haben keine direkte Entsprechung in _Maxima_ und werden daher als normale "
+"Zeichen interpretiert. Falls _Maxima_ eine Lisp-Version verwendet, die "
+"Unicode nicht unterstützt, kann das eine Fehlermeldung verursachen."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:210
+#, fuzzy, no-wrap
+#| msgid "It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.  To solve that problem, select other fonts (using: Edit -> Configure -> Style)."
+msgid ""
+"It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.\n"
+"To solve that problem, select other fonts (using: Edit -> Configure -> Style).\n"
+msgstr "Es kann passieren, dass z.B. griechische Buchstaben oder mathematische Symbole in der ausgewählten Schriftart nicht vorhanden sind, dann können sie nicht dargestellt werden. Um das Problem zu lösen, bitte eine andere Schriftart wählen (Bearbeiten -> Einstellungen -> Stil)."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:211
+#, fuzzy, no-wrap
+#| msgid "### Unicode replacement"
+msgid "Unicode replacement"
+msgstr "### Unicode Ersetzung"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:214
+msgid ""
+"wxMaxima will replace several Unicode characters with their respective "
+"Maxima expressions, e.g. `²` with `^2`, `³` with `^3`, the square root sign "
+"with the function `sqrt()`, the (mathematical) Sigma sign (which is not the "
+"same Unicode character as the corresponding Greek letter) with `sum()`, etc."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:217
+msgid ""
+"Unicode has several \"common\" fractions encoded as one Unicode code point: "
+"`¼, ½, ¾, ⅐, ⅑, ⅒, ⅓, ⅔, ⅕, ⅖, ⅗, ⅘, ⅙, ⅚, ⅛, ⅜, ⅝, ⅞`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:219
+msgid ""
+"wxMaxima will replace them with their Maxima representations, e.g `(1/4)` "
+"before the input is sent do Maxima. There are also `⅟`, which will be "
+"replaced by `1/` and `↉` (used in baseball), which will be replaced by "
+"`(0/3)`."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:221
+msgid ""
+"It is recommended to use **Maxima code** (not these Unicode code points) in "
+"input cells (Rationale: (a) it might be possible, that the used font for "
+"math input does not contain them; (b) if you save the document as `wxm`-"
+"file, it is usually readable by (command line) Maxima, but these changes "
+"will of course not work in command line Maxima); but they may occur, if you "
+"cut&paste a formula from another document."
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:222
+#, fuzzy, no-wrap
+#| msgid "### Side Panes"
+msgid "Side Panes"
+msgstr "### Seitenleisten"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:225
+msgid ""
+"Shortcuts to the most important _Maxima_ commands, things like a table of "
+"contents, windows with debug messages or a history of the last issued "
+"commands can be accessed using the side panes. They can be enabled using the "
+"\"View\" menu. They all can be moved to other locations inside or outside "
+"the _wxMaxima_ window. Other useful panes is the one that allows to input "
+"Greek letters using the mouse."
+msgstr ""
+"Die meisten _Maxima_-Befehle, ein Inhaltsverzeichnis, Debug-Meldungen oder "
+"die Liste der zuletzt verwendeten Befehle werden in Seitenleisten angeboten, "
+"die über das \"Ansicht\"-Menü aktiviert und an beliebige Stellen in oder "
+"außerhalb des _wxMaxima_-Fensters verschoben werden können. Ebenso kann eine "
+"Seitenleiste mit griechischen Buchstaben geöffnet werden, die eine "
+"alternative Methode anbietet, griechische Buchstaben einzugeben."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:227
+msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
+msgstr ""
+"![Beispiele verschiedener Seitenbereiche](./SidePanes.png)"
+"{ id=img_SidePanes }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:230
+msgid ""
+"In the \"table of contents\" side pane, one can increase or decrease a "
+"heading by just clicking on the heading with the right mouse button and "
+"select the next higher or lower heading type."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:232
+msgid ""
+"![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-"
+"headings.png){ id=Sidepane-TOC-convert-headings }"
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:233
+#, fuzzy, no-wrap
+#| msgid "### MathML output"
+msgid "MathML output"
+msgstr "### MathML-Ausgabe"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:236
+msgid ""
+"Several word processors and similar programs either recognize [MathML]"
+"(https://www.w3.org/Math/) input and automatically insert it as an editable "
+"2D equation - or (like LibreOffice) have an equation editor that offers an "
+"“import MathML from clipboard” feature. Others support RTF maths. "
+"_WxMaxima_, therefore, offers several entries in the right-click menu."
+msgstr ""
+"Einige Textverarbeitungen verstehen entweder [MathML](https://www.w3.org/"
+"Math/) oder (wie LibreOffice) haben einen Formeleditor, der die Option "
+"“importiere MathML aus der Zwischenablage” unterstützt. Andere unterstützen "
+"Mathematik im RTF-Format. _wxMaxima_ bietet daher einige entsprechende "
+"Optionen im Rechtsklick-Menü an. "
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:237
+#, fuzzy, no-wrap
+#| msgid "### Markdown support"
+msgid "Markdown support"
+msgstr "### Markdown Unterstützung"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:240
+msgid ""
+"_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/wiki/"
+"Markdown) conventions that don’t collide with mathematical notation. One of "
+"these elements is bullet lists."
+msgstr ""
+"_WxMaxima_ unterstützt einige [Markdown](https://en.wikipedia.org/wiki/"
+"Markdown)-Kommandos, die nicht mit Konstrukten kollidieren, die in "
+"mathematischen Formeln vorkommen. Eines dieser Elemente sind Aufzählungen:"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:241
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```text\n"
+#| "Ordinary text\n"
+#| " * One item, indentation level 1\n"
+#| " * Another item at indentation level 1\n"
+#| "   * An item at a second indentation level\n"
+#| "   * A second item at the second indentation level\n"
+#| " * A third item at the first indentation level\n"
+#| "Ordinary text\n"
+#| "```\n"
+msgid ""
+"Ordinary text\n"
+" * One item, indentation level 1\n"
+" * Another item at indentation level 1\n"
+"   * An item at a second indentation level\n"
+"   * A second item at the second indentation level\n"
+" * A third item at the first indentation level\n"
+"Ordinary text\n"
+msgstr ""
+"```text\n"
+"Normaler Text\n"
+" * Ein eingerückter Aufzählungspunkt\n"
+" * Ein zweiter Aufzählungspunkt\n"
+"   * Eine Aufzählung in der Aufzählung\n"
+"   * Ein zweiter Aufzählungspunkt der Aufzählung in der Aufzählung\n"
+" * Ein Punkt in der äußeren Aufzählung\n"
+"Normaler text\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:252
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
+msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
+msgstr "_WxMaxima_ erkennt Text, der mit einem `>` beginnt, als ein Zitat:"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:253
+#, fuzzy, no-wrap
+#| msgid ""
+#| "Ordinary text\n"
+#| "> quote quote quote quote\n"
+#| "> quote quote quote quote\n"
+#| "> quote quote quote quote\n"
+#| "Ordinary text\n"
+msgid ""
+"Ordinary text\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"Ordinary text\n"
+msgstr ""
+"Normaler Text\n"
+"> Zitat Zitat Zitat\n"
+"> Zitat Zitat Zitat\n"
+"> Zitat Zitat Zitat\n"
+"> Zitat Zitat Zitat\n"
+"Normaler Text\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:262
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:"
+msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:\n"
+msgstr "Die TeX- und HTML-Ausgabe von _WxMaxima_ erkennt auch `=>` und ersetzt es durch das entsprechende Unicode-Symbol:"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:263
+#, fuzzy, no-wrap
+#| msgid "```text cogito => sum.  ```"
+msgid "cogito => sum.\n"
+msgstr "```text cogito => sum. ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:268
+#, fuzzy, no-wrap
+#| msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized."
+msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.\n"
+msgstr "Andere Symbole, die vom HTML- und TeX-Export erkannt werden, sind `<=` und `>=` (Vergleichsoperatoren), ein Doppelpfeil (`<=>`), einfache Pfeile (`<->`, `->` und `<-`) und `+/-`. Die TeX-Ausgabe erkennt zusätzlich `<<` und `>>`."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:269
+#, fuzzy, no-wrap
+#| msgid "### Hotkeys"
+msgid "Hotkeys"
+msgstr "### Tastenkürzel"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:272
+msgid ""
+"Most hotkeys can be found in the text of the respective menus. Since they "
+"are actually taken from the menu text and thus can be customized by the "
+"translations of _wxMaxima_ to match the needs of users of the local "
+"keyboard, we do not document them here. A few hotkeys or hotkey aliases, "
+"though, are not documented in the menus:"
+msgstr ""
+"Die meisten Tastenkürzel entstammen den Menüs, was bedeutet, dass sie mit "
+"diesen übersetzt werden können, falls die Tastatur der aktuellen Sprache "
+"dies erforderlich macht. Nicht dort dokumentiert ist:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid ""
+"<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
+msgstr ""
+"<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> löscht eine komplette "
+"Zelle."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid ""
+"<kbd>CTRL</kbd>+<kbd>TAB</kbd> or <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</"
+"kbd> triggers the auto-completion mechanism."
+msgstr ""
+"<kbd>CTRL</kbd>+<kbd>TAB</kbd> oder <kbd>CTRL</kbd>+<kbd>SHIFT</"
+"kbd>+<kbd>TAB</kbd> aktiviert die Auto-Vervollständigung."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
+msgstr ""
+"<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> fügt ein nicht-umbrechbares Leerzeichen "
+"ein."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:277
+#, fuzzy, no-wrap
+#| msgid "### Raw TeX in the TeX export"
+msgid "Raw TeX in the TeX export"
+msgstr "### Direkte Eingabe von TeX-Befehlen im TeX-Export"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:280
+msgid ""
+"If a text cell begins with `TeX:` the TeX export contains the literal text "
+"that follows the `TeX:` marker. Using this feature allows the entry of TeX "
+"markup within the _wxMaxima_ workbook."
+msgstr ""
+"Wenn eine Textzelle mit \"TeX:\" beginnt, wird der Rest ihres Inhalts bei "
+"der Konvertierung des Dokuments nach TeX unverändert ausgegeben."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:281
+#, fuzzy, no-wrap
+#| msgid "## File Formats"
+msgid "File Formats"
+msgstr "## Dateiformate"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:284
+msgid ""
+"The material that is developed in a _wxMaxima_ session can be stored for "
+"later use in any of three ways:"
+msgstr "Das Arbeitsblatt kann auf verschiedene Weisen gespeichert werden:"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:285
+#, fuzzy, no-wrap
+#| msgid "### .mac"
+msgid ".mac"
+msgstr "### .mac"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:288
+msgid ""
+"`.mac` files are ordinary text files that contain _Maxima_ commands. They "
+"can be read using _Maxima_’s `batch()` or `load()` command or _wxMaxima_’s "
+"File/Batch File menu entry."
+msgstr ""
+".mac-Dateien sind Textdateien mit _Maxima_-Befehlen. Sie können über "
+"Maxima's `batch()` oder `load()`-Befehl oder in wxMaxima über \"Datei/Batch "
+"File laden\" gelesen werden."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:291
+msgid ""
+"One example is shown below. `Quadratic.mac` defines a function and afterward "
+"generates a plot with `wxdraw2d()`.  Afterward the contents of the file "
+"`Quadratic.mac` are printed and newly defined function `f()` is evaluated."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:293
+msgid "![Loading a file with `batch()`](./BatchImage.png){ id=img_BatchImage }"
+msgstr ""
+"![Laden einer Datei mit `batch()`](./BatchImage.png){ id=img_BatchImage }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:295
+msgid ""
+"Attention: Although the file `Quadratic.mac` has a usual _Maxima_ extension "
+"(`.mac`), it can only be read by _wxMaxima_, since the command `wxdraw2d()` "
+"is a wxMaxima-extension to _Maxima_. (Command line) Maxima will ignore the "
+"unknown command `wxdraw2d()` and print it as output again."
+msgstr ""
+"Achtung: Obwohl die Datei `Quadratic.mac` eine übliche Maxima-extension hat "
+"(`.mac`), kann sie nur durch wxMaxima verarbeitet werden, der Befehl "
+"`wxdraw2d()` ist eine wxMaxima-Erweiterung für _Maxima_. (Kommandozeilen)-"
+"Maxima wird den unbekannten Befehl ignorieren und ihn als Ausgabe erneut "
+"ausgeben."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:297
+msgid ""
+"You can be use `.mac` files for writing your own library of macros. But "
+"since they don’t contain enough structural information they cannot be read "
+"back as a _wxMaxima_ session."
+msgstr ""
+"`.mac`-Dateien eignen sich dafür, eine Bibliothek von Maxima-Befehlen "
+"aufzubauen. Ausreichend Information über die Struktur eines _wxMaxima_-"
+"Arbeitsblatts, dass sie es erlauben, dieses wieder zu rekonstruieren, "
+"enthalten sie aber nicht."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:298
+#, fuzzy, no-wrap
+#| msgid "### .wxm"
+msgid ".wxm"
+msgstr "### .wxm"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:302
+#, fuzzy, no-wrap
+#| msgid "`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files can be. With this plain-text format, it sometimes is unavoidable that worksheets that use new features are not downwards-compatible with older versions of _wxMaxima_."
+msgid ""
+"`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.\n"
+"You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.\n"
+msgstr "`.wxm`-Dateien sollten das Arbeitsblatt außer _Maxima_'s Ausgabe enthalten. _Maxima_ >5.38 kann `.wxm`-Dateien über den `load()`-Befehl lesen (wie `.mac`-Dateien). Worksheets, die neue Features enthalten, sind - wenn sie in diesem textbasierten Format gespeichert werden, manchmal nicht abwärtskompatibel zu älteren Versionen von _wxMaxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:304
+#, fuzzy
+#| msgid ""
+#| "`.wxm` files contain the worksheet except for _Maxima_’s output. On "
+#| "Maxima versions >5.38 they can be read using _Maxima_’s `load()` function "
+#| "just as .mac files can be. With this plain-text format, it sometimes is "
+#| "unavoidable that worksheets that use new features are not downwards-"
+#| "compatible with older versions of _wxMaxima_."
+msgid ""
+"With this plain-text format, it sometimes is unavoidable that worksheets "
+"that use new features are not downwards-compatible with older versions of "
+"_wxMaxima_."
+msgstr ""
+"`.wxm`-Dateien sollten das Arbeitsblatt außer _Maxima_'s Ausgabe enthalten. "
+"_Maxima_ >5.38 kann `.wxm`-Dateien über den `load()`-Befehl lesen (wie `."
+"mac`-Dateien). Worksheets, die neue Features enthalten, sind - wenn sie in "
+"diesem textbasierten Format gespeichert werden, manchmal nicht "
+"abwärtskompatibel zu älteren Versionen von _wxMaxima_."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:305
+#, fuzzy, no-wrap
+#| msgid "#### File format of wxm files"
+msgid "File format of wxm files"
+msgstr "#### Dateiformat von wxm-Dateien"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:308
+msgid ""
+"This is just a plain text file (you can open it with a text editor), "
+"containing the cell contents as some special Maxima comments."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:310
+msgid "It starts with the following comment:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:311
+#, no-wrap
+msgid ""
+"/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/\n"
+"/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:317
+msgid ""
+"And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:318
+#, no-wrap
+msgid ""
+"/* [wxMaxima: section start ]\n"
+"Title of the section\n"
+"   [wxMaxima: section end   ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:325
+msgid ""
+"or (in a Math cell the input is of course *not* commented out (the output is "
+"not saved in a `wxm` file)):"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:326
+#, no-wrap
+msgid ""
+"/* [wxMaxima: input   start ] */\n"
+"f(x):=x^2+1$\n"
+"f(2);\n"
+"/* [wxMaxima: input   end   ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:334
+msgid ""
+"Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the "
+"image type as first line):"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:335
+#, no-wrap
+msgid ""
+"/* [wxMaxima: image   start ]\n"
+"jpg\n"
+"[very chaotic looking character sequence]\n"
+"   [wxMaxima: image   end   ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:343
+msgid "A page break is just one line containing:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:344
+#, no-wrap
+msgid "/* [wxMaxima: page break    ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:349
+msgid "And folded cells marked by:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:350
+#, no-wrap
+msgid ""
+"/* [wxMaxima: fold    start ] */\n"
+"...\n"
+"/* [wxMaxima: fold    end   ] */\n"
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:356
+#, fuzzy, no-wrap
+#| msgid "### .wxmx"
+msgid ".wxmx"
+msgstr "### .wxmx"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:359
+msgid ""
+"This XML-based file format saves the complete worksheet including things "
+"like the zoom factor and the watchlist. It is the preferred file format."
+msgstr ""
+"Dieses XML basiertes Dateiformat enthält das gesamte Arbeitsblatt, inklusive "
+"Eigenschaften wie den Zoom-Faktor oder die Watchlist. Es ist das empfohlene "
+"Dateiformat für wxMaxima-Arbeitsblätter."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:360
+#, fuzzy, no-wrap
+#| msgid "#### File format of wxmx files"
+msgid "File format of wxmx files"
+msgstr "#### Dateiformat von wxmx-Dateien"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:364
+msgid ""
+"A `wxmx`-file seems to be a binary format, but one can handle it with tools, "
+"which are included in your OS. It is a zip file, one can decompress it with "
+"`unzip` (maybe rename it before, so that is recognized by the unzip program "
+"of your OS).  We do not use the compression function, just the possibility "
+"to merge several files into one file - images are already compressed and the "
+"rest is simple text (probably much smaller, than huge images, which are "
+"included)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:366
+msgid "It does contain the following files:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-"
+"wxmathml`"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`format.txt`: a short description about wxMaxima and the wxmx file format"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima "
+"session and included images."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`content.xml`: a XML document, which contains the various cells of your "
+"document in XML format."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:373
+msgid ""
+"So, if something goes wrong, you can unzip a wxMaxima document (maybe rename "
+"it before to a `zip`-file), maybe make changes in the `content.xml` file "
+"with a text editor, or replace an broken image, zip the files again, "
+"probably rename the `zip` to a `wxmx`-file - and you get another modified "
+"`wxmx`-file."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:374
+#, fuzzy, no-wrap
+#| msgid "## Configuration options"
+msgid "Configuration options"
+msgstr "## Konfigurations-Optionen"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:377
+msgid ""
+"For some common configuration variables _wxMaxima_ offers two ways of "
+"configuring:"
+msgstr ""
+"Einige Variablen, über die Maxima konfiguriert wird, können auf zwei Arten "
+"eingestellt werden:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:380
+msgid ""
+"The configuration dialog box below lets you change their default values for "
+"the current and subsequent sessions."
+msgstr "Die können global im Konfigurationsdialog eingestellt werden."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:380
+msgid ""
+"Also, the values for most configuration variables can be changed for the "
+"current session only by overwriting their values from the worksheet, as "
+"shown below."
+msgstr ""
+"Die Werte der meisten Konfigrations-Variablen können nur für die aktuelle "
+"Sitzung geändert werden, indem die Werte im Arbeitsblatt geändert werden, "
+"wie unten gezeigt."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:382
+msgid ""
+"![wxMaxima configuration 1](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
+msgstr ""
+"![wxMaxima Konfiguration 1](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:383
+#, fuzzy, no-wrap
+#| msgid "### Default animation framerate"
+msgid "Default animation framerate"
+msgstr "### Die Standard-Bildwiederholrate bei Animationen"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:386
+msgid ""
+"The animation framerate that is used for new animations is kept in the "
+"variable `wxanimate_framerate`. The initial value this variable will contain "
+"in a new worksheet can be changed using the configuration dialogue."
+msgstr ""
+"Die Bildwiederholgeschwindigkeit für Animationen wird in der Variable "
+"`wxanimate_framerate` gespeichert. wxMaxima setzt sie auf den Wert aus dem "
+"Konfigurationsdialog, wenn ein neues _Maxima_ gestartet wird."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:387
+#, fuzzy, no-wrap
+#| msgid "### Default plot size for new _maxima_ sessions"
+msgid "Default plot size for new _maxima_ sessions"
+msgstr "### Standardgröße der Diagramme bei neuen _Maxima_ Sitzungen"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:390
+msgid ""
+"After the next start, plots embedded into the worksheet will be created with "
+"this size if the value of `wxplot_size` isn’t changed by _maxima_."
+msgstr ""
+"Beim nächsten Start werden im Arbeitsblatt eingebettete Diagramme mit dieser "
+"Größe erstellt, wenn der Wert von `wxplot_size` nicht geändert wird."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:392
+msgid ""
+"In order to set the plot size of a single graph only use the following "
+"notation can be used that sets a variable’s value for one command only:"
+msgstr ""
+"Diese Variable kann notfalls auch nur für das aktuelle Diagramm gesetzt "
+"werden:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:393
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw2d(\n"
+#| "   explicit(\n"
+#| "       x^2,\n"
+#| "       x,-5,5\n"
+#| "   )\n"
+#| "), wxplot_size=[480,480]$\n"
+#| "```\n"
+msgid ""
+"wxdraw2d(\n"
+"   explicit(\n"
+"       x^2,\n"
+"       x,-5,5\n"
+"   )\n"
+"), wxplot_size=[480,480]$\n"
+msgstr ""
+"```maxima\n"
+"wxdraw2d(\n"
+"   explicit(\n"
+"       x^2,\n"
+"\t   x,-5,5\n"
+"   )\n"
+"), wxplot_size=[480,480]$\n"
+"```\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:402
+#, fuzzy, no-wrap
+#| msgid "### Match parenthesis in text controls"
+msgid "Match parenthesis in text controls"
+msgstr "### Automatisches Schließen von Klammern"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:405
+msgid "This option enables two things:"
+msgstr "Diese Option schaltet zwei Funktionen ein:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:408
+msgid ""
+"If an opening parenthesis, bracket, or double quote is entered _wxMaxima_ "
+"will insert a closing one after it."
+msgstr ""
+"Wenn eine öffnende Klammer, eckige Klammer oder ein Anführungszeichen "
+"eingegeben wird, fügt _wxMaxima_ automatisch das schließende Zeichen danach "
+"ein."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:408
+msgid ""
+"If text is selected if any of these keys is pressed the selected text will "
+"be put between the matched signs."
+msgstr ""
+"Markierter Text wird, wenn man eine geöffnete Klammer einzugeben versucht, "
+"automatisch in Klammern gesetzt."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:409
+#, fuzzy, no-wrap
+#| msgid "### Don’t save the worksheet automatically"
+msgid "Don’t save the worksheet automatically"
+msgstr "### Arbeitsblatt nicht automatisch speichern"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:412
+msgid ""
+"If this option is set, the file where the worksheet is will be overwritten "
+"only the request of the user. In case of a crash/power loss/... a recent "
+"backup copy is still made available in the temp directory, though."
+msgstr ""
+"Wenn diese Option gewählt ist, wird das Arbeitsblatt nur überschrieben, wenn "
+"der Benutzer es speichert. Ein aktuelles Backup wird in diesem Fall im temp-"
+"Verzeichnis abgelegt."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:414
+msgid ""
+"If this option isn’t set _wxMaxima_ behaves more like a modern cellphone app:"
+msgstr ""
+"Ist diese Option nicht angewählt, arbeitet _wxMaxima_ wie eine moderne Handy-"
+"App:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:417
+msgid "Files are saved automatically on exit"
+msgstr "Dateien werden beim Schließen automatisch gespeichert"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:417
+msgid "And the file will automatically be saved every 3 minutes."
+msgstr "Und die Datei wird automatisch alle 3 Minuten gespeichert."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:418
+#, fuzzy, no-wrap
+#| msgid "### Where is the configuration saved?"
+msgid "Where is the configuration saved?"
+msgstr "### Wo wird die Konfiguration gespeichert?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:422
+#, fuzzy, no-wrap
+#| msgid "If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).  (Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden)."
+msgid ""
+"If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).\n"
+"(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).\n"
+msgstr ""
+"Auf Linux/Unix-Rechnern wird die Konfiguration im Home-Verzeichnis in der Datei `.wxMaxima` gespeichert, oder (für wxWidgets >3.1.1) in `.config/wxMaxima.conf` (XDG-Standard). Die wxWidgets-Version kann über `wxbuild_info()` oder über das Hilfe->Über-Menü abgerufen werden. [wxWidgets](https://www.wxwidgets.org/) ist eine Bibliothek für graphische Benutzeroberflächen, die auf verschiedensten Betriebssystemen läuft und für das `wx` im Namen von wxMaxima verantwortlich ist.\n"
+"(Da der Dateiname mit einem Punkt beginnt, ist `.wxMaxima` oder `.config` eine versteckte Datei)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:424
+msgid ""
+"If you are using Windows, the configuration will be stored in the registry. "
+"You will find the entries for _wxMaxima_ at the following position in the "
+"registry: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
+msgstr ""
+"Unter Windows wird die Konfiguration in der Registry unter "
+"`HKEY_CURRENT_USER\\Software\\wxMaxima` gespeichert."
+
+#. type: Title #
+#: ../../info/wxmaxima.md:427
+#, fuzzy, no-wrap
+#| msgid "# Extensions to _Maxima_"
+msgid "Extensions to _Maxima_"
+msgstr "# Erweiterungen für _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:430
+msgid ""
+"_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
+"its main purpose is to pass along commands to _Maxima_ and to report the "
+"results of executing those commands. In some cases, however, _wxMaxima_ adds "
+"functionality to _Maxima_. _WxMaxima_’s ability to generate reports by "
+"exporting a workbook’s contents to HTML and LaTeX files has been mentioned. "
+"This section considers some ways that _wxMaxima_ enhances the inclusion of "
+"graphics in a session."
+msgstr ""
+"_wxMaxima_'s Hauptaufgabe ist es, die Ein- und Ausgaben von Maxima graphisch "
+"darzustellen. An einigen Stellen fügt es jedoch Funktionalitäten zu _Maxima_ "
+"hinzu. WxMaxima's Fähigkeiten, Reports zu generieren, indem Arbeitsblätter "
+"nach HTML und LaTeX exportiert werden können, wurde erwähnt. Dieser "
+"Abschnitt betrachtet einige Arten, wie _wxMaxima_ die Einbindung von "
+"Graphiken in ein Arbeitsblatt verbessert"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:431
+#, fuzzy, no-wrap
+#| msgid "## Subscripted variables"
+msgid "Subscripted variables"
+msgstr "## Variablen mit tiefgestelltem Index"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:434
+msgid ""
+"`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript "
+"variable names:"
+msgstr ""
+"`wxsubscripts` gibt an, wie (und ob) _wxMaxima_ Variablennamen automatisch "
+"tiefstellen wird:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:436
+msgid ""
+"If it is `false`, the functionality is off, wxMaxima will not autosubscript "
+"part of variable names after an underscore."
+msgstr ""
+"Falls es `false` gesetzt wird, wird die Funktion deaktiviert, wxMaxima wird "
+"nicht Teile von Variablennamen nach einem Unterstrich tiefstellen."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:438
+msgid ""
+"If it is set to `'all`, everything after an underscore will be subscripted."
+msgstr ""
+"Falls es auf `'all` gesetzt wird, wird alles nach einem Unterstrich "
+"tiefgestellt."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:440
+msgid ""
+"If it is set to `true` variable names of the format `x_y` are displayed "
+"using a subscript if"
+msgstr ""
+"Wenn es auf `true` gesetzt ist, werden Variablennamen im Format `x_y` mit "
+"einem tiefgestellten `y` dargestellt, wenn"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:443
+msgid "Either `x` or `y` is a single letter or"
+msgstr "Entweder `x` oder `y` ist ein einzelner Buchstabe ist oder"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:443
+msgid "`y` is an integer (can include more than one character)."
+msgstr "`y` ist eine ganze Zahl (kann länger als ein Zeichen lang sein)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:445
+msgid ""
+"![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png)"
+"{ id=img_wxsubscripts }"
+msgstr ""
+"![Wie Variablen mit wxsubscripts automatisch tiefgestellt werden](./"
+"wxsubscripts.png){ id=img_wxsubscripts }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:447
+msgid ""
+"If the variable name doesn’t match these requirements, it can still be "
+"declared as \"to be subscripted\" using the command "
+"`wxdeclare_subscript(variable_name);` or "
+"`wxdeclare_subscript([variable_name1,variable_name2,...]);` Declaring a "
+"variable as subscripted can be reverted using the following command: "
+"`wxdeclare_subscript(variable_name,false);`"
+msgstr ""
+"Wenn nicht, kann jede Variable als mit tiefgestelltem `y` ausgestattet "
+"deklariert werden mittels `wxdeclare_subscript(variablenname);` oder "
+"`wxdeclare_subscript([variablenname1,variablenname2,...]);`\n"
+"Rückgängig gemacht werden kann dies mittels "
+"`wxdeclare_subscript(variablenname,false);`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:449
+#, fuzzy, no-wrap
+#| msgid "You can use the menu \"View->Autosubscript\" to set these values."
+msgid "You can use the menu \"View->Autosubscript\" to set these values.\n"
+msgstr "Sie können das Menü \"Anzeige->Automatisches Tiefstellen\" verwenden, um diese Werte zu setzen."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:450
+#, fuzzy, no-wrap
+#| msgid "## User feedback in the status bar"
+msgid "User feedback in the status bar"
+msgstr "## Meldungen in der Statusleiste"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:453
+msgid ""
+"Long-running commands can provide user feedback in the status bar. This user "
+"feedback is replaced by any new feedback that is placed there (allowing to "
+"use it as a progress indicator) and is deleted as soon as the current "
+"command sent to _Maxima_ is finished. It is safe to use `wxstatusbar()` even "
+"in libraries that might be used with plain _Maxima_ (as opposed to "
+"_wxMaxima_): If _wxMaxima_ isn’t present the `wxstatusbar()` command will "
+"just be left unevaluated."
+msgstr ""
+"Kommandos, die lange arbeiten, können Fortschrittsinformationen in die "
+"Statuszeile ausgeben. Diese Informationen überschreiben deren Inhalt. "
+"`wxstatusbar()` kann sogar in Bibliotheken verwendet werden, bei denen nicht "
+"bekannt ist, ob sie mit _wxMaxima_ oder in einem _Maxima_ ohne Frontend "
+"verwendet werden: Wenn _wxMaxima_ diese Funktion nicht definiert hat, wird "
+"sie von Maxima einfach als undefinierte Funktion betrachtet und nicht weiter "
+"bearbeitet."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:454
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "for i:1 thru 10 do (\n"
+#| "    /* Tell the user how far we got */\n"
+#| "    wxstatusbar(concat(\"Pass \",i)),\n"
+#| "    /* (sleep n) is a Lisp function, which can be used */\n"
+#| "    /* with the character \"?\" before. It delays the */\n"
+#| "    /* program execution (here: for 3 seconds) */\n"
+#| "    ?sleep(3)\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"for i:1 thru 10 do (\n"
+"    /* Tell the user how far we got */\n"
+"    wxstatusbar(concat(\"Pass \",i)),\n"
+"    /* (sleep n) is a Lisp function, which can be used */\n"
+"    /* with the character \"?\" before. It delays the */\n"
+"    /* program execution (here: for 3 seconds) */\n"
+"    ?sleep(3)\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"    for i:1 thru 10 do (\n"
+"        /* Gib dem User Bescheid, wie weit wir schon sind */\n"
+"        wxstatusbar(concat(\"Pass \",i)),\n"
+"        /* (sleep n) ist eine Lisp-Funktion, die mit einem */\n"
+"        /* \"?\" Zeichen vorher verwendet werden kann. */\n"
+"        /* Sie verzögert die Programmausführung für n Sekunden */\n"
+"        /* (in diesem Beispiel: für 3 Sekunden). */\n"
+"        ?sleep(3)\n"
+"    )$\n"
+"```\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:465
+#, no-wrap
+msgid "Exporting the worksheet from within Maxima"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:468
+msgid ""
+"The command `wxworksheettohtml()` exports the current worksheet to an HTML "
+"file from within a running _Maxima_ session, which is convenient for "
+"scripted or batch export. Like `wxstatusbar()` it is safe to use in code "
+"that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present "
+"the command is simply left unevaluated."
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:469
+#, no-wrap
+msgid ""
+"wxworksheettohtml(\"report.html\")$\n"
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:475
+msgid ""
+"A relative file name is interpreted relative to _Maxima_’s working "
+"directory. The optional keyword options are:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:480
+#, no-wrap
+msgid ""
+"| option   | values                                          | meaning                                             |\n"
+"| -------- | ----------------------------------------------- | --------------------------------------------------- |\n"
+"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |\n"
+"| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:482
+msgid ""
+"The `flavor` values match the equation formats offered by the graphical "
+"**File → Export** dialog: `mathml` produces a self-contained page that needs "
+"no internet connection, `mathjax` adds a MathJaX fall-back for browsers that "
+"still lack MathML, and `svg`/`bitmap` render every equation to an image."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:484
+msgid ""
+"The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file "
+"the same way:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:485
+#, no-wrap
+msgid ""
+"wxworksheettotex(\"report.tex\")$\n"
+"wxworksheettotex(\"report.tex\", documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:494
+#, no-wrap
+msgid ""
+"| option                 | meaning                                                              |\n"
+"| ---------------------- | -------------------------------------------------------------------- |\n"
+"| `documentclass`        | overrides the LaTeX `\\documentclass` (e.g. `\"article\"`, `\"report\"`)  |\n"
+"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:496
+msgid "Support for `wxworksheettopdf()` is planned."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:497
+#, fuzzy, no-wrap
+#| msgid "## Plotting"
+msgid "Plotting"
+msgstr "## Diagramme"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:500
+msgid ""
+"Plotting (having fundamentally to do with graphics) is a place where a "
+"graphical user interface will have to provide some extensions to the "
+"original program."
+msgstr ""
+"Diagramme haben per definitionem mit einer graphischen Benutzerumgebung zu "
+"tun, weswegen an dieser Stelle Erweiterungen von Maxima zu erwarten sind."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:501
+#, fuzzy, no-wrap
+#| msgid "### Embedding a plot into the worksheet"
+msgid "Embedding a plot into the worksheet"
+msgstr "### Diagramme in das Arbeitsblatt einbetten"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:504
+msgid ""
+"_Maxima_ normally instructs the external program _Gnuplot_ to open a "
+"separate window for every diagram it creates. Since many times it is "
+"convenient to embed graphs into the worksheet instead _wxMaxima_ provides "
+"its own set of plot functions that don’t differ from the corresponding "
+"_maxima_ functions save in their name: They are all prefixed by a “wx”."
+msgstr ""
+"_Maxima_ weist normalerweise Gnuplot an, Diagramme in eigenen Fenstern "
+"darzustellen. Wenn dem entsprechenden `draw` oder `plot`-Kommando ein \"wx\" "
+"vorangestellt wird, wird das Bild stattdessen in das Arbeitsblatt eingebaut."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:506
+msgid "The following plotting functions have wx-counterparts:"
+msgstr "Die folgenden Plot-Funktionen haben wx-Äquivalente:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:520
+#, no-wrap
+msgid ""
+"| wxMaxima’s plot function | Maxima’s plot function                                                                          |\n"
+"| ------------------------ | ----------------------------------------------------------------------------------------------- |\n"
+"| `wxplot2d()`             | [plot2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot2d)               |\n"
+"| `wxplot3d()`             | [plot3d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot3d)               |\n"
+"| `wxdraw2d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw2d)               |\n"
+"| `wxdraw3d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw3d)               |\n"
+"| `wxdraw()`               | [draw](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw)                   |\n"
+"| `wximplicit_plot()`      | [implicit_plot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#implicit_plot) |\n"
+"| `wxhistogram()`          | [histogram](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#histogram)         |\n"
+"| `wxscatterplot()`        | [scatterplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#scatterplot)     |\n"
+"| `wxbarsplot()`           | [barsplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#barsplot)           |\n"
+"| `wxpiechart()`           | [piechart](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#piechart)           |\n"
+"| `wxboxplot()`            | [boxplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#boxplot)             |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:522
+msgid ""
+"If a `wxm`-file is read by (console) Maxima, these functions are ignored "
+"(and printed as output, as other unknown functions in Maxima)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:524
+msgid ""
+"If you got problems with one of these functions, please check, if the "
+"problem exists in the the Maxima function too (e.g. you got an error with "
+"`wxplot2d()`, check the same plot in the Maxima command `plot2d()` (which "
+"opens the plot in a separate Window)). If the problem does not disappear, it "
+"is most likely a Maxima issue and should be reported in the [Maxima "
+"bugtracker](https://sourceforge.net/p/maxima/bugs/). Or maybe a Gnuplot "
+"issue."
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:525
+#, fuzzy, no-wrap
+#| msgid "### Making embedded plots bigger or smaller"
+msgid "Making embedded plots bigger or smaller"
+msgstr "### Eingebettete Diagramme größer oder kleiner machen"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:528
+msgid ""
+"As noted above, the configure dialog provides a way to change the default "
+"size plots created which sets the starting value of `wxplot_size`. The "
+"plotting routines of _wxMaxima_ respect this variable that specifies the "
+"size of a plot in pixels. It can always be queried or used to set the size "
+"of the following plots:"
+msgstr ""
+"Wie bereits beschrieben kann die Größe von Diagrammen mittels der Variable "
+"`wxplot_size` definiert werden. Die plot-Funktionen von _wxMaxima_ beachten "
+"den Inhalt dieser Variablen, die die Größe von Plots in Pixeln angibt. Ihr "
+"Inhalt kann jederzeit ausgelesen oder geändert werden:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:529
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxplot_size:[1200,800]$\n"
+#| "wxdraw2d(\n"
+#| "    explicit(\n"
+#| "        sin(x),\n"
+#| "        x,1,10\n"
+#| "    )\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"wxplot_size:[1200,800]$\n"
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"wxplot_size:[1200,800]$\n"
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:540
+msgid ""
+"If the size of only one plot is to be changed _Maxima_ provides a canonical "
+"way to change an attribute only for the current cell. In this usage the "
+"specification `wxplot_size = [value1, value2]` is appended to the "
+"`wxdraw2d( )` command, and is not part of the `wxdraw2d` command."
+msgstr ""
+"Wenn die Größe nur des aktuellen Diagramms geändert werden soll, erlaubt "
+"_Maxima_ dies für die aktuelle Zelle zu machen. In diesem Beispiel wird "
+"`wxplot_size = [wert1, wert2]` an den `wxdraw2d( )` Befehl angehängt, es ist "
+"nicht Teil des `wxdraw2d` Befehls."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:541
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw2d(\n"
+#| "    explicit(\n"
+#| "        sin(x),\n"
+#| "        x,1,10\n"
+#| "    )\n"
+#| "),wxplot_size=[1600,800]$\n"
+#| "```\n"
+msgid ""
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+"),wxplot_size=[1600,800]$\n"
+msgstr ""
+"```maxima\n"
+"    wxdraw2d(\n"
+"        explicit(\n"
+"            sin(x),\n"
+"            x,1,10\n"
+"        )\n"
+"    ),wxplot_size=[1600,800]$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:551
+msgid ""
+"Setting the size of embedded plot with `wxplot_size` works for embedded "
+"plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` "
+"commands and for embedded animations with `with_slider_draw` and `wxanimate` "
+"commands."
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:552
+#, fuzzy, no-wrap
+#| msgid "### Better quality plots"
+msgid "Better quality plots"
+msgstr "### Hochqualitativere Diagramme"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:555
+#, fuzzy
+#| msgid ""
+#| "_Gnuplot_ doesn’t seem to provide a portable way of determining whether "
+#| "it supports the high-quality bitmap output that the cairo library "
+#| "provides. On systems where _gnuplot_ is compiled to use this library the "
+#| "pngcairo option from the configuration menu (that can be overridden by "
+#| "the variable `wxplot_pngcairo`) enables support for antialiasing and "
+#| "additional line styles. If `wxplot_pngcairo` is set without _gnuplot_ "
+#| "supporting this the result will be error messages instead of graphics."
+msgid ""
+"_Gnuplot_ doesn’t seem to provide a portable way of determining whether it "
+"supports the high-quality bitmap output that the Cairo library provides. On "
+"systems where _Gnuplot_ is compiled to use this library the pngCairo option "
+"from the configuration menu (that can be overridden by the variable "
+"`wxplot_pngcairo`) enables support for antialiasing and additional line "
+"styles. If `wxplot_pngCairo` is set without _Gnuplot_ supporting this the "
+"result will be error messages instead of graphics."
+msgstr ""
+"Gnuplot bietet keine portable Möglichkeit an, festzustellen, ob es Cairo "
+"unterstützt, eine Bibliothek, die Graphik mit Antialiasing und den "
+"unterschiedlichsten Linienmustern zu zeichnen erlaubt. Wurde Gnuplot mit "
+"diesen Möglichkeiten compiliert, schaltet die entsprechende Option im "
+"Konfigurationsmenü oder ein `wxplot_pngcairo:true` die Unterstützung hierfür "
+"ein. Wurde Gnuplot ohne Cairo-Unterstützung compiliert, führt "
+"`wxplot_pngcairo:true` jedoch zu Fehlermeldungen anstelle von Plots."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:556
+#, fuzzy, no-wrap
+#| msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
+msgid "Opening embedded plots in interactive _Gnuplot_ windows"
+msgstr "### Öffnen eingebetteter Diagramme in interaktiven _Gnuplot_ Fenstern"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:559
+msgid ""
+"If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
+"`wxplot3d` isn’t supported by this feature) and the file size of the "
+"underlying _Gnuplot_ project isn’t way too high _wxMaxima_ offers a right-"
+"click menu that allows to open the plot in an interactive _Gnuplot_ window."
+msgstr ""
+"Wenn ein Diagramm mittels einem `wxdraw`-ähnlichen Befehl erstellt wurde "
+"(`wxplot2d` und `wxplot3d` werden hier nicht unterstützt) und die Gnuplot-"
+"Datei nicht allzu lang ist, bietet _wxMaxima_ einen Rechts-Klick-Menüpunkt "
+"an, der das Diagramm in einem interaktiven Gnuplot-Fenster öffnet."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:560
+#, fuzzy, no-wrap
+#| msgid "### Opening Gnuplot’s command console in `plot` windows"
+msgid "Opening Gnuplot’s command console in `plot` windows"
+msgstr "### Öffnen der Gnuplot Kommandozeile in `plot` Fenstern"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:564
+#, fuzzy
+#| msgid ""
+#| "On MS Windows, if in _Maxima_'s variable `gnuplot_command` \"gnuplot\" is "
+#| "replaced by \"wgnuplot\", _gnuplot_ offers the possibility to open a "
+#| "console window, where _gnuplot_ commands can be entered into. "
+#| "Unfortunately, enabling this feature causes _gnuplot_ to \"steal\" the "
+#| "keyboard focus for a short time every time a plot is prepared."
+msgid ""
+"On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and `wgnuplot."
+"exe`.  You can configure, which command should be used using the "
+"configuration menu. `wgnuplot.exe` offers the possibility to open a console "
+"window, where _gnuplot_ commands can be entered into, `gnuplot.exe` does not "
+"offer this possibility. Unfortunately, `wgnuplot.exe` causes _Gnuplot_ to "
+"\"steal\" the keyboard focus for a short time every time a plot is prepared."
+msgstr ""
+"Wenn unter Windows die Variable `gnuplot_command` auf \"wgnuplot\" geändert "
+"wird, erlaubt gnuplot, eine Kommandokonsole zu öffnen, stiehlt aber jedes "
+"Mal, wenn ein Diagramm gezeichnet wird, den Tastaturfokus für kurze Zeit "
+"(die Zeichen, die währenddessen eingegeben werden, verschwinden)."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:565
+#, fuzzy, no-wrap
+#| msgid "### Embedding animations into the spreadsheet"
+msgid "Embedding animations into the spreadsheet"
+msgstr "### Einbetten von Animationen in das Arbeitsblatt"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:568
+msgid ""
+"3D diagrams tend to make it hard to read quantitative data. A viable "
+"alternative might be to assign the 3rd parameter to the mouse wheel. The "
+"`with_slider_draw` command is a version of `wxdraw2d` that does prepare "
+"multiple plots and allows to switch between them by moving the slider on top "
+"of the screen. _WxMaxima_ allows to export this animation as an animated gif."
+msgstr ""
+"Es ist meist schwer, aus 3D-Diagrammen quantitative Aussagen zu entnehmen. "
+"Eine Alternative ist es, den 3. Parameter auf das Mausrad zu legen. Das "
+"Kommando `with_slider_draw` ist eine Version von  `wxdraw2d`, die mehrere "
+"Plots erstellt und es erlaubt, mittels eines Schiebers zwischen diesen hin- "
+"und herzuschalten. _WxMaxima_ kann die Animation auch als animierte `.gif`-"
+"Datei exportieren."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:570
+msgid ""
+"The first two arguments for `with_slider_draw` are the name of the variable "
+"that is stepped between the plots and a list of the values of these "
+"variable. The arguments that follow are the ordinary arguments for "
+"`wxdraw2d`:"
+msgstr ""
+"Die ersten beiden Argumente von `with_slider_draw` sind der Name der "
+"Variable des zu variierenden Parameters und die Liste der Werte, die dieser "
+"annehmen soll. Darauf folgen die ganz normalen Argumente, die `wxdraw2d` "
+"akzeptiert:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:571
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "with_slider_draw(\n"
+#| "    f,[1,2,3,4,5,6,7,10],\n"
+#| "    title=concat(\"f=\",f,\"Hz\"),\n"
+#| "    explicit(\n"
+#| "        sin(2*%pi*f*x),\n"
+#| "        x,0,1\n"
+#| "    ),grid=true\n"
+#| ");\n"
+#| "```\n"
+msgid ""
+"with_slider_draw(\n"
+"    f,[1,2,3,4,5,6,7,10],\n"
+"    title=concat(\"f=\",f,\"Hz\"),\n"
+"    explicit(\n"
+"        sin(2*%pi*f*x),\n"
+"        x,0,1\n"
+"    ),grid=true\n"
+");\n"
+msgstr ""
+"```maxima\n"
+"with_slider_draw(\n"
+"    f,[1,2,3,4,5,6,7,10],\n"
+"    title=concat(\"f=\",f,\"Hz\"),\n"
+"    explicit(\n"
+"        sin(2*%pi*f*x),\n"
+"        x,0,1\n"
+"    ),grid=true\n"
+");\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:583
+msgid ""
+"The same functionality for 3D plots is accessible as `with_slider_draw3d`, "
+"which allows for rotating 3d plots:"
+msgstr ""
+"Für 3D-Diagramme ist dieselbe Funktionalität als `with_slider_draw3d` "
+"verfügbar, die auch rotierende 3D-Diagramme erstellen kann:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:584
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxanimate_autoplay:true;\n"
+#| "wxanimate_framerate:20;\n"
+#| "with_slider_draw3d(\n"
+#| "    α,makelist(i,i,1,360,3),\n"
+#| "    title=sconcat(\"α=\",α),\n"
+#| "    surface_hide=true,\n"
+#| "    contour=both,\n"
+#| "    view=[60,α],\n"
+#| "    explicit(\n"
+#| "        sin(x)*sin(y),\n"
+#| "        x,-π,π,\n"
+#| "        y,-π,π\n"
+#| "    )\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    α,makelist(i,i,1,360,3),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,α],\n"
+"    explicit(\n"
+"        sin(x)*sin(y),\n"
+"        x,-π,π,\n"
+"        y,-π,π\n"
+"    )\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    α,makelist(i,i,1,360,3),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,α],\n"
+"    explicit(\n"
+"        sin(x)*sin(y),\n"
+"        x,-π,π,\n"
+"        y,-π,π\n"
+"    )\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:602
+msgid ""
+"If the general shape of the plot is what matters it might suffice to move "
+"the plot just a little bit in order to make its 3D nature available to the "
+"intuition:"
+msgstr ""
+"Wenn es nur um die generelle Form der Kurve geht, reicht es oft, das Bild "
+"ein wenig zu bewegen, so, dass es von der Intuition erfasst werden kann:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:603
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxanimate_autoplay:true;\n"
+#| "wxanimate_framerate:20;\n"
+#| "with_slider_draw3d(\n"
+#| "    t,makelist(i,i,0,2*π,.05*π),\n"
+#| "    title=sconcat(\"α=\",α),\n"
+#| "    surface_hide=true,\n"
+#| "    contour=both,\n"
+#| "    view=[60,30+5*sin(t)],\n"
+#| "    explicit(\n"
+#| "        sin(x)*y^2,\n"
+#| "        x,-2*π,2*π,\n"
+#| "        y,-2*π,2*π\n"
+#| "    )\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    t,makelist(i,i,0,2*π,.05*π),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,30+5*sin(t)],\n"
+"    explicit(\n"
+"        sin(x)*y^2,\n"
+"        x,-2*π,2*π,\n"
+"        y,-2*π,2*π\n"
+"    )\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    t,makelist(i,i,0,2*π,.05*π),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,30+5*sin(t)],\n"
+"    explicit(\n"
+"        sin(x)*y^2,\n"
+"        x,-2*π,2*π,\n"
+"        y,-2*π,2*π\n"
+"    )\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:621
+msgid ""
+"For those more familiar with `plot` than with `draw`, there is a second set "
+"of functions:"
+msgstr ""
+"Wer `plot` `draw` vorzieht, dem steht ein zweiter Satz an Funktionen zur "
+"Verfügung:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:624
+msgid "`with_slider` and"
+msgstr "- `with_slider` und"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:624
+msgid "`wxanimate`."
+msgstr "`wxanimate`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:626
+msgid ""
+"Normally the animations are played back or exported with the frame rate "
+"chosen in the configuration of _wxMaxima_. To set the speed at an individual "
+"animation is played back the variable `wxanimate_framerate` can be used:"
+msgstr ""
+"Die Standard-Bildwiederholrate für Animationen kann im Konfigurations-Dialog "
+"von _wxMaxima_ eingestellt werden. Um die Geschwindigkeit einer einzelnen "
+"Animation zu ändern, kann die Variable `wxanimate_framerate` geändert werden:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:627
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxanimate(a, 10,\n"
+#| "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+#| "```\n"
+msgid ""
+"wxanimate(a, 10,\n"
+"    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+msgstr ""
+"```maxima\n"
+"    wxanimate(a, 10,\n"
+"        sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:633
+msgid ""
+"The animation functions use _Maxima_’s `makelist` command and therefore "
+"share the pitfall that the slider variable’s value is substituted into the "
+"expression only if the variable is directly visible in the expression. "
+"Therefore the following example will fail:"
+msgstr ""
+"Die Animations-Funktionen haben eine Eigentümlichkeit, die daher rührt, dass "
+"sie `makelist` verwenden: Der Parameter, der sich von Bild zu Bild ändert, "
+"wird nur eingesetzt, wenn die Variable direkt sichtbar ist. Das folgende "
+"Beispiel scheitert daher:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:634
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "f:sin(a*x);\n"
+#| "with_slider_draw(\n"
+#| "    a,makelist(i/2,i,1,10),\n"
+#| "    title=concat(\"a=\",float(a)),\n"
+#| "    grid=true,\n"
+#| "    explicit(f,x,0,10)\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    a,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(a)),\n"
+"    grid=true,\n"
+"    explicit(f,x,0,10)\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    a,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(a)),\n"
+"    grid=true,\n"
+"    explicit(f,x,0,10)\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:645
+msgid ""
+"If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
+"works fine instead:"
+msgstr ""
+"Wenn _Maxima_ explizit gebeten wird, den Wert einzusetzen, funktioniert der "
+"Befehl stattdessen:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:646
+#, fuzzy, no-wrap
+#| msgid ""
+#| "f:sin(a*x);\n"
+#| "with_slider_draw(\n"
+#| "    b,makelist(i/2,i,1,10),\n"
+#| "    title=concat(\"a=\",float(b)),\n"
+#| "    grid=true,\n"
+#| "    explicit(\n"
+#| "        subst(a=b,f),\n"
+#| "        x,0,10\n"
+#| "    )\n"
+#| ")$\n"
+msgid ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    b,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(b)),\n"
+"    grid=true,\n"
+"    explicit(\n"
+"        subst(a=b,f),\n"
+"        x,0,10\n"
+"    )\n"
+")$\n"
+msgstr ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    b,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(b)),\n"
+"    grid=true,\n"
+"    explicit(\n"
+"        subst(a=b,f),\n"
+"        x,0,10\n"
+"    )\n"
+")$\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:659
+#, fuzzy, no-wrap
+#| msgid "### Opening multiple plots in contemporaneous windows"
+msgid "Opening multiple plots in contemporaneous windows"
+msgstr "### Mehrere Diagramme gleichzeitig in Fenstern öffnen"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:662
+msgid ""
+"While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups "
+"that support it) sometimes comes in handily. The following example comes "
+"from a post from Mario Rodriguez to the _Maxima_ mailing list:"
+msgstr ""
+"Strenggenommen kein Feature von _wxMaxima_. Aber Maxima erlaubt auf vielen "
+"Systemen das folgende Beispiel von Mario Rodriguez auszuführen:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:663
+#, no-wrap
+msgid ""
+"load(draw);\n"
+"\n"
+"/* Parabola in window #1 */\n"
+"draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Parabola in window #2 */\n"
+"draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Paraboloid in window #3 */\n"
+"draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:677
+msgid ""
+"Plotting multiple plots in the same window is possible, too (the same is "
+"possible in command line Maxima with the standard `draw()` command):"
+msgstr ""
+"Mehrere Diagramme in einem Fenster sind auch möglich (dies ist auch möglich "
+"in Kommandozeilen-Maxima mit dem Standard-`draw()`-Befehl:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:678
+#, no-wrap
+msgid ""
+"wxdraw(\n"
+"  gr2d(\n"
+"    key=\"sin (x)\",grid=[2,2],\n"
+"    explicit(sin(x),x,0,2*%pi)),\n"
+"  gr2d(\n"
+"    key=\"cos (x)\",grid=[2,2],\n"
+"    explicit(cos(x),x,0,2*%pi))\n"
+");\n"
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:689
+#, fuzzy, no-wrap
+#| msgid "### The \"Plot using draw\" side pane"
+msgid "The \"Plot using draw\" side pane"
+msgstr "### Die \"Plotte mittels Draw\"-Seitenleiste"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:692
+msgid ""
+"The \"Plot using draw\" sidebar hides a simple code generator that allows "
+"generating scenes that make use of some of the flexibility of the _draw_ "
+"package _maxima_ comes with."
+msgstr ""
+"Die \"Plotte mittels Draw\"-Seitenleiste enthält einen Codegenerator, der es "
+"erlaubt, einen Teil der Flexibilität des _draw_-Pakets von _Maxima_ zu "
+"nutzen."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:693
+#, no-wrap
+msgid "2D"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:696
+#, fuzzy
+#| msgid ""
+#| "Generates the skeleton of a `draw()` command that draws a 2D scene. This "
+#| "scene later has to be filled with commands that generate the scene's "
+#| "contents, for example by using the buttons in the rows below the \"2D\" "
+#| "button."
+msgid ""
+"Generates the skeleton of a `draw()` command that draws a 2D scene. This "
+"scene later has to be filled with commands that generate the scene’s "
+"contents, for example by using the buttons in the rows below the \"2D\" "
+"button."
+msgstr ""
+"Generiert einen `draw()`-Befehl, der mittels der anderen Knöpfe der "
+"Seitenleiste mit einer 2D-Szene gefüllt werden kann."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:698
+#, fuzzy
+#| msgid ""
+#| "One helpful feature of the 2D button is that it allows to setup the scene "
+#| "as an animation in which a variable (by default it is _t_) has a "
+#| "different value in each frame: Often an moving 2D plot allows easier "
+#| "interpretation than the same data in a non-moving 3D one."
+msgid ""
+"One helpful feature of the 2D button is that it allows to set up the scene "
+"as an animation in which a variable (by default it is _t_) has a different "
+"value in each frame: Often a moving 2D plot allows easier interpretation "
+"than the same data in a non-moving 3D one."
+msgstr ""
+"Dieser Knopf ist hauptsächlich dann praktisch, wenn eine Animation erstellt "
+"werden soll: Ein sich bewegendes flaches Diagramm ist einfacher abzulesen, "
+"als ein räumliches Solches."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:699
+#, no-wrap
+msgid "3D"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:702
+#, fuzzy
+#| msgid ""
+#| "Generates the skeleton of a `draw()` command that draws a 3D scene. If "
+#| "neither a 2D or a 3D scene are set up all of the other buttons set up a "
+#| "2D scene that contains the command the button generates."
+msgid ""
+"Generates the skeleton of a `draw()` command that draws a 3D scene. If "
+"neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D "
+"scene that contains the command the button generates."
+msgstr "Wie \"2D\", aber für dreidimensionale Diagramme."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:703
+#, fuzzy, no-wrap
+#| msgid "#### Expression"
+msgid "Expression"
+msgstr "#### Ausdruck"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:706
+msgid ""
+"Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or "
+"`x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is "
+"no draw command a 2D scene with the plot is generated. Each scene can be "
+"filled with any number of plots."
+msgstr ""
+"Fügt den aktuellen `draw()`-Befehl den Plot einer Kurve wie `sin(x)`, "
+"`x*sin(x)` oder `x^2+2*x-4` hinzu. Besteht noch kein `draw()`-Befehl, wird "
+"automatisch eine 2D-Szene erzeugt. Jede Szene kann beliebig viele Plots "
+"beinhalten."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:707
+#, fuzzy, no-wrap
+#| msgid "#### Implicit plot"
+msgid "Implicit plot"
+msgstr "#### Impliziter Plot"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:710
+msgid ""
+"Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or "
+"`x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command "
+"the cursor currently is in. If there is no draw command a 2D scene with the "
+"plot is generated."
+msgstr ""
+"Markiert alle Punkte, an denen eine Bedingung wie `y=sin(x)`, `y*sin(x)=3` "
+"oder `x^2+y^2=4` erfüllt ist und zeichnet diese Kurve in das aktuelle "
+"Diagramm ein. Gibt es kein aktuelles Diagramm, wird ein 2D-Diagramm erzeugt."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:711
+#, fuzzy, no-wrap
+#| msgid "#### Parametric plot"
+msgid "Parametric plot"
+msgstr "#### Parametrischer Plot"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:714
+msgid ""
+"Steps a variable from a lower limit to an upper limit and uses two "
+"expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in "
+"3D plots also z) coordinates of a curve that is put into the current draw "
+"command."
+msgstr ""
+"Bewegt eine Variable von einem Start- zu einem Endwert und verwendet "
+"getrennte Ausdrücke wie `t*sin(t)` und `t*cos(t)`, um die x-, die y- (und in "
+"3D-Diagrammen auch die z-) Koordinaten zu generieren."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:715
+#, fuzzy, no-wrap
+#| msgid "#### Points"
+msgid "Points"
+msgstr "#### Punkte"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:718
+msgid ""
+"Draws many points that can optionally be joined. The coordinates of the "
+"points are taken from a list of lists, a 2D array or one list or array for "
+"each axis."
+msgstr ""
+"Zeichnet eine Reihe von Punkten, die optional miteinander verbunden werden. "
+"Die Koordinaten der Punkte können aus einer Liste von Listen, einem 2-"
+"dimensionalen Array oder einer Liste oder einem Array pro Achse entnommen "
+"werden."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:719
+#, fuzzy, no-wrap
+#| msgid "#### Diagram title"
+msgid "Diagram title"
+msgstr "#### Diagrammtitel"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:722
+msgid "Draws a title on the upper end of the diagram,"
+msgstr "Bestimmt den Titel des Diagramms."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:723
+#, fuzzy, no-wrap
+#| msgid "#### Axis"
+msgid "Axis"
+msgstr "#### Achsen"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:726
+msgid "Sets up the axis."
+msgstr "Die Einstellungen für die Achsen."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:727
+#, fuzzy, no-wrap
+#| msgid "#### Contour"
+msgid "Contour"
+msgstr "#### Höhenlinien"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:730
+#, fuzzy
+#| msgid ""
+#| "(Only for 3D plots): Adds contour lines similar to the ones one can find "
+#| "in a map of a mountain to the plot commands that follow in the current "
+#| "draw() command and/or to the ground plane of the diagram. Alternatively "
+#| "this wizard allows skipping drawing the curves entirely only showing the "
+#| "contour plot."
+msgid ""
+"(Only for 3D plots): Adds contour lines similar to the ones one can find in "
+"a map of a mountain to the plot commands that follow in the current `draw()` "
+"command and/or to the ground plane of the diagram. Alternatively, this "
+"wizard allows skipping drawing the curves entirely only showing the contour "
+"plot."
+msgstr ""
+"(Nur für 3D-Diagramme): Erzeugt Höhenlinien auf der zu zeichnenden "
+"Oberfläche, dem Boden des Diagramms oder auf Beiden. Kann optional auch nur "
+"die Höhenlinien in der Ansicht von Oben zeichnen."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:731
+#, fuzzy, no-wrap
+#| msgid "#### Plot name"
+msgid "Plot name"
+msgstr "#### Name des Plots"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:734
+msgid ""
+"Adds a legend entry showing the next plot’s name to the legend of the "
+"diagram. An empty name disables generating legend entries for the following "
+"plots."
+msgstr ""
+"Fügt einen Eintrag zur Legende hinzu, der für die nächsten Objekte gilt. Ein "
+"leerer Name bedeutet, dass die nun folgenden Objekte keinen eigenen Eintrag "
+"erhalten."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:735
+#, fuzzy, no-wrap
+#| msgid "#### Line colour"
+msgid "Line colour"
+msgstr "#### Linienfarbe"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:738
+msgid ""
+"Sets the line colour for the following plots the current draw command "
+"contains."
+msgstr ""
+"Setzt die Linienfarbe für die nun folgenden Plots des aktuellen draw-Befehls."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:739
+#, fuzzy, no-wrap
+#| msgid "#### Fill colour"
+msgid "Fill colour"
+msgstr "#### Füllfarbe"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:742
+msgid ""
+"Sets the fill colour for the following plots the current draw command "
+"contains."
+msgstr ""
+"Setzt die Füllfarbe für die nun folgenden Objekte des aktuellen `draw`-"
+"Kommandos."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:743
+#, fuzzy, no-wrap
+#| msgid "#### Grid"
+msgid "Grid"
+msgstr "#### Gitternetz"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:746
+msgid "Pops up a wizard that allows to set up grid lines."
+msgstr "Ein Assistent, der die Gitterlinien einzustellen hilft."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:747
+#, fuzzy, no-wrap
+#| msgid "#### Accuracy"
+msgid "Accuracy"
+msgstr "#### Genauigkeit"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:750
+msgid ""
+"Allows to select an adequate point in the speed vs. accuracy tradeoff that "
+"is part of any plot program."
+msgstr ""
+"Erlaubt das Wählen zwischen Geschwindigkeit und Genauigkeit bei der "
+"Erstellung der folgenden Kurven."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:751
+#, fuzzy, no-wrap
+#| msgid "### Modify font and font size for plots"
+msgid "Modify font and font size for plots"
+msgstr "### Schrift und Schriftgröße for Plots ändern"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:754
+msgid ""
+"Especially when you use a high resolution display, the default font size "
+"might be very small. For the `draw`-based commands, you can set the font / "
+"font size using options like `font=...`, `font_size=...`, e.g.:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:755
+#, fuzzy, no-wrap
+#| msgid ""
+#| "pngdraw2d(\"Test\",\n"
+#| "        explicit(sin(x),x,1,10)\n"
+#| ");\n"
+#| "~~~~\n"
+msgid ""
+"wxdraw2d(\n"
+"     font=\"Helvetica\",\n"
+"     font_size=30,\n"
+"     explicit(sin(x),x,1,10));\n"
+msgstr ""
+"pngdraw2d(\\\"Test\\\",\n"
+"        explicit(sin(x),x,1,10)\n"
+");\n"
+"~~~~\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:763
+msgid ""
+"For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts "
+"can be set using the `gnuplot_preamble` command, e.g.:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:764
+#, no-wrap
+msgid ""
+"wxplot2d(sin(x),[x,1,10],\n"
+"         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:770
+msgid ""
+"This sets the font for the numbers to Arial with size 30, the size for the "
+"xlabel and ylabel font to 20 (with the default font)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:773
+msgid ""
+"Read the Maxima and Gnuplot documentation for further information.  Note: "
+"Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue "
+"1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966)."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:774
+#, fuzzy, no-wrap
+#| msgid "## Embedding graphics"
+msgid "Embedding graphics"
+msgstr "## Einbetten von Bildern"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:777
+msgid ""
+"If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
+"project can be done as easily as per drag-and-drop. But sometimes (for "
+"example if an image’s contents might change later on in a session) it is "
+"better to tell the file to load the image on evaluation:"
+msgstr ""
+"Das `.wxmx`-Dateiformat erlaubt es, Bilder per Drag-And-Drop einzubetten. "
+"Manchmal (z.B. wenn die Bildinhalte sich später während einer Sitzung ändern "
+"könnten) ist es besser, die Bilddatei während der Auswertung zu laden:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:778
+#, fuzzy, no-wrap
+#| msgid "show_image(\"man.png\");\n"
+msgid "show_image(\"man.png\");\n"
+msgstr "show_image(\"Mensch.png\");\n"
+
+# ## Startbefehle
+#. type: Title ##
+#: ../../info/wxmaxima.md:782
+#, fuzzy, no-wrap
+#| msgid "## Startup files"
+msgid "Startup files"
+msgstr "## Startbefehle"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:785
+msgid ""
+"The config dialogue of _wxMaxima_ offers to edit two files with commands "
+"that are executed on startup:"
+msgstr ""
+"Der Konfigurationsdialog von _wxMaxima_ bietet an, zwei Dateien mit _Maxima_-"
+"Befehlen zu bearbeiten:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:788
+msgid ""
+"A file that contains commands that are executed on starting up _Maxima_: "
+"`maxima-init.mac`"
+msgstr ""
+"Eine Datei mit Befehlen, die _Maxima_ beim Hochfahren ausführt: `maxima-init."
+"mac`"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:788
+#, fuzzy
+#| msgid ""
+#| "A file that contains commands that are executed on starting up _Maxima_: "
+#| "`maxima-init.mac`"
+msgid ""
+"one file of additional commands that are executed if _wxMaxima_ is starting "
+"_Maxima_: `wxmaxima-init.mac`"
+msgstr ""
+"Eine Datei mit Befehlen, die _Maxima_ beim Hochfahren ausführt: `maxima-init."
+"mac`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:790
+msgid ""
+"For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add "
+"`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` "
+"or any other path) to these files."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:792
+#, fuzzy
+#| msgid ""
+#| "These files are in the Maxima user directory (usually `maxima` in "
+#| "Windows, `.maxima` otherwise) in the user's home directory / user profile "
+#| "directory. The location can be found out with the command: "
+#| "`maxima_userdir;`"
+msgid ""
+"These files are in the Maxima user directory (usually `%USERPROFILE%/maxima` "
+"in Windows, `$HOME/.maxima` otherwise). The location can be found out with "
+"the command: `maxima_userdir;`"
+msgstr ""
+"Diese Dateien liegen im Benutzerverzeichnis von Maxima, normalerweise im "
+"Ordner `.maxima` im Home-Verzeichnis. Der genaue Ort kann über das Kommando "
+"`maxima_userdir;` ermittelt werden."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:793
+#, fuzzy, no-wrap
+#| msgid "## Special variables wx..."
+msgid "Special variables wx..."
+msgstr "## Spezielle Variablen, die wxMaxima definiert"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxsubscripts` tells _Maxima_ if it should convert variable names that "
+"contain an underscore (`R_150` or the like) into subscripted variables. See "
+"`wxdeclare_subscript` for details which variable names are automatically "
+"converted."
+msgstr ""
+"`wxsubscripts` informiert _Maxima_, welche Variablen mit Unterstrich (z.B. "
+"`R_150`) in Variablen mit Subscript konvertieren soll. Details werden unter "
+"`wxdeclare_subscript` beschrieben."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxfilename`: This variable contains the name of the file currently opened "
+"in _wxMaxima_."
+msgstr ""
+"`wxfilename`: Diese Variable sagt, welchen Dateinamen das Arbeitsblatt laut "
+"_wxMaxima_ besitzt."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirname`: This variable contains the name the directory, in which the "
+"file currently opened in _wxMaxima_ is."
+msgstr ""
+"`wxdirname`: Diese Variable enthält den Namen des Verzeichnisses, in welchem "
+"die aktuelle Datei geöffnet wurde."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_’s pngcairo "
+"terminal that provides more line styles and a better overall graphics "
+"quality."
+msgstr ""
+"`wxplot_pngcairo` sagt Maxima, ob es versuchen soll, Gnuplot zu instruieren, "
+"pngcairo zu nutzen, das mehr Linientypen und hochqualitative Bilder "
+"unterstützt."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxplot_size` defines the resolution of embedded plots."
+msgstr "`wxplot_size` legt die Größe eingebetteter Diagramme fest."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
+"_Maxima_’s working directory to the directory of the current file. This "
+"allows file I/O (e.g. by `read_matrix`) to work without specifying the whole "
+"path to the file that has to be read or written. On Windows this feature "
+"sometimes causes error messages and therefore can be set to `false` from the "
+"config dialogue."
+msgstr ""
+"`wxchangedir`: Normalerweise setzt _wxMaxima_ _Maxima_'s Arbeitsverzeichnis "
+"auf dasjenige, in dem sich das Arbeitsblatt befindet. Dies ist praktisch, "
+"wenn Maxima auf Dateien zugreifen soll (z.B. via `read_matrix`). Unter "
+"Windows geht dieses Feature manchmal schief und kann daher auf `false` "
+"gesetzt werden."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxanimate_framerate`: The number of frames per second the following "
+"animations have to be played back with."
+msgstr ""
+"`wxanimate_framerate`: Die Geschwindigkeit, mit der Animationen abgespielt "
+"werden sollen."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxanimate_autoplay`: Automatically play animations by default?"
+msgstr ""
+"`wxanimate_autoplay`: Sollen Animationen automatisch abgespielt werden?"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
+msgstr "`wxmaximaversion`: Ergibt die Versionsnummer von _wxMaxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
+msgstr ""
+"`wxwidgetsversion`: Ergibt die Versionsnummer der verwendeten wxWidgets-"
+"Version."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these "
+"differ by maintainer, distribution and operating system:"
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@userconfdir`: The directory the user's configuration is stored in. "
+"Same directory as `maxima_userdir` (see above) - both point at the same "
+"place, `wxdirs@userconfdir` is only useful if that is more convenient to "
+"reach from a `.mac` file than the Maxima-side variable."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the built-in "
+"autocompletion list, ...) is installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@helpdir`: The directory the offline copy of this manual is installed "
+"in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@localedir`: The directory _wxMaxima_'s translation files are "
+"installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_ is "
+"configured to start."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:812
+#, fuzzy, no-wrap
+#| msgid "## Pretty-printing 2D output"
+msgid "Pretty-printing 2D output"
+msgstr "## 2D-Tabellen sauber ausgeben"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:815
+msgid ""
+"The function `table_form()` displays a 2D list in a form that is more "
+"readable than the output from _Maxima_’s default output routine. The input "
+"is a list of one or more lists. Like the \"print\" command, this command "
+"displays output even when ended with a dollar sign. Ending the command with "
+"a semicolon results in the same table along with a \"done\" statement."
+msgstr ""
+"Die Funktion `table_form()` konvertiert 2D-Listen in eine lesbarere "
+"Tabellenform als _Maxima_ selbst. Die Eingabe ist eine Liste von einer oder "
+"mehreren Listen. Wie der \"print\" Befehl wird die Ausgabe auch gemacht, "
+"wenn der Befehl durch ein Dollarzeichen abgeschlossen wurde. Das "
+"abschließende `done` kann durch Verwendung eines `$` anstelle eines `;` "
+"unterdrückt werden."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:816
+#, fuzzy, no-wrap
+#| msgid ""
+#| "table_form(\n"
+#| "    [\n"
+#| "        [1,2],\n"
+#| "        [3,4]\n"
+#| "    ]\n"
+#| ")$\n"
+msgid ""
+"table_form(\n"
+"    [\n"
+"        [1,2],\n"
+"        [3,4]\n"
+"    ]\n"
+")$\n"
+msgstr ""
+"    table_form(\n"
+"        [\n"
+"            [1,2],\n"
+"            [3,4]\n"
+"        ]\n"
+"    )$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:826
+msgid ""
+"As the next example shows, the lists that are assembled by the `table_form` "
+"command can be created before the command is executed."
+msgstr ""
+"Das folgende Beispiel zeigt das Zusammensetzen der Listen für solch eine "
+"Tabelle."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:828
+msgid ""
+"![A third table example](./MatrixTableExample.png)"
+"{ id=img_MatrixTableExample }"
+msgstr ""
+"![Ein drittes Tabellen-Beispiel](./MatrixTableExample.png)"
+"{ id=img_MatrixTableExample }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:830
+msgid ""
+"Also, because a matrix is a list of lists, matrices can be converted to "
+"tables in a similar fashion."
+msgstr ""
+"Da Matrizen effektiv Listen von Listen sind, können auch sie in Tabellen "
+"verwandelt werden."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:832
+msgid ""
+"![Another table_form example](./SecondTableExample.png)"
+"{ id=img_SecondTableExample }"
+msgstr "![Ein anderes table_form Beispiel](./SecondTableExample.png)"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:834
+msgid ""
+"The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that "
+"allows for more flexible formatting of matrices in wxMaxima:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:836
+#, no-wrap
+msgid "**`wx_matrix( <matrix>, [options] )`**\n"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`lines=true`**: Draws internal separator lines between the cells. This is "
+"required to visually separate headings from data."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`rownames=true`**: Tells wxMaxima that the first column of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`colnames=true`**: Tells wxMaxima that the first row of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
+"around the matrix. Supported styles are: `round` `()`, `square` `[]`, "
+"`angled` `<>`, `straight` `||`, or `none`."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:843
+#, fuzzy
+#| msgid "One Example:"
+msgid "Example:"
+msgstr "Ein Beispiel:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:844
+#, no-wrap
+msgid ""
+"wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
+"          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:849
+#, fuzzy, no-wrap
+#| msgid "## Bug reporting"
+msgid "Bug reporting"
+msgstr "## Fehler melden"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:852
+msgid ""
+"_WxMaxima_ provides a few functions that gather bug reporting information "
+"about the current system:"
+msgstr "_WxMaxima_ bietet einige Funktionen für das Melden von Fehlern an:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:855
+msgid ""
+"`wxbuild_info()` gathers information about the currently running version of "
+"_wxMaxima_"
+msgstr ""
+"`wxbuild_info()` sammelt Informationen über die derzeit ausgeführte Version "
+"von _wxMaxima_"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:855
+msgid "`wxbug_report()` tells how and where to file bugs"
+msgstr "`wxbug_report()` sagt, wo und wie Fehler gemeldet werden können"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:856
+#, fuzzy, no-wrap
+#| msgid "## Marking output being drawn in red"
+msgid "Marking output being drawn in red"
+msgstr "## Rotes Markieren von Formelteilen"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:860
+#, fuzzy
+#| msgid ""
+#| "_Maxima_'s `box()` command causes _wxMaxima_ to print its argument with a "
+#| "red foreground."
+msgid ""
+"_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a "
+"red foreground, if the second argument to the command is the text "
+"`highlight`."
+msgstr "Der `box()`-Befehl stellt sein Argument in _wxMaxima_ rot dar."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:861
+#, no-wrap
+msgid "Output rendering."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:864
+msgid "With `set_display()` one can set, how wxMaxima will render the output."
+msgstr ""
+"Mittels `set_display()` kann man angeben, wie wxMaxima die Ausgabe anzeigt."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:866
+msgid ""
+"`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima "
+"using an (machine readable) XML-dialect (can be seen in the \"Raw XML "
+"sidebar\") and outputs the resulting formulas nicely rendered, e.g. pretty "
+"Matrices, Square root signs, fractions, etc."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:869
+#, no-wrap
+msgid ""
+"<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->\n"
+"`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:871
+msgid ""
+"`set_display('none)` causes 'one-line' ASCII results - the same as the "
+"command line Maxima command `display2d:false;` does."
+msgstr ""
+"`set_display('none)` bewirkt  'einzeilige' ASCII Ausgaben - dasselbe was "
+"(Kommandozeilen-)Maxima mit `display2d:false;` macht."
+
+#. type: Title #
+#: ../../info/wxmaxima.md:872
+#, fuzzy, no-wrap
+#| msgid "# Help menu"
+msgid "Help menu"
+msgstr "# Hilfemenü"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:875
+msgid ""
+"WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, "
+"tips, some example worksheets and in command line Maxima included demos (the "
+"`demo()` command)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:877
+msgid "Please notice, that the demos write:"
+msgstr ""
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:878
+#, no-wrap
+msgid "At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:883
+#, no-wrap
+msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:885
+#, no-wrap
+msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)\n"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:888
+#, fuzzy, no-wrap
+#| msgid "# Troubleshooting"
+msgid "Troubleshooting"
+msgstr "# Fehlersuche"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:890
+#, fuzzy, no-wrap
+#| msgid "## Cannot connect to _Maxima_"
+msgid "Cannot connect to _Maxima_"
+msgstr "## Keine Verbindung zu _Maxima_ möglich"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:893
+#, fuzzy
+#| msgid ""
+#| "Since _Maxima_ (the program that does the actual mathematics) and "
+#| "_wxMaxima_ (providing the easy-to-use user interface) are separate "
+#| "programs that communicate by the means of a local network connection. "
+#| "Therefore the most probable cause is that this connection is somehow not "
+#| "working. For example a firewall could be set up in a way that it doesn’t "
+#| "just prevent unauthorized connections from the internet (and perhaps to "
+#| "intercept some connections to the internet, too), but it also to blocks "
+#| "inter-process-communication inside the same computer. Note that since "
+#| "_Maxima_ is being run by a Lisp processor the process communication that "
+#| "is blocked from does not necessarily have to be named \"maxima\". Common "
+#| "names of the program that opens the network connection would be sbcl, "
+#| "gcl, ccl, lisp.exe or similar names."
+msgid ""
+"Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ "
+"(providing the easy-to-use user interface) are separate programs that "
+"communicate by the means of a local network connection. Therefore the most "
+"probable cause is that this connection is somehow not working. For example, "
+"a firewall could be set up in a way that it doesn’t just prevent "
+"unauthorized connections from the internet (and perhaps intercept some "
+"connections to the internet, too), but also blocks inter-process-"
+"communication inside the same computer. Note that since _Maxima_ is being "
+"run by a Lisp processor the process communication that is blocked does not "
+"necessarily have to be named \"maxima\". Common names of the program that "
+"opens the network connection would be sbcl, gcl, ccl, lisp.exe, or similar "
+"names."
+msgstr ""
+"_Maxima_ und wxMaxima kommunizieren über ein lokales Netzwerk miteinander. "
+"Dies kann durch eine übereifrige Firewall unterbunden werden, die auch "
+"Verbindungen innerhalb des Rechners verbietet. Manchmal ist es schwer, "
+"herauszufinden, welches Programm erlaubt sein soll, da _Maxima_ manchmal "
+"unter Namen wie sbcl, gcl, ccl, lisp.exe oder ähnlichen firmiert."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:895
+msgid ""
+"On Unix computers another possible reason would be that the loopback network "
+"that provides network connections between two programs in the same computer "
+"isn’t properly configured."
+msgstr ""
+"Auf Unix/Linux-Rechnern kann ein weiterer Grund sein, dass das \"loopback\"-"
+"Netzwerkgerät (erlaubt Netzwerkverbindungen zwischen 2 Prorammen am selben "
+"Rechner) nicht korrekt eingestellt ist."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:896
+#, fuzzy, no-wrap
+#| msgid "## How to save data from a broken .wxmx file"
+msgid "How to save data from a broken .wxmx file"
+msgstr "## Wie repariere ich kaputte .wxmx-Dateien?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:899
+msgid ""
+"Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ "
+"doesn’t turn on compression, so the contents of `.wxmx` files can be viewed "
+"in any text editor."
+msgstr ""
+"Die meisten modernen XML-basierten Formate sind von ihrem Inhalt her "
+"einfache .zip-Dateien. _wxMaxima_ schaltet bei ihnen die Kompression nicht "
+"ein, weswegen ihr Inhalt in einem normalen Texteditor lesbar ist."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:901
+#, fuzzy
+#| msgid ""
+#| "If the zip signature at the end of the file is still intact after "
+#| "renaming a broken .wxmx file to .zip most operating systems will provide "
+#| "a way to extract any portion of information that is stored inside it. "
+#| "This can be done when there is the need of recovering the original image "
+#| "files from a text processor document. If the zip signature isn’t intact "
+#| "that does not need to be the end of the world: If _wxMaxima_ during "
+#| "saving detected that something went wrong there will be a `wxmx~` file "
+#| "whose contents might help."
+msgid ""
+"If the zip signature at the end of the file is still intact after renaming a "
+"broken `.wxmx` file to `.zip` most operating systems will provide a way to "
+"extract any portion of the information that is stored inside it. This can be "
+"done when there is a need of recovering the original image files from a text "
+"processor document. If the zip signature isn’t intact that does not need to "
+"be the end of the world: If _wxMaxima_ during saving detected that something "
+"went wrong there will be a `.wxmx~` file whose contents might help."
+msgstr ""
+"Wenn die Zip-Signatur am Ende der Datei intakt ist, kann man die Datei nach "
+"`<irgendwas>.zip` umbenennen, entpacken, reparieren, neu packen und wieder "
+"nach `<irgendwas>.wxmx` umbenennen. Dies ist auch eine praktische "
+"Möglichkeit, Word oder Powerpoint die originalen Bilddateien zu entlocken. "
+"Ist dies nicht der Fall, ist dies nicht das Ende der Welt: Oft gibt es eine "
+"funktionierende `wxmx~`-Datei."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:903
+#, fuzzy, no-wrap
+#| msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file's contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).\n"
+msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).\n"
+msgstr "Und auch wenn diese Datei nicht existiert: Eine `.wxmx`-Datei ist ein Containerformat, und der XML-Anteil wird unkomprimiert gespeichert. Es ist möglich, die `.wxmx`-Datei in eine `.txt`Datei umzubenennen und mit einem Texteditor den XML-Anteil der Datei (beginnt mit `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` und endet mit `</wxMaximaDocument>` zu sichern. Vor und nach diesem Text wird unlesbarer (binärer) Inhalt im Texteditor sichtbar sein).\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:905
+msgid ""
+"If a text file containing only these contents (e.g. copy and paste this text "
+"into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know "
+"how to recover the text from the document."
+msgstr ""
+"Wird eine Textdatei mit diesem Text (z.B. indem er mit Copy+Paste in eine "
+"neue Datei eingefügt wird) als `.xml`-Datei gespeichert, weiß _wxMaxima_, "
+"wie man den Text-Teil des Dokuments rekonstruiert."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:906
+#, fuzzy, no-wrap
+#| msgid "## I want some debug info to be displayed on the screen before my command has finished"
+msgid "I want some debug info to be displayed on the screen before my command has finished"
+msgstr "## Ich will Statusmeldungen am Bildschirm ausgeben, während mein Befehl ausgeführt wird"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:909
+msgid ""
+"Normally _wxMaxima_ waits for the whole 2D formula to be transferred before "
+"it begins to typeset. This saves time for making many attempts to typeset a "
+"only partially completed equation. There is a `disp` command, though, that "
+"will provide debug output immediately and without waiting for the current "
+"_Maxima_ command to finish:"
+msgstr ""
+"Normalerweise gibt _wxMaxima_ erst etwas aus, wenn die komplette Ausgabe "
+"steht. Das `disp`-Kommando wird hingegen sofort ausgeführt:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:910
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "for i:1 thru 10 do (\n"
+#| "   disp(i),\n"
+#| "   /* (sleep n) is a Lisp function, which can be used */\n"
+#| "   /* with the character \"?\" before. It delays the */\n"
+#| "   /* program execution (here: for 3 seconds) */\n"
+#| "   ?sleep(3)\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"for i:1 thru 10 do (\n"
+"   disp(i),\n"
+"   /* (sleep n) is a Lisp function, which can be used */\n"
+"   /* with the character \"?\" before. It delays the */\n"
+"   /* program execution (here: for 3 seconds) */\n"
+"   ?sleep(3)\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"for i:1 thru 10 do (\n"
+"   disp(i),\n"
+"   /* (sleep n) ist eine Lisp-Funktion, die mit einem */\n"
+"   /* \"?\" Zeichen vorher verwendet werden kann. */\n"
+"   /* Sie verzögert die Programmausführung für n Sekunden */\n"
+"   /* (in diesem Beispiel: für 3 Sekunden). */\n"
+"   ?sleep(3)\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:921
+msgid "Alternatively one can look for the `wxstatusbar()` command above."
+msgstr "Alternativ kann man sich das `wxstatusbar()`-Kommando oben ansehen."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:922
+#, fuzzy, no-wrap
+#| msgid "## Plotting only shows a closed empty envelope with an error message"
+msgid "Plotting only shows a closed empty envelope with an error message"
+msgstr "## Statt eines Diagramms wird ein Briefumschlag mit einer Fehlermeldung dargestellt"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:925
+msgid ""
+"This means that _wxMaxima_ could not read the file _Maxima_ that was "
+"supposed to instruct _Gnuplot_ to create."
+msgstr ""
+"_wxMaxima_ konnte die Datei, die _Maxima_ _Gnuplot_ instruiert hat, zu "
+"generieren, nicht lesen."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:927
+msgid "Possible reasons for this error are:"
+msgstr "Mögliche Gründe für diesen Fehler sind:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+msgid ""
+"The plotting command is part of a third-party package like `implicit_plot` "
+"but this package was not loaded by _Maxima_’s `load()` command before trying "
+"to plot."
+msgstr ""
+"`implicit_plot` wurde verwendet, ohne vorher via `load()` geladen zu werden."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+#, fuzzy
+#| msgid ""
+#| "_Maxima_ tried to do something the currently installed version of "
+#| "_gnuplot_ isn’t able to understand. In this case, a file ending in `."
+#| "gnuplot` located in the directory, which _Maxima_’s variable "
+#| "`maxima_userdir` is pointing, contains the instructions from _Maxima_ to "
+#| "_gnuplot_. Most of the time, this file’s contents therefore are helpful "
+#| "when debugging the problem."
+msgid ""
+"_Maxima_ tried to do something the currently installed version of _Gnuplot_ "
+"isn’t able to understand. In this case, a file ending in `.gnuplot` located "
+"in the directory, which _Maxima_’s variable `maxima_userdir` is pointing, "
+"contains the instructions from _Maxima_ to _Gnuplot_. Most of the time, this "
+"file’s contents therefore are helpful when debugging the problem."
+msgstr ""
+"_Maxima_ hat versucht, _Gnuplot_ zu etwas zu bewegen, was die installierte  "
+"Version von _Gnuplot_ nicht versteht. In diesem Fall stehen die betreffenden "
+"Befehle in dem Verzeichnis, auf das `maxima_userdir` zeigt in einer Datei "
+"mit der Endung `.gnuplot`. Der Inhalt dieser Datei ist oft hilfreich, um den "
+"Fehler zu suchen."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+#, fuzzy
+#| msgid ""
+#| "Gnuplot was instructed to use the pngcairo library that provides "
+#| "antialiasing and additional line styles, but it was not compiled to "
+#| "support this possibility. Solution: Uncheck the \"Use the cairo terminal "
+#| "for plot\" checkbox in the configuration dialog and don’t set "
+#| "`wxplot_pngcairo` to true from _Maxima_."
+msgid ""
+"Gnuplot was instructed to use the pngCairo library that provides "
+"antialiasing and additional line styles, but it was not compiled to support "
+"this possibility. Solution: Uncheck the \"Use the Cairo terminal for the "
+"plot\" checkbox in the configuration dialog and don’t set `wxplot_pngcairo` "
+"to true from _Maxima_."
+msgstr ""
+"Gnuplot wurde über _wxMaxima_'s Konfigurationsdialog instruiert, pngcairo zu "
+"verwenden, unterstützt diese Ausgabefunktionen aber nicht. Dies ist auf dem "
+"Mac ein typisches Problem."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+msgid "Gnuplot didn’t output a valid `.png` file."
+msgstr "Gnuplot hat keine gültige `.png`-Datei ausgegeben."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:933
+#, fuzzy, no-wrap
+#| msgid "## Plotting an animation results in “error: undefined variable”"
+msgid "Plotting an animation results in “error: undefined variable”"
+msgstr "## Animationen enden in \"Error: Undefined Variable\""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:936
+#, fuzzy
+#| msgid ""
+#| "The value of the slider variable by default is only substituted into the "
+#| "expression that is to be plotted if it is visible there. Using a `subst` "
+#| "command that substitutes the slider variable into the equation to plot "
+#| "resolves this problem. At the end of section [Embedding animations into "
+#| "the spreadsheet](#embedding-animations-into-the-spreadsheet) you can see "
+#| "an example."
+msgid ""
+"The value of the slider variable by default is only substituted into the "
+"expression that is to be plotted if it is visible there. Using a `subst` "
+"command that substitutes the slider variable into the equation to plot "
+"resolves this problem. At the end of section [Embedding animations into the "
+"spreadsheet](#embedding-animations-into-the-spreadsheet), you can see an "
+"example."
+msgstr ""
+"Der Wert für den Parameter, der bei der Animation variiert werden soll, war "
+"für _Maxima_ nicht sichtbar. Ein explizites `subst()` behebt dieses Problem, "
+"wie in einem Beispiel weiter oben gezeigt wird."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:937
+#, fuzzy, no-wrap
+#| msgid "## I lost cell content and undo doesn’t remember"
+msgid "I lost cell content and undo doesn’t remember"
+msgstr "## Rückgängig-machen erinnert sich nicht an das, was ich brauche"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:940
+msgid ""
+"There are separate undo functions for cell operations and for changes inside "
+"of cells so chances are low that this ever happens. If it does there are "
+"several methods to recover data:"
+msgstr ""
+"Es gibt zwei Rückgängigmach- Funktionen, die beide die wichtige Information "
+"enthalten können:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+#, fuzzy
+#| msgid ""
+#| "_wxMaxima_ actually has two undo features: The global undo buffer that is "
+#| "active if no cell is selected and a per-cell undo buffer that is active "
+#| "if the cursor is inside a cell. It is worth trying to use both undo "
+#| "options in order to see if an old value can still be accessed."
+msgid ""
+"_WxMaxima_ actually has two undo features: The global undo buffer that is "
+"active if no cell is selected and a per-cell undo buffer that is active if "
+"the cursor is inside a cell. It is worth trying to use both undo options in "
+"order to see if an old value can still be accessed."
+msgstr ""
+"Ein Rückgängigmach-Speicher für die aktuell ausgewählte Zelle und einer für "
+"das gesamte Arbeitsblatt, der aktiv ist, wenn keine Zelle ausgewählt ist.Es "
+"lohnt sich, beide Rückgängigmach-Optionen zu probieren, um zu sehen, ob ein "
+"alter Wert wiederhergestellt werden kann."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+msgid ""
+"If you still have a way to find out what label _Maxima_ has assigned to the "
+"cell just type in the cell’s label and its contents will reappear."
+msgstr ""
+"Wenn die Ausgabe einer Marke (z.B. `%o20`) zugewiesen wurde, kann diese "
+"Marke eingegeben werden und der betreffende Text erscheint."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+msgid ""
+"If you don’t: Don’t panic. In the “View” menu there is a way to show a "
+"history pane that shows all _Maxima_ commands that have been issued recently."
+msgstr ""
+"Wenn nicht: Keine Panik: Im “Ansicht”-Menü kann eine Seitenleiste "
+"eingeschaltet werden, die die letzten Befehle anzeigt."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+msgid "If nothing else helps _Maxima_ contains a replay feature:"
+msgstr ""
+"Wenn nichts anderes funktioniert, bietet Maxima die Möglichkeit an, alle "
+"bisherigen Befehle nochmals auszuführen:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:946
+#, no-wrap
+msgid "playback();\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:950
+#, fuzzy, no-wrap
+#| msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
+msgid "_WxMaxima_ starts up with the message “Maxima process terminated.”"
+msgstr "## _WxMaxima_ meldet gleich beim Hochfahren \"Maxima hat sich beendet.\""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:953
+msgid ""
+"One possible reason is that _Maxima_ cannot be found in the location that is "
+"set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore "
+"won’t run at all. Setting the path to a working _Maxima_ binary should fix "
+"this problem."
+msgstr ""
+"Ein möglicher Grund ist, dass Maxima nicht dort gefunden worden kann, wo "
+"dies in wxMaxima's Konfigurationsdialog angegeben ist. Korrektur des dort "
+"angegebenen Pfades zum Programm löst dieses Problem."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:954
+#, fuzzy, no-wrap
+#| msgid "## Maxima is forever calculating and not responding to input"
+msgid "Maxima is forever calculating and not responding to input"
+msgstr "## Maxima hört nicht auf zu rechnen und reagiert nicht auf Eingaben"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:957
+msgid ""
+"It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ "
+"has finished calculating and therefore never gets informed it can send new "
+"data to _Maxima_. If this is the case “Trigger evaluation” might "
+"resynchronize the two programs."
+msgstr ""
+"Theoretisch kann es passieren, daß wxMaxima nicht erkennt, dass Maxima mit "
+"der Berechnung fertig ist und daher nie neue Befehle an Maxima sendet. In "
+"diesem Fall kann der Befehl 'Trigger Evaluation' die Synchronisation wieder "
+"herstellen."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:958
+#, fuzzy, no-wrap
+#| msgid "## My SBCL-based _Maxima_ runs out of memory"
+msgid "My SBCL-based _Maxima_ runs out of memory"
+msgstr "## _Maxima_ (mit SBCL compilliert) beschwert sich über einen Mangel an Speicher"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:961
+#, fuzzy
+#| msgid ""
+#| "The Lisp compiler SBCL by default comes with a memory limit that allows "
+#| "it to run even on low-end computers. When compiling a big software "
+#| "package like Lapack or dealing with extremely big lists or equations this "
+#| "limit might be too low. In order to extend the limits SBCL can be "
+#| "provided with the command line parameter `--dynamic-space-size` that "
+#| "tells SBCL how many megabytes it should reserve. A 32bit Windows-SBCL can "
+#| "reserve up to 999 Megabytes. A 64-bit SBCL version running on Windows can "
+#| "be instructed to use more than the about 1280 Megabytes compiling Lapack "
+#| "needs."
+msgid ""
+"The Lisp compiler SBCL by default comes with a memory limit that allows it "
+"to run even on low-end computers. When compiling a big software package like "
+"Lapack or dealing with extremely big lists of equations this limit might be "
+"too low. In order to extend the limits, SBCL can be provided with the "
+"command line parameter `--dynamic-space-size` that tells SBCL how many "
+"megabytes it should reserve. A 32bit Windows-SBCL can reserve up to 999 "
+"Megabytes. A 64-bit SBCL version running on Windows can be instructed to use "
+"more than the about 1280 Megabytes compiling Lapack needs."
+msgstr ""
+"Der Lisp Compiler SBCL reserviert gleich beim Hochfahren allen Speicher, den "
+"es im Betrieb nutzen will. Wird mehr Speicher benötigt, muss ihm über den "
+"Kommandozeilenparameter `--dynamic-space-size` gesagt werden, wie viel "
+"Speicher benötigt wird. SBCL kann nur in etwa die Hälfte des freien "
+"Speichers des Systems verwenden. Auf 32-Bit-Rechnern ist dies meist unter "
+"999 Megabytes. Auf 64-Bit-Systemen können mehr als 1280 MB verwendet werden, "
+"was notwendig ist um das Lapack-Paket zu compilieren."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:963
+msgid ""
+"One way to provide _Maxima_ (and thus SBCL) with command line parameters is "
+"the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration "
+"dialogue."
+msgstr ""
+"Kommandozeilenparameter für _Maxima_ (und daher für SBCL) können in "
+"_wxMaxima_'s Konfigurationsdialog eingegeben werden."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:965
+msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
+msgstr "![SBCL Speicherkonfiguration](./sbclMemory.png){ id=img_sbclMemory }"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:966
+#, fuzzy, no-wrap
+#| msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgstr "## Ubuntu: Die Tastatur ist langsam oder ignoriert einzelne Tasten"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:969
+msgid ""
+"Installing the package `ibus-gtk` should resolve this issue. See ([https://"
+"bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs."
+"launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) for details."
+msgstr ""
+"Das Installieren von `ibus-gtk` behebt dieses Problem meist. Auf ([https://"
+"bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs."
+"launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) findet man genauere "
+"Angaben dazu."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:970
+#, fuzzy, no-wrap
+#| msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgid "_WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgstr "## _WxMaxima_ stoppt, wenn _Maxima_ griechische Buchstaben oder Umlaute verarbeitet"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:973
+msgid ""
+"If your _Maxima_ is based on SBCL the following lines have to be added to "
+"your `.sbclrc`:"
+msgstr ""
+"Wenn _Maxima_ mittels SBCL compiliert wurde, können die folgenden Befehle "
+"zur `.sbclrc` hinzugefügt werden:"
+
+#. type: Fenced code block (commonlisp)
+#: ../../info/wxmaxima.md:974
+#, fuzzy, no-wrap
+#| msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
+msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
+msgstr "(setf sb-impl::*default-external-format* :utf-8)\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:979
+msgid ""
+"The folder where this file has to be placed is system- and installation-"
+"specific. But any SBCL-based _Maxima_ that already has evaluated a cell in "
+"the current session will happily tell where it can be found after getting "
+"the following command:"
+msgstr ""
+"Wo diese Datei abgelegt werden muss, ist systemabhängig. Aber ein mit SBCL "
+"compiliertes Maxima kann durch den folgenden Befehl angewiesen werden, den "
+"Ort zu nennen:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:980
+#, fuzzy, no-wrap
+#| msgid ":lisp (sb-impl::userinit-pathname)\n"
+msgid ":lisp (sb-impl::userinit-pathname)\n"
+msgstr ":lisp (sb-impl::userinit-pathname)\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:984
+#, fuzzy, no-wrap
+#| msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
+msgid "Note concerning Wayland (recent Linux/BSD distributions)"
+msgstr "## Anmerkung bezüglich Wayland (aktuelle Linux/BSD Distributionen)"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:988
+msgid ""
+"There seem to be issues with the Wayland Display Server and wxWidgets.  "
+"WxMaxima may be affected, e.g. that sidebars are not moveable."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:992
+msgid ""
+"You can either disable Wayland and use X11 instead (globally)  or just tell, "
+"that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:994
+msgid "E.g. start wxMaxima with:"
+msgstr "z.B. Wxmaxima wie folgt starten:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:996
+msgid "`GDK_BACKEND=x11 wxmaxima`"
+msgstr "`GDK_BACKEND=x11 wxmaxima`"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:997
+#, no-wrap
+msgid "The menu bar disappears on KDE Plasma"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1003
+msgid ""
+"On some KDE Plasma installations the global menu bar disappears when "
+"clicked.  As this is a bug in the global menu proxy, the only way to avoid "
+"it is to tell that wxMaxima should use its own menu bar instead of the "
+"global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1007
+msgid ""
+"Starting with version 26.05.0, wxMaxima attempts to set this variable "
+"automatically if it detects an affected system (KDE, Unity, or Ubuntu with "
+"older wxWidgets versions)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1009
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1011
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1012
+#, fuzzy, no-wrap
+#| msgid "## Why is the external manual browser not working on my Linux box?"
+msgid "Why is the integrated manual browser not offered on my Windows PC?"
+msgstr "## Warum funktioniert der externe Hilfebrowser nicht unter Linux?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1016
+msgid ""
+"Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or "
+"Microsoft’s webview2 isn’t installed."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1017
+#, fuzzy, no-wrap
+#| msgid "## Why is the external manual browser not working on my Linux box?"
+msgid "Why is the external manual browser not working on my Linux box?"
+msgstr "## Warum funktioniert der externe Hilfebrowser nicht unter Linux?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1024
+msgid ""
+"The HTML browser might be a snap, flatpack or appimage version. All of these "
+"typically cannot access files that are installed on your local system. "
+"Another reason might be that maxima or wxMaxima is installed as a snap, "
+"flatpack or something else that doesn’t give the host system access to its "
+"contents. A third reason might be that the maxima HTML manual isn’t "
+"installed and the online one cannot be accessed."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1025
+#, fuzzy, no-wrap
+#| msgid "## Can I make _wxMaxima_ output both image files and embedded plots at once?"
+msgid "Can I make _wxMaxima_ output both image files and embedded plots at once?"
+msgstr "### Kann _wxMaxima_ das eingebettete Diagramm gleich noch als Datei ausgeben?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1028
+msgid ""
+"The worksheet embeds `.png files. _WxMaxima_ allows the user to specify "
+"where they should be generated:"
+msgstr ""
+"Das Arbeitsblatt enthält png-Dateien. _WxMaxima_ erlaubt dem User anzugeben, "
+"wo sie generiert werden sollen:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1029
+#, fuzzy, no-wrap
+#| msgid ""
+#| "~~~~\n"
+#| "wxdraw2d(\n"
+#| "    file_name=\"test\",\n"
+#| "    explicit(sin(x),x,1,10)\n"
+#| ");\n"
+#| "~~~~\n"
+msgid ""
+"wxdraw2d(\n"
+"    file_name=\"test\",  /* extension .png automatically added */\n"
+"    explicit(sin(x),x,1,10)\n"
+");\n"
+msgstr ""
+"wxdraw2d(\n"
+"    file_name=\"test\",\n"
+"    explicit(sin(x),x,1,10)\n"
+");\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1037
+msgid ""
+"If a different format is to be used, it is easier to generate the images and "
+"then import them into the worksheet again:"
+msgstr ""
+"Wenn ein unterschiedliches Format benutzt wird, ist es einfacher, Bilder zu "
+"generieren und dann in das Arbeitsblatt zu importieren:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1038
+#, fuzzy, no-wrap
+#| msgid ""
+#| "~~~~\n"
+#| "load(\"draw\");\n"
+#| "pngdraw(name,[contents]):=\n"
+#| "(\n"
+#| "    draw(\n"
+#| "        append(\n"
+#| "            [\n"
+#| "                terminal=pngcairo,\n"
+#| "                dimensions=wxplot_size,\n"
+#| "                file_name=name\n"
+#| "            ],\n"
+#| "            contents\n"
+#| "        )\n"
+#| "    ),\n"
+#| "    show_image(printf(false,\"~a.png\",name))\n"
+#| ");\n"
+#| "pngdraw2d(name,[contents]):=\n"
+#| "    pngdraw(name,gr2d(contents));\n"
+msgid ""
+"load(\"draw\");\n"
+"pngdraw(name,[contents]):=\n"
+"(\n"
+"    draw(\n"
+"        append(\n"
+"            [\n"
+"                terminal=pngcairo,\n"
+"                dimensions=wxplot_size,\n"
+"                file_name=name\n"
+"            ],\n"
+"            contents\n"
+"        )\n"
+"    ),\n"
+"    show_image(printf(false,\"~a.png\",name))\n"
+");\n"
+"pngdraw2d(name,[contents]):=\n"
+"    pngdraw(name,gr2d(contents));\n"
+"\n"
+"pngdraw2d(\"Test\",\n"
+"        explicit(sin(x),x,1,10)\n"
+");\n"
+msgstr ""
+"~~~~\n"
+"load(\\\"draw\\\");\n"
+"pngdraw(name,[contents]):=\n"
+"(\n"
+"    draw(\n"
+"        append(\n"
+"            [\n"
+"                terminal=pngcairo,\n"
+"                dimensions=wxplot_size,\n"
+"                file_name=name\n"
+"            ],\n"
+"            contents\n"
+"        )\n"
+"    ),\n"
+"    show_image(printf(false,\\\"~a.png\\\",name))\n"
+");\n"
+"pngdraw2d(name,[contents]):=\n"
+"    pngdraw(name,gr2d(contents)\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1062
+#, fuzzy, no-wrap
+#| msgid "## Can I set the aspect ratio of an embedded plot?"
+msgid "Can I set the aspect ratio of an embedded plot?"
+msgstr "Kann ich das Seitenverhältnis eines eingebetteten Plots angeben?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1065
+msgid "Use the variable `wxplot_size`:"
+msgstr "Verwenden Sie die Variable `wxplot_size`:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1066
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw2d(\n"
+#| "    explicit(sin(x),x,1,10)\n"
+#| "),wxplot_size=[1000,1000];\n"
+#| "```\n"
+msgid ""
+"wxdraw2d(\n"
+"    explicit(sin(x),x,1,10)\n"
+"),wxplot_size=[1000,1000];\n"
+msgstr ""
+"```maxima\n"
+"     wxdraw2d(\n"
+"         proportional_axis=xy,\n"
+"         explicit(sin(x),x,1,10)\n"
+"     ),wxplot_size=[1000,1000];\n"
+"```\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1072
+#, fuzzy, no-wrap
+#| msgid "## After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
+msgid "After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
+msgstr "### Nach dem Upgrade auf MacOS 13.1 geben Plot- oder Draw Befehle Fehlermeldungen aus, wie"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:1074
+#, no-wrap
+msgid ""
+"1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102\n"
+"2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52\n"
+"3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408\n"
+"...\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1082
+#, no-wrap
+msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1083
+#, fuzzy, no-wrap
+#| msgid "## Logging"
+msgid "Logging"
+msgstr "## Fehlerprotokollierung"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1088
+#, no-wrap
+msgid ""
+"Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build,\n"
+"the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable\n"
+"this window using the \"View->Toggle log window\" menu entry.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1090
+msgid ""
+"Messages are not 'lost', if the log window is not shown, if you select to "
+"show the log window later, you will see past log messages (if you did not "
+"clear the messages)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1092
+msgid ""
+"Such messages may be helpful, when you create bug reports (or trying to find "
+"a bug by yourself)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1095
+msgid ""
+"Log messages can (additionally) be printed to STDERR, when using the command "
+"line option \"--logtostderr\". On Windows a separate text console will be "
+"opened, as a Windows GUI application does not have the standard IO connected."
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1098
+#, no-wrap
+msgid "FAQ"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1100
+#, fuzzy, no-wrap
+#| msgid "## Is there a way to make more text fit on a LaTeX page?"
+msgid "Is there a way to make more text fit on a LaTeX page?"
+msgstr "## Gibt es eine Möglichkeit mehr Text auf eine LaTeX-Seite zu schreiben?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1103
+msgid ""
+"Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to "
+"specify the size of the borders."
+msgstr ""
+"Ja. Verwenden Sie das [LaTeX Paket \"geometry\"](https://ctan.org/pkg/"
+"geometry) um die Größe der Ränder anzugeben."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1105
+#, fuzzy, no-wrap
+#| msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):"
+msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):\n"
+msgstr "Ja, gibt es. Geben Sie einfach die folgenden Zeilen im LaTeX-Vorspann (z.B. indem sie das entsprechende Feld im Konfigurationsdialog (\"Exportieren\"->\"Zusätzliche Zeilen für die LaTeX preamble\") angeben, um Ränder von 1cm zu setzen):"
+
+#. type: Fenced code block (latex)
+#: ../../info/wxmaxima.md:1106
+#, fuzzy, no-wrap
+#| msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+msgstr "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1110
+#, fuzzy, no-wrap
+#| msgid "## Is there a dark mode?"
+msgid "Is there a dark mode?"
+msgstr "## Gibt es einen Dark Mode?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1113
+#, fuzzy
+#| msgid ""
+#| "If wxWidgets is new enough _wxMaxima_ will automatically be in dark mode "
+#| "if the rest of the operating system is. The worksheet itself is by "
+#| "default equipped with a bright background. But it can be configured "
+#| "otherwise. Alternatively there is a `View/Invert worksheet brightness` "
+#| "menu entry that allows to quickly convert the worksheet from dark to "
+#| "bright and vice versa."
+msgid ""
+"If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if "
+"the rest of the operating system is. The worksheet itself is by default "
+"equipped with a bright background. But it can be configured otherwise. "
+"Alternatively, there is a `View/Invert worksheet brightness` menu entry that "
+"allows to quickly convert the worksheet from dark to bright and vice versa."
+msgstr ""
+"Wenn wxWidgets neu genug ist, sollte wxMaxima sich automatisch im Dark Mode "
+"befinden, wenn der Rest des Betriebssystems es ist. Das Arbeitsblatt selbst "
+"besitzt standardmäßig einen hellen Hintergrund. Dies kann aber über die "
+"Konfiguration geändert werden. Als Alternative erlaubt `Ansicht/Invertiere "
+"die Helligkeit des Arbeitsblattes`, das Arbeitsblatt schnell zwischen hell "
+"und dunkel umzustellen."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1114
+#, fuzzy, no-wrap
+#| msgid "## _WxMaxima_ sometimes hangs for several seconds once in the first minute"
+msgid "_WxMaxima_ sometimes hangs for several seconds once in the first minute"
+msgstr "## _WxMaxima_ hängt manchmal in der ersten Minute einmal für mehrere Sekunden"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1117
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work."
+msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.\n"
+msgstr "WxMaxima lagert große Aufgaben, wie das Interpretieren des >1000-Seiten-Handbuchs von Maxima an Hintergrundtasks aus. Solange die Ergebnisse dieser Tasks nicht benötigt werden, kann während dieser Zeit ganz normal weitergearbeitet werden. Wird aber eine Aktion ausgeführt, für die die Ergebnisse eines Tasks benötigt werden, muss _wxMaxima_ warten, bis dieser beendet ist."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1118
+#, fuzzy, no-wrap
+#| msgid "## Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+msgid "Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+msgstr "## Speziell wenn man neue Spracheinstellungen testet, kann eine Nachrichtenbox \"locale 'xx_YY' can not be set\" angezeigt werden."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1121
+msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
+msgstr "![Locale Warnung](./locale-warning.png){ id=img_locale_warning}"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1125
+msgid ""
+"(The same problem can occur with other applications too). The translations "
+"seem okay after you click on ’OK’. WxMaxima does not only use its own "
+"translations but the translations of the wxWidgets framework too."
+msgstr ""
+"(Dieses Problem kann bei anderen Anwendungen auch auftreten). Die "
+"Übersetzungen scheinen okay zu sein, nachdem auf 'OK' geklickt wurde. "
+"WxMaxima verwendet nicht nur die eigenen Übersetzungen sondern auch "
+"Übersetzungen des wxWidgets Frameworks."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1128
+msgid ""
+"These locales maybe not present in the system. On Ubuntu/Debian systems they "
+"can be generated using: `dpkg-reconfigure locales`"
+msgstr ""
+"Diese Übersetzungen sind möglicherweise im System nicht vorhanden. Auf "
+"Ubuntu/Debian Linux-Systemen können sie mit `dpkg-reconfigure locales` "
+"erzeugt werden."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1129
+#, fuzzy, no-wrap
+#| msgid "## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
+msgid "How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
+msgstr "## Wie kann man Symbole für reele Zahlen, ganze Zahlen (ℝ, ℕ), etc. verwenden?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1132
+msgid ""
+"You can find these symbols in the Unicode sidebar (search for ’double-struck "
+"capital’). But the selected font must also support these symbols. If they do "
+"not display properly, select another font."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1133
+#, fuzzy, no-wrap
+#| msgid "## How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
+msgid "How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
+msgstr "## Wie kann ein Maxima-Skript feststellen, ob es unter wxMaxima oder Kommandozeilen-Maxima läuft?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1136
+msgid ""
+"If wxMaxima is used, the Maxima variable `maxima_frontend` is set to "
+"`wxmaxima`. The Maxima variable `maxima_frontend_version` contains the "
+"wxMaxima version in this case."
+msgstr ""
+"Wenn wxMaxima verwendet wird, hat die Maxima-Variable `maxima_frontend` den "
+"Wert wxmaxima`. Die Maxima-Variable `maxima_frontend_version` enthält dann "
+"die wxMaxima-Version."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1138
+msgid ""
+"If no frontend is used (you are using command line Maxima), these variables "
+"are `false`."
+msgstr ""
+"Wenn kein Frontend verwendet wird (Kommandozeilen-Maxima wird verwendet), "
+"dann haben diese Variablen den Wert `false`)."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1139
+#, no-wrap
+msgid "Help! I can not save my document!"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1142
+#, no-wrap
+msgid "If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.\n"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1145
+#, fuzzy, no-wrap
+#| msgid "# Command-line arguments"
+msgid "Command-line arguments"
+msgstr "# Kommandozeilen-Optionen"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1148
+msgid ""
+"Usually you can start programs with a graphical user interface just by "
+"clicking on a desktop icon or desktop menu entry. WxMaxima - if started from "
+"the command line - still provides some command-line switches, though."
+msgstr ""
+"Üblicherweise werden Programme mit einer graphischen Oberfläche einfach mit "
+"einem Mausklick auf ein Desktop-Icon oder einen Desktop-Menüeintrag "
+"gestartet. WxMaxima - falls es von der Kommandozeile aus gestartet wird - "
+"bietet doch einige Kommandozeilen-Optionen."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-v` or `--version`: Output the version information"
+msgstr "`-v` oder `--version`: Gibt die Versionsnummer aus"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-h` or `--help`: Output a short help text"
+msgstr "`-h` oder `--help`: Gibt einen kurzen Hilfetext aus"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid ""
+"`-o` or `--open=<str>`: Open the filename given as an argument to this "
+"command-line switch"
+msgstr ""
+"`-o` oder `--open=<str>`: Öffnet den Dateinamen, der als Argument dieser "
+"Kommandozeilenoption angegeben wurde."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-e` or `--eval`: Evaluate the file after opening it."
+msgstr "`-e` oder `--eval`: Evaluiere die Datei nach dem Öffnen."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+#, fuzzy
+#| msgid ""
+#| "`-b` or `--batch`: If the command-line opens a file all cells in this "
+#| "file are evaluated and the file is saved afterwards. This is for example "
+#| "useful if the session described in the file makes _Maxima_ generate "
+#| "output files. Batch-processing will be stopped if _wxMaxima_ detects that "
+#| "_Maxima_ has output an error and will pause if _Maxima_ has a question: "
+#| "Mathematics is somewhat interactive by nature so a completely interaction-"
+#| "free batch processing cannot always be guaranteed."
+msgid ""
+"`-b` or `--batch`: If the command-line opens a file all cells in this file "
+"are evaluated and the file is saved afterward. This is for example useful if "
+"the session described in the file makes _Maxima_ generate output files. "
+"Batch-processing will be stopped if _wxMaxima_ detects that _Maxima_ has "
+"output an error and will pause if _Maxima_ has a question: Mathematics is "
+"somewhat interactive by nature so a completely interaction-free batch "
+"processing cannot always be guaranteed."
+msgstr ""
+"`-b` oder `--batch`: Nach dem Öffnen werden alle Code-Zellen der Datei(en) "
+"evaluiert und die Datei danach geschlossen. Dies ist beispielsweise "
+"praktisch, wenn _Maxima_ Dateien generiert. Wenn Maxima Fehler detektiert, "
+"wird dieser Vorgang abgebrochen, eventuelle Fragen an den User (Mathematik "
+"ist an einigen Stellen ein interaktiver Prozess) werden wie üblich an den "
+"User weitergereicht."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1164
+#, fuzzy, no-wrap
+#| msgid ""
+#| "* `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
+#| "* `--pipe`:                        Pipe messages from Maxima to stdout.\n"
+#| "* `--exit-on-error`:               Close the program on any maxima error.\n"
+#| "* `-f` or `--ini=<str>`: Use the init file that was given as argument to this command-line switch\n"
+#| "* `-u`, `--use-version=<str>`:     Use maxima version `<str>`.\n"
+#| "* `-l`, `--lisp=<str>`:              Use a Maxima compiled with Lisp compiler `<str>`.\n"
+#| "* `-X`, `--extra-args=<str>`:        Allows to specify extra Maxima arguments\n"
+#| "* `-m` or `--maxima=<str>`:    allows to specify the location of the _maxima_ binary\n"
+#| "* `--enableipc`: Lets Maxima control wxMaxima via interprocess communications. Use this option with care.\n"
+msgid ""
+"- `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
+"- `--pipe`:                        Pipe messages from Maxima to stdout.\n"
+"- `--exit-on-error`:               Close the program on any maxima error.\n"
+"- `-f` or `--ini=<str>`: Use the init file that was given as an argument to this command-line switch\n"
+"- `-u`, `--use-version=<str>`:     Use maxima version `<str>`.\n"
+"- `-l`, `--lisp=<str>`:              Use a Maxima compiled with Lisp compiler `<str>`.\n"
+"- `-X`, `--extra-args=<str>`:        Allows to specify extra Maxima arguments\n"
+"- `-m` or `--maxima=<str>`:    allows specifying the location of the _maxima_ binary\n"
+"- `--enableipc`: Lets Maxima control wxMaxima via interprocess communications. Use this option with care.\n"
+"- `--wxmathml-lisp=<str>`:   Location of wxMathML.lisp (if not the built-in should be used, mainly for developers).\n"
+msgstr ""
+"* `--logtostderr`:                 Gebe alle all Debug-Nachrichten auch auf der Standardfehlerausgabe (stderr) aus.\n"
+"* `--pipe`:                        Gebe die Nachrichten von Maxima auch auf die Konsole aus.\n"
+"* `--exit-on-error`:               Schließe wxMaxima, wenn Maxima einen Fehler detektiert.\n"
+"* `-f` oder `--ini=<str>`:           Speichere die Konfiguration in der Datei `<str>`\n"
+"* `-u`, `--use-version=<str>`:     Verwende Maxima-Version `<str>`\n"
+"* `-l`, `--lisp=<str>`:            Verwende ein Maxima, das mit dem Lisp Compiler `<str>` compiliert wurde.\n"
+"* `-X`, `--extra-args=<str>`:      Erlaubt, Maxima zusätzliche Argumente mitzugeben\n"
+"* `-m` oder `--maxima=<str>`:      Sagt, wo die ausführbare Datei von _maxima_ liegt.\n"
+"* `--enableipc`: Lässt Maxima wxMaxima über Interprozesskommunikation ansteuern. Diese Option vorsichtig verwenden.\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1166
+msgid ""
+"Instead of a minus, some operating systems might use a dash in front of the "
+"command-line switches."
+msgstr ""
+"Manche Betriebssysteme verwenden bei Kommandozeilenparametern einen "
+"Schrägstrich statt eines Minuszeichens."
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1169
+#, fuzzy, no-wrap
+#| msgid "# About the program, contributing to wxMaxima"
+msgid "About the program, contributing to wxMaxima"
+msgstr "# Über das Programm, zu wxMaxima beitragen"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1172
+msgid ""
+"wxMaxima is mainly developed using the programming language C++ using the "
+"[wxWidgets framework](https://www.wxwidgets.org), as build system we use "
+"[CMake](https://www.cmake.org), a small part is written in Lisp. You can "
+"contribute to wxMaxima, join the wxMaxima project at <https://github.com/"
+"wxMaxima-developers/wxmaxima>, if you have knowledge of these programming "
+"languages and want to help and contribute to the open source project "
+"wxMaxima."
+msgstr ""
+"WxMaxima wird hauptsächlich in der Programmiersprache C++ entwickelt, "
+"verwendet das [wxWidgets framework](https://www.wxwidgets.org), als Build-"
+"System verwenden wir CMake, ein kleiner Teil ist in Lisp geschrieben. Sie "
+"können zu wxMaxima beitragen, werden Sie Teil des wxMaxima-Projekts auf "
+"<https://github.com/wxMaxima-developers/wxmaxima>, wenn Sie Kenntnisse "
+"dieser Programmiersprachen haben und zum Open-Source-Projekt wxMaxima etwas "
+"beitragen können."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1174
+msgid ""
+"But not only programmers are necessary! You can also contribute to wxMaxima, "
+"if you help to improve the documentation, find and report bugs (and maybe "
+"bugfixes), suggest new features, help to translate wxMaxima or the manual to "
+"your language (read the README.md in the [locale subdirectory](https://"
+"github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and "
+"the manual can be translated)."
+msgstr ""
+"Aber nicht nur Programmierer sind notwendig! Sie können auch zu wxMaxima "
+"beitragen, indem Sie die Dokumentation verbessern, Fehler finden und melden "
+"(und vielleicht auch Fehlerlösungen) oder wxMaxima oder die Anleitung "
+"übersetzen helfen (Siehe die Readme-Datei im [locale subdirectory](https://"
+"github.com/wxMaxima-developers/wxmaxima/tree/main/locales), wie das "
+"übersetzen funktioniert."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1176
+msgid "Or answer questions of other users in the discussion forum."
+msgstr "Oder Fragen von anderen Benutzern im Diskussionsforum beantworten."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1178
+msgid ""
+"The source code of wxMaxima is documented using Doxygen [here](https://"
+"wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+msgstr ""
+"Der Quellcode von wxMaxima ist mit Doxygen [hier](https://wxmaxima-"
+"developers.github.io/wxmaxima/Doxygen-documentation/) dokumentiert."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1180
+msgid ""
+"The program is nearly self-contained, so except for system libraries (and "
+"the wxWidgets library), no external dependencies (like graphic files or the "
+"Lisp part (the `wxmathML.lisp`-file) is needed, these files are included in "
+"the executable."
+msgstr ""
+"Das Programm ist nahezu unabhängig, ausser einiger Systembibliotheken (und "
+"der wxWidgets-Bibliothek) sind keine externen Abhängigkeiten (z.B. externe "
+"Graphiken oder der Lisp-Teil (die `wxMathML.lisp`-Datei) notwendig, diese "
+"Dateien sind alle in wxMaxima eingebaut."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1181
+#, fuzzy, no-wrap
+#| msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one."
+msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.\n"
+msgstr "Wenn Sie ein Entwickler sind und eine modifizierte `wxmathML.lisp`-Datei verwenden wollen, ohne alles neu zu compilieren, kann mit der Kommandozeilenoption `--wxmathml-lisp=<str>` eine andere Lisp-Datei verwendet werden, nicht die eincompilierte Variante."
+
+#, fuzzy
+#~| msgid "    load(draw);\n"
+#~ msgid "```maxima load(draw);"
+#~ msgstr "    load(draw);\n"
+
+#, fuzzy
+#~| msgid ""
+#~| "    /* Parabola in window #1 */\n"
+#~| "    draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+#~ msgid ""
+#~ "/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
+#~ msgstr ""
+#~ "    /* Eine Parabel in Fenster #1 */\n"
+#~ "    draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+
+#, fuzzy
+#~| msgid ""
+#~| "    /* Parabola in window #2 */\n"
+#~| "    draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+#~ msgid ""
+#~ "/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
+#~ msgstr ""
+#~ "    /* Eine Parabel in Fenster #2 */\n"
+#~ "    draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+
+#, fuzzy
+#~| msgid ""
+#~| "    /* Paraboloid in window #3 */\n"
+#~| "    draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
+#~| "```\n"
+#~ msgid ""
+#~ "/* Paraboloid in window #3 */ draw3d(terminal=[wxt,3],explicit(x^2+y^2,"
+#~ "x,-1,1,y,-1,1)); ```"
+#~ msgstr ""
+#~ "    /* Ein Paraboloid in Fenster #3 */\n"
+#~ "    draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
+
+#~ msgid "#### 2D"
+#~ msgstr "#### 2D"
+
+#~ msgid "#### 3D"
+#~ msgstr "#### 3D"
+
+#~ msgid "```maxima playback(); ```"
+#~ msgstr "```maxima playback(); ```"
+
+#, fuzzy
+#~| msgid ""
+#~| "pngdraw2d(\"Test\",\n"
+#~| "        explicit(sin(x),x,1,10)\n"
+#~| ");\n"
+#~| "~~~~\n"
+#~ msgid ""
+#~ "pngdraw2d(\"Test\",\n"
+#~ "        explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "pngdraw2d(\\\"Test\\\",\n"
+#~ "        explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+#~ "~~~~\n"

--- a/locales/manual/es.po
+++ b/locales/manual/es.po
@@ -1,0 +1,4820 @@
+# Spanish transaltion for wxmaxima 20.12.2 manual
+# Copyright (C) 2021 Free Software Foundation, Inc.
+# This file is distributed under the same license as the wxMAxima package.
+# F. Javier Serrador <fserrador@gmail.com>, 2021.
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: wxmaxima-gui\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-04 07:28+0000\n"
+"PO-Revision-Date: 2026-08-02 11:42\n"
+"Last-Translator: \n"
+"Language-Team: Spanish\n"
+"Language: es_ES\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: wxmaxima-gui\n"
+"X-Crowdin-Project-ID: 917703\n"
+"X-Crowdin-Language: es-ES\n"
+"X-Crowdin-File: /main/locales/wxMaxima/wxMaxima.pot\n"
+"X-Crowdin-File-ID: 8\n"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1
+#, fuzzy, no-wrap
+#| msgid "# The wxMaxima user manual"
+msgid "The wxMaxima user manual"
+msgstr "# El manual del usuario de wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:4
+msgid ""
+"WxMaxima is a graphical user interface (GUI) for the _Maxima_ computer "
+"algebra system (CAS). WxMaxima allows one to use all of _Maxima_’s "
+"functions. In addition, it provides convenient wizards for accessing the "
+"most commonly used features. This manual describes some of the features that "
+"make wxMaxima one of the most popular GUIs for _Maxima_."
+msgstr ""
+"WxMaxima es un interfaz gráfico del usuario (IGU) para el sistema algebraico "
+"de computación _Maxima_ (CAS). WxMaxima le permite a uno utilizar todas las "
+"funciones de _Maxima_.  Además, proporciona asistentes convenientes para "
+"acceder a las características más comúnmente utilizadas.  Este manual "
+"describe alguna de las características que hacen de wxMaxima una de las IGU "
+"más populares para _Maxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:6
+msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
+msgstr "![Logotipo wxMaxima](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:9
+#, fuzzy, no-wrap
+#| msgid "# Introduction to wxMaxima"
+msgid "Introduction to wxMaxima"
+msgstr "# Introducción a wxMaxima"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:11
+#, fuzzy, no-wrap
+#| msgid "## _Maxima_ and wxMaxima"
+msgid "_Maxima_ and wxMaxima"
+msgstr "## _Maxima_ y wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:14
+msgid ""
+"In the open-source domain, big systems are normally split into smaller "
+"projects that are easier to handle for small groups of developers. For "
+"example a CD burner program will consist of a command-line tool that "
+"actually burns the CD and a graphical user interface that allows users to "
+"implement it without having to learn about all the command line switches and "
+"in fact without using the command line at all. One advantage of this "
+"approach is that the developing work that was invested into the command-line "
+"program can be shared by many programs: The same CD-burner command-line "
+"program can be used as a “send-to-CD”-plug-in for a file manager "
+"application, for the “burn to CD” function of a music player and as the CD "
+"writer for a DVD backup tool. Another advantage is that splitting one big "
+"task into smaller parts allows the developers to provide several user "
+"interfaces for the same program."
+msgstr ""
+"En el dominio de código abierto, los sistemas grandes están divididos "
+"normalmente en proyectos más pequeños que son más fáciles para manipular en "
+"grupos pequeños de desarrolladores.  Por ejemplo un programa para el quemado "
+"del DVD consistirá de una herramienta de línea de instrucciones que "
+"actualmente quema el CD un interfaz gráfico de usuario que permite a los "
+"usuarios implementarlo sin tener que aprenderse todas las opciones de línea "
+"de instrucciones como complemento “enviar-a-CD” para una aplicación de "
+"gestión de archivos, para la función N “quemar a CD” de un reproductor de "
+"música y como el grabador de CD para una herramienta de respaldo DVD.  Otra "
+"ventaja es que dividiendo una tarea grande en partes más pequeñas permite a "
+"los desarrolladores proporcionar varios interfaces de usuarios para el mismo "
+"programa."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:16
+msgid ""
+"A computer algebra system (CAS) like _Maxima_ fits into this framework. A "
+"CAS can provide the logic behind an arbitrary precision calculator "
+"application or it can do automatic transforms of formulas in the background "
+"of a bigger system (e.g., [Sage](https://www.sagemath.org/)). Alternatively, "
+"it can be used directly as a free-standing system. _Maxima_ can be accessed "
+"via a command line. Often, however, an interface like _wxMaxima_ proves a "
+"more efficient way to access the software, especially for newcomers."
+msgstr ""
+"Un sistema de computación algebraico (CAS) como _Maxima_ encaja dentro de "
+"este marco referencial. Un CAS puede proporcionar la lógica detrás de la "
+"aplicación de precisión de cálculo arbitrario o puede hacer transformaciones "
+"automáticas de fórmulas en el segundo plano de un sistema más grande (p.e., "
+"[Sage] (https://www.sagemath.org/)).  Alternativamente, puede ser utilizado "
+"directamente como un sistema independiente.  _Maxima_ pude ser accedido vía "
+"una línea de instrucción.  A menudo, sin embargo, un interfaz como "
+"_wxMaxima_ proporciona una manera más eficiente para acceder al software, "
+"especialmente para los recién llegados."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:17
+#, fuzzy, no-wrap
+#| msgid "### _Maxima_"
+msgid "_Maxima_"
+msgstr "### _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:20
+msgid ""
+"_Maxima_ is a full-featured computer algebra system (CAS). A CAS is a "
+"program that can solve mathematical problems by rearranging formulas and "
+"finding a formula that solves the problem as opposed to just outputting the "
+"numeric value of the result. In other words, _Maxima_ can serve as a "
+"calculator that gives numerical representations of variables, and it can "
+"also provide analytical solutions. Furthermore, it offers a range of "
+"numerical methods of analysis for equations or systems of equations that "
+"cannot be solved analytically."
+msgstr ""
+"_Maxima_ es un sistema algebraico computador completo (CAS) de "
+"características. Un CAS es un programa que puede resolver problemas "
+"matemáticos reconociendo fórmulas y encontrando una fórmula que resuelva el "
+"problema como difícil a ajustar la salida del valor numérico del resultado.  "
+"En otras palabras, _Maxima_ pude servir como una calculadora que proporciona "
+"representaciones numéricas de variables, y además puede proporcionar "
+"soluciones analíticas.  Más aún, ofrece un rango de métodos numéricos para "
+"ecuaciones o sistemas de ecuaciones que no pueden ser analíticamente "
+"resueltos."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:22
+msgid ""
+"![Maxima screenshot, command line](./maxima_screenshot.png)"
+"{ id=img_maxima_screenshot }"
+msgstr ""
+"![Pantallazo de Maxima, línea intrucción](./maxima_screenshot.png)"
+"{ id=img_maxima_pantallazo }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:24
+#, fuzzy, no-wrap
+#| msgid "Extensive documentation for _Maxima_ is [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor."
+msgid "Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.\n"
+msgstr "Documentación extensiva para _Maxima_ está [disponible en Internet](https://maxima.sourceforge.io/documentation.html).  Parte de esta documentación además está disponible en el menú de ayuda de wxMaxima.  Pulsando la tecla Ayuda (en muchos sistemas la tecla <kbd>F1</kbd>) causa que la característica de contexto de ayuda distinguible de _wxMaxima_ automáticamente vaya a la página del manual de _Maxima_ para la instrucción en el cursor."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:25
+#, fuzzy, no-wrap
+#| msgid "### WxMaxima"
+msgid "WxMaxima"
+msgstr "### WxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:28
+msgid ""
+"_WxMaxima_ is a graphical user interface that provides the full "
+"functionality and flexibility of _Maxima_. WxMaxima offers users a graphical "
+"display and many features that make working with _Maxima_ easier. For "
+"example _wxMaxima_ allows one to export any cell’s contents (or, if that is "
+"needed, any part of a formula, as well) as text, as LaTeX or as MathML "
+"specification at a simple right-click. Indeed, an entire workbook can be "
+"exported, either as a HTML file or as a LaTeX file. Documentation for "
+"_wxMaxima_, including workbooks to illustrate aspects of its use, is online "
+"at the _wxMaxima_ [help site](https://wxMaxima-developers.github.io/wxmaxima/"
+"help.html), as well as via the help menu."
+msgstr ""
+"_WxMaxima_ es un interfaz gráfico de usuario que proporciona la "
+"funcionalidad y flexibilidad completa de _Maxima_. WxMaxima ofrece a los "
+"usuarios una pantalla gráfica y varias características que hacen trabajar "
+"más fácilmente con _Maxima_.  Por ejemplo _wxMaxima_ permite a uno exportar "
+"cualquier contenido de celdas (o, si eso es necesario, cualquier parte de "
+"una fórmula, también) como texto, como LaTeX o especificación MathML en una "
+"sola pulsación secundaria.  Por cierto, puede exportarse un cuaderno "
+"completo, ya sea como un archivo HTML o como un archivo LaTeX.  La "
+"documentación para _wxMaxima_, incluyendo los cuadernos para ilustrar "
+"aspectos de su uso, está por conexión al [sitio web](https://wxMaxima-"
+"developers.github.io/wxmaxima/help.html) de _wxMaxima_, así como a través "
+"del menú de ayuda."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:30
+msgid "![wxMaxima window](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
+msgstr "![Ventana de wxMaxima](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:32
+msgid ""
+"The calculations that are entered in _wxMaxima_ are performed by the "
+"_Maxima_ command-line tool in the background."
+msgstr ""
+"Los cálculos que son introducidos en _wxMaxima_ son realizados por la "
+"herramienta de línea de instrucciones de _Maxima_ en el segundo plano."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:33
+#, fuzzy, no-wrap
+#| msgid "## Workbook basics"
+msgid "Workbook basics"
+msgstr "## Cuaderno básico"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:36
+msgid ""
+"Much of _wxMaxima_ is self-explaining, but some details require attention. "
+"[This site](https://wxMaxima-developers.github.io/wxmaxima/help.html) "
+"contains a number of workbooks that address various aspects of _wxMaxima_. "
+"Working through some of these (particularly the \"10 minute _(wx)Maxima_ "
+"tutorial\") will increase one’s familiarity with both the content of "
+"_Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. This manual "
+"concentrates on describing aspects of _wxMaxima_ that are not likely to be "
+"self-evident and that might not be covered in the online material."
+msgstr ""
+"Mucho de _wxMaxima_ son auto-explicativos, pero algunos detalles requieren "
+"atención.  [Este sitio](https://wxMaxima-developers.github.io/wxmaxima/help."
+"html) contiene un número de cuadernos que dirige varios aspectos de "
+"_wxMaxima_.  Trabaja a lo largo de estos (particularmente el tutorial de «10 "
+"minutos _(wx)Maxima_») incrementará la familiaridad de uno con ambos del "
+"contenido de _Maxima_ y el uso de _wxMAxima_ para interactuar con _Maxima_.  "
+"Este manual se concentra en describir aspectos de _wxMaxima_ que no son como "
+"los evidentes y que tal vez no está cubierto dentro del material en línea."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:37
+#, fuzzy, no-wrap
+#| msgid "### The workbook approach"
+msgid "The workbook approach"
+msgstr "### La aproximación del cuaderno"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:40
+msgid ""
+"One of the very few things that are not standard in _wxMaxima_ is that it "
+"organizes the data for _Maxima_ into cells that are evaluated (which means: "
+"sent to _Maxima_) only when the user requests this. When a cell is "
+"evaluated, all commands in that cell, and only that cell, are evaluated as a "
+"batch. (The preceding statement is not quite accurate: One can select a set "
+"of adjacent cells and evaluate them together. Also, one can instruct "
+"_Maxima_ to evaluate all cells in a workbook in one pass.) _WxMaxima_’s "
+"approach to submitting commands for execution might feel unfamiliar at the "
+"first sight. It does, however, drastically ease work with big documents "
+"(where the user does not want every change to automatically trigger a full "
+"re-evaluation of the whole document). Also, this approach is very handy for "
+"debugging."
+msgstr ""
+"Una de las muy pocas cosas que no están normalizadas en _wxMaxima_ es que se "
+"organiza los datos para _Maxima_ dentro de celdas que son evaluadas (la cual "
+"indica: envía a _Maxima_) solamente cuando solicita el usuario esto.  Cuando "
+"una celda es evaluada, todas las instrucciones dentro de esa celda, y "
+"solamente esa celda, son evaluadas como un guion. (El enunciado precedente "
+"no es muy preciso: uno puede seleccionar un conjunto de celdas adyacentes y "
+"evaluarlas a la vez. Además, uno puede instruir a _Maxima_ que evalúe todas "
+"las celdas dentro de un cuaderno en una pasada). La aproximación de "
+"_wxMaxima para enviar instrucciones para ejecutar tal vez se sienta poco "
+"familiar en el primer momento. Sin embargo, drásticamente trabaja fácilmente "
+"con documentos grandes (cuando el usuario no desea cada modificación para "
+"disparar automáticamente una re-evaluación completa del todo el documento).  "
+"Además, esta aproximación es muy útil para depurar."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:42
+msgid ""
+"If text is typed into _wxMaxima_ it automatically creates a new worksheet "
+"cell. The type of this cell can be selected in the toolbar. If a code cell "
+"is created the cell can be sent to _Maxima_, which causes the result of the "
+"calculation to be displayed below the code. A pair of such commands is shown "
+"below."
+msgstr ""
+"Si el texto está tecleado en _wxMaxima_ automáticamente crea una celda de "
+"hoja de trabajo nueva.  El tipo de esta celda puede ser seleccionado en la "
+"barra de herramientas.  Si se crea una celda de código, la celda puede ser "
+"enviada a _Maxima_, la cual causa que el resultado del cálculo es desplegado "
+"debajo del código.  Una pareja de dichas instrucciones se muestra debajo."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:44
+msgid "![Input/output cell](./InputCell.png){ id=img_InputCell }"
+msgstr "![Celda de entrada/salida](./InputCell.png){ id=img_InputCell }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:46
+msgid ""
+"On evaluation of an input cell’s contents the input cell _Maxima_ assigns a "
+"label to the input (by default shown in red and recognizable by the `%i`) by "
+"which it can be referenced later in the _wxMaxima_ session. The output that "
+"_Maxima_ generates also gets a label that begins with `%o` and by default is "
+"hidden, except if the user assigns the output a name. In this case by "
+"default the user-defined label is displayed. The `%o`-style label _Maxima_ "
+"auto-generates will also be accessible, though."
+msgstr ""
+"En la evaluación de los contenidos de celda de entrada la celda _Maxima_ de "
+"entrada asigna una etiqueta a la entrada (por defecto muestra en rojo y "
+"reconocible por el `%i`) por el cual puede ser referenciado posteriormente "
+"dentro de la sesión _wxMaxima_.  La salida que genera _Maxima_ además "
+"obtiene una etiqueta que comience con `%o` y por defecto está oculta, "
+"excepto si el usuario asigna la salida un nombre.  En este caso por defecto "
+"el etiquetado definido por el usuario está desplegado.  El estilo `%o` de "
+"etiquetado _Maxima_ auto-genera además será accesible, sin embargo."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:48
+msgid ""
+"Besides the input cells _wxMaxima_ allows for text cells for documentation, "
+"image cells, title cells, chapter cells and section cells. Every cell has "
+"its own undo buffer so debugging by changing the values of several cells and "
+"then gradually reverting the unneeded changes is rather easy. Furthermore "
+"the worksheet itself has a global undo buffer that can undo cell edits, adds "
+"and deletes."
+msgstr ""
+"Al lado de las celdas de entradas _wxMaxima_ permite celdas de texto para "
+"documentación, celdas de imagen, celdas de título, celdas de capítulo y "
+"celdas de sección.  Cada celda tiene su propio tampón para deshacer por lo "
+"que se depura a través de modificar los valores de varias celdas y después "
+"gradualmente es más fácil revertir las modificaciones no necesarias.  Además "
+"la misma hoja de trabajo tiene un tampón global para deshacer que puede "
+"deshacer celdas editadas, agregar y borrar."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:50
+msgid ""
+"The figure below shows different cell types (title cells, section cells, "
+"subsection cells, text cells, input/output cells and image cells)."
+msgstr ""
+"La figura inferior muestra tipos de celda diferentes (celdas título, "
+"sección, subsección, texto, E/S e imagen)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:52
+msgid ""
+"![Example of different wxMaxima cells](./cell-example.png){ id=img_cell-"
+"example }"
+msgstr ""
+"![Ejemplo de celdas wxMaxima](./cell-example.png){ id=img_cell-example }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:53
+#, fuzzy, no-wrap
+#| msgid "### Cells"
+msgid "Cells"
+msgstr "### Celdas"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:56
+msgid ""
+"The worksheet is organized in cells. WxMaxima knows the following cell types:"
+msgstr ""
+"La hoja de trabajo está organizada dentro de celdas.  wxmaxima conoce los "
+"tipos de celdas siguientes:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+#, fuzzy
+#| msgid "one or more lines of _Maxima_ input"
+msgid "Math cells, containing one or more lines of _Maxima_ input."
+msgstr "una o más líneas _Maxima_ de entrada"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+#, fuzzy
+#| msgid "output of, or a question from, _Maxima_"
+msgid "Output of, or a question from, _Maxima_."
+msgstr "salida de, o una pregunta desde, _Maxima_"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Image cells."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+#, fuzzy
+#| msgid "a text block that can for example be used for documentation"
+msgid "Text cells, that can for example be used for documentation."
+msgstr ""
+"un bloque de texto que puede por ejemplo ser utilizado para documentación"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid ""
+"A title, section or a subsection. 6 levels of different headings are "
+"possible."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Page breaks."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:65
+msgid ""
+"The default behavior of _wxMaxima_ when text is entered is to automatically "
+"create a math cell. Cells of other types can be created using the Cell menu, "
+"using the hot keys shown in the menu or using the drop-down list in the "
+"toolbar. Once the non-math cell is created, whatever is typed into the file "
+"is interpreted as text."
+msgstr ""
+"El comportamiento predeterminado de _wxMaxima_ cuando el texto es teclado "
+"para creación automática de una celda matemática.  Las celdas de otros tipos "
+"puede ser creadas utilizando el menú Celda, utilizando las teclas resaltadas "
+"mostradas dentro del menú o utilizando el listado de arrastrar-bajar dentro "
+"de la barra de herramientas.  Una vez que la celda no matemática es creada, "
+"lo que se teclee dentro del archivo es interpretado como texto."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:67
+msgid ""
+"A (C-style) [comment text](https://maxima.sourceforge.io/docs/manual/"
+"maxima_singlepage.html#Comments) can be part of a math cell as follows: `/* "
+"This comment will be ignored by Maxima */`"
+msgstr ""
+"Un [comentario de texto] (C-style)(https://maxima.sourceforge.io/docs/manual/"
+"maxima_singlepage.html#Comments) puede ser parte de una celda matemática "
+"como sigue: `/* Este comentario será ignorado por Maxima */`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:69
+msgid "\"`/*`\" marks the start of the comment, \"`*/`\" the end."
+msgstr "\"`/*`\" marca el inicio del comentario, \"`*/`\" el final."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:70
+#, fuzzy, no-wrap
+#| msgid "### Horizontal and vertical cursors"
+msgid "Horizontal and vertical cursors"
+msgstr "### Cursores horizontales y verticales"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:73
+msgid ""
+"If the user tries to select a complete sentence, a word processor will try "
+"to extend the selection to automatically begin and end with a word boundary. "
+"Likewise, if more than one cell is selected, _wxMaxima_ will extend the "
+"selection to whole cells."
+msgstr ""
+"Si el usuario intenta seccionar una oración completa, un procesador de "
+"palabras intentará extender la selección para iniciar y finalizar "
+"automáticamente con una palabra acotada.  Así mismo, si está seleccionada "
+"más de una celda, _wxMaxima_ extenderá la selección a todas las celdas."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:75
+msgid ""
+"What isn’t standard is that _wxMaxima_ provides drag-and-drop flexibility by "
+"defining two types of cursors. _WxMaxima_ will switch between them "
+"automatically when needed:"
+msgstr ""
+"Que no es estándar es que _wxMaxima_ proporciona flexibilidad para arrastrar-"
+"y-soltar definiendo dos tipos de cursores. _wxMaxima_ conmutará entre ellos "
+"automáticamente cuando lo necesite:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:78
+msgid ""
+"The cursor is drawn horizontally if it is moved in the space between two "
+"cells or by clicking there."
+msgstr ""
+"El cursor es dibujado horizontalmente si es trasladado dentro del espacio "
+"entre dos celdas o pulsando allí."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:78
+#, fuzzy
+#| msgid ""
+#| "- The cursor is drawn horizontally if it is moved in the space between "
+#| "two cells or by clicking there.  - A vertical cursor that works inside a "
+#| "cell. This cursor is activated by moving the cursor inside a cell using "
+#| "the mouse pointer or the cursor keys and works much like the cursor in a "
+#| "text editor."
+msgid ""
+"A vertical cursor that works inside a cell. This cursor is activated by "
+"moving the cursor inside a cell using the mouse pointer or the cursor keys "
+"and works much like the cursor in a text editor."
+msgstr ""
+"- El cursor se dibuja horizontalmente si es trasladado dentro del espacio "
+"entre dos celdas o pulsando allí.  - Puede funcionar un cursor vertical "
+"dentro de una celda. Este cursor está activado moviendo el cursor dentro de "
+"una celda utilizando el puntero del ratón o las teclas del cursor y funciona "
+"como el cursor en un editor de texto."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:80
+#, fuzzy, no-wrap
+#| msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`)."
+msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).\n"
+msgstr "Cuando arranque wxMaxima, solo verá el cursor horizontal parpadeando. Si inicia al teclear, automáticamente será creada una celda matemática y el cursor cambiará a una vertical usual (verá una flecha derecha como \"petición\", tras ser evaluada la celda matemática (<kbd>CTRL</kbd>+<kbd>ENTRAR</kbd>), verá las etiquetas, p.ej. `(%i1)`, `(%o1)`)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:82
+msgid ""
+"![(blinking) horizontal cursor after wxMaxima start](./horizontal-cursor-"
+"only.png){ id=img_horizontal_cursor_only }"
+msgstr ""
+"![(parpadeando) cursor horizontal tras iniciar wxMaxima](./horizontal-cursor-"
+"only.png){ id=img_horizontal_cursor_only }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:84
+msgid ""
+"You might want to create a different cell type (using the \"Cell\" menu), "
+"maybe a title cell or text cell, which describes, what will be done, when "
+"you start creating your worksheet."
+msgstr ""
+"Quizá desea crear un tipo de celda diferente (utilizando el menú «Celda»), "
+"puede ser una celda titular o de texto, la cual describe que será hecho, "
+"cuando inicia crear su hoja de trabajo."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:86
+msgid ""
+"If you navigate between the different cells, you will also see the "
+"(blinking) horizontal cursor, where you can insert a cell into your "
+"worksheet (either a math cell, by just start typing your formula - or a "
+"different cell type using the menu)."
+msgstr ""
+"Si navegas entre las celdas diferentes, además verá el (parpadeo) cursor "
+"horizontal, donde puede insertar una celda a su hoja de trabajo (bien una "
+"celda matemática, por tan solo inicie tecleando su fórmula - o un tipo de "
+"celda diferente utilizando el menú)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:88
+msgid ""
+"![(blinking) horizontal cursor between cells](./horizontal-cursor-between-"
+"cells.png){ id=img_horizontal_cursor_between_cells }"
+msgstr ""
+"![(parpadeo) del cursor horizontal entre celdas](./horizontal-cursor-between-"
+"cells.png){ id=img_horizontal_cursor_between_cells }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:89
+#, fuzzy, no-wrap
+#| msgid "### Sending cells to Maxima"
+msgid "Sending cells to Maxima"
+msgstr "### Enviar celdas a “Maxima”"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:92
+#, fuzzy, no-wrap
+#| msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>."
+msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.\n"
+msgstr "La instrucción dentro de una celda de código es ejecutada una vez pulsando <kbd>CTRL</kbd>+<kbd>ENTRAR</kbd>, <kbd>MAYÚS</kbd>+<kbd>ENTRAR</kbd> o la tecla <kbd>ENTRAR</kbd> en el teclado numérico. Lo predeterminado de _wxMaxima_ es introducir instrucciones cuando se introduzca <kbd>CTRL</kbd>+<kbd>ENTRAR</kbd> o <kbd>MAYÚS</kbd>+<kbd>ENTRAR</kbd>, pero _wxMaxima_ puede ser configurado para ejecutar instrucciones como respuesta al <kbd>ENTRAR</kbd>."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:93
+#, fuzzy, no-wrap
+#| msgid "### Command autocompletion"
+msgid "Command autocompletion"
+msgstr "### Instrucción con auto-completado"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:96
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units."
+msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.\n"
+msgstr "_WxMaxima_ contiene una característica de auto-completado que es disparada a través del menú (Celda/Palabra Completa) o alternativamente pulsando la combinación de teclas <kbd>CTRL</kbd>+<kbd>ESPACIO</kbd>.  El auto-completado distingue MAYÚS/minús.  Por ejemplo si está activado dentro de una especificación unitaria para ezUnits ofrecerá un listado de unidades aplicables."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:98
+msgid "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
+msgstr "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:100
+#, fuzzy, no-wrap
+#| msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template)."
+msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).\n"
+msgstr "Al lado de completar un nombre de archivo, un nombre de unidad o la instrucción actual o el nombre de variable, el auto-completado es capas de mostrar una plantilla para muchas de las instrucciones iniciando el tipo (y significado) de los parámetros que este programa espera. Para activar esta característica presione <kbd>MAYÚS</kbd>+<kbd>CTRL</kbd>+<kbd>ESPACIO</kbd> o seleccione el ítem del menú respectivo (Celda/Mostrar plantilla)."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:101
+#, fuzzy, no-wrap
+#| msgid "#### Greek characters"
+msgid "Greek characters"
+msgstr "#### Caracteres griegos"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:104
+msgid ""
+"Computers traditionally stored characters in 8-bit values. This allows for a "
+"maximum of 256 different characters. All letters, numbers, and control "
+"symbols (end of transmission, end of string, lines and edges for drawing "
+"rectangles for menus _etc_.) of nearly any given language can fit within "
+"that limit."
+msgstr ""
+"Equipos tradicionalmente almacenados en valores 8-bit.  Esto permite para un "
+"máximo de 256 caracteres diferentes.  Todas las letras, números t y símbolos "
+"de control (final de transmisión, final de cadena, líneas y bordes para "
+"dibujar rectángulos para menús :etc_.) de cerca cualquier idioma puede caber "
+"dentro de ese límite."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:106
+msgid ""
+"For most countries, the codepage of 256 characters that has been chosen does "
+"not include things like Greek letters, though, that are frequently used in "
+"mathematics. To overcome this type of limitation [Unicode](https://home."
+"unicode.org/) has been invented: An encoding that makes English text work "
+"like normal, but to use much more than 256 characters."
+msgstr ""
+"Para muchos países, la página de código de 256 caracteres que han sido "
+"elegidos no incluyen cosas como letras griegas, por lo que, eso es utilizado "
+"frecuentemente en matemáticas.  Para solucionar este tipo de limitación "
+"[Unicode] (https://home.unicode.org/) ha sido inventado: una codificación "
+"que hace que el texto inglés funcione como normal, pero para utilizar más "
+"que los 256 caracteres."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:108
+msgid ""
+"_Maxima_ allows Unicode if it was compiled using a Lisp compiler that either "
+"supports Unicode or that doesn’t care about the font encoding. As at least "
+"one of this pair of conditions is likely to be true. _WxMaxima_ provides a "
+"method of entering Greek characters using the keyboard:"
+msgstr ""
+"_Maxima_ permite Unicode si fue compilado utilizando un compilador Lisp que "
+"o bien admite Unicode o que no tomen en cuenta acerca de la codificación "
+"tipográfica.  Al menos una de este par de condiciones debe ser cierta. "
+"_wxMaxima_ proporciona un método de introducción de caracteres griegos "
+"utilizando el teclado:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:111
+msgid ""
+"A Greek letter can be entered by pressing the <kbd>ESC</kbd> key and then "
+"starting to type the Greek character’s name."
+msgstr ""
+"Puede introducir una tecla griega pulsando la tecla <kbd>ESC</kbd> y después "
+"pulsando la tecla del nombre del carácter griego."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:111
+#, fuzzy
+#| msgid ""
+#| "- A Greek letter can be entered by pressing the <kbd>ESC</kbd> key and "
+#| "then starting to type the Greek character’s name.  - Alternatively it can "
+#| "be entered by pressing <kbd>ESC</kbd>, one letter (or two for the Greek "
+#| "letter omicron) and <kbd>ESC</kbd> again. In this case the following "
+#| "letters are supported:"
+msgid ""
+"Alternatively it can be entered by pressing <kbd>ESC</kbd>, one letter (or "
+"two for the Greek letter omicron) and <kbd>ESC</kbd> again. In this case the "
+"following letters are supported:"
+msgstr ""
+"- Puede introducirse una letra griega pulsando la tecla <kbd>ESC</kbd> y "
+"después inicia el tecleo del nombre del carácter griego.  - Alternativamente "
+"puede ser introducido pulsando <kbd>ESC</kbd>, una letra (o dos para letra "
+"griega omicrón) y <kbd>Esc</kbd> otra vez. En este caso son admitidas las "
+"letras siguientes:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:130
+#, no-wrap
+msgid ""
+"| key | Greek letter | key | Greek letter | key | Greek letter |\n"
+"| :-: | :----------: | :-: | :----------: | :-: | :----------: |\n"
+"|  a  |    alpha     |  i  |     iota     |  r  |     rho      |\n"
+"|  b  |     beta     |  k  |    kappa     |  s  |    sigma     |\n"
+"|  g  |    gamma     |  l  |    lambda    |  t  |     tau      |\n"
+"|  d  |    delta     |  m  |      mu      |  u  |   upsilon    |\n"
+"|  e  |   epsilon    |  n  |      nu      |  f  |     phi      |\n"
+"|  z  |     zeta     |  x  |      xi      |  c  |     chi      |\n"
+"|  h  |     eta      | om  |   omicron    |  y  |     psi      |\n"
+"|  q  |    theta     |  p  |      pi      |  o  |    omega     |\n"
+"|  A  |    Alpha     |  I  |     Iota     |  R  |     Rho      |\n"
+"|  B  |     Beta     |  K  |    Kappa     |  S  |    Sigma     |\n"
+"|  G  |    Gamma     |  L  |    Lambda    |  T  |     Tau      |\n"
+"|  D  |    Delta     |  M  |      Mu      |  U  |   Upsilon    |\n"
+"|  E  |   Epsilon    |  N  |      Nu      |  P  |     Phi      |\n"
+"|  Z  |     Zeta     |  X  |      Xi      |  C  |     Chi      |\n"
+"|  H  |     Eta      | Om  |   Omicron    |  Y  |     Psi      |\n"
+"|  T  |    Theta     |  P  |      Pi      |  O  |    Omega     |\n"
+msgstr ""
+"| tecla | Letra griega | tecla | Letra griega | tecla | Letra griega |\n"
+"|:-----:|:------------:|:-----:|:------------:|:---- :|:------------:|\n"
+"|   a   |     alfa     |   i   |    iota      |   r   |     rho      |\n"
+"|   b   |      beta    |   k   |    kappa     |   s   |    sigma     |\n"
+"|   g   |     gamma    |   l   |    lambda    |   t   |     tau      |\n"
+"|   d   |     delta    |   m   |      mu      |   u   |   upsilon    |\n"
+"|   e   |    épsilon   |   n   |      nu      |   f   |      phi     |\n"
+"|   z   |     zeta     |   x   |      xi      |   c   |      chi     |\n"
+"|   h   |      eta     |  om   |    ómicron   |   y   |      psi     |\n"
+"|   q   |     teta     |   p   |      pi      |   o   |     omega    |\n"
+"|   A   |     Alfa     |   I   |     Iota     |   R   |      Ro      |\n"
+"|   B   |      Beta    |   K   |     Kappa    |   S   |     Sigma    |\n"
+"|   G   |     Gamma    |   L   |     Lambda   |   T   |      Tau     |\n"
+"|   D   |     Delta    |   M   |      Mu      |   U   |    Upsilon   |\n"
+"|   E   |    Épsilon   |   N   |      Nu      |   P   |      Phi     |\n"
+"|   Z   |      Zeta    |   X   |      Xi      |   C   |      Chi     |\n"
+"|   H   |      Eta     |  Om   |    Ómicron   |   Y   |      Psi     |\n"
+"|   T   |     Teta     |   P   |      Pi      |   O   |     Omega    |\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:132
+msgid ""
+"You can also use the \"Greek letters\"-sidebar to enter the Greek letters."
+msgstr ""
+"Además puede utilizar la barra lateral de «Teclas griegas» para introducir "
+"las letras griegas."
+
+#. type: Title #####
+#: ../../info/wxmaxima.md:133
+#, no-wrap
+msgid "Attention: Lookalike characters"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:138
+msgid ""
+"Several Latin letters look like the Greek letters, e.g. the Latin letter "
+"\"A\" and the Greek letter \"Alpha\". Although they look identical, they are "
+"two different Unicode characters, represented by different Unicode code "
+"points (numbers)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:143
+msgid ""
+"This might be problematic, if you assign a value to the variable A and later "
+"use the Greek letter Alpha to do something with this variable, especially on "
+"printouts.  For the Greek letter my (which is also used as prefix for micro) "
+"there are also two different Unicode code points."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:146
+msgid ""
+"The \"Greek letters\"-sidebar therefore has the option, that lookalike "
+"characters are not available (which can be changed using a right-click menu)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:148
+msgid ""
+"The same mechanism also allows to enter some miscellaneous mathematical "
+"symbols:"
+msgstr ""
+"El mismo mecanismo también permite introducir algunos símbolos matemáticos "
+"adicionales:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:199
+#, no-wrap
+msgid ""
+"| keys to enter  | mathematical symbol                                   |\n"
+"| -------------- | ----------------------------------------------------- |\n"
+"| hbar           | Planck constant: a h with a horizontal bar above it   |\n"
+"| Hbar           | a H with a horizontal bar above it                    |\n"
+"| 2              | squared                                               |\n"
+"| 3              | to the power of three                                 |\n"
+"| /2             | 1/2                                                   |\n"
+"| partial        | partial sign (the d of dx/dt)                         |\n"
+"| integral       | integral sign                                         |\n"
+"| sq             | square root                                           |\n"
+"| ii             | imaginary                                             |\n"
+"| ee             | element                                               |\n"
+"| in             | in                                                    |\n"
+"| impl implies   | implies                                               |\n"
+"| inf            | infinity                                              |\n"
+"| empty          | empty                                                 |\n"
+"| TB             | big triangle right                                    |\n"
+"| tb             | small triangle right                                  |\n"
+"| and            | and                                                   |\n"
+"| or             | or                                                    |\n"
+"| xor            | xor                                                   |\n"
+"| nand           | nand                                                  |\n"
+"| nor            | nor                                                   |\n"
+"| equiv          | equivalent to                                         |\n"
+"| not            | not                                                   |\n"
+"| union          | union                                                 |\n"
+"| inter          | intersection                                          |\n"
+"| subseteq       | subset or equal                                       |\n"
+"| subset         | subset                                                |\n"
+"| notsubseteq    | not subset or equal                                   |\n"
+"| notsubset      | not subset                                            |\n"
+"| approx         | approximately                                         |\n"
+"| propto         | proportional to                                       |\n"
+"| neq != /= or # | not equal to                                          |\n"
+"| +/- or pm      | a plus/minus sign                                     |\n"
+"| \\<= or leq     | equal or less than                                    |\n"
+"| >= or geq      | equal or greater than                                 |\n"
+"| \\<\\< or ll     | much less than                                        |\n"
+"| >> or gg       | much greater than                                     |\n"
+"| qed            | end of proof                                          |\n"
+"| nabla          | a nabla operator                                      |\n"
+"| sum            | sum sign                                              |\n"
+"| prod           | product sign                                          |\n"
+"| exists         | there exists sign                                     |\n"
+"| nexists        | there is no sign                                      |\n"
+"| parallel       | a parallel sign                                       |\n"
+"| perp           | a perpendicular sign                                  |\n"
+"| leadsto        | a leads to sign                                       |\n"
+"| ->             | a right arrow                                         |\n"
+"| -->            | a long right arrow                                    |\n"
+msgstr ""
+"| teclas a introd| símbolos matemáticos                                  |\n"
+"|----------------|-------------------------------------------------------|\n"
+"| barh           | constante de Planck: una h con una barra a hor. sobre |\n"
+"| barH           | una H con una barra hor. por encima de ésta           |\n"
+"| 2              | al cuadrado                                           |\n"
+"| 3              | al cubo                                               |\n"
+"| /2             | 1/2                                                   |\n"
+"| parcial        | signo parcial (la d de dx/dt)                         |\n"
+"| integral       | signo integral                                        |\n"
+"| sq             | raíz cuadrada                                         |\n"
+"| ii             | imaginario                                            |\n"
+"| ee             | elemento                                              |\n"
+"| in             | en, dentro de                                         |\n"
+"| impl implies   | implica                                               |\n"
+"| inf            | infinito                                              |\n"
+"| empty          | vacío                                                 |\n"
+"| TB             | triángulo derecho grande                              |\n"
+"| tb             | triángulo derecho pequeño                             |\n"
+"| and            | y                                                     |\n"
+"| or             | o                                                     |\n"
+"| xor            | ¬o                                                    |\n"
+"| nand           | ¬y                                                    |\n"
+"| nor            | ¬o                                                    |\n"
+"| equiv          | equivalente                                           |\n"
+"| not            | no                                                    |\n"
+"| union          | unión                                                 |\n"
+"| inter          | intersección                                          |\n"
+"| subseteq       | subconjunto o igual                                   |\n"
+"| subset         | subconjunto                                           |\n"
+"| notsubseteq    | no subconjunto o igual                                |\n"
+"| notsubset      | no subconjunto                                        |\n"
+"| approx         | aproximadamente                                       |\n"
+"| propto         | proporcional a                                        |\n"
+"| neq != /= o #  | no igual a                                            |\n"
+"| +/- o pm       | un signo suma/resta                                   |\n"
+"| \\<= o meq      | igual o menor que                                     |\n"
+"| >= o Meq       | igual o Mayor que                                     |\n"
+"| \\<\\< o ll      | mucho menor que                                       |\n"
+"| >> o gg        | mucho mayor que                                       |\n"
+"| equiv          | equivalente a                                         |\n"
+"| qed            | final de prueba                                       |\n"
+"| nabla          | un operador nabla                                     |\n"
+"| sum            | signo suma                                            |\n"
+"| prod           | signo producto                                        |\n"
+"| exists         | existe signo                                          |\n"
+"| nexists        | no existe signo                                       |\n"
+"| parallel       | un signo paralelo                                     |\n"
+"| perp           | un signo perpendicular                                |\n"
+"| leadsto        | una cabecera de signo                                 |\n"
+"| ->             | una flecha derecha                                    |\n"
+"| -->            | una flecha derecha más grande                         |\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:201
+msgid ""
+"You can also use the \"Symbols\"-sidebar to enter these Mathematical symbols."
+msgstr ""
+"Puede utilizar también los «Símbolos» de la barra lateral para introducir "
+"estos símbolos matemáticos."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:203
+#, fuzzy, no-wrap
+#| msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet."
+msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.\n"
+msgstr "Si un símbolo especial no está dentro del listado, es posible introducir caracteres Unicode arbitrarios pulsando <kbd>ESC</kbd> \\[número del carácter (hexadecimal)\\] <kbd>ESC</kbd>. Adicionalmente los \"símbolos\" de barra lateral tiene un menú de pulsación secundaria que permite representar un listado de todos los símbolos Unicode disponibles uno puede añadir a esta barra de herramientas o para la hoja de trabajo."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:205
+#, fuzzy, no-wrap
+#| msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`."
+msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.\n"
+msgstr "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> por tanto los resultados en una `a`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:207
+msgid ""
+"Please note that most of these symbols (notable exceptions are the logic "
+"symbols) do not have a special meaning in _Maxima_ and therefore will be "
+"interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp "
+"that doesn’t support Unicode characters they might cause an error message."
+msgstr ""
+"Note que muchos de estos símbolos (notablemente excepciones son los símbolos "
+"lógicos) no tiene un significado especial dentro de _Maxima_ y por lo tanto "
+"serán interpretados como caracteres ordinarios.  Si _Maxima_ está compilado "
+"utilizando un Lisp que no admite caracteres Unicode quizá cause un mensaje "
+"de error."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:210
+#, fuzzy, no-wrap
+#| msgid "It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.  To solve that problem, select other fonts (using: Edit -> Configure -> Style)."
+msgid ""
+"It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.\n"
+"To solve that problem, select other fonts (using: Edit -> Configure -> Style).\n"
+msgstr "Puede ser el caso que p.ej. caracteres griegos o símbolos matemáticos no estén incluidos dentro de la tipografía seleccionada, entonces puede no ser reproducibles.  Para resolver ese problema, seleccione otras tipografías (utilizando: Editar→Configurar→Estilo)."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:211
+#, fuzzy, no-wrap
+#| msgid "### Unicode replacement"
+msgid "Unicode replacement"
+msgstr "### Sustitución Unicode"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:214
+msgid ""
+"wxMaxima will replace several Unicode characters with their respective "
+"Maxima expressions, e.g. `²` with `^2`, `³` with `^3`, the square root sign "
+"with the function `sqrt()`, the (mathematical) Sigma sign (which is not the "
+"same Unicode character as the corresponding Greek letter) with `sum()`, etc."
+msgstr ""
+"wxMaxima sustituirá varios caracteres Unicode por sus expresiones "
+"respectivas de Maxima, p.ej. \"²\" por \"^2\", \"³\" por \"^3\", el signo de "
+"raíz cuadrada por la función `sqrt()`, el signo Sigma (matemático) el cual "
+"no es el mismo carácter Unicode como la letra griega correspondiente) por "
+"`sum()`, etc."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:217
+msgid ""
+"Unicode has several \"common\" fractions encoded as one Unicode code point: "
+"`¼, ½, ¾, ⅐, ⅑, ⅒, ⅓, ⅔, ⅕, ⅖, ⅗, ⅘, ⅙, ⅚, ⅛, ⅜, ⅝, ⅞`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:219
+msgid ""
+"wxMaxima will replace them with their Maxima representations, e.g `(1/4)` "
+"before the input is sent do Maxima. There are also `⅟`, which will be "
+"replaced by `1/` and `↉` (used in baseball), which will be replaced by "
+"`(0/3)`."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:221
+msgid ""
+"It is recommended to use **Maxima code** (not these Unicode code points) in "
+"input cells (Rationale: (a) it might be possible, that the used font for "
+"math input does not contain them; (b) if you save the document as `wxm`-"
+"file, it is usually readable by (command line) Maxima, but these changes "
+"will of course not work in command line Maxima); but they may occur, if you "
+"cut&paste a formula from another document."
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:222
+#, fuzzy, no-wrap
+#| msgid "### Side Panes"
+msgid "Side Panes"
+msgstr "### Paneles Laterales"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:225
+msgid ""
+"Shortcuts to the most important _Maxima_ commands, things like a table of "
+"contents, windows with debug messages or a history of the last issued "
+"commands can be accessed using the side panes. They can be enabled using the "
+"\"View\" menu. They all can be moved to other locations inside or outside "
+"the _wxMaxima_ window. Other useful panes is the one that allows to input "
+"Greek letters using the mouse."
+msgstr ""
+"Enlaces para las instrucciones de _Maxima_ más importantes, cosas como un "
+"índice de contenido, ventanas con mensajes de depuración o un historial de "
+"las últimas instrucciones emitidas pueden ser accedidas utilizando los "
+"paneles laterales.  Puede ser habilitados utilizando el menú de \"Vistas\".  "
+"Todos ellos pueden ser trasladas a otras localización dentro o fuera de la "
+"ventana de _wxMaxima.  Otro de los paneles útiles es el que permite "
+"introducir letras griegas utilizando el ratón."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:227
+msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
+msgstr ""
+"![Ejemplo de diferentes paneles laterales](./SidePanes.png)"
+"{ id=img_SidePanes }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:230
+msgid ""
+"In the \"table of contents\" side pane, one can increase or decrease a "
+"heading by just clicking on the heading with the right mouse button and "
+"select the next higher or lower heading type."
+msgstr ""
+"En el panal lateral de \"table de contenido\", uno puede incrementar o "
+"decrementar un encabezado tan solo pulsando sobre la cabecera con el botón "
+"de ratón secundario y seleccionar el siguiente tipo de cabecera más alto o "
+"bajo."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:232
+msgid ""
+"![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-"
+"headings.png){ id=Sidepane-TOC-convert-headings }"
+msgstr ""
+"![Incrementa o decrementa cabeceras dentro del panel lateral TOC](./Sidepane-"
+"TOC-convert-headings.png){ id=Sidepane-TOC-convert-headings }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:233
+#, fuzzy, no-wrap
+#| msgid "### MathML output"
+msgid "MathML output"
+msgstr "### Salida MathML"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:236
+msgid ""
+"Several word processors and similar programs either recognize [MathML]"
+"(https://www.w3.org/Math/) input and automatically insert it as an editable "
+"2D equation - or (like LibreOffice) have an equation editor that offers an "
+"“import MathML from clipboard” feature. Others support RTF maths. "
+"_WxMaxima_, therefore, offers several entries in the right-click menu."
+msgstr ""
+"Varios procesadores de palabras y programas similares o bien reconocen "
+"entradas de [MathML](https://www.w3.org/Math/) y lo insertan automáticamente "
+"como una ecuación editable 2D - o bien (como LibreOffice 5.1) tiene un "
+"editor de ecuación que ofrece una característica “importar MathML desde "
+"portapapeles”.  Otros admiten matemáticas RTF.  _WxMaxima_ por lo tanto "
+"ofrece varios apuntes dentro del menú a través de la pulsación secundaria "
+"del menú."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:237
+#, fuzzy, no-wrap
+#| msgid "### Markdown support"
+msgid "Markdown support"
+msgstr "### Asistente Markdown"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:240
+msgid ""
+"_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/wiki/"
+"Markdown) conventions that don’t collide with mathematical notation. One of "
+"these elements is bullet lists."
+msgstr ""
+"_WxMaxima_ ofrece un conjunto de convenciones de [Markdown](https://es."
+"wikipedia.org/wiki/Markdown) estándar que no colisione con la notación "
+"matemática.  Una vez que estos elementos son listados de puntos."
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:241
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```text\n"
+#| "Ordinary text\n"
+#| " * One item, indentation level 1\n"
+#| " * Another item at indentation level 1\n"
+#| "   * An item at a second indentation level\n"
+#| "   * A second item at the second indentation level\n"
+#| " * A third item at the first indentation level\n"
+#| "Ordinary text\n"
+#| "```\n"
+msgid ""
+"Ordinary text\n"
+" * One item, indentation level 1\n"
+" * Another item at indentation level 1\n"
+"   * An item at a second indentation level\n"
+"   * A second item at the second indentation level\n"
+" * A third item at the first indentation level\n"
+"Ordinary text\n"
+msgstr ""
+"```text\n"
+"Texto ordinario\n"
+" * Un ítem, nivel 1 de sangrado\n"
+" * Otro ítem en nivel 1 de sangrado\n"
+"   * Un ítem en un nivel de sangrado 2\n"
+"   * Un segundo ítem en el nivel 2 de sangrado\n"
+" * Un tercer ítem en el nivel 1 del sangrado\n"
+"Texto ordinario\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:252
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
+msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
+msgstr "_WxMaxima_ reconocerá texto iniciando con los caracteres `>` como entrecomillado de bloque:"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:253
+#, fuzzy, no-wrap
+#| msgid "```text Ordinary text > quote quote quote quote > quote quote quote quote > quote quote quote quote Ordinary text ```"
+msgid ""
+"Ordinary text\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"Ordinary text\n"
+msgstr "```text Texto ordinario > comilla comilla comilla > comilla comilla comilla > comilla comilla comilla Texto ordinario ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:262
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:"
+msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:\n"
+msgstr "Las salidas de TeX y HTML de _wxMaxima_ también reconocerán `=>` y lo reemplazarán por el signo correspondiente de Unicode:"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:263
+#, fuzzy, no-wrap
+#| msgid "```text cogito => sum.  ```"
+msgid "cogito => sum.\n"
+msgstr "```text cogito => sum.  ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:268
+#, fuzzy, no-wrap
+#| msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized."
+msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.\n"
+msgstr "Otros símbolos de exportación HTML y TeX reconocerán son `<=` y `>=` para comparaciones, una flecha doble doble-apuntada (`<=>`), flechas con cabecera única (`<->`, `->` y `<-`) y `+/-` como el signo respectivo.  Para salida TeX además son reconocidos `<<` y `>>`."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:269
+#, fuzzy, no-wrap
+#| msgid "### Hotkeys"
+msgid "Hotkeys"
+msgstr "### Teclas rápidas"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:272
+msgid ""
+"Most hotkeys can be found in the text of the respective menus. Since they "
+"are actually taken from the menu text and thus can be customized by the "
+"translations of _wxMaxima_ to match the needs of users of the local "
+"keyboard, we do not document them here. A few hotkeys or hotkey aliases, "
+"though, are not documented in the menus:"
+msgstr ""
+"Muchas teclas resaltadas pueden ser encontradas dentro del texto de los "
+"respectivos menús.  Desde que son tomados actualmente desde el texto del "
+"menú y por lo tanto puede ser adaptados por las traducciones de _wxMaxima_ "
+"para coincidir con las necesidades de los usuarios del teclado local, no lo "
+"documentamos aquí.  Unas pocas teclas especiales o aliases, sin embargo , no "
+"están documentadas dentro de los menús:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid ""
+"<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
+msgstr ""
+"<kbd>CTRL</kbd>+<kbd>MAYÚS</kbd>+<kbd>SUPR</kbd> borra una celda completa."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+#, fuzzy
+#| msgid ""
+#| "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete "
+#| "cell."
+msgid ""
+"<kbd>CTRL</kbd>+<kbd>TAB</kbd> or <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</"
+"kbd> triggers the auto-completion mechanism."
+msgstr ""
+"<kbd>CTRL</kbd>+<kbd>MAYÚS</kbd>+<kbd>SUPR</kbd> borra una celda completa."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
+msgstr "<kbd>MAYÚS</kbd>+<kbd>ESPACIO</kbd> introduce un espacio sin ruptura."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:277
+#, fuzzy, no-wrap
+#| msgid "### Raw TeX in the TeX export"
+msgid "Raw TeX in the TeX export"
+msgstr "## TeX crudo dentro de la exportación TeX"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:280
+msgid ""
+"If a text cell begins with `TeX:` the TeX export contains the literal text "
+"that follows the `TeX:` marker. Using this feature allows the entry of TeX "
+"markup within the _wxMaxima_ workbook."
+msgstr ""
+"Si una celda de texto comienza con `TeX:` la exportación de TeX contiene el "
+"texto literal que continua el marcador `TeX:`.  Utilizando esta "
+"característica permite al apunte del marcado TeX sin el cuaderno _wxMaxima_."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:281
+#, fuzzy, no-wrap
+#| msgid "## File Formats"
+msgid "File Formats"
+msgstr "## Formatos de Archivos"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:284
+msgid ""
+"The material that is developed in a _wxMaxima_ session can be stored for "
+"later use in any of three ways:"
+msgstr ""
+"El material desarrollado en una sesión _wxMaxima_ puede ser almacenado para "
+"un posterior uso en cualquiera de estas tras maneras:"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:285
+#, fuzzy, no-wrap
+#| msgid "### .mac"
+msgid ".mac"
+msgstr "### .mac"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:288
+msgid ""
+"`.mac` files are ordinary text files that contain _Maxima_ commands. They "
+"can be read using _Maxima_’s `batch()` or `load()` command or _wxMaxima_’s "
+"File/Batch File menu entry."
+msgstr ""
+"Los archivos `.mac` son archivos de texto ordinarios que contienen "
+"instrucciones de _Maxima_.  Pueden ser leídos utilizando la instrucción "
+"`batch()` o `load()` de _Maxima_ o un apunte del menú de archivo del "
+"«Archivo/Menú de archivo guion» de _wxMaxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:291
+msgid ""
+"One example is shown below. `Quadratic.mac` defines a function and afterward "
+"generates a plot with `wxdraw2d()`.  Afterward the contents of the file "
+"`Quadratic.mac` are printed and newly defined function `f()` is evaluated."
+msgstr ""
+"Un ejemplo se muestra debajo.  `Quadratic.mac` define una función y "
+"posteriormente genera un tramado con `wxdraw2d()`.  Posteriormente el "
+"contenido del archivo `Quadratic.mac` es representado y la función `f()` "
+"nueva definida es evaluada."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:293
+msgid "![Loading a file with `batch()`](./BatchImage.png){ id=img_BatchImage }"
+msgstr ""
+"![Cargando un archivo con `batch()`](./BatchImage.png){ id=img_BatchImage }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:295
+#, fuzzy
+#| msgid ""
+#| "Attention: Although the file `Quadratic.mac` has a usual _Maxima_ "
+#| "extension (`.mac`), it can only be read by _wxMaxima_, since the command "
+#| "`wxdraw2d()` is a wxMaxima-extension to _Maxima_."
+msgid ""
+"Attention: Although the file `Quadratic.mac` has a usual _Maxima_ extension "
+"(`.mac`), it can only be read by _wxMaxima_, since the command `wxdraw2d()` "
+"is a wxMaxima-extension to _Maxima_. (Command line) Maxima will ignore the "
+"unknown command `wxdraw2d()` and print it as output again."
+msgstr ""
+"Atención: aunque el archivo `Quadratic.mac` tiene una extensión usual de "
+"_Maxima_ (`.mac`), solamente puede ser leído por _wxMaxima_, ya que la "
+"instrucción `wxdraw2d()` es una extensión de wxMaxima para _Maxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:297
+msgid ""
+"You can be use `.mac` files for writing your own library of macros. But "
+"since they don’t contain enough structural information they cannot be read "
+"back as a _wxMaxima_ session."
+msgstr ""
+"Puede utilizar los archivos `.mac` para escribir su propia biblioteca de "
+"macros.  Pero desde que no contengan suficiente información estructural no "
+"pueden releer como una sesión _wxMaxima_."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:298
+#, fuzzy, no-wrap
+#| msgid "### .wxm"
+msgid ".wxm"
+msgstr "### .wxm"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:302
+#, fuzzy, no-wrap
+#| msgid "`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files can be. With this plain-text format, it sometimes is unavoidable that worksheets that use new features are not downwards-compatible with older versions of _wxMaxima_."
+msgid ""
+"`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.\n"
+"You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.\n"
+msgstr "Los archivos `.wxm` contienen la hoja de trabajo excepto para la salida de _Maxima_.  En las versiones >5.38 de Maxima pueden leerse utilizando la función `load()` de _Maxima_ tan solo como sean archivos .mac.  Con este formato de texto simple, algunas veces es inevitable que las hojas de trabajo que utilicen características nuevas no sean compatibles con las versiones más antiguas de _wxMaxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:304
+#, fuzzy
+#| msgid ""
+#| "`.wxm` files contain the worksheet except for _Maxima_’s output. On "
+#| "Maxima versions >5.38 they can be read using _Maxima_’s `load()` function "
+#| "just as .mac files can be. With this plain-text format, it sometimes is "
+#| "unavoidable that worksheets that use new features are not downwards-"
+#| "compatible with older versions of _wxMaxima_."
+msgid ""
+"With this plain-text format, it sometimes is unavoidable that worksheets "
+"that use new features are not downwards-compatible with older versions of "
+"_wxMaxima_."
+msgstr ""
+"Los archivos `.wxm` contienen la hoja de trabajo excepto para la salida de "
+"_Maxima_.  En las versiones >5.38 de Maxima pueden leerse utilizando la "
+"función `load()` de _Maxima_ tan solo como sean archivos .mac.  Con este "
+"formato de texto simple, algunas veces es inevitable que las hojas de "
+"trabajo que utilicen características nuevas no sean compatibles con las "
+"versiones más antiguas de _wxMaxima_."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:305
+#, fuzzy, no-wrap
+#| msgid "#### File format of wxm files"
+msgid "File format of wxm files"
+msgstr "#### Formato de archivo de archivos wxm"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:308
+msgid ""
+"This is just a plain text file (you can open it with a text editor), "
+"containing the cell contents as some special Maxima comments."
+msgstr ""
+"Esto es tan solo un archivo de texto simple (puede abrirlo con un editor de "
+"texto), conteniendo el contenido de celda como algunos comentarios Maxima "
+"especial."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:310
+msgid "It starts with the following comment:"
+msgstr "Comienza con el siguiente comentario:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:311
+#, fuzzy, no-wrap
+#| msgid "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
+msgid ""
+"/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/\n"
+"/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */\n"
+msgstr "```maxima /* [archivo de guion wxMaxima versión 1] [ ¡NO LO EDITE A MANO! ]*/ /* [ Creado con wxMaxima versión 24.02.2_DevelopmentSnapshot ] */ ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:317
+msgid ""
+"And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
+msgstr ""
+"Y entonces las celdas siguientes, codificados como comentarios Maxima, p."
+"ej., una celda de sección:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:318
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "/* [wxMaxima: section start ]\n"
+#| "Title of the section\n"
+#| "   [wxMaxima: section end   ] */\n"
+#| "```\n"
+msgid ""
+"/* [wxMaxima: section start ]\n"
+"Title of the section\n"
+"   [wxMaxima: section end   ] */\n"
+msgstr ""
+"```maxima\n"
+"/* [wxMaxima: inicio de sesión ]\n"
+"Título de la sección\n"
+"   [wxMaxima: final de sección   ] */\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:325
+msgid ""
+"or (in a Math cell the input is of course *not* commented out (the output is "
+"not saved in a `wxm` file)):"
+msgstr ""
+"o (en una celda matemática la entrada es por supuesto *no* comentada afuera "
+"(la salida no es guardada en un archivo `wxm`)):"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:326
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "/* [wxMaxima: input   start ] */\n"
+#| "f(x):=x^2+1$\n"
+#| "f(2);\n"
+#| "/* [wxMaxima: input   end   ] */\n"
+#| "```\n"
+msgid ""
+"/* [wxMaxima: input   start ] */\n"
+"f(x):=x^2+1$\n"
+"f(2);\n"
+"/* [wxMaxima: input   end   ] */\n"
+msgstr ""
+"```maxima\n"
+"/* [wxMaxima: entrada   inicio ] */\n"
+"f(x):=x^2+1$\n"
+"f(2);\n"
+"/* [wxMaxima: entrada   final   ] */\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:334
+msgid ""
+"Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the "
+"image type as first line):"
+msgstr ""
+"Imágenes están [codificadas en base64](https://es.wikipedia.org/wiki/Base64) "
+"con el tipo de imagen como primera línea):"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:335
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "/* [wxMaxima: image   start ]\n"
+#| "jpg\n"
+#| "[very chaotic looking character sequence]\n"
+#| "   [wxMaxima: image   end   ] */\n"
+#| "```\n"
+msgid ""
+"/* [wxMaxima: image   start ]\n"
+"jpg\n"
+"[very chaotic looking character sequence]\n"
+"   [wxMaxima: image   end   ] */\n"
+msgstr ""
+"```maxima\n"
+"/* [wxMaxima: imagen  inicio ]\n"
+"jpg\n"
+"[vista de secuencia de caracteres muy caótica]\n"
+"   [wxMaxima: imagen  final  ] */\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:343
+msgid "A page break is just one line containing:"
+msgstr "Un salto de página es tan solo una línea conteniendo:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:344
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "/* [wxMaxima: page break    ] */\n"
+#| "```\n"
+msgid "/* [wxMaxima: page break    ] */\n"
+msgstr ""
+"```maxima\n"
+"/* [wxMaxima: salto de página    ] */\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:349
+msgid "And folded cells marked by:"
+msgstr "Y las celdas encarpetadas marcadas por:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:350
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "/* [wxMaxima: fold    start ] */\n"
+#| "...\n"
+#| "/* [wxMaxima: fold    end   ] */\n"
+#| "```\n"
+msgid ""
+"/* [wxMaxima: fold    start ] */\n"
+"...\n"
+"/* [wxMaxima: fold    end   ] */\n"
+msgstr ""
+"```maxima\n"
+"/* [wxMaxima: carpeta    inicio ] */\n"
+"...\n"
+"/* [wxMaxima: carpeta    final  ] */\n"
+"```\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:356
+#, fuzzy, no-wrap
+#| msgid "### .wxmx"
+msgid ".wxmx"
+msgstr "### .wxmx"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:359
+msgid ""
+"This XML-based file format saves the complete worksheet including things "
+"like the zoom factor and the watchlist. It is the preferred file format."
+msgstr ""
+"Este archivo cuyo formato está basado en XML guarda la hoja de trabajo "
+"completa incluyendo cosas como el factor de zoom y el listado de vigía.  Es "
+"el formato de archivo preferido."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:360
+#, fuzzy, no-wrap
+#| msgid "#### File format of wxmx files"
+msgid "File format of wxmx files"
+msgstr "#### Formato de archivo de archivos wxm"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:364
+msgid ""
+"A `wxmx`-file seems to be a binary format, but one can handle it with tools, "
+"which are included in your OS. It is a zip file, one can decompress it with "
+"`unzip` (maybe rename it before, so that is recognized by the unzip program "
+"of your OS).  We do not use the compression function, just the possibility "
+"to merge several files into one file - images are already compressed and the "
+"rest is simple text (probably much smaller, than huge images, which are "
+"included)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:366
+#, fuzzy
+#| msgid "It starts with the following comment:"
+msgid "It does contain the following files:"
+msgstr "Comienza con el siguiente comentario:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-"
+"wxmathml`"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`format.txt`: a short description about wxMaxima and the wxmx file format"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima "
+"session and included images."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`content.xml`: a XML document, which contains the various cells of your "
+"document in XML format."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:373
+msgid ""
+"So, if something goes wrong, you can unzip a wxMaxima document (maybe rename "
+"it before to a `zip`-file), maybe make changes in the `content.xml` file "
+"with a text editor, or replace an broken image, zip the files again, "
+"probably rename the `zip` to a `wxmx`-file - and you get another modified "
+"`wxmx`-file."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:374
+#, fuzzy, no-wrap
+#| msgid "## Configuration options"
+msgid "Configuration options"
+msgstr "## Opciones de configuración"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:377
+msgid ""
+"For some common configuration variables _wxMaxima_ offers two ways of "
+"configuring:"
+msgstr ""
+"Para algunas configuraciones comunes de variables _wxMaxima_ ofrecen dos "
+"maneras de configurarlas:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:380
+msgid ""
+"The configuration dialog box below lets you change their default values for "
+"the current and subsequent sessions."
+msgstr ""
+"La caja de diálogo de configuración de abajo le permite modificar sus "
+"valores predeterminados para las sesiones actuales y subsecuentes."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:380
+#, fuzzy
+#| msgid ""
+#| "- The configuration dialog box below lets you change their default values "
+#| "for the current and subsequent sessions.  - Also, the values for most "
+#| "configuration variables can be changed for the current session only by "
+#| "overwriting their values from the worksheet, as shown below."
+msgid ""
+"Also, the values for most configuration variables can be changed for the "
+"current session only by overwriting their values from the worksheet, as "
+"shown below."
+msgstr ""
+"- La caja del diálogo de configuración debajo le permite cambiar sus valores "
+"por defectos para las sesiones actuales y posteriores.  - Además, los "
+"valores para muchas variables de configuración pueden ser cambiadas para la "
+"sesión actual solamente sobrescribiendo sus valores desde la hoja de "
+"trabajo, tal como muestra a continuación."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:382
+msgid ""
+"![wxMaxima configuration 1](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
+msgstr ""
+"![Configuración de wxMaxima 1](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:383
+#, fuzzy, no-wrap
+#| msgid "### Default animation framerate"
+msgid "Default animation framerate"
+msgstr "### Velocidad de cuadros de animación predeterminada"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:386
+msgid ""
+"The animation framerate that is used for new animations is kept in the "
+"variable `wxanimate_framerate`. The initial value this variable will contain "
+"in a new worksheet can be changed using the configuration dialogue."
+msgstr ""
+"La tasa del marco de animación que se utiliza para animaciones nuevas se "
+"conserva dentro de la variable `wxanimate_framerate`.  El valor inicial de "
+"esta variable contiene dentro una hoja de trabajo nueva que puede ser "
+"modificada utilizando el diálogo de configuración."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:387
+#, fuzzy, no-wrap
+#| msgid "### Default plot size for new _maxima_ sessions"
+msgid "Default plot size for new _maxima_ sessions"
+msgstr "### Tamaño de trama predet. para sesiones _maxima_ nuevas"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:390
+msgid ""
+"After the next start, plots embedded into the worksheet will be created with "
+"this size if the value of `wxplot_size` isn’t changed by _maxima_."
+msgstr ""
+"Tras el siguiente inicio, tramas empotradas a la hoja del trabajo será "
+"creada con este tamaño si el valor de `wxplot_size` no es modificado por "
+"_maxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:392
+msgid ""
+"In order to set the plot size of a single graph only use the following "
+"notation can be used that sets a variable’s value for one command only:"
+msgstr ""
+"Con la intención de establecer el tamaño de trama de un grafo único "
+"solamente utilice la notación siguiente puede ser utilizada que fija un "
+"valor de variable solamente para una sola instrucción:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:393
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw2d(\n"
+#| "   explicit(\n"
+#| "       x^2,\n"
+#| "       x,-5,5\n"
+#| "   )\n"
+#| "), wxplot_size=[480,480]$\n"
+#| "```\n"
+msgid ""
+"wxdraw2d(\n"
+"   explicit(\n"
+"       x^2,\n"
+"       x,-5,5\n"
+"   )\n"
+"), wxplot_size=[480,480]$\n"
+msgstr ""
+"```maxima\n"
+"wxdraw2d(\n"
+"   explicit(\n"
+"       x^2,\n"
+"\t   x,-5,5\n"
+"   )\n"
+"), wxplot_size=[480,480]$\n"
+"```\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:402
+#, fuzzy, no-wrap
+#| msgid "### Match parenthesis in text controls"
+msgid "Match parenthesis in text controls"
+msgstr "### Coincide paréntesis en controles de texto"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:405
+msgid "This option enables two things:"
+msgstr "Esta opción habilita dos cosas:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:408
+#, fuzzy
+#| msgid ""
+#| "- If an opening parenthesis, bracket, or double quote is entered "
+#| "_wxMaxima_ will insert a closing one after it.  - If text is selected if "
+#| "any of these keys is pressed the selected text will be put between the "
+#| "matched signs."
+msgid ""
+"If an opening parenthesis, bracket, or double quote is entered _wxMaxima_ "
+"will insert a closing one after it."
+msgstr ""
+"- Si se introduce un paréntesis de apertura, corchete o entrecomillado doble "
+"_wxMaxima insertará un cierre tras éste.  - Si el texto está seleccionado si "
+"cualquiera de estas teclas está presenta el texto seleccionado será puesto "
+"entre los signos coincidentes."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:408
+msgid ""
+"If text is selected if any of these keys is pressed the selected text will "
+"be put between the matched signs."
+msgstr ""
+"Si el texto está seleccionad si cualquiera de estas teclas es pulsada el "
+"texto seleccionado será puedes entre los signos coincidan."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:409
+#, fuzzy, no-wrap
+#| msgid "### Don’t save the worksheet automatically"
+msgid "Don’t save the worksheet automatically"
+msgstr "### No guardar automáticamente la hoja de trabajo"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:412
+msgid ""
+"If this option is set, the file where the worksheet is will be overwritten "
+"only the request of the user. In case of a crash/power loss/... a recent "
+"backup copy is still made available in the temp directory, though."
+msgstr ""
+"Si esta opción está puesta, el archivo donde la hoja de trabajo será "
+"sobrescrita solamente al solicitar el usuario.  En caso de un cuelgue/corte "
+"de luz/... sin embargo, aún está disponible una copia de respaldo reciente "
+"dentro del directorio temporal ‘temp’."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:414
+msgid ""
+"If this option isn’t set _wxMaxima_ behaves more like a modern cellphone app:"
+msgstr ""
+"Si esta opción no está fijada _wxMaxima_ se comporta más como una app "
+"telefónica moderna:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:417
+msgid "Files are saved automatically on exit"
+msgstr "Ficheros son guardados automáticamente al salir"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:417
+#, fuzzy
+#| msgid ""
+#| "- Files are saved automatically on exit - And the file will automatically "
+#| "be saved every 3 minutes."
+msgid "And the file will automatically be saved every 3 minutes."
+msgstr ""
+"- Los archivos son guardados automáticamente al salir - Y el archivo será "
+"auto-guardado cada 3 minutos."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:418
+#, fuzzy, no-wrap
+#| msgid "### Where is the configuration saved?"
+msgid "Where is the configuration saved?"
+msgstr "### ¿Donde está la configuración guardada?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:422
+#, fuzzy, no-wrap
+#| msgid "If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).  (Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden)."
+msgid ""
+"If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).\n"
+"(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).\n"
+msgstr "Si está utilizando Unix/Linux, la información de la configuración será guardada dentro de un archivo `.wxMaxima` dentro de su directorio personal (si está utilizando wxWidgets < 3.1.1), o `.config/wxMaxima.conf`((XDG-Estandarizado) si wxWidgets ≥ 3.1.1).  Puede obtener la versión de wxWidgets desde la instrucción `wxbuild_info();` o para utilizar la opción del menú Ayuda→Acerca de. [wxWidgets](https://www.wxwidgets.org/) es la biblioteca IGU de plataforma cruzada lo cual es la base para _wxMaxima_ (por lo tanto el `wx` dentro del nombre).  (Cuando el nombre del archivo comience con un punto, `.wxmaxima` o `.config` estarán ocultos)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:424
+msgid ""
+"If you are using Windows, the configuration will be stored in the registry. "
+"You will find the entries for _wxMaxima_ at the following position in the "
+"registry: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
+msgstr ""
+"Si está utilizando Windows, la configuración será almacenada dentro del "
+"registro.  Encontrará los apuntes para _wxMaxima_ en la posición siguiente "
+"dentro del registro:\n"
+"`HKEY_CURRENT_USER\\Software\\wxMaxima`"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:427
+#, fuzzy, no-wrap
+#| msgid "# Extensions to _Maxima_"
+msgid "Extensions to _Maxima_"
+msgstr "# Extensiones para _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:430
+msgid ""
+"_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
+"its main purpose is to pass along commands to _Maxima_ and to report the "
+"results of executing those commands. In some cases, however, _wxMaxima_ adds "
+"functionality to _Maxima_. _WxMaxima_’s ability to generate reports by "
+"exporting a workbook’s contents to HTML and LaTeX files has been mentioned. "
+"This section considers some ways that _wxMaxima_ enhances the inclusion of "
+"graphics in a session."
+msgstr ""
+"_WxMaxima_ es primariamente un interfaz gráfico de usuario para _Maxima_.  "
+"Por lo tanto, su propósito principal es enviar órdenes a _Maxima_ y "
+"comunicar los resultados de ejecutar esas órdenes.  En algunos casos, sin "
+"embargo, _wxMaxima agrega funcionalidades a _Maxima_. La capacidad de "
+"_wxMaxima_ para generar informes exportando un contenido del cuaderno a HTML "
+"y LaTeX ha sido mencionado.  Esta sección considera algunas maneras que "
+"_wxMaxima_ mejora la inclusión de gráficos dentro de una sesión."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:431
+#, fuzzy, no-wrap
+#| msgid "## Subscripted variables"
+msgid "Subscripted variables"
+msgstr "## Variables subescritas"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:434
+msgid ""
+"`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript "
+"variable names:"
+msgstr ""
+"Especificidades `wxsubscripts`, si (y como) _wxMaxima_ auto-suscribirá "
+"nombres de variable:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:436
+msgid ""
+"If it is `false`, the functionality is off, wxMaxima will not autosubscript "
+"part of variable names after an underscore."
+msgstr ""
+"Si es falso, la funcionalidad está apagada, wxMaxima no auto-suscribirá "
+"parte de nombres de variable tras un subrayado."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:438
+msgid ""
+"If it is set to `'all`, everything after an underscore will be subscripted."
+msgstr ""
+"Si está fijado a `all`, todo será escrito debajo tras un guion bajo (_)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:440
+msgid ""
+"If it is set to `true` variable names of the format `x_y` are displayed "
+"using a subscript if"
+msgstr ""
+"Si está fijado a `true` (verdadero) los nombres de variables del formato "
+"`x_y` están representados utilizando un subguion ‘if’"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:443
+#, fuzzy
+#| msgid "`y` is a single letter"
+msgid "Either `x` or `y` is a single letter or"
+msgstr "‘y’ es una letra única"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:443
+#, fuzzy
+#| msgid ""
+#| "- Either `x` or `y` is a single letter or - `y` is an integer (can "
+#| "include more than one character)."
+msgid "`y` is an integer (can include more than one character)."
+msgstr ""
+"- O bien `x` o bien `y` es una única letra o - `y` es un entero (puede "
+"incluir más de un carácter)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:445
+msgid ""
+"![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png)"
+"{ id=img_wxsubscripts }"
+msgstr ""
+"![Como variables son auto-suscritas utilizando wxsubscripts](./wxsubscripts."
+"png){ id=img_wxsubscripts }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:447
+msgid ""
+"If the variable name doesn’t match these requirements, it can still be "
+"declared as \"to be subscripted\" using the command "
+"`wxdeclare_subscript(variable_name);` or "
+"`wxdeclare_subscript([variable_name1,variable_name2,...]);` Declaring a "
+"variable as subscripted can be reverted using the following command: "
+"`wxdeclare_subscript(variable_name,false);`"
+msgstr ""
+"Si el nombre de variable no coincide estos requerimientos, aún puede ser "
+"declarado como \"para ser sub-guionado\" utilizando la instrucción "
+"`wxdeclare_subscript(nombre_variable);` o "
+"`wxdeclare_subscript([nombre_variable1,nombre_variable2,...]);` declarando "
+"una variable como sub-guion puede ser revertido utilizando la instrucción "
+"siguiente: `wxdeclare_subscript(nombre_variable,false);`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:449
+#, fuzzy, no-wrap
+#| msgid "You can use the menu \"View->Autosubscript\" to set these values."
+msgid "You can use the menu \"View->Autosubscript\" to set these values.\n"
+msgstr "Puede utilizar el menú «Vista→Auto-subguion» para fijar estos valores."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:450
+#, fuzzy, no-wrap
+#| msgid "## User feedback in the status bar"
+msgid "User feedback in the status bar"
+msgstr "## Comentario del usuario en la barra de estado"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:453
+msgid ""
+"Long-running commands can provide user feedback in the status bar. This user "
+"feedback is replaced by any new feedback that is placed there (allowing to "
+"use it as a progress indicator) and is deleted as soon as the current "
+"command sent to _Maxima_ is finished. It is safe to use `wxstatusbar()` even "
+"in libraries that might be used with plain _Maxima_ (as opposed to "
+"_wxMaxima_): If _wxMaxima_ isn’t present the `wxstatusbar()` command will "
+"just be left unevaluated."
+msgstr ""
+"Las instrucciones de ejecución largas pueden proporcionar al usuario su "
+"estado dentro de la barra de estado.  Esta comentario es sustituído por "
+"cualquier comentario devuelto que es colocada allí (permitiendo utilizarlo "
+"como un indicador de progreso) y es borrado tan pronto como la instrucción "
+"actual enviada a _Maxima_ ha finalizado.  Es seguro de utilizar "
+"`wxstatusbar()` incluso dentro de bibliotecas que tal vez sean utilizadas "
+"con el simple _Maxima_ (como opuesto a _wxMaxima_): si _wxMaxima_ no está "
+"presente la instrucción `wxstatusbar()` será tan solo dejada sin evaluar."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:454
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "for i:1 thru 10 do (\n"
+#| "    /* Tell the user how far we got */\n"
+#| "    wxstatusbar(concat(\"Pass \",i)),\n"
+#| "    /* (sleep n) is a Lisp function, which can be used */\n"
+#| "    /* with the character \"?\" before. It delays the */\n"
+#| "    /* program execution (here: for 3 seconds) */\n"
+#| "    ?sleep(3)\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"for i:1 thru 10 do (\n"
+"    /* Tell the user how far we got */\n"
+"    wxstatusbar(concat(\"Pass \",i)),\n"
+"    /* (sleep n) is a Lisp function, which can be used */\n"
+"    /* with the character \"?\" before. It delays the */\n"
+"    /* program execution (here: for 3 seconds) */\n"
+"    ?sleep(3)\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"for i:1 thru 10 do (\n"
+"    /* Dice al usuario como de lejos obtuvo */\n"
+"    wxstatusbar(concat(\"Pass \",i)),\n"
+"    /* (sleep n) es una función Lisp, la cual puede utilizarse */\n"
+"    /* con el carácter \"?\" antes. Retarda el */\n"
+"    /* la ejecución del programa (aquí: para 3 segundos) */\n"
+"    ?sleep(3)\n"
+")$\n"
+"```\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:465
+#, no-wrap
+msgid "Exporting the worksheet from within Maxima"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:468
+msgid ""
+"The command `wxworksheettohtml()` exports the current worksheet to an HTML "
+"file from within a running _Maxima_ session, which is convenient for "
+"scripted or batch export. Like `wxstatusbar()` it is safe to use in code "
+"that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present "
+"the command is simply left unevaluated."
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:469
+#, no-wrap
+msgid ""
+"wxworksheettohtml(\"report.html\")$\n"
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:475
+msgid ""
+"A relative file name is interpreted relative to _Maxima_’s working "
+"directory. The optional keyword options are:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:480
+#, no-wrap
+msgid ""
+"| option   | values                                          | meaning                                             |\n"
+"| -------- | ----------------------------------------------- | --------------------------------------------------- |\n"
+"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |\n"
+"| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:482
+msgid ""
+"The `flavor` values match the equation formats offered by the graphical "
+"**File → Export** dialog: `mathml` produces a self-contained page that needs "
+"no internet connection, `mathjax` adds a MathJaX fall-back for browsers that "
+"still lack MathML, and `svg`/`bitmap` render every equation to an image."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:484
+msgid ""
+"The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file "
+"the same way:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:485
+#, no-wrap
+msgid ""
+"wxworksheettotex(\"report.tex\")$\n"
+"wxworksheettotex(\"report.tex\", documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:494
+#, no-wrap
+msgid ""
+"| option                 | meaning                                                              |\n"
+"| ---------------------- | -------------------------------------------------------------------- |\n"
+"| `documentclass`        | overrides the LaTeX `\\documentclass` (e.g. `\"article\"`, `\"report\"`)  |\n"
+"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:496
+msgid "Support for `wxworksheettopdf()` is planned."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:497
+#, fuzzy, no-wrap
+#| msgid "## Plotting"
+msgid "Plotting"
+msgstr "## Tramar"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:500
+msgid ""
+"Plotting (having fundamentally to do with graphics) is a place where a "
+"graphical user interface will have to provide some extensions to the "
+"original program."
+msgstr ""
+"Tramar (teniendo fundamentalmente hacerlo con gráficas) es un lugar donde un "
+"interfaz gráfico del usuario tendrá para proporcionar algunas extensiones "
+"para el programa original."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:501
+#, fuzzy, no-wrap
+#| msgid "### Embedding a plot into the worksheet"
+msgid "Embedding a plot into the worksheet"
+msgstr "### Empotrar una trama dentro de la hoja de trabajo"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:504
+msgid ""
+"_Maxima_ normally instructs the external program _Gnuplot_ to open a "
+"separate window for every diagram it creates. Since many times it is "
+"convenient to embed graphs into the worksheet instead _wxMaxima_ provides "
+"its own set of plot functions that don’t differ from the corresponding "
+"_maxima_ functions save in their name: They are all prefixed by a “wx”."
+msgstr ""
+"_Maxima_ normalmente instrumenta el programa _Gnuplot_ externo para abrir "
+"una ventana separada por cada diagrama que crea.  Debido a que muchas veces "
+"es conveniente empotrar grafos a la hoja de trabajo en vez que _wxMaxima_ "
+"proporcione su propio conjunto de funciones de trama que no difieran desde "
+"las funciones correspondientes a _maxima_ que guarda dentro de su nombre: "
+"todo está prefijado por un “wx”."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:506
+msgid "The following plotting functions have wx-counterparts:"
+msgstr "Las siguientes funciones de tramado tienen contrapartes wx:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:520
+#, no-wrap
+msgid ""
+"| wxMaxima’s plot function | Maxima’s plot function                                                                          |\n"
+"| ------------------------ | ----------------------------------------------------------------------------------------------- |\n"
+"| `wxplot2d()`             | [plot2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot2d)               |\n"
+"| `wxplot3d()`             | [plot3d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot3d)               |\n"
+"| `wxdraw2d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw2d)               |\n"
+"| `wxdraw3d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw3d)               |\n"
+"| `wxdraw()`               | [draw](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw)                   |\n"
+"| `wximplicit_plot()`      | [implicit_plot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#implicit_plot) |\n"
+"| `wxhistogram()`          | [histogram](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#histogram)         |\n"
+"| `wxscatterplot()`        | [scatterplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#scatterplot)     |\n"
+"| `wxbarsplot()`           | [barsplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#barsplot)           |\n"
+"| `wxpiechart()`           | [piechart](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#piechart)           |\n"
+"| `wxboxplot()`            | [boxplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#boxplot)             |\n"
+msgstr ""
+"| Función tramado wxMaxima | Función de plot de Maxima                                                                       |\n"
+"| ------------------------ | ----------------------------------------------------------------------------------------------- |\n"
+"| `wxplot2d()`             | [plot2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot2d)               |\n"
+"| `wxplot3d()`             | [plot3d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot3d)               |\n"
+"| `wxdraw2d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw2d)               |\n"
+"| `wxdraw3d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw3d)               |\n"
+"| `wxdraw()`               | [draw](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw)                   |\n"
+"| `wximplicit_plot()`      | [implicit_plot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#implicit_plot) |\n"
+"| `wxhistogram()`          | [histogram](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#histogram)         |\n"
+"| `wxscatterplot()`        | [scatterplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#scatterplot)     |\n"
+"| `wxbarsplot()`           | [barsplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#barsplot)           |\n"
+"| `wxpiechart()`           | [piechart](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#piechart)           |\n"
+"| `wxboxplot()`            | [boxplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#boxplot)             |\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:522
+msgid ""
+"If a `wxm`-file is read by (console) Maxima, these functions are ignored "
+"(and printed as output, as other unknown functions in Maxima)."
+msgstr ""
+"Si un archivo de `wxm` es leído por (consola) Maxima, estas funciones son "
+"ignoradas (y escritas como salida, como otras funciones desconocidas en "
+"Maxima)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:524
+msgid ""
+"If you got problems with one of these functions, please check, if the "
+"problem exists in the the Maxima function too (e.g. you got an error with "
+"`wxplot2d()`, check the same plot in the Maxima command `plot2d()` (which "
+"opens the plot in a separate Window)). If the problem does not disappear, it "
+"is most likely a Maxima issue and should be reported in the [Maxima "
+"bugtracker](https://sourceforge.net/p/maxima/bugs/). Or maybe a Gnuplot "
+"issue."
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:525
+#, fuzzy, no-wrap
+#| msgid "### Making embedded plots bigger or smaller"
+msgid "Making embedded plots bigger or smaller"
+msgstr "### Creación de tramas empotradas más mayores o menores"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:528
+msgid ""
+"As noted above, the configure dialog provides a way to change the default "
+"size plots created which sets the starting value of `wxplot_size`. The "
+"plotting routines of _wxMaxima_ respect this variable that specifies the "
+"size of a plot in pixels. It can always be queried or used to set the size "
+"of the following plots:"
+msgstr ""
+"Tal como notó arriba, el dialogo de configuración proporciona una manera de "
+"modificar el tamaño de trama predeterminada lo cual fija el valor de inicio "
+"de `wxplot_size`.  Las rutinas de tramado de _wxMaxima_ respeta esta "
+"variable que especifica el tamaño de una trama en píxeles.  Siempre puede "
+"ser solicitado o utilizado para fijar el tamaño de las tramas siguientes:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:529
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxplot_size:[1200,800]$\n"
+#| "wxdraw2d(\n"
+#| "    explicit(\n"
+#| "        sin(x),\n"
+#| "        x,1,10\n"
+#| "    )\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"wxplot_size:[1200,800]$\n"
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"wxplot_size:[1200,800]$\n"
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:540
+msgid ""
+"If the size of only one plot is to be changed _Maxima_ provides a canonical "
+"way to change an attribute only for the current cell. In this usage the "
+"specification `wxplot_size = [value1, value2]` is appended to the "
+"`wxdraw2d( )` command, and is not part of the `wxdraw2d` command."
+msgstr ""
+"Si el tamaño de solamente una trama va a ser modificada, _Maxima_ "
+"proporciona una manera canónica para modificar un atributo solamente para la "
+"celda actual.  En este uso la especificación `wxplot_size = [valor1, "
+"valor2]` es agregada a la instrucción `wxdraw2d( )`, y no es parte de la "
+"instrucción `wxdraw2d`."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:541
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw2d(\n"
+#| "    explicit(\n"
+#| "        sin(x),\n"
+#| "        x,1,10\n"
+#| "    )\n"
+#| "),wxplot_size=[1600,800]$\n"
+#| "```\n"
+msgid ""
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+"),wxplot_size=[1600,800]$\n"
+msgstr ""
+"```maxima\n"
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+"),wxplot_size=[1600,800]$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:551
+msgid ""
+"Setting the size of embedded plot with `wxplot_size` works for embedded "
+"plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` "
+"commands and for embedded animations with `with_slider_draw` and `wxanimate` "
+"commands."
+msgstr ""
+"Estableciendo el tamaño de trazas empotradas con `wxplot_size` funciona para "
+"trazos empotrados utilizando p.e. instrucciones `wxplot`, `wxdraw`, "
+"`wxcontour_plot` y `wximplicit_plot` y para animaciones empotradas con "
+"instrucciones `with_slider_draw` y `wxanimate`."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:552
+#, fuzzy, no-wrap
+#| msgid "### Better quality plots"
+msgid "Better quality plots"
+msgstr "## Tramas de mayor calidad"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:555
+msgid ""
+"_Gnuplot_ doesn’t seem to provide a portable way of determining whether it "
+"supports the high-quality bitmap output that the Cairo library provides. On "
+"systems where _Gnuplot_ is compiled to use this library the pngCairo option "
+"from the configuration menu (that can be overridden by the variable "
+"`wxplot_pngcairo`) enables support for antialiasing and additional line "
+"styles. If `wxplot_pngCairo` is set without _Gnuplot_ supporting this the "
+"result will be error messages instead of graphics."
+msgstr ""
+"_Gnuplot_ parece no proporcionar una manera portable de determinar si admite "
+"bitmap de salida de calidad alta que la biblioteca Cairo proporciona. En los "
+"sistemas donde está compilado _Gnuplot_ para utilizar esta biblioteca la "
+"opción pngCairo desde el menú de configuración (que puede ser sobrescrito "
+"por la variable `wxplot_pngcairo`) habilita el mantenimiento para antialias "
+"y estilos de línea adicional. Si `wxplot_pngCairo` está establecido sin "
+"_Gnuplot_ admitiendo esto el resultado dará mensajes de error en vez de "
+"gráficos."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:556
+#, fuzzy, no-wrap
+#| msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
+msgid "Opening embedded plots in interactive _Gnuplot_ windows"
+msgstr "### Abriendo tramados empotrados en ventanas _Gnuplot_ interactivas"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:559
+msgid ""
+"If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
+"`wxplot3d` isn’t supported by this feature) and the file size of the "
+"underlying _Gnuplot_ project isn’t way too high _wxMaxima_ offers a right-"
+"click menu that allows to open the plot in an interactive _Gnuplot_ window."
+msgstr ""
+"Si fue generada una trama utilizando las instrucciones de tipo `wxdraw` "
+"(`wxplot2d` y `wxplot3d` no son admitidas por esta característica) y el "
+"tamaño del archivo del proyecto _Gnuplot_ subyacente no es una manera "
+"demasiado buena que _wxMaxima_ ofrezca un menú de pulsación secundaria que "
+"permita abrir el tramado dentro de una ventana interactiva de _Gnuplot_."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:560
+#, fuzzy, no-wrap
+#| msgid "### Opening Gnuplot’s command console in `plot` windows"
+msgid "Opening Gnuplot’s command console in `plot` windows"
+msgstr "### Abrir consola para instrucciones Gnuplot en las ventanas `tramado`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:564
+#, fuzzy
+#| msgid ""
+#| "On MS Windows, if in _Maxima_’s variable `gnuplot_command` \"gnuplot\" is "
+#| "replaced by \"wgnuplot\", _Gnuplot_ offers the possibility to open a "
+#| "console window, where _gnuplot_ commands can be entered into. "
+#| "Unfortunately, enabling this feature causes _Gnuplot_ to \"steal\" the "
+#| "keyboard focus for a short time every time a plot is prepared."
+msgid ""
+"On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and `wgnuplot."
+"exe`.  You can configure, which command should be used using the "
+"configuration menu. `wgnuplot.exe` offers the possibility to open a console "
+"window, where _gnuplot_ commands can be entered into, `gnuplot.exe` does not "
+"offer this possibility. Unfortunately, `wgnuplot.exe` causes _Gnuplot_ to "
+"\"steal\" the keyboard focus for a short time every time a plot is prepared."
+msgstr ""
+"En MS Windows, si dentro de la variable `gnuplot_command` de _Maxima_ "
+"\"gnuplot\" es reemplazado por \"wgnuplot\", _Gnuplot_ ofrece la posibilidad "
+"de abrir una ventana de la consola, donde las instrucciones de _gnuplot_ "
+"pueden ser introducidas.  Desafortunadamente, habilitando esta "
+"característica causa que _Gnuplot_ \"roba\" el foco del teclado por un breve "
+"tiempo mientras se prepara un tramado."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:565
+#, fuzzy, no-wrap
+#| msgid "### Embedding animations into the spreadsheet"
+msgid "Embedding animations into the spreadsheet"
+msgstr "### Empotrar animaciones dentro de la hoja de cálculo"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:568
+msgid ""
+"3D diagrams tend to make it hard to read quantitative data. A viable "
+"alternative might be to assign the 3rd parameter to the mouse wheel. The "
+"`with_slider_draw` command is a version of `wxdraw2d` that does prepare "
+"multiple plots and allows to switch between them by moving the slider on top "
+"of the screen. _WxMaxima_ allows to export this animation as an animated gif."
+msgstr ""
+"Diagramas 3D tienden hacerlo difícil para lectura de datos cuantitativos. "
+"Una alternativa viable sería asignar el 3er parámetro a la rueda del ratón.  "
+"La instrucción `with_slider_draw` es una versión de `wxdraw2d` que prepara "
+"múltiples tramados y permite conmutar entre ellos moviendo el arrastre en la "
+"cima de la pantalla.  _wxMaxima_ permite exportar esta animación como un gif "
+"animado."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:570
+msgid ""
+"The first two arguments for `with_slider_draw` are the name of the variable "
+"that is stepped between the plots and a list of the values of these "
+"variable. The arguments that follow are the ordinary arguments for "
+"`wxdraw2d`:"
+msgstr ""
+"Los primeros dos argumentos para `with_slider_draw` son el nombre de la "
+"variable que está pasada entre las tramas y un listado de los valores de "
+"estas variables.  Los argumentos que siguen son los argumentos ordinarios "
+"para `wxdraw2d`:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:571
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "with_slider_draw(\n"
+#| "    f,[1,2,3,4,5,6,7,10],\n"
+#| "    title=concat(\"f=\",f,\"Hz\"),\n"
+#| "    explicit(\n"
+#| "        sin(2*%pi*f*x),\n"
+#| "        x,0,1\n"
+#| "    ),grid=true\n"
+#| ");\n"
+#| "```\n"
+msgid ""
+"with_slider_draw(\n"
+"    f,[1,2,3,4,5,6,7,10],\n"
+"    title=concat(\"f=\",f,\"Hz\"),\n"
+"    explicit(\n"
+"        sin(2*%pi*f*x),\n"
+"        x,0,1\n"
+"    ),grid=true\n"
+");\n"
+msgstr ""
+"```maxima\n"
+"with_slider_draw(\n"
+"    f,[1,2,3,4,5,6,7,10],\n"
+"    title=concat(\"f=\",f,\"Hz\"),\n"
+"    explicit(\n"
+"        sin(2*%pi*f*x),\n"
+"        x,0,1\n"
+"    ),grid=true\n"
+");\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:583
+msgid ""
+"The same functionality for 3D plots is accessible as `with_slider_draw3d`, "
+"which allows for rotating 3d plots:"
+msgstr ""
+"La misma funcionalidad para tramas de 3D es accesible como ‘with_slider:"
+"draw3d’, el cual permite rotación en tramas de 3D:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:584
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxanimate_autoplay:true;\n"
+#| "wxanimate_framerate:20;\n"
+#| "with_slider_draw3d(\n"
+#| "    α,makelist(i,i,1,360,3),\n"
+#| "    title=sconcat(\"α=\",α),\n"
+#| "    surface_hide=true,\n"
+#| "    contour=both,\n"
+#| "    view=[60,α],\n"
+#| "    explicit(\n"
+#| "        sin(x)*sin(y),\n"
+#| "        x,-π,π,\n"
+#| "        y,-π,π\n"
+#| "    )\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    α,makelist(i,i,1,360,3),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,α],\n"
+"    explicit(\n"
+"        sin(x)*sin(y),\n"
+"        x,-π,π,\n"
+"        y,-π,π\n"
+"    )\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    α,makelist(i,i,1,360,3),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,α],\n"
+"    explicit(\n"
+"        sin(x)*sin(y),\n"
+"        x,-π,π,\n"
+"        y,-π,π\n"
+"    )\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:602
+msgid ""
+"If the general shape of the plot is what matters it might suffice to move "
+"the plot just a little bit in order to make its 3D nature available to the "
+"intuition:"
+msgstr ""
+"Si el formato general de la trama es que pasa quizá sufra mover el tramado "
+"tan solo un pequeño bit con el fin de crear su naturaleza 3D disponible a la "
+"intuición:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:603
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxanimate_autoplay:true;\n"
+#| "wxanimate_framerate:20;\n"
+#| "with_slider_draw3d(\n"
+#| "    t,makelist(i,i,0,2*π,.05*π),\n"
+#| "    title=sconcat(\"α=\",α),\n"
+#| "    surface_hide=true,\n"
+#| "    contour=both,\n"
+#| "    view=[60,30+5*sin(t)],\n"
+#| "    explicit(\n"
+#| "        sin(x)*y^2,\n"
+#| "        x,-2*π,2*π,\n"
+#| "        y,-2*π,2*π\n"
+#| "    )\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    t,makelist(i,i,0,2*π,.05*π),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,30+5*sin(t)],\n"
+"    explicit(\n"
+"        sin(x)*y^2,\n"
+"        x,-2*π,2*π,\n"
+"        y,-2*π,2*π\n"
+"    )\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    t,makelist(i,i,0,2*π,.05*π),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,30+5*sin(t)],\n"
+"    explicit(\n"
+"        sin(x)*y^2,\n"
+"        x,-2*π,2*π,\n"
+"        y,-2*π,2*π\n"
+"    )\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:621
+msgid ""
+"For those more familiar with `plot` than with `draw`, there is a second set "
+"of functions:"
+msgstr ""
+"Para aquello más familiar con `trama` en vez de `dibujo`, hay un segundo "
+"conjunto de funciones:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:624
+#, fuzzy
+#| msgid "- `with_slider` and - `wxanimate`."
+msgid "`with_slider` and"
+msgstr "- `with_slider` y - `wxanimate`."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:624
+msgid "`wxanimate`."
+msgstr "`wxanimate`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:626
+msgid ""
+"Normally the animations are played back or exported with the frame rate "
+"chosen in the configuration of _wxMaxima_. To set the speed at an individual "
+"animation is played back the variable `wxanimate_framerate` can be used:"
+msgstr ""
+"Normalmente las animaciones son retro-reproducidas o exportadas con la parte "
+"de marco elegida dentro de la configuración de _wxMaxima_.  Para establecer "
+"la velocidad se reproduce una animación individual de vuelta a la variable "
+"`wxanimate_framerate` puede utilizarse:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:627
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxanimate(a, 10,\n"
+#| "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+#| "```\n"
+msgid ""
+"wxanimate(a, 10,\n"
+"    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+msgstr ""
+"```maxima\n"
+"wxanimate(a, 10,\n"
+"    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:633
+msgid ""
+"The animation functions use _Maxima_’s `makelist` command and therefore "
+"share the pitfall that the slider variable’s value is substituted into the "
+"expression only if the variable is directly visible in the expression. "
+"Therefore the following example will fail:"
+msgstr ""
+"Las funciones de animación utilizan las instrucciones `makelist` de _Maxima_ "
+"y por lo tanto comparte el escollo que el valor de variable del arrastre se "
+"sustituye dentro de la expresión solamente si la variable es visible "
+"directamente dentro de la expresión.  Por lo tanto el siguiente ejemplo "
+"fallará:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:634
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "f:sin(a*x);\n"
+#| "with_slider_draw(\n"
+#| "    a,makelist(i/2,i,1,10),\n"
+#| "    title=concat(\"a=\",float(a)),\n"
+#| "    grid=true,\n"
+#| "    explicit(f,x,0,10)\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    a,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(a)),\n"
+"    grid=true,\n"
+"    explicit(f,x,0,10)\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    a,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(a)),\n"
+"    grid=true,\n"
+"    explicit(f,x,0,10)\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:645
+msgid ""
+"If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
+"works fine instead:"
+msgstr ""
+"Si _Maxima_ solicita explícitamente sustituir el valor del tramado "
+"deslizante funciona bien en su lugar:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:646
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "f:sin(a*x);\n"
+#| "with_slider_draw(\n"
+#| "    b,makelist(i/2,i,1,10),\n"
+#| "    title=concat(\"a=\",float(b)),\n"
+#| "    grid=true,\n"
+#| "    explicit(\n"
+#| "        subst(a=b,f),\n"
+#| "        x,0,10\n"
+#| "    )\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    b,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(b)),\n"
+"    grid=true,\n"
+"    explicit(\n"
+"        subst(a=b,f),\n"
+"        x,0,10\n"
+"    )\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    b,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(b)),\n"
+"    grid=true,\n"
+"    explicit(\n"
+"        subst(a=b,f),\n"
+"        x,0,10\n"
+"    )\n"
+")$\n"
+"```\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:659
+#, fuzzy, no-wrap
+#| msgid "### Opening multiple plots in contemporaneous windows"
+msgid "Opening multiple plots in contemporaneous windows"
+msgstr "### Abrir múltiples tramas en ventanas contemporáneas"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:662
+msgid ""
+"While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups "
+"that support it) sometimes comes in handily. The following example comes "
+"from a post from Mario Rodriguez to the _Maxima_ mailing list:"
+msgstr ""
+"Mientras no sean proporcionados por _wxMaxima_ esta característica de "
+"_Maxima_ (sobre configuraciones que la admitan) algunas veces vienen "
+"manualmente.  Los siguientes ejemplos vienen desde una carta desde Mario "
+"Rodríguez al listado de correo de _Maxima_:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:663
+#, no-wrap
+msgid ""
+"load(draw);\n"
+"\n"
+"/* Parabola in window #1 */\n"
+"draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Parabola in window #2 */\n"
+"draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Paraboloid in window #3 */\n"
+"draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:677
+msgid ""
+"Plotting multiple plots in the same window is possible, too (the same is "
+"possible in command line Maxima with the standard `draw()` command):"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:678
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "\twxdraw(\n"
+#| "\t\tgr2d(\n"
+#| "\t    \tkey=\"sin (x)\",grid=[2,2],\n"
+#| "\t    \texplicit(sin(x),x,0,2*%pi)),\n"
+#| "\t\tgr2d(\n"
+#| "\t   \tkey=\"cos (x)\",grid=[2,2],\n"
+#| "\t   \texplicit(cos(x),x,0,2*%pi))\n"
+#| "\t );\n"
+#| "```\n"
+msgid ""
+"wxdraw(\n"
+"  gr2d(\n"
+"    key=\"sin (x)\",grid=[2,2],\n"
+"    explicit(sin(x),x,0,2*%pi)),\n"
+"  gr2d(\n"
+"    key=\"cos (x)\",grid=[2,2],\n"
+"    explicit(cos(x),x,0,2*%pi))\n"
+");\n"
+msgstr ""
+"```maxima\n"
+"\twxdraw(\n"
+"\t\tgr2d(\n"
+"\t    \tkey=\"sin (x)\",grid=[2,2],\n"
+"\t    \texplicit(sin(x),x,0,2*%pi)),\n"
+"\t\tgr2d(\n"
+"\t   \tkey=\"cos (x)\",grid=[2,2],\n"
+"\t   \texplicit(cos(x),x,0,2*%pi))\n"
+"\t );\n"
+"```\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:689
+#, fuzzy, no-wrap
+#| msgid "### The \"Plot using draw\" side pane"
+msgid "The \"Plot using draw\" side pane"
+msgstr "### El panel lateral «Tramado utilizando dibujo»"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:692
+msgid ""
+"The \"Plot using draw\" sidebar hides a simple code generator that allows "
+"generating scenes that make use of some of the flexibility of the _draw_ "
+"package _maxima_ comes with."
+msgstr ""
+"La barra lateral «Tramado utilizando dibujo» oculta un generador de código "
+"simple que permite generar escenas que hagan uso de alguna de la "
+"flexibilidad del paquete _draw_ con el que _maxima_ viene."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:693
+#, no-wrap
+msgid "2D"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:696
+msgid ""
+"Generates the skeleton of a `draw()` command that draws a 2D scene. This "
+"scene later has to be filled with commands that generate the scene’s "
+"contents, for example by using the buttons in the rows below the \"2D\" "
+"button."
+msgstr ""
+"Genera el esqueleto de una instrucción `draw()` que dibuja una escena 2D.  "
+"Esta escena posterior tiene que ser completada con instrucciones que generan "
+"los contenidos de la escena, por ejemplo utilizando los botones dentro de "
+"las filas debajo del botón \"2D\"."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:698
+msgid ""
+"One helpful feature of the 2D button is that it allows to set up the scene "
+"as an animation in which a variable (by default it is _t_) has a different "
+"value in each frame: Often a moving 2D plot allows easier interpretation "
+"than the same data in a non-moving 3D one."
+msgstr ""
+"La característica de ayuda del botón 2D es que permite configurar la escena "
+"como una animación en la cual una variable (por defecto es _t_) tiene un "
+"valor diferente dentro de cada marco: a menudo un movimiento de trama 2D "
+"permite una interpretación más fácil que el de datos dentro de uno sin "
+"movimiento 3D."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:699
+#, no-wrap
+msgid "3D"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:702
+msgid ""
+"Generates the skeleton of a `draw()` command that draws a 3D scene. If "
+"neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D "
+"scene that contains the command the button generates."
+msgstr ""
+"Genera el esqueleto de una instrucción `draw()` que dibuja una escena 3D.  "
+"Si no está configurada ninguna escena 2D o 3D, todo de los otros botones "
+"configuran una escena 2D que contenga la instrucción que el botón genera."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:703
+#, fuzzy, no-wrap
+#| msgid "#### Expression"
+msgid "Expression"
+msgstr "#### Expresión"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:706
+msgid ""
+"Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or "
+"`x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is "
+"no draw command a 2D scene with the plot is generated. Each scene can be "
+"filled with any number of plots."
+msgstr ""
+"Adjunta una trama común de una expresión como `sin(x)`, `x*sin(x)` o "
+"`x^2+2*x-4` para la instrucción `draw()` el cursor actualmente está dentro.  "
+"Si no hay ninguna instrucción de dibujo en una escena 2D con la trama es "
+"generada.  Cada escena puede ser completada con cualquier número de tramas."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:707
+#, fuzzy, no-wrap
+#| msgid "#### Implicit plot"
+msgid "Implicit plot"
+msgstr "#### Tramado implícito"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:710
+msgid ""
+"Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or "
+"`x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command "
+"the cursor currently is in. If there is no draw command a 2D scene with the "
+"plot is generated."
+msgstr ""
+"Intenta encontrar todos los puntos como una expresión `y=sin(x)`, "
+"`y*sin(x)=3` o `x^2+y^2=4` es verdadero y trama de la curva resultante "
+"dentro de la instrucción `draw()` el cursor actualmente está dentro.  Si no "
+"hay instrucción de dibujo en escena de 2D con el trama es generado."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:711
+#, fuzzy, no-wrap
+#| msgid "#### Parametric plot"
+msgid "Parametric plot"
+msgstr "#### Trama paramétrica"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:714
+msgid ""
+"Steps a variable from a lower limit to an upper limit and uses two "
+"expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in "
+"3D plots also z) coordinates of a curve that is put into the current draw "
+"command."
+msgstr ""
+"Para un paso de una variable desde un límite inferior a un límite superior y "
+"utiliza dos expresiones como `t*sin(t)` y `t*cos(t)` para generar "
+"coordenadas x, y (y en tramas 3D también z) de una curva que es puesta "
+"dentro de la instrucción de actual del dibujo."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:715
+#, fuzzy, no-wrap
+#| msgid "#### Points"
+msgid "Points"
+msgstr "#### Puntos"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:718
+msgid ""
+"Draws many points that can optionally be joined. The coordinates of the "
+"points are taken from a list of lists, a 2D array or one list or array for "
+"each axis."
+msgstr ""
+"Dibuja muchos puntos que pueden ser unidos opcionalmente.  Las coordenadas "
+"de los puntos son tomados desde un listado de listas, una unimatriz 2D o un "
+"listado o unimatriz por cada eje."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:719
+#, fuzzy, no-wrap
+#| msgid "#### Diagram title"
+msgid "Diagram title"
+msgstr "#### Título del diagrama"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:722
+msgid "Draws a title on the upper end of the diagram,"
+msgstr "Dibuja un título sobre el final superior del diagrama,"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:723
+#, fuzzy, no-wrap
+#| msgid "#### 2D"
+msgid "Axis"
+msgstr "#### 2D"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:726
+msgid "Sets up the axis."
+msgstr "Establece los ejes."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:727
+#, fuzzy, no-wrap
+#| msgid "#### Contour"
+msgid "Contour"
+msgstr "#### Contorno"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:730
+msgid ""
+"(Only for 3D plots): Adds contour lines similar to the ones one can find in "
+"a map of a mountain to the plot commands that follow in the current `draw()` "
+"command and/or to the ground plane of the diagram. Alternatively, this "
+"wizard allows skipping drawing the curves entirely only showing the contour "
+"plot."
+msgstr ""
+"(Solo para tramas 3D): agrega líneas de contorno similares a los que puedan "
+"ser encontrados dentro de una asociación de una montaña a la trama de "
+"instrucciones que continúe dentro de la instrucción ‘draw()’ actual y/o al "
+"plano de tierra del diagrama.  Alternativamente, este asistente permite "
+"descartar el dibujo de las curvas completamente."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:731
+#, fuzzy, no-wrap
+#| msgid "#### Plot name"
+msgid "Plot name"
+msgstr "#### Nombre de trama"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:734
+msgid ""
+"Adds a legend entry showing the next plot’s name to the legend of the "
+"diagram. An empty name disables generating legend entries for the following "
+"plots."
+msgstr ""
+"Agrega un apunte para leyenda mostrando el nombre del siguiente tramado de "
+"la leyenda del diagrama. Un nombre vacío deshabilita generando apuntes de "
+"leyenda para las tramas siguientes."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:735
+#, fuzzy, no-wrap
+#| msgid "#### Line colour"
+msgid "Line colour"
+msgstr "#### Color de línea"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:738
+msgid ""
+"Sets the line colour for the following plots the current draw command "
+"contains."
+msgstr ""
+"Establece el color de línea para las tramas seguidas que contiene la "
+"instrucción de dibujo actual."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:739
+#, fuzzy, no-wrap
+#| msgid "#### Fill colour"
+msgid "Fill colour"
+msgstr "#### Color de relleno"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:742
+msgid ""
+"Sets the fill colour for the following plots the current draw command "
+"contains."
+msgstr ""
+"Establece un color de relleno para tramas seguidas que contiene la "
+"instrucción de dibujo actual."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:743
+#, fuzzy, no-wrap
+#| msgid "#### 2D"
+msgid "Grid"
+msgstr "#### 2D"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:746
+msgid "Pops up a wizard that allows to set up grid lines."
+msgstr "Aparece un asistente que permite establecer las líneas de rejilla."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:747
+#, fuzzy, no-wrap
+#| msgid "#### Accuracy"
+msgid "Accuracy"
+msgstr "#### Precisión"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:750
+msgid ""
+"Allows to select an adequate point in the speed vs. accuracy tradeoff that "
+"is part of any plot program."
+msgstr ""
+"Permite seleccionar un punto adecuado dentro de la velocidad versus "
+"exactitud compensada que es parte de cualquier programa de trama."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:751
+#, no-wrap
+msgid "Modify font and font size for plots"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:754
+msgid ""
+"Especially when you use a high resolution display, the default font size "
+"might be very small. For the `draw`-based commands, you can set the font / "
+"font size using options like `font=...`, `font_size=...`, e.g.:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:755
+#, fuzzy, no-wrap
+#| msgid ""
+#| "pngdraw2d(\"Test\",\n"
+#| "        explicit(sin(x),x,1,10)\n"
+#| ");\n"
+#| "```\n"
+msgid ""
+"wxdraw2d(\n"
+"     font=\"Helvetica\",\n"
+"     font_size=30,\n"
+"     explicit(sin(x),x,1,10));\n"
+msgstr ""
+"pngdraw2d(\"Prueba\",\n"
+"        explicit(sin(x),x,1,10)\n"
+");\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:763
+msgid ""
+"For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts "
+"can be set using the `gnuplot_preamble` command, e.g.:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:764
+#, no-wrap
+msgid ""
+"wxplot2d(sin(x),[x,1,10],\n"
+"         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:770
+msgid ""
+"This sets the font for the numbers to Arial with size 30, the size for the "
+"xlabel and ylabel font to 20 (with the default font)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:773
+msgid ""
+"Read the Maxima and Gnuplot documentation for further information.  Note: "
+"Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue "
+"1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966)."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:774
+#, fuzzy, no-wrap
+#| msgid "## Embedding graphics"
+msgid "Embedding graphics"
+msgstr "## Gráficos empotrados"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:777
+msgid ""
+"If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
+"project can be done as easily as per drag-and-drop. But sometimes (for "
+"example if an image’s contents might change later on in a session) it is "
+"better to tell the file to load the image on evaluation:"
+msgstr ""
+"Si el formato de archivo `.wxmx` está siendo utilizado empotrando archivos "
+"dentro de un proyecto _wxMaxima_ puede ser hecho como fácilmente como por "
+"arrastrar-y-soltar.  Pero algunas veces (por ejemplo si el contenido de la "
+"imagen es modificado posteriormente sobre una sesión) es mejor decirle al "
+"archivo que cargue la imagen al evaluar:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:778
+#, fuzzy, no-wrap
+#| msgid "```maxima show_image(\"man.png\"); ```"
+msgid "show_image(\"man.png\");\n"
+msgstr "```maxima show_image(\"man.png\"); ```"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:782
+#, fuzzy, no-wrap
+#| msgid "## Startup files"
+msgid "Startup files"
+msgstr "## Archivos de inicio"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:785
+msgid ""
+"The config dialogue of _wxMaxima_ offers to edit two files with commands "
+"that are executed on startup:"
+msgstr ""
+"El diálogo de configuración de _wxMaxima_ ofrece editar dos archivos con "
+"instrucciones que son ejecutadas al inicializar:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:788
+msgid ""
+"A file that contains commands that are executed on starting up _Maxima_: "
+"`maxima-init.mac`"
+msgstr ""
+"Un fichero que contenga instrucciones que estén ejecutadas al iniciar "
+"_Maxima_: «maxima-init.mac»"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:788
+#, fuzzy
+#| msgid ""
+#| "A file that contains commands that are executed on starting up _Maxima_: "
+#| "`maxima-init.mac`"
+msgid ""
+"one file of additional commands that are executed if _wxMaxima_ is starting "
+"_Maxima_: `wxmaxima-init.mac`"
+msgstr ""
+"Un fichero que contenga instrucciones que estén ejecutadas al iniciar "
+"_Maxima_: «maxima-init.mac»"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:790
+msgid ""
+"For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add "
+"`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` "
+"or any other path) to these files."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:792
+#, fuzzy
+#| msgid ""
+#| "These files are in the Maxima user directory (usually `maxima` in "
+#| "Windows, `.maxima` otherwise) in the user’s home directory / user profile "
+#| "directory. The location can be found out with the command: "
+#| "`maxima_userdir;`"
+msgid ""
+"These files are in the Maxima user directory (usually `%USERPROFILE%/maxima` "
+"in Windows, `$HOME/.maxima` otherwise). The location can be found out with "
+"the command: `maxima_userdir;`"
+msgstr ""
+"Estos archivos están dentro del directorio del usuario de Maxima (usualmente "
+"`maxima` en Windows, `.maxima` en otros sitios) dentro del directorio "
+"inicial del usuario / perfil.  La ubicación puede ser encontrada fuera con "
+"la instrucción: `maxima_userdir;`"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:793
+#, fuzzy, no-wrap
+#| msgid "## Special variables wx..."
+msgid "Special variables wx..."
+msgstr "## Variables especiales wx..."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxsubscripts` tells _Maxima_ if it should convert variable names that "
+"contain an underscore (`R_150` or the like) into subscripted variables. See "
+"`wxdeclare_subscript` for details which variable names are automatically "
+"converted."
+msgstr ""
+"‘wxsubscripts’ le dice a _Maxima_ si debería convertir los nombres de "
+"variables que contengan un guión bajo (‘R_150’ o lo similar) en variables "
+"sub-guion.  Vea ‘wxdeclare_subscript’ para detalles los cuales nombres de "
+"variables son convertidos automáticamente."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxfilename`: This variable contains the name of the file currently opened "
+"in _wxMaxima_."
+msgstr ""
+"`wxfilename`: esta variable contiene el nombre del fichero actualmente "
+"abierto en _wxMaxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+#, fuzzy
+#| msgid ""
+#| "`wxfilename`: This variable contains the name of the file currently "
+#| "opened in _wxMaxima_."
+msgid ""
+"`wxdirname`: This variable contains the name the directory, in which the "
+"file currently opened in _wxMaxima_ is."
+msgstr ""
+"`wxfilename`: esta variable contiene el nombre del fichero actualmente "
+"abierto en _wxMaxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+#, fuzzy
+#| msgid ""
+#| "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _gnuplot_’s "
+#| "pngcairo terminal that provides more line styles and a better overall "
+#| "graphics quality."
+msgid ""
+"`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_’s pngcairo "
+"terminal that provides more line styles and a better overall graphics "
+"quality."
+msgstr ""
+"`wxplot_pngcairo` indica si _wxMaxima_ intenta utilizar el terminal de "
+"pngcairo _gnuplot_ que proporciona más estilos de línea y un mejor calidad "
+"gráfica sobre todo."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxplot_size` defines the resolution of embedded plots."
+msgstr "`wxplot_size` define la resolución de tramas empotradas."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
+"_Maxima_’s working directory to the directory of the current file. This "
+"allows file I/O (e.g. by `read_matrix`) to work without specifying the whole "
+"path to the file that has to be read or written. On Windows this feature "
+"sometimes causes error messages and therefore can be set to `false` from the "
+"config dialogue."
+msgstr ""
+"`wxchangedir`: en la mayoría de los sistemas _wxMaxima_ establece "
+"automáticamente el directorio de trabajo de _Maxima_ al directorio del "
+"fichero actual.  Esto permite la E/S del fichero (p.ej. a través de "
+"`read_matrix`) para trabajar sin especificar la ruta completa del fichero "
+"que tiene que ser leído o escrito.  En Windows algunas veces esta "
+"característica causa mensajes de error y por lo tanto puede ser puesta a "
+"`false` desde el dialogo de configuración."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxanimate_framerate`: The number of frames per second the following "
+"animations have to be played back with."
+msgstr ""
+"`wxanimate_framerate`: El número de marcos por segundo de las siguientes "
+"animaciones con las que tienen que ser representadas."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxanimate_autoplay`: Automatically play animations by default?"
+msgstr ""
+"`wxanimate_autoplay`: Reproduce automáticamente animaciones "
+"predeterminadamente?"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these "
+"differ by maintainer, distribution and operating system:"
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@userconfdir`: The directory the user's configuration is stored in. "
+"Same directory as `maxima_userdir` (see above) - both point at the same "
+"place, `wxdirs@userconfdir` is only useful if that is more convenient to "
+"reach from a `.mac` file than the Maxima-side variable."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the built-in "
+"autocompletion list, ...) is installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@helpdir`: The directory the offline copy of this manual is installed "
+"in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@localedir`: The directory _wxMaxima_'s translation files are "
+"installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_ is "
+"configured to start."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:812
+#, fuzzy, no-wrap
+#| msgid "## Pretty-printing 2D output"
+msgid "Pretty-printing 2D output"
+msgstr "## Salida de 2D con impresión bonita"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:815
+msgid ""
+"The function `table_form()` displays a 2D list in a form that is more "
+"readable than the output from _Maxima_’s default output routine. The input "
+"is a list of one or more lists. Like the \"print\" command, this command "
+"displays output even when ended with a dollar sign. Ending the command with "
+"a semicolon results in the same table along with a \"done\" statement."
+msgstr ""
+"La función `table_form()` representa un listado 2D dentro de un formulario "
+"que es más legible que la salida desde la rutina de salida predeterminada de "
+"_Maxima_. La entrada es un listado de uno o más listados. Como la "
+"instrucción \"print\", esta instrucción representa la salida incluso cuando "
+"finalizó con signo de dólar. Finalifilledzando la instrucción con un "
+"resultado punto y coma devuelve el resultado en la misma tabla a lo largo "
+"con un enunciado \"done\"."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:816
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "table_form(\n"
+#| "    [\n"
+#| "        [1,2],\n"
+#| "        [3,4]\n"
+#| "    ]\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"table_form(\n"
+"    [\n"
+"        [1,2],\n"
+"        [3,4]\n"
+"    ]\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"table_form(\n"
+"    [\n"
+"        [1,2],\n"
+"        [3,4]\n"
+"    ]\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:826
+msgid ""
+"As the next example shows, the lists that are assembled by the `table_form` "
+"command can be created before the command is executed."
+msgstr ""
+"Como se muestra en el ejemplo siguiente, los listados que son ensamblados "
+"por la instrucción ‘table_form’ pueden ser creados antes que la instrucción "
+"sea ejecutada."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:828
+msgid ""
+"![A third table example](./MatrixTableExample.png)"
+"{ id=img_MatrixTableExample }"
+msgstr ""
+"![Un tercer ejemplo de tabla](./MatrixTableExample.png)"
+"{ id=img_MatrixTableExample }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:830
+msgid ""
+"Also, because a matrix is a list of lists, matrices can be converted to "
+"tables in a similar fashion."
+msgstr ""
+"Además, porque una matriz es un listado de listados, las matrices pueden "
+"convertirse a tablas de una aparición similar."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:832
+msgid ""
+"![Another table_form example](./SecondTableExample.png)"
+"{ id=img_SecondTableExample }"
+msgstr ""
+"![Otro ejemplo de tabla_formulario](./EjemploSegundaTabla.png)"
+"{ id=img_EjemploSegundaTabla }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:834
+msgid ""
+"The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that "
+"allows for more flexible formatting of matrices in wxMaxima:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:836
+#, no-wrap
+msgid "**`wx_matrix( <matrix>, [options] )`**\n"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`lines=true`**: Draws internal separator lines between the cells. This is "
+"required to visually separate headings from data."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`rownames=true`**: Tells wxMaxima that the first column of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`colnames=true`**: Tells wxMaxima that the first row of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
+"around the matrix. Supported styles are: `round` `()`, `square` `[]`, "
+"`angled` `<>`, `straight` `||`, or `none`."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:843
+msgid "Example:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:844
+#, no-wrap
+msgid ""
+"wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
+"          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:849
+#, fuzzy, no-wrap
+#| msgid "## Bug reporting"
+msgid "Bug reporting"
+msgstr "## Comunicar fallo"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:852
+msgid ""
+"_WxMaxima_ provides a few functions that gather bug reporting information "
+"about the current system:"
+msgstr ""
+"_WxMaxima_ proporciona unas pocas funciones que obtenga información de "
+"comunicados de fallos acerca del sistema actual:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:855
+#, fuzzy
+#| msgid ""
+#| "- `wxbuild_info()` gathers information about the currently running "
+#| "version of _wxMaxima_ - `wxbug_report()` tells how and where to file bugs"
+msgid ""
+"`wxbuild_info()` gathers information about the currently running version of "
+"_wxMaxima_"
+msgstr ""
+"- `wxbuild_info()` obtiene información sobre la versión de _wxMaxima_ "
+"actualmente en ejecución - `wxbug_report()` dice como y donde están los "
+"archivos de fallos"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:855
+msgid "`wxbug_report()` tells how and where to file bugs"
+msgstr "`wxbug_report()` informa cómo y donde archivar los gazapos"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:856
+#, fuzzy, no-wrap
+#| msgid "## Marking output being drawn in red"
+msgid "Marking output being drawn in red"
+msgstr "## Marcar que la salida sea dibujada en rojo"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:860
+msgid ""
+"_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a "
+"red foreground, if the second argument to the command is the text "
+"`highlight`."
+msgstr ""
+"La instrucción `box()` de _Maxima_ causa que _wxMaxima_ escriba su argumento "
+"con un fondo rojo, si el segundo argumento para la instrucción es el texto "
+"`resaltado`."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:861
+#, no-wrap
+msgid "Output rendering."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:864
+msgid "With `set_display()` one can set, how wxMaxima will render the output."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:866
+msgid ""
+"`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima "
+"using an (machine readable) XML-dialect (can be seen in the \"Raw XML "
+"sidebar\") and outputs the resulting formulas nicely rendered, e.g. pretty "
+"Matrices, Square root signs, fractions, etc."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:869
+#, no-wrap
+msgid ""
+"<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->\n"
+"`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:871
+msgid ""
+"`set_display('none)` causes 'one-line' ASCII results - the same as the "
+"command line Maxima command `display2d:false;` does."
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:872
+#, fuzzy, no-wrap
+#| msgid "# Help menu"
+msgid "Help menu"
+msgstr "# Menú de ayuda"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:875
+msgid ""
+"WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, "
+"tips, some example worksheets and in command line Maxima included demos (the "
+"`demo()` command)."
+msgstr ""
+"El menú de ayuda de wxMaxima proporciona acceso para el manual de Maxima y "
+"wxMaxima, consejos, algunos ejemplos de hojas de trabajo y en la línea de "
+"instrucción de Maxima incluyó demos (la instrucción `demo()`)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:877
+msgid "Please notice, that the demos write:"
+msgstr "Infórmese, que las demos escriben:"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:878
+#, fuzzy, no-wrap
+#| msgid "~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.  ~~~"
+msgid "At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.\n"
+msgstr "~~~text En la solicitud ’_’, teclee ’;’ y <entrar> para proceder con la demostración.  ~~~"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:883
+#, fuzzy, no-wrap
+#| msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>"
+msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>\n"
+msgstr "Eso es válido para línea de instrucciones de Maxima, sin embargo en wxMaxima por defecto es necesario continuar la demostración con: <kbd>CTRL</kbd>+<kbd>ENTRAR</kbd>"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:885
+#, fuzzy, no-wrap
+#| msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)"
+msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)\n"
+msgstr "(Eso puede ser configurado en el menú Configurar→Hoja de trabajo→\"Teclas directas para enviar instrucciones a Maxima\".)"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:888
+#, fuzzy, no-wrap
+#| msgid "# Troubleshooting"
+msgid "Troubleshooting"
+msgstr "# Solución de problemas"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:890
+#, fuzzy, no-wrap
+#| msgid "## Cannot connect to _Maxima_"
+msgid "Cannot connect to _Maxima_"
+msgstr "## No se puede conectar a _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:893
+msgid ""
+"Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ "
+"(providing the easy-to-use user interface) are separate programs that "
+"communicate by the means of a local network connection. Therefore the most "
+"probable cause is that this connection is somehow not working. For example, "
+"a firewall could be set up in a way that it doesn’t just prevent "
+"unauthorized connections from the internet (and perhaps intercept some "
+"connections to the internet, too), but also blocks inter-process-"
+"communication inside the same computer. Note that since _Maxima_ is being "
+"run by a Lisp processor the process communication that is blocked does not "
+"necessarily have to be named \"maxima\". Common names of the program that "
+"opens the network connection would be sbcl, gcl, ccl, lisp.exe, or similar "
+"names."
+msgstr ""
+"Desde _Maxima_ (el programa que hace las matemáticas actuales) y _wxMaxima_ "
+"(proporcionando el interfaz de usuario de uso-fácil) con programas separados "
+"que se comunican por los medios de una conexión de red local.  Por lo tanto "
+"la causa más probable es que esta conexión es algo que no funciona.  Por "
+"ejemplo un cortafuegos pudo configurarse de una manera que no tan solo "
+"impida conexiones no autorizadas desde Internet (y quizá intercepta algunas "
+"conexiones de Internet, también), pero además bloquea la comunicación de "
+"inter-procesos dentro del mismo equipo.  Nótese que desde _Maxima_ se está "
+"ejecutando por un proceso Lisp la comunicación del proceso que está "
+"bloqueado desde unos no necesariamente tiene que ser nombrado como "
+"\"maxima\".  Los nombres comunes del programa que abre la conexión de red "
+"sería sbcl, gcl, ccl, lisp.exe o nombres similares."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:895
+msgid ""
+"On Unix computers another possible reason would be that the loopback network "
+"that provides network connections between two programs in the same computer "
+"isn’t properly configured."
+msgstr ""
+"En las máquinas Un\\*x otra razón posible sería que la red del bucle "
+"invertido que proporciona conexiones de red entre dos programas dentro del "
+"mismo equipo no está configurado apropiadamente."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:896
+#, fuzzy, no-wrap
+#| msgid "## How to save data from a broken .wxmx file"
+msgid "How to save data from a broken .wxmx file"
+msgstr "## Cómo guardar datos desde un archivo .wxmx defectuoso"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:899
+msgid ""
+"Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ "
+"doesn’t turn on compression, so the contents of `.wxmx` files can be viewed "
+"in any text editor."
+msgstr ""
+"Internamente muchos formatos modernos basados en XML están normalmente en "
+"archivos zip. _WxMaxima_ no activa la compresión, por lo que el contenido de "
+"los archivos `.wxmx` pueden verse en cualquier editor de texto."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:901
+msgid ""
+"If the zip signature at the end of the file is still intact after renaming a "
+"broken `.wxmx` file to `.zip` most operating systems will provide a way to "
+"extract any portion of the information that is stored inside it. This can be "
+"done when there is a need of recovering the original image files from a text "
+"processor document. If the zip signature isn’t intact that does not need to "
+"be the end of the world: If _wxMaxima_ during saving detected that something "
+"went wrong there will be a `.wxmx~` file whose contents might help."
+msgstr ""
+"Si la firma zip en el final del archivo aún está intacta tras renombrar un "
+"archivo `.wxmx` estropeado a `.zip` muchos sistemas operativos "
+"proporcionarán una manera de extraer cualquier porción de información que "
+"esté almacenada dentro de ésta.  Esto puede ser hecho cuando hay la "
+"necesitad de recuperar los archivos de imagen original desde un documento de "
+"procesamiento de texto.  Si la firma zip no está intacta que no necesita "
+"estar el final del mundo: si _wxMaxima_ al guardar ha detectado que algo es "
+"erróneo habrá un archivo `.wxmx~` cuyo contenido quizá ayude."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:903
+#, fuzzy, no-wrap
+#| msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor)."
+msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).\n"
+msgstr "E incluso si no hay un archivo: el archivo `.wxmx` es un formato de contenedor y la porción XML es almacenada sin comprimir.  Es posible renombrar el archivo `.wxmx` a un archivo `.txt` y utilizar un editor de texto para recuperar la porción XML del contenido del archivo (se inicia con `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` y termina con `</wxMaximaDocument>`. Antes y después de ese texto verá algún contenido binario no legible dentro del editor del texto)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:905
+msgid ""
+"If a text file containing only these contents (e.g. copy and paste this text "
+"into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know "
+"how to recover the text from the document."
+msgstr ""
+"Si un archivo de texto conteniendo solamente estos contenidos (p.ej. copiar "
+"y pegar este texto a un archivo nuevo) es guardado como un archivo "
+"terminando en `.xml`, _wxMaxima_ conocerá como recuperar el texto desde el "
+"documento."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:906
+#, fuzzy, no-wrap
+#| msgid "## I want some debug info to be displayed on the screen before my command has finished"
+msgid "I want some debug info to be displayed on the screen before my command has finished"
+msgstr "## Deseo algo del informe de depuración para ser desplegada sobre la pantalla antes de que mi instrucción haya finalizado"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:909
+msgid ""
+"Normally _wxMaxima_ waits for the whole 2D formula to be transferred before "
+"it begins to typeset. This saves time for making many attempts to typeset a "
+"only partially completed equation. There is a `disp` command, though, that "
+"will provide debug output immediately and without waiting for the current "
+"_Maxima_ command to finish:"
+msgstr ""
+"Normalmente _wxMaxima_ espera a la fórmula 2D completa para ser transferida "
+"antes que comenzar a configurar el conjunto del tipo.  Esto guarda tiempo "
+"para crear muchos intentos para tipos de teclas para solo ecuación "
+"parcialmente completada.  Hay una instrucción `disp`, por lo que, eso "
+"proporcionará salida de depuración inmediatamente y sin esperar a que la "
+"instrucción de _Maxima_ finalice:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:910
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "for i:1 thru 10 do (\n"
+#| "   disp(i),\n"
+#| "   /* (sleep n) is a Lisp function, which can be used */\n"
+#| "   /* with the character \"?\" before. It delays the */\n"
+#| "   /* program execution (here: for 3 seconds) */\n"
+#| "   ?sleep(3)\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"for i:1 thru 10 do (\n"
+"   disp(i),\n"
+"   /* (sleep n) is a Lisp function, which can be used */\n"
+"   /* with the character \"?\" before. It delays the */\n"
+"   /* program execution (here: for 3 seconds) */\n"
+"   ?sleep(3)\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"for i:1 thru 10 do (\n"
+"   disp(i),\n"
+"   /* (sleep n) es una función de Lisp, la cual puede utilizarse */\n"
+"   /* con el carácter \"?\" antes.  Retrasa la ejecución del */\n"
+"   /* programa (aquí: por 3 segundos) */\n"
+"   ?sleep(3)\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:921
+msgid "Alternatively one can look for the `wxstatusbar()` command above."
+msgstr ""
+"Alternativamente uno puede buscar la instrucción `wxstatusbar()` arriba."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:922
+#, fuzzy, no-wrap
+#| msgid "## Plotting only shows a closed empty envelope with an error message"
+msgid "Plotting only shows a closed empty envelope with an error message"
+msgstr "## El tramado solamente muestra una cobertura de sobre vacío cerrado con un mensaje de error"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:925
+msgid ""
+"This means that _wxMaxima_ could not read the file _Maxima_ that was "
+"supposed to instruct _Gnuplot_ to create."
+msgstr ""
+"Esto significa que _wxMaxima_ no pudo leer el archivo _Maxima_ que fue "
+"proporcionado a la instrucción _Gnuplot_ para crear."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:927
+msgid "Possible reasons for this error are:"
+msgstr "Las posibles razones de este error son:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+msgid ""
+"The plotting command is part of a third-party package like `implicit_plot` "
+"but this package was not loaded by _Maxima_’s `load()` command before trying "
+"to plot."
+msgstr ""
+"La instrucción de tramado es parte de un paquete de tercera parte como "
+"‘implicit_plot’ pero este paquete no fue cargado por la instrucción ‘load()’ "
+"de _Maxima_ porque está intentando puntear."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+msgid ""
+"_Maxima_ tried to do something the currently installed version of _Gnuplot_ "
+"isn’t able to understand. In this case, a file ending in `.gnuplot` located "
+"in the directory, which _Maxima_’s variable `maxima_userdir` is pointing, "
+"contains the instructions from _Maxima_ to _Gnuplot_. Most of the time, this "
+"file’s contents therefore are helpful when debugging the problem."
+msgstr ""
+"_Maxima_ intentó hacer algo que la versión actualmente instalada de "
+"_gnuplot_ no es capaz de entender.  En este caso, un fichero terminando en `."
+"gnuplot` localizado en el directorio, el cual la variable `maxima_userdir` "
+"está apuntando, contiene las instrucciones desde _Maxima_ para _gnuplot_.  "
+"La mayoría del tiempo, estos contenidos del fichero contiene por lo tanto "
+"ayuda cuando se depura el problema."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+msgid ""
+"Gnuplot was instructed to use the pngCairo library that provides "
+"antialiasing and additional line styles, but it was not compiled to support "
+"this possibility. Solution: Uncheck the \"Use the Cairo terminal for the "
+"plot\" checkbox in the configuration dialog and don’t set `wxplot_pngcairo` "
+"to true from _Maxima_."
+msgstr ""
+"Gnuplot fue instruido para utilizar la biblioteca pngcairo que proporciona "
+"antialias y estilos de líneas adicionales, pero no fue compilado para "
+"admitir esta posibilidad.  Solución: Desmarque la casilla «Utilizar el "
+"terminal cairo para tramas» dentro del diálogo de configuración y no "
+"establezca `wxplot_pngcairo` a cierto desde _Maxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+msgid "Gnuplot didn’t output a valid `.png` file."
+msgstr "Gnuplot no saca un fichero «.png» válido."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:933
+#, fuzzy, no-wrap
+#| msgid "## Plotting an animation results in “error: undefined variable”"
+msgid "Plotting an animation results in “error: undefined variable”"
+msgstr "## Tramar una animación de resultados en «error: variable no definida»"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:936
+msgid ""
+"The value of the slider variable by default is only substituted into the "
+"expression that is to be plotted if it is visible there. Using a `subst` "
+"command that substitutes the slider variable into the equation to plot "
+"resolves this problem. At the end of section [Embedding animations into the "
+"spreadsheet](#embedding-animations-into-the-spreadsheet), you can see an "
+"example."
+msgstr ""
+"El valor de la variable desplazada por defecto únicamente es sustituido "
+"dentro de la expresión que está para ser tramado si es visible ahí.  "
+"Utilizando una orden `subst` que sustituya la variable de arrastre dentro de "
+"la ecuación para tramar soluciones que resuelvan este problema.  Al final de "
+"la sección [Animaciones empotradas a la hoja de cálculo](#embedding-"
+"animations-into-the-spreadsheet), puede consultar un ejemplo."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:937
+#, fuzzy, no-wrap
+#| msgid "## I lost cell content and undo doesn’t remember"
+msgid "I lost cell content and undo doesn’t remember"
+msgstr "## He perdido el contenido de una celda y al deshacer no lo recuerda"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:940
+msgid ""
+"There are separate undo functions for cell operations and for changes inside "
+"of cells so chances are low that this ever happens. If it does there are "
+"several methods to recover data:"
+msgstr ""
+"Hay funciones de deshacer separadas para operaciones de celdas y para "
+"modificaciones dentro de celdas tales que modifiquen son bajos que este a "
+"veces ocurran.  Si no hay varios métodos para cubrir datos:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+msgid ""
+"_WxMaxima_ actually has two undo features: The global undo buffer that is "
+"active if no cell is selected and a per-cell undo buffer that is active if "
+"the cursor is inside a cell. It is worth trying to use both undo options in "
+"order to see if an old value can still be accessed."
+msgstr ""
+"_wxMaxima_ actualmente tiene dos características de deshacer: el búfer de "
+"deshacer global que está activo si ninguna celda está seleccionada y un "
+"deshacer por celda que está activo si el cursor está dentro de una celda.  "
+"Es peor intentar utilizar ambas opciones con el fin de ver si un valor "
+"anterior aún puede ser accedido."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+msgid ""
+"If you still have a way to find out what label _Maxima_ has assigned to the "
+"cell just type in the cell’s label and its contents will reappear."
+msgstr ""
+"Si todavía tiene una manera de encontrar cual etiqueta de _Maxima_ ha "
+"asignado a la celda tan solo teclee dentro de la etiqueta de la celda y sus "
+"contenidos aparecerán."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+msgid ""
+"If you don’t: Don’t panic. In the “View” menu there is a way to show a "
+"history pane that shows all _Maxima_ commands that have been issued recently."
+msgstr ""
+"Si no: no se asuste. En el menú “Vista” hay una manera de ver un panel "
+"histórico que muestra todas las instrucciones de _Maxima_ que han sido "
+"emitidas recientemente."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+msgid "If nothing else helps _Maxima_ contains a replay feature:"
+msgstr ""
+"Si nada más ayuda _Maxima_ contiene una característica de reproducción:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:946
+#, no-wrap
+msgid "playback();\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:950
+#, fuzzy, no-wrap
+#| msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
+msgid "_WxMaxima_ starts up with the message “Maxima process terminated.”"
+msgstr "## _WxMaxima_ arranca con el mensaje «Proceso de Maxima terminado.»"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:953
+msgid ""
+"One possible reason is that _Maxima_ cannot be found in the location that is "
+"set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore "
+"won’t run at all. Setting the path to a working _Maxima_ binary should fix "
+"this problem."
+msgstr ""
+"Una razón posible es que _Maxima_ no puede ser encontrada dentro de la "
+"localización que está fijada dentro de la etiqueta “Maxima” del diálogo de "
+"configuración de _wxMaxima_ y por lo tanto no ejecutará nada.  Estableciendo "
+"la ruta a un _Maxima_ binario para el trabajo debería solucionar este "
+"problema."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:954
+#, fuzzy, no-wrap
+#| msgid "## Maxima is forever calculating and not responding to input"
+msgid "Maxima is forever calculating and not responding to input"
+msgstr "## ‘Maxima’ está calculando para siempre y no responde a la entrada"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:957
+msgid ""
+"It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ "
+"has finished calculating and therefore never gets informed it can send new "
+"data to _Maxima_. If this is the case “Trigger evaluation” might "
+"resynchronize the two programs."
+msgstr ""
+"Es posible teóricamente que _wxMaxima_ no realiza que _Maxima_ ha finalizado "
+"el cálculo y por lo tanto nunca está informado que puede enviar datos nuevos "
+"a _Maxima_. Si esto es el caso “Disparar evaluación” tal vez re-sincronice "
+"los dos programas."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:958
+#, fuzzy, no-wrap
+#| msgid "## My SBCL-based _Maxima_ runs out of memory"
+msgid "My SBCL-based _Maxima_ runs out of memory"
+msgstr "## Mi _Maxima_ basada en SBCL se ejecuta fuera de la memoria"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:961
+msgid ""
+"The Lisp compiler SBCL by default comes with a memory limit that allows it "
+"to run even on low-end computers. When compiling a big software package like "
+"Lapack or dealing with extremely big lists of equations this limit might be "
+"too low. In order to extend the limits, SBCL can be provided with the "
+"command line parameter `--dynamic-space-size` that tells SBCL how many "
+"megabytes it should reserve. A 32bit Windows-SBCL can reserve up to 999 "
+"Megabytes. A 64-bit SBCL version running on Windows can be instructed to use "
+"more than the about 1280 Megabytes compiling Lapack needs."
+msgstr ""
+"El compilador Lisp SBCL por defecto viene con un límite de memoria que lo "
+"permite ejecutar incluso en equipos de bajo nivel.  Cuando compile un "
+"paquete de software grande como Lapack u ocupándose con listados "
+"extremadamente grandes de ecuaciones este límite tal vez sea demasiado "
+"bajo.  Con el fin de extender los límites SBCL puede ser previsto con la "
+"línea del parámetro de instrucción `--dynamic-space-size` que indica a SBCL "
+"cuantos megabytes debería reservar.  Una ventana SBCL de 32-bit puede "
+"reservar hasta 999 megabytes, una versión SBCL de 64-bit ejecutándose en "
+"Windows pude ser instruido para utilizar más que la cantidad de 1280 "
+"megabytes compilando las necesidades Lapack."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:963
+msgid ""
+"One way to provide _Maxima_ (and thus SBCL) with command line parameters is "
+"the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration "
+"dialogue."
+msgstr ""
+"Una manera de proporcionar a _Maxima_ (y por lo tanto SBCL) con parámetros "
+"de línea de instrucción es el campo «Parámetros adicionales para Maxima» del "
+"diálogo de configuración de _wxMaxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:965
+msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
+msgstr "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:966
+#, fuzzy, no-wrap
+#| msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgstr "## Algunas veces las teclas de entrada son vagas/perezosas en Ubuntu"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:969
+msgid ""
+"Installing the package `ibus-gtk` should resolve this issue. See ([https://"
+"bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs."
+"launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) for details."
+msgstr ""
+"La instalación del paquete «ibus-gtk» debería resolver este problema.  Vea "
+"[https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558]"
+"(https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) para "
+"los detalles."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:970
+#, fuzzy, no-wrap
+#| msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgid "_WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgstr "## _WxMaxima_ se detiene cuando _Maxima_ procesa caracteres griegos o ümlaut"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:973
+msgid ""
+"If your _Maxima_ is based on SBCL the following lines have to be added to "
+"your `.sbclrc`:"
+msgstr ""
+"Si su _Maxima_ está basado en SBCL las siguientes líneas tienen que ser "
+"agregadas a su `.sbclrc`:"
+
+#. type: Fenced code block (commonlisp)
+#: ../../info/wxmaxima.md:974
+#, fuzzy, no-wrap
+#| msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
+msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
+msgstr "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:979
+msgid ""
+"The folder where this file has to be placed is system- and installation-"
+"specific. But any SBCL-based _Maxima_ that already has evaluated a cell in "
+"the current session will happily tell where it can be found after getting "
+"the following command:"
+msgstr ""
+"La carpeta donde este archivo tiene que colocarse es específico del sistema "
+"e instalación.  Pero cualquier _Maxima_ basada en SBCL que ya ha evaluado "
+"una celda dentro de la sesión actual felizmente dirá donde puede ser "
+"encontrada tras obtener la instrucción siguiente:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:980
+#, fuzzy, no-wrap
+#| msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
+msgid ":lisp (sb-impl::userinit-pathname)\n"
+msgstr "```maxima :lisp (sb-impl::userinit-pathname)  ```"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:984
+#, fuzzy, no-wrap
+#| msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
+msgid "Note concerning Wayland (recent Linux/BSD distributions)"
+msgstr "## Nota concerniente a Wayland (distribuciones recientes de Linux/BSD)"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:988
+msgid ""
+"There seem to be issues with the Wayland Display Server and wxWidgets.  "
+"WxMaxima may be affected, e.g. that sidebars are not moveable."
+msgstr ""
+"Parecen ser emitidos con el Servidor de Pantalla Wayland y wxWidgets.  "
+"WxMaxima puede ser afectado, p.ej. esas barras laterales no son movibles."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:992
+msgid ""
+"You can either disable Wayland and use X11 instead (globally)  or just tell, "
+"that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
+msgstr ""
+"Puede o bien desactivar Wayland y utilizar X11 en su lugar (globalmente) o "
+"tan solo decir, que wxMaxima utilizaría el X Window System poniendo: "
+"`GDK_BACKEND=x11`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:994
+msgid "E.g. start wxMaxima with:"
+msgstr "P.ej. inicia wxMaxima con:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:996
+msgid "`GDK_BACKEND=x11 wxmaxima`"
+msgstr "`GDK_BACKEND=x11 wxmaxima`"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:997
+#, no-wrap
+msgid "The menu bar disappears on KDE Plasma"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1003
+msgid ""
+"On some KDE Plasma installations the global menu bar disappears when "
+"clicked.  As this is a bug in the global menu proxy, the only way to avoid "
+"it is to tell that wxMaxima should use its own menu bar instead of the "
+"global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1007
+msgid ""
+"Starting with version 26.05.0, wxMaxima attempts to set this variable "
+"automatically if it detects an affected system (KDE, Unity, or Ubuntu with "
+"older wxWidgets versions)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1009
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1011
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1012
+#, fuzzy, no-wrap
+#| msgid "## Why is the integrated manual browser not offered on my Windows PC?"
+msgid "Why is the integrated manual browser not offered on my Windows PC?"
+msgstr "### ¿Por qué no es ofrecido el explorador manual integrado en mi PC Windows?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1016
+msgid ""
+"Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or "
+"Microsoft’s webview2 isn’t installed."
+msgstr ""
+"O bien wxWidgets no fueron compilados con mantenimiento para webview2 o "
+"webview2 de Microsoft no está instalado."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1017
+#, fuzzy, no-wrap
+#| msgid "## Why is the external manual browser not working on my Linux box?"
+msgid "Why is the external manual browser not working on my Linux box?"
+msgstr "### ¿Por qué el explorador manual externo no funciona en mi caja Linux?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1024
+msgid ""
+"The HTML browser might be a snap, flatpack or appimage version. All of these "
+"typically cannot access files that are installed on your local system. "
+"Another reason might be that maxima or wxMaxima is installed as a snap, "
+"flatpack or something else that doesn’t give the host system access to its "
+"contents. A third reason might be that the maxima HTML manual isn’t "
+"installed and the online one cannot be accessed."
+msgstr ""
+"El explorador HTML quizá es una versión de «snap», «flatpack» o «appimage». "
+"Todo de estos típicamente no puede acceder archivos que son instalados en su "
+"sistema local. Otra razón quizá sea que «maxima» o «wxMaxima» es instalado "
+"como un «snap», «flatpack» o algo más que no proporciona el acceso al "
+"sistema hospedante para sus contenidos. Una tercera razón sería que el "
+"manual HTML de maxima no está instalado y la conexión por línea no puede ser "
+"accedida."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1025
+#, fuzzy, no-wrap
+#| msgid "## Can I make _wxMaxima_ output both image files and embedded plots at once?"
+msgid "Can I make _wxMaxima_ output both image files and embedded plots at once?"
+msgstr "### ¿Se puede crear la salida de _wxMaxima_ por ambos archivo de imagen y tramas empotradas a la vez?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1028
+msgid ""
+"The worksheet embeds `.png files. _WxMaxima_ allows the user to specify "
+"where they should be generated:"
+msgstr ""
+"La hoja de trabajo empotra archivos .png. _wxMaxima_ permite al usuario "
+"especificar donde serían generados:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1029
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw2d(\n"
+#| "    file_name=\"test\",\n"
+#| "    explicit(sin(x),x,1,10)\n"
+#| ");\n"
+#| "```\n"
+msgid ""
+"wxdraw2d(\n"
+"    file_name=\"test\",  /* extension .png automatically added */\n"
+"    explicit(sin(x),x,1,10)\n"
+");\n"
+msgstr ""
+"```maxima\n"
+"wxdraw2d(\n"
+"    file_name=\"prueba\",\n"
+"    explicit(sin(x),x,1,10)\n"
+");\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1037
+msgid ""
+"If a different format is to be used, it is easier to generate the images and "
+"then import them into the worksheet again:"
+msgstr ""
+"Si es un formato diferente para ser utilizado, es más fácil generar las "
+"imágenes y después importarlas dentro de la hoja de trabajo de nuevo:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1038
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "load(\"draw\");\n"
+#| "pngdraw(name,[contents]):=\n"
+#| "(\n"
+#| "    draw(\n"
+#| "        append(\n"
+#| "            [\n"
+#| "                terminal=pngcairo,\n"
+#| "                dimensions=wxplot_size,\n"
+#| "                file_name=name\n"
+#| "            ],\n"
+#| "            contents\n"
+#| "        )\n"
+#| "    ),\n"
+#| "    show_image(printf(false,\"~a.png\",name))\n"
+#| ");\n"
+#| "pngdraw2d(name,[contents]):=\n"
+#| "    pngdraw(name,gr2d(contents));\n"
+msgid ""
+"load(\"draw\");\n"
+"pngdraw(name,[contents]):=\n"
+"(\n"
+"    draw(\n"
+"        append(\n"
+"            [\n"
+"                terminal=pngcairo,\n"
+"                dimensions=wxplot_size,\n"
+"                file_name=name\n"
+"            ],\n"
+"            contents\n"
+"        )\n"
+"    ),\n"
+"    show_image(printf(false,\"~a.png\",name))\n"
+");\n"
+"pngdraw2d(name,[contents]):=\n"
+"    pngdraw(name,gr2d(contents));\n"
+"\n"
+"pngdraw2d(\"Test\",\n"
+"        explicit(sin(x),x,1,10)\n"
+");\n"
+msgstr ""
+"```maxima\n"
+"load(\"draw\");\n"
+"pngdraw(name,[contents]):=\n"
+"(\n"
+"    draw(\n"
+"        append(\n"
+"            [\n"
+"                terminal=pngcairo,\n"
+"                dimensions=wxplot_size,\n"
+"                file_name=name\n"
+"            ],\n"
+"            contents\n"
+"        )\n"
+"    ),\n"
+"    show_image(printf(false,\"~a.png\",name))\n"
+");\n"
+"pngdraw2d(name,[contents]):=\n"
+"    pngdraw(name,gr2d(contents));\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1062
+#, fuzzy, no-wrap
+#| msgid "## Can I set the aspect ratio of an embedded plot?"
+msgid "Can I set the aspect ratio of an embedded plot?"
+msgstr "### ¿Se puede establecer la proporción de aspecto de una trama?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1065
+msgid "Use the variable `wxplot_size`:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1066
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw2d(\n"
+#| "    proportional_axis=xy,\n"
+#| "    explicit(sin(x),x,1,10)\n"
+#| "),wxplot_size=[1000,1000];\n"
+#| "```\n"
+msgid ""
+"wxdraw2d(\n"
+"    explicit(sin(x),x,1,10)\n"
+"),wxplot_size=[1000,1000];\n"
+msgstr ""
+"```maxima\n"
+"wxdraw2d(\n"
+"    proportional_axis=xy,\n"
+"    explicit(sin(x),x,1,10)\n"
+"),wxplot_size=[1000,1000];\n"
+"```\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1072
+#, fuzzy, no-wrap
+#| msgid "## After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
+msgid "After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
+msgstr "### Tras mejorar a MacOS 13.1 los mensajes de error de salida para las instrucciones de trama y/o dibujos como"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:1074
+#, fuzzy, no-wrap
+#| msgid "1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```"
+msgid ""
+"1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102\n"
+"2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52\n"
+"3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408\n"
+"...\n"
+msgstr "1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1082
+#, fuzzy, no-wrap
+#| msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information."
+msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.\n"
+msgstr "Esto quizá sea un asunto con el sistema operativo. Desactive el oculto de la barra de menú (SystemSettings => Desktop & Dock => Menu Bar) tal vez resuelve el asunto.  Consulte [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) para más información."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1083
+#, no-wrap
+msgid "Logging"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1088
+#, no-wrap
+msgid ""
+"Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build,\n"
+"the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable\n"
+"this window using the \"View->Toggle log window\" menu entry.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1090
+msgid ""
+"Messages are not 'lost', if the log window is not shown, if you select to "
+"show the log window later, you will see past log messages (if you did not "
+"clear the messages)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1092
+msgid ""
+"Such messages may be helpful, when you create bug reports (or trying to find "
+"a bug by yourself)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1095
+msgid ""
+"Log messages can (additionally) be printed to STDERR, when using the command "
+"line option \"--logtostderr\". On Windows a separate text console will be "
+"opened, as a Windows GUI application does not have the standard IO connected."
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1098
+#, no-wrap
+msgid "FAQ"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1100
+#, fuzzy, no-wrap
+#| msgid "## Is there a way to make more text fit on a LaTeX page?"
+msgid "Is there a way to make more text fit on a LaTeX page?"
+msgstr "## ¿Hay una manera de crear más texto que quepa en una página LaTeX?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1103
+msgid ""
+"Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to "
+"specify the size of the borders."
+msgstr ""
+"Sí.  Utilice el [paquete \"geometry\" de LaTeX](https://ctan.org/pkg/"
+"geometry) para especificar el tamaño de los bordes."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1105
+#, fuzzy, no-wrap
+#| msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):"
+msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):\n"
+msgstr "Puede agregar la línea siguiente al preámbulo LaTeX (por ejemplo utilizando el campo respectivo dentro del diálogo de configuración («Exportar» → «Líneas adicionales para el preámbulo TeX»), para fijar bordes de 1cm):"
+
+#. type: Fenced code block (latex)
+#: ../../info/wxmaxima.md:1106
+#, fuzzy, no-wrap
+#| msgid "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
+msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+msgstr "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1110
+#, fuzzy, no-wrap
+#| msgid "## Is there a dark mode?"
+msgid "Is there a dark mode?"
+msgstr "## ¿Hay un modo oscuro?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1113
+msgid ""
+"If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if "
+"the rest of the operating system is. The worksheet itself is by default "
+"equipped with a bright background. But it can be configured otherwise. "
+"Alternatively, there is a `View/Invert worksheet brightness` menu entry that "
+"allows to quickly convert the worksheet from dark to bright and vice versa."
+msgstr ""
+"Si wxWidgets es suficientemente nuevo _wxMaxima_ automáticamente estará en "
+"modo oscuro si el resto del sistema operativo también lo está.  La misma "
+"hoja de trabajo por defecto está equipada con un fondo brillante.  Pero "
+"puede ser configurado de otras maneras.  Alternativamente hay un apunte del "
+"menú para ‘Ver/Invertir brillo de la hoja de trabajo’ para convertir "
+"rápidamente la hoja de trabajo desde oscuro a claro y viceversa."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1114
+#, fuzzy, no-wrap
+#| msgid "## _WxMaxima_ sometimes hangs for several seconds once in the first minute"
+msgid "_WxMaxima_ sometimes hangs for several seconds once in the first minute"
+msgstr "## _WxMaxima_ algunas veces se cuelga durante varios segundos una vez en el primer minuto"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1117
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work."
+msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.\n"
+msgstr "_WxMaxima_ delega algunas tareas grandes como interpretar el manual de página >1000 de _Maxima_ para tareas en segundo plano, lo cual normalmente va totalmente no comunicado.  En el momento que el resultado de dicha tarea es necesaria, es posible que _wxMaxima_ necesite esperar un par de segundos antes de poder continuar su trabajo."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1118
+#, fuzzy, no-wrap
+#| msgid "## Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+msgid "Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+msgstr "## Especialmente cuando pruebe parámetros locales nuevos, sucede una caja con el mensaje \"locale ’xx_YY’ no puede ser fijada\""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1121
+msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
+msgstr "![Aviso local](./locale-warning.png){ id=img_locale_warning}"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1125
+msgid ""
+"(The same problem can occur with other applications too). The translations "
+"seem okay after you click on ’OK’. WxMaxima does not only use its own "
+"translations but the translations of the wxWidgets framework too."
+msgstr ""
+"(El mismo problema puede suceder con otras aplicaciones también). Los "
+"traslados parecen ok tras que pulse sobre ‘Aceptar’. Wxmaxima no solo "
+"utiliza su propias transacciones sino también las transacciones del marco de "
+"trabajo de wxWidgets."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1128
+msgid ""
+"These locales maybe not present in the system. On Ubuntu/Debian systems they "
+"can be generated using: `dpkg-reconfigure locales`"
+msgstr ""
+"Estos locales quizá no sean presente dentro del sistema. En sistemas Ubuntu/"
+"Debian pueden ser generados utilizando: `dpkg-reconfigure locales`"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1129
+#, fuzzy, no-wrap
+#| msgid "## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
+msgid "How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
+msgstr "## ¿Cómo puedo utilizar símbolos para números reales, naturales (ℝ, ℕ), etc.?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1132
+msgid ""
+"You can find these symbols in the Unicode sidebar (search for ’double-struck "
+"capital’). But the selected font must also support these symbols. If they do "
+"not display properly, select another font."
+msgstr ""
+"Puede encontrar estos símbolos en la barra lateral Unicode (busca ’doble-"
+"stuck capital’). Pero la tipografía seleccionada además debe mantener estos "
+"símbolos. Si no representan apropiadamente, seleccione otra tipografía."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1133
+#, fuzzy, no-wrap
+#| msgid "## How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
+msgid "How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
+msgstr "## ¿Cómo puede un guion Maxima determinar, si está ejecutándose bajo wxMaxima o línea de instrucción de Maxima?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1136
+msgid ""
+"If wxMaxima is used, the Maxima variable `maxima_frontend` is set to "
+"`wxmaxima`. The Maxima variable `maxima_frontend_version` contains the "
+"wxMaxima version in this case."
+msgstr ""
+"Si se utiliza wxMaxima, la variable `maxima_frontend` de Maxima está fijada "
+"a `wxmaxima`. La variable Maxima `maxima_frontend_version` contiene la "
+"versión de wxMaxima en este caso."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1138
+msgid ""
+"If no frontend is used (you are using command line Maxima), these variables "
+"are `false`."
+msgstr ""
+"Si no ningún frontend es utilizado (está utilizando Maxima en línea de "
+"instrucción), estas variables son falsas."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1139
+#, no-wrap
+msgid "Help! I can not save my document!"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1142
+#, no-wrap
+msgid "If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.\n"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1145
+#, fuzzy, no-wrap
+#| msgid "# Command-line arguments"
+msgid "Command-line arguments"
+msgstr "# Argumentos de línea de instrucción"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1148
+msgid ""
+"Usually you can start programs with a graphical user interface just by "
+"clicking on a desktop icon or desktop menu entry. WxMaxima - if started from "
+"the command line - still provides some command-line switches, though."
+msgstr ""
+"Usualmente puede iniciar programas con un interfaz gráfico de usuario tan "
+"solo pulsando en un icono de escritorio o apunte de menú del escritorio. "
+"wxMaxima -si inició desde la línea de instrucción- aún proporciona algunos "
+"interruptores en línea de instrucción, sin embargo."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-v` or `--version`: Output the version information"
+msgstr "‘-v’ o ‘--version’: extrae la información de la versión"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-h` or `--help`: Output a short help text"
+msgstr "‘-h’ o ‘--help’: extrae un texto breve de ayuda"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid ""
+"`-o` or `--open=<str>`: Open the filename given as an argument to this "
+"command-line switch"
+msgstr ""
+"`-o` u `--open=<cad>`: abre el nombre del archivo proporcionado como un "
+"argumento a este interruptor de línea de instrucción"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-e` or `--eval`: Evaluate the file after opening it."
+msgstr "‘-e’ o ‘--eval’: evalúa el archivo tras abrirlo."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid ""
+"`-b` or `--batch`: If the command-line opens a file all cells in this file "
+"are evaluated and the file is saved afterward. This is for example useful if "
+"the session described in the file makes _Maxima_ generate output files. "
+"Batch-processing will be stopped if _wxMaxima_ detects that _Maxima_ has "
+"output an error and will pause if _Maxima_ has a question: Mathematics is "
+"somewhat interactive by nature so a completely interaction-free batch "
+"processing cannot always be guaranteed."
+msgstr ""
+"`-b` o `--batch`: si la línea de orden abre un archivo todas las celdas "
+"dentro de este archivo son evaluadas y el archivo es guardado después.  Esto "
+"es por ejemplo útil si la sesión descrita dentro del archivo hace que "
+"_Maxima_ genere archivos de salida.   El guion de procesamiento será "
+"detenido si _wxMaxima_ detecta que _Maxima_ tiene un error de salida y lo "
+"detendrá si _Maxima_ tiene una cuestión: las matemáticas es algo interactivo "
+"por naturaliza por lo que un proceso de guion libre de interacción no puede "
+"ser garantizado completamente."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1164
+#, no-wrap
+msgid ""
+"- `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
+"- `--pipe`:                        Pipe messages from Maxima to stdout.\n"
+"- `--exit-on-error`:               Close the program on any maxima error.\n"
+"- `-f` or `--ini=<str>`: Use the init file that was given as an argument to this command-line switch\n"
+"- `-u`, `--use-version=<str>`:     Use maxima version `<str>`.\n"
+"- `-l`, `--lisp=<str>`:              Use a Maxima compiled with Lisp compiler `<str>`.\n"
+"- `-X`, `--extra-args=<str>`:        Allows to specify extra Maxima arguments\n"
+"- `-m` or `--maxima=<str>`:    allows specifying the location of the _maxima_ binary\n"
+"- `--enableipc`: Lets Maxima control wxMaxima via interprocess communications. Use this option with care.\n"
+"- `--wxmathml-lisp=<str>`:   Location of wxMathML.lisp (if not the built-in should be used, mainly for developers).\n"
+msgstr ""
+"- `--logtostdout`:                 Registra todos los mensajes de la barra lateral\n"
+"                                     \"mensajes de depuración\" a ‘stderr’, también.\n"
+"- `--pipe`:                        Conducto de mensajes desde ‘Maxima’ a ‘stdout’.\n"
+"- `--exit-on-error`:               Cierra el programa en cualquier error de ‘maxima’.\n"
+"- `-f` o `--ini=<cad>`:            Utiliza el archivo de ‘init’ que fue proporcionado\n"
+"                                      como argumento a este intercambio de línea de instrucción.\n"
+"- `-u`, `--use-version=<cad>`:     Utiliza la `<cad>` de la versión de ‘maxima’.\n"
+"- `-l`, `--lisp=<cad>`:            Utiliza un compilador de ‘maxima’ compilado con Lisp `<cad>`.\n"
+"- `-X`, `--extra-args=<cad>`:      Permite especificar argumentos adicionales de “Maxima”\n"
+"- `-m` o `--maxima=<cad>`:         Permite especificar la ubicación del binario de _maxima_\n"
+"- `--enableipc`:                   Permite que “Maxima” controle “wxMaxima” a través de\n"
+"                                     comunicaciones de interprocesos.  Utilice esa opción con\n"
+"                                     cuidado.\n"
+"- `--wxmathml-lisp=<cdn>`:         Ubicación de wxMathML.lisp (si no es el empotrado sería utilizado,\n"
+"                                     mayormente para desarrolladores).\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1166
+msgid ""
+"Instead of a minus, some operating systems might use a dash in front of the "
+"command-line switches."
+msgstr ""
+"En vez de un menos, algunos sistemas operativos tal vez utilicen un guion "
+"breve al frente de los conmutadores de línea de instrucciones."
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1169
+#, fuzzy, no-wrap
+#| msgid "# About the program, contributing to wxMaxima"
+msgid "About the program, contributing to wxMaxima"
+msgstr "# Sobre el programa, contribuyendo a wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1172
+msgid ""
+"wxMaxima is mainly developed using the programming language C++ using the "
+"[wxWidgets framework](https://www.wxwidgets.org), as build system we use "
+"[CMake](https://www.cmake.org), a small part is written in Lisp. You can "
+"contribute to wxMaxima, join the wxMaxima project at <https://github.com/"
+"wxMaxima-developers/wxmaxima>, if you have knowledge of these programming "
+"languages and want to help and contribute to the open source project "
+"wxMaxima."
+msgstr ""
+"wxMaxima es principalmente desarrollado utilizando el lenguaje de "
+"programación C++ utilizando el [marco de trabajo wxWidgets](https://www."
+"wxwidgets.org), como sistema de compilación utilizamos [CMake](https://www."
+"cmake.org), una parte pequeña escrita en Lisp. Puede contribuir al proyecto "
+"wxMaxima en <https://github.com/wxMaxima-developers/wxmaxima>, si tiene "
+"conocimiento de estos lenguajes de programación y desea ayudar y contribuir "
+"al proyecto de software libre de wxMaxima."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1174
+msgid ""
+"But not only programmers are necessary! You can also contribute to wxMaxima, "
+"if you help to improve the documentation, find and report bugs (and maybe "
+"bugfixes), suggest new features, help to translate wxMaxima or the manual to "
+"your language (read the README.md in the [locale subdirectory](https://"
+"github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and "
+"the manual can be translated)."
+msgstr ""
+"¡Pero no solamente los programadores son necesarios! Puede contribuir además "
+"a wxMaxima, si ayuda para mejorar la documentación, encontrar e informar "
+"defectos (y quizá repararlas), sugerir características nuevas, ayudar a "
+"traducir wxMaxima o el manual a su idioma (lea el README.md en el "
+"[subdirectorio de idioma](https://github.com/wxMaxima-developers/wxmaxima/"
+"tree/main/locales) como wxMaxima y el manual puede ser traducido)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1176
+msgid "Or answer questions of other users in the discussion forum."
+msgstr "O responda preguntas de otros usuarios en el foro de debate."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1178
+msgid ""
+"The source code of wxMaxima is documented using Doxygen [here](https://"
+"wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+msgstr ""
+"El código fuente de wxMaxima está documentado utilizando Doxygen [aquí]"
+"(https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1180
+msgid ""
+"The program is nearly self-contained, so except for system libraries (and "
+"the wxWidgets library), no external dependencies (like graphic files or the "
+"Lisp part (the `wxmathML.lisp`-file) is needed, these files are included in "
+"the executable."
+msgstr ""
+"El programa es casi autónomo, por tanto excepto para bibliotecas del sistema "
+"(y la biblioteca wxWidgets), ninguna dependencia externa (como archivos "
+"gráficos o la parte Lisp (el archivo `wxmathML.lisp`) es necesario, se "
+"incluyen estos archivos dentro del ejecutable."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1181
+#, fuzzy, no-wrap
+#| msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one."
+msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.\n"
+msgstr "Si es un desarrollador, quizá desea intentar un archivo modificado de `wxmathML.lisp` sin tener que recompilar todo, uno puede utilizar la opción de línea de instrucción `--wxmathml-lisp=<str>` para utilizar otro archivo Lisp, no el incluido."
+
+#~ msgid "______________________________________________________________________\n"
+#~ msgstr "______________________________________________________________________\n"
+
+#, fuzzy
+#~| msgid ""
+#~| "```maxima\n"
+#~| "    load(draw);\n"
+#~ msgid "```maxima load(draw);"
+#~ msgstr ""
+#~ "```maxima\n"
+#~ "    load(dibujo);\n"
+
+#, fuzzy
+#~| msgid ""
+#~| "    /* Parabola in window #1 */\n"
+#~| "    draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+#~ msgid ""
+#~ "/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
+#~ msgstr ""
+#~ "    /* Parábola en ventana nº1 */\n"
+#~ "    draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+
+#, fuzzy
+#~| msgid ""
+#~| "    /* Parabola in window #2 */\n"
+#~| "    draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+#~ msgid ""
+#~ "/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
+#~ msgstr ""
+#~ "    /* Parábola en ventana nº2 */\n"
+#~ "    draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+
+#, fuzzy
+#~| msgid ""
+#~| "    /* Paraboloid in window #3 */\n"
+#~| "    draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
+#~| "```\n"
+#~ msgid ""
+#~ "/* Paraboloid in window #3 */ draw3d(terminal=[wxt,3],explicit(x^2+y^2,"
+#~ "x,-1,1,y,-1,1)); ```"
+#~ msgstr ""
+#~ "    /* Paraboloide en ventana nº3 */\n"
+#~ "    draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
+#~ "```\n"
+
+#~ msgid "#### 2D"
+#~ msgstr "#### 2D"
+
+#~ msgid "#### 3D"
+#~ msgstr "#### 3D"
+
+#~ msgid "```maxima playback(); ```"
+#~ msgstr "```maxima playback(); ```"
+
+#, fuzzy
+#~| msgid ""
+#~| "pngdraw2d(\"Test\",\n"
+#~| "        explicit(sin(x),x,1,10)\n"
+#~| ");\n"
+#~| "```\n"
+#~ msgid ""
+#~ "pngdraw2d(\"Test\",\n"
+#~ "        explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "pngdraw2d(\"Prueba\",\n"
+#~ "        explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+#~ "```\n"

--- a/locales/manual/fr.po
+++ b/locales/manual/fr.po
@@ -1,0 +1,5194 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: wxmaxima-gui\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-04 07:28+0000\n"
+"PO-Revision-Date: 2026-08-02 11:42\n"
+"Last-Translator: \n"
+"Language-Team: French\n"
+"Language: fr_FR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Crowdin-Project: wxmaxima-gui\n"
+"X-Crowdin-Project-ID: 917703\n"
+"X-Crowdin-Language: fr\n"
+"X-Crowdin-File: /main/locales/wxMaxima/wxMaxima.pot\n"
+"X-Crowdin-File-ID: 8\n"
+
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#. type: Title #
+#: ../../info/wxmaxima.md:1
+#, fuzzy, no-wrap
+#| msgid "# The wxMaxima user manual"
+msgid "The wxMaxima user manual"
+msgstr "# Manuel de l'utilisateur de wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:4
+#, fuzzy
+#| msgid ""
+#| "WxMaxima is a graphical user interface (GUI) for the _Maxima_ computer "
+#| "algebra system (CAS). WxMaxima allows one to use all of _Maxima_âs "
+#| "functions. In addition, it provides convenient wizards for accessing the "
+#| "most commonly used features. This manual describes some of the features "
+#| "that make wxMaxima one of the most popular GUIs for _Maxima_."
+msgid ""
+"WxMaxima is a graphical user interface (GUI) for the _Maxima_ computer "
+"algebra system (CAS). WxMaxima allows one to use all of _Maxima_’s "
+"functions. In addition, it provides convenient wizards for accessing the "
+"most commonly used features. This manual describes some of the features that "
+"make wxMaxima one of the most popular GUIs for _Maxima_."
+msgstr ""
+"WxMaxima est une interface graphique (GUI) pour le système de calcul formel "
+"(CAS) _Maxima_.  WxMaxima permet d’utiliser toutes les fonctions de "
+"_Maxima_. De plus, il fournit des assistants pratiques pour accéder aux "
+"fonctionnalités les plus couramment utilisées. Ce manuel décrit certaines "
+"des caractéristiques qui font de wxMaxima l’une des interfaces graphiques "
+"les plus populaires pour _Maxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:6
+msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
+msgstr "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:9
+#, fuzzy, no-wrap
+#| msgid "# Introduction to wxMaxima"
+msgid "Introduction to wxMaxima"
+msgstr "# Présentation de wxMaxima"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:11
+#, fuzzy, no-wrap
+#| msgid "## _Maxima_ and wxMaxima"
+msgid "_Maxima_ and wxMaxima"
+msgstr "## _Maxima_ et wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:14
+#, fuzzy
+#| msgid ""
+#| "In the open-source domain, big systems are normally split into smaller "
+#| "projects that are easier to handle for small groups of developers. For "
+#| "example a CD burner program will consist of a command-line tool that "
+#| "actually burns the CD and a graphical user interface that allows users to "
+#| "implement it without having to learn about all the command line switches "
+#| "and in fact without using the command line at all. One advantage of this "
+#| "approach is that the developing work that was invested into the command-"
+#| "line program can be shared by many programs: The same CD-burner command-"
+#| "line program can be used as a âsend-to-CDâ-plug-in for a file manager "
+#| "application, for the âburn to CDâ function of a music player and as the "
+#| "CD writer for a DVD backup tool. Another advantage is that splitting one "
+#| "big task into smaller parts allows the developers to provide several user "
+#| "interfaces for the same program."
+msgid ""
+"In the open-source domain, big systems are normally split into smaller "
+"projects that are easier to handle for small groups of developers. For "
+"example a CD burner program will consist of a command-line tool that "
+"actually burns the CD and a graphical user interface that allows users to "
+"implement it without having to learn about all the command line switches and "
+"in fact without using the command line at all. One advantage of this "
+"approach is that the developing work that was invested into the command-line "
+"program can be shared by many programs: The same CD-burner command-line "
+"program can be used as a “send-to-CD”-plug-in for a file manager "
+"application, for the “burn to CD” function of a music player and as the CD "
+"writer for a DVD backup tool. Another advantage is that splitting one big "
+"task into smaller parts allows the developers to provide several user "
+"interfaces for the same program."
+msgstr ""
+"Dans le domaine open-source, les grands systèmes sont généralement divisés "
+"en projets plus petits, plus faciles à gérer pour de petits groupes de "
+"développeurs. Par exemple, un programme de gravure de CD peut se composer "
+"d’un outil en ligne de commande qui effectue réellement la gravure du CD, et "
+"d’une interface graphique permettant aux utilisateurs de l’utiliser sans "
+"avoir à apprendre toutes les options de la ligne de commande, voire sans "
+"jamais y recourir. Un avantage de cette méthode est que le travail de "
+"développement réalisé dans le programme en ligne de commande peut être "
+"partagé par de nombreuses applications : le même programme de gravure en "
+"ligne de commande peut servir de module \"Envoyer vers un CD\",  pour un "
+"gestionnaire de fichiers, de fonction \"Graver sur CD\" pour un lecteur "
+"multimédia, ou encore de graveur de CD pour un outil de sauvegarde sur DVD. "
+"Un autre avantage est que la division d’une tâche complexe en parties plus "
+"réduites permet aux développeurs de proposer plusieurs interfaces "
+"utilisateur pour un même programme."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:16
+msgid ""
+"A computer algebra system (CAS) like _Maxima_ fits into this framework. A "
+"CAS can provide the logic behind an arbitrary precision calculator "
+"application or it can do automatic transforms of formulas in the background "
+"of a bigger system (e.g., [Sage](https://www.sagemath.org/)). Alternatively, "
+"it can be used directly as a free-standing system. _Maxima_ can be accessed "
+"via a command line. Often, however, an interface like _wxMaxima_ proves a "
+"more efficient way to access the software, especially for newcomers."
+msgstr ""
+"Un système de calcul formel (CAS) comme _Maxima_ s'intègre dans ce cadre. Un "
+"CAS peut fournir la logique derrière une application de type calculatrice à "
+"précision arbitraire ou effectuer des transformations automatiques de "
+"formules en arrière-plan d'un système plus large (par exemple, [Sage]"
+"(https://www.sagemath.org/)). Alternativement, il peut être utilisé "
+"directement comme un logiciel autonome. _Maxima_ peut être accessible via "
+"une ligne de commande. Cependant, une interface comme _wxMaxima_ s'avère "
+"souvent un moyen plus efficace d'accéder au logiciel, surtout pour les "
+"nouveaux utilisateurs."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:17
+#, fuzzy, no-wrap
+#| msgid "### _Maxima_"
+msgid "_Maxima_"
+msgstr "### _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:20
+msgid ""
+"_Maxima_ is a full-featured computer algebra system (CAS). A CAS is a "
+"program that can solve mathematical problems by rearranging formulas and "
+"finding a formula that solves the problem as opposed to just outputting the "
+"numeric value of the result. In other words, _Maxima_ can serve as a "
+"calculator that gives numerical representations of variables, and it can "
+"also provide analytical solutions. Furthermore, it offers a range of "
+"numerical methods of analysis for equations or systems of equations that "
+"cannot be solved analytically."
+msgstr ""
+"_Maxima_ est un système complet de calcul formel (CAS). Un CAS est un "
+"programme capable de résoudre des problèmes mathématiques en manipulant des "
+"formules et en retournant des expressions algébriques qui résolvent le "
+"problème, plutôt que de simplement fournir une valeur numérique du résultat. "
+"Autrement dit, _Maxima_ peut fonctionner comme une calculatrice qui donne  "
+"des valeurs numériques des variables, mais il peut aussi fournir des "
+"solutions analytiques formelles. De plus, il propose une gamme de méthodes "
+"numériques pour analyser des équations ou des systèmes d’équations qui ne "
+"peuvent pas être résolus de manière formelle."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:22
+msgid ""
+"![Maxima screenshot, command line](./maxima_screenshot.png)"
+"{ id=img_maxima_screenshot }"
+msgstr ""
+"![Copie d'écran Maxima, ligne de commande](./maxima_screenshot.png)"
+"{ id=img_maxima_screenshot }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:24
+#, fuzzy, no-wrap
+#| msgid "Extensive documentation for _Maxima_ is [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaximaâs help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_âs context-sensitive help feature to automatically jump to _Maxima_âs manual page for the command at the cursor."
+msgid "Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.\n"
+msgstr "Une documentation complète pour _Maxima_ est [disponible en ligne](https://maxima.sourceforge.io/documentation.html). Une partie de cette documentation est également accessible via le menu d’aide de wxMaxima. En appuyant sur la touche d’aide (généralement la touche <kbd>F1</kbd> sur la plupart des systèmes), la fonction d’aide contextuelle de _wxMaxima_ ouvre automatiquement la page du manuel de _Maxima_ correspondant à la commande située sous le curseur."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:25
+#, fuzzy, no-wrap
+#| msgid "### WxMaxima"
+msgid "WxMaxima"
+msgstr "### WxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:28
+#, fuzzy
+#| msgid ""
+#| "_WxMaxima_ is a graphical user interface that provides the full "
+#| "functionality and flexibility of _Maxima_. WxMaxima offers users a "
+#| "graphical display and many features that make working with _Maxima_ "
+#| "easier. For example _wxMaxima_ allows one to export any cellâs contents "
+#| "(or, if that is needed, any part of a formula, as well) as text, as LaTeX "
+#| "or as MathML specification at a simple right-click. Indeed, an entire "
+#| "workbook can be exported, either as a HTML file or as a LaTeX file. "
+#| "Documentation for _wxMaxima_, including workbooks to illustrate aspects "
+#| "of its use, is online at the _wxMaxima_ [help site](https://wxMaxima-"
+#| "developers.github.io/wxmaxima/help.html), as well as via the help menu."
+msgid ""
+"_WxMaxima_ is a graphical user interface that provides the full "
+"functionality and flexibility of _Maxima_. WxMaxima offers users a graphical "
+"display and many features that make working with _Maxima_ easier. For "
+"example _wxMaxima_ allows one to export any cell’s contents (or, if that is "
+"needed, any part of a formula, as well) as text, as LaTeX or as MathML "
+"specification at a simple right-click. Indeed, an entire workbook can be "
+"exported, either as a HTML file or as a LaTeX file. Documentation for "
+"_wxMaxima_, including workbooks to illustrate aspects of its use, is online "
+"at the _wxMaxima_ [help site](https://wxMaxima-developers.github.io/wxmaxima/"
+"help.html), as well as via the help menu."
+msgstr ""
+"_WxMaxima_ est une interface graphique qui offre toute les fonctionnalités "
+"et la flexibilité de _Maxima_. WxMaxima propose aux utilisateurs un "
+"affichage graphique ainsi que de nombreuses fonctionnalités qui facilitent "
+"l’utilisation de _Maxima_. Par exemple, _wxMaxima_ permet d’exporter le "
+"contenu de n’importe quelle cellule (ou, si nécessaire, une partie d’une "
+"formule) sous forme de texte, de code LaTeX ou de codage MathML, simplement "
+"en effectuant un clic droit. En outre, un notebook entier peut être exporté, "
+"soit en tant que fichier HTML, soit en tant que fichier LaTeX. La "
+"documentation de _wxMaxima_, incluant des notebooks d’exemples illustrant "
+"ses différentes fonctionnalités, est disponible en ligne sur le [site d’aide "
+"de wxMaxima](https://wxMaxima-developers.github.io/wxmaxima/help.html), "
+"ainsi que via le menu d’aide."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:30
+msgid "![wxMaxima window](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
+msgstr "![fenêtre de wxMaxima](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:32
+msgid ""
+"The calculations that are entered in _wxMaxima_ are performed by the "
+"_Maxima_ command-line tool in the background."
+msgstr ""
+"Les calculs saisis dans _wxMaxima_ sont exécutés en arrière-plan par l'outil "
+"en ligne de commande _Maxima_."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:33
+#, fuzzy, no-wrap
+#| msgid "## Workbook basics"
+msgid "Workbook basics"
+msgstr "## Notions de base d'un notebook"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:36
+#, fuzzy
+#| msgid ""
+#| "Much of _wxMaxima_ is self-explaining, but some details require "
+#| "attention. [This site](https://wxMaxima-developers.github.io/wxmaxima/"
+#| "help.html) contains a number of workbooks that address various aspects of "
+#| "_wxMaxima_. Working through some of these (particularly the \"10 minute "
+#| "_(wx)Maxima_ tutorial\") will increase oneâs familiarity with both the "
+#| "content of _Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. "
+#| "This manual concentrates on describing aspects of _wxMaxima_ that are not "
+#| "likely to be self-evident and that might not be covered in the online "
+#| "material."
+msgid ""
+"Much of _wxMaxima_ is self-explaining, but some details require attention. "
+"[This site](https://wxMaxima-developers.github.io/wxmaxima/help.html) "
+"contains a number of workbooks that address various aspects of _wxMaxima_. "
+"Working through some of these (particularly the \"10 minute _(wx)Maxima_ "
+"tutorial\") will increase one’s familiarity with both the content of "
+"_Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. This manual "
+"concentrates on describing aspects of _wxMaxima_ that are not likely to be "
+"self-evident and that might not be covered in the online material."
+msgstr ""
+"Une grande partie de wxMaxima est intuitive, mais certains détails "
+"nécessitent une attention particulière. [Ce site](https://wxMaxima-"
+"developers.github.io/wxmaxima/help.html) contient plusieurs notebooks qui "
+"abordent divers aspects de _wxMaxima_. Parcourir certains d’entre eux "
+"(notamment le « tutoriel de 10 minutes sur (wx)Maxima ») permettra de mieux "
+"maîtriser à la fois le contenu de _Maxima_ et l’utilisation de _wxMaxima_ "
+"pour interagir avec _Maxima_. Ce manuel se concentre sur la description des "
+"aspects de _wxMaxima_ qui ne sont pas nécessairement évidents et qui "
+"pourraient ne pas être présentés dans les ressources en ligne."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:37
+#, fuzzy, no-wrap
+#| msgid "### The workbook approach"
+msgid "The workbook approach"
+msgstr "### Fondamentaux du notebook"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:40
+#, fuzzy
+#| msgid ""
+#| "One of the very few things that are not standard in _wxMaxima_ is that it "
+#| "organizes the data for _Maxima_ into cells that are evaluated (which "
+#| "means: sent to _Maxima_) only when the user requests this. When a cell is "
+#| "evaluated, all commands in that cell, and only that cell, are evaluated "
+#| "as a batch. (The preceding statement is not quite accurate: One can "
+#| "select a set of adjacent cells and evaluate them together. Also, one can "
+#| "instruct _Maxima_ to evaluate all cells in a workbook in one pass.) "
+#| "_WxMaxima_âs approach to submitting commands for execution might feel "
+#| "unfamiliar at the first sight. It does, however, drastically ease work "
+#| "with big documents (where the user does not want every change to "
+#| "automatically trigger a full re-evaluation of the whole document). Also, "
+#| "this approach is very handy for debugging."
+msgid ""
+"One of the very few things that are not standard in _wxMaxima_ is that it "
+"organizes the data for _Maxima_ into cells that are evaluated (which means: "
+"sent to _Maxima_) only when the user requests this. When a cell is "
+"evaluated, all commands in that cell, and only that cell, are evaluated as a "
+"batch. (The preceding statement is not quite accurate: One can select a set "
+"of adjacent cells and evaluate them together. Also, one can instruct "
+"_Maxima_ to evaluate all cells in a workbook in one pass.) _WxMaxima_’s "
+"approach to submitting commands for execution might feel unfamiliar at the "
+"first sight. It does, however, drastically ease work with big documents "
+"(where the user does not want every change to automatically trigger a full "
+"re-evaluation of the whole document). Also, this approach is very handy for "
+"debugging."
+msgstr ""
+"L'une des très rares choses qui ne sont pas standard avec _wxMaxima_ est "
+"qu'il organise les données pour _Maxima_ en cellules qui ne sont évaluées "
+"(c'est-à-dire envoyées à _Maxima_) que lorsque l'utilisateur le demande. "
+"Lorsqu'une cellule est évaluée, toutes les commandes de cette cellule, et "
+"uniquement de cette cellule, sont évaluées en bloc. (La phrase précédente "
+"n'est pas tout à fait exacte : on peut sélectionner un ensemble de cellules "
+"adjacentes et les évaluer ensemble. On peut aussi demander à _Maxima_ "
+"d'évaluer toutes les cellules d'un notebook  en une seule fois.) L'approche "
+"de _wxMaxima_ pour exécuter les commandes peut sembler inhabituelle au "
+"premier abord. Elle facilite cependant grandement le travail avec de grands "
+"documents (où l'utilisateur ne souhaite pas que chaque modification "
+"déclenche automatiquement une réévaluation complète de l'ensemble du "
+"document). De plus, cette approche est très pratique pour le débogage."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:42
+msgid ""
+"If text is typed into _wxMaxima_ it automatically creates a new worksheet "
+"cell. The type of this cell can be selected in the toolbar. If a code cell "
+"is created the cell can be sent to _Maxima_, which causes the result of the "
+"calculation to be displayed below the code. A pair of such commands is shown "
+"below."
+msgstr ""
+"Si du texte est saisi dans _wxMaxima_, une nouvelle cellule est "
+"automatiquement créée dans le notebook. Le type de cette cellule peut être "
+"sélectionné dans la barre d'outils. Si une cellule de code est créée, elle "
+"peut être envoyée à _Maxima_, ce qui affiche le résultat du calcul en "
+"dessous du code. Une paire de ce type de commandes est présentée ci-dessous."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:44
+msgid "![Input/output cell](./InputCell.png){ id=img_InputCell }"
+msgstr "![Cellules entrée/sortie cell](./InputCell.png){ id=img_InputCell }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:46
+#, fuzzy
+#| msgid ""
+#| "On evaluation of an input cellâs contents the input cell _Maxima_ assigns "
+#| "a label to the input (by default shown in red and recognizable by the "
+#| "`%i`) by which it can be referenced later in the _wxMaxima_ session. The "
+#| "output that _Maxima_ generates also gets a label that begins with `%o` "
+#| "and by default is hidden, except if the user assigns the output a name. "
+#| "In this case by default the user-defined label is displayed. The `%o`-"
+#| "style label _Maxima_ auto-generates will also be accessible, though."
+msgid ""
+"On evaluation of an input cell’s contents the input cell _Maxima_ assigns a "
+"label to the input (by default shown in red and recognizable by the `%i`) by "
+"which it can be referenced later in the _wxMaxima_ session. The output that "
+"_Maxima_ generates also gets a label that begins with `%o` and by default is "
+"hidden, except if the user assigns the output a name. In this case by "
+"default the user-defined label is displayed. The `%o`-style label _Maxima_ "
+"auto-generates will also be accessible, though."
+msgstr ""
+"Lors de l’évaluation du contenu d’une cellule d’entrée, _Maxima_ attribue un "
+"identifiant à l’entrée (affiché par défaut en rouge et reconnaissable par le "
+"`%i`), ce qui permet d’y faire référence plus tard dans la session "
+"_wxMaxima_. La sortie générée par _Maxima_ reçoit également un identifiant "
+"commençant par `%o`, masqué par défaut, sauf si l’utilisateur attribue un "
+"nom à cette sortie. Dans ce cas, l’identifiant défini par l’utilisateur "
+"s’affiche par défaut, mais l’identifiant automatique de type `%o` reste "
+"accessible."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:48
+msgid ""
+"Besides the input cells _wxMaxima_ allows for text cells for documentation, "
+"image cells, title cells, chapter cells and section cells. Every cell has "
+"its own undo buffer so debugging by changing the values of several cells and "
+"then gradually reverting the unneeded changes is rather easy. Furthermore "
+"the worksheet itself has a global undo buffer that can undo cell edits, adds "
+"and deletes."
+msgstr ""
+"Outre les cellules d’entrée, _wxMaxima_ permet d’insérer des cellules de "
+"texte pour la documentation, des cellules d’image, des cellules de titre, de "
+"chapitre et de section. Chaque cellule dispose de son propre historique "
+"d’annulation, ce qui facilite le débogage en modifiant les valeurs de "
+"plusieurs cellules puis en annulant progressivement les changements "
+"inutiles. De plus, le notebook en lui-même possède un historique "
+"d’annulation global qui permet d’annuler les modifications, ajouts et "
+"suppressions de cellules."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:50
+msgid ""
+"The figure below shows different cell types (title cells, section cells, "
+"subsection cells, text cells, input/output cells and image cells)."
+msgstr ""
+"La figure ci-dessous montre différents types de cellules (cellules de titre, "
+"cellules de section, cellules de sous-section, cellules de texte, cellules "
+"d’entrée/sortie et cellules d’image)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:52
+msgid ""
+"![Example of different wxMaxima cells](./cell-example.png){ id=img_cell-"
+"example }"
+msgstr ""
+"![Exemple de cellules différentes de wxMaxima](./cell-example.png)"
+"{ id=img_cell-example }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:53
+#, fuzzy, no-wrap
+#| msgid "### Cells"
+msgid "Cells"
+msgstr "### Cellules"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:56
+msgid ""
+"The worksheet is organized in cells. WxMaxima knows the following cell types:"
+msgstr ""
+"Le notebook est organisé en cellules. WxMaxima distingue les types de "
+"cellules suivants  :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Math cells, containing one or more lines of _Maxima_ input."
+msgstr ""
+"Cellules mathématiques, contenant une ou plusieurs lignes de saisie _Maxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Output of, or a question from, _Maxima_."
+msgstr "Sortie de, ou une question de, _Maxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Image cells."
+msgstr "Cellules image."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Text cells, that can for example be used for documentation."
+msgstr ""
+"Cellules de texte, qui peuvent par exemple être utilisées pour la "
+"documentation."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid ""
+"A title, section or a subsection. 6 levels of different headings are "
+"possible."
+msgstr ""
+"Un titre, une section ou une sous-section. 6 niveaux de titres différents "
+"sont possibles."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Page breaks."
+msgstr "Sauts de page."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:65
+msgid ""
+"The default behavior of _wxMaxima_ when text is entered is to automatically "
+"create a math cell. Cells of other types can be created using the Cell menu, "
+"using the hot keys shown in the menu or using the drop-down list in the "
+"toolbar. Once the non-math cell is created, whatever is typed into the file "
+"is interpreted as text."
+msgstr ""
+"Par défaut, _wxMaxima_ crée automatiquement une cellule de calcul lorsque du "
+"texte est saisi. Pour créer des cellules d’un autre type, utilisez le menu "
+"Cellule, les raccourcis clavier indiqués dans ce menu ou la liste déroulante "
+"de la barre d’outils. Une fois qu’une cellule non mathématique est créée, "
+"tout ce qui y est saisi est interprété comme du texte."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:67
+msgid ""
+"A (C-style) [comment text](https://maxima.sourceforge.io/docs/manual/"
+"maxima_singlepage.html#Comments) can be part of a math cell as follows: `/* "
+"This comment will be ignored by Maxima */`"
+msgstr ""
+"Un [commentaire (style C)](https://maxima.sourceforge.io/docs/manual/"
+"maxima_singlepage.html#Comments) peut être inséré dans une cellule de calcul "
+"comme suit : `/* Ce commentaire sera ignoré par Maxima */`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:69
+msgid "\"`/*`\" marks the start of the comment, \"`*/`\" the end."
+msgstr "\"`/*`\" indique le début du commentaire, \"`*/`\" la fin."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:70
+#, fuzzy, no-wrap
+#| msgid "### Horizontal and vertical cursors"
+msgid "Horizontal and vertical cursors"
+msgstr "### curseurs horizontaux et verticaux"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:73
+msgid ""
+"If the user tries to select a complete sentence, a word processor will try "
+"to extend the selection to automatically begin and end with a word boundary. "
+"Likewise, if more than one cell is selected, _wxMaxima_ will extend the "
+"selection to whole cells."
+msgstr ""
+"Si l’utilisateur tente de sélectionner une phrase complète, un traitement de "
+"texte étendra automatiquement la sélection pour qu’elle commence et se "
+"termine aux limites d’un mot. De même, si plusieurs cellules sont  "
+"sélectionnées, _wxMaxima_ étendra la sélection aux cellules entières."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:75
+#, fuzzy
+#| msgid ""
+#| "What isnât standard is that _wxMaxima_ provides drag-and-drop flexibility "
+#| "by defining two types of cursors. _WxMaxima_ will switch between them "
+#| "automatically when needed:"
+msgid ""
+"What isn’t standard is that _wxMaxima_ provides drag-and-drop flexibility by "
+"defining two types of cursors. _WxMaxima_ will switch between them "
+"automatically when needed:"
+msgstr ""
+"Ce qui est moins conventionnel, c’est que _wxMaxima_ offre une facilité de "
+"glisser-déposer en définissant deux types de curseurs. _wxMaxima_ basculera "
+"automatiquement entre eux selon le besoin :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:78
+msgid ""
+"The cursor is drawn horizontally if it is moved in the space between two "
+"cells or by clicking there."
+msgstr ""
+"Le curseur est dessiné horizontalement s’il est déplacé dans l’espace entre "
+"deux cellules ou en cliquant à cet endroit."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:78
+msgid ""
+"A vertical cursor that works inside a cell. This cursor is activated by "
+"moving the cursor inside a cell using the mouse pointer or the cursor keys "
+"and works much like the cursor in a text editor."
+msgstr ""
+"Un curseur vertical qui fonctionne à l’intérieur d’une cellule. Ce curseur "
+"est activé en déplaçant le curseur à l’intérieur d’une cellule à l’aide du "
+"pointeur de la souris ou des touches de direction, et fonctionne de manière "
+"similaire à celui d’un éditeur de texte."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:80
+#, fuzzy, no-wrap
+#| msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`)."
+msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).\n"
+msgstr "Quand vous lancez wxMaxima, vous ne verrez que le curseur horizontal clignotant. Si vous commencez à taper, une cellule mathématique sera automatiquement créée et le curseur deviendra un curseur vertical classique (vous verrez une flèche vers la droite comme \"invite\", et après avoir évalué la cellule mathématique (<kbd>CTRL</kbd>+<kbd>ENTRÉE</kbd>), les étiquettes apparaîtront, par exemple `(%i1)`, `(%o1)`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:82
+msgid ""
+"![(blinking) horizontal cursor after wxMaxima start](./horizontal-cursor-"
+"only.png){ id=img_horizontal_cursor_only }"
+msgstr ""
+"![curseur horizontal (clignotant) après le démarrage de wxMaxima](./"
+"horizontal-cursor-only.png){ id=img_horizontal_cursor_only }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:84
+msgid ""
+"You might want to create a different cell type (using the \"Cell\" menu), "
+"maybe a title cell or text cell, which describes, what will be done, when "
+"you start creating your worksheet."
+msgstr ""
+"Vous pourrez peut-être vouloir créer un type de cellule différent (via le "
+"menu \"Cellule\"), comme une cellule de titre ou une cellule de texte, pour "
+"décrire ce que vous allez faire lorsque vous commencerez à créer votre "
+"notebook."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:86
+msgid ""
+"If you navigate between the different cells, you will also see the "
+"(blinking) horizontal cursor, where you can insert a cell into your "
+"worksheet (either a math cell, by just start typing your formula - or a "
+"different cell type using the menu)."
+msgstr ""
+"Si vous naviguez entre les différentes cellules, vous verrez également le "
+"curseur horizontal (clignotant), indiquant l'endroit où vous pouvez insérer "
+"une nouvelle cellule dans votre notebook (soit une cellule mathématique, en "
+"commençant simplement à saisir votre formule, soit un autre type de cellule "
+"en utilisant le menu)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:88
+msgid ""
+"![(blinking) horizontal cursor between cells](./horizontal-cursor-between-"
+"cells.png){ id=img_horizontal_cursor_between_cells }"
+msgstr ""
+"![curseur horizontal (clignotant) entre deux cellules](./horizontal-cursor-"
+"between-cells.png){ id=img_horizontal_cursor_between_cells }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:89
+#, fuzzy, no-wrap
+#| msgid "### Sending cells to Maxima"
+msgid "Sending cells to Maxima"
+msgstr "### Envoyer des cellules à Maxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:92
+#, fuzzy, no-wrap
+#| msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>."
+msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.\n"
+msgstr "La commande dans une cellule de code est exécutée en appuyant une fois sur <kbd>CTRL</kbd>+<kbd>ENTRÉE</kbd>, <kbd>MAJ</kbd>+<kbd>ENTRÉE</kbd> ou la touche <kbd>ENTRÉE</kbd> du pavé numérique. Par défaut, _wxMaxima_ exécute les commandes lorsque <kbd>CTRL</kbd>+<kbd>ENTRÉE</kbd> ou <kbd>MAJ</kbd>+<kbd>ENTRÉE</kbd> est pressé, mais il est possible de configurer _wxMaxima_ pour qu’il exécute les commandes en réponse à la touche <kbd>ENTRÉE</kbd>."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:93
+#, fuzzy, no-wrap
+#| msgid "### Command autocompletion"
+msgid "Command autocompletion"
+msgstr "### Complétion automatique des commandes"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:96
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units."
+msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.\n"
+msgstr "_wxMaxima_ dispose d’une fonction de complétion automatique, accessible via le menu (Cellule/Compléter le mot) ou en appuyant sur la combinaison de touches <kbd>CTRL</kbd>+<kbd>ESPACE</kbd>. Cette complétion est sensible au contexte : par exemple, si elle est activée lors d'une spécification d’unité pour ezUnits, elle proposera une liste des unités applicables."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:98
+msgid "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
+msgstr "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:100
+#, fuzzy, no-wrap
+#| msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template)."
+msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).\n"
+msgstr "Outre la complétion des noms de fichiers, d’unités, de commandes ou de variables, la complétion automatique peut aussi afficher un modèle pour la plupart des commandes, indiquant le type (et la signification) des paramètres attendus par le programme. Pour activer cette fonctionnalité, appuyez sur <kbd>MAJ</kbd>+<kbd>CTRL</kbd>+<kbd>ESPACE</kbd> ou sélectionnez l’option correspondante dans le menu (Cellule/Afficher le modèle)."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:101
+#, fuzzy, no-wrap
+#| msgid "#### Greek characters"
+msgid "Greek characters"
+msgstr "#### Caractères grecs"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:104
+msgid ""
+"Computers traditionally stored characters in 8-bit values. This allows for a "
+"maximum of 256 different characters. All letters, numbers, and control "
+"symbols (end of transmission, end of string, lines and edges for drawing "
+"rectangles for menus _etc_.) of nearly any given language can fit within "
+"that limit."
+msgstr ""
+"Traditionnellement, les ordinateurs stockaient les caractères sur 8 bits, ce "
+"qui permet un maximum de 256 caractères différents. Toutes les lettres, "
+"chiffres et symboles de contrôle (fin de transmission, fin de chaîne, lignes "
+"et bordures pour dessiner des rectangles autour des menus, etc.) de presque "
+"n'importe quelle langue pouvaient tenir avec cette limite."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:106
+msgid ""
+"For most countries, the codepage of 256 characters that has been chosen does "
+"not include things like Greek letters, though, that are frequently used in "
+"mathematics. To overcome this type of limitation [Unicode](https://home."
+"unicode.org/) has been invented: An encoding that makes English text work "
+"like normal, but to use much more than 256 characters."
+msgstr ""
+"Pour la plupart des pays, la page de codes de 256 caractères choisie "
+"n'inclut cependant pas des éléments comme les lettres grecques, pourtant "
+"fréquemment utilisées en mathématiques. Pour surmonter ce type de "
+"limitation, [Unicode](https://home.unicode.org/) a été inventé : il s'agit "
+"d'un encodage qui permet aux textes en anglais de s'afficher normalement, "
+"tout en utilisant bien plus que 256 caractères."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:108
+#, fuzzy
+#| msgid ""
+#| "_Maxima_ allows Unicode if it was compiled using a Lisp compiler that "
+#| "either supports Unicode or that doesnât care about the font encoding. As "
+#| "at least one of this pair of conditions is likely to be true. _WxMaxima_ "
+#| "provides a method of entering Greek characters using the keyboard:"
+msgid ""
+"_Maxima_ allows Unicode if it was compiled using a Lisp compiler that either "
+"supports Unicode or that doesn’t care about the font encoding. As at least "
+"one of this pair of conditions is likely to be true. _WxMaxima_ provides a "
+"method of entering Greek characters using the keyboard:"
+msgstr ""
+"_Maxima_ prend en charge Unicode s'il a été compilé avec un compilateur Lisp "
+"qui supporte Unicode ou qui ne tient pas compte de l'encodage de la police. "
+"Comme au moins une de ces deux conditions est probablement remplie, "
+"_wxMaxima_ fournit une méthode pour saisir des caractères grecs à l'aide du "
+"clavier :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:111
+#, fuzzy
+#| msgid ""
+#| "A Greek letter can be entered by pressing the <kbd>ESC</kbd> key and then "
+#| "starting to type the Greek characterâs name."
+msgid ""
+"A Greek letter can be entered by pressing the <kbd>ESC</kbd> key and then "
+"starting to type the Greek character’s name."
+msgstr ""
+"Une lettre grecque peut être saisie en appuyant sur la touche <kbd>ÉCHAP</"
+"kbd>, puis en commençant à taper le nom du caractère grec."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:111
+msgid ""
+"Alternatively it can be entered by pressing <kbd>ESC</kbd>, one letter (or "
+"two for the Greek letter omicron) and <kbd>ESC</kbd> again. In this case the "
+"following letters are supported:"
+msgstr ""
+"- Une lettre grecque peut être saisie en appuyant sur la touche <kbd>ÉCHAP</"
+"kbd>, puis en commençant à taper le nom du caractère grec. \n"
+"- Elle peut aussi être saisie en appuyant sur <kbd>ÉCHAP</kbd>, une lettre "
+"(ou deux pour la lettre grecque omicron), puis à nouveau sur <kbd>ÉCHAP</"
+"kbd>. Dans ce cas, les lettres suivantes sont prises en charge :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:130
+#, no-wrap
+msgid ""
+"| key | Greek letter | key | Greek letter | key | Greek letter |\n"
+"| :-: | :----------: | :-: | :----------: | :-: | :----------: |\n"
+"|  a  |    alpha     |  i  |     iota     |  r  |     rho      |\n"
+"|  b  |     beta     |  k  |    kappa     |  s  |    sigma     |\n"
+"|  g  |    gamma     |  l  |    lambda    |  t  |     tau      |\n"
+"|  d  |    delta     |  m  |      mu      |  u  |   upsilon    |\n"
+"|  e  |   epsilon    |  n  |      nu      |  f  |     phi      |\n"
+"|  z  |     zeta     |  x  |      xi      |  c  |     chi      |\n"
+"|  h  |     eta      | om  |   omicron    |  y  |     psi      |\n"
+"|  q  |    theta     |  p  |      pi      |  o  |    omega     |\n"
+"|  A  |    Alpha     |  I  |     Iota     |  R  |     Rho      |\n"
+"|  B  |     Beta     |  K  |    Kappa     |  S  |    Sigma     |\n"
+"|  G  |    Gamma     |  L  |    Lambda    |  T  |     Tau      |\n"
+"|  D  |    Delta     |  M  |      Mu      |  U  |   Upsilon    |\n"
+"|  E  |   Epsilon    |  N  |      Nu      |  P  |     Phi      |\n"
+"|  Z  |     Zeta     |  X  |      Xi      |  C  |     Chi      |\n"
+"|  H  |     Eta      | Om  |   Omicron    |  Y  |     Psi      |\n"
+"|  T  |    Theta     |  P  |      Pi      |  O  |    Omega     |\n"
+msgstr ""
+"| touche | Lettre grecque | touche | Lettre grecque | touche | Lettre grecque |\n"
+"| :-: | :----------: | :-: | :----------: | :-: | :----------: |\n"
+"|  a  |    alpha     |  i  |     iota     |  r  |     rho      |\n"
+"|  b  |     beta     |  k  |    kappa     |  s  |    sigma     |\n"
+"|  g  |    gamma     |  l  |    lambda    |  t  |     tau      |\n"
+"|  d  |    delta     |  m  |      mu      |  u  |   upsilon    |\n"
+"|  e  |   epsilon    |  n  |      nu      |  f  |     phi      |\n"
+"|  z  |     zeta     |  x  |      xi      |  c  |     chi      |\n"
+"|  h  |     eta      | om  |   omicron    |  y  |     psi      |\n"
+"|  q  |    theta     |  p  |      pi      |  o  |    omega     |\n"
+"|  A  |    Alpha     |  I  |     Iota     |  R  |     Rho      |\n"
+"|  B  |     Beta     |  K  |    Kappa     |  S  |    Sigma     |\n"
+"|  G  |    Gamma     |  L  |    Lambda    |  T  |     Tau      |\n"
+"|  D  |    Delta     |  M  |      Mu      |  U  |   Upsilon    |\n"
+"|  E  |   Epsilon    |  N  |      Nu      |  P  |     Phi      |\n"
+"|  Z  |     Zeta     |  X  |      Xi      |  C  |     Chi      |\n"
+"|  H  |     Eta      | Om  |   Omicron    |  Y  |     Psi      |\n"
+"|  T  |    Theta     |  P  |      Pi      |  O  |    Omega     |\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:132
+msgid ""
+"You can also use the \"Greek letters\"-sidebar to enter the Greek letters."
+msgstr ""
+"Vous pouvez également utiliser la barre latérale « Lettres grecques » pour "
+"insérer les lettres grecques."
+
+#. type: Title #####
+#: ../../info/wxmaxima.md:133
+#, fuzzy, no-wrap
+#| msgid "##### Attention: Lookalike characters"
+msgid "Attention: Lookalike characters"
+msgstr "##### Attention aux caractères similaires"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:138
+msgid ""
+"Several Latin letters look like the Greek letters, e.g. the Latin letter "
+"\"A\" and the Greek letter \"Alpha\". Although they look identical, they are "
+"two different Unicode characters, represented by different Unicode code "
+"points (numbers)."
+msgstr ""
+"Plusieurs lettres latines ressemblent aux lettres grecques, par exemple la "
+"lettre latine \"A\" et la lettre grecque \"Alpha\". Bien qu'elles aient la "
+"même apparence, ce sont deux caractères Unicode distincts, représentés par "
+"des codages Unicode (nombres) différents."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:143
+msgid ""
+"This might be problematic, if you assign a value to the variable A and later "
+"use the Greek letter Alpha to do something with this variable, especially on "
+"printouts.  For the Greek letter my (which is also used as prefix for micro) "
+"there are also two different Unicode code points."
+msgstr ""
+"Cela peut poser problème si vous attribuez une valeur à la variable A et que "
+"vous utilisez ensuite la lettre grecque Alpha pour faire quelque chose avec "
+"cette variable, notamment sur les impressions. Pour la lettre grecque mu "
+"(utilisée aussi comme préfixe pour micro), il existe également deux codages "
+"Unicode différents."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:146
+msgid ""
+"The \"Greek letters\"-sidebar therefore has the option, that lookalike "
+"characters are not available (which can be changed using a right-click menu)."
+msgstr ""
+"La barre latérale « Lettres grecques » offre donc l’option de désactiver les "
+"caractères similaires (ce paramètre peut être modifié via un menu accessible "
+"par un clic droit)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:148
+msgid ""
+"The same mechanism also allows to enter some miscellaneous mathematical "
+"symbols:"
+msgstr ""
+"Le même mécanisme permet également de saisir divers symboles mathématiques :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:199
+#, no-wrap
+msgid ""
+"| keys to enter  | mathematical symbol                                   |\n"
+"| -------------- | ----------------------------------------------------- |\n"
+"| hbar           | Planck constant: a h with a horizontal bar above it   |\n"
+"| Hbar           | a H with a horizontal bar above it                    |\n"
+"| 2              | squared                                               |\n"
+"| 3              | to the power of three                                 |\n"
+"| /2             | 1/2                                                   |\n"
+"| partial        | partial sign (the d of dx/dt)                         |\n"
+"| integral       | integral sign                                         |\n"
+"| sq             | square root                                           |\n"
+"| ii             | imaginary                                             |\n"
+"| ee             | element                                               |\n"
+"| in             | in                                                    |\n"
+"| impl implies   | implies                                               |\n"
+"| inf            | infinity                                              |\n"
+"| empty          | empty                                                 |\n"
+"| TB             | big triangle right                                    |\n"
+"| tb             | small triangle right                                  |\n"
+"| and            | and                                                   |\n"
+"| or             | or                                                    |\n"
+"| xor            | xor                                                   |\n"
+"| nand           | nand                                                  |\n"
+"| nor            | nor                                                   |\n"
+"| equiv          | equivalent to                                         |\n"
+"| not            | not                                                   |\n"
+"| union          | union                                                 |\n"
+"| inter          | intersection                                          |\n"
+"| subseteq       | subset or equal                                       |\n"
+"| subset         | subset                                                |\n"
+"| notsubseteq    | not subset or equal                                   |\n"
+"| notsubset      | not subset                                            |\n"
+"| approx         | approximately                                         |\n"
+"| propto         | proportional to                                       |\n"
+"| neq != /= or # | not equal to                                          |\n"
+"| +/- or pm      | a plus/minus sign                                     |\n"
+"| \\<= or leq     | equal or less than                                    |\n"
+"| >= or geq      | equal or greater than                                 |\n"
+"| \\<\\< or ll     | much less than                                        |\n"
+"| >> or gg       | much greater than                                     |\n"
+"| qed            | end of proof                                          |\n"
+"| nabla          | a nabla operator                                      |\n"
+"| sum            | sum sign                                              |\n"
+"| prod           | product sign                                          |\n"
+"| exists         | there exists sign                                     |\n"
+"| nexists        | there is no sign                                      |\n"
+"| parallel       | a parallel sign                                       |\n"
+"| perp           | a perpendicular sign                                  |\n"
+"| leadsto        | a leads to sign                                       |\n"
+"| ->             | a right arrow                                         |\n"
+"| -->            | a long right arrow                                    |\n"
+msgstr ""
+"Touches à saisir | symbole mathématique                                            |\n"
+"|---------------|-----------------------------------------------------------------|\n"
+"| hbar           | Constante de Planck : un h avec une barre horizontale au-dessus |\n"
+"| Hbar           | un H avec une barre horizontale au-dessus                       |\n"
+"| 2              | au carré                                                        |\n"
+"| 3              | à la puissance trois                                            |\n"
+"| /2             | 1/2                                                             |\n"
+"| partial        | symbole de dérivation partielle (le d de dx/dt)                 |\n"
+"| integral       | symbole intégrale                                               |\n"
+"| sq             | racine carrée                                                   |\n"
+"| ii             | imaginaire                                                      |\n"
+"| ee             | appartient à                                                    |\n"
+"| in             | dans                                                            |\n"
+"| impl implies   | implique                                                        |\n"
+"| inf            | infini                                                          |\n"
+"| empty          | ensemble vide                                                   |\n"
+"| TB             | grand triangle vers la droite                                   |\n"
+"| tb             | petit triangle vers la droite                                   |\n"
+"| and            | et                                                              |\n"
+"| or             | ou                                                              |\n"
+"| xor            | ou exclusif                                                     |\n"
+"| nand           | et non                                                          |\n"
+"| nor            | ni                                                              |\n"
+"| equiv          | équivalent à                                                    |\n"
+"| not            | non                                                             |\n"
+"| union          | union                                                           |\n"
+"| inter          | intersection                                                    |\n"
+"| subseteq       | sous-ensemble ou égal                                           |\n"
+"| subset         | sous-ensemble                                                   |\n"
+"| notsubseteq    | n'est pas un  sous-ensemble ou égal                             |\n"
+"| notsubset      | n'est pas un sous-ensemble                                      |\n"
+"| approx         | approximativement                                               |\n"
+"| propto         | proportionnel à                                                 |\n"
+"| neq != /= ou # | différent de                                                    |\n"
+"| +/- ou pm      | signe plus/moins                                                |\n"
+"| \\<= ou leq     | inférieur ou égal à                                             |\n"
+"| >= ou geq      | supérieur ou égal à                                             |\n"
+"| \\<\\< ou ll     | beaucoup plus petit que                                         |\n"
+"| >> ou gg       | beaucoup plus grand que                                         |\n"
+"| qed            | fin de preuve                                                   |\n"
+"| nabla          | opérateur nabla                                                 |\n"
+"| sum            | symbole somme                                                   |\n"
+"| prod           | symbole produit                                                 |\n"
+"| exists         | il existe                                                       |\n"
+"| nexists        | il n'existe pas                                                 |\n"
+"| parallel       | symbole parallèle                                               |\n"
+"| perp           | symbole perpendiculaire                                         |\n"
+"| leadsto        | symbole mène à                                                  |\n"
+"| ->             | flèche vers la droite                                           |\n"
+"| -->            | longue flèche vers la droite                                    |\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:201
+msgid ""
+"You can also use the \"Symbols\"-sidebar to enter these Mathematical symbols."
+msgstr ""
+"Vous pouvez aussi utiliser la barre latérale « Symboles » pour saisir ces "
+"symboles mathématiques."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:203
+#, fuzzy, no-wrap
+#| msgid "If a special symbol isnât in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet."
+msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.\n"
+msgstr "Si un symbole spécial ne figure pas dans la liste, il est possible de saisir des caractères Unicode arbitraires en appuyant sur <kbd>ÉCHAP</kbd> \\[numéro du caractère (en hexadécimal)\\] <kbd>ÉCHAP</kbd>. De plus, la barre latérale « Symboles » dispose d’un menu accessible par un clic droit, qui permet d’afficher une liste de tous les symboles Unicode disponibles que l’on peut ajouter à cette barre d’outils ou insérer dans le notebook."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:205
+#, fuzzy, no-wrap
+#| msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`."
+msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.\n"
+msgstr "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd>  est une séquence qui produit un `a`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:207
+#, fuzzy
+#| msgid ""
+#| "Please note that most of these symbols (notable exceptions are the logic "
+#| "symbols) do not have a special meaning in _Maxima_ and therefore will be "
+#| "interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp "
+#| "that doesnât support Unicode characters they might cause an error message."
+msgid ""
+"Please note that most of these symbols (notable exceptions are the logic "
+"symbols) do not have a special meaning in _Maxima_ and therefore will be "
+"interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp "
+"that doesn’t support Unicode characters they might cause an error message."
+msgstr ""
+"Veuillez noter que la plupart de ces symboles (à l'exception notable des "
+"symboles logiques) n'ont pas de signification particulière dans _Maxima_ et "
+"seront donc interprétés comme des caractères ordinaires. Si _Maxima_ est "
+"compilé avec un Lisp qui ne supporte pas les caractères Unicode, ceux-ci "
+"peuvent provoquer un message d'erreur."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:210
+#, fuzzy, no-wrap
+#| msgid "It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.  To solve that problem, select other fonts (using: Edit -> Configure -> Style)."
+msgid ""
+"It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.\n"
+"To solve that problem, select other fonts (using: Edit -> Configure -> Style).\n"
+msgstr "Il est possible que, par exemple, les caractères grecs ou les symboles mathématiques ne soient pas inclus dans la police sélectionnée et ne puissent donc pas s'afficher. Pour résoudre ce problème, choisissez une autre police (via : Édition -> Configurer -> Style)."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:211
+#, fuzzy, no-wrap
+#| msgid "### Unicode replacement"
+msgid "Unicode replacement"
+msgstr "### Remplacement de caractères Unicode"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:214
+#, fuzzy
+#| msgid ""
+#| "wxMaxima will replace several Unicode characters with their respective "
+#| "Maxima expressions, e.g. `Â²` with `^2`, `Â³` with `^3`, the square root "
+#| "sign with the function `sqrt()`, the (mathematical) Sigma sign (which is "
+#| "not the same Unicode character as the corresponding Greek letter) with "
+#| "`sum()`, etc."
+msgid ""
+"wxMaxima will replace several Unicode characters with their respective "
+"Maxima expressions, e.g. `²` with `^2`, `³` with `^3`, the square root sign "
+"with the function `sqrt()`, the (mathematical) Sigma sign (which is not the "
+"same Unicode character as the corresponding Greek letter) with `sum()`, etc."
+msgstr ""
+"wxMaxima remplacera plusieurs caractères Unicode par leurs expressions "
+"Maxima correspondantes, par exemple `Â²` par `^2`, `Â³` par `^3`, le symbole "
+"de la racine carrée par la fonction `sqrt()`, le symbole Sigma mathématique "
+"(qui n’est pas le même caractère Unicode que la lettre grecque "
+"correspondante) par `sum()`, etc."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:217
+#, fuzzy
+#| msgid ""
+#| "Unicode has several \"common\" fractions encoded as one Unicode code "
+#| "point: `Â¼, Â½, Â¾, â, â, â, â, â, â, â, â, â, â, â, â, â, â, â`"
+msgid ""
+"Unicode has several \"common\" fractions encoded as one Unicode code point: "
+"`¼, ½, ¾, ⅐, ⅑, ⅒, ⅓, ⅔, ⅕, ⅖, ⅗, ⅘, ⅙, ⅚, ⅛, ⅜, ⅝, ⅞`"
+msgstr ""
+"Unicode comprend plusieurs fractions « courantes » encodées sous la forme "
+"d’un seul point de code : `¼, ½, ¾, ⅐, ⅑, ⅒, ⅓, ⅔, ⅕, ⅖, ⅗, ⅘, ⅙, ⅚, ⅛, ⅜, "
+"⅝, ⅞`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:219
+#, fuzzy
+#| msgid ""
+#| "wxMaxima will replace them with their Maxima representations, e.g `(1/4)` "
+#| "before the input is sent do Maxima. There are also `â`, which will be replaced by `1/` and `â` (used in baseball), which will "
+#| "be replaced by `(0/3)`."
+msgid ""
+"wxMaxima will replace them with their Maxima representations, e.g `(1/4)` "
+"before the input is sent do Maxima. There are also `⅟`, which will be "
+"replaced by `1/` and `↉` (used in baseball), which will be replaced by "
+"`(0/3)`."
+msgstr ""
+"wxMaxima les remplacera par leurs représentations dans Maxima, par exemple "
+"`(1/4)` avant que l’entrée ne soit envoyée à Maxima. Il existe aussi `⅟`, "
+"qui sera remplacé par `1/`, et `↉` (utilisé au baseball), qui sera remplacé "
+"par `(0/3)`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:221
+msgid ""
+"It is recommended to use **Maxima code** (not these Unicode code points) in "
+"input cells (Rationale: (a) it might be possible, that the used font for "
+"math input does not contain them; (b) if you save the document as `wxm`-"
+"file, it is usually readable by (command line) Maxima, but these changes "
+"will of course not work in command line Maxima); but they may occur, if you "
+"cut&paste a formula from another document."
+msgstr ""
+"Il est recommandé d’utiliser le **code Maxima** (et non ces points de code "
+"Unicode) dans les cellules de saisie. Raisons : (a) il se peut que la police "
+"utilisée pour la saisie mathématique ne les contienne pas ;  (b) si vous "
+"enregistrez le document au format `wxm`, celui-ci est généralement lisible "
+"par Maxima en ligne de commande, mais ces substitutions ne fonctionneront "
+"évidemment pas dans Maxima en ligne de commande. Toutefois, ces caractères "
+"peuvent apparaître si vous copiez-collez une formule depuis un autre "
+"document."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:222
+#, fuzzy, no-wrap
+#| msgid "### Side Panes"
+msgid "Side Panes"
+msgstr "### Les panneaux latéraux"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:225
+msgid ""
+"Shortcuts to the most important _Maxima_ commands, things like a table of "
+"contents, windows with debug messages or a history of the last issued "
+"commands can be accessed using the side panes. They can be enabled using the "
+"\"View\" menu. They all can be moved to other locations inside or outside "
+"the _wxMaxima_ window. Other useful panes is the one that allows to input "
+"Greek letters using the mouse."
+msgstr ""
+"Les raccourcis vers les commandes les plus importantes de _Maxima_, comme "
+"une table des matières, des fenêtres avec des messages de débogage ou un "
+"historique des dernières commandes exécutées, peuvent être accessibles via "
+"les panneaux latéraux. Ceux-ci peuvent être activés depuis le menu "
+"« Affichage ». Ils peuvent tous être déplacés vers d’autres emplacements, à "
+"l’intérieur ou à l’extérieur de la fenêtre de _wxMaxima_. Un autre volet "
+"utile est celui qui permet de saisir des lettres grecques avec la souris."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:227
+msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
+msgstr ""
+"![Illustration de différents volets latéraux](./SidePanes.png)"
+"{ id=img_SidePanes }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:230
+msgid ""
+"In the \"table of contents\" side pane, one can increase or decrease a "
+"heading by just clicking on the heading with the right mouse button and "
+"select the next higher or lower heading type."
+msgstr ""
+"Dans le volet latéral « table des matières », vous pouvez augmenter ou "
+"diminuer le niveau d’un titre en cliquant simplement dessus avec le bouton "
+"droit de la souris et en sélectionnant le niveau de titre supérieur ou "
+"inférieur."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:232
+msgid ""
+"![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-"
+"headings.png){ id=Sidepane-TOC-convert-headings }"
+msgstr ""
+"![Augmenter ou diminuer le niveau de titres dans le panneau latéral Table "
+"des Matières](./Sidepane-TOC-convert-headings.png){ id=Sidepane-TOC-convert-"
+"headings }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:233
+#, fuzzy, no-wrap
+#| msgid "### MathML output"
+msgid "MathML output"
+msgstr "### Export MathML"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:236
+#, fuzzy
+#| msgid ""
+#| "Several word processors and similar programs either recognize [MathML]"
+#| "(https://www.w3.org/Math/) input and automatically insert it as an "
+#| "editable 2D equation - or (like LibreOffice) have an equation editor that "
+#| "offers an âimport MathML from clipboardâ feature. Others support RTF "
+#| "maths. _WxMaxima_, therefore, offers several entries in the right-click "
+#| "menu."
+msgid ""
+"Several word processors and similar programs either recognize [MathML]"
+"(https://www.w3.org/Math/) input and automatically insert it as an editable "
+"2D equation - or (like LibreOffice) have an equation editor that offers an "
+"“import MathML from clipboard” feature. Others support RTF maths. "
+"_WxMaxima_, therefore, offers several entries in the right-click menu."
+msgstr ""
+"Plusieurs logiciels de traitement de texte et programmes similaires "
+"reconnaissent soit  une entrée  [MathML](https://www.w3.org/Math/)  et "
+"l'insère automatiquement sous forme d'équation 2D modifiable, soit (comme "
+"LibreOffice) disposent d'un éditeur d'équations proposant une fonction "
+"« Importer du MathML depuis le presse-papiers ». D'autres prennent en charge "
+"les équations en RTF. _WxMaxima_ offre donc plusieurs options dans le menu "
+"contextuel (clic droit)."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:237
+#, fuzzy, no-wrap
+#| msgid "### Markdown support"
+msgid "Markdown support"
+msgstr "### Prise en charge de Markdown"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:240
+#, fuzzy
+#| msgid ""
+#| "_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/"
+#| "wiki/Markdown) conventions that donât collide with mathematical notation. "
+#| "One of these elements is bullet lists."
+msgid ""
+"_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/wiki/"
+"Markdown) conventions that don’t collide with mathematical notation. One of "
+"these elements is bullet lists."
+msgstr ""
+"_WxMaxima_ propose un ensemble de balises [Markdown](https://en.wikipedia."
+"org/wiki/Markdown) standard qui n’entrent pas en conflit avec la notation "
+"mathématique. L’un de ces éléments est les listes à puces."
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:241
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```text\n"
+#| "Ordinary text\n"
+#| " * One item, indentation level 1\n"
+#| " * Another item at indentation level 1\n"
+#| "   * An item at a second indentation level\n"
+#| "   * A second item at the second indentation level\n"
+#| " * A third item at the first indentation level\n"
+#| "Ordinary text\n"
+#| "```\n"
+msgid ""
+"Ordinary text\n"
+" * One item, indentation level 1\n"
+" * Another item at indentation level 1\n"
+"   * An item at a second indentation level\n"
+"   * A second item at the second indentation level\n"
+" * A third item at the first indentation level\n"
+"Ordinary text\n"
+msgstr ""
+"```text\n"
+"Texte ordinaire\n"
+"* Un élément, niveau d'indentation 1\n"
+"* Un autre élément au niveau d'indentation 1\n"
+"  * Un élément au deuxième niveau d'indentation\n"
+"  * Un deuxième élément au deuxième niveau d'indentation\n"
+"* Un troisième élément au premier niveau d'indentation\n"
+"Texte ordinaire\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:252
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
+msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
+msgstr "_WxMaxima_ reconnaîtra le texte commençant par le caractère `>` comme des blocs de citations  :"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:253
+#, fuzzy, no-wrap
+#| msgid "```text Ordinary text > quote quote quote quote > quote quote quote quote > quote quote quote quote Ordinary text ```"
+msgid ""
+"Ordinary text\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"Ordinary text\n"
+msgstr "```text Texte ordinaire > citation citation citation citation > citation citation citation citation > citation citation citation citation Texte ordinaire```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:262
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_âs TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:"
+msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:\n"
+msgstr "_WxMaxima_ reconnaîtra `=>` dans ses sorties TeX et HTML et le remplacera par le symbole Unicode correspondant :"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:263
+#, fuzzy, no-wrap
+#| msgid "```text cogito => sum.  ```"
+msgid "cogito => sum.\n"
+msgstr "```text cogito => sum.  ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:268
+#, fuzzy, no-wrap
+#| msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized."
+msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.\n"
+msgstr "D’autres symboles reconnus par les exports HTML et TeX sont `<=` et `>=` pour les comparaisons, une double flèche à double pointe (`<=>`), des flèches à une seule direction (`<->`, `->` et `<-`) ainsi que `+/-` pour le symbole correspondant. Pour la sortie TeX, les symboles `<<` et `>>` sont également reconnus."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:269
+#, fuzzy, no-wrap
+#| msgid "### Hotkeys"
+msgid "Hotkeys"
+msgstr "### Raccourcis clavier"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:272
+msgid ""
+"Most hotkeys can be found in the text of the respective menus. Since they "
+"are actually taken from the menu text and thus can be customized by the "
+"translations of _wxMaxima_ to match the needs of users of the local "
+"keyboard, we do not document them here. A few hotkeys or hotkey aliases, "
+"though, are not documented in the menus:"
+msgstr ""
+"La plupart des raccourcis clavier peuvent être trouvés dans le texte des "
+"menus associés. Comme ils sont effectivement tirés du texte des menus, ils "
+"peuvent ainsi être personnalisés par les traductions de _wxMaxima_ pour "
+"correspondre aux besoins des utilisateurs des claviers locaux, nous ne les "
+"documentons pas ici. Cependant, quelques raccourcis clavier ou alias de "
+"raccourcis ne sont pas documentés dans les menus :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid ""
+"<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
+msgstr ""
+"<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> supprime complètement une "
+"cellule."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid ""
+"<kbd>CTRL</kbd>+<kbd>TAB</kbd> or <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</"
+"kbd> triggers the auto-completion mechanism."
+msgstr ""
+"<kbd>CTRL</kbd>+<kbd>TAB</kbd> or <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</"
+"kbd> déclenche le mécanisme de saisie automatique."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
+msgstr "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> insère un espace insécable."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:277
+#, fuzzy, no-wrap
+#| msgid "### Raw TeX in the TeX export"
+msgid "Raw TeX in the TeX export"
+msgstr "### TeX brut dans l'export TeX"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:280
+msgid ""
+"If a text cell begins with `TeX:` the TeX export contains the literal text "
+"that follows the `TeX:` marker. Using this feature allows the entry of TeX "
+"markup within the _wxMaxima_ workbook."
+msgstr ""
+"Si une cellule de texte commence par `TeX:`, l'export TeX inclut le texte "
+"littéral qui suit le marqueur `TeX:`. Cette fonctionnalité permet d'insérer "
+"du code TeX directement dans le classeur _wxMaxima_."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:281
+#, fuzzy, no-wrap
+#| msgid "## File Formats"
+msgid "File Formats"
+msgstr "## Formats de fichiers"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:284
+msgid ""
+"The material that is developed in a _wxMaxima_ session can be stored for "
+"later use in any of three ways:"
+msgstr ""
+"Le contenu développé lors d'une session _wxMaxima_ peut être enregistré pour "
+"une utilisation ultérieure de trois manières différentes :"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:285
+#, fuzzy, no-wrap
+#| msgid "### .mac"
+msgid ".mac"
+msgstr "### .mac"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:288
+#, fuzzy
+#| msgid ""
+#| "`.mac` files are ordinary text files that contain _Maxima_ commands. They "
+#| "can be read using _Maxima_âs `batch()` or `load()` command or "
+#| "_wxMaxima_âs File/Batch File menu entry."
+msgid ""
+"`.mac` files are ordinary text files that contain _Maxima_ commands. They "
+"can be read using _Maxima_’s `batch()` or `load()` command or _wxMaxima_’s "
+"File/Batch File menu entry."
+msgstr ""
+"Les fichiers `.mac` sont des fichiers texte ordinaires qui contiennent des "
+"commandes _Maxima_. Ils peuvent être lus à l'aide de la commande `batch()` "
+"ou `load()` de _Maxima_, ou via l'entrée de menu Fichier/Charger un "
+"packetage de _wxMaxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:291
+msgid ""
+"One example is shown below. `Quadratic.mac` defines a function and afterward "
+"generates a plot with `wxdraw2d()`.  Afterward the contents of the file "
+"`Quadratic.mac` are printed and newly defined function `f()` is evaluated."
+msgstr ""
+"Un exemple est présenté ci-dessous. `Quadratic.mac` définit une fonction, "
+"puis génère un tracé avec `wxdraw2d()`. Ensuite, le contenu du fichier "
+"`Quadratic.mac` est affiché et la fonction nouvellement définie `f()` est "
+"évaluée."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:293
+msgid "![Loading a file with `batch()`](./BatchImage.png){ id=img_BatchImage }"
+msgstr ""
+"![Chargement d'un fichier avec `batch()`](./BatchImage.png)"
+"{ id=img_BatchImage }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:295
+msgid ""
+"Attention: Although the file `Quadratic.mac` has a usual _Maxima_ extension "
+"(`.mac`), it can only be read by _wxMaxima_, since the command `wxdraw2d()` "
+"is a wxMaxima-extension to _Maxima_. (Command line) Maxima will ignore the "
+"unknown command `wxdraw2d()` and print it as output again."
+msgstr ""
+"Attention : Bien que le fichier `Quadratic.mac` ait l'extension habituelle "
+"de _Maxima_ (`.mac`), il ne peut être lu que par _wxMaxima_, car la commande "
+"`wxdraw2d()` est une extension de wxMaxima à _Maxima_. _Maxima_ en ligne de "
+"commande ignorera la commande inconnue `wxdraw2d()` et l'affichera à "
+"l'identique en sortie."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:297
+#, fuzzy
+#| msgid ""
+#| "You can be use `.mac` files for writing your own library of macros. But "
+#| "since they donât contain enough structural information they cannot be "
+#| "read back as a _wxMaxima_ session."
+msgid ""
+"You can be use `.mac` files for writing your own library of macros. But "
+"since they don’t contain enough structural information they cannot be read "
+"back as a _wxMaxima_ session."
+msgstr ""
+"Vous pouvez utiliser les fichiers `.mac` pour écrire votre propre "
+"bibliothèque de macros. Cependant, comme ils ne contiennent pas assez "
+"d’informations structurelles, ils ne peuvent pas être relus en tant que "
+"session _wxMaxima_."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:298
+#, fuzzy, no-wrap
+#| msgid "### .wxm"
+msgid ".wxm"
+msgstr "### .wxm"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:302
+#, fuzzy, no-wrap
+#| msgid "`.wxm` files contain the worksheet except for _Maxima_âs output. On Maxima versions >5.38 they can be read using _Maxima_âs `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.  You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know."
+msgid ""
+"`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.\n"
+"You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.\n"
+msgstr "Les fichiers `.wxm` contiennent la feuille de travail, à l’exception de la sortie de _Maxima_.  Dans les versions de Maxima supérieures à 5.38, ils peuvent être lus à l’aide de la fonction `load()` de _Maxima_, tout comme les fichiers `.mac` — enfin, pour la plupart.  Les questions (comme `asksign(x)`) posent problème, car la réponse est écrite dans le fichier `.wxm` (afin qu’elle puisse être proposée après le chargement), mais Maxima ne peut pas l’évaluer.  Vous pouvez empêcher Maxima de poser des questions en utilisant `assume()` pour déclarer certaines propriétés que Maxima a besoin de connaître."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:304
+msgid ""
+"With this plain-text format, it sometimes is unavoidable that worksheets "
+"that use new features are not downwards-compatible with older versions of "
+"_wxMaxima_."
+msgstr ""
+"Avec ce format en texte brut, il est parfois inévitable que les feuilles de "
+"calcul utilisant de nouvelles fonctionnalités ne soient pas rétrocompatibles "
+"avec les anciennes versions de _wxMaxima_."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:305
+#, fuzzy, no-wrap
+#| msgid "#### File format of wxm files"
+msgid "File format of wxm files"
+msgstr "#### Format de fichier des fichiers wxm"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:308
+msgid ""
+"This is just a plain text file (you can open it with a text editor), "
+"containing the cell contents as some special Maxima comments."
+msgstr ""
+"Il s'agit simplement d'un fichier texte brut (vous pouvez l'ouvrir avec un "
+"éditeur de texte), contenant le contenu des cellules sous forme de "
+"commentaires spéciaux Maxima."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:310
+msgid "It starts with the following comment:"
+msgstr "Cela commence par le commentaire suivant :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:311
+#, fuzzy, no-wrap
+#| msgid "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
+msgid ""
+"/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/\n"
+"/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */\n"
+msgstr "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:317
+msgid ""
+"And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
+msgstr ""
+"Puis les cellules suivent, encodées sous forme de commentaires Maxima, par "
+"exemple une cellule de section :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:318
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "/* [wxMaxima: section start ]\n"
+#| "Title of the section\n"
+#| "   [wxMaxima: section end   ] */\n"
+#| "```\n"
+msgid ""
+"/* [wxMaxima: section start ]\n"
+"Title of the section\n"
+"   [wxMaxima: section end   ] */\n"
+msgstr ""
+"```maxima\n"
+"/* [wxMaxima: section start ]\n"
+"Titre de la section\n"
+"   [wxMaxima: section end   ] */\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:325
+msgid ""
+"or (in a Math cell the input is of course *not* commented out (the output is "
+"not saved in a `wxm` file)):"
+msgstr ""
+"ou (dans une cellule Math, l'entrée n'est bien sûr *pas* mise en commentaire "
+"(la sortie n'est pas enregistrée dans un fichier `wxm`)) :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:326
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "/* [wxMaxima: input   start ] */\n"
+#| "f(x):=x^2+1$\n"
+#| "f(2);\n"
+#| "/* [wxMaxima: input   end   ] */\n"
+#| "```\n"
+msgid ""
+"/* [wxMaxima: input   start ] */\n"
+"f(x):=x^2+1$\n"
+"f(2);\n"
+"/* [wxMaxima: input   end   ] */\n"
+msgstr ""
+"```maxima\n"
+"/* [wxMaxima: input   start ] */\n"
+"f(x):=x^2+1$\n"
+"f(2);\n"
+"/* [wxMaxima: input   end   ] */\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:334
+msgid ""
+"Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the "
+"image type as first line):"
+msgstr ""
+"Les images sont [encodées en Base64](https://en.wikipedia.org/wiki/Base64) "
+"avec l'indication du type de l'image sur la première ligne):"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:335
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "/* [wxMaxima: image   start ]\n"
+#| "jpg\n"
+#| "[very chaotic looking character sequence]\n"
+#| "   [wxMaxima: image   end   ] */\n"
+#| "```\n"
+msgid ""
+"/* [wxMaxima: image   start ]\n"
+"jpg\n"
+"[very chaotic looking character sequence]\n"
+"   [wxMaxima: image   end   ] */\n"
+msgstr ""
+"```maxima\n"
+"/* [wxMaxima: image   start ]\n"
+"jpg\n"
+"[séquence de caractères très chaotique à première vue]\n"
+"   [wxMaxima: image   end   ] */\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:343
+msgid "A page break is just one line containing:"
+msgstr "Une saut de page est simplement une ligne contenant :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:344
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "/* [wxMaxima: page break    ] */\n"
+#| "```\n"
+msgid "/* [wxMaxima: page break    ] */\n"
+msgstr ""
+"```maxima\n"
+"/* [wxMaxima: saut de page    ] */\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:349
+msgid "And folded cells marked by:"
+msgstr "Et les cellules repliées sont marquées par :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:350
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "/* [wxMaxima: fold    start ] */\n"
+#| "...\n"
+#| "/* [wxMaxima: fold    end   ] */\n"
+#| "```\n"
+msgid ""
+"/* [wxMaxima: fold    start ] */\n"
+"...\n"
+"/* [wxMaxima: fold    end   ] */\n"
+msgstr ""
+"```maxima\n"
+"/* [wxMaxima: fold    start ] */\n"
+"...\n"
+"/* [wxMaxima: fold    end   ] */\n"
+"```\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:356
+#, fuzzy, no-wrap
+#| msgid "### .wxmx"
+msgid ".wxmx"
+msgstr "### .wxmx"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:359
+msgid ""
+"This XML-based file format saves the complete worksheet including things "
+"like the zoom factor and the watchlist. It is the preferred file format."
+msgstr ""
+"Ce format de fichier basé sur le XML enregistre la feuille de travail "
+"complète, y compris des éléments comme le facteur de zoom et la liste de "
+"suivi du notebook. C'est le format de fichier recommandé."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:360
+#, fuzzy, no-wrap
+#| msgid "#### File format of wxmx files"
+msgid "File format of wxmx files"
+msgstr "#### Format de fichier des fichiers wxmx"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:364
+msgid ""
+"A `wxmx`-file seems to be a binary format, but one can handle it with tools, "
+"which are included in your OS. It is a zip file, one can decompress it with "
+"`unzip` (maybe rename it before, so that is recognized by the unzip program "
+"of your OS).  We do not use the compression function, just the possibility "
+"to merge several files into one file - images are already compressed and the "
+"rest is simple text (probably much smaller, than huge images, which are "
+"included)."
+msgstr ""
+"Un fichier `wxmx` semble être un format binaire, mais on peut le gérer avec "
+"des outils inclus dans votre système d'exploitation. Il s'agit d'un fichier "
+"zip, que l'on peut décompresser avec `unzip` (peut-être faut-il le renommer "
+"au préalable pour qu'il soit reconnu par le programme de décompression de "
+"votre OS). Nous n'utilisons pas la fonction de compression, seulement la "
+"possibilité de regrouper plusieurs fichiers en un seul — les images sont "
+"déjà compressées et le reste est du texte simple (probablement bien plus "
+"petit que les images volumineuses qu'il contient)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:366
+msgid "It does contain the following files:"
+msgstr "Il contient les fichiers suivants :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-"
+"wxmathml`"
+msgstr ""
+"`mimetype` : ce fichier contient le type MIME des fichiers wxMaxima : `text/"
+"x-wxmathml`"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`format.txt`: a short description about wxMaxima and the wxmx file format"
+msgstr ""
+"`format.txt` : une brève description de wxMaxima et du format de fichier wxmx"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima "
+"session and included images."
+msgstr ""
+"Images (par ex. png, jpeg) : graphiques intégrés produits lors de la session "
+"wxMaxima et images incluses."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`content.xml`: a XML document, which contains the various cells of your "
+"document in XML format."
+msgstr ""
+"`content.xml` : un document XML contenant les différentes cellules de votre "
+"document au format XML."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:373
+msgid ""
+"So, if something goes wrong, you can unzip a wxMaxima document (maybe rename "
+"it before to a `zip`-file), maybe make changes in the `content.xml` file "
+"with a text editor, or replace an broken image, zip the files again, "
+"probably rename the `zip` to a `wxmx`-file - and you get another modified "
+"`wxmx`-file."
+msgstr ""
+"Donc, si quelque chose ne va pas, vous pouvez décompresser un document "
+"wxMaxima (peut-être en le renommant au préalable en `.zip`), éventuellement "
+"modifier le fichier `content.xml` avec un éditeur de texte ou remplacer une "
+"image corrompue, recompresser les fichiers, probablement renommer le `.zip` "
+"en `.wxmx` — et vous obtiendrez un autre fichier `wxmx` modifié."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:374
+#, fuzzy, no-wrap
+#| msgid "## Configuration options"
+msgid "Configuration options"
+msgstr "## Options pour la configuration"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:377
+msgid ""
+"For some common configuration variables _wxMaxima_ offers two ways of "
+"configuring:"
+msgstr ""
+"Pour certaines variables courantes liées à la configuration, _wxMaxima_ "
+"propose deux méthodes de configuration :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:380
+msgid ""
+"The configuration dialog box below lets you change their default values for "
+"the current and subsequent sessions."
+msgstr ""
+"La boîte de dialogue de configuration ci-dessous vous permet de modifier "
+"leurs valeurs par défaut pour la session en cours et les suivantes."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:380
+msgid ""
+"Also, the values for most configuration variables can be changed for the "
+"current session only by overwriting their values from the worksheet, as "
+"shown below."
+msgstr ""
+"De plus, les valeurs de la plupart des variables de configuration peuvent "
+"être modifiées uniquement pour la session en cours en remplaçant leurs "
+"valeurs depuis la feuille de calcul, comme illustré ci-dessous."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:382
+msgid ""
+"![wxMaxima configuration 1](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
+msgstr ""
+"![configuration 1 de wxMaxima](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:383
+#, fuzzy, no-wrap
+#| msgid "### Default animation framerate"
+msgid "Default animation framerate"
+msgstr "### Fréquence par défaut des images pour les animations"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:386
+msgid ""
+"The animation framerate that is used for new animations is kept in the "
+"variable `wxanimate_framerate`. The initial value this variable will contain "
+"in a new worksheet can be changed using the configuration dialogue."
+msgstr ""
+"La fréquence des images utilisée pour les nouvelles animations est stockée "
+"dans la variable `wxanimate_framerate`. La valeur initiale de cette variable "
+"dans un nouveau notebook peut être modifiée via la boîte de dialogue de "
+"configuration."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:387
+#, fuzzy, no-wrap
+#| msgid "### Default plot size for new _maxima_ sessions"
+msgid "Default plot size for new _maxima_ sessions"
+msgstr "### Dimensions par défaut des graphiques pour les nouvelles sessions de _maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:390
+#, fuzzy
+#| msgid ""
+#| "After the next start, plots embedded into the worksheet will be created "
+#| "with this size if the value of `wxplot_size` isnât changed by _maxima_."
+msgid ""
+"After the next start, plots embedded into the worksheet will be created with "
+"this size if the value of `wxplot_size` isn’t changed by _maxima_."
+msgstr ""
+"Lors du prochain démarrage, les graphiques intégrés au notebook seront créés "
+"avec ces dimensions, sauf si la valeur de `wxplot_size` est modifiée par "
+"_Maxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:392
+#, fuzzy
+#| msgid ""
+#| "In order to set the plot size of a single graph only use the following "
+#| "notation can be used that sets a variableâs value for one command only:"
+msgid ""
+"In order to set the plot size of a single graph only use the following "
+"notation can be used that sets a variable’s value for one command only:"
+msgstr ""
+"Afin de définir la taille d'un seul graphique, la notation suivante peut "
+"être utilisée afin d'affecter une valeur à une variable pour une seule "
+"commande :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:393
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw2d(\n"
+#| "   explicit(\n"
+#| "       x^2,\n"
+#| "       x,-5,5\n"
+#| "   )\n"
+#| "), wxplot_size=[480,480]$\n"
+#| "```\n"
+msgid ""
+"wxdraw2d(\n"
+"   explicit(\n"
+"       x^2,\n"
+"       x,-5,5\n"
+"   )\n"
+"), wxplot_size=[480,480]$\n"
+msgstr ""
+"```maxima\n"
+"wxdraw2d(\n"
+"   explicit(\n"
+"       x^2,\n"
+"       x,-5,5\n"
+"   )\n"
+"), wxplot_size=[480,480]$\n"
+"```\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:402
+#, fuzzy, no-wrap
+#| msgid "### Match parenthesis in text controls"
+msgid "Match parenthesis in text controls"
+msgstr "### Correspondance des parenthèses dans les zones de texte"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:405
+msgid "This option enables two things:"
+msgstr "Cette option active deux fonctionnalités :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:408
+msgid ""
+"If an opening parenthesis, bracket, or double quote is entered _wxMaxima_ "
+"will insert a closing one after it."
+msgstr ""
+"Si une parenthèse ouvrante, un crochet ouvrant ou un guillemet double est "
+"saisi, _wxMaxima_ insère automatiquement le caractère de fermeture "
+"correspondant."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:408
+msgid ""
+"If text is selected if any of these keys is pressed the selected text will "
+"be put between the matched signs."
+msgstr ""
+"Si du texte est sélectionné lorsque l’une de ces touches est enfoncée, le "
+"texte sélectionné est placé entre les signes correspondants appariés."
+
+# Entrées ajoutées depuis fr2.po
+#. type: Title ###
+#: ../../info/wxmaxima.md:409
+#, fuzzy, no-wrap
+#| msgid "### Don’t save the worksheet automatically"
+msgid "Don’t save the worksheet automatically"
+msgstr "### Ne pas enregistrer automatiquement le notebook"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:412
+msgid ""
+"If this option is set, the file where the worksheet is will be overwritten "
+"only the request of the user. In case of a crash/power loss/... a recent "
+"backup copy is still made available in the temp directory, though."
+msgstr ""
+"Si cette option est activée, le fichier du notebook ne sera écrasé que sur "
+"demande de l'utilisateur. En cas de plantage, de coupure de courant ou autre "
+"incident, une copie de sauvegarde récente reste cependant disponible dans le "
+"dossier temporaire."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:414
+#, fuzzy
+#| msgid ""
+#| "If this option isnât set _wxMaxima_ behaves more like a modern cellphone "
+#| "app:"
+msgid ""
+"If this option isn’t set _wxMaxima_ behaves more like a modern cellphone app:"
+msgstr ""
+"Si cette option n'est pas activée, _wxMaxima_ se comporte davantage comme "
+"une application moderne de smartphone :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:417
+msgid "Files are saved automatically on exit"
+msgstr ""
+"Les fichiers sont sauvegardés automatiquement lorsque l'on quitte le "
+"programme"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:417
+msgid "And the file will automatically be saved every 3 minutes."
+msgstr "Et le fichier sera automatiquement sauvegardé toutes les 3 minutes."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:418
+#, fuzzy, no-wrap
+#| msgid "### Where is the configuration saved?"
+msgid "Where is the configuration saved?"
+msgstr "### Où est enregistrée la configuration  ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:422
+#, fuzzy, no-wrap
+#| msgid "If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).  (Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden)."
+msgid ""
+"If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).\n"
+"(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).\n"
+msgstr "Si vous utilisez Unix/Linux, les informations de configuration sont enregistrées dans un fichier `.wxMaxima` de votre répertoire personnel (si vous utilisez wxWidgets < 3.1.1), ou dans `.config/wxMaxima.conf` (norme XDG, si wxWidgets >= 3.1.1 est utilisé). Vous pouvez connaître la version de wxWidgets avec la commande `wxbuild_info();` ou via le menu Aide → À propos. [wxWidgets](https://www.wxwidgets.org/) est la bibliothèque d'interface graphique multiplateforme sur laquelle repose _wxMaxima_ (d'où le `wx` dans le nom). (Ces fichiers ou dossiers, commençant par un point, `.wxMaxima` ou `.config`, sont donc des fichiers cachés)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:424
+msgid ""
+"If you are using Windows, the configuration will be stored in the registry. "
+"You will find the entries for _wxMaxima_ at the following position in the "
+"registry: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
+msgstr ""
+"Si vous utilisez Windows, la configuration est stockée dans le registre. "
+"Vous trouverez les entrées pour _wxMaxima_ à l'emplacement suivant du "
+"registre : `HKEY_CURRENT_USER\\Software\\wxMaxima`"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:427
+#, fuzzy, no-wrap
+#| msgid "# Extensions to _Maxima_"
+msgid "Extensions to _Maxima_"
+msgstr "# Extensions pour _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:430
+#, fuzzy
+#| msgid ""
+#| "_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
+#| "its main purpose is to pass along commands to _Maxima_ and to report the "
+#| "results of executing those commands. In some cases, however, _wxMaxima_ "
+#| "adds functionality to _Maxima_. _WxMaxima_âs ability to generate reports "
+#| "by exporting a workbookâs contents to HTML and LaTeX files has been "
+#| "mentioned. This section considers some ways that _wxMaxima_ enhances the "
+#| "inclusion of graphics in a session."
+msgid ""
+"_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
+"its main purpose is to pass along commands to _Maxima_ and to report the "
+"results of executing those commands. In some cases, however, _wxMaxima_ adds "
+"functionality to _Maxima_. _WxMaxima_’s ability to generate reports by "
+"exporting a workbook’s contents to HTML and LaTeX files has been mentioned. "
+"This section considers some ways that _wxMaxima_ enhances the inclusion of "
+"graphics in a session."
+msgstr ""
+"_WxMaxima_ est avant tout une interface graphique pour _Maxima_. Ainsi, son "
+"rôle principal consiste à transmettre les commandes à _Maxima_ et à afficher "
+"les résultats de leur exécution. Cependant, _WxMaxima_ ajoute également "
+"certaines fonctionnalités à _Maxima_. La capacité de _WxMaxima_ à générer "
+"des rapports en exportant le contenu d'un notebook vers des fichiers HTML et "
+"LaTeX a déjà été évoquée. Cette section aborde certaines améliorations "
+"apportées par _WxMaxima_ pour l'inclusion de graphiques dans une session."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:431
+#, fuzzy, no-wrap
+#| msgid "## Subscripted variables"
+msgid "Subscripted variables"
+msgstr "## Variables en indice"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:434
+msgid ""
+"`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript "
+"variable names:"
+msgstr ""
+"`wxsubscripts` définit si (et comment) _wxMaxima appliquera automatiquement "
+"des indices aux noms de variables :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:436
+msgid ""
+"If it is `false`, the functionality is off, wxMaxima will not autosubscript "
+"part of variable names after an underscore."
+msgstr ""
+"Si sa valeur est `false`, cette fonctionnalité est désactivée : wxMaxima ne "
+"transformera pas automatiquement en indices les parties des noms de "
+"variables suivant un tiret bas."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:438
+msgid ""
+"If it is set to `'all`, everything after an underscore will be subscripted."
+msgstr ""
+"Si elle est définie sur `'all`, tout ce qui suit un tiret bas sera converti "
+"en indice."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:440
+msgid ""
+"If it is set to `true` variable names of the format `x_y` are displayed "
+"using a subscript if"
+msgstr ""
+"Si elle est définie sur `true`, les noms de variables au format `x_y` "
+"s'affichent avec un indice uniquement si"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:443
+msgid "Either `x` or `y` is a single letter or"
+msgstr "Soit `x` soit `y` est une lettre unique ou"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:443
+msgid "`y` is an integer (can include more than one character)."
+msgstr "`y` est un entier (peut inclure plus d'un caractère)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:445
+msgid ""
+"![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png)"
+"{ id=img_wxsubscripts }"
+msgstr ""
+"![Comment les variables sont automatiquement mises en indices en utilisant "
+"wxsubscripts](./wxsubscripts.png){ id=img_wxsubscripts }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:447
+#, fuzzy
+#| msgid ""
+#| "If the variable name doesnât match these requirements, it can still be "
+#| "declared as \"to be subscripted\" using the command "
+#| "`wxdeclare_subscript(variable_name);` or "
+#| "`wxdeclare_subscript([variable_name1,variable_name2,...]);` Declaring a "
+#| "variable as subscripted can be reverted using the following command: "
+#| "`wxdeclare_subscript(variable_name,false);`"
+msgid ""
+"If the variable name doesn’t match these requirements, it can still be "
+"declared as \"to be subscripted\" using the command "
+"`wxdeclare_subscript(variable_name);` or "
+"`wxdeclare_subscript([variable_name1,variable_name2,...]);` Declaring a "
+"variable as subscripted can be reverted using the following command: "
+"`wxdeclare_subscript(variable_name,false);`"
+msgstr ""
+"Si le nom de la variable ne répond pas à ces exigences, il peut toujours "
+"être déclaré comme « à mettre en indice » en utilisant la commande "
+"`wxdeclare_subscript(nom_variable);` ou `wxdeclare_subscript([nom_variable1, "
+"nom_variable2, ...]);`Une déclaration de variable en tant qu’indice peut "
+"être annulée avec la commande suivante : `wxdeclare_subscript(nom_variable, "
+"false);`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:449
+#, fuzzy, no-wrap
+#| msgid "You can use the menu \"View->Autosubscript\" to set these values."
+msgid "You can use the menu \"View->Autosubscript\" to set these values.\n"
+msgstr "Vous pouvez utiliser le menu \"Affichage->Mise en indice automatique\" pour définir ces valeurs."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:450
+#, fuzzy, no-wrap
+#| msgid "## User feedback in the status bar"
+msgid "User feedback in the status bar"
+msgstr "## Message utilisateur dans la barre d'état"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:453
+#, fuzzy
+#| msgid ""
+#| "Long-running commands can provide user feedback in the status bar. This "
+#| "user feedback is replaced by any new feedback that is placed there "
+#| "(allowing to use it as a progress indicator) and is deleted as soon as "
+#| "the current command sent to _Maxima_ is finished. It is safe to use "
+#| "`wxstatusbar()` even in libraries that might be used with plain _Maxima_ "
+#| "(as opposed to _wxMaxima_): If _wxMaxima_ isnât present the "
+#| "`wxstatusbar()` command will just be left unevaluated."
+msgid ""
+"Long-running commands can provide user feedback in the status bar. This user "
+"feedback is replaced by any new feedback that is placed there (allowing to "
+"use it as a progress indicator) and is deleted as soon as the current "
+"command sent to _Maxima_ is finished. It is safe to use `wxstatusbar()` even "
+"in libraries that might be used with plain _Maxima_ (as opposed to "
+"_wxMaxima_): If _wxMaxima_ isn’t present the `wxstatusbar()` command will "
+"just be left unevaluated."
+msgstr ""
+"Les commandes qui durent longtemps peuvent générer un message pour "
+"l'utilisateur dans la barre d'état. Ce dernier est remplacé par tout nouveau "
+"message qui apparait dans cette barre (ce qui permet de l'utiliser comme "
+"indicateur de progression) et est supprimé dès que la commande actuelle "
+"envoyée à _Maxima_ est terminée. Il n'y a pas de risque à utiliser "
+"`wxstatusbar()` même avec des bibliothèques qui pourraient être utilisées "
+"avec _Maxima_ standard (par opposition à _wxMaxima_) : si _wxMaxima_ n'est "
+"pas présent, la commande `wxstatusbar()` restera simplement non évaluée."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:454
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "for i:1 thru 10 do (\n"
+#| "    /* Tell the user how far we got */\n"
+#| "    wxstatusbar(concat(\"Pass \",i)),\n"
+#| "    /* (sleep n) is a Lisp function, which can be used */\n"
+#| "    /* with the character \"?\" before. It delays the */\n"
+#| "    /* program execution (here: for 3 seconds) */\n"
+#| "    ?sleep(3)\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"for i:1 thru 10 do (\n"
+"    /* Tell the user how far we got */\n"
+"    wxstatusbar(concat(\"Pass \",i)),\n"
+"    /* (sleep n) is a Lisp function, which can be used */\n"
+"    /* with the character \"?\" before. It delays the */\n"
+"    /* program execution (here: for 3 seconds) */\n"
+"    ?sleep(3)\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"for i:1 thru 10 do (\n"
+"    /* Informe l'utilisateur de l'avancement. */\n"
+"    wxstatusbar(concat(\"Pass \",i)),\n"
+"    /* (sleep n) est une fonction Lisp, qui peut être utilisée */\n"
+"    /* avec le caractère \"?\" avant. Cela retarde */\n"
+"    /* l'exécution du programme (dans ce cas : pour 3 secondes) */\n"
+"    ?sleep(3)\n"
+")$\n"
+"```\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:465
+#, no-wrap
+msgid "Exporting the worksheet from within Maxima"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:468
+msgid ""
+"The command `wxworksheettohtml()` exports the current worksheet to an HTML "
+"file from within a running _Maxima_ session, which is convenient for "
+"scripted or batch export. Like `wxstatusbar()` it is safe to use in code "
+"that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present "
+"the command is simply left unevaluated."
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:469
+#, no-wrap
+msgid ""
+"wxworksheettohtml(\"report.html\")$\n"
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:475
+msgid ""
+"A relative file name is interpreted relative to _Maxima_’s working "
+"directory. The optional keyword options are:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:480
+#, no-wrap
+msgid ""
+"| option   | values                                          | meaning                                             |\n"
+"| -------- | ----------------------------------------------- | --------------------------------------------------- |\n"
+"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |\n"
+"| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:482
+msgid ""
+"The `flavor` values match the equation formats offered by the graphical "
+"**File → Export** dialog: `mathml` produces a self-contained page that needs "
+"no internet connection, `mathjax` adds a MathJaX fall-back for browsers that "
+"still lack MathML, and `svg`/`bitmap` render every equation to an image."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:484
+msgid ""
+"The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file "
+"the same way:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:485
+#, no-wrap
+msgid ""
+"wxworksheettotex(\"report.tex\")$\n"
+"wxworksheettotex(\"report.tex\", documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:494
+#, no-wrap
+msgid ""
+"| option                 | meaning                                                              |\n"
+"| ---------------------- | -------------------------------------------------------------------- |\n"
+"| `documentclass`        | overrides the LaTeX `\\documentclass` (e.g. `\"article\"`, `\"report\"`)  |\n"
+"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:496
+msgid "Support for `wxworksheettopdf()` is planned."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:497
+#, fuzzy, no-wrap
+#| msgid "## Plotting"
+msgid "Plotting"
+msgstr "## Graphiques"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:500
+msgid ""
+"Plotting (having fundamentally to do with graphics) is a place where a "
+"graphical user interface will have to provide some extensions to the "
+"original program."
+msgstr ""
+"La création de courbes (qui repose fondamentalement sur des éléments "
+"graphiques) est un domaine où une interface utilisateur graphique devra "
+"apporter certaines extensions au programme d'origine."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:501
+#, fuzzy, no-wrap
+#| msgid "### Embedding a plot into the worksheet"
+msgid "Embedding a plot into the worksheet"
+msgstr "### Intégrer un graphique dans le notebook"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:504
+#, fuzzy
+#| msgid ""
+#| "_Maxima_ normally instructs the external program _Gnuplot_ to open a "
+#| "separate window for every diagram it creates. Since many times it is "
+#| "convenient to embed graphs into the worksheet instead _wxMaxima_ provides "
+#| "its own set of plot functions that donât differ from the corresponding "
+#| "_maxima_ functions save in their name: They are all prefixed by a âwxâ."
+msgid ""
+"_Maxima_ normally instructs the external program _Gnuplot_ to open a "
+"separate window for every diagram it creates. Since many times it is "
+"convenient to embed graphs into the worksheet instead _wxMaxima_ provides "
+"its own set of plot functions that don’t differ from the corresponding "
+"_maxima_ functions save in their name: They are all prefixed by a “wx”."
+msgstr ""
+"Normalement, _Maxima_ demande au programme externe _Gnuplot_ d'ouvrir une "
+"fenêtre séparée pour chaque graphique qu'il génère. Comme il est souvent "
+"plus pratique d'intégrer les graphiques directement dans le notebook, "
+"_wxMaxima_ propose son propre ensemble de fonctions graphiques. Celles-ci ne "
+"diffèrent des fonctions _Maxima_ correspondantes que par leur nom : elles "
+"sont toutes préfixées par « wx »."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:506
+msgid "The following plotting functions have wx-counterparts:"
+msgstr ""
+"Les fonctions graphiques suivantes ont leurs équivalents préfixés par « wx "
+"» :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:520
+#, fuzzy, no-wrap
+#| msgid ""
+#| "| wxMaximaâs plot function | Maximaâs plot function                                                                          |\n"
+#| "| ------------------------ | ----------------------------------------------------------------------------------------------- |\n"
+#| "| `wxplot2d()`             | [plot2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot2d)               |\n"
+#| "| `wxplot3d()`             | [plot3d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot3d)               |\n"
+#| "| `wxdraw2d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw2d)               |\n"
+#| "| `wxdraw3d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw3d)               |\n"
+#| "| `wxdraw()`               | [draw](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw)                   |\n"
+#| "| `wximplicit_plot()`      | [implicit_plot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#implicit_plot) |\n"
+#| "| `wxhistogram()`          | [histogram](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#histogram)         |\n"
+#| "| `wxscatterplot()`        | [scatterplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#scatterplot)     |\n"
+#| "| `wxbarsplot()`           | [barsplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#barsplot)           |\n"
+#| "| `wxpiechart()`           | [piechart](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#piechart)           |\n"
+#| "| `wxboxplot()`            | [boxplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#boxplot)             |\n"
+msgid ""
+"| wxMaxima’s plot function | Maxima’s plot function                                                                          |\n"
+"| ------------------------ | ----------------------------------------------------------------------------------------------- |\n"
+"| `wxplot2d()`             | [plot2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot2d)               |\n"
+"| `wxplot3d()`             | [plot3d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot3d)               |\n"
+"| `wxdraw2d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw2d)               |\n"
+"| `wxdraw3d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw3d)               |\n"
+"| `wxdraw()`               | [draw](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw)                   |\n"
+"| `wximplicit_plot()`      | [implicit_plot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#implicit_plot) |\n"
+"| `wxhistogram()`          | [histogram](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#histogram)         |\n"
+"| `wxscatterplot()`        | [scatterplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#scatterplot)     |\n"
+"| `wxbarsplot()`           | [barsplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#barsplot)           |\n"
+"| `wxpiechart()`           | [piechart](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#piechart)           |\n"
+"| `wxboxplot()`            | [boxplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#boxplot)             |\n"
+msgstr ""
+"| wxMaximaâ fonction graphique | Maxima fonction graphique                                                                          |\n"
+"| ------------------------ | ----------------------------------------------------------------------------------------------- |\n"
+"| `wxplot2d()`             | [plot2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot2d)               |\n"
+"| `wxplot3d()`             | [plot3d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot3d)               |\n"
+"| `wxdraw2d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw2d)               |\n"
+"| `wxdraw3d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw3d)               |\n"
+"| `wxdraw()`               | [draw](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw)                   |\n"
+"| `wximplicit_plot()`      | [implicit_plot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#implicit_plot) |\n"
+"| `wxhistogram()`          | [histogram](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#histogram)         |\n"
+"| `wxscatterplot()`        | [scatterplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#scatterplot)     |\n"
+"| `wxbarsplot()`           | [barsplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#barsplot)           |\n"
+"| `wxpiechart()`           | [piechart](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#piechart)           |\n"
+"| `wxboxplot()`            | [boxplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#boxplot)             |\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:522
+msgid ""
+"If a `wxm`-file is read by (console) Maxima, these functions are ignored "
+"(and printed as output, as other unknown functions in Maxima)."
+msgstr ""
+"Si un fichier `.wxm` est lu par _Maxima_ (en mode console), ces fonctions "
+"sont ignorées (et affichées à l'identique en sortie, comme toute autre "
+"fonction inconnue dans _Maxima_)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:524
+msgid ""
+"If you got problems with one of these functions, please check, if the "
+"problem exists in the the Maxima function too (e.g. you got an error with "
+"`wxplot2d()`, check the same plot in the Maxima command `plot2d()` (which "
+"opens the plot in a separate Window)). If the problem does not disappear, it "
+"is most likely a Maxima issue and should be reported in the [Maxima "
+"bugtracker](https://sourceforge.net/p/maxima/bugs/). Or maybe a Gnuplot "
+"issue."
+msgstr ""
+"Si vous rencontrez des problèmes avec l'une de ces fonctions, veuillez "
+"vérifier si le problème existe également pour la fonction Maxima "
+"correspondante (par exemple, si vous obtenez une erreur avec `wxplot2d()`, "
+"testez le même graphique avec la commande Maxima `plot2d()` (qui ouvre le "
+"graphique dans une fenêtre séparée)). Si le problème persiste, il s'agit "
+"probablement d'un problème de Maxima qui devrait être signalé dans le [suivi "
+"des bogues de Maxima](https://sourceforge.net/p/maxima/bugs/). Ou peut-être "
+"un problème de Gnuplot."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:525
+#, fuzzy, no-wrap
+#| msgid "### Making embedded plots bigger or smaller"
+msgid "Making embedded plots bigger or smaller"
+msgstr "### Agrandir ou diminuer les graphiques intégrés"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:528
+msgid ""
+"As noted above, the configure dialog provides a way to change the default "
+"size plots created which sets the starting value of `wxplot_size`. The "
+"plotting routines of _wxMaxima_ respect this variable that specifies the "
+"size of a plot in pixels. It can always be queried or used to set the size "
+"of the following plots:"
+msgstr ""
+"Comme indiqué précédemment, la boîte de dialogue de configuration permet de "
+"modifier la taille par défaut des graphiques créés, en définissant la valeur "
+"initiale de `wxplot_size`. Les routines graphiques de _wxMaxima_ tiennent "
+"compte de cette variable, qui spécifie la taille d'un graphique en pixels. "
+"Il est toujours possible d'interroger ou de définir cette variable pour "
+"ajuster la taille des graphiques suivants :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:529
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxplot_size:[1200,800]$\n"
+#| "wxdraw2d(\n"
+#| "    explicit(\n"
+#| "        sin(x),\n"
+#| "        x,1,10\n"
+#| "    )\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"wxplot_size:[1200,800]$\n"
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"wxplot_size:[1200,800]$\n"
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:540
+msgid ""
+"If the size of only one plot is to be changed _Maxima_ provides a canonical "
+"way to change an attribute only for the current cell. In this usage the "
+"specification `wxplot_size = [value1, value2]` is appended to the "
+"`wxdraw2d( )` command, and is not part of the `wxdraw2d` command."
+msgstr ""
+"Si la dimension d'un seul graphique doit être modifiée, _Maxima_ offre une "
+"méthode standard pour changer l'attribut de taille uniquement pour la "
+"cellule actuelle. Dans ce cas, la spécification `wxplot_size = [valeur1, "
+"valeur2]` est ajoutée à la commande `wxdraw2d()`, sans faire partie "
+"intégrante de cette commande."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:541
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw2d(\n"
+#| "    explicit(\n"
+#| "        sin(x),\n"
+#| "        x,1,10\n"
+#| "    )\n"
+#| "),wxplot_size=[1600,800]$\n"
+#| "```\n"
+msgid ""
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+"),wxplot_size=[1600,800]$\n"
+msgstr ""
+"```maxima\n"
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+"),wxplot_size=[1600,800]$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:551
+msgid ""
+"Setting the size of embedded plot with `wxplot_size` works for embedded "
+"plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` "
+"commands and for embedded animations with `with_slider_draw` and `wxanimate` "
+"commands."
+msgstr ""
+"Le réglage de la taille des graphiques intégrés avec `wxplot_size` "
+"fonctionne pour les graphiques en ligne utilisant par exemple les commandes "
+"`wxplot`, `wxdraw`, `wxcontour_plot` et `wximplicit_plot`, ainsi que pour "
+"les animations intégrées avec les commandes `with_slider_draw` et "
+"`wxanimate`."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:552
+#, fuzzy, no-wrap
+#| msgid "### Better quality plots"
+msgid "Better quality plots"
+msgstr "### Des graphiques de meilleur qualité"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:555
+#, fuzzy
+#| msgid ""
+#| "_Gnuplot_ doesnât seem to provide a portable way of determining whether "
+#| "it supports the high-quality bitmap output that the Cairo library "
+#| "provides. On systems where _Gnuplot_ is compiled to use this library the "
+#| "pngCairo option from the configuration menu (that can be overridden by "
+#| "the variable `wxplot_pngcairo`) enables support for antialiasing and "
+#| "additional line styles. If `wxplot_pngCairo` is set without _Gnuplot_ "
+#| "supporting this the result will be error messages instead of graphics."
+msgid ""
+"_Gnuplot_ doesn’t seem to provide a portable way of determining whether it "
+"supports the high-quality bitmap output that the Cairo library provides. On "
+"systems where _Gnuplot_ is compiled to use this library the pngCairo option "
+"from the configuration menu (that can be overridden by the variable "
+"`wxplot_pngcairo`) enables support for antialiasing and additional line "
+"styles. If `wxplot_pngCairo` is set without _Gnuplot_ supporting this the "
+"result will be error messages instead of graphics."
+msgstr ""
+"Il semble que _Gnuplot_ ne propose pas de méthode portable pour déterminer "
+"s'il prend en charge la sortie bitmap haute qualité fournie par la "
+"bibliothèque Cairo. Sur les systèmes où _Gnuplot_ est compilé pour utiliser "
+"cette bibliothèque, l'option pngCairo du menu de configuration (qui peut "
+"être écrasée par la variable `wxplot_pngcairo`) active la prise en charge de "
+"l'antialiasing et des styles de ligne supplémentaires. Si `wxplot_pngcairo` "
+"est définie alors que _Gnuplot_ ne supporte pas cette fonctionnalité, le "
+"résultat résultera en des messages d'erreur au lieu des graphiques."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:556
+#, fuzzy, no-wrap
+#| msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
+msgid "Opening embedded plots in interactive _Gnuplot_ windows"
+msgstr "### Ouvrir les graphiques intégrés dans les fenêtres interactives de _Gnuplot_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:559
+#, fuzzy
+#| msgid ""
+#| "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
+#| "`wxplot3d` isnât supported by this feature) and the file size of the "
+#| "underlying _Gnuplot_ project isnât way too high _wxMaxima_ offers a right-"
+#| "click menu that allows to open the plot in an interactive _Gnuplot_ "
+#| "window."
+msgid ""
+"If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
+"`wxplot3d` isn’t supported by this feature) and the file size of the "
+"underlying _Gnuplot_ project isn’t way too high _wxMaxima_ offers a right-"
+"click menu that allows to open the plot in an interactive _Gnuplot_ window."
+msgstr ""
+"Si un graphique a été généré avec des commandes de type `wxdraw` (`wxplot2d` "
+"et `wxplot3d` ne sont pas pris en charge par cette fonctionnalité) et que la "
+"taille du fichier du projet _Gnuplot_ correspondant n'est pas trop élevée, "
+"_wxMaxima_ propose un menu contextuel (clic droit) permettant d'ouvrir le "
+"graphique dans une fenêtre interactive _Gnuplot_."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:560
+#, fuzzy, no-wrap
+#| msgid "### Opening Gnuplot’s command console in `plot` windows"
+msgid "Opening Gnuplot’s command console in `plot` windows"
+msgstr "### Ouvrir la console de commandes de Gnuplot dans les fenêtres `plot`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:564
+msgid ""
+"On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and `wgnuplot."
+"exe`.  You can configure, which command should be used using the "
+"configuration menu. `wgnuplot.exe` offers the possibility to open a console "
+"window, where _gnuplot_ commands can be entered into, `gnuplot.exe` does not "
+"offer this possibility. Unfortunately, `wgnuplot.exe` causes _Gnuplot_ to "
+"\"steal\" the keyboard focus for a short time every time a plot is prepared."
+msgstr ""
+"Sous MS Windows, il existe deux programmes Gnuplot : `gnuplot.exe` et "
+"`wgnuplot.exe`. Vous pouvez configurer lequel utiliser via le menu de "
+"configuration. `wgnuplot.exe` permet d'ouvrir une fenêtre de console où les "
+"commandes _Gnuplot_ peuvent être saisies, ce que `gnuplot.exe` ne propose "
+"pas. Malheureusement, `wgnuplot.exe` provoque un bref \"décrochage\" du "
+"focus clavier à chaque génération d'un graphique."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:565
+#, fuzzy, no-wrap
+#| msgid "### Embedding animations into the spreadsheet"
+msgid "Embedding animations into the spreadsheet"
+msgstr "### Intégrer des animations dans le notebook"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:568
+msgid ""
+"3D diagrams tend to make it hard to read quantitative data. A viable "
+"alternative might be to assign the 3rd parameter to the mouse wheel. The "
+"`with_slider_draw` command is a version of `wxdraw2d` that does prepare "
+"multiple plots and allows to switch between them by moving the slider on top "
+"of the screen. _WxMaxima_ allows to export this animation as an animated gif."
+msgstr ""
+"Les diagrammes en 3D impliquent souvent que la lecture des données "
+"quantitatives soit difficile. Une alternative intéressante consiste à "
+"associer le 3ᵉ paramètre à la molette de la souris. La commande "
+"`with_slider_draw` est une version de `wxdraw2d` qui génère plusieurs "
+"graphiques et permet de basculer entre eux à l'aide d'un curseur situé en "
+"haut de l'écran. _WxMaxima_ permet d'exporter cette animation au format GIF "
+"animé."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:570
+msgid ""
+"The first two arguments for `with_slider_draw` are the name of the variable "
+"that is stepped between the plots and a list of the values of these "
+"variable. The arguments that follow are the ordinary arguments for "
+"`wxdraw2d`:"
+msgstr ""
+"Les deux premiers arguments de `with_slider_draw` sont le nom du paramètre "
+"qui varie entre les graphiques et une liste des valeurs prises par ce "
+"paramètre. Les arguments suivants sont les arguments classiques de la "
+"commande `wxdraw2d` :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:571
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "with_slider_draw(\n"
+#| "    f,[1,2,3,4,5,6,7,10],\n"
+#| "    title=concat(\"f=\",f,\"Hz\"),\n"
+#| "    explicit(\n"
+#| "        sin(2*%pi*f*x),\n"
+#| "        x,0,1\n"
+#| "    ),grid=true\n"
+#| ");\n"
+#| "```\n"
+msgid ""
+"with_slider_draw(\n"
+"    f,[1,2,3,4,5,6,7,10],\n"
+"    title=concat(\"f=\",f,\"Hz\"),\n"
+"    explicit(\n"
+"        sin(2*%pi*f*x),\n"
+"        x,0,1\n"
+"    ),grid=true\n"
+");\n"
+msgstr ""
+"```maxima\n"
+"with_slider_draw(\n"
+"    f,[1,2,3,4,5,6,7,10],\n"
+"    title=concat(\"f=\",f,\"Hz\"),\n"
+"    explicit(\n"
+"        sin(2*%pi*f*x),\n"
+"        x,0,1\n"
+"    ),grid=true\n"
+");\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:583
+msgid ""
+"The same functionality for 3D plots is accessible as `with_slider_draw3d`, "
+"which allows for rotating 3d plots:"
+msgstr ""
+"La même fonctionnalité pour les graphiques 3D est accessible avec "
+"`with_slider_draw3d`, qui permet de faire tourner les graphiques 3D :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:584
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxanimate_autoplay:true;\n"
+#| "wxanimate_framerate:20;\n"
+#| "with_slider_draw3d(\n"
+#| "    Î±,makelist(i,i,1,360,3),\n"
+#| "    title=sconcat(\"Î±=\",Î±),\n"
+#| "    surface_hide=true,\n"
+#| "    contour=both,\n"
+#| "    view=[60,Î±],\n"
+#| "    explicit(\n"
+#| "        sin(x)*sin(y),\n"
+#| "        x,-Ï,Ï,\n"
+#| "        y,-Ï,Ï\n"
+#| "    )\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    α,makelist(i,i,1,360,3),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,α],\n"
+"    explicit(\n"
+"        sin(x)*sin(y),\n"
+"        x,-π,π,\n"
+"        y,-π,π\n"
+"    )\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    Î±,makelist(i,i,1,360,3),\n"
+"    title=sconcat(\"Î±=\",Î±),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,Î±],\n"
+"    explicit(\n"
+"        sin(x)*sin(y),\n"
+"        x,-Ï,Ï,\n"
+"        y,-Ï,Ï\n"
+"    )\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:602
+msgid ""
+"If the general shape of the plot is what matters it might suffice to move "
+"the plot just a little bit in order to make its 3D nature available to the "
+"intuition:"
+msgstr ""
+"Si c'est plutôt la forme générale du graphique qui importe, un léger "
+"déplacement peut suffire pour rendre la visualisation 3D plus intuitive :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:603
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxanimate_autoplay:true;\n"
+#| "wxanimate_framerate:20;\n"
+#| "with_slider_draw3d(\n"
+#| "    t,makelist(i,i,0,2*Ï,.05*Ï),\n"
+#| "    title=sconcat(\"Î±=\",Î±),\n"
+#| "    surface_hide=true,\n"
+#| "    contour=both,\n"
+#| "    view=[60,30+5*sin(t)],\n"
+#| "    explicit(\n"
+#| "        sin(x)*y^2,\n"
+#| "        x,-2*Ï,2*Ï,\n"
+#| "        y,-2*Ï,2*Ï\n"
+#| "    )\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    t,makelist(i,i,0,2*π,.05*π),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,30+5*sin(t)],\n"
+"    explicit(\n"
+"        sin(x)*y^2,\n"
+"        x,-2*π,2*π,\n"
+"        y,-2*π,2*π\n"
+"    )\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    t,makelist(i,i,0,2*Ï,.05*Ï),\n"
+"    title=sconcat(\"Î±=\",Î±),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,30+5*sin(t)],\n"
+"    explicit(\n"
+"        sin(x)*y^2,\n"
+"        x,-2*Ï,2*Ï,\n"
+"        y,-2*Ï,2*Ï\n"
+"    )\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:621
+msgid ""
+"For those more familiar with `plot` than with `draw`, there is a second set "
+"of functions:"
+msgstr ""
+"Pour ceux qui maîtrisent mieux la commande `plot` que `draw`, il existe un "
+"second ensemble de fonctions :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:624
+msgid "`with_slider` and"
+msgstr "- `with_slider` et"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:624
+msgid "`wxanimate`."
+msgstr "`wxanimate`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:626
+msgid ""
+"Normally the animations are played back or exported with the frame rate "
+"chosen in the configuration of _wxMaxima_. To set the speed at an individual "
+"animation is played back the variable `wxanimate_framerate` can be used:"
+msgstr ""
+"Normalement, les animations sont lues ou exportées avec le taux de "
+"rafraîchissement défini dans la configuration de _wxMaxima_. Pour régler la "
+"vitesse de lecture d'une animation donnée, on peut utiliser la variable "
+"`wxanimate_framerate` :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:627
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxanimate(a, 10,\n"
+#| "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+#| "```\n"
+msgid ""
+"wxanimate(a, 10,\n"
+"    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+msgstr ""
+"```maxima\n"
+"wxanimate(a, 10,\n"
+"    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:633
+#, fuzzy
+#| msgid ""
+#| "The animation functions use _Maxima_âs `makelist` command and therefore "
+#| "share the pitfall that the slider variableâs value is substituted into "
+#| "the expression only if the variable is directly visible in the "
+#| "expression. Therefore the following example will fail:"
+msgid ""
+"The animation functions use _Maxima_’s `makelist` command and therefore "
+"share the pitfall that the slider variable’s value is substituted into the "
+"expression only if the variable is directly visible in the expression. "
+"Therefore the following example will fail:"
+msgstr ""
+"Les fonctions d'animation utilisent la commande `makelist` de _Maxima_ et "
+"partagent donc le même écueil : la valeur de la variable du curseur n'est "
+"substituée dans l'expression que si cette variable y apparaît explicitement. "
+"Par conséquent, l'exemple suivant échouera :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:634
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "f:sin(a*x);\n"
+#| "with_slider_draw(\n"
+#| "    a,makelist(i/2,i,1,10),\n"
+#| "    title=concat(\"a=\",float(a)),\n"
+#| "    grid=true,\n"
+#| "    explicit(f,x,0,10)\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    a,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(a)),\n"
+"    grid=true,\n"
+"    explicit(f,x,0,10)\n"
+")$\n"
+msgstr ""
+"``maxima\n"
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    a,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(a)),\n"
+"    grid=true,\n"
+"    explicit(f,x,0,10)\n"
+")$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:645
+#, fuzzy
+#| msgid ""
+#| "If _Maxima_ is explicitly asked to substitute the sliderâs value plotting "
+#| "works fine instead:"
+msgid ""
+"If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
+"works fine instead:"
+msgstr ""
+"Si _Maxima_ est explicitement invité à substituer la valeur du curseur, le "
+"tracé fonctionne correctement :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:646
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "f:sin(a*x);\n"
+#| "with_slider_draw(\n"
+#| "    b,makelist(i/2,i,1,10),\n"
+#| "    title=concat(\"a=\",float(b)),\n"
+#| "    grid=true,\n"
+#| "    explicit(\n"
+#| "        subst(a=b,f),\n"
+#| "        x,0,10\n"
+#| "    )\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    b,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(b)),\n"
+"    grid=true,\n"
+"    explicit(\n"
+"        subst(a=b,f),\n"
+"        x,0,10\n"
+"    )\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    b,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(b)),\n"
+"    grid=true,\n"
+"    explicit(\n"
+"        subst(a=b,f),\n"
+"        x,0,10\n"
+"    )\n"
+")$\n"
+"```\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:659
+#, fuzzy, no-wrap
+#| msgid "### Opening multiple plots in contemporaneous windows"
+msgid "Opening multiple plots in contemporaneous windows"
+msgstr "### Ouvrir plusieurs graphiques dans des fenêtres de manière simultanée"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:662
+msgid ""
+"While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups "
+"that support it) sometimes comes in handily. The following example comes "
+"from a post from Mario Rodriguez to the _Maxima_ mailing list:"
+msgstr ""
+"Cette fonctionnalité de _Maxima_ (sur les configurations qui la supportent), "
+"bien qu'elle ne soit pas disponible via  _wxMaxima_, s'avère parfois bien "
+"pratique. L'exemple suivant provient d'un message de Mario Rodriguez sur la "
+"_liste de diffusion de Maxima_ :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:663
+#, no-wrap
+msgid ""
+"load(draw);\n"
+"\n"
+"/* Parabola in window #1 */\n"
+"draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Parabola in window #2 */\n"
+"draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Paraboloid in window #3 */\n"
+"draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:677
+msgid ""
+"Plotting multiple plots in the same window is possible, too (the same is "
+"possible in command line Maxima with the standard `draw()` command):"
+msgstr ""
+"Il est également possible de tracer plusieurs graphiques dans une même "
+"fenêtre (la même chose est réalisable avec la commande standard `draw()` de "
+"Maxima en ligne de commande) :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:678
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw(\n"
+#| "  gr2d(\n"
+#| "    key=\"sin (x)\",grid=[2,2],\n"
+#| "    explicit(sin(x),x,0,2*%pi)),\n"
+#| "  gr2d(\n"
+#| "    key=\"cos (x)\",grid=[2,2],\n"
+#| "    explicit(cos(x),x,0,2*%pi))\n"
+#| ");\n"
+#| "```\n"
+msgid ""
+"wxdraw(\n"
+"  gr2d(\n"
+"    key=\"sin (x)\",grid=[2,2],\n"
+"    explicit(sin(x),x,0,2*%pi)),\n"
+"  gr2d(\n"
+"    key=\"cos (x)\",grid=[2,2],\n"
+"    explicit(cos(x),x,0,2*%pi))\n"
+");\n"
+msgstr ""
+"```maxima\n"
+"wxdraw(\n"
+"  gr2d(\n"
+"    key=\"sin (x)\",grid=[2,2],\n"
+"    explicit(sin(x),x,0,2*%pi)),\n"
+"  gr2d(\n"
+"    key=\"cos (x)\",grid=[2,2],\n"
+"    explicit(cos(x),x,0,2*%pi))\n"
+");\n"
+"```\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:689
+#, fuzzy, no-wrap
+#| msgid "### The \"Plot using draw\" side pane"
+msgid "The \"Plot using draw\" side pane"
+msgstr "### Le panneau latéral \"Graphiques avec draw\""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:692
+msgid ""
+"The \"Plot using draw\" sidebar hides a simple code generator that allows "
+"generating scenes that make use of some of the flexibility of the _draw_ "
+"package _maxima_ comes with."
+msgstr ""
+"Le panneau latéral \"Graphiques avec draw\" cache un générateur simple de "
+"code qui permet de créer des représentations graphiques exploitant une "
+"partie des fonctionnalités du package _draw_ intégré à _Maxima_."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:693
+#, no-wrap
+msgid "2D"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:696
+#, fuzzy
+#| msgid ""
+#| "Generates the skeleton of a `draw()` command that draws a 2D scene. This "
+#| "scene later has to be filled with commands that generate the sceneâs "
+#| "contents, for example by using the buttons in the rows below the \"2D\" "
+#| "button."
+msgid ""
+"Generates the skeleton of a `draw()` command that draws a 2D scene. This "
+"scene later has to be filled with commands that generate the scene’s "
+"contents, for example by using the buttons in the rows below the \"2D\" "
+"button."
+msgstr ""
+"Génère le squelette d'une commande `draw()` pour dessiner une scène 2D. "
+"Cette scène doit ensuite être complétée avec des commandes qui génèrent son "
+"contenu, par exemple en utilisant les boutons situés dans les lignes en "
+"dessous du bouton \"2D\"."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:698
+msgid ""
+"One helpful feature of the 2D button is that it allows to set up the scene "
+"as an animation in which a variable (by default it is _t_) has a different "
+"value in each frame: Often a moving 2D plot allows easier interpretation "
+"than the same data in a non-moving 3D one."
+msgstr ""
+"Une fonctionnalité utile du bouton 2D est qu'il permet de configurer la "
+"scène comme une animation dans laquelle un paramètre (par défaut, _t_) prend "
+"une valeur différente à chaque image : une courbe 2D animée facilite souvent "
+"l'interprétation des données plus qu'une représentation 3D statique des "
+"mêmes informations."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:699
+#, no-wrap
+msgid "3D"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:702
+msgid ""
+"Generates the skeleton of a `draw()` command that draws a 3D scene. If "
+"neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D "
+"scene that contains the command the button generates."
+msgstr ""
+"Génère le squelette d'une commande `draw()` pour tracer une scène 3D. Si "
+"aucune scène 2D ou 3D n'est définie, tous les autres boutons configurent "
+"automatiquement une scène 2D contenant la commande générée par le bouton."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:703
+#, fuzzy, no-wrap
+#| msgid "#### Expression"
+msgid "Expression"
+msgstr "#### Expression"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:706
+msgid ""
+"Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or "
+"`x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is "
+"no draw command a 2D scene with the plot is generated. Each scene can be "
+"filled with any number of plots."
+msgstr ""
+"Ajoute un tracé standard d'une expression comme `sin(x)`, `x*sin(x)` ou "
+"`x^2+2*x-4` à la commande `draw()` où se trouve actuellement le curseur. Si "
+"aucune commande `draw()` n'existe, une scène 2D avec ce tracé est générée. "
+"Chaque scène peut contenir un nombre illimité de graphiques."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:707
+#, fuzzy, no-wrap
+#| msgid "#### Implicit plot"
+msgid "Implicit plot"
+msgstr "#### Courbe définie de manière implicite"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:710
+msgid ""
+"Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or "
+"`x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command "
+"the cursor currently is in. If there is no draw command a 2D scene with the "
+"plot is generated."
+msgstr ""
+"Tente de trouver tous les points où une expression comme `y=sin(x)`, "
+"`y*sin(x)=3` ou `x^2+y^2=4` est vérifiée et trace la courbe résultante dans "
+"la commande `draw()` où se trouve le curseur. Si aucune commande `draw()` "
+"n'existe, une scène 2D avec ce tracé est générée."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:711
+#, fuzzy, no-wrap
+#| msgid "#### Parametric plot"
+msgid "Parametric plot"
+msgstr "#### Courbe paramétrique"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:714
+msgid ""
+"Steps a variable from a lower limit to an upper limit and uses two "
+"expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in "
+"3D plots also z) coordinates of a curve that is put into the current draw "
+"command."
+msgstr ""
+"Fait varier une variable entre une borne inférieure et une borne supérieure, "
+"puis utilise deux expressions comme `t*sin(t)` et `t*cos(t)` pour générer "
+"les coordonnées x, y (et z dans le cas des tracés 3D) d'une courbe, qui est "
+"ensuite insérée dans la commande `draw()` actuelle."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:715
+#, fuzzy, no-wrap
+#| msgid "#### Points"
+msgid "Points"
+msgstr "#### Points"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:718
+msgid ""
+"Draws many points that can optionally be joined. The coordinates of the "
+"points are taken from a list of lists, a 2D array or one list or array for "
+"each axis."
+msgstr ""
+"Trace plusieurs points, éventuellement reliés entre eux. Les coordonnées des "
+"points peuvent provenir d'une liste de listes, d'un tableau 2D, ou d'une "
+"liste ou d'un tableau pour chaque axe."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:719
+#, fuzzy, no-wrap
+#| msgid "#### Diagram title"
+msgid "Diagram title"
+msgstr "#### Titre du graphique"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:722
+msgid "Draws a title on the upper end of the diagram,"
+msgstr "Ajoute un titre en haut du graphique,"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:723
+#, fuzzy, no-wrap
+#| msgid "#### Axis"
+msgid "Axis"
+msgstr "#### Axes"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:726
+msgid "Sets up the axis."
+msgstr "Configurer l'axe."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:727
+#, fuzzy, no-wrap
+#| msgid "#### Contour"
+msgid "Contour"
+msgstr "#### Lignes de niveau"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:730
+msgid ""
+"(Only for 3D plots): Adds contour lines similar to the ones one can find in "
+"a map of a mountain to the plot commands that follow in the current `draw()` "
+"command and/or to the ground plane of the diagram. Alternatively, this "
+"wizard allows skipping drawing the curves entirely only showing the contour "
+"plot."
+msgstr ""
+"(Uniquement pour les tracés 3D) : Ajoute des lignes de niveau similaires à "
+"celles que l'on trouve sur une carte de montagne aux commandes du tracé qui "
+"suivent dans la commande `draw()` actuelle et/ou au plan de base du "
+"graphique. Alternativement, cet assistant permet de sauter entièrement le "
+"tracé des courbes et d'afficher uniquement le tracé des lignes de niveau."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:731
+#, fuzzy, no-wrap
+#| msgid "#### Plot name"
+msgid "Plot name"
+msgstr "#### Légende du graphique"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:734
+#, fuzzy
+#| msgid ""
+#| "Adds a legend entry showing the next plotâs name to the legend of the "
+#| "diagram. An empty name disables generating legend entries for the "
+#| "following plots."
+msgid ""
+"Adds a legend entry showing the next plot’s name to the legend of the "
+"diagram. An empty name disables generating legend entries for the following "
+"plots."
+msgstr ""
+"Ajoute une nouvelle entrée pour la légende affichant le nom du prochain "
+"tracé à la légende actuelle du graphique. Un nom vide désactive la "
+"génération d'entrées des légende pour les tracés suivants."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:735
+#, fuzzy, no-wrap
+#| msgid "#### Line colour"
+msgid "Line colour"
+msgstr "#### Couleur de la ligne du tracé"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:738
+msgid ""
+"Sets the line colour for the following plots the current draw command "
+"contains."
+msgstr ""
+"Définit la couleur de ligne pour les tracés suivants contenus dans la "
+"commande `draw()` actuelle."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:739
+#, fuzzy, no-wrap
+#| msgid "#### Fill colour"
+msgid "Fill colour"
+msgstr "#### Couleur de remplissage"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:742
+msgid ""
+"Sets the fill colour for the following plots the current draw command "
+"contains."
+msgstr ""
+"Définit la couleur de remplissage pour les tracés suivants contenus dans la "
+"commande `draw()` actuelle."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:743
+#, fuzzy, no-wrap
+#| msgid "#### Grid"
+msgid "Grid"
+msgstr "#### Quadrillage"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:746
+msgid "Pops up a wizard that allows to set up grid lines."
+msgstr "Ouvre un assistant permettant de configurer les lignes du quadrillage."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:747
+#, fuzzy, no-wrap
+#| msgid "#### Accuracy"
+msgid "Accuracy"
+msgstr "#### Précision"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:750
+msgid ""
+"Allows to select an adequate point in the speed vs. accuracy tradeoff that "
+"is part of any plot program."
+msgstr ""
+"Permet de choisir un compromis adapté entre vitesse et précision, inhérent à "
+"tout programme de tracé graphique."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:751
+#, fuzzy, no-wrap
+#| msgid "### Modify font and font size for plots"
+msgid "Modify font and font size for plots"
+msgstr "### Modifier la police et la taille de police pour les graphiques"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:754
+msgid ""
+"Especially when you use a high resolution display, the default font size "
+"might be very small. For the `draw`-based commands, you can set the font / "
+"font size using options like `font=...`, `font_size=...`, e.g.:"
+msgstr ""
+"Surtout lorsque vous utilisez un affichage haute résolution, la taille de "
+"police par défaut peut être très petite. Pour les commandes basées sur "
+"`draw`, vous pouvez définir la police et la taille de police à l'aide "
+"d'options comme `font=...`, `font_size=...`, par exemple :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:755
+#, fuzzy, no-wrap
+#| msgid ""
+#| "~~~maxima\n"
+#| "wxdraw2d(\n"
+#| "     font=\"Helvetica\",\n"
+#| "     font_size=30,\n"
+#| "     explicit(sin(x),x,1,10));\n"
+#| "~~~\n"
+msgid ""
+"wxdraw2d(\n"
+"     font=\"Helvetica\",\n"
+"     font_size=30,\n"
+"     explicit(sin(x),x,1,10));\n"
+msgstr ""
+"~~~maxima\n"
+"wxdraw2d(\n"
+"     font=\"Helvetica\",\n"
+"     font_size=30,\n"
+"     explicit(sin(x),x,1,10));\n"
+"~~~\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:763
+msgid ""
+"For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts "
+"can be set using the `gnuplot_preamble` command, e.g.:"
+msgstr ""
+"Pour les commandes de type `plot` (par exemple `wxplot2d`, `wxplot3d`), les "
+"tailles et polices de caractères peuvent être définies à l'aide de la "
+"commande `gnuplot_preamble`, par exemple :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:764
+#, fuzzy, no-wrap
+#| msgid ""
+#| "~~~maxima\n"
+#| "wxplot2d(sin(x),[x,1,10],\n"
+#| "         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
+#| "~~~\n"
+msgid ""
+"wxplot2d(sin(x),[x,1,10],\n"
+"         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
+msgstr ""
+"~~~maxima\n"
+"wxplot2d(sin(x),[x,1,10],\n"
+"         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
+"~~~\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:770
+msgid ""
+"This sets the font for the numbers to Arial with size 30, the size for the "
+"xlabel and ylabel font to 20 (with the default font)."
+msgstr ""
+"Cela définit la police pour les nombres en Arial avec une taille de 30, et "
+"la taille de la police des étiquettes xlabel et ylabel à 20 (avec la police "
+"par défaut)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:773
+msgid ""
+"Read the Maxima and Gnuplot documentation for further information.  Note: "
+"Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue "
+"1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966)."
+msgstr ""
+"Consultez la documentation de Maxima et Gnuplot pour plus d'informations. "
+"Remarque : Gnuplot semble rencontrer des problèmes avec les polices de "
+"grande taille, voir [wxMaxima issue 1966](https://github.com/wxMaxima-"
+"developers/wxmaxima/issues/1966)."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:774
+#, fuzzy, no-wrap
+#| msgid "## Embedding graphics"
+msgid "Embedding graphics"
+msgstr "## Graphiques intégrés"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:777
+#, fuzzy
+#| msgid ""
+#| "If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
+#| "project can be done as easily as per drag-and-drop. But sometimes (for "
+#| "example if an imageâs contents might change later on in a session) it is "
+#| "better to tell the file to load the image on evaluation:"
+msgid ""
+"If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
+"project can be done as easily as per drag-and-drop. But sometimes (for "
+"example if an image’s contents might change later on in a session) it is "
+"better to tell the file to load the image on evaluation:"
+msgstr ""
+"Si le format de fichier `.wxmx` est utilisé, l'intégration de fichiers dans "
+"un notebook _wxMaxima_ peut se faire simplement par glisser-déposer. Mais "
+"parfois (par exemple si le contenu d'une image est susceptible de changer "
+"plus tard dans une session), il est préférable d'indiquer au fichier de "
+"charger l'image lors de l'évaluation :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:778
+#, fuzzy, no-wrap
+#| msgid "```maxima show_image(\"man.png\"); ```"
+msgid "show_image(\"man.png\");\n"
+msgstr "```maxima show_image(\"man.png\"); ```"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:782
+#, fuzzy, no-wrap
+#| msgid "## Startup files"
+msgid "Startup files"
+msgstr "## Fichiers au démarrage"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:785
+msgid ""
+"The config dialogue of _wxMaxima_ offers to edit two files with commands "
+"that are executed on startup:"
+msgstr ""
+"La boîte de dialogue de configuration de _wxMaxima_ permet de modifier deux "
+"fichiers contenant des commandes exécutées au démarrage :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:788
+msgid ""
+"A file that contains commands that are executed on starting up _Maxima_: "
+"`maxima-init.mac`"
+msgstr ""
+"Un fichier contenant des commandes exécutées au démarrage de _Maxima_ : "
+"`maxima-init.mac`"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:788
+msgid ""
+"one file of additional commands that are executed if _wxMaxima_ is starting "
+"_Maxima_: `wxmaxima-init.mac`"
+msgstr ""
+"un fichier d'instructions supplémentaires exécutées lorsque _wxMaxima_ "
+"démarre _Maxima_ : `wxmaxima-init.mac`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:790
+msgid ""
+"For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add "
+"`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` "
+"or any other path) to these files."
+msgstr ""
+"Par exemple, si Gnuplot est installé dans `/opt` (peut-être sur macOS), vous "
+"pouvez ajouter `gnuplot_command:\"/opt/local/bin/gnuplot\"$` (ou `/opt/"
+"gnuplot/bin/gnuplot` ou tout autre chemin) à ces fichiers."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:792
+msgid ""
+"These files are in the Maxima user directory (usually `%USERPROFILE%/maxima` "
+"in Windows, `$HOME/.maxima` otherwise). The location can be found out with "
+"the command: `maxima_userdir;`"
+msgstr ""
+"Ces fichiers se trouvent dans le répertoire utilisateur de Maxima "
+"(généralement `%USERPROFILE%/maxima` sous Windows, ou `$HOME/.maxima` "
+"sinon). Vous pouvez connaître leur emplacement avec la commande : "
+"`maxima_userdir;`"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:793
+#, fuzzy, no-wrap
+#| msgid "## Special variables wx..."
+msgid "Special variables wx..."
+msgstr "## Variables spéciales wx..."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxsubscripts` tells _Maxima_ if it should convert variable names that "
+"contain an underscore (`R_150` or the like) into subscripted variables. See "
+"`wxdeclare_subscript` for details which variable names are automatically "
+"converted."
+msgstr ""
+"`wxsubscripts` indique à _Maxima_ s'il doit convertir les noms de variables "
+"contenant un tiret bas (`R_150` ou similaire) en variables avec indices en "
+"bas de ligne. Voir `wxdeclare_subscript` pour les détails sur les noms de "
+"variables automatiquement convertis."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxfilename`: This variable contains the name of the file currently opened "
+"in _wxMaxima_."
+msgstr ""
+"`wxfilename` : Cette variable contient le nom du fichier actuellement ouvert "
+"dans _wxMaxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirname`: This variable contains the name the directory, in which the "
+"file currently opened in _wxMaxima_ is."
+msgstr ""
+"`wxdirname` : Cette variable contient le nom du répertoire dans lequel se "
+"trouve le fichier actuellement ouvert dans _wxMaxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+#, fuzzy
+#| msgid ""
+#| "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_âs "
+#| "pngcairo terminal that provides more line styles and a better overall "
+#| "graphics quality."
+msgid ""
+"`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_’s pngcairo "
+"terminal that provides more line styles and a better overall graphics "
+"quality."
+msgstr ""
+"`wxplot_pngcairo` indique si _wxMaxima_ essaie d'utiliser le terminal "
+"pngcairo de _Gnuplot_ qui fournit plus de styles de lignes et une meilleure "
+"qualité graphique globale."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxplot_size` defines the resolution of embedded plots."
+msgstr "`wxplot_size` définit la résolution des graphiques intégrés."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+#, fuzzy
+#| msgid ""
+#| "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
+#| "_Maxima_âs working directory to the directory of the current file. This "
+#| "allows file I/O (e.g. by `read_matrix`) to work without specifying the "
+#| "whole path to the file that has to be read or written. On Windows this "
+#| "feature sometimes causes error messages and therefore can be set to "
+#| "`false` from the config dialogue."
+msgid ""
+"`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
+"_Maxima_’s working directory to the directory of the current file. This "
+"allows file I/O (e.g. by `read_matrix`) to work without specifying the whole "
+"path to the file that has to be read or written. On Windows this feature "
+"sometimes causes error messages and therefore can be set to `false` from the "
+"config dialogue."
+msgstr ""
+"`wxchangedir` : Sur la plupart des systèmes d'exploitation, _wxMaxima_ "
+"définit automatiquement le répertoire de travail de _Maxima_ à partir du "
+"répertoire du fichier actuel. Cela permet aux opérations d'entrée/sortie de "
+"fichiers (par exemple avec `read_matrix`) de fonctionner sans spécifier le "
+"chemin complet vers le fichier à lire ou à écrire. Sur Windows, cette "
+"fonctionnalité peut parfois causer des messages d'erreur et peut donc être "
+"désactivée en la réglant à `false` depuis la boîte de dialogue de "
+"configuration."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxanimate_framerate`: The number of frames per second the following "
+"animations have to be played back with."
+msgstr ""
+"`wxanimate_framerate` : Le nombre d'images par seconde pour la lecture des "
+"animations suivantes."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxanimate_autoplay`: Automatically play animations by default?"
+msgstr ""
+"`wxanimate_autoplay` : Jouer automatiquement les animations par défaut ?"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
+msgstr "`wxmaximaversion` : Retourne le numéro de version de _wxMaxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
+msgstr ""
+"`wxwidgetsversion` : Retourne la version de wxWidgets utilisée par "
+"_wxMaxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these "
+"differ by maintainer, distribution and operating system:"
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@userconfdir`: The directory the user's configuration is stored in. "
+"Same directory as `maxima_userdir` (see above) - both point at the same "
+"place, `wxdirs@userconfdir` is only useful if that is more convenient to "
+"reach from a `.mac` file than the Maxima-side variable."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the built-in "
+"autocompletion list, ...) is installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@helpdir`: The directory the offline copy of this manual is installed "
+"in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@localedir`: The directory _wxMaxima_'s translation files are "
+"installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_ is "
+"configured to start."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:812
+#, fuzzy, no-wrap
+#| msgid "## Pretty-printing 2D output"
+msgid "Pretty-printing 2D output"
+msgstr "## Affichage formaté en 2D"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:815
+#, fuzzy
+#| msgid ""
+#| "The function `table_form()` displays a 2D list in a form that is more "
+#| "readable than the output from _Maxima_âs default output routine. The "
+#| "input is a list of one or more lists. Like the \"print\" command, this "
+#| "command displays output even when ended with a dollar sign. Ending the "
+#| "command with a semicolon results in the same table along with a \"done\" "
+#| "statement."
+msgid ""
+"The function `table_form()` displays a 2D list in a form that is more "
+"readable than the output from _Maxima_’s default output routine. The input "
+"is a list of one or more lists. Like the \"print\" command, this command "
+"displays output even when ended with a dollar sign. Ending the command with "
+"a semicolon results in the same table along with a \"done\" statement."
+msgstr ""
+"La fonction `table_form()` affiche une liste 2D sous une forme plus lisible "
+"que le résultat produit par la sortie par défaut de _Maxima_. L'argument "
+"doit être une liste contenant une ou plusieurs listes. Comme la commande "
+"\"print\", cette commande affiche le résultat même si elle se termine par un "
+"dollar (`$`). Si elle se termine par un point-virgule (`;`), le tableau "
+"s'affiche accompagné d'un message \"done\"."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:816
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "table_form(\n"
+#| "    [\n"
+#| "        [1,2],\n"
+#| "        [3,4]\n"
+#| "    ]\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"table_form(\n"
+"    [\n"
+"        [1,2],\n"
+"        [3,4]\n"
+"    ]\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"table_form(\n"
+"    [\n"
+"        [1,2],\n"
+"        [3,4]\n"
+"    ]\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:826
+msgid ""
+"As the next example shows, the lists that are assembled by the `table_form` "
+"command can be created before the command is executed."
+msgstr ""
+"Comme le montre l'exemple suivant, les listes utilisées par la commande "
+"`table_form` peuvent être créées avant son exécution."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:828
+msgid ""
+"![A third table example](./MatrixTableExample.png)"
+"{ id=img_MatrixTableExample }"
+msgstr ""
+"![Un troisième exemple de tableau](./MatrixTableExample.png)"
+"{ id=img_MatrixTableExample }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:830
+msgid ""
+"Also, because a matrix is a list of lists, matrices can be converted to "
+"tables in a similar fashion."
+msgstr ""
+"De même, comme une matrice est une liste de listes, elle peut être convertie "
+"en tableau de manière similaire."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:832
+msgid ""
+"![Another table_form example](./SecondTableExample.png)"
+"{ id=img_SecondTableExample }"
+msgstr ""
+"![Un autre exemple avec table_form](./SecondTableExample.png)"
+"{ id=img_SecondTableExample }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:834
+msgid ""
+"The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that "
+"allows for more flexible formatting of matrices in wxMaxima:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:836
+#, no-wrap
+msgid "**`wx_matrix( <matrix>, [options] )`**\n"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`lines=true`**: Draws internal separator lines between the cells. This is "
+"required to visually separate headings from data."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`rownames=true`**: Tells wxMaxima that the first column of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`colnames=true`**: Tells wxMaxima that the first row of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
+"around the matrix. Supported styles are: `round` `()`, `square` `[]`, "
+"`angled` `<>`, `straight` `||`, or `none`."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:843
+msgid "Example:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:844
+#, no-wrap
+msgid ""
+"wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
+"          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:849
+#, fuzzy, no-wrap
+#| msgid "## Bug reporting"
+msgid "Bug reporting"
+msgstr "## Signalement de bugs"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:852
+msgid ""
+"_WxMaxima_ provides a few functions that gather bug reporting information "
+"about the current system:"
+msgstr ""
+"_WxMaxima_ propose quelques fonctions qui collectent des informations utiles "
+"pour signaler un bug concernant le système actuel :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:855
+msgid ""
+"`wxbuild_info()` gathers information about the currently running version of "
+"_wxMaxima_"
+msgstr ""
+"- `wxbuild_info()` : Rassemble des informations sur la version en cours "
+"d'exécution  de _wxMaxima_"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:855
+msgid "`wxbug_report()` tells how and where to file bugs"
+msgstr "`wxbug_report()` indique comment et où signaler les bogues"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:856
+#, fuzzy, no-wrap
+#| msgid "## Marking output being drawn in red"
+msgid "Marking output being drawn in red"
+msgstr "## Ecrire le résultat de la sortie en rouge"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:860
+#, fuzzy
+#| msgid ""
+#| "_Maxima_âs `box()` command causes _wxMaxima_ to print its argument with a "
+#| "red foreground, if the second argument to the command is the text "
+#| "`highlight`."
+msgid ""
+"_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a "
+"red foreground, if the second argument to the command is the text "
+"`highlight`."
+msgstr ""
+"La commande `box()` de _Maxima_ permet à _wxMaxima_ d'afficher son argument "
+"en rouge, si le deuxième argument de la commande est le texte `highlight`."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:861
+#, fuzzy, no-wrap
+#| msgid "## Output rendering."
+msgid "Output rendering."
+msgstr "## Rendu de la sortie."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:864
+msgid "With `set_display()` one can set, how wxMaxima will render the output."
+msgstr ""
+"Avec `set_display()`, on peut définir de quelle manière wxMaxima affichera "
+"la sortie."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:866
+msgid ""
+"`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima "
+"using an (machine readable) XML-dialect (can be seen in the \"Raw XML "
+"sidebar\") and outputs the resulting formulas nicely rendered, e.g. pretty "
+"Matrices, Square root signs, fractions, etc."
+msgstr ""
+"`set_display('xml)` est la valeur par défaut. Ici, Maxima communique avec "
+"wxMaxima en utilisant un dialecte XML (lisible par machine) (visible dans la "
+"barre latérale « XML brut ») et affiche les formules résultantes avec un "
+"visuel mathématique, par exemple des matrices bien délimitées et "
+"structurées, des signes de racine carrée, des fractions, etc."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:869
+#, fuzzy, no-wrap
+#| msgid "<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) --> `set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art."
+msgid ""
+"<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->\n"
+"`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.\n"
+msgstr "<!--- Actuellement, cela ne fonctionne pas comme prévu : la ligne avec l’étiquette de sortie est décalée vers la droite (problème : #2006) --> `set_display('ascii)` fait en sorte que wxMaxima affiche les formules comme dans Maxima en ligne de commande — en ASCII-Art."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:871
+msgid ""
+"`set_display('none)` causes 'one-line' ASCII results - the same as the "
+"command line Maxima command `display2d:false;` does."
+msgstr ""
+"`set_display('none)` produit des résultats ASCII « sur une seule ligne » — "
+"comme le fait la commande de Maxima en ligne de commande `display2d:false;`."
+
+#. type: Title #
+#: ../../info/wxmaxima.md:872
+#, fuzzy, no-wrap
+#| msgid "# Help menu"
+msgid "Help menu"
+msgstr "# Menu d'aide"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:875
+#, fuzzy
+#| msgid ""
+#| "WxMaximaâs help menu provides access to the Maxima and wxMaxima manual, "
+#| "tips, some example worksheets and in command line Maxima included demos "
+#| "(the `demo()` command)."
+msgid ""
+"WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, "
+"tips, some example worksheets and in command line Maxima included demos (the "
+"`demo()` command)."
+msgstr ""
+"Le menu d'aide de _wxMaxima_ donne accès au manuel de Maxima et à celui de "
+"wxMaxima, à des astuces, à des exemples de notebooks, ainsi qu'aux exemples "
+"intégrés dans Maxima en ligne de commande (via la commande `demo()`)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:877
+msgid "Please notice, that the demos write:"
+msgstr "Veuillez noter que les exemples indiquent :"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:878
+#, fuzzy, no-wrap
+#| msgid "~~~ At the â_â prompt, type â;â and <enter> to proceed with the demonstration.  ~~~"
+msgid "At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.\n"
+msgstr "~~~ À l’invite `’_’`, tapez `;` puis `<entrée>` pour poursuivre la démonstration.  ~~~"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:883
+#, fuzzy, no-wrap
+#| msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>"
+msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>\n"
+msgstr "Cela est valable pour Maxima en ligne de commande, mais dans wxMaxima, par défaut, il est nécessaire de poursuivre la démonstration avec : <kbd>CTRL</kbd> + <kbd>ENTRÉE</kbd>"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:885
+#, fuzzy, no-wrap
+#| msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)"
+msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)\n"
+msgstr "(Ce comportement peut être configuré dans le menu Configurer → Notebook → \" Raccourcis pour envoyer des commandes à Maxima\".)"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:888
+#, fuzzy, no-wrap
+#| msgid "# Troubleshooting"
+msgid "Troubleshooting"
+msgstr "# Résolution des problèmes"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:890
+#, fuzzy, no-wrap
+#| msgid "## Cannot connect to _Maxima_"
+msgid "Cannot connect to _Maxima_"
+msgstr "## Impossible de se connecter à _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:893
+#, fuzzy
+#| msgid ""
+#| "Since _Maxima_ (the program that does the actual mathematics) and "
+#| "_wxMaxima_ (providing the easy-to-use user interface) are separate "
+#| "programs that communicate by the means of a local network connection. "
+#| "Therefore the most probable cause is that this connection is somehow not "
+#| "working. For example, a firewall could be set up in a way that it doesnât "
+#| "just prevent unauthorized connections from the internet (and perhaps "
+#| "intercept some connections to the internet, too), but also blocks inter-"
+#| "process-communication inside the same computer. Note that since _Maxima_ "
+#| "is being run by a Lisp processor the process communication that is "
+#| "blocked does not necessarily have to be named \"maxima\". Common names of "
+#| "the program that opens the network connection would be sbcl, gcl, ccl, "
+#| "lisp.exe, or similar names."
+msgid ""
+"Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ "
+"(providing the easy-to-use user interface) are separate programs that "
+"communicate by the means of a local network connection. Therefore the most "
+"probable cause is that this connection is somehow not working. For example, "
+"a firewall could be set up in a way that it doesn’t just prevent "
+"unauthorized connections from the internet (and perhaps intercept some "
+"connections to the internet, too), but also blocks inter-process-"
+"communication inside the same computer. Note that since _Maxima_ is being "
+"run by a Lisp processor the process communication that is blocked does not "
+"necessarily have to be named \"maxima\". Common names of the program that "
+"opens the network connection would be sbcl, gcl, ccl, lisp.exe, or similar "
+"names."
+msgstr ""
+"Puisque _Maxima_ (le programme qui effectue les calculs mathématiques) et "
+"_wxMaxima_ (qui fournit l’interface utilisateur conviviale) sont deux "
+"programmes distincts qui communiquent via une connexion réseau locale, la "
+"cause la plus probable d'un dysfonctionnement est que cette connexion ne "
+"s'établit pas correctement. Par exemple, un pare-feu peut être configuré non "
+"seulement pour bloquer les connexions non autorisées depuis Internet (et "
+"éventuellement intercepter certaines connexions sortantes), mais aussi pour "
+"empêcher la communication entre processus sur un même ordinateur. Notez que, "
+"comme Maxima est exécuté via un processeur Lisp, le processus bloqué ne "
+"porte pas nécessairement le nom \"maxima\". Les noms usuels pour le "
+"programme ouvrant la connexion réseau peuvent être sbcl, gcl, ccl, lisp.exe, "
+"ou des noms similaires."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:895
+#, fuzzy
+#| msgid ""
+#| "On Unix computers another possible reason would be that the loopback "
+#| "network that provides network connections between two programs in the "
+#| "same computer isnât properly configured."
+msgid ""
+"On Unix computers another possible reason would be that the loopback network "
+"that provides network connections between two programs in the same computer "
+"isn’t properly configured."
+msgstr ""
+"Sur les ordinateurs Unix, une autre cause possible serait que le réseau "
+"loopback, qui permet les connexions entre deux programmes sur le même "
+"ordinateur, ne soit pas correctement configuré."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:896
+#, fuzzy, no-wrap
+#| msgid "## How to save data from a broken .wxmx file"
+msgid "How to save data from a broken .wxmx file"
+msgstr "## Comment récupérer les données d’un fichier .wxmx corrompu"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:899
+#, fuzzy
+#| msgid ""
+#| "Internally most modern XML-based formats are ordinary zip files. "
+#| "_WxMaxima_ doesnât turn on compression, so the contents of `.wxmx` files "
+#| "can be viewed in any text editor."
+msgid ""
+"Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ "
+"doesn’t turn on compression, so the contents of `.wxmx` files can be viewed "
+"in any text editor."
+msgstr ""
+"En informatique, la plupart des formats modernes basés sur XML sont en "
+"réalité des fichiers zip ordinaires. _WxMaxima_ n’active pas la compression, "
+"donc le contenu des fichiers `.wxmx` peut être consulté avec n’importe quel "
+"éditeur de texte."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:901
+#, fuzzy
+#| msgid ""
+#| "If the zip signature at the end of the file is still intact after "
+#| "renaming a broken `.wxmx` file to `.zip` most operating systems will "
+#| "provide a way to extract any portion of the information that is stored "
+#| "inside it. This can be done when there is a need of recovering the "
+#| "original image files from a text processor document. If the zip signature "
+#| "isnât intact that does not need to be the end of the world: If _wxMaxima_ "
+#| "during saving detected that something went wrong there will be a `.wxmx~` "
+#| "file whose contents might help."
+msgid ""
+"If the zip signature at the end of the file is still intact after renaming a "
+"broken `.wxmx` file to `.zip` most operating systems will provide a way to "
+"extract any portion of the information that is stored inside it. This can be "
+"done when there is a need of recovering the original image files from a text "
+"processor document. If the zip signature isn’t intact that does not need to "
+"be the end of the world: If _wxMaxima_ during saving detected that something "
+"went wrong there will be a `.wxmx~` file whose contents might help."
+msgstr ""
+"Si la signature du zip à la fin du fichier est toujours intacte après avoir "
+"renommé un fichier `.wxmx` corrompu en `.zip`, la plupart des systèmes "
+"d’exploitation permettront d’extraire une partie des informations qu’il "
+"contient. Cette méthode est souvent utilisée pour récupérer les fichiers "
+"image originaux d’un document issu d'un traitement de texte. Si la signature "
+"du zip n’est plus intacte, ce n’est pas forcément une impasse : si "
+"_wxMaxima_ a détecté une erreur lors de l’enregistrement, un fichier `."
+"wxmx~` aura probablement été créé et son contenu pourrait s’avérer utile."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:903
+#, fuzzy, no-wrap
+#| msgid "And even if there isnât such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the fileâs contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor)."
+msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).\n"
+msgstr "Et même s’il n’existe pas un tel fichier : le format `.wxmx` est un format conteneur et la partie XML y est stockée sans compression. Il est possible de renommer le fichier `.wxmx` en `.txt` et d’utiliser un éditeur de texte pour récupérer la portion XML du contenu (elle commence par `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` et se termine par `</wxMaximaDocument>`. Avant et après ce texte, vous verrez du contenu binaire illisible dans l’éditeur)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:905
+msgid ""
+"If a text file containing only these contents (e.g. copy and paste this text "
+"into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know "
+"how to recover the text from the document."
+msgstr ""
+"Si vous enregistrez un fichier texte contenant uniquement ce contenu (par "
+"exemple, en copiant et collant ce texte dans un nouveau fichier) avec une "
+"extension `.xml`, _wxMaxima_ saura comment récupérer le texte du document."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:906
+#, fuzzy, no-wrap
+#| msgid "## I want some debug info to be displayed on the screen before my command has finished"
+msgid "I want some debug info to be displayed on the screen before my command has finished"
+msgstr "## Je souhaite afficher des informations de débogage à l’écran avant que ma commande ne soit terminée"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:909
+msgid ""
+"Normally _wxMaxima_ waits for the whole 2D formula to be transferred before "
+"it begins to typeset. This saves time for making many attempts to typeset a "
+"only partially completed equation. There is a `disp` command, though, that "
+"will provide debug output immediately and without waiting for the current "
+"_Maxima_ command to finish:"
+msgstr ""
+"Normalement, _wxMaxima_ attend que la formule 2D soit transférée en totalité "
+"avant de commencer la composition typographique. Cela permet d’économiser du "
+"temps en évitant de tenter d'écrire une équation incomplète. Cependant, il "
+"existe une commande `disp` qui affiche immédiatement des informations de "
+"débogage, sans attendre la fin de l’exécution de la commande _Maxima_ en "
+"cours :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:910
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "for i:1 thru 10 do (\n"
+#| "   disp(i),\n"
+#| "   /* (sleep n) is a Lisp function, which can be used */\n"
+#| "   /* with the character \"?\" before. It delays the */\n"
+#| "   /* program execution (here: for 3 seconds) */\n"
+#| "   ?sleep(3)\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"for i:1 thru 10 do (\n"
+"   disp(i),\n"
+"   /* (sleep n) is a Lisp function, which can be used */\n"
+"   /* with the character \"?\" before. It delays the */\n"
+"   /* program execution (here: for 3 seconds) */\n"
+"   ?sleep(3)\n"
+")$\n"
+msgstr ""
+"``maxima\n"
+"for i:1 thru 10 do (\n"
+"   disp(i),\n"
+"   /* (sleep n) is a Lisp function, which can be used */\n"
+"   /* with the character \"?\" before. It delays the */\n"
+"   /* program execution (here: for 3 seconds) */\n"
+"   ?sleep(3)\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:921
+msgid "Alternatively one can look for the `wxstatusbar()` command above."
+msgstr ""
+"Sinon, on peut utiliser la commande `wxstatusbar()` mentionnée ci-dessus."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:922
+#, fuzzy, no-wrap
+#| msgid "## Plotting only shows a closed empty envelope with an error message"
+msgid "Plotting only shows a closed empty envelope with an error message"
+msgstr "## La création d'un graphique n'affiche qu'une enveloppe vide encadrée avec un message d'erreur"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:925
+msgid ""
+"This means that _wxMaxima_ could not read the file _Maxima_ that was "
+"supposed to instruct _Gnuplot_ to create."
+msgstr ""
+"Cela signifie que _wxMaxima_ n'a pas pu lire le fichier généré par _Maxima_, "
+"qui était censé donner les instructions à _Gnuplot_ pour créer le graphique."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:927
+msgid "Possible reasons for this error are:"
+msgstr "Les causes possibles de cette erreur sont :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+#, fuzzy
+#| msgid ""
+#| "The plotting command is part of a third-party package like "
+#| "`implicit_plot` but this package was not loaded by _Maxima_âs `load()` "
+#| "command before trying to plot."
+msgid ""
+"The plotting command is part of a third-party package like `implicit_plot` "
+"but this package was not loaded by _Maxima_’s `load()` command before trying "
+"to plot."
+msgstr ""
+"La commande de tracé fait partie d’un paquet externe comme `implicit_plot`, "
+"mais ce paquet n’a pas été chargé par la commande `load()` de _Maxima_ avant "
+"le lancement de cette commande."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+#, fuzzy
+#| msgid ""
+#| "_Maxima_ tried to do something the currently installed version of "
+#| "_Gnuplot_ isnât able to understand. In this case, a file ending in `."
+#| "gnuplot` located in the directory, which _Maxima_âs variable "
+#| "`maxima_userdir` is pointing, contains the instructions from _Maxima_ to "
+#| "_Gnuplot_. Most of the time, this fileâs contents therefore are helpful "
+#| "when debugging the problem."
+msgid ""
+"_Maxima_ tried to do something the currently installed version of _Gnuplot_ "
+"isn’t able to understand. In this case, a file ending in `.gnuplot` located "
+"in the directory, which _Maxima_’s variable `maxima_userdir` is pointing, "
+"contains the instructions from _Maxima_ to _Gnuplot_. Most of the time, this "
+"file’s contents therefore are helpful when debugging the problem."
+msgstr ""
+"_Maxima_ a tenté de faire quelque chose que la version actuellement "
+"installée de _Gnuplot_ ne peut pas interpréter. Dans ce cas, un fichier se "
+"terminant par `.gnuplot`, situé dans le répertoire vers lequel pointe la "
+"variable `maxima_userdir` de _Maxima_, contient les instructions envoyées "
+"par _Maxima_ à _Gnuplot_. Le contenu de ce fichier est donc souvent utile "
+"pour déboguer le problème."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+#, fuzzy
+#| msgid ""
+#| "Gnuplot was instructed to use the pngCairo library that provides "
+#| "antialiasing and additional line styles, but it was not compiled to "
+#| "support this possibility. Solution: Uncheck the \"Use the Cairo terminal "
+#| "for the plot\" checkbox in the configuration dialog and donât set "
+#| "`wxplot_pngcairo` to true from _Maxima_."
+msgid ""
+"Gnuplot was instructed to use the pngCairo library that provides "
+"antialiasing and additional line styles, but it was not compiled to support "
+"this possibility. Solution: Uncheck the \"Use the Cairo terminal for the "
+"plot\" checkbox in the configuration dialog and don’t set `wxplot_pngcairo` "
+"to true from _Maxima_."
+msgstr ""
+"Gnuplot a reçu la consigne d’utiliser la bibliothèque pngCairo, qui fournit "
+"l’anticrénelage et des styles de ligne supplémentaires, mais il n’a pas été "
+"compilé pour prendre en charge cette fonctionnalité.  Solution : décochez la "
+"case « Utiliser le terminal Cairo pour le tracé » dans la boîte de dialogue "
+"de configuration et ne définissez pas `wxplot_pngcairo` sur true depuis "
+"_Maxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+msgid "Gnuplot didn’t output a valid `.png` file."
+msgstr "Gnuplot n'a pas produit un fichier .png valide."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:933
+#, fuzzy, no-wrap
+#| msgid "## Plotting an animation results in “error: undefined variable”"
+msgid "Plotting an animation results in “error: undefined variable”"
+msgstr "## Le tracé d'une animation génère l'erreur \"error: undefined variable\""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:936
+msgid ""
+"The value of the slider variable by default is only substituted into the "
+"expression that is to be plotted if it is visible there. Using a `subst` "
+"command that substitutes the slider variable into the equation to plot "
+"resolves this problem. At the end of section [Embedding animations into the "
+"spreadsheet](#embedding-animations-into-the-spreadsheet), you can see an "
+"example."
+msgstr ""
+"Par défaut, la valeur du paramètre pour le curseur n'est substituée dans "
+"l'expression à tracer que si elle y est visible. L'utilisation d'une "
+"commande `subst` qui substitue la variable du curseur dans l'équation à "
+"tracer résout ce problème. À la fin de la section [Intégrer des animations "
+"dans le notebook](#embedding-animations-into-the-spreadsheet), vous pouvez "
+"voir un exemple."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:937
+#, fuzzy, no-wrap
+#| msgid "## I lost cell content and undo doesn’t remember"
+msgid "I lost cell content and undo doesn’t remember"
+msgstr "## J’ai perdu le contenu d’une cellule et la fonction Annuler ne le restaure pas"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:940
+msgid ""
+"There are separate undo functions for cell operations and for changes inside "
+"of cells so chances are low that this ever happens. If it does there are "
+"several methods to recover data:"
+msgstr ""
+"Il existe des fonctions Annuler distinctes pour les opérations sur les "
+"cellules et pour les modifications à l’intérieur des cellules, donc il est "
+"peu probable que cela arrive. Si cela se produit, plusieurs méthodes "
+"permettent de récupérer les données :"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+msgid ""
+"_WxMaxima_ actually has two undo features: The global undo buffer that is "
+"active if no cell is selected and a per-cell undo buffer that is active if "
+"the cursor is inside a cell. It is worth trying to use both undo options in "
+"order to see if an old value can still be accessed."
+msgstr ""
+"_WxMaxima_ dispose en fait de deux fonctions d’annulation : une mémoire "
+"d’annulation globale, active lorsqu’aucune cellule n’est sélectionnée, et "
+"une mémoire d’annulation par cellule, active lorsque le curseur se trouve à "
+"l’intérieur d’une cellule. Cela vaut la peine d’essayer les deux options "
+"d’annulation pour voir si une ancienne valeur peut encore être récupérée."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+#, fuzzy
+#| msgid ""
+#| "If you still have a way to find out what label _Maxima_ has assigned to "
+#| "the cell just type in the cellâs label and its contents will reappear."
+msgid ""
+"If you still have a way to find out what label _Maxima_ has assigned to the "
+"cell just type in the cell’s label and its contents will reappear."
+msgstr ""
+"Si vous avez encore un moyen de retrouver l’étiquette que _Maxima_ a "
+"attribuée à la cellule, il vous suffit de taper cette étiquette, et le "
+"contenu de la cellule réapparaîtra."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+#, fuzzy
+#| msgid ""
+#| "If you donât: Donât panic. In the âViewâ menu there is a way to show a "
+#| "history pane that shows all _Maxima_ commands that have been issued "
+#| "recently."
+msgid ""
+"If you don’t: Don’t panic. In the “View” menu there is a way to show a "
+"history pane that shows all _Maxima_ commands that have been issued recently."
+msgstr ""
+"Si ce n’est pas le cas, ne paniquez pas. Le menu « Affichage » propose une "
+"option permettant d’afficher un panneau d’historique qui montre toutes les "
+"commandes _Maxima_ exécutées récemment."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+msgid "If nothing else helps _Maxima_ contains a replay feature:"
+msgstr ""
+"Si rien d’autre ne fonctionne, _Maxima_ contient une fonction de replay :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:946
+#, no-wrap
+msgid "playback();\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:950
+#, fuzzy, no-wrap
+#| msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
+msgid "_WxMaxima_ starts up with the message “Maxima process terminated.”"
+msgstr "## _WxMaxima_ démarre avec le message  Maxima process terminated"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:953
+#, fuzzy
+#| msgid ""
+#| "One possible reason is that _Maxima_ cannot be found in the location that "
+#| "is set in the âMaximaâ tab of _wxMaxima_âs configuration dialog and "
+#| "therefore wonât run at all. Setting the path to a working _Maxima_ binary "
+#| "should fix this problem."
+msgid ""
+"One possible reason is that _Maxima_ cannot be found in the location that is "
+"set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore "
+"won’t run at all. Setting the path to a working _Maxima_ binary should fix "
+"this problem."
+msgstr ""
+"Une cause possible est que le programme _Maxima_ n’est pas trouvé à "
+"l’emplacement indiqué dans l’onglet Maxima de la boîte de dialogue de "
+"configuration de _wxMaxima_, ce qui l’empêche de démarrer. Vérifiez et "
+"corrigez le chemin vers l’exécutable _Maxima_ pour résoudre ce problème."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:954
+#, fuzzy, no-wrap
+#| msgid "## Maxima is forever calculating and not responding to input"
+msgid "Maxima is forever calculating and not responding to input"
+msgstr "## Maxima calcule indéfiniment et ne répond plus aux commandes entrées"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:957
+#, fuzzy
+#| msgid ""
+#| "It is theoretically possible that _wxMaxima_ doesnât realize that "
+#| "_Maxima_ has finished calculating and therefore never gets informed it "
+#| "can send new data to _Maxima_. If this is the case âTrigger evaluationâ "
+#| "might resynchronize the two programs."
+msgid ""
+"It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ "
+"has finished calculating and therefore never gets informed it can send new "
+"data to _Maxima_. If this is the case “Trigger evaluation” might "
+"resynchronize the two programs."
+msgstr ""
+"Il est théoriquement possible que _wxMaxima_ ne détecte pas que _Maxima_ a "
+"terminé ses calculs et, de ce fait, n’autorise pas l’envoi de nouvelles "
+"données. Dans ce cas, l’option Déclencher l’évaluation (« Trigger "
+"evaluation ») peut resynchroniser les deux programmes."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:958
+#, fuzzy, no-wrap
+#| msgid "## My SBCL-based _Maxima_ runs out of memory"
+msgid "My SBCL-based _Maxima_ runs out of memory"
+msgstr "## Mon _Maxima_ basé sur SBCL manque de mémoire"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:961
+msgid ""
+"The Lisp compiler SBCL by default comes with a memory limit that allows it "
+"to run even on low-end computers. When compiling a big software package like "
+"Lapack or dealing with extremely big lists of equations this limit might be "
+"too low. In order to extend the limits, SBCL can be provided with the "
+"command line parameter `--dynamic-space-size` that tells SBCL how many "
+"megabytes it should reserve. A 32bit Windows-SBCL can reserve up to 999 "
+"Megabytes. A 64-bit SBCL version running on Windows can be instructed to use "
+"more than the about 1280 Megabytes compiling Lapack needs."
+msgstr ""
+"Le compilateur Lisp SBCL est configuré par défaut avec une limite de mémoire "
+"qui lui permet de fonctionner même sur des ordinateurs peu puissants. "
+"Cependant, lors de la compilation de gros packages logiciels comme Lapack ou "
+"du traitement de listes d'équations extrêmement longues, cette limite peut "
+"s'avérer insuffisante. Pour l'augmenter, vous pouvez utiliser le paramètre "
+"en ligne de commande `--dynamic-space-size` lors du lancement de SBCL, qui "
+"indique combien de mégaoctets doivent être réservés. - Une version 32 bits "
+"de SBCL sous Windows peut réserver jusqu'à 999 Mo. - Une version 64 bits "
+"sous Windows peut aller au-delà des 1280 Mo nécessaires pour compiler Lapack."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:963
+#, fuzzy
+#| msgid ""
+#| "One way to provide _Maxima_ (and thus SBCL) with command line parameters "
+#| "is the \"Additional parameters for Maxima\" field of _wxMaxima_âs "
+#| "configuration dialogue."
+msgid ""
+"One way to provide _Maxima_ (and thus SBCL) with command line parameters is "
+"the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration "
+"dialogue."
+msgstr ""
+"Une façon de fournir des paramètres en ligne de commande à _Maxima_ (et donc "
+"à SBCL) est d’utiliser le champ \"Paramètres supplémentaires pour Maxima\" "
+"dans la boîte de dialogue de configuration de _wxMaxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:965
+msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
+msgstr "![mémoire pour sbcl](./sbclMemory.png){ id=img_sbclMemory }"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:966
+#, fuzzy, no-wrap
+#| msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgstr "## Sous Ubuntu, la saisie est parfois lente ou certaines touches sont ignorées"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:969
+msgid ""
+"Installing the package `ibus-gtk` should resolve this issue. See ([https://"
+"bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs."
+"launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) for details."
+msgstr ""
+"L'installation du paquet 'ibus-gtk' devrait résoudre ce problème. Pour plus "
+"de détails, voir : [https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/"
+"+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/"
+"+bug/1421558)."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:970
+#, fuzzy, no-wrap
+#| msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgid "_WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgstr "## _WxMaxima_ se fige lorsque _Maxima_ traite des caractères grecs ou des lettres accentuées (comme les umlauts)"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:973
+msgid ""
+"If your _Maxima_ is based on SBCL the following lines have to be added to "
+"your `.sbclrc`:"
+msgstr ""
+"Si votre _Maxima_ est basé sur SBCL, ajoutez les lignes suivantes à votre "
+"fichier `.sbclrc` :"
+
+#. type: Fenced code block (commonlisp)
+#: ../../info/wxmaxima.md:974
+#, fuzzy, no-wrap
+#| msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
+msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
+msgstr "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:979
+msgid ""
+"The folder where this file has to be placed is system- and installation-"
+"specific. But any SBCL-based _Maxima_ that already has evaluated a cell in "
+"the current session will happily tell where it can be found after getting "
+"the following command:"
+msgstr ""
+"Le dossier où ce fichier doit être placé dépend du système et de "
+"l’installation. Cependant, toute version de _Maxima_ basée sur SBCL, ayant "
+"déjà évalué une cellule durant la session en cours, peut gentiment indiquer "
+"son emplacement après exécution de la commande suivante :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:980
+#, fuzzy, no-wrap
+#| msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
+msgid ":lisp (sb-impl::userinit-pathname)\n"
+msgstr "```maxima :lisp (sb-impl::userinit-pathname)  ```"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:984
+#, fuzzy, no-wrap
+#| msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
+msgid "Note concerning Wayland (recent Linux/BSD distributions)"
+msgstr "## Remarque concernant Wayland (distributions Linux/BSD récentes)"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:988
+msgid ""
+"There seem to be issues with the Wayland Display Server and wxWidgets.  "
+"WxMaxima may be affected, e.g. that sidebars are not moveable."
+msgstr ""
+"Il semble y avoir des problèmes de compatibilité entre le serveur "
+"d'affichage Wayland et wxWidgets. WxMaxima peut en être affecté, par exemple "
+"avec des barres latérales qui ne peuvent pas être déplacées."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:992
+msgid ""
+"You can either disable Wayland and use X11 instead (globally)  or just tell, "
+"that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
+msgstr ""
+"Vous pouvez soit : - désactiver Wayland et utiliser X11 à la place (de "
+"manière globale), - ou forcer WxMaxima à utiliser le système X Window en "
+"définissant la variable d’environnement :  `GDK_BACKEND=x11`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:994
+msgid "E.g. start wxMaxima with:"
+msgstr "Par exemple, lancez WxMaxima avec la commande :"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:996
+msgid "`GDK_BACKEND=x11 wxmaxima`"
+msgstr "`GDK_BACKEND=x11 wxmaxima`"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:997
+#, no-wrap
+msgid "The menu bar disappears on KDE Plasma"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1003
+msgid ""
+"On some KDE Plasma installations the global menu bar disappears when "
+"clicked.  As this is a bug in the global menu proxy, the only way to avoid "
+"it is to tell that wxMaxima should use its own menu bar instead of the "
+"global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1007
+msgid ""
+"Starting with version 26.05.0, wxMaxima attempts to set this variable "
+"automatically if it detects an affected system (KDE, Unity, or Ubuntu with "
+"older wxWidgets versions)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1009
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1011
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1012
+#, fuzzy, no-wrap
+#| msgid "## Why is the integrated manual browser not offered on my Windows PC?"
+msgid "Why is the integrated manual browser not offered on my Windows PC?"
+msgstr "## Pourquoi le navigateur pour le manuel intégré n’est-il pas disponible sur mon PC Windows ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1016
+#, fuzzy
+#| msgid ""
+#| "Either wxWidgets wasnât compiled with support for Microsoftâs webview2 or "
+#| "Microsoftâs webview2 isnât installed."
+msgid ""
+"Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or "
+"Microsoft’s webview2 isn’t installed."
+msgstr ""
+"Soit wxWidgets n’a pas été compilé avec le support de Microsoft WebView2, "
+"soit WebView2 n’est pas installé sur votre système."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1017
+#, fuzzy, no-wrap
+#| msgid "## Why is the external manual browser not working on my Linux box?"
+msgid "Why is the external manual browser not working on my Linux box?"
+msgstr "## Pourquoi le navigateur pour le manuel externe ne fonctionne-t-il pas sur ma machine Linux ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1024
+#, fuzzy
+#| msgid ""
+#| "The HTML browser might be a snap, flatpack or appimage version. All of "
+#| "these typically cannot access files that are installed on your local "
+#| "system. Another reason might be that maxima or wxMaxima is installed as a "
+#| "snap, flatpack or something else that doesnât give the host system access "
+#| "to its contents. A third reason might be that the maxima HTML manual "
+#| "isnât installed and the online one cannot be accessed."
+msgid ""
+"The HTML browser might be a snap, flatpack or appimage version. All of these "
+"typically cannot access files that are installed on your local system. "
+"Another reason might be that maxima or wxMaxima is installed as a snap, "
+"flatpack or something else that doesn’t give the host system access to its "
+"contents. A third reason might be that the maxima HTML manual isn’t "
+"installed and the online one cannot be accessed."
+msgstr ""
+"Plusieurs raisons peuvent expliquer ce problème : - Le navigateur HTML peut "
+"être une version Snap, Flatpak ou AppImage, qui ne peut généralement pas "
+"accéder aux fichiers installés localement sur votre système. - Maxima ou "
+"wxMaxima peut être installé en tant que Snap, Flatpak ou autre format "
+"limitant l’accès aux fichiers du système hôte. - Le manuel HTML de Maxima "
+"peut ne pas être installé, et la version en ligne n’est pas accessible."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1025
+#, fuzzy, no-wrap
+#| msgid "## Can I make _wxMaxima_ output both image files and embedded plots at once?"
+msgid "Can I make _wxMaxima_ output both image files and embedded plots at once?"
+msgstr "## Puis-je faire en sorte que _wxMaxima_ génère à la fois des fichiers image et des graphiques en ligne en même temps ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1028
+msgid ""
+"The worksheet embeds `.png files. _WxMaxima_ allows the user to specify "
+"where they should be generated:"
+msgstr ""
+"Le notebook intègre les fichiers `.png`. _WxMaxima_ permet à l'utilisateur "
+"de spécifier où ces fichiers doivent être générés :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1029
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw2d(\n"
+#| "    file_name=\"test\",  /* extension .png automatically added */\n"
+#| "    explicit(sin(x),x,1,10)\n"
+#| ");\n"
+#| "```\n"
+msgid ""
+"wxdraw2d(\n"
+"    file_name=\"test\",  /* extension .png automatically added */\n"
+"    explicit(sin(x),x,1,10)\n"
+");\n"
+msgstr ""
+"```maxima\n"
+"wxdraw2d(\n"
+"    file_name=\"test\",  /* extension .png automatically added */\n"
+"    explicit(sin(x),x,1,10)\n"
+");\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1037
+msgid ""
+"If a different format is to be used, it is easier to generate the images and "
+"then import them into the worksheet again:"
+msgstr ""
+"Si vous souhaitez utiliser un format différent, il est plus simple de "
+"générer les images séparément, puis de les réimporter dans le notebook :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1038
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "load(\"draw\");\n"
+#| "pngdraw(name,[contents]):=\n"
+#| "(\n"
+#| "    draw(\n"
+#| "        append(\n"
+#| "            [\n"
+#| "                terminal=pngcairo,\n"
+#| "                dimensions=wxplot_size,\n"
+#| "                file_name=name\n"
+#| "            ],\n"
+#| "            contents\n"
+#| "        )\n"
+#| "    ),\n"
+#| "    show_image(printf(false,\"~a.png\",name))\n"
+#| ");\n"
+#| "pngdraw2d(name,[contents]):=\n"
+#| "    pngdraw(name,gr2d(contents));\n"
+msgid ""
+"load(\"draw\");\n"
+"pngdraw(name,[contents]):=\n"
+"(\n"
+"    draw(\n"
+"        append(\n"
+"            [\n"
+"                terminal=pngcairo,\n"
+"                dimensions=wxplot_size,\n"
+"                file_name=name\n"
+"            ],\n"
+"            contents\n"
+"        )\n"
+"    ),\n"
+"    show_image(printf(false,\"~a.png\",name))\n"
+");\n"
+"pngdraw2d(name,[contents]):=\n"
+"    pngdraw(name,gr2d(contents));\n"
+"\n"
+"pngdraw2d(\"Test\",\n"
+"        explicit(sin(x),x,1,10)\n"
+");\n"
+msgstr ""
+"```maxima\n"
+"load(\"draw\");\n"
+"pngdraw(name,[contents]):=\n"
+"(\n"
+"    draw(\n"
+"        append(\n"
+"            [\n"
+"                terminal=pngcairo,\n"
+"                dimensions=wxplot_size,\n"
+"                file_name=name\n"
+"            ],\n"
+"            contents\n"
+"        )\n"
+"    ),\n"
+"    show_image(printf(false,\"~a.png\",name))\n"
+");\n"
+"pngdraw2d(name,[contents]):=\n"
+"    pngdraw(name,gr2d(contents));\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1062
+#, fuzzy, no-wrap
+#| msgid "## Can I set the aspect ratio of an embedded plot?"
+msgid "Can I set the aspect ratio of an embedded plot?"
+msgstr "## Puis-je définir le rapport hauteur/largeur (aspect ratio) d’un graphique en ligne ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1065
+msgid "Use the variable `wxplot_size`:"
+msgstr "Utilisez la variable `wxplot_size` :"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1066
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw2d(\n"
+#| "    explicit(sin(x),x,1,10)\n"
+#| "),wxplot_size=[1000,1000];\n"
+#| "```\n"
+msgid ""
+"wxdraw2d(\n"
+"    explicit(sin(x),x,1,10)\n"
+"),wxplot_size=[1000,1000];\n"
+msgstr ""
+"```maxima\n"
+"wxdraw2d(\n"
+"    explicit(sin(x),x,1,10)\n"
+"),wxplot_size=[1000,1000];\n"
+"```\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1072
+#, fuzzy, no-wrap
+#| msgid "## After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
+msgid "After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
+msgstr "## Après la mise à niveau vers macOS 13.1, les commandes plot et/ou draw affichent des messages d'erreur du type"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:1074
+#, fuzzy, no-wrap
+#| msgid "```text 1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```"
+msgid ""
+"1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102\n"
+"2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52\n"
+"3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408\n"
+"...\n"
+msgstr "```text 1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1082
+#, fuzzy, no-wrap
+#| msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information."
+msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.\n"
+msgstr "Ce problème pourrait être lié au système d'exploitation. Désactiver le masquage automatique de la barre de menus (via Réglages Système => Bureau et Dock => Barre des menus) pourrait résoudre le problème. Pour plus d'informations, voir [l'issue wxMaxima #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746)."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1083
+#, fuzzy, no-wrap
+#| msgid "## Logging"
+msgid "Logging"
+msgstr "## Journalisation"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1088
+#, fuzzy, no-wrap
+#| msgid "Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build, the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable this window using the \"View->Toggle log window\" menu entry."
+msgid ""
+"Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build,\n"
+"the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable\n"
+"this window using the \"View->Toggle log window\" menu entry.\n"
+msgstr "Les messages du journal peuvent être utiles pour déboguer des problèmes. WxMaxima peut enregistrer de nombreux événements. La plupart des entrées du journal seront utiles aux développeurs, notamment en cas de problème ou de bogue. Si vous exécutez une version « Release », la fenêtre du journal n’est pas affichée par défaut ; si vous exécutez une version de développement, elle est affichée par défaut comme une seconde fenêtre. Vous pouvez activer ou désactiver cette fenêtre via le menu « Affichage -> Basculer la fenêtre du journal »."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1090
+msgid ""
+"Messages are not 'lost', if the log window is not shown, if you select to "
+"show the log window later, you will see past log messages (if you did not "
+"clear the messages)."
+msgstr ""
+"Les messages ne sont pas « perdus » si la fenêtre du journal n’est pas "
+"affichée. Si vous choisissez d’afficher la fenêtre du journal plus tard, "
+"vous verrez les anciens messages du journal (à condition de ne pas les avoir "
+"effacés)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1092
+msgid ""
+"Such messages may be helpful, when you create bug reports (or trying to find "
+"a bug by yourself)."
+msgstr ""
+"Ces messages peuvent être utiles lorsque vous créez des rapports de bogues "
+"(ou que vous essayez de résoudre un bogue par vous-même)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1095
+msgid ""
+"Log messages can (additionally) be printed to STDERR, when using the command "
+"line option \"--logtostderr\". On Windows a separate text console will be "
+"opened, as a Windows GUI application does not have the standard IO connected."
+msgstr ""
+"Les messages du journal peuvent également être envoyés vers STDERR en "
+"utilisant l’option de ligne de commande « --logtostderr ». Sous Windows, une "
+"console texte distincte sera ouverte, car une application graphique Windows "
+"n’a pas de flux d’entrée/sortie standard connecté."
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1098
+#, fuzzy, no-wrap
+#| msgid "# FAQ"
+msgid "FAQ"
+msgstr "# FAQ"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1100
+#, fuzzy, no-wrap
+#| msgid "## Is there a way to make more text fit on a LaTeX page?"
+msgid "Is there a way to make more text fit on a LaTeX page?"
+msgstr "## Comment faire tenir plus de texte sur une page LaTeX ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1103
+msgid ""
+"Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to "
+"specify the size of the borders."
+msgstr ""
+"Oui. Utilisez le [package LaTeX \"geometry\"](https://ctan.org/pkg/geometry) "
+"pour définir la taille des marges."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1105
+#, fuzzy, no-wrap
+#| msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):"
+msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):\n"
+msgstr "Vous pouvez ajouter la ligne suivante dans le préambule LaTeX (par exemple via le champ dédié dans la fenêtre de configuration : (\"Export\" → \"Lignes supplémentaires pour le préambule TeX\") pour régler les marges à 1 cm :"
+
+#. type: Fenced code block (latex)
+#: ../../info/wxmaxima.md:1106
+#, fuzzy, no-wrap
+#| msgid "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
+msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+msgstr "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1110
+#, fuzzy, no-wrap
+#| msgid "## Is there a dark mode?"
+msgid "Is there a dark mode?"
+msgstr "## Un mode sombre existe-t-il ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1113
+msgid ""
+"If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if "
+"the rest of the operating system is. The worksheet itself is by default "
+"equipped with a bright background. But it can be configured otherwise. "
+"Alternatively, there is a `View/Invert worksheet brightness` menu entry that "
+"allows to quickly convert the worksheet from dark to bright and vice versa."
+msgstr ""
+"Si wxWidgets est suffisamment récent, _wxMaxima_ passera automatiquement en "
+"mode sombre si le système d'exploitation l'est également. Par défaut, la "
+"feuille de travail a un fond clair, mais cela peut être personnalisé. Sinon, "
+"il existe une option 'Affichage/Inverser la luminosité de la feuille' qui "
+"permet de basculer rapidement entre un fond clair et un fond sombre."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1114
+#, fuzzy, no-wrap
+#| msgid "## _WxMaxima_ sometimes hangs for several seconds once in the first minute"
+msgid "_WxMaxima_ sometimes hangs for several seconds once in the first minute"
+msgstr "## _WxMaxima_ se fige parfois pendant plusieurs secondes lors de la première minute d'utilisation"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1117
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_âs >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work."
+msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.\n"
+msgstr "_WxMaxima_ délègue certaines tâches lourdes, comme la recherche dans le manuel de _Maxima_ (plus de 1000 pages), à des processus en arrière-plan, ce qui passe généralement inaperçu. Cependant, lorsque le résultat de ces tâches est requis, il est possible que _wxMaxima_ doive attendre quelques secondes avant de pouvoir reprendre son fonctionnement normal."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1118
+#, fuzzy, no-wrap
+#| msgid "## Especially when testing new locale settings, a message box \"locale âxx_YYâ can not be set\" occurs"
+msgid "Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+msgstr "## Lors des tests pour les nouveaux paramètres de langue locale, un message d'erreur \"la locale ‘xx_YY’ ne peut pas être définie\" peut apparaître"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1121
+msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
+msgstr ""
+"![Avertissement sur la langue locale](./locale-warning.png)"
+"{ id=img_locale_warning}"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1125
+#, fuzzy
+#| msgid ""
+#| "(The same problem can occur with other applications too). The "
+#| "translations seem okay after you click on âOKâ. WxMaxima does not only "
+#| "use its own translations but the translations of the wxWidgets framework "
+#| "too."
+msgid ""
+"(The same problem can occur with other applications too). The translations "
+"seem okay after you click on ’OK’. WxMaxima does not only use its own "
+"translations but the translations of the wxWidgets framework too."
+msgstr ""
+"(Ce problème peut également survenir avec d'autres applications). Les "
+"traductions semblent correctes après avoir cliqué sur OK. _WxMaxima_ "
+"n'utilise pas seulement ses propres traductions, mais aussi celles du "
+"framework wxWidgets."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1128
+msgid ""
+"These locales maybe not present in the system. On Ubuntu/Debian systems they "
+"can be generated using: `dpkg-reconfigure locales`"
+msgstr ""
+"Ces langues locales peuvent ne pas être présentes dans le système. Sur les "
+"systèmes Ubuntu/Debian, elles peuvent être générées avec : `dpkg-reconfigure "
+"locales`"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1129
+#, fuzzy, no-wrap
+#| msgid "## How can I use symbols for real numbers, natural numbers (â, â), etc.?"
+msgid "How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
+msgstr "## Comment utiliser les symboles pour les nombres réels, pour les entiers naturels (ℝ, ℕ), etc. ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1132
+#, fuzzy
+#| msgid ""
+#| "You can find these symbols in the Unicode sidebar (search for âdouble-"
+#| "struck capitalâ). But the selected font must also support these symbols. "
+#| "If they do not display properly, select another font."
+msgid ""
+"You can find these symbols in the Unicode sidebar (search for ’double-struck "
+"capital’). But the selected font must also support these symbols. If they do "
+"not display properly, select another font."
+msgstr ""
+"Vous pouvez trouver ces symboles dans la barre latérale des symboles Unicode "
+"(recherchez « double-struck capital »). Cependant, la police sélectionnée "
+"doit également les prendre en charge. Si ceux-ci ne s'affichent pas "
+"correctement, choisissez une autre police."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1133
+#, fuzzy, no-wrap
+#| msgid "## How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
+msgid "How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
+msgstr "## Comment un script Maxima peut-il déterminer s'il s'exécute sous wxMaxima ou en ligne de commande ?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1136
+msgid ""
+"If wxMaxima is used, the Maxima variable `maxima_frontend` is set to "
+"`wxmaxima`. The Maxima variable `maxima_frontend_version` contains the "
+"wxMaxima version in this case."
+msgstr ""
+"Si wxMaxima est utilisé, la variable Maxima `maxima_frontend` est définie "
+"sur `wxmaxima`. Dans ce cas, la variable Maxima `maxima_frontend_version` "
+"contient la version de wxMaxima."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1138
+msgid ""
+"If no frontend is used (you are using command line Maxima), these variables "
+"are `false`."
+msgstr ""
+"Si aucun programme pour le frontend n'est utilisé (si vous utilisez Maxima "
+"en ligne de commande), ces variables valent `false`."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1139
+#, fuzzy, no-wrap
+#| msgid "## Help! I can not save my document!"
+msgid "Help! I can not save my document!"
+msgstr "## De l'aide ! Je ne peux pas sauvegarder mon document !"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1142
+#, no-wrap
+msgid "If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.\n"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1145
+#, fuzzy, no-wrap
+#| msgid "# Command-line arguments"
+msgid "Command-line arguments"
+msgstr "# Arguments en ligne de commande"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1148
+msgid ""
+"Usually you can start programs with a graphical user interface just by "
+"clicking on a desktop icon or desktop menu entry. WxMaxima - if started from "
+"the command line - still provides some command-line switches, though."
+msgstr ""
+"Généralement, les programmes dotés d'une interface graphique se lancent "
+"simplement en cliquant sur une icône ou une entrée de menu. WxMaxima, "
+"lorsqu'il est démarré depuis la ligne de commande, accepte néanmoins "
+"certains arguments."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-v` or `--version`: Output the version information"
+msgstr "`-v` ou `--version` : affiche les informations de version"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-h` or `--help`: Output a short help text"
+msgstr "`-h` ou `--help` : affiche un texte d'aide succinct"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid ""
+"`-o` or `--open=<str>`: Open the filename given as an argument to this "
+"command-line switch"
+msgstr ""
+"`-o` ou `--open=<fichier>` : ouvre le fichier spécifié en argument de cette "
+"option de la ligne de commande"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-e` or `--eval`: Evaluate the file after opening it."
+msgstr "`-e` ou `--eval` : évalue le fichier après l'avoir ouvert."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid ""
+"`-b` or `--batch`: If the command-line opens a file all cells in this file "
+"are evaluated and the file is saved afterward. This is for example useful if "
+"the session described in the file makes _Maxima_ generate output files. "
+"Batch-processing will be stopped if _wxMaxima_ detects that _Maxima_ has "
+"output an error and will pause if _Maxima_ has a question: Mathematics is "
+"somewhat interactive by nature so a completely interaction-free batch "
+"processing cannot always be guaranteed."
+msgstr ""
+"`-b` ou `--batch` : si un fichier est ouvert en ligne de commande, toutes "
+"ses cellules sont évaluées et le fichier est ensuite enregistré. Cela peut "
+"être utile, par exemple, si la session décrite dans le fichier amène "
+"_Maxima_ à générer des fichiers de sortie. Le traitement en mode batch "
+"s'arrête si _wxMaxima_ détecte une erreur émise par _Maxima_, et "
+"s'interrompt au cas où _Maxima_ pose une question : la nature interactive "
+"des mathématiques ne permet pas toujours un traitement entièrement "
+"automatisé."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1164
+#, no-wrap
+msgid ""
+"- `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
+"- `--pipe`:                        Pipe messages from Maxima to stdout.\n"
+"- `--exit-on-error`:               Close the program on any maxima error.\n"
+"- `-f` or `--ini=<str>`: Use the init file that was given as an argument to this command-line switch\n"
+"- `-u`, `--use-version=<str>`:     Use maxima version `<str>`.\n"
+"- `-l`, `--lisp=<str>`:              Use a Maxima compiled with Lisp compiler `<str>`.\n"
+"- `-X`, `--extra-args=<str>`:        Allows to specify extra Maxima arguments\n"
+"- `-m` or `--maxima=<str>`:    allows specifying the location of the _maxima_ binary\n"
+"- `--enableipc`: Lets Maxima control wxMaxima via interprocess communications. Use this option with care.\n"
+"- `--wxmathml-lisp=<str>`:   Location of wxMathML.lisp (if not the built-in should be used, mainly for developers).\n"
+msgstr ""
+"- `--logtostderr` : redirige aussi les messages de débogage (barre latérale) vers stderr.\n"
+"- `--pipe` : transmet les messages de Maxima vers stdout.\n"
+"- `--exit-on-error` : ferme le programme en cas d’erreur Maxima.\n"
+"- `-f` ou `--ini=<fichier>` : utilise le fichier d’initialisation spécifié en argument.\n"
+"- `-u`, `--use-version=<version>` : utilise la version `<version>` de Maxima.\n"
+"- `-l`, `--lisp=<compilateur>` : utilise une version de Maxima compilée avec le compilateur Lisp `<compilateur>`.\n"
+"- `-X`, `--extra-args=<args>` : permet de passer des arguments supplémentaires à Maxima.\n"
+"- `-m` ou `--maxima=<chemin>` : spécifie l’emplacement du binaire maxima.\n"
+"- `--enableipc` : permet à Maxima de contrôler wxMaxima via une communication inter-processus (à utiliser avec prudence).\n"
+"- `--wxmathml-lisp=<fichier>` : indique l’emplacement de `wxMathML.lisp` (pour remplacer la version intégrée, principalement pour les développeur·ses).\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1166
+msgid ""
+"Instead of a minus, some operating systems might use a dash in front of the "
+"command-line switches."
+msgstr ""
+"Certains systèmes d'exploitation peuvent utiliser un tiret long (—) au lieu "
+"d'un tiret court (-) devant les options en ligne de commande."
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1169
+#, fuzzy, no-wrap
+#| msgid "# About the program, contributing to wxMaxima"
+msgid "About the program, contributing to wxMaxima"
+msgstr "# À propos du logiciel et des contributions à wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1172
+msgid ""
+"wxMaxima is mainly developed using the programming language C++ using the "
+"[wxWidgets framework](https://www.wxwidgets.org), as build system we use "
+"[CMake](https://www.cmake.org), a small part is written in Lisp. You can "
+"contribute to wxMaxima, join the wxMaxima project at <https://github.com/"
+"wxMaxima-developers/wxmaxima>, if you have knowledge of these programming "
+"languages and want to help and contribute to the open source project "
+"wxMaxima."
+msgstr ""
+"wxMaxima est principalement développé en C++ avec le framework [wxWidgets]"
+"(https://www.wxwidgets.org), et utilise [CMake](https://www.cmake.org) comme "
+"système de build. Une petite partie est écrite en Lisp. Si vous maîtrisez "
+"ces langages et souhaitez contribuer à ce projet open source, vous pouvez "
+"rejoindre l’équipe sur [GitHub](https://github.com/wxMaxima-developers/"
+"wxmaxima)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1174
+msgid ""
+"But not only programmers are necessary! You can also contribute to wxMaxima, "
+"if you help to improve the documentation, find and report bugs (and maybe "
+"bugfixes), suggest new features, help to translate wxMaxima or the manual to "
+"your language (read the README.md in the [locale subdirectory](https://"
+"github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and "
+"the manual can be translated)."
+msgstr ""
+"Mais les programmeurs ne sont pas les seul·es à pouvoir contribuer ! Vous "
+"pouvez aussi aider à améliorer wxMaxima en améliorant la documentation, en "
+"signalant (ou corrigeant) des bugs, en proposant de nouvelles "
+"fonctionnalités, en traduisant l’interface ou le manuel dans votre langue "
+"(consultez le fichier README.md dans le [dossier locales](https://github.com/"
+"wxMaxima-developers/wxmaxima/tree/main/locales) pour savoir comment "
+"procéder)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1176
+msgid "Or answer questions of other users in the discussion forum."
+msgstr ""
+"Ou répondre aux questions d'autres utilisateurs sur le forum de discussion."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1178
+msgid ""
+"The source code of wxMaxima is documented using Doxygen [here](https://"
+"wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+msgstr ""
+"Le code source de wxMaxima est documenté avec Doxygen, disponible [ici]"
+"(https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1180
+msgid ""
+"The program is nearly self-contained, so except for system libraries (and "
+"the wxWidgets library), no external dependencies (like graphic files or the "
+"Lisp part (the `wxmathML.lisp`-file) is needed, these files are included in "
+"the executable."
+msgstr ""
+"Le programme est quasi complet : hormis les bibliothèques système (et la "
+"bibliothèque wxWidgets), il ne nécessite aucune dépendance externe (comme "
+"des fichiers graphiques ou le logiciel Lisp.   Les éléments comme le fichier "
+"( `wxmathML.lisp`) sont intégrés directement dans l'exécutable."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1181
+#, fuzzy, no-wrap
+#| msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one."
+msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.\n"
+msgstr "Si vous êtes développeur et que vous souhaitez tester une version modifiée du fichier `wxmathML.lisp`  sans tout recompiler, vous pouvez utiliser l'option en ligne de commande : `--wxmathml-lisp=<chemin>` pour spécifier un autre fichier Lisp à la place de celui intégré à la version actuelle."
+
+#~ msgid "______________________________________________________________________\n"
+#~ msgstr "______________________________________________________________________\n"
+
+#~ msgid "```maxima load(draw);"
+#~ msgstr "```maxima load(draw);"
+
+#~ msgid ""
+#~ "/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
+#~ msgstr ""
+#~ "/* Une parabole dans une fenêtre #1 */ draw2d(terminal=[wxt,1],"
+#~ "explicit(x^2,x,-1,1));"
+
+#~ msgid ""
+#~ "/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
+#~ msgstr ""
+#~ "/* Une parabole dans une fenêtre #2 */ draw2d(terminal=[wxt,2],"
+#~ "explicit(x^2,x,-1,1));"
+
+#~ msgid ""
+#~ "/* Paraboloid in window #3 */ draw3d(terminal=[wxt,3],explicit(x^2+y^2,"
+#~ "x,-1,1,y,-1,1)); ```"
+#~ msgstr ""
+#~ "/* Un paraboloide dans une fenêtre #3 */ draw3d(terminal=[wxt,3],"
+#~ "explicit(x^2+y^2,x,-1,1,y,-1,1)); ```"
+
+#~ msgid "#### 2D"
+#~ msgstr "#### 2D"
+
+#~ msgid "#### 3D"
+#~ msgstr "#### 3D"
+
+#~ msgid "```maxima playback(); ```"
+#~ msgstr "```maxima playback(); ```"
+
+#~ msgid ""
+#~ "pngdraw2d(\"Test\",\n"
+#~ "        explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "pngdraw2d(\"Test\",\n"
+#~ "        explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+#~ "```\n"

--- a/locales/manual/it.po
+++ b/locales/manual/it.po
@@ -1,30 +1,37 @@
-# SOME DESCRIPTIVE TITLE
-# Copyright (C) YEAR Free Software Foundation, Inc.
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# The wxMaxima User Manual Translation
+# Copyright (C) 2020-2023 Free Software Foundation, Inc.
+# Questo file viene distribuito nei termini della stessa licenza del pacchetto wxMaxima.
+# Marco Ciampa <ciampix@posteo.net>, 2020-2023.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: wxmaxima-gui\n"
+"Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-08-04 07:28+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2026-08-02 11:43\n"
+"Last-Translator: \n"
+"Language-Team: Italian\n"
+"Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: wxmaxima-gui\n"
+"X-Crowdin-Project-ID: 917703\n"
+"X-Crowdin-Language: it\n"
+"X-Crowdin-File: /main/locales/wxMaxima/wxMaxima.pot\n"
+"X-Crowdin-File-ID: 8\n"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "# The wxMaxima user manual"
 msgid "The wxMaxima user manual"
-msgstr ""
+msgstr "# Il manuale utente di wxMaxima {-}"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:4
-#, markdown-text
 msgid ""
 "WxMaxima is a graphical user interface (GUI) for the _Maxima_ computer "
 "algebra system (CAS). WxMaxima allows one to use all of _Maxima_’s "
@@ -32,28 +39,34 @@ msgid ""
 "most commonly used features. This manual describes some of the features that "
 "make wxMaxima one of the most popular GUIs for _Maxima_."
 msgstr ""
+"wxMaxima è un'interfaccia utente grafica (GUI) per il sistema di algebra "
+"computazionale (CAS) _Maxima_. wxMaxima consente di utilizzare tutte le "
+"funzioni di _Maxima_, inoltre, fornisce comode procedure guidate per "
+"accedere alle funzionalità più comunemente utilizzate. Questo manuale "
+"descrive alcune delle funzionalità che rendono wxMaxima una delle GUI più "
+"popolari per _Maxima_."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:6
-#, markdown-text
 msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
-msgstr ""
+msgstr "![logo wxMaxima](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:9
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "# Introduction to wxMaxima"
 msgid "Introduction to wxMaxima"
-msgstr ""
+msgstr "# Introduzione a wxMaxima"
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:11
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "## _Maxima_ and wxMaxima"
 msgid "_Maxima_ and wxMaxima"
-msgstr ""
+msgstr "## _Maxima_ e wxMaxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:14
-#, markdown-text
 msgid ""
 "In the open-source domain, big systems are normally split into smaller "
 "projects that are easier to handle for small groups of developers. For "
@@ -69,10 +82,24 @@ msgid ""
 "task into smaller parts allows the developers to provide several user "
 "interfaces for the same program."
 msgstr ""
+"Nel dominio open source, i grandi sistemi sono normalmente suddivisi in "
+"progetti più piccoli che sono più facili da gestire per piccoli gruppi di "
+"sviluppatori. Ad esempio, un programma di masterizzazione di CD sarà "
+"costituito da uno strumento a riga di comando che effettivamente masterizza "
+"il CD e da un'interfaccia utente grafica che consente agli utenti di "
+"utilizzarlo senza dover conoscere tutte le opzioni della riga di comando, e "
+"di fatto senza utilizzare affatto la riga di comando. Un vantaggio di questo "
+"approccio è che il lavoro di sviluppo che è stato investito nel programma a "
+"riga di comando può essere condiviso da molti programmi: lo stesso programma "
+"a riga di comando del masterizzatore CD può essere utilizzato come plug-in "
+"\"invia-al-CD\" per un'applicazione di gestione file, per la funzione "
+"\"masterizza su CD\" di un lettore musicale e come masterizzatore di CD per "
+"uno strumento di backup su DVD. Un altro vantaggio è che suddividere una "
+"grande attività in parti più piccole consente agli sviluppatori di fornire "
+"diverse interfacce utente per lo stesso programma."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:16
-#, markdown-text
 msgid ""
 "A computer algebra system (CAS) like _Maxima_ fits into this framework. A "
 "CAS can provide the logic behind an arbitrary precision calculator "
@@ -82,16 +109,25 @@ msgid ""
 "via a command line. Often, however, an interface like _wxMaxima_ proves a "
 "more efficient way to access the software, especially for newcomers."
 msgstr ""
+"Un sistema di algebra computazionale (CAS) come _Maxima_ si inserisce in "
+"questo quadro. Un CAS può fornire la logica dietro un'applicazione di "
+"calcolatrice di precisione arbitraria o può fare trasformazioni automatiche "
+"di formule sullo sfondo di un sistema più grande (ad esempio, [Sage] "
+"(https://www.sagemath.org/)). In alternativa, può essere utilizzato "
+"direttamente come sistema indipendente. _Maxima_ è utilizzabile tramite riga "
+"di comando. Spesso, tuttavia, un'interfaccia come _wxMaxima_ si rivela un "
+"modo più efficiente per accedere al software, in particolare per i nuovi "
+"utenti."
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:17
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### _Maxima_"
 msgid "_Maxima_"
-msgstr ""
+msgstr "### _Maxima_"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:20
-#, markdown-text
 msgid ""
 "_Maxima_ is a full-featured computer algebra system (CAS). A CAS is a "
 "program that can solve mathematical problems by rearranging formulas and "
@@ -102,36 +138,40 @@ msgid ""
 "numerical methods of analysis for equations or systems of equations that "
 "cannot be solved analytically."
 msgstr ""
+"_Maxima_ è un sistema di algebra computazionale (CAS) completo. Un CAS è un "
+"programma in grado di risolvere problemi matematici riorganizzando le "
+"formule e trovando una formula che risolve il problema invece di emettere "
+"semplicemente il valore numerico del risultato. In altre parole, _Maxima_ "
+"può fungere da calcolatrice che fornisce rappresentazioni numeriche di "
+"variabili e può anche fornire soluzioni analitiche. Inoltre, offre una gamma "
+"di metodi numerici di analisi per equazioni o sistemi di equazioni che non "
+"possono essere risolti analiticamente."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:22
-#, markdown-text
 msgid ""
-"![Maxima screenshot, command line](./maxima_screenshot.png){ "
-"id=img_maxima_screenshot }"
+"![Maxima screenshot, command line](./maxima_screenshot.png)"
+"{ id=img_maxima_screenshot }"
 msgstr ""
+"![schermata di Maxima, riga di comando](./maxima_screenshot.png)"
+"{ id=img_maxima_screenshot }"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:24
-#, markdown-text, no-wrap
-msgid ""
-"Extensive documentation for _Maxima_ is  [available in the "
-"internet](https://maxima.sourceforge.io/documentation.html). Part of this "
-"documentation is also available in wxMaxima’s help menu. Pressing the Help "
-"key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s "
-"context-sensitive help feature to automatically jump to _Maxima_’s manual "
-"page for the command at the cursor.\n"
-msgstr ""
+#, fuzzy, no-wrap
+#| msgid "Extensive documentation for _Maxima_ is [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor."
+msgid "Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.\n"
+msgstr "Ampia documentazione per _Maxima_ è [disponibile su Internet] (https://maxima.sourceforge.io/documentation.html). Parte di questa documentazione è disponibile anche nel menu di aiuto di wxMaxima. Premendo il tasto Guida (sulla maggior parte dei sistemi il tasto  <kbd>F1</kbd>), la funzione di guida sensibile al contesto di _wxMaxima_ passa automaticamente alla pagina di manuale di _Maxima_ per il comando sotto il cursore."
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:25
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### WxMaxima"
 msgid "WxMaxima"
-msgstr ""
+msgstr "### wxMaxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:28
-#, markdown-text
 msgid ""
 "_WxMaxima_ is a graphical user interface that provides the full "
 "functionality and flexibility of _Maxima_. WxMaxima offers users a graphical "
@@ -141,55 +181,73 @@ msgid ""
 "specification at a simple right-click. Indeed, an entire workbook can be "
 "exported, either as a HTML file or as a LaTeX file. Documentation for "
 "_wxMaxima_, including workbooks to illustrate aspects of its use, is online "
-"at the _wxMaxima_ [help "
-"site](https://wxMaxima-developers.github.io/wxmaxima/help.html), as well as "
-"via the help menu."
+"at the _wxMaxima_ [help site](https://wxMaxima-developers.github.io/wxmaxima/"
+"help.html), as well as via the help menu."
 msgstr ""
+"_wxMaxima_ è un'interfaccia utente grafica che fornisce flessibilità e tutte "
+"le funzionalità di _Maxima_. wxMaxima offre agli utenti una visualizzazione "
+"grafica e molte caratteristiche che rendono più facile lavorare con "
+"_Maxima_. Ad esempio _wxMaxima_ consente di esportare il contenuto di una "
+"qualsiasi cella (o, se necessario, anche qualsiasi parte di una formula) "
+"come testo, come LaTeX o come specifica MathML con un semplice clic destro. "
+"In effetti, è possibile esportare un'intera cartella di lavoro, sia come "
+"file HTML che come file LaTeX. La documentazione per _wxMaxima_, comprese le "
+"cartelle di lavoro per illustrare gli aspetti del suo utilizzo, è online su "
+"_wxMaxima_ [sito della guida](https://wxMaxima-developers.github.io/wxmaxima/"
+"help.html), nonché tramite il menu della guida."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:30
-#, markdown-text
 msgid "![wxMaxima window](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
-msgstr ""
+msgstr "![wxMaxima window](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:32
-#, markdown-text
 msgid ""
 "The calculations that are entered in _wxMaxima_ are performed by the "
 "_Maxima_ command-line tool in the background."
 msgstr ""
+"I calcoli immessi in _wxMaxima_ vengono eseguiti dallo strumento della riga "
+"di comando _Maxima_ in background."
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:33
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "## Workbook basics"
 msgid "Workbook basics"
-msgstr ""
+msgstr "## Nozioni di base sulle cartelle di lavoro"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:36
-#, markdown-text
 msgid ""
-"Much of _wxMaxima_ is self-explaining, but some details require "
-"attention. [This "
-"site](https://wxMaxima-developers.github.io/wxmaxima/help.html) contains a "
-"number of workbooks that address various aspects of _wxMaxima_. Working "
-"through some of these (particularly the \"10 minute _(wx)Maxima_ tutorial\") "
-"will increase one’s familiarity with both the content of _Maxima_ and the "
-"use of _wxMaxima_ to interact with _Maxima_. This manual concentrates on "
-"describing aspects of _wxMaxima_ that are not likely to be self-evident and "
-"that might not be covered in the online material."
+"Much of _wxMaxima_ is self-explaining, but some details require attention. "
+"[This site](https://wxMaxima-developers.github.io/wxmaxima/help.html) "
+"contains a number of workbooks that address various aspects of _wxMaxima_. "
+"Working through some of these (particularly the \"10 minute _(wx)Maxima_ "
+"tutorial\") will increase one’s familiarity with both the content of "
+"_Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. This manual "
+"concentrates on describing aspects of _wxMaxima_ that are not likely to be "
+"self-evident and that might not be covered in the online material."
 msgstr ""
+"Gran parte di _wxMaxima_ si spiega da sé, ma alcuni dettagli richiedono "
+"attenzione. [Questo sito](https://wxMaxima-developers.github.io/wxmaxima/"
+"help.html) contiene una serie di cartelle di lavoro che affrontano vari "
+"aspetti di _wxMaxima_. Lavorare attraverso alcuni di questi (in particolare "
+"il \"tutorial _(wx)Maxima_ di 10 minuti\") può essere utile ad aumentare la "
+"propria familiarità sia con il contenuto di _Maxima_ sia con l'uso di "
+"_wxMaxima_ per interagire con _Maxima_. Questo manuale si concentra sulla "
+"descrizione degli aspetti di _wxMaxima_ che probabilmente non sono evidenti "
+"e che potrebbero non essere trattati nel materiale online."
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:37
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### The workbook approach"
 msgid "The workbook approach"
-msgstr ""
+msgstr "### L'approccio della cartella di lavoro"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:40
-#, markdown-text
 msgid ""
 "One of the very few things that are not standard in _wxMaxima_ is that it "
 "organizes the data for _Maxima_ into cells that are evaluated (which means: "
@@ -204,10 +262,22 @@ msgid ""
 "re-evaluation of the whole document). Also, this approach is very handy for "
 "debugging."
 msgstr ""
+"Una delle pochissime cose che non sono standard in _wxMaxima_ è che "
+"organizza i dati per _Maxima_ in celle che vengono elaborate (ovvero: "
+"inviate a _Maxima_) solo quando l'utente lo richiede. Quando viene elaborata "
+"una cella, tutti i comandi in quella cella, e solo quella cella, vengono "
+"valutati in modalità 'batch'. (L'affermazione precedente non è del tutto "
+"accurata: si può selezionare un insieme di celle adiacenti e valutarle tutte "
+"assieme. Inoltre, si può istruire _Maxima_ a valutare tutte le celle in una "
+"cartella di lavoro in un solo passaggio.) L'approccio di _wxMaxima_ "
+"all'invio di comandi per l'esecuzione potrebbe sembrare poco familiare a "
+"prima vista. Tuttavia, facilita drasticamente il lavoro con documenti di "
+"grandi dimensioni (dove l'utente potrebbe non desiderare che ogni modifica "
+"attivi automaticamente una rivalutazione completa dell'intero documento). "
+"Inoltre, questo approccio è molto utile per la ricerca difetti."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:42
-#, markdown-text
 msgid ""
 "If text is typed into _wxMaxima_ it automatically creates a new worksheet "
 "cell. The type of this cell can be selected in the toolbar. If a code cell "
@@ -215,16 +285,20 @@ msgid ""
 "calculation to be displayed below the code. A pair of such commands is shown "
 "below."
 msgstr ""
+"Se il testo viene digitato in _wxMaxima_, si crea automaticamente una nuova "
+"cella del foglio di lavoro. Il tipo di questa cella può essere selezionato "
+"nella barra degli strumenti. Se viene creata una cella di codice, la cella "
+"può essere inviata a _Maxima_, il che fa sì che il risultato del calcolo "
+"venga visualizzato sotto il codice. Di seguito viene mostrata una coppia di "
+"tali comandi."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:44
-#, markdown-text
 msgid "![Input/output cell](./InputCell.png){ id=img_InputCell }"
-msgstr ""
+msgstr "![Input/output cell](./InputCell.png){ id=img_InputCell }"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:46
-#, markdown-text
 msgid ""
 "On evaluation of an input cell’s contents the input cell _Maxima_ assigns a "
 "label to the input (by default shown in red and recognizable by the `%i`) by "
@@ -234,10 +308,18 @@ msgid ""
 "default the user-defined label is displayed. The `%o`-style label _Maxima_ "
 "auto-generates will also be accessible, though."
 msgstr ""
+"Sulla valutazione del contenuto di una cella di ingresso, la cella di "
+"ingresso _Maxima_ assegna un'etichetta all'ingresso (per impostazione "
+"predefinita mostrata in rosso e riconoscibile da `%i`) con la quale può "
+"essere referenziata successivamente durante la sessione. L'uscita generata "
+"da _Maxima_ ottiene anch'essa un'etichetta, la quale inizia con `%o` e, per "
+"impostazione predefinita, è nascosta, tranne se l'utente assegna un nome "
+"all'uscita. In questo caso, ancora per impostazione predefinita, viene "
+"visualizzata un'etichetta definita dall'utente. Anche l'etichetta in stile "
+"`%o`\\ _Maxima_ e generata automaticamente, sarà accessibile."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:48
-#, markdown-text
 msgid ""
 "Besides the input cells _wxMaxima_ allows for text cells for documentation, "
 "image cells, title cells, chapter cells and section cells. Every cell has "
@@ -246,78 +328,86 @@ msgid ""
 "the worksheet itself has a global undo buffer that can undo cell edits, adds "
 "and deletes."
 msgstr ""
+"Oltre alle celle di ingresso, _wxMaxima_ consente l'uso di celle di testo "
+"per la documentazione, celle immagine, celle titolo, celle capitolo e celle "
+"sezione. Ogni cella ha una propria memoria degli annullamenti, quindi "
+"eseguire la correzione modificando i valori di più celle e quindi "
+"ripristinare gradualmente le modifiche non necessarie, è piuttosto semplice. "
+"Inoltre, il foglio di lavoro stesso ha una memoria degli annullamenti "
+"globale che può annullare le modifiche, le aggiunte e le eliminazioni delle "
+"celle."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:50
-#, markdown-text
 msgid ""
 "The figure below shows different cell types (title cells, section cells, "
 "subsection cells, text cells, input/output cells and image cells)."
 msgstr ""
+"La figura seguente mostra diversi tipi di celle (celle titolo, celle "
+"sezione, celle sottosezione, celle testo, celle ingresso/uscita e celle "
+"immagine)."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:52
-#, markdown-text
 msgid ""
-"![Example of different wxMaxima cells](./cell-example.png){ "
-"id=img_cell-example }"
+"![Example of different wxMaxima cells](./cell-example.png){ id=img_cell-"
+"example }"
 msgstr ""
+"![Esempio di celle wxMaxima diverse](./cell-example.png){ id=img_cell-"
+"example }"
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:53
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Cells"
 msgid "Cells"
-msgstr ""
+msgstr "### Celle"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:56
-#, markdown-text
 msgid ""
-"The worksheet is organized in cells. WxMaxima knows the following cell "
-"types:"
+"The worksheet is organized in cells. WxMaxima knows the following cell types:"
 msgstr ""
+"Il foglio di lavoro è organizzato in celle. wxMaxima riconosce i seguenti "
+"tipi di celle:"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
-#, markdown-text
 msgid "Math cells, containing one or more lines of _Maxima_ input."
-msgstr ""
+msgstr "Celle matematiche, contenenti una o più righe di ingresso _Maxima_."
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
-#, markdown-text
 msgid "Output of, or a question from, _Maxima_."
-msgstr ""
+msgstr "Uscita di, o una domanda da parte di, _Maxima_."
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
-#, markdown-text
 msgid "Image cells."
-msgstr ""
+msgstr "Celle immagine."
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
-#, markdown-text
 msgid "Text cells, that can for example be used for documentation."
 msgstr ""
+"Celle di testo, che per esempio possono essere usate per documentazione."
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
-#, markdown-text
 msgid ""
 "A title, section or a subsection. 6 levels of different headings are "
 "possible."
 msgstr ""
+"Un titolo, sezione o sottosezione. Sono possibili 6 livelli diversi di "
+"intestazione."
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
-#, markdown-text
 msgid "Page breaks."
-msgstr ""
+msgstr "Interruzioni di pagina."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:65
-#, markdown-text
 msgid ""
 "The default behavior of _wxMaxima_ when text is entered is to automatically "
 "create a math cell. Cells of other types can be created using the Cell menu, "
@@ -325,175 +415,178 @@ msgid ""
 "toolbar. Once the non-math cell is created, whatever is typed into the file "
 "is interpreted as text."
 msgstr ""
+"Il comportamento predefinito di _wxMaxima_ quando viene inserito del testo è "
+"creare automaticamente una cella matematica. È possibile creare celle di "
+"altro tipo utilizzando il menu Cella, utilizzando i tasti di scelta rapida "
+"visualizzati nel menu o utilizzando l'elenco a discesa nella barra degli "
+"strumenti. Una volta creata la cella non-matematica, tutto ciò che viene "
+"digitato nel file viene interpretato come testo."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:67
-#, markdown-text
 msgid ""
-"A (C-style) [comment "
-"text](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#Comments) "
-"can be part of a math cell as follows: `/* This comment will be ignored by "
-"Maxima */`"
+"A (C-style) [comment text](https://maxima.sourceforge.io/docs/manual/"
+"maxima_singlepage.html#Comments) can be part of a math cell as follows: `/* "
+"This comment will be ignored by Maxima */`"
 msgstr ""
+"Un testo di commento (in stile linguaggio C) può fare parte di una cella "
+"matematica come di seguito: `/* Questo commento verrà ignorato da Maxima */`"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:69
-#, markdown-text
 msgid "\"`/*`\" marks the start of the comment, \"`*/`\" the end."
-msgstr ""
+msgstr "\"`/*`\" marca l'inizio del commento, mentre \"`*/`\" la sua fine."
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:70
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Horizontal and vertical cursors"
 msgid "Horizontal and vertical cursors"
-msgstr ""
+msgstr "### Cursori orizzontali e verticali"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:73
-#, markdown-text
 msgid ""
 "If the user tries to select a complete sentence, a word processor will try "
-"to extend the selection to automatically begin and end with a word "
-"boundary. Likewise, if more than one cell is selected, _wxMaxima_ will "
-"extend the selection to whole cells."
+"to extend the selection to automatically begin and end with a word boundary. "
+"Likewise, if more than one cell is selected, _wxMaxima_ will extend the "
+"selection to whole cells."
 msgstr ""
+"Se l'utente tenta di selezionare una frase completa, un elaboratore di testi "
+"tenterà di estendere la selezione per iniziare e terminare automaticamente "
+"con un limite di parola. Allo stesso modo _wxMaxima_ se viene selezionata "
+"più di una cella estenderà la selezione alle celle intere."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:75
-#, markdown-text
 msgid ""
 "What isn’t standard is that _wxMaxima_ provides drag-and-drop flexibility by "
 "defining two types of cursors. _WxMaxima_ will switch between them "
 "automatically when needed:"
 msgstr ""
+"Ciò che non è standard è che _wxMaxima_ fornisce flessibilità di "
+"trascinamento della selezione definendo due tipi di cursori. _wxMaxima_ "
+"passerà da uno all'altro automaticamente alla bisogna:"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:78
-#, markdown-text
 msgid ""
 "The cursor is drawn horizontally if it is moved in the space between two "
 "cells or by clicking there."
 msgstr ""
+"Il cursore viene disegnato orizzontalmente se viene spostato nello spazio "
+"tra due celle o facendo clic lì."
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:78
-#, markdown-text
 msgid ""
 "A vertical cursor that works inside a cell. This cursor is activated by "
 "moving the cursor inside a cell using the mouse pointer or the cursor keys "
 "and works much like the cursor in a text editor."
 msgstr ""
+"Un cursore verticale che funziona all'interno di una cella. Questo cursore "
+"viene attivato spostando il cursore all'interno di una cella utilizzando il "
+"puntatore del mouse o i tasti cursore e funziona in modo molto simile al "
+"cursore in un editor di testo."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:80
-#, markdown-text, no-wrap
-msgid ""
-"When you start wxMaxima, you will only see the blinking horizontal "
-"cursor. If you start typing, a math cell will be automatically created and "
-"the cursor will change to a regular vertical one (you will see a right arrow "
-"as \"prompt\", after the Math cell is evaluated "
-"(<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, "
-"`(%o1)`).\n"
-msgstr ""
+#, fuzzy, no-wrap
+#| msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`)."
+msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).\n"
+msgstr "Quando si avvia wxMaxima, è visibile solo un cursore orizzontale lampeggiante. Se si inizia a digitare, viene creata automaticamente una cella matematica e il cursore diventa verticale (si vedrà una freccia destra come \"prompt\", dopo l'elaborazione della cella matematica (<kbd>CTRL+INVIO</kbd >), si noteranno, ad esempio, le etichette `(%i1)` e `(%o1)`)."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:82
-#, markdown-text
 msgid ""
-"![(blinking) horizontal cursor after wxMaxima "
-"start](./horizontal-cursor-only.png){ id=img_horizontal_cursor_only }"
+"![(blinking) horizontal cursor after wxMaxima start](./horizontal-cursor-"
+"only.png){ id=img_horizontal_cursor_only }"
 msgstr ""
+"![(blinking) cursore orizzontale dopo l'avvio di wxMaxima](./horizontal-"
+"cursor-only.png){ id=img_horizontal_cursor_only }"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:84
-#, markdown-text
 msgid ""
 "You might want to create a different cell type (using the \"Cell\" menu), "
 "maybe a title cell or text cell, which describes, what will be done, when "
 "you start creating your worksheet."
 msgstr ""
+"Si potrebbe voler creare un altro tipo di cella (usando il menu \"Cella\"), "
+"magari una cella titolo o una cella di testo, che descriva cosa verrà fatto "
+"quando si inizi a creare il foglio di lavoro."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:86
-#, markdown-text
 msgid ""
 "If you navigate between the different cells, you will also see the "
 "(blinking) horizontal cursor, where you can insert a cell into your "
 "worksheet (either a math cell, by just start typing your formula - or a "
 "different cell type using the menu)."
 msgstr ""
+"Se si naviga tra le diverse celle, si vedrà anche il cursore orizzontale "
+"(lampeggiante), col quale si può inserire una cella nel foglio di lavoro "
+"(una cella matematica, semplicemente iniziando a digitare la formula, o un "
+"altro tipo di cella utilizzando il menu)."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:88
-#, markdown-text
 msgid ""
-"![(blinking) horizontal cursor between "
-"cells](./horizontal-cursor-between-cells.png){ "
-"id=img_horizontal_cursor_between_cells }"
+"![(blinking) horizontal cursor between cells](./horizontal-cursor-between-"
+"cells.png){ id=img_horizontal_cursor_between_cells }"
 msgstr ""
+"![(blinking) cursore orizzontale tra celle](./horizontal-cursor-between-"
+"cells.png){ id=img_horizontal_cursor_between_cells }"
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:89
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Sending cells to Maxima"
 msgid "Sending cells to Maxima"
-msgstr ""
+msgstr "### Invio delle celle a Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:92
-#, markdown-text, no-wrap
-msgid ""
-"The command in a code cell is executed once by pressing "
-"<kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the "
-"<kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter "
-"commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or "
-"<kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be "
-"configured to execute commands in response to <kbd>ENTER</kbd>.\n"
-msgstr ""
+#, fuzzy, no-wrap
+#| msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>."
+msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.\n"
+msgstr "Il comando in una cella di codice viene eseguito una volta premuti i tasti <kbd>CTRL</kbd>+<kbd>INVIO</kbd>, <kbd>MAIUSC</kbd>+<kbd>INVIO</kbd> o <kbd>INVIO</kbd> sulla tastiera. L'impostazione predefinita di _wxMaxima_ prevede l'immissione di comandi quando viene inserito <kbd>CTRL</kbd>+<kbd>INVIO</kbd> o <kbd>MAIUSC</kbd>+<kbd>INVIO</kbd>, ma _wxMaxima_ può essere configurato per eseguire comandi in risposta anche a solo <kbd>INVIO</kbd>."
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:93
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Command autocompletion"
 msgid "Command autocompletion"
-msgstr ""
+msgstr "### Autocompletamento comandi"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:96
-#, markdown-text, no-wrap
-msgid ""
-"_WxMaxima_ contains an autocompletion feature that is triggered via the menu "
-"(Cell/Complete Word) or alternatively by pressing the key combination "
-"<kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is "
-"context-sensitive. For example, if activated within a unit specification for "
-"ezUnits it will offer a list of applicable units.\n"
-msgstr ""
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units."
+msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.\n"
+msgstr "_wxMaxima_ contiene una funzione di completamento automatico che viene attivata tramite il menu (Cella/Parola completa) o in alternativa premendo la combinazione di tasti <kbd>CTRL</kbd>+<kbd>SPAZIO</kbd>. Il completamento automatico è sensibile al contesto. Ad esempio, se attivato all'interno di una specifica di unità di ezUnits, offrirà un elenco di unità applicabili."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:98
-#, markdown-text
 msgid "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
-msgstr ""
+msgstr "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:100
-#, markdown-text, no-wrap
-msgid ""
-"Besides completing a file name, a unit name, or the current command or "
-"variable name, the autocompletion is able to show a template for most of the "
-"commands indicating the type (and meaning) of the parameters this program "
-"expects. To activate this feature press "
-"<kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective "
-"menu item (Cell/Show Template).\n"
-msgstr ""
+#, fuzzy, no-wrap
+#| msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template)."
+msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).\n"
+msgstr "Oltre a completare un nome di file, un nome di unità o il nome del comando o della variabile corrente, l'autocompletamento è in grado di mostrare un modello per la maggior parte dei comandi indicando il tipo (e il significato) dei parametri che questo programma si aspetta. Per attivare questa funzione premere <kbd>MAIUSC</kbd>+<kbd>CTRL</kbd>+<kbd>SPAZIO</kbd> o selezionare la rispettiva voce di menu (Cella/Mostra modello)."
 
 #. type: Title ####
 #: ../../info/wxmaxima.md:101
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "#### Greek characters"
 msgid "Greek characters"
-msgstr ""
+msgstr "#### Caratteri greci"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:104
-#, markdown-text
 msgid ""
 "Computers traditionally stored characters in 8-bit values. This allows for a "
 "maximum of 256 different characters. All letters, numbers, and control "
@@ -501,49 +594,65 @@ msgid ""
 "rectangles for menus _etc_.) of nearly any given language can fit within "
 "that limit."
 msgstr ""
+"I computer tradizionalmente memorizzavano i caratteri in valori a 8 bit. Ciò "
+"consente un massimo di 256 caratteri diversi. Tutte le lettere, i numeri e i "
+"simboli di controllo (fine trasmissione, fine stringa, linee e bordi per "
+"disegnare rettangoli per i menu, _ecc._ .) di quasi tutte le lingue possono "
+"essere compresi in tale limitazione."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:106
-#, markdown-text
 msgid ""
 "For most countries, the codepage of 256 characters that has been chosen does "
 "not include things like Greek letters, though, that are frequently used in "
-"mathematics. To overcome this type of limitation "
-"[Unicode](https://home.unicode.org/) has been invented: An encoding that "
-"makes English text work like normal, but to use much more than 256 "
-"characters."
+"mathematics. To overcome this type of limitation [Unicode](https://home."
+"unicode.org/) has been invented: An encoding that makes English text work "
+"like normal, but to use much more than 256 characters."
 msgstr ""
+"Per la maggior parte dei paesi, la codifica di 256 caratteri che è stata "
+"scelta non include per esempio le lettere greche, che sono usate "
+"frequentemente in matematica. Per superare questo tipo di limitazione è "
+"stato inventato [Unicode](https://home.unicode.org/): una codifica che fa "
+"funzionare normalmente il testo inglese, ma può andare molto oltre il limite "
+"dei 256 caratteri."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:108
-#, markdown-text
 msgid ""
 "_Maxima_ allows Unicode if it was compiled using a Lisp compiler that either "
 "supports Unicode or that doesn’t care about the font encoding. As at least "
 "one of this pair of conditions is likely to be true. _WxMaxima_ provides a "
 "method of entering Greek characters using the keyboard:"
 msgstr ""
+"_Maxima_ consente Unicode, se è stato compilato utilizzando un compilatore "
+"Lisp che supporta Unicode o che non si preoccupa della codifica dei "
+"caratteri. Dato che è molto probabile che almeno una di questa coppia di "
+"condizioni sia vera, _wxMaxima_ fornisce un metodo per inserire caratteri "
+"greci usando la tastiera:"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:111
-#, markdown-text
 msgid ""
 "A Greek letter can be entered by pressing the <kbd>ESC</kbd> key and then "
 "starting to type the Greek character’s name."
 msgstr ""
+"È possibile inserire una lettera greca premendo il tasto <kbd>ESC</kbd> e "
+"quindi iniziare a digitare il nome del carattere greco."
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:111
-#, markdown-text
 msgid ""
 "Alternatively it can be entered by pressing <kbd>ESC</kbd>, one letter (or "
 "two for the Greek letter omicron) and <kbd>ESC</kbd> again. In this case the "
 "following letters are supported:"
 msgstr ""
+"In alternativa può essere inserito premendo <kbd>ESC</kbd>, una lettera (o "
+"due per la lettera greca omicron) e <kbd>ESC</kbd> nuovamente. In questo "
+"caso sono supportate le seguenti lettere:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:130
-#, markdown-text, no-wrap
+#, no-wrap
 msgid ""
 "| key | Greek letter | key | Greek letter | key | Greek letter |\n"
 "| :-: | :----------: | :-: | :----------: | :-: | :----------: |\n"
@@ -564,22 +673,39 @@ msgid ""
 "|  H  |     Eta      | Om  |   Omicron    |  Y  |     Psi      |\n"
 "|  T  |    Theta     |  P  |      Pi      |  O  |    Omega     |\n"
 msgstr ""
+"|tasto|Lettera greca |tasto|Lettera greca |Tasto|Lettera greca |\n"
+"|:---:|:------------:|:---:|:------------:|:---:|:------------:|\n"
+"|  a  |     alpha    |  i  |     iota     |  r  |      rho     |\n"
+"|  b  |     beta     |  k  |     kappa    |  s  |     sigma    |\n"
+"|  g  |     gamma    |  l  |    lambda    |  t  |      tau     |\n"
+"|  d  |     delta    |  m  |      mu      |  u  |    upsilon   |\n"
+"|  e  |    epsilon   |  n  |      nu      |  f  |      phi     |\n"
+"|  z  |     zeta     |  x  |      xi      |  c  |      chi     |\n"
+"|  h  |      eta     |  om |    omicron   |  y  |      psi     |\n"
+"|  q  |     theta    |  p  |      pi      |  o  |     omega    |\n"
+"|  A  |     Alpha    |  I  |     Iota     |  R  |      Rho     |\n"
+"|  B  |     Beta     |  K  |     Kappa    |  S  |     Sigma    |\n"
+"|  G  |     Gamma    |  L  |    Lambda    |  T  |      Tau     |\n"
+"|  D  |     Delta    |  M  |      Mu      |  U  |    Upsilon   |\n"
+"|  E  |    Epsilon   |  N  |      Nu      |  P  |      Phi     |\n"
+"|  Z  |     Zeta     |  X  |      Xi      |  C  |      Chi     |\n"
+"|  H  |      Eta     |  Om |    Omicron   |  Y  |      Psi     |\n"
+"|  T  |     Theta    |  P  |      Pi      |  O  |     Omega    |\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:132
-#, markdown-text
-msgid "You can also use the \"Greek letters\"-sidebar to enter the Greek letters."
+msgid ""
+"You can also use the \"Greek letters\"-sidebar to enter the Greek letters."
 msgstr ""
 
 #. type: Title #####
 #: ../../info/wxmaxima.md:133
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Attention: Lookalike characters"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:138
-#, markdown-text
 msgid ""
 "Several Latin letters look like the Greek letters, e.g. the Latin letter "
 "\"A\" and the Greek letter \"Alpha\". Although they look identical, they are "
@@ -589,7 +715,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:143
-#, markdown-text
 msgid ""
 "This might be problematic, if you assign a value to the variable A and later "
 "use the Greek letter Alpha to do something with this variable, especially on "
@@ -599,24 +724,74 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:146
-#, markdown-text
 msgid ""
 "The \"Greek letters\"-sidebar therefore has the option, that lookalike "
-"characters are not available (which can be changed using a right-click "
-"menu)."
+"characters are not available (which can be changed using a right-click menu)."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:148
-#, markdown-text
 msgid ""
 "The same mechanism also allows to enter some miscellaneous mathematical "
 "symbols:"
 msgstr ""
+"Lo stesso meccanismo permette anche di inserire alcuni simboli matematici "
+"vari:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:199
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "| keys to enter  | mathematical symbol                                   |\n"
+#| "|----------------|-------------------------------------------------------|\n"
+#| "| hbar           | Planck constant: a h with a horizontal bar above it   |\n"
+#| "| Hbar           | a H with a horizontal bar above it                    |\n"
+#| "| 2              | squared                                               |\n"
+#| "| 3              | to the power of three                                 |\n"
+#| "| /2             | 1/2                                                   |\n"
+#| "| partial        | partial sign (the d of dx/dt)                         |\n"
+#| "| integral       | integral sign                                         |\n"
+#| "| sq             | square root                                           |\n"
+#| "| ii             | imaginary                                             |\n"
+#| "| ee             | element                                               |\n"
+#| "| in             | in                                                    |\n"
+#| "| impl implies   | implies                                               |\n"
+#| "| inf            | infinity                                              |\n"
+#| "| empty          | empty                                                 |\n"
+#| "| TB             | big triangle right                                    |\n"
+#| "| tb             | small triangle right                                  |\n"
+#| "| and            | and                                                   |\n"
+#| "| or             | or                                                    |\n"
+#| "| xor            | xor                                                   |\n"
+#| "| nand           | nand                                                  |\n"
+#| "| nor            | nor                                                   |\n"
+#| "| equiv          | equivalent to                                         |\n"
+#| "| not            | not                                                   |\n"
+#| "| union          | union                                                 |\n"
+#| "| inter          | intersection                                          |\n"
+#| "| subseteq       | subset or equal                                       |\n"
+#| "| subset         | subset                                                |\n"
+#| "| notsubseteq    | not subset or equal                                   |\n"
+#| "| notsubset      | not subset                                            |\n"
+#| "| approx         | approximately                                         |\n"
+#| "| propto         | proportional to                                       |\n"
+#| "| neq != /= or # | not equal to                                          |\n"
+#| "| +/- or pm      | a plus/minus sign                                     |\n"
+#| "| <= or leq      | equal or less than                                    |\n"
+#| "| >= or geq      | equal or greater than                                 |\n"
+#| "| << or ll       | much less than                                        |\n"
+#| "| >> or gg       | much greater than                                     |\n"
+#| "| qed            | end of proof                                          |\n"
+#| "| nabla          | a nabla operator                                      |\n"
+#| "| sum            | sum sign                                              |\n"
+#| "| prod           | product sign                                          |\n"
+#| "| exists         | there exists sign                                     |\n"
+#| "| nexists        | there is no sign                                      |\n"
+#| "| parallel       | a parallel sign                                       |\n"
+#| "| perp           | a perpendicular sign                                  |\n"
+#| "| leadsto        | a leads to sign                                       |\n"
+#| "| ->             | a right arrow                                         |\n"
+#| "| -->            | a long right arrow                                    |\n"
 msgid ""
 "| keys to enter  | mathematical symbol                                   |\n"
 "| -------------- | ----------------------------------------------------- |\n"
@@ -653,11 +828,9 @@ msgid ""
 "| propto         | proportional to                                       |\n"
 "| neq != /= or # | not equal to                                          |\n"
 "| +/- or pm      | a plus/minus sign                                     |\n"
-"| \\<= or leq     | equal or less than                                    "
-"|\n"
+"| \\<= or leq     | equal or less than                                    |\n"
 "| >= or geq      | equal or greater than                                 |\n"
-"| \\<\\< or ll     | much less than                                        "
-"|\n"
+"| \\<\\< or ll     | much less than                                        |\n"
 "| >> or gg       | much greater than                                     |\n"
 "| qed            | end of proof                                          |\n"
 "| nabla          | a nabla operator                                      |\n"
@@ -671,63 +844,117 @@ msgid ""
 "| ->             | a right arrow                                         |\n"
 "| -->            | a long right arrow                                    |\n"
 msgstr ""
+"|tasti da premere| Simboli matematici                                    |\n"
+"|----------------|-------------------------------------------------------|\n"
+"| hbar           | Costante di Planck: una h con una barra orizzontale   |\n"
+"| Hbar           | Una H (maiuscola) con una barra orizzontale           |\n"
+"| 2              | al quadrato                                           |\n"
+"| 3              | al cubo                                               |\n"
+"| /2             | 1/2                                                   |\n"
+"| partial        | simbolo di derivata (la d di dx/dt)                   |\n"
+"| integral       | simbolo di integrale                                  |\n"
+"| sq             | radice quadrata                                       |\n"
+"| ii             | immaginario                                           |\n"
+"| ee             | elemento                                              |\n"
+"| in             | in                                                    |\n"
+"| impl implies   | implica                                               |\n"
+"| inf            | infinito                                              |\n"
+"| empty          | vuoto                                                 |\n"
+"| TB             | grande triangolo a destra                             |\n"
+"| tb             | piccolo triangolo a destra                            |\n"
+"| and            | and                                                   |\n"
+"| or             | or                                                    |\n"
+"| xor            | xor                                                   |\n"
+"| nand           | nand                                                  |\n"
+"| nor            | nor                                                   |\n"
+"| equiv          | equivalente a                                         |\n"
+"| not            | not                                                   |\n"
+"| union          | unione                                                |\n"
+"| inter          | intersezione                                          |\n"
+"| subseteq       | sottoinsieme o uguale                                 |\n"
+"| subset         | sottoinsieme                                          |\n"
+"| notsubseteq    | non sottoinsieme o uguale                             |\n"
+"| notsubset      | non sottoinsieme                                      |\n"
+"| approx         | approssimatamente                                     |\n"
+"| propto         | proporzionale a                                       |\n"
+"| neq != /= or # | non uguale a                                          |\n"
+"| +/- or pm      | simbolo di più/meno                                   |\n"
+"| <= or leq      | uguale o minore di                                    |\n"
+"| >= or geq      | uguale o maggiore di                                  |\n"
+"| << or ll       | molto più piccolo di                                  |\n"
+"| >> or gg       | molto maggiore di                                     |\n"
+"| qed            | cvd                                                   |\n"
+"| nabla          | un operatore nabla                                    |\n"
+"| sum            | simbolo di sommatoria                                 |\n"
+"| prod           | simbolo di prodotto                                   |\n"
+"| exists         | simbolo di esistenza                                  |\n"
+"| nexists        | simbolo di non esistenza                              |\n"
+"| parallel       | simbolo di parallelo                                  |\n"
+"| perp           | simbolo di perpendicolare                             |\n"
+"| leadsto        | simbol di conseguenza                                 |\n"
+"| ->             | una freccia a destra                                  |\n"
+"| -->            | una freccia a destra lunga                            |\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:201
-#, markdown-text
 msgid ""
-"You can also use the \"Symbols\"-sidebar to enter these Mathematical "
-"symbols."
+"You can also use the \"Symbols\"-sidebar to enter these Mathematical symbols."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:203
-#, markdown-text, no-wrap
-msgid ""
-"If a special symbol isn’t in the list, it is possible to input arbitrary "
-"Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character "
-"(hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a "
-"right-click menu that allow to display a list of all available Unicode "
-"symbols one can add to this toolbar or to the worksheet.\n"
-msgstr ""
+#, fuzzy, no-wrap
+#| msgid "If a special symbol isn’t in the list it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> [number of the character (hexadecimal)] <kbd>ESC</kbd>.\n"
+msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.\n"
+msgstr "Se un simbolo speciale non compare nell'elenco, è possibile inserire caratteri Unicode arbitrari premendo <kbd>ESC</kbd> [numero del carattere (esadecimale)] <kbd>ESC</kbd>.\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:205
-#, markdown-text, no-wrap
-msgid ""
-"<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an "
-"`a`.\n"
-msgstr ""
+#, fuzzy, no-wrap
+#| msgid "<kbd>ESC</kbd> <kbd>61</kbd> <kbd>ESC</kbd> therefore results in an `a`.\n"
+msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.\n"
+msgstr "<kbd>ESC</kbd> <kbd>61</kbd> <kbd>ESC</kbd> diventa quindi una `a`.\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:207
-#, markdown-text
+#, fuzzy
+#| msgid ""
+#| "Please note that most of these symbols (notable exceptions are the logic "
+#| "symbols) do not have a special meaning in _Maxima_ and therefore will be "
+#| "interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp "
+#| "that doesn’t support dealing with Unicode characters they might cause an "
+#| "error message instead."
 msgid ""
 "Please note that most of these symbols (notable exceptions are the logic "
 "symbols) do not have a special meaning in _Maxima_ and therefore will be "
 "interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp "
 "that doesn’t support Unicode characters they might cause an error message."
 msgstr ""
+"Si noti che la maggior parte di questi simboli (eccezioni degne di nota sono "
+"i simboli logici) non hanno un significato speciale in _Maxima_ e pertanto "
+"verranno interpretati come caratteri ordinari. Se _Maxima_ viene compilato "
+"utilizzando un Lisp che non supporta la gestione dei caratteri Unicode, "
+"potrebbero invece causare un messaggio di errore."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:210
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.  To solve that problem, select other fonts (using: Edit -> Configure -> Style)."
 msgid ""
-"It may be the case that e.g. Greek characters or mathematical symbols are "
-"not included in the selected font, then they can not be displayed.\n"
-"To solve that problem, select other fonts (using: Edit -> Configure -> "
-"Style).\n"
+"It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.\n"
+"To solve that problem, select other fonts (using: Edit -> Configure -> Style).\n"
 msgstr ""
+"Potrebbe capitare che, ad es. caratteri greci o simboli matematici non siano stati inclusi nel font selezionato, e quindi non possano essere visualizzati.\n"
+"Per risolvere questo problema, provare a selezionare un altro font (tramite: Modifica -> Configura -> Stile)."
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:211
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Unicode replacement"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:214
-#, markdown-text
 msgid ""
 "wxMaxima will replace several Unicode characters with their respective "
 "Maxima expressions, e.g. `²` with `^2`, `³` with `^3`, the square root sign "
@@ -737,7 +964,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:217
-#, markdown-text
 msgid ""
 "Unicode has several \"common\" fractions encoded as one Unicode code point: "
 "`¼, ½, ¾, ⅐, ⅑, ⅒, ⅓, ⅔, ⅕, ⅖, ⅗, ⅘, ⅙, ⅚, ⅛, ⅜, ⅝, ⅞`"
@@ -745,7 +971,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:219
-#, markdown-text
 msgid ""
 "wxMaxima will replace them with their Maxima representations, e.g `(1/4)` "
 "before the input is sent do Maxima. There are also `⅟`, which will be "
@@ -755,25 +980,24 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:221
-#, markdown-text
 msgid ""
 "It is recommended to use **Maxima code** (not these Unicode code points) in "
 "input cells (Rationale: (a) it might be possible, that the used font for "
-"math input does not contain them; (b) if you save the document as "
-"`wxm`-file, it is usually readable by (command line) Maxima, but these "
-"changes will of course not work in command line Maxima); but they may occur, "
-"if you cut&paste a formula from another document."
+"math input does not contain them; (b) if you save the document as `wxm`-"
+"file, it is usually readable by (command line) Maxima, but these changes "
+"will of course not work in command line Maxima); but they may occur, if you "
+"cut&paste a formula from another document."
 msgstr ""
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:222
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Side Panes"
 msgid "Side Panes"
-msgstr ""
+msgstr "### Pannelli laterali"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:225
-#, markdown-text
 msgid ""
 "Shortcuts to the most important _Maxima_ commands, things like a table of "
 "contents, windows with debug messages or a history of the last issued "
@@ -782,67 +1006,106 @@ msgid ""
 "the _wxMaxima_ window. Other useful panes is the one that allows to input "
 "Greek letters using the mouse."
 msgstr ""
+"È possibile accedere più velocemente ai comandi _Maxima_ più importanti o a "
+"cose come il sommario, finestre con messaggi diagnostici o la cronologia "
+"degli ultimi comandi emessi utilizzando i riquadri laterali. Questi possono "
+"essere abilitati utilizzando il menu \"Visualizza\". Tutti possono essere "
+"spostati in altre posizioni all'interno o all'esterno della finestra "
+"_wxMaxima_. Altro riquadro utile è quello che permette di inserire le "
+"lettere greche utilizzando il mouse."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:227
-#, markdown-text
 msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
 msgstr ""
+"![Esempio di diversi pannelli laterali](./SidePanes.png){ id=img_SidePanes }"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:230
-#, markdown-text
 msgid ""
 "In the \"table of contents\" side pane, one can increase or decrease a "
 "heading by just clicking on the heading with the right mouse button and "
 "select the next higher or lower heading type."
 msgstr ""
+"Nel riquadro laterale \"sommario\" è possibile elevare o abbassare di "
+"livello un'intestazione; è sufficiente fare clic sull'intestazione con il "
+"tasto destro del mouse e selezionare il tipo di intestazione successiva "
+"superiore o inferiore."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:232
-#, markdown-text
 msgid ""
-"![Increase or decrease headings in the TOC side "
-"pane](./Sidepane-TOC-convert-headings.png){ id=Sidepane-TOC-convert-headings "
-"}"
+"![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-"
+"headings.png){ id=Sidepane-TOC-convert-headings }"
 msgstr ""
+"![Eleva o abbassa le intestazioni nel riquadro laterale del sommario](./"
+"Sidepane-TOC-convert-headings.png){ id=Sidepane-TOC-convert-headings }"
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:233
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### MathML output"
 msgid "MathML output"
-msgstr ""
+msgstr "### Uscita MathML"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:236
-#, markdown-text
+#, fuzzy
+#| msgid ""
+#| "Several word processors and similar programs either recognize MathML "
+#| "input and automatically insert it as an editable 2D equation - or (like "
+#| "LibreOffice 5.1) have an equation editor that offers an “import MathML "
+#| "from clipboard” feature. Others support RTF maths. _wxMaxima_ therefore "
+#| "offers several entries in the right-click menu."
 msgid ""
-"Several word processors and similar programs either recognize "
-"[MathML](https://www.w3.org/Math/) input and automatically insert it as an "
-"editable 2D equation - or (like LibreOffice) have an equation editor that "
-"offers an “import MathML from clipboard” feature. Others support RTF "
-"maths. _WxMaxima_, therefore, offers several entries in the right-click "
-"menu."
+"Several word processors and similar programs either recognize [MathML]"
+"(https://www.w3.org/Math/) input and automatically insert it as an editable "
+"2D equation - or (like LibreOffice) have an equation editor that offers an "
+"“import MathML from clipboard” feature. Others support RTF maths. "
+"_WxMaxima_, therefore, offers several entries in the right-click menu."
 msgstr ""
+"Diversi elaboratori di testo e programmi simili riconoscono in ingresso "
+"MathML e lo inseriscono automaticamente come un'equazione 2D modificabile o "
+"(come LibreOffice 5.1) dispongono di un editor di equazioni che offre una "
+"funzione di \"importazione MathML dagli appunti\". Altri supportano la "
+"matematica nel formato RTF. _wxMaxima_ offre quindi diverse voci nel menu di "
+"scelta rapida."
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:237
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Markdown support"
 msgid "Markdown support"
-msgstr ""
+msgstr "### Supporto Markdown"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:240
-#, markdown-text
+#, fuzzy
+#| msgid ""
+#| "_wxMaxima_ offers a set of standard markdown conventions that don't "
+#| "collide with mathematical notation. One of this elements is bullet lists."
 msgid ""
-"_WxMaxima_ offers a set of standard "
-"[Markdown](https://en.wikipedia.org/wiki/Markdown) conventions that don’t "
-"collide with mathematical notation. One of these elements is bullet lists."
+"_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/wiki/"
+"Markdown) conventions that don’t collide with mathematical notation. One of "
+"these elements is bullet lists."
 msgstr ""
+"_wxMaxima_ offre una serie di convenzioni markdown standard che non entrano "
+"in conflitto con la notazione matematica. Una di queste sono gli elenchi "
+"puntati."
 
 #. type: Fenced code block (text)
 #: ../../info/wxmaxima.md:241
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```text\n"
+#| "Ordinary text\n"
+#| " * One item, indentation level 1\n"
+#| " * Another item at indentation level 1\n"
+#| "   * An item at a second indentation level\n"
+#| "   * A second item at the second indentation level\n"
+#| " * A third item at the first indentation level\n"
+#| "Ordinary text\n"
+#| "```\n"
 msgid ""
 "Ordinary text\n"
 " * One item, indentation level 1\n"
@@ -852,16 +1115,30 @@ msgid ""
 " * A third item at the first indentation level\n"
 "Ordinary text\n"
 msgstr ""
+"Testo normale\n"
+" * Un elemento, livello indentazione 1\n"
+" * Un altro elemento a livello indentazione 1\n"
+"   * Un elemento al secondo livello di indentazione\n"
+"   * Un secondo elemento al secondo livello di indentazione\n"
+" * Un terzo elemento al primo livello di indentazione\n"
+"Testo normale\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:252
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
 msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
-msgstr ""
+msgstr "_wxMaxima_ riconoscerà il testo che inizia con i caratteri `>` come virgolette di blocco:"
 
 #. type: Fenced code block (text)
 #: ../../info/wxmaxima.md:253
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "Ordinary text\n"
+#| "> quote quote quote quote\n"
+#| "> quote quote quote quote\n"
+#| "> quote quote quote quote\n"
+#| "Ordinary text\n"
 msgid ""
 "Ordinary text\n"
 "> quote quote quote quote\n"
@@ -869,40 +1146,42 @@ msgid ""
 "> quote quote quote quote\n"
 "Ordinary text\n"
 msgstr ""
+"Testo normale\n"
+"> citazione citazione citazione\n"
+"> citazione citazione citazione\n"
+"> citazione citazione citazione\n"
+"Testo normale\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:262
-#, markdown-text, no-wrap
-msgid ""
-"_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by "
-"the corresponding Unicode sign:\n"
-msgstr ""
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:"
+msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:\n"
+msgstr "Anche l'uscita TeX e HTML di _wxMaxima_ riconoscerà `=>` e lo sostituirà con il corrispondente simbolo Unicode:"
 
 #. type: Fenced code block (text)
 #: ../../info/wxmaxima.md:263
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid "cogito => sum.\n"
 msgid "cogito => sum.\n"
-msgstr ""
+msgstr "cogito => sum.\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:268
-#, markdown-text, no-wrap
-msgid ""
-"Other symbols the HTML and TeX export will recognize are `<=` and `>=` for "
-"comparisons, a double-pointed double arrow (`<=>`), single-headed arrows "
-"(`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also "
-"`<<` and `>>` are recognized.\n"
-msgstr ""
+#, fuzzy, no-wrap
+#| msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized."
+msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.\n"
+msgstr "Altri simboli che l'esportazione HTML e TeX riconoscerà sono `<=` e `>=` per i confronti, una doppia freccia a doppia punta (`<=>`), frecce a punta singola (`<->`, `-> ` e `<-`) e `+/-` come simbolo. Per l'uscita TeX sono riconosciuti anche `<<` e `>>`."
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:269
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Hotkeys"
 msgid "Hotkeys"
-msgstr ""
+msgstr "### Scorciatoie da tastiera"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:272
-#, markdown-text
 msgid ""
 "Most hotkeys can be found in the text of the respective menus. Since they "
 "are actually taken from the menu text and thus can be customized by the "
@@ -910,143 +1189,188 @@ msgid ""
 "keyboard, we do not document them here. A few hotkeys or hotkey aliases, "
 "though, are not documented in the menus:"
 msgstr ""
+"La maggior parte dei tasti di scelta rapida si trova nel testo dei "
+"rispettivi menu. Dal momento che sono effettivamente presi dal testo del "
+"menu e quindi possono essere personalizzati dalle traduzioni di _wxMaxima_ "
+"per soddisfare le esigenze degli utenti della tastiera locale, non vengono "
+"documentati quì. Alcuni tasti di scelta rapida o alias di tasti di scelta "
+"rapida, tuttavia, non sono documentati neanche nei menu:"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:276
-#, markdown-text
-msgid "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
-msgstr ""
-
-#. type: Bullet: '- '
-#: ../../info/wxmaxima.md:276
-#, markdown-text
 msgid ""
-"<kbd>CTRL</kbd>+<kbd>TAB</kbd> or "
-"<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</kbd> triggers the auto-completion "
-"mechanism."
+"<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
 msgstr ""
+"<kbd>CTRL</kbd>+<kbd>MAIUSC</kbd>+<kbd>CANC</kbd> elimina una cella intera."
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:276
-#, markdown-text
+#, fuzzy
+#| msgid ""
+#| "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete "
+#| "cell."
+msgid ""
+"<kbd>CTRL</kbd>+<kbd>TAB</kbd> or <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</"
+"kbd> triggers the auto-completion mechanism."
+msgstr ""
+"<kbd>CTRL</kbd>+<kbd>MAIUSC</kbd>+<kbd>CANC</kbd> elimina una cella intera."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
 msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
 msgstr ""
+"<kbd>MAIUSC</kbd>+<kbd>SPAZIO</kbd> inserisce uno spazio non divisibile."
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:277
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Raw TeX in the TeX export"
 msgid "Raw TeX in the TeX export"
-msgstr ""
+msgstr "### TeX grezzo nell'esportazione TeX"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:280
-#, markdown-text
 msgid ""
 "If a text cell begins with `TeX:` the TeX export contains the literal text "
 "that follows the `TeX:` marker. Using this feature allows the entry of TeX "
 "markup within the _wxMaxima_ workbook."
 msgstr ""
+"Se una cella di testo inizia con `TeX:`, l'esportazione TeX contiene il "
+"testo letterale che segue l'indicatore `TeX:`. L'utilizzo di questa funzione "
+"consente l'inserimento del marcatore TeX all'interno della cartella di "
+"lavoro _wxMaxima_."
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:281
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "## File Formats"
 msgid "File Formats"
-msgstr ""
+msgstr "## Formati di file"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:284
-#, markdown-text
 msgid ""
 "The material that is developed in a _wxMaxima_ session can be stored for "
 "later use in any of three ways:"
 msgstr ""
+"Il materiale sviluppato in una sessione _wxMaxima_ può essere archiviato per "
+"un uso successivo in uno dei seguenti tre modi:"
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:285
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### .mac"
 msgid ".mac"
-msgstr ""
+msgstr "### .mac"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:288
-#, markdown-text
 msgid ""
 "`.mac` files are ordinary text files that contain _Maxima_ commands. They "
 "can be read using _Maxima_’s `batch()` or `load()` command or _wxMaxima_’s "
 "File/Batch File menu entry."
 msgstr ""
+"I file `.mac` sono normali file di testo che contengono comandi _Maxima_. "
+"Possono essere letti usando il comando `batch()` o `load()` di _Maxima_ o la "
+"voce di menu File/File batch di _wxMaxima_."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:291
-#, markdown-text
 msgid ""
 "One example is shown below. `Quadratic.mac` defines a function and afterward "
 "generates a plot with `wxdraw2d()`.  Afterward the contents of the file "
 "`Quadratic.mac` are printed and newly defined function `f()` is evaluated."
 msgstr ""
+"Un esempio viene mostrato di seguito. `Quadratic.mac` definisce una funzione "
+"e successivamente genera un grafico con `wxdraw2d()`. Successivamente viene "
+"stampato il contenuto del file `Quadratic.mac` e viene valutata la nuova "
+"funzione definita `f()`."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:293
-#, markdown-text
+#, fuzzy
+#| msgid ""
+#| "![Loading a `.mac` file with `batch()`](./BatchImage.png)"
+#| "{ id=img_BatchImage }"
 msgid "![Loading a file with `batch()`](./BatchImage.png){ id=img_BatchImage }"
 msgstr ""
+"![Caricamento di un file `.mac` con `batch()`](./BatchImage.png)"
+"{ id=img_BatchImage }"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:295
-#, markdown-text
+#, fuzzy
+#| msgid ""
+#| "Attention: Although the file `Quadratic.mac` has a usual _Maxima_ "
+#| "extension (`.mac`), it can only be read by _wxMaxima_, since the command "
+#| "`wxdraw2d()` is a wxMaxima-extension to _Maxima_."
 msgid ""
 "Attention: Although the file `Quadratic.mac` has a usual _Maxima_ extension "
 "(`.mac`), it can only be read by _wxMaxima_, since the command `wxdraw2d()` "
 "is a wxMaxima-extension to _Maxima_. (Command line) Maxima will ignore the "
 "unknown command `wxdraw2d()` and print it as output again."
 msgstr ""
+"Attenzione: Sebbene il file `Quadratic.mac` abbia una normale estensione "
+"_Maxima_ (`.mac`), può essere letto solo da _wxMaxima_, poiché il comando "
+"`wxdraw2d()` è un'estensione wxMaxima di _Maxima_."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:297
-#, markdown-text
 msgid ""
 "You can be use `.mac` files for writing your own library of macros. But "
 "since they don’t contain enough structural information they cannot be read "
 "back as a _wxMaxima_ session."
 msgstr ""
+"Si può usare i file `.mac` per scrivere la propria libreria di macro. Ma dal "
+"momento che non contengono informazioni strutturali sufficienti, non possono "
+"essere rilette come sessioni _wxMaxima_."
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:298
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### .wxm"
 msgid ".wxm"
-msgstr ""
+msgstr "### .wxm"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:302
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid ".wxm files contain the worksheet except _Maxima_'s output. On Maxima versions >5.38 they can be read using _Maxima_'s `load()` function just as .mac files can be. With this plain-text format it sometimes is unavoidable that worksheets that use new features are not downwards-compatible with older versions of _wxMaxima_.\n"
 msgid ""
-"`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima "
-"versions >5.38 they can be read using _Maxima_’s `load()` function just as "
-".mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as "
-"the answer is written in the `.wxm` file (so that it can be suggested after "
-"loading), but that can Maxima not evaluate.\n"
-"You can prevent Maxima from asking questions by using `assume()` to declare "
-"some properties, Maxima wants to know.\n"
-msgstr ""
+"`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.\n"
+"You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.\n"
+msgstr "I file .wxm contengono il foglio di lavoro tranne l'uscita di _Maxima_. Nelle versioni di Maxima >5.38 possono essere letti usando la funzione `load()` di _Maxima_ proprio come possono esserlo i file .mac. Con questo formato di testo semplice a volte è inevitabile che i fogli di lavoro che utilizzano nuove funzionalità non siano compatibili verso il basso con le versioni precedenti di _wxMaxima_.\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:304
-#, markdown-text
+#, fuzzy
+#| msgid ""
+#| ".wxm files contain the worksheet except _Maxima_'s output. On Maxima "
+#| "versions >5.38 they can be read using _Maxima_'s `load()` function just "
+#| "as .mac files can be. With this plain-text format it sometimes is "
+#| "unavoidable that worksheets that use new features are not downwards-"
+#| "compatible with older versions of _wxMaxima_.\n"
 msgid ""
 "With this plain-text format, it sometimes is unavoidable that worksheets "
 "that use new features are not downwards-compatible with older versions of "
 "_wxMaxima_."
 msgstr ""
+"I file .wxm contengono il foglio di lavoro tranne l'uscita di _Maxima_. "
+"Nelle versioni di Maxima >5.38 possono essere letti usando la funzione "
+"`load()` di _Maxima_ proprio come possono esserlo i file .mac. Con questo "
+"formato di testo semplice a volte è inevitabile che i fogli di lavoro che "
+"utilizzano nuove funzionalità non siano compatibili verso il basso con le "
+"versioni precedenti di _wxMaxima_.\n"
 
 #. type: Title ####
 #: ../../info/wxmaxima.md:305
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "File Formats"
 msgid "File format of wxm files"
-msgstr ""
+msgstr "Formati di file"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:308
-#, markdown-text
 msgid ""
 "This is just a plain text file (you can open it with a text editor), "
 "containing the cell contents as some special Maxima comments."
@@ -1054,7 +1378,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:310
-#, markdown-text
 msgid "It starts with the following comment:"
 msgstr ""
 
@@ -1068,8 +1391,8 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:317
-#, markdown-text
-msgid "And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
+msgid ""
+"And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
 msgstr ""
 
 #. type: Fenced code block (maxima)
@@ -1083,7 +1406,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:325
-#, markdown-text
 msgid ""
 "or (in a Math cell the input is of course *not* commented out (the output is "
 "not saved in a `wxm` file)):"
@@ -1101,7 +1423,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:334
-#, markdown-text
 msgid ""
 "Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the "
 "image type as first line):"
@@ -1119,7 +1440,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:343
-#, markdown-text
 msgid "A page break is just one line containing:"
 msgstr ""
 
@@ -1131,7 +1451,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:349
-#, markdown-text
 msgid "And folded cells marked by:"
 msgstr ""
 
@@ -1146,27 +1465,31 @@ msgstr ""
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:356
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### .wxmx"
 msgid ".wxmx"
-msgstr ""
+msgstr "### .wxmx"
 
+# FIXME: translation of watchlist
 #. type: Plain text
 #: ../../info/wxmaxima.md:359
-#, markdown-text
 msgid ""
 "This XML-based file format saves the complete worksheet including things "
 "like the zoom factor and the watchlist. It is the preferred file format."
 msgstr ""
+"Questo formato di file basato su XML salva il foglio di lavoro completo, "
+"inclusi elementi come il fattore di zoom e la watchlist. È il formato di "
+"file preferito."
 
 #. type: Title ####
 #: ../../info/wxmaxima.md:360
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "File Formats"
 msgid "File format of wxmx files"
-msgstr ""
+msgstr "Formati di file"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:364
-#, markdown-text
 msgid ""
 "A `wxmx`-file seems to be a binary format, but one can handle it with tools, "
 "which are included in your OS. It is a zip file, one can decompress it with "
@@ -1179,27 +1502,24 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:366
-#, markdown-text
 msgid "It does contain the following files:"
 msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:371
-#, markdown-text
 msgid ""
-"`mimetype`: this file does contain the mimetype of wxMaxima files: "
-"`text/x-wxmathml`"
+"`mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-"
+"wxmathml`"
 msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:371
-#, markdown-text
-msgid "`format.txt`: a short description about wxMaxima and the wxmx file format"
+msgid ""
+"`format.txt`: a short description about wxMaxima and the wxmx file format"
 msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:371
-#, markdown-text
 msgid ""
 "Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima "
 "session and included images."
@@ -1207,7 +1527,6 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:371
-#, markdown-text
 msgid ""
 "`content.xml`: a XML document, which contains the various cells of your "
 "document in XML format."
@@ -1215,7 +1534,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:373
-#, markdown-text
 msgid ""
 "So, if something goes wrong, you can unzip a wxMaxima document (maybe rename "
 "it before to a `zip`-file), maybe make changes in the `content.xml` file "
@@ -1226,83 +1544,105 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:374
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "## Configuration options"
 msgid "Configuration options"
-msgstr ""
+msgstr "## Opzioni di configurazione"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:377
-#, markdown-text
 msgid ""
 "For some common configuration variables _wxMaxima_ offers two ways of "
 "configuring:"
 msgstr ""
+"Per alcune variabili di configurazione comuni _wxMaxima_ offre due modalità "
+"di configurazione:"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:380
-#, markdown-text
 msgid ""
 "The configuration dialog box below lets you change their default values for "
 "the current and subsequent sessions."
 msgstr ""
+"La finestra di dialogo di configurazione sottostante consente di modificare "
+"i valori predefiniti per le sessioni correnti e successive."
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:380
-#, markdown-text
 msgid ""
 "Also, the values for most configuration variables can be changed for the "
 "current session only by overwriting their values from the worksheet, as "
 "shown below."
 msgstr ""
+"Inoltre, i valori per la maggior parte delle variabili di configurazione "
+"possono essere modificati per la sessione corrente solo sovrascrivendo i "
+"loro valori dal foglio di lavoro, come mostrato di seguito."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:382
-#, markdown-text
 msgid ""
-"![wxMaxima configuration 1](./wxMaxima_configuration_001.png){ "
-"id=img_wxMaxima_configuration_001 }"
+"![wxMaxima configuration 1](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
 msgstr ""
+"![Configurazione wxMaxima 1](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:383
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Default animation framerate"
 msgid "Default animation framerate"
-msgstr ""
+msgstr "### Frequenza di quadro animazioni predefinita"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:386
-#, markdown-text
 msgid ""
 "The animation framerate that is used for new animations is kept in the "
 "variable `wxanimate_framerate`. The initial value this variable will contain "
 "in a new worksheet can be changed using the configuration dialogue."
 msgstr ""
+"La frequenza di quadro dell'animazione usata per le nuove animazioni è "
+"conservata nella variabile `wxanimate_framerate`. Il valore iniziale che "
+"questa variabile conterrà in un nuovo foglio di lavoro può essere modificato "
+"utilizzando la finestra di configurazione."
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:387
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Default plot size for new _maxima_ sessions"
 msgid "Default plot size for new _maxima_ sessions"
-msgstr ""
+msgstr "### Dimensione predefinita dei grafici per le nuove sessioni _maxima_"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:390
-#, markdown-text
 msgid ""
 "After the next start, plots embedded into the worksheet will be created with "
 "this size if the value of `wxplot_size` isn’t changed by _maxima_."
 msgstr ""
+"Al prossimo riavvio, i grafici incorporati nel foglio di lavoro verranno "
+"creati con questa dimensione se il valore di `wxplot_size` non viene "
+"modificato da _maxima_."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:392
-#, markdown-text
 msgid ""
 "In order to set the plot size of a single graph only use the following "
 "notation can be used that sets a variable’s value for one command only:"
 msgstr ""
+"Per impostare la dimensione del grafico di un singolo grafico è possibile "
+"utilizzare solo la seguente notazione che imposta il valore di una variabile "
+"per un solo comando:"
 
 #. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:393
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxdraw2d(\n"
+#| "   explicit(\n"
+#| "       x^2,\n"
+#| "\t   x,-5,5\n"
+#| "   )\n"
+#| "), wxplot_size=[480,480]$\n"
 msgid ""
 "wxdraw2d(\n"
 "   explicit(\n"
@@ -1311,129 +1651,146 @@ msgid ""
 "   )\n"
 "), wxplot_size=[480,480]$\n"
 msgstr ""
+"wxdraw2d(\n"
+"   explicit(\n"
+"       x^2,\n"
+"\t   x,-5,5\n"
+"   )\n"
+"), wxplot_size=[480,480]$\n"
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:402
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Match parenthesis in text controls"
 msgid "Match parenthesis in text controls"
-msgstr ""
+msgstr "### Abbina parentesi nei controlli di testo"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:405
-#, markdown-text
 msgid "This option enables two things:"
-msgstr ""
+msgstr "Questa opzione abilita due cose:"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:408
-#, markdown-text
 msgid ""
 "If an opening parenthesis, bracket, or double quote is entered _wxMaxima_ "
 "will insert a closing one after it."
 msgstr ""
+"Se viene inserita una apertura parentesi tonda, quadra o virgolette doppie "
+"_wxMaxima_ ne inserirà una di chiusura dopo di essa."
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:408
-#, markdown-text
 msgid ""
 "If text is selected if any of these keys is pressed the selected text will "
 "be put between the matched signs."
 msgstr ""
+"Se il testo è selezionato e viene premuto uno di questi tasti, questo verrà "
+"inserito in una coppia di segni corrispondenti."
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:409
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Don’t save the worksheet automatically"
 msgid "Don’t save the worksheet automatically"
-msgstr ""
+msgstr "### Non salvare il foglio di lavoro automaticamente"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:412
-#, markdown-text
 msgid ""
 "If this option is set, the file where the worksheet is will be overwritten "
 "only the request of the user. In case of a crash/power loss/... a recent "
 "backup copy is still made available in the temp directory, though."
 msgstr ""
+"Se questa opzione è impostata, il file in cui si trova il foglio di lavoro "
+"verrà sovrascritto solo su richiesta dell'utente. Tuttavia, in caso di "
+"arresto anomalo/interruzione dell'alimentazione/... una copia di backup "
+"recente sarà ancora disponibile nella directory temp."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:414
-#, markdown-text
 msgid ""
-"If this option isn’t set _wxMaxima_ behaves more like a modern cellphone "
-"app:"
+"If this option isn’t set _wxMaxima_ behaves more like a modern cellphone app:"
 msgstr ""
+"Se questa opzione non è impostata, _wxMaxima_ si comporta più come una "
+"moderna app per cellulari:"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:417
-#, markdown-text
 msgid "Files are saved automatically on exit"
-msgstr ""
+msgstr "I file vengono salvati automaticamente all'uscita"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:417
-#, markdown-text
 msgid "And the file will automatically be saved every 3 minutes."
-msgstr ""
+msgstr "E il file verrà automaticamente salvato ogni 3 minuti."
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:418
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Where is the configuration saved?"
 msgid "Where is the configuration saved?"
-msgstr ""
+msgstr "### Dove viene salvata la configurazione?"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:422
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets < 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).\n"
+#| "(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).\n"
 msgid ""
-"If you are using Unix/Linux, the configuration information will be saved in "
-"a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< "
-"3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is "
-"used). You can retrieve the wxWidgets version from the command "
-"`wxbuild_info();` or by using the menu option "
-"Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform "
-"GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the "
-"name).\n"
-"(Since the filename starts with a dot, `.wxMaxima` or `.config` will be "
-"hidden).\n"
+"If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).\n"
+"(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).\n"
 msgstr ""
+"Se si sta usando Unix/Linux, le informazioni di configurazione saranno salvate in un file `.wxMaxima` nella propria cartella utente (se si sta usando wxWidgets < 3.1.1), o `.config/wxMaxima.conf` ((XDG- Standard) se si utilizza wxWidgets >= 3.1.1). Si può recuperare la versione di wxWidgets dal comando `wxbuild_info();` o usando l'opzione di menu Aiuto->Informazioni. [wxWidgets](https://www.wxwidgets.org/) è la libreria GUI multipiattaforma, che è la base per _wxMaxima_ (quindi `wx` nel nome).\n"
+"(Poiché il nome del file inizia con un punto, `.wxMaxima` o `.config` saranno nascosti).\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:424
-#, markdown-text
 msgid ""
-"If you are using Windows, the configuration will be stored in the "
-"registry. You will find the entries for _wxMaxima_ at the following position "
-"in the registry: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
+"If you are using Windows, the configuration will be stored in the registry. "
+"You will find the entries for _wxMaxima_ at the following position in the "
+"registry: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
 msgstr ""
+"Se si sta usando Windows, la configurazione verrà memorizzata nel registro "
+"di sistema. Le voci per _wxMaxima_ sono nella seguente posizione nel "
+"registro: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
 
 #. type: Title #
 #: ../../info/wxmaxima.md:427
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "# Extensions to _Maxima_"
 msgid "Extensions to _Maxima_"
-msgstr ""
+msgstr "# Estensioni a _Maxima_"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:430
-#, markdown-text
 msgid ""
 "_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
 "its main purpose is to pass along commands to _Maxima_ and to report the "
 "results of executing those commands. In some cases, however, _wxMaxima_ adds "
 "functionality to _Maxima_. _WxMaxima_’s ability to generate reports by "
-"exporting a workbook’s contents to HTML and LaTeX files has been "
-"mentioned. This section considers some ways that _wxMaxima_ enhances the "
-"inclusion of graphics in a session."
+"exporting a workbook’s contents to HTML and LaTeX files has been mentioned. "
+"This section considers some ways that _wxMaxima_ enhances the inclusion of "
+"graphics in a session."
 msgstr ""
+"_wxMaxima_ è principalmente un'interfaccia utente grafica per _Maxima_. In "
+"quanto tale, il suo scopo principale è passare i comandi a _Maxima_ e "
+"riportare i risultati dell'esecuzione di tali comandi. In alcuni casi, "
+"tuttavia, _wxMaxima_ aggiunge funzionalità a _Maxima_. È stata menzionata la "
+"capacità di _wxMaxima_ di generare report esportando il contenuto di una "
+"cartella di lavoro in file HTML e LaTeX. Questa sezione descrive alcuni modi "
+"in cui _wxMaxima_ migliora l'inclusione della grafica in una sessione."
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:431
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "## Subscripted variables"
 msgid "Subscripted variables"
-msgstr ""
+msgstr "## Variabili pedice"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:434
-#, markdown-text
 msgid ""
 "`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript "
 "variable names:"
@@ -1441,7 +1798,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:436
-#, markdown-text
 msgid ""
 "If it is `false`, the functionality is off, wxMaxima will not autosubscript "
 "part of variable names after an underscore."
@@ -1449,41 +1805,40 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:438
-#, markdown-text
-msgid "If it is set to `'all`, everything after an underscore will be subscripted."
+msgid ""
+"If it is set to `'all`, everything after an underscore will be subscripted."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:440
-#, markdown-text
 msgid ""
 "If it is set to `true` variable names of the format `x_y` are displayed "
 "using a subscript if"
 msgstr ""
+"se `wxsubscripts` è impostato su vera i nomi delle variabili nel formato "
+"`x_y` vengono visualizzati utilizzando un pedice se"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:443
-#, markdown-text
+#, fuzzy
+#| msgid "`y` is a single letter"
 msgid "Either `x` or `y` is a single letter or"
-msgstr ""
+msgstr "`y` è una singola lettera"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:443
-#, markdown-text
 msgid "`y` is an integer (can include more than one character)."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:445
-#, markdown-text
 msgid ""
-"![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png){ "
-"id=img_wxsubscripts }"
+"![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png)"
+"{ id=img_wxsubscripts }"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:447
-#, markdown-text
 msgid ""
 "If the variable name doesn’t match these requirements, it can still be "
 "declared as \"to be subscripted\" using the command "
@@ -1492,22 +1847,28 @@ msgid ""
 "variable as subscripted can be reverted using the following command: "
 "`wxdeclare_subscript(variable_name,false);`"
 msgstr ""
+"Se il nome della variabile non soddisfa questi requisiti, può comunque "
+"essere dichiarato come \"da rendere pedice\" usando il comando "
+"`wxdeclare_subscript(nome_variabile);` o "
+"`wxdeclare_subscript([nome_variabile1,nome_variabile2,...]);` Dichiarare una "
+"variabile pedice può essere ripristinata usando il seguente comando: "
+"`wxdeclare_subscript(nome_variabile,false);`"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:449
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "You can use the menu \"View->Autosubscript\" to set these values.\n"
 msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:450
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "## User feedback in the status bar"
 msgid "User feedback in the status bar"
-msgstr ""
+msgstr "## Feedback utente nella barra di stato"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:453
-#, markdown-text
 msgid ""
 "Long-running commands can provide user feedback in the status bar. This user "
 "feedback is replaced by any new feedback that is placed there (allowing to "
@@ -1517,10 +1878,27 @@ msgid ""
 "_wxMaxima_): If _wxMaxima_ isn’t present the `wxstatusbar()` command will "
 "just be left unevaluated."
 msgstr ""
+"I comandi a esecuzione prolungata possono fornire feedback all'utente nella "
+"barra di stato. Questo feedback all'utente viene sostituito da qualsiasi "
+"nuovo feedback inserito lì (consentendo di utilizzarlo come indicatore di "
+"avanzamento) e viene eliminato non appena il comando corrente inviato a "
+"_Maxima_ viene terminato. È sicuro usare `wxstatusbar()` anche nelle "
+"librerie che potrebbero essere usate semplicemente solo con _Maxima_ (invece "
+"che con _wxMaxima_): Se _wxMaxima_ non è presente, il comando "
+"`wxstatusbar()` non viene valutato."
 
 #. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:454
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "for i:1 thru 10 do (\n"
+#| "    /* Tell the user how far we got */\n"
+#| "    wxstatusbar(concat(\"Pass \",i)),\n"
+#| "    /* (sleep n) is a Lisp function, which can be used */\n"
+#| "    /* with the character \"?\" before. It delays the */\n"
+#| "    /* program execution (here: for 3 seconds) */\n"
+#| "    ?sleep(3)\n"
+#| ")$\n"
 msgid ""
 "for i:1 thru 10 do (\n"
 "    /* Tell the user how far we got */\n"
@@ -1531,16 +1909,23 @@ msgid ""
 "    ?sleep(3)\n"
 ")$\n"
 msgstr ""
+"for i:1 thru 10 do (\n"
+"    /* Dice all'utente a che punto è l'esecuzione */\n"
+"    wxstatusbar(concat(\"Pass \",i)),\n"
+"    /* (sleep n) è una funzione Lisp, che può essere usata */\n"
+"    /* con prima il carattere \"?\". Ritarda */\n"
+"    /* l'esecuzione del programma (qui per 3 secondi) */\n"
+"    ?sleep(3)\n"
+")$\n"
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:465
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Exporting the worksheet from within Maxima"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:468
-#, markdown-text
 msgid ""
 "The command `wxworksheettohtml()` exports the current worksheet to an HTML "
 "file from within a running _Maxima_ session, which is convenient for "
@@ -1559,7 +1944,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:475
-#, markdown-text
 msgid ""
 "A relative file name is interpreted relative to _Maxima_’s working "
 "directory. The optional keyword options are:"
@@ -1567,21 +1951,16 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:480
-#, markdown-text, no-wrap
+#, no-wrap
 msgid ""
-"| option   | values                                          | meaning                                             "
-"|\n"
-"| -------- | ----------------------------------------------- | "
-"--------------------------------------------------- |\n"
-"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the "
-"equations are rendered in the exported page |\n"
-"| `wxmx`   | `false` (default), `true`                       | embed a "
-"downloadable `.wxmx` copy of the session    |\n"
+"| option   | values                                          | meaning                                             |\n"
+"| -------- | ----------------------------------------------- | --------------------------------------------------- |\n"
+"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |\n"
+"| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:482
-#, markdown-text
 msgid ""
 "The `flavor` values match the equation formats offered by the graphical "
 "**File → Export** dialog: `mathml` produces a self-contained page that needs "
@@ -1591,7 +1970,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:484
-#, markdown-text
 msgid ""
 "The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file "
 "the same way:"
@@ -1602,54 +1980,61 @@ msgstr ""
 #, no-wrap
 msgid ""
 "wxworksheettotex(\"report.tex\")$\n"
-"wxworksheettotex(\"report.tex\", documentclass=\"report\", "
-"documentclassoptions=\"12pt,a4paper\")$\n"
+"wxworksheettotex(\"report.tex\", documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:494
-#, markdown-text, no-wrap
+#, no-wrap
 msgid ""
-"| option                 | meaning                                                              "
-"|\n"
-"| ---------------------- | "
-"-------------------------------------------------------------------- |\n"
-"| `documentclass`        | overrides the LaTeX `\\documentclass` "
-"(e.g. `\"article\"`, `\"report\"`)  |\n"
-"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        "
-"|\n"
+"| option                 | meaning                                                              |\n"
+"| ---------------------- | -------------------------------------------------------------------- |\n"
+"| `documentclass`        | overrides the LaTeX `\\documentclass` (e.g. `\"article\"`, `\"report\"`)  |\n"
+"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        |\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:496
-#, markdown-text
 msgid "Support for `wxworksheettopdf()` is planned."
 msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:497
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "## Plotting"
 msgid "Plotting"
-msgstr ""
+msgstr "## Diagrammi"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:500
-#, markdown-text
 msgid ""
 "Plotting (having fundamentally to do with graphics) is a place where a "
 "graphical user interface will have to provide some extensions to the "
 "original program."
 msgstr ""
+"Fare diagrammi (che ha fondamentalmente a che fare con la grafica) è un "
+"luogo in cui un'interfaccia utente grafica dovrà fornire alcune estensioni "
+"al programma originale."
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:501
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Embedding a plot into the worksheet"
 msgid "Embedding a plot into the worksheet"
-msgstr ""
+msgstr "### Incorporare un diagramma nel foglio di lavoro"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:504
-#, markdown-text
+#, fuzzy
+#| msgid ""
+#| "_Maxima_ normally instructs the external program _gnuplot_ to open a "
+#| "separate window for every diagram it creates. Since many times it is "
+#| "convenient to embed graphs into the work sheet instead _wxMaxima_ "
+#| "provides its own set of plot functions that don’t differ from the "
+#| "corresponding _maxima_ functions save in their name: They are all "
+#| "prefixed by a “wx”. For example `wxplot2d` corresponds to `plot2d`, "
+#| "`wxplot3d` corresponds to `plot3d`, `wxdraw` corresponds to `draw` and "
+#| "`wxhistogram` corresponds to `histogram`."
 msgid ""
 "_Maxima_ normally instructs the external program _Gnuplot_ to open a "
 "separate window for every diagram it creates. Since many times it is "
@@ -1657,60 +2042,41 @@ msgid ""
 "its own set of plot functions that don’t differ from the corresponding "
 "_maxima_ functions save in their name: They are all prefixed by a “wx”."
 msgstr ""
+"_Maxima_ normalmente istruisce il programma esterno _gnuplot_ ad aprire una "
+"finestra separata per ogni diagramma che crea. Poiché molte volte è "
+"conveniente incorporare i grafici nel foglio di lavoro, _wxMaxima_ fornisce "
+"il proprio set di funzioni per fare diagrammi che non differiscono dalle "
+"corrispondenti funzioni _maxima_ tranne nel nome: sono tutte precedute da "
+"\"wx\". Ad esempio, `wxplot2d` corrisponde a `plot2d`, `wxplot3d` "
+"corrisponde a `plot3d`, `wxdraw` corrisponde a `draw` e `wxhistogram` "
+"corrisponde a `histogram`."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:506
-#, markdown-text
 msgid "The following plotting functions have wx-counterparts:"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:520
-#, markdown-text, no-wrap
+#, no-wrap
 msgid ""
-"| wxMaxima’s plot function | Maxima’s plot function                                                                          "
-"|\n"
-"| ------------------------ | "
-"----------------------------------------------------------------------------------------------- "
-"|\n"
-"| `wxplot2d()`             | "
-"[plot2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot2d)               "
-"|\n"
-"| `wxplot3d()`             | "
-"[plot3d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot3d)               "
-"|\n"
-"| `wxdraw2d()`             | "
-"[draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw2d)               "
-"|\n"
-"| `wxdraw3d()`             | "
-"[draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw3d)               "
-"|\n"
-"| `wxdraw()`               | "
-"[draw](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw)                   "
-"|\n"
-"| `wximplicit_plot()`      | "
-"[implicit_plot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#implicit_plot) "
-"|\n"
-"| `wxhistogram()`          | "
-"[histogram](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#histogram)         "
-"|\n"
-"| `wxscatterplot()`        | "
-"[scatterplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#scatterplot)     "
-"|\n"
-"| `wxbarsplot()`           | "
-"[barsplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#barsplot)           "
-"|\n"
-"| `wxpiechart()`           | "
-"[piechart](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#piechart)           "
-"|\n"
-"| `wxboxplot()`            | "
-"[boxplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#boxplot)             "
-"|\n"
+"| wxMaxima’s plot function | Maxima’s plot function                                                                          |\n"
+"| ------------------------ | ----------------------------------------------------------------------------------------------- |\n"
+"| `wxplot2d()`             | [plot2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot2d)               |\n"
+"| `wxplot3d()`             | [plot3d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot3d)               |\n"
+"| `wxdraw2d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw2d)               |\n"
+"| `wxdraw3d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw3d)               |\n"
+"| `wxdraw()`               | [draw](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw)                   |\n"
+"| `wximplicit_plot()`      | [implicit_plot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#implicit_plot) |\n"
+"| `wxhistogram()`          | [histogram](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#histogram)         |\n"
+"| `wxscatterplot()`        | [scatterplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#scatterplot)     |\n"
+"| `wxbarsplot()`           | [barsplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#barsplot)           |\n"
+"| `wxpiechart()`           | [piechart](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#piechart)           |\n"
+"| `wxboxplot()`            | [boxplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#boxplot)             |\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:522
-#, markdown-text
 msgid ""
 "If a `wxm`-file is read by (console) Maxima, these functions are ignored "
 "(and printed as output, as other unknown functions in Maxima)."
@@ -1718,7 +2084,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:524
-#, markdown-text
 msgid ""
 "If you got problems with one of these functions, please check, if the "
 "problem exists in the the Maxima function too (e.g. you got an error with "
@@ -1731,13 +2096,13 @@ msgstr ""
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:525
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Making embedded plots bigger or smaller"
 msgid "Making embedded plots bigger or smaller"
-msgstr ""
+msgstr "### Rendere i diagrammi incorporati più grandi o più piccoli"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:528
-#, markdown-text
 msgid ""
 "As noted above, the configure dialog provides a way to change the default "
 "size plots created which sets the starting value of `wxplot_size`. The "
@@ -1745,10 +2110,24 @@ msgid ""
 "size of a plot in pixels. It can always be queried or used to set the size "
 "of the following plots:"
 msgstr ""
+"Come evidenziato sopra, la finestra di dialogo di configurazione fornisce un "
+"modo per modificare le dimensioni predefinite dei grafici creati impostando "
+"il valore iniziale di `wxplot_size`. Le routine di graficazione di "
+"_wxMaxima_ rispettano questa variabile che specifica la dimensione di un "
+"grafico in pixel. Può sempre essere interrogata o utilizzata per impostare "
+"la dimensione dei seguenti grafici:"
 
 #. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:529
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxplot_size:[1200,800]$\n"
+#| "wxdraw2d(\n"
+#| "    explicit(\n"
+#| "        sin(x),\n"
+#| "        x,1,10\n"
+#| "    )\n"
+#| ")$\n"
 msgid ""
 "wxplot_size:[1200,800]$\n"
 "wxdraw2d(\n"
@@ -1758,20 +2137,40 @@ msgid ""
 "    )\n"
 ")$\n"
 msgstr ""
+"wxplot_size:[1200,800]$\n"
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+")$\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:540
-#, markdown-text
 msgid ""
 "If the size of only one plot is to be changed _Maxima_ provides a canonical "
 "way to change an attribute only for the current cell. In this usage the "
-"specification `wxplot_size = [value1, value2]` is appended to the `wxdraw2d( "
-")` command, and is not part of the `wxdraw2d` command."
+"specification `wxplot_size = [value1, value2]` is appended to the "
+"`wxdraw2d( )` command, and is not part of the `wxdraw2d` command."
 msgstr ""
+"Se è necessario modificare la dimensione di un solo grafico, _Maxima_ "
+"fornisce un modo canonico per modificare un attributo solo per la cella "
+"corrente. Con questo metodo di utilizzo la specifica `wxplot_size = [value1, "
+"value2]` viene aggiunta al comando `wxdraw2d()` e non fa parte del comando "
+"`wxdraw2d`."
 
 #. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:541
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw2d(\n"
+#| "    explicit(\n"
+#| "        sin(x),\n"
+#| "        x,1,10\n"
+#| "    )\n"
+#| "),wxplot_size=[1600,800]$\n"
+#| "```\n"
 msgid ""
 "wxdraw2d(\n"
 "    explicit(\n"
@@ -1780,10 +2179,15 @@ msgid ""
 "    )\n"
 "),wxplot_size=[1600,800]$\n"
 msgstr ""
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+"),wxplot_size=[1600,800]$\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:551
-#, markdown-text
 msgid ""
 "Setting the size of embedded plot with `wxplot_size` works for embedded "
 "plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` "
@@ -1793,13 +2197,22 @@ msgstr ""
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:552
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Better quality plots"
 msgid "Better quality plots"
-msgstr ""
+msgstr "### Grafici di qualità superiore"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:555
-#, markdown-text
+#, fuzzy
+#| msgid ""
+#| "_Gnuplot_ doesn’t seem to provide a portable way of determining whether "
+#| "it supports the high-quality bitmap output that the cairo library "
+#| "provides. On systems where _gnuplot_ is compiled to use this library the "
+#| "pngcairo option from the configuration menu (that can be overridden by "
+#| "the variable `wxplot_pngcairo`) enables support for antialiasing and "
+#| "additional line styles. If `wxplot_pngcairo` is set without _gnuplot_ "
+#| "supporting this the result will be error messages instead of graphics."
 msgid ""
 "_Gnuplot_ doesn’t seem to provide a portable way of determining whether it "
 "supports the high-quality bitmap output that the Cairo library provides. On "
@@ -1809,73 +2222,121 @@ msgid ""
 "styles. If `wxplot_pngCairo` is set without _Gnuplot_ supporting this the "
 "result will be error messages instead of graphics."
 msgstr ""
+"_Gnuplot_ non sembra fornire un modo portatile per determinare se supporta "
+"l'uscita bitmap di alta qualità fornito dalla libreria cairo. Sui sistemi in "
+"cui _gnuplot_ è compilato per utilizzare questa libreria, l'opzione pngcairo "
+"dal menu di configurazione (che può essere sovrascritta dalla variabile "
+"`wxplot_pngcairo`) abilita il supporto per l'antialiasing e stili di linea "
+"aggiuntivi. Se `wxplot_pngcairo` è impostato senza che _gnuplot_ lo "
+"supporti, il risultato saranno messaggi di errore invece di grafici."
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:556
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
 msgid "Opening embedded plots in interactive _Gnuplot_ windows"
-msgstr ""
+msgstr "### Aprire grafici incorporati in finestre interattive _gnuplot_"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:559
-#, markdown-text
+#, fuzzy
+#| msgid ""
+#| "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
+#| "`wxplot3d` isn't supported by this feature) and the file size of the "
+#| "underlying _gnuplot_ project isn't way too high _wxMaxima_ offers a right-"
+#| "click menu that allows to open the plot in an interactive _gnuplot_ "
+#| "window."
 msgid ""
 "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
 "`wxplot3d` isn’t supported by this feature) and the file size of the "
-"underlying _Gnuplot_ project isn’t way too high _wxMaxima_ offers a "
-"right-click menu that allows to open the plot in an interactive _Gnuplot_ "
-"window."
+"underlying _Gnuplot_ project isn’t way too high _wxMaxima_ offers a right-"
+"click menu that allows to open the plot in an interactive _Gnuplot_ window."
 msgstr ""
+"Se un grafico è stato generato utilizzando i comandi di tipo `wxdraw` "
+"(`wxplot2d` e `wxplot3d` non sono supportati da questa funzione) e la "
+"dimensione del file del progetto _gnuplot_ sottostante non è troppo alta "
+"_wxMaxima_ offre un menu accessibile tramite clic con il pulsante destro del "
+"mouse che permette di aprire il grafico in una finestra _gnuplot_ "
+"interattiva."
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:560
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Opening Gnuplot’s command console in `plot` windows"
 msgid "Opening Gnuplot’s command console in `plot` windows"
-msgstr ""
+msgstr "### Apertura della console dei comandi di gnuplot in finestra `plot`"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:564
-#, markdown-text
+#, fuzzy
+#| msgid ""
+#| "On MS Windows, if in _Maxima_'s variable `gnuplot_command` \"gnuplot\" is "
+#| "replaced by \"wgnuplot\", _gnuplot_ offers the possibility to open a "
+#| "console window, where _gnuplot_ commands can be entered into. "
+#| "Unfortunately, enabling this feature causes _gnuplot_ to \"steal\" the "
+#| "keyboard focus for a short time every time a plot is prepared."
 msgid ""
-"On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and "
-"`wgnuplot.exe`.  You can configure, which command should be used using the "
+"On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and `wgnuplot."
+"exe`.  You can configure, which command should be used using the "
 "configuration menu. `wgnuplot.exe` offers the possibility to open a console "
 "window, where _gnuplot_ commands can be entered into, `gnuplot.exe` does not "
 "offer this possibility. Unfortunately, `wgnuplot.exe` causes _Gnuplot_ to "
 "\"steal\" the keyboard focus for a short time every time a plot is prepared."
 msgstr ""
+"Su MS Windows, se nella variabile `gnuplot_command` di _Maxima_ \"gnuplot\" "
+"viene sostituito da \"wgnuplot\", _gnuplot_ offre la possibilità di aprire "
+"una finestra della console, dove è possibile inserire i comandi _gnuplot_. "
+"Sfortunatamente, l'abilitazione di questa funzione fa sì che _gnuplot_ "
+"\"rubi\" il focus della tastiera per un breve periodo ogni volta che viene "
+"preparato un grafico."
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:565
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Embedding animations into the spreadsheet"
 msgid "Embedding animations into the spreadsheet"
-msgstr ""
+msgstr "### Incorporamento di animazioni nel foglio di calcolo"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:568
-#, markdown-text
 msgid ""
 "3D diagrams tend to make it hard to read quantitative data. A viable "
 "alternative might be to assign the 3rd parameter to the mouse wheel. The "
 "`with_slider_draw` command is a version of `wxdraw2d` that does prepare "
 "multiple plots and allows to switch between them by moving the slider on top "
-"of the screen. _WxMaxima_ allows to export this animation as an animated "
-"gif."
+"of the screen. _WxMaxima_ allows to export this animation as an animated gif."
 msgstr ""
+"I diagrammi 3D tendono a rendere difficile la lettura dei dati quantitativi. "
+"Una valida alternativa potrebbe essere quella di assegnare il 3° parametro "
+"alla rotellina del mouse. Il comando `with_slider_draw` è una versione di "
+"`wxdraw2d` che prepara più grafici e consente di passare da uno all'altro "
+"muovendo il cursore nella parte superiore dello schermo. _wxMaxima_ consente "
+"di esportare questa animazione come gif animata."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:570
-#, markdown-text
 msgid ""
 "The first two arguments for `with_slider_draw` are the name of the variable "
 "that is stepped between the plots and a list of the values of these "
 "variable. The arguments that follow are the ordinary arguments for "
 "`wxdraw2d`:"
 msgstr ""
+"I primi due argomenti per `with_slider_draw` sono il nome della variabile "
+"che si trova tra i grafici e un elenco dei valori di queste variabili. Gli "
+"argomenti che seguono sono gli argomenti ordinari per `wxdraw2d`:"
 
 #. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:571
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "with_slider_draw(\n"
+#| "    f,[1,2,3,4,5,6,7,10],\n"
+#| "    title=concat(\"f=\",f,\"Hz\"),\n"
+#| "    explicit(\n"
+#| "        sin(2*%pi*f*x),\n"
+#| "        x,0,1\n"
+#| "    ),grid=true\n"
+#| ");\n"
 msgid ""
 "with_slider_draw(\n"
 "    f,[1,2,3,4,5,6,7,10],\n"
@@ -1886,18 +2347,42 @@ msgid ""
 "    ),grid=true\n"
 ");\n"
 msgstr ""
+"with_slider_draw(\n"
+"    f,[1,2,3,4,5,6,7,10],\n"
+"    title=concat(\"f=\",f,\"Hz\"),\n"
+"    explicit(\n"
+"        sin(2*%pi*f*x),\n"
+"        x,0,1\n"
+"    ),grid=true\n"
+");\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:583
-#, markdown-text
 msgid ""
 "The same functionality for 3D plots is accessible as `with_slider_draw3d`, "
 "which allows for rotating 3d plots:"
 msgstr ""
+"La stessa funzionalità per i grafici 3D è accessibile come "
+"`with_slider_draw3d`, che consente di ruotare i grafici 3D:"
 
 #. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:584
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxanimate_autoplay:true;\n"
+#| "wxanimate_framerate:20;\n"
+#| "with_slider_draw3d(\n"
+#| "    α,makelist(i,i,1,360,3),\n"
+#| "    title=sconcat(\"α=\",α),\n"
+#| "    surface_hide=true,\n"
+#| "    contour=both,\n"
+#| "    view=[60,α],\n"
+#| "    explicit(\n"
+#| "        sin(x)*sin(y),\n"
+#| "        x,-π,π,\n"
+#| "        y,-π,π\n"
+#| "    )\n"
+#| ")$\n"
 msgid ""
 "wxanimate_autoplay:true;\n"
 "wxanimate_framerate:20;\n"
@@ -1914,19 +2399,49 @@ msgid ""
 "    )\n"
 ")$\n"
 msgstr ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    α,makelist(i,i,1,360,3),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,α],\n"
+"    explicit(\n"
+"        sin(x)*sin(y),\n"
+"        x,-π,π,\n"
+"        y,-π,π\n"
+"    )\n"
+")$\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:602
-#, markdown-text
 msgid ""
 "If the general shape of the plot is what matters it might suffice to move "
 "the plot just a little bit in order to make its 3D nature available to the "
 "intuition:"
 msgstr ""
+"Se ciò che conta è la forma generale del grafico, potrebbe bastare spostare "
+"leggermente il grafico per rendere intuibile la sua natura 3D:"
 
 #. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:603
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxanimate_autoplay:true;\n"
+#| "wxanimate_framerate:20;\n"
+#| "with_slider_draw3d(\n"
+#| "    t,makelist(i,i,0,2*π,.05*π),\n"
+#| "    title=sconcat(\"α=\",α),\n"
+#| "    surface_hide=true,\n"
+#| "    contour=both,\n"
+#| "    view=[60,30+5*sin(t)],\n"
+#| "    explicit(\n"
+#| "        sin(x)*y^2,\n"
+#| "        x,-2*π,2*π,\n"
+#| "        y,-2*π,2*π\n"
+#| "    )\n"
+#| ")$\n"
 msgid ""
 "wxanimate_autoplay:true;\n"
 "wxanimate_framerate:20;\n"
@@ -1943,57 +2458,89 @@ msgid ""
 "    )\n"
 ")$\n"
 msgstr ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    t,makelist(i,i,0,2*π,.05*π),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,30+5*sin(t)],\n"
+"    explicit(\n"
+"        sin(x)*y^2,\n"
+"        x,-2*π,2*π,\n"
+"        y,-2*π,2*π\n"
+"    )\n"
+")$\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:621
-#, markdown-text
 msgid ""
 "For those more familiar with `plot` than with `draw`, there is a second set "
 "of functions:"
 msgstr ""
+"Per coloro che hanno più familiarità con `plot` che con `draw` c'è un "
+"secondo insieme di funzioni:"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:624
-#, markdown-text
 msgid "`with_slider` and"
-msgstr ""
+msgstr "`with_slider` e"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:624
-#, markdown-text
 msgid "`wxanimate`."
-msgstr ""
+msgstr "`wxanimate`."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:626
-#, markdown-text
 msgid ""
 "Normally the animations are played back or exported with the frame rate "
 "chosen in the configuration of _wxMaxima_. To set the speed at an individual "
 "animation is played back the variable `wxanimate_framerate` can be used:"
 msgstr ""
+"Normalmente le animazioni vengono riprodotte o esportate con la frequenza di "
+"quadro scelta nella configurazione di _wxMaxima_. Per impostare la velocità "
+"di riproduzione di una singola animazione è possibile utilizzare la "
+"variabile `wxanimate_framerate`:"
 
 #. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:627
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxanimate(a, 10,\n"
+#| "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
 msgid ""
 "wxanimate(a, 10,\n"
 "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
 msgstr ""
+"wxanimate(a, 10,\n"
+"    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:633
-#, markdown-text
 msgid ""
 "The animation functions use _Maxima_’s `makelist` command and therefore "
 "share the pitfall that the slider variable’s value is substituted into the "
-"expression only if the variable is directly visible in the "
-"expression. Therefore the following example will fail:"
+"expression only if the variable is directly visible in the expression. "
+"Therefore the following example will fail:"
 msgstr ""
+"Le funzioni di animazione usano il comando `makelist` di _Maxima_ e quindi "
+"condividono il problema che il valore della variabile slider viene "
+"sostituito nell'espressione solo se la variabile è direttamente visibile "
+"nell'espressione. Pertanto il seguente esempio fallirà:"
 
 #. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:634
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "f:sin(a*x);\n"
+#| "with_slider_draw(\n"
+#| "    a,makelist(i/2,i,1,10),\n"
+#| "    title=concat(\"a=\",float(a)),\n"
+#| "    grid=true,\n"
+#| "    explicit(f,x,0,10)\n"
+#| ")$\n"
 msgid ""
 "f:sin(a*x);\n"
 "with_slider_draw(\n"
@@ -2003,18 +2550,37 @@ msgid ""
 "    explicit(f,x,0,10)\n"
 ")$\n"
 msgstr ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    a,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(a)),\n"
+"    grid=true,\n"
+"    explicit(f,x,0,10)\n"
+")$\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:645
-#, markdown-text
 msgid ""
 "If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
 "works fine instead:"
 msgstr ""
+"Se a _Maxima_ viene chiesto esplicitamente di sostituire il valore del "
+"dispositivo di scorrimento, il tracciato funziona invece correttamente:"
 
 #. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:646
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "f:sin(a*x);\n"
+#| "with_slider_draw(\n"
+#| "    b,makelist(i/2,i,1,10),\n"
+#| "    title=concat(\"a=\",float(b)),\n"
+#| "    grid=true,\n"
+#| "    explicit(\n"
+#| "        subst(a=b,f),\n"
+#| "        x,0,10\n"
+#| "    )\n"
+#| ")$\n"
 msgid ""
 "f:sin(a*x);\n"
 "with_slider_draw(\n"
@@ -2027,21 +2593,34 @@ msgid ""
 "    )\n"
 ")$\n"
 msgstr ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    b,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(b)),\n"
+"    grid=true,\n"
+"    explicit(\n"
+"        subst(a=b,f),\n"
+"        x,0,10\n"
+"    )\n"
+")$\n"
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:659
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "### Opening multiple plots in contemporaneous windows"
 msgid "Opening multiple plots in contemporaneous windows"
-msgstr ""
+msgstr "### Apertura di più grafici in più finestre contemporaneamente"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:662
-#, markdown-text
 msgid ""
 "While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups "
 "that support it) sometimes comes in handily. The following example comes "
 "from a post from Mario Rodriguez to the _Maxima_ mailing list:"
 msgstr ""
+"Sebbene non sia fornita da _wxMaxima_, questa funzionalità di _Maxima_ (nei "
+"setup che la supportano) a volte è utile. L'esempio seguente viene da un "
+"post di Mario Rodriguez alla mailing list _Maxima_:"
 
 #. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:663
@@ -2061,7 +2640,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:677
-#, markdown-text
 msgid ""
 "Plotting multiple plots in the same window is possible, too (the same is "
 "possible in command line Maxima with the standard `draw()` command):"
@@ -2069,7 +2647,16 @@ msgstr ""
 
 #. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:678
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "\twxdraw(\n"
+#| "\t\tgr2d(\n"
+#| "\t    \tkey=\"sin (x)\",grid=[2,2],\n"
+#| "\t    \texplicit(sin(x),x,0,2*%pi)),\n"
+#| "\t\tgr2d(\n"
+#| "\t   \tkey=\"cos (x)\",grid=[2,2],\n"
+#| "\t   \texplicit(cos(x),x,0,2*%pi))\n"
+#| "\t );\n"
 msgid ""
 "wxdraw(\n"
 "  gr2d(\n"
@@ -2080,16 +2667,23 @@ msgid ""
 "    explicit(cos(x),x,0,2*%pi))\n"
 ");\n"
 msgstr ""
+"\twxdraw(\n"
+"\t\tgr2d(\n"
+"\t    \tkey=\"sin (x)\",grid=[2,2],\n"
+"\t    \texplicit(sin(x),x,0,2*%pi)),\n"
+"\t\tgr2d(\n"
+"\t   \tkey=\"cos (x)\",grid=[2,2],\n"
+"\t   \texplicit(cos(x),x,0,2*%pi))\n"
+"\t );\n"
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:689
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "The \"Plot using draw\" side pane"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:692
-#, markdown-text
 msgid ""
 "The \"Plot using draw\" sidebar hides a simple code generator that allows "
 "generating scenes that make use of some of the flexibility of the _draw_ "
@@ -2098,13 +2692,12 @@ msgstr ""
 
 #. type: Title ####
 #: ../../info/wxmaxima.md:693
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "2D"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:696
-#, markdown-text
 msgid ""
 "Generates the skeleton of a `draw()` command that draws a 2D scene. This "
 "scene later has to be filled with commands that generate the scene’s "
@@ -2114,7 +2707,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:698
-#, markdown-text
 msgid ""
 "One helpful feature of the 2D button is that it allows to set up the scene "
 "as an animation in which a variable (by default it is _t_) has a different "
@@ -2124,13 +2716,12 @@ msgstr ""
 
 #. type: Title ####
 #: ../../info/wxmaxima.md:699
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "3D"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:702
-#, markdown-text
 msgid ""
 "Generates the skeleton of a `draw()` command that draws a 3D scene. If "
 "neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D "
@@ -2139,13 +2730,12 @@ msgstr ""
 
 #. type: Title ####
 #: ../../info/wxmaxima.md:703
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Expression"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:706
-#, markdown-text
 msgid ""
 "Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or "
 "`x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is "
@@ -2155,13 +2745,12 @@ msgstr ""
 
 #. type: Title ####
 #: ../../info/wxmaxima.md:707
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Implicit plot"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:710
-#, markdown-text
 msgid ""
 "Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or "
 "`x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command "
@@ -2171,13 +2760,12 @@ msgstr ""
 
 #. type: Title ####
 #: ../../info/wxmaxima.md:711
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Parametric plot"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:714
-#, markdown-text
 msgid ""
 "Steps a variable from a lower limit to an upper limit and uses two "
 "expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in "
@@ -2187,13 +2775,13 @@ msgstr ""
 
 #. type: Title ####
 #: ../../info/wxmaxima.md:715
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "#### Points"
 msgid "Points"
-msgstr ""
+msgstr "#### Punti"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:718
-#, markdown-text
 msgid ""
 "Draws many points that can optionally be joined. The coordinates of the "
 "points are taken from a list of lists, a 2D array or one list or array for "
@@ -2202,37 +2790,35 @@ msgstr ""
 
 #. type: Title ####
 #: ../../info/wxmaxima.md:719
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Diagram title"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:722
-#, markdown-text
 msgid "Draws a title on the upper end of the diagram,"
 msgstr ""
 
 #. type: Title ####
 #: ../../info/wxmaxima.md:723
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "#### Axis"
 msgid "Axis"
-msgstr ""
+msgstr "#### Assi"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:726
-#, markdown-text
 msgid "Sets up the axis."
 msgstr ""
 
 #. type: Title ####
 #: ../../info/wxmaxima.md:727
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Contour"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:730
-#, markdown-text
 msgid ""
 "(Only for 3D plots): Adds contour lines similar to the ones one can find in "
 "a map of a mountain to the plot commands that follow in the current `draw()` "
@@ -2243,13 +2829,12 @@ msgstr ""
 
 #. type: Title ####
 #: ../../info/wxmaxima.md:731
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Plot name"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:734
-#, markdown-text
 msgid ""
 "Adds a legend entry showing the next plot’s name to the legend of the "
 "diagram. An empty name disables generating legend entries for the following "
@@ -2258,13 +2843,12 @@ msgstr ""
 
 #. type: Title ####
 #: ../../info/wxmaxima.md:735
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Line colour"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:738
-#, markdown-text
 msgid ""
 "Sets the line colour for the following plots the current draw command "
 "contains."
@@ -2272,13 +2856,13 @@ msgstr ""
 
 #. type: Title ####
 #: ../../info/wxmaxima.md:739
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "#### Fill colour"
 msgid "Fill colour"
-msgstr ""
+msgstr "#### Colore riempimento"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:742
-#, markdown-text
 msgid ""
 "Sets the fill colour for the following plots the current draw command "
 "contains."
@@ -2286,25 +2870,24 @@ msgstr ""
 
 #. type: Title ####
 #: ../../info/wxmaxima.md:743
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "#### Grid"
 msgid "Grid"
-msgstr ""
+msgstr "#### Griglia"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:746
-#, markdown-text
 msgid "Pops up a wizard that allows to set up grid lines."
 msgstr ""
 
 #. type: Title ####
 #: ../../info/wxmaxima.md:747
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Accuracy"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:750
-#, markdown-text
 msgid ""
 "Allows to select an adequate point in the speed vs. accuracy tradeoff that "
 "is part of any plot program."
@@ -2312,13 +2895,12 @@ msgstr ""
 
 #. type: Title ###
 #: ../../info/wxmaxima.md:751
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Modify font and font size for plots"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:754
-#, markdown-text
 msgid ""
 "Especially when you use a high resolution display, the default font size "
 "might be very small. For the `draw`-based commands, you can set the font / "
@@ -2327,17 +2909,29 @@ msgstr ""
 
 #. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:755
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxdraw2d(\n"
+#| "    explicit(\n"
+#| "        sin(x),\n"
+#| "        x,1,10\n"
+#| "    )\n"
+#| "),wxplot_size=[1600,800]$\n"
 msgid ""
 "wxdraw2d(\n"
 "     font=\"Helvetica\",\n"
 "     font_size=30,\n"
 "     explicit(sin(x),x,1,10));\n"
 msgstr ""
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+"),wxplot_size=[1600,800]$\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:763
-#, markdown-text
 msgid ""
 "For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts "
 "can be set using the `gnuplot_preamble` command, e.g.:"
@@ -2348,13 +2942,11 @@ msgstr ""
 #, no-wrap
 msgid ""
 "wxplot2d(sin(x),[x,1,10],\n"
-"         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel "
-"font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
+"         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:770
-#, markdown-text
 msgid ""
 "This sets the font for the numbers to Arial with size 30, the size for the "
 "xlabel and ylabel font to 20 (with the default font)."
@@ -2362,7 +2954,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:773
-#, markdown-text
 msgid ""
 "Read the Maxima and Gnuplot documentation for further information.  Note: "
 "Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue "
@@ -2371,13 +2962,12 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:774
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Embedding graphics"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:777
-#, markdown-text
 msgid ""
 "If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
 "project can be done as easily as per drag-and-drop. But sometimes (for "
@@ -2393,13 +2983,12 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:782
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Startup files"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:785
-#, markdown-text
 msgid ""
 "The config dialogue of _wxMaxima_ offers to edit two files with commands "
 "that are executed on startup:"
@@ -2407,7 +2996,6 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:788
-#, markdown-text
 msgid ""
 "A file that contains commands that are executed on starting up _Maxima_: "
 "`maxima-init.mac`"
@@ -2415,7 +3003,6 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:788
-#, markdown-text
 msgid ""
 "one file of additional commands that are executed if _wxMaxima_ is starting "
 "_Maxima_: `wxmaxima-init.mac`"
@@ -2423,7 +3010,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:790
-#, markdown-text
 msgid ""
 "For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add "
 "`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` "
@@ -2432,7 +3018,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:792
-#, markdown-text
 msgid ""
 "These files are in the Maxima user directory (usually `%USERPROFILE%/maxima` "
 "in Windows, `$HOME/.maxima` otherwise). The location can be found out with "
@@ -2441,13 +3026,12 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:793
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Special variables wx..."
 msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:811
-#, markdown-text
 msgid ""
 "`wxsubscripts` tells _Maxima_ if it should convert variable names that "
 "contain an underscore (`R_150` or the like) into subscripted variables. See "
@@ -2457,7 +3041,6 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:811
-#, markdown-text
 msgid ""
 "`wxfilename`: This variable contains the name of the file currently opened "
 "in _wxMaxima_."
@@ -2465,7 +3048,6 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:811
-#, markdown-text
 msgid ""
 "`wxdirname`: This variable contains the name the directory, in which the "
 "file currently opened in _wxMaxima_ is."
@@ -2473,7 +3055,6 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:811
-#, markdown-text
 msgid ""
 "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_’s pngcairo "
 "terminal that provides more line styles and a better overall graphics "
@@ -2482,13 +3063,11 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:811
-#, markdown-text
 msgid "`wxplot_size` defines the resolution of embedded plots."
 msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:811
-#, markdown-text
 msgid ""
 "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
 "_Maxima_’s working directory to the directory of the current file. This "
@@ -2500,7 +3079,6 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:811
-#, markdown-text
 msgid ""
 "`wxanimate_framerate`: The number of frames per second the following "
 "animations have to be played back with."
@@ -2508,25 +3086,21 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:811
-#, markdown-text
 msgid "`wxanimate_autoplay`: Automatically play animations by default?"
 msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:811
-#, markdown-text
 msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
 msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:811
-#, markdown-text
 msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
 msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:811
-#, markdown-text
 msgid ""
 "`wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these "
 "differ by maintainer, distribution and operating system:"
@@ -2534,17 +3108,15 @@ msgstr ""
 
 #. type: Bullet: '  - '
 #: ../../info/wxmaxima.md:811
-#, markdown-text
 msgid ""
-"`wxdirs@userconfdir`: The directory the user's configuration is stored "
-"in. Same directory as `maxima_userdir` (see above) - both point at the same "
+"`wxdirs@userconfdir`: The directory the user's configuration is stored in. "
+"Same directory as `maxima_userdir` (see above) - both point at the same "
 "place, `wxdirs@userconfdir` is only useful if that is more convenient to "
 "reach from a `.mac` file than the Maxima-side variable."
 msgstr ""
 
 #. type: Bullet: '  - '
 #: ../../info/wxmaxima.md:811
-#, markdown-text
 msgid ""
 "`wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the built-in "
 "autocompletion list, ...) is installed in."
@@ -2552,7 +3124,6 @@ msgstr ""
 
 #. type: Bullet: '  - '
 #: ../../info/wxmaxima.md:811
-#, markdown-text
 msgid ""
 "`wxdirs@helpdir`: The directory the offline copy of this manual is installed "
 "in."
@@ -2560,7 +3131,6 @@ msgstr ""
 
 #. type: Bullet: '  - '
 #: ../../info/wxmaxima.md:811
-#, markdown-text
 msgid ""
 "`wxdirs@localedir`: The directory _wxMaxima_'s translation files are "
 "installed in."
@@ -2568,7 +3138,6 @@ msgstr ""
 
 #. type: Bullet: '  - '
 #: ../../info/wxmaxima.md:811
-#, markdown-text
 msgid ""
 "`wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_ is "
 "configured to start."
@@ -2576,13 +3145,12 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:812
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Pretty-printing 2D output"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:815
-#, markdown-text
 msgid ""
 "The function `table_form()` displays a 2D list in a form that is more "
 "readable than the output from _Maxima_’s default output routine. The input "
@@ -2605,7 +3173,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:826
-#, markdown-text
 msgid ""
 "As the next example shows, the lists that are assembled by the `table_form` "
 "command can be created before the command is executed."
@@ -2613,15 +3180,13 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:828
-#, markdown-text
 msgid ""
-"![A third table example](./MatrixTableExample.png){ "
-"id=img_MatrixTableExample }"
+"![A third table example](./MatrixTableExample.png)"
+"{ id=img_MatrixTableExample }"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:830
-#, markdown-text
 msgid ""
 "Also, because a matrix is a list of lists, matrices can be converted to "
 "tables in a similar fashion."
@@ -2629,15 +3194,13 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:832
-#, markdown-text
 msgid ""
-"![Another table_form example](./SecondTableExample.png){ "
-"id=img_SecondTableExample }"
+"![Another table_form example](./SecondTableExample.png)"
+"{ id=img_SecondTableExample }"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:834
-#, markdown-text
 msgid ""
 "The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that "
 "allows for more flexible formatting of matrices in wxMaxima:"
@@ -2645,13 +3208,12 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:836
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "**`wx_matrix( <matrix>, [options] )`**\n"
 msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:841
-#, markdown-text
 msgid ""
 "**`lines=true`**: Draws internal separator lines between the cells. This is "
 "required to visually separate headings from data."
@@ -2659,7 +3221,6 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:841
-#, markdown-text
 msgid ""
 "**`rownames=true`**: Tells wxMaxima that the first column of the matrix "
 "contains labels."
@@ -2667,7 +3228,6 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:841
-#, markdown-text
 msgid ""
 "**`colnames=true`**: Tells wxMaxima that the first row of the matrix "
 "contains labels."
@@ -2675,7 +3235,6 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:841
-#, markdown-text
 msgid ""
 "**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
 "around the matrix. Supported styles are: `round` `()`, `square` `[]`, "
@@ -2684,7 +3243,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:843
-#, markdown-text
 msgid "Example:"
 msgstr ""
 
@@ -2698,13 +3256,12 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:849
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Bug reporting"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:852
-#, markdown-text
 msgid ""
 "_WxMaxima_ provides a few functions that gather bug reporting information "
 "about the current system:"
@@ -2712,7 +3269,6 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:855
-#, markdown-text
 msgid ""
 "`wxbuild_info()` gathers information about the currently running version of "
 "_wxMaxima_"
@@ -2720,19 +3276,17 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:855
-#, markdown-text
 msgid "`wxbug_report()` tells how and where to file bugs"
 msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:856
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Marking output being drawn in red"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:860
-#, markdown-text
 msgid ""
 "_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a "
 "red foreground, if the second argument to the command is the text "
@@ -2741,19 +3295,17 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:861
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Output rendering."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:864
-#, markdown-text
 msgid "With `set_display()` one can set, how wxMaxima will render the output."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:866
-#, markdown-text
 msgid ""
 "`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima "
 "using an (machine readable) XML-dialect (can be seen in the \"Raw XML "
@@ -2763,17 +3315,14 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:869
-#, markdown-text, no-wrap
+#, no-wrap
 msgid ""
-"<!--- Currently that does not work as it should, the line with the output "
-"label is shifted right (issue: #2006) -->\n"
-"`set_display('ascii)` causes wxMaxima to output formulas as in command line "
-"Maxima - as ASCII-Art.\n"
+"<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->\n"
+"`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:871
-#, markdown-text
 msgid ""
 "`set_display('none)` causes 'one-line' ASCII results - the same as the "
 "command line Maxima command `display2d:false;` does."
@@ -2781,13 +3330,12 @@ msgstr ""
 
 #. type: Title #
 #: ../../info/wxmaxima.md:872
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Help menu"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:875
-#, markdown-text
 msgid ""
 "WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, "
 "tips, some example worksheets and in command line Maxima included demos (the "
@@ -2796,7 +3344,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:877
-#, markdown-text
 msgid "Please notice, that the demos write:"
 msgstr ""
 
@@ -2808,36 +3355,32 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:883
-#, markdown-text, no-wrap
-msgid ""
-"That is valid for command-line Maxima, however in wxMaxima by default it is "
-"necessary to continue the demonstration with: "
-"<kbd>CTRL</kbd>+<kbd>ENTER</kbd>\n"
+#, no-wrap
+msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:885
-#, markdown-text, no-wrap
-msgid ""
-"(That can be configured in the Configure->Worksheet->\"Hotkeys for sending "
-"commands to Maxima\" menu.)\n"
+#, no-wrap
+msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)\n"
 msgstr ""
 
 #. type: Title #
 #: ../../info/wxmaxima.md:888
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "# Troubleshooting"
 msgid "Troubleshooting"
-msgstr ""
+msgstr "# Risoluzione dei problemi"
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:890
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "## Cannot connect to _Maxima_"
 msgid "Cannot connect to _Maxima_"
-msgstr ""
+msgstr "## Estensioni a _Maxima_"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:893
-#, markdown-text
 msgid ""
 "Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ "
 "(providing the easy-to-use user interface) are separate programs that "
@@ -2845,17 +3388,16 @@ msgid ""
 "probable cause is that this connection is somehow not working. For example, "
 "a firewall could be set up in a way that it doesn’t just prevent "
 "unauthorized connections from the internet (and perhaps intercept some "
-"connections to the internet, too), but also blocks "
-"inter-process-communication inside the same computer. Note that since "
-"_Maxima_ is being run by a Lisp processor the process communication that is "
-"blocked does not necessarily have to be named \"maxima\". Common names of "
-"the program that opens the network connection would be sbcl, gcl, ccl, "
-"lisp.exe, or similar names."
+"connections to the internet, too), but also blocks inter-process-"
+"communication inside the same computer. Note that since _Maxima_ is being "
+"run by a Lisp processor the process communication that is blocked does not "
+"necessarily have to be named \"maxima\". Common names of the program that "
+"opens the network connection would be sbcl, gcl, ccl, lisp.exe, or similar "
+"names."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:895
-#, markdown-text
 msgid ""
 "On Unix computers another possible reason would be that the loopback network "
 "that provides network connections between two programs in the same computer "
@@ -2864,13 +3406,12 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:896
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "How to save data from a broken .wxmx file"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:899
-#, markdown-text
 msgid ""
 "Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ "
 "doesn’t turn on compression, so the contents of `.wxmx` files can be viewed "
@@ -2879,7 +3420,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:901
-#, markdown-text
 msgid ""
 "If the zip signature at the end of the file is still intact after renaming a "
 "broken `.wxmx` file to `.zip` most operating systems will provide a way to "
@@ -2892,20 +3432,12 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:903
-#, markdown-text, no-wrap
-msgid ""
-"And even if there isn’t such a file: The `.wxmx` file is a container format "
-"and the XML portion is stored uncompressed. It it is possible to rename the "
-"`.wxmx` file to a `.txt` file and to use a text editor to recover the XML "
-"portion of the file’s contents (it starts with `<?xml version=\"1.0\" "
-"encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after "
-"that text you will see some unreadable binary contents in the text "
-"editor).\n"
+#, no-wrap
+msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:905
-#, markdown-text
 msgid ""
 "If a text file containing only these contents (e.g. copy and paste this text "
 "into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know "
@@ -2914,15 +3446,12 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:906
-#, markdown-text, no-wrap
-msgid ""
-"I want some debug info to be displayed on the screen before my command has "
-"finished"
+#, no-wrap
+msgid "I want some debug info to be displayed on the screen before my command has finished"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:909
-#, markdown-text
 msgid ""
 "Normally _wxMaxima_ waits for the whole 2D formula to be transferred before "
 "it begins to typeset. This saves time for making many attempts to typeset a "
@@ -2933,7 +3462,16 @@ msgstr ""
 
 #. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:910
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "for i:1 thru 10 do (\n"
+#| "    /* Tell the user how far we got */\n"
+#| "    wxstatusbar(concat(\"Pass \",i)),\n"
+#| "    /* (sleep n) is a Lisp function, which can be used */\n"
+#| "    /* with the character \"?\" before. It delays the */\n"
+#| "    /* program execution (here: for 3 seconds) */\n"
+#| "    ?sleep(3)\n"
+#| ")$\n"
 msgid ""
 "for i:1 thru 10 do (\n"
 "   disp(i),\n"
@@ -2943,22 +3481,28 @@ msgid ""
 "   ?sleep(3)\n"
 ")$\n"
 msgstr ""
+"for i:1 thru 10 do (\n"
+"    /* Dice all'utente a che punto è l'esecuzione */\n"
+"    wxstatusbar(concat(\"Pass \",i)),\n"
+"    /* (sleep n) è una funzione Lisp, che può essere usata */\n"
+"    /* con prima il carattere \"?\". Ritarda */\n"
+"    /* l'esecuzione del programma (qui per 3 secondi) */\n"
+"    ?sleep(3)\n"
+")$\n"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:921
-#, markdown-text
 msgid "Alternatively one can look for the `wxstatusbar()` command above."
 msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:922
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Plotting only shows a closed empty envelope with an error message"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:925
-#, markdown-text
 msgid ""
 "This means that _wxMaxima_ could not read the file _Maxima_ that was "
 "supposed to instruct _Gnuplot_ to create."
@@ -2966,13 +3510,11 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:927
-#, markdown-text
 msgid "Possible reasons for this error are:"
 msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:932
-#, markdown-text
 msgid ""
 "The plotting command is part of a third-party package like `implicit_plot` "
 "but this package was not loaded by _Maxima_’s `load()` command before trying "
@@ -2981,7 +3523,6 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:932
-#, markdown-text
 msgid ""
 "_Maxima_ tried to do something the currently installed version of _Gnuplot_ "
 "isn’t able to understand. In this case, a file ending in `.gnuplot` located "
@@ -2992,7 +3533,6 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:932
-#, markdown-text
 msgid ""
 "Gnuplot was instructed to use the pngCairo library that provides "
 "antialiasing and additional line styles, but it was not compiled to support "
@@ -3003,19 +3543,17 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:932
-#, markdown-text
 msgid "Gnuplot didn’t output a valid `.png` file."
 msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:933
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Plotting an animation results in “error: undefined variable”"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:936
-#, markdown-text
 msgid ""
 "The value of the slider variable by default is only substituted into the "
 "expression that is to be plotted if it is visible there. Using a `subst` "
@@ -3027,13 +3565,12 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:937
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "I lost cell content and undo doesn’t remember"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:940
-#, markdown-text
 msgid ""
 "There are separate undo functions for cell operations and for changes inside "
 "of cells so chances are low that this ever happens. If it does there are "
@@ -3042,7 +3579,6 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:945
-#, markdown-text
 msgid ""
 "_WxMaxima_ actually has two undo features: The global undo buffer that is "
 "active if no cell is selected and a per-cell undo buffer that is active if "
@@ -3052,7 +3588,6 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:945
-#, markdown-text
 msgid ""
 "If you still have a way to find out what label _Maxima_ has assigned to the "
 "cell just type in the cell’s label and its contents will reappear."
@@ -3060,16 +3595,13 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:945
-#, markdown-text
 msgid ""
 "If you don’t: Don’t panic. In the “View” menu there is a way to show a "
-"history pane that shows all _Maxima_ commands that have been issued "
-"recently."
+"history pane that shows all _Maxima_ commands that have been issued recently."
 msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:945
-#, markdown-text
 msgid "If nothing else helps _Maxima_ contains a replay feature:"
 msgstr ""
 
@@ -3081,13 +3613,12 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:950
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "_WxMaxima_ starts up with the message “Maxima process terminated.”"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:953
-#, markdown-text
 msgid ""
 "One possible reason is that _Maxima_ cannot be found in the location that is "
 "set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore "
@@ -3097,13 +3628,12 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:954
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Maxima is forever calculating and not responding to input"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:957
-#, markdown-text
 msgid ""
 "It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ "
 "has finished calculating and therefore never gets informed it can send new "
@@ -3113,13 +3643,12 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:958
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "My SBCL-based _Maxima_ runs out of memory"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:961
-#, markdown-text
 msgid ""
 "The Lisp compiler SBCL by default comes with a memory limit that allows it "
 "to run even on low-end computers. When compiling a big software package like "
@@ -3133,7 +3662,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:963
-#, markdown-text
 msgid ""
 "One way to provide _Maxima_ (and thus SBCL) with command line parameters is "
 "the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration "
@@ -3142,34 +3670,31 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:965
-#, markdown-text
 msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
 msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:966
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:969
-#, markdown-text
 msgid ""
-"Installing the package `ibus-gtk` should resolve this issue. See "
-"([https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) "
-"for details."
+"Installing the package `ibus-gtk` should resolve this issue. See ([https://"
+"bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs."
+"launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) for details."
 msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:970
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "_WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:973
-#, markdown-text
 msgid ""
 "If your _Maxima_ is based on SBCL the following lines have to be added to "
 "your `.sbclrc`:"
@@ -3183,12 +3708,11 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:979
-#, markdown-text
 msgid ""
-"The folder where this file has to be placed is system- and "
-"installation-specific. But any SBCL-based _Maxima_ that already has "
-"evaluated a cell in the current session will happily tell where it can be "
-"found after getting the following command:"
+"The folder where this file has to be placed is system- and installation-"
+"specific. But any SBCL-based _Maxima_ that already has evaluated a cell in "
+"the current session will happily tell where it can be found after getting "
+"the following command:"
 msgstr ""
 
 #. type: Fenced code block (maxima)
@@ -3199,13 +3723,12 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:984
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Note concerning Wayland (recent Linux/BSD distributions)"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:988
-#, markdown-text
 msgid ""
 "There seem to be issues with the Wayland Display Server and wxWidgets.  "
 "WxMaxima may be affected, e.g. that sidebars are not moveable."
@@ -3213,7 +3736,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:992
-#, markdown-text
 msgid ""
 "You can either disable Wayland and use X11 instead (globally)  or just tell, "
 "that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
@@ -3221,25 +3743,22 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:994
-#, markdown-text
 msgid "E.g. start wxMaxima with:"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:996
-#, markdown-text
 msgid "`GDK_BACKEND=x11 wxmaxima`"
 msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:997
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "The menu bar disappears on KDE Plasma"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1003
-#, markdown-text
 msgid ""
 "On some KDE Plasma installations the global menu bar disappears when "
 "clicked.  As this is a bug in the global menu proxy, the only way to avoid "
@@ -3249,7 +3768,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1007
-#, markdown-text
 msgid ""
 "Starting with version 26.05.0, wxMaxima attempts to set this variable "
 "automatically if it detects an affected system (KDE, Unity, or Ubuntu with "
@@ -3258,25 +3776,22 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1009
-#, markdown-text
 msgid "If the automatic fix fails, you can manually start wxMaxima with:"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1011
-#, markdown-text
 msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
 msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:1012
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Why is the integrated manual browser not offered on my Windows PC?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1016
-#, markdown-text
 msgid ""
 "Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or "
 "Microsoft’s webview2 isn’t installed."
@@ -3284,31 +3799,29 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:1017
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Why is the external manual browser not working on my Linux box?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1024
-#, markdown-text
 msgid ""
 "The HTML browser might be a snap, flatpack or appimage version. All of these "
-"typically cannot access files that are installed on your local "
-"system. Another reason might be that maxima or wxMaxima is installed as a "
-"snap, flatpack or something else that doesn’t give the host system access to "
-"its contents. A third reason might be that the maxima HTML manual isn’t "
+"typically cannot access files that are installed on your local system. "
+"Another reason might be that maxima or wxMaxima is installed as a snap, "
+"flatpack or something else that doesn’t give the host system access to its "
+"contents. A third reason might be that the maxima HTML manual isn’t "
 "installed and the online one cannot be accessed."
 msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:1025
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Can I make _wxMaxima_ output both image files and embedded plots at once?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1028
-#, markdown-text
 msgid ""
 "The worksheet embeds `.png files. _WxMaxima_ allows the user to specify "
 "where they should be generated:"
@@ -3326,7 +3839,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1037
-#, markdown-text
 msgid ""
 "If a different format is to be used, it is easier to generate the images and "
 "then import them into the worksheet again:"
@@ -3361,39 +3873,48 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:1062
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Can I set the aspect ratio of an embedded plot?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1065
-#, markdown-text
 msgid "Use the variable `wxplot_size`:"
 msgstr ""
 
 #. type: Fenced code block (maxima)
 #: ../../info/wxmaxima.md:1066
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxdraw2d(\n"
+#| "    explicit(\n"
+#| "        sin(x),\n"
+#| "        x,1,10\n"
+#| "    )\n"
+#| "),wxplot_size=[1600,800]$\n"
 msgid ""
 "wxdraw2d(\n"
 "    explicit(sin(x),x,1,10)\n"
 "),wxplot_size=[1000,1000];\n"
 msgstr ""
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+"),wxplot_size=[1600,800]$\n"
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:1072
-#, markdown-text, no-wrap
-msgid ""
-"After upgrading to MacOS 13.1 plot and/or draw commands output error "
-"messages like"
+#, no-wrap
+msgid "After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
 msgstr ""
 
 #. type: Fenced code block (text)
 #: ../../info/wxmaxima.md:1074
 #, no-wrap
 msgid ""
-"1 HIToolbox 0x00007ff80cd91726 "
-"_ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102\n"
+"1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102\n"
 "2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52\n"
 "3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408\n"
 "...\n"
@@ -3401,36 +3922,27 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1082
-#, markdown-text, no-wrap
-msgid ""
-"This might be an issue with the operating system. Disable the hiding of the "
-"menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the "
-"issue. See [wxMaxima issue "
-"#1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more "
-"information.\n"
+#, no-wrap
+msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.\n"
 msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:1083
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Logging"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1088
-#, markdown-text, no-wrap
+#, no-wrap
 msgid ""
-"Log messages might be helpful to debug problems. WxMaxima can log many "
-"events. Most log entries will be helpful for developers, especially in case "
-"of problems or bugs. If you run a \"Release\"-Build,\n"
-"the log windows is not shown by default, if you run a development version, "
-"it is shown by default as a second window. You can enable and disable\n"
+"Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build,\n"
+"the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable\n"
 "this window using the \"View->Toggle log window\" menu entry.\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1090
-#, markdown-text
 msgid ""
 "Messages are not 'lost', if the log window is not shown, if you select to "
 "show the log window later, you will see past log messages (if you did not "
@@ -3439,7 +3951,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1092
-#, markdown-text
 msgid ""
 "Such messages may be helpful, when you create bug reports (or trying to find "
 "a bug by yourself)."
@@ -3447,29 +3958,26 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1095
-#, markdown-text
 msgid ""
 "Log messages can (additionally) be printed to STDERR, when using the command "
 "line option \"--logtostderr\". On Windows a separate text console will be "
-"opened, as a Windows GUI application does not have the standard IO "
-"connected."
+"opened, as a Windows GUI application does not have the standard IO connected."
 msgstr ""
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1098
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "FAQ"
 msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:1100
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Is there a way to make more text fit on a LaTeX page?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1103
-#, markdown-text
 msgid ""
 "Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to "
 "specify the size of the borders."
@@ -3477,11 +3985,8 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1105
-#, markdown-text, no-wrap
-msgid ""
-"You can add the following line to the LaTeX preamble (for example by using "
-"the respective field in the config dialogue (\"Export\"->\"Additional lines "
-"for the TeX preamble\"), to set borders of 1cm):\n"
+#, no-wrap
+msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):\n"
 msgstr ""
 
 #. type: Fenced code block (latex)
@@ -3492,56 +3997,45 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:1110
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Is there a dark mode?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1113
-#, markdown-text
 msgid ""
 "If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if "
 "the rest of the operating system is. The worksheet itself is by default "
-"equipped with a bright background. But it can be configured "
-"otherwise. Alternatively, there is a `View/Invert worksheet brightness` menu "
-"entry that allows to quickly convert the worksheet from dark to bright and "
-"vice versa."
+"equipped with a bright background. But it can be configured otherwise. "
+"Alternatively, there is a `View/Invert worksheet brightness` menu entry that "
+"allows to quickly convert the worksheet from dark to bright and vice versa."
 msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:1114
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "_WxMaxima_ sometimes hangs for several seconds once in the first minute"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1117
-#, markdown-text, no-wrap
-msgid ""
-"_WxMaxima_ delegates some big tasks like parsing _Maxima_’s "
-">1000-page-manual to background tasks, which normally goes totally "
-"unnoticed. At the moment the result of such a task is needed, though, it is "
-"possible that _wxMaxima_ needs to wait a couple of seconds before it can "
-"continue its work.\n"
+#, no-wrap
+msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.\n"
 msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:1118
-#, markdown-text, no-wrap
-msgid ""
-"Especially when testing new locale settings, a message box \"locale ’xx_YY’ "
-"can not be set\" occurs"
+#, no-wrap
+msgid "Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1121
-#, markdown-text
 msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1125
-#, markdown-text
 msgid ""
 "(The same problem can occur with other applications too). The translations "
 "seem okay after you click on ’OK’. WxMaxima does not only use its own "
@@ -3550,7 +4044,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1128
-#, markdown-text
 msgid ""
 "These locales maybe not present in the system. On Ubuntu/Debian systems they "
 "can be generated using: `dpkg-reconfigure locales`"
@@ -3558,13 +4051,12 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:1129
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1132
-#, markdown-text
 msgid ""
 "You can find these symbols in the Unicode sidebar (search for ’double-struck "
 "capital’). But the selected font must also support these symbols. If they do "
@@ -3573,15 +4065,12 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:1133
-#, markdown-text, no-wrap
-msgid ""
-"How can a Maxima script determine, if it is running under wxMaxima or "
-"command line Maxima?"
+#, no-wrap
+msgid "How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1136
-#, markdown-text
 msgid ""
 "If wxMaxima is used, the Maxima variable `maxima_frontend` is set to "
 "`wxmaxima`. The Maxima variable `maxima_frontend_version` contains the "
@@ -3590,7 +4079,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1138
-#, markdown-text
 msgid ""
 "If no frontend is used (you are using command line Maxima), these variables "
 "are `false`."
@@ -3598,29 +4086,25 @@ msgstr ""
 
 #. type: Title ##
 #: ../../info/wxmaxima.md:1139
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "Help! I can not save my document!"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1142
-#, markdown-text, no-wrap
-msgid ""
-"If saving as wxmx file does not work, try saving the document as wxm file "
-"(and vice versa). And you can also try to remove all output (Menu "
-"Cell->Remove all output) and save that file, maybe some unexpected output "
-"causes issues during the save process.\n"
+#, no-wrap
+msgid "If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.\n"
 msgstr ""
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1145
-#, markdown-text, no-wrap
+#, fuzzy, no-wrap
+#| msgid "# Command-line arguments"
 msgid "Command-line arguments"
-msgstr ""
+msgstr "# Argomenti della riga di comando"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1148
-#, markdown-text
 msgid ""
 "Usually you can start programs with a graphical user interface just by "
 "clicking on a desktop icon or desktop menu entry. WxMaxima - if started from "
@@ -3629,19 +4113,16 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:1164
-#, markdown-text
 msgid "`-v` or `--version`: Output the version information"
 msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:1164
-#, markdown-text
 msgid "`-h` or `--help`: Output a short help text"
 msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:1164
-#, markdown-text
 msgid ""
 "`-o` or `--open=<str>`: Open the filename given as an argument to this "
 "command-line switch"
@@ -3649,49 +4130,39 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:1164
-#, markdown-text
 msgid "`-e` or `--eval`: Evaluate the file after opening it."
 msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:1164
-#, markdown-text
 msgid ""
 "`-b` or `--batch`: If the command-line opens a file all cells in this file "
 "are evaluated and the file is saved afterward. This is for example useful if "
-"the session described in the file makes _Maxima_ generate output "
-"files. Batch-processing will be stopped if _wxMaxima_ detects that _Maxima_ "
-"has output an error and will pause if _Maxima_ has a question: Mathematics "
-"is somewhat interactive by nature so a completely interaction-free batch "
+"the session described in the file makes _Maxima_ generate output files. "
+"Batch-processing will be stopped if _wxMaxima_ detects that _Maxima_ has "
+"output an error and will pause if _Maxima_ has a question: Mathematics is "
+"somewhat interactive by nature so a completely interaction-free batch "
 "processing cannot always be guaranteed."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1164
-#, markdown-text, no-wrap
+#, no-wrap
 msgid ""
-"- `--logtostderr`:                 Log all \"debug messages\" sidebar "
-"messages to stderr, too.\n"
+"- `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
 "- `--pipe`:                        Pipe messages from Maxima to stdout.\n"
 "- `--exit-on-error`:               Close the program on any maxima error.\n"
-"- `-f` or `--ini=<str>`: Use the init file that was given as an argument to "
-"this command-line switch\n"
+"- `-f` or `--ini=<str>`: Use the init file that was given as an argument to this command-line switch\n"
 "- `-u`, `--use-version=<str>`:     Use maxima version `<str>`.\n"
-"- `-l`, `--lisp=<str>`:              Use a Maxima compiled with Lisp "
-"compiler `<str>`.\n"
-"- `-X`, `--extra-args=<str>`:        Allows to specify extra Maxima "
-"arguments\n"
-"- `-m` or `--maxima=<str>`:    allows specifying the location of the "
-"_maxima_ binary\n"
-"- `--enableipc`: Lets Maxima control wxMaxima via interprocess "
-"communications. Use this option with care.\n"
-"- `--wxmathml-lisp=<str>`:   Location of wxMathML.lisp (if not the built-in "
-"should be used, mainly for developers).\n"
+"- `-l`, `--lisp=<str>`:              Use a Maxima compiled with Lisp compiler `<str>`.\n"
+"- `-X`, `--extra-args=<str>`:        Allows to specify extra Maxima arguments\n"
+"- `-m` or `--maxima=<str>`:    allows specifying the location of the _maxima_ binary\n"
+"- `--enableipc`: Lets Maxima control wxMaxima via interprocess communications. Use this option with care.\n"
+"- `--wxmathml-lisp=<str>`:   Location of wxMathML.lisp (if not the built-in should be used, mainly for developers).\n"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1166
-#, markdown-text
 msgid ""
 "Instead of a minus, some operating systems might use a dash in front of the "
 "command-line switches."
@@ -3699,52 +4170,47 @@ msgstr ""
 
 #. type: Title #
 #: ../../info/wxmaxima.md:1169
-#, markdown-text, no-wrap
+#, no-wrap
 msgid "About the program, contributing to wxMaxima"
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1172
-#, markdown-text
 msgid ""
 "wxMaxima is mainly developed using the programming language C++ using the "
 "[wxWidgets framework](https://www.wxwidgets.org), as build system we use "
 "[CMake](https://www.cmake.org), a small part is written in Lisp. You can "
-"contribute to wxMaxima, join the wxMaxima project at "
-"<https://github.com/wxMaxima-developers/wxmaxima>, if you have knowledge of "
-"these programming languages and want to help and contribute to the open "
-"source project wxMaxima."
+"contribute to wxMaxima, join the wxMaxima project at <https://github.com/"
+"wxMaxima-developers/wxmaxima>, if you have knowledge of these programming "
+"languages and want to help and contribute to the open source project "
+"wxMaxima."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1174
-#, markdown-text
 msgid ""
 "But not only programmers are necessary! You can also contribute to wxMaxima, "
 "if you help to improve the documentation, find and report bugs (and maybe "
 "bugfixes), suggest new features, help to translate wxMaxima or the manual to "
-"your language (read the README.md in the [locale "
-"subdirectory](https://github.com/wxMaxima-developers/wxmaxima/tree/main/locales) "
-"how wxMaxima and the manual can be translated)."
+"your language (read the README.md in the [locale subdirectory](https://"
+"github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and "
+"the manual can be translated)."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1176
-#, markdown-text
 msgid "Or answer questions of other users in the discussion forum."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1178
-#, markdown-text
 msgid ""
-"The source code of wxMaxima is documented using Doxygen "
-"[here](https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+"The source code of wxMaxima is documented using Doxygen [here](https://"
+"wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
 msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1180
-#, markdown-text
 msgid ""
 "The program is nearly self-contained, so except for system libraries (and "
 "the wxWidgets library), no external dependencies (like graphic files or the "
@@ -3754,10 +4220,6 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1181
-#, markdown-text, no-wrap
-msgid ""
-"If you are a developer, you might want to try out a modified "
-"`wxmathML.lisp`-file without recompiling everything, one can use the command "
-"line option `--wxmathml-lisp=<str>` to use another Lisp file, not the "
-"included one.\n"
+#, no-wrap
+msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.\n"
 msgstr ""

--- a/locales/manual/po4a.cfg.in
+++ b/locales/manual/po4a.cfg.in
@@ -1,4 +1,4 @@
 [po4a_langs] ${LANGUAGES_SPACESEPARATED}
-[po4a_paths] ${CMAKE_SOURCE_DIR}/locales/manual/wxmaxima.md.pot $lang:${CMAKE_SOURCE_DIR}/locales/wxMaxima/$lang.po
-[type: text] ${WXMAXIMA_MD_RELATIVE} $lang:${CMAKE_SOURCE_DIR}/info/wxmaxima.$lang.md opt:"-k 5"
+[po4a_paths] ${CMAKE_SOURCE_DIR}/locales/manual/wxmaxima.md.pot $lang:${CMAKE_SOURCE_DIR}/locales/manual/$lang.po
+[type: text] ${WXMAXIMA_MD_RELATIVE} $lang:${CMAKE_SOURCE_DIR}/info/wxmaxima.$lang.md opt:"-k 5 -o markdown"
 

--- a/locales/manual/ru.po
+++ b/locales/manual/ru.po
@@ -1,0 +1,4773 @@
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+#
+# SPDX-FileCopyrightText: 2025 Sergey Kazorin <translation-team@basealt.ru>
+# SPDX-FileCopyrightText: 2025, 2026 Olesya Gerasimenko <goa@altlinux.org>
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: wxmaxima-gui\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-04 07:28+0000\n"
+"PO-Revision-Date: 2026-08-02 11:43\n"
+"Last-Translator: \n"
+"Language-Team: Russian\n"
+"Language: ru_RU\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=((n%10==1 && n%100!=11) ? 0 : ((n%10 >= 2 "
+"&& n%10 <=4 && (n%100 < 12 || n%100 > 14)) ? 1 : ((n%10 == 0 || (n%10 >= 5 "
+"&& n%10 <=9)) || (n%100 >= 11 && n%100 <= 14)) ? 2 : 3));\n"
+"X-Crowdin-Project: wxmaxima-gui\n"
+"X-Crowdin-Project-ID: 917703\n"
+"X-Crowdin-Language: ru\n"
+"X-Crowdin-File: /main/locales/wxMaxima/wxMaxima.pot\n"
+"X-Crowdin-File-ID: 8\n"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1
+#, fuzzy, no-wrap
+#| msgid "# The wxMaxima user manual"
+msgid "The wxMaxima user manual"
+msgstr "# Руководство пользователя wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:4
+msgid ""
+"WxMaxima is a graphical user interface (GUI) for the _Maxima_ computer "
+"algebra system (CAS). WxMaxima allows one to use all of _Maxima_’s "
+"functions. In addition, it provides convenient wizards for accessing the "
+"most commonly used features. This manual describes some of the features that "
+"make wxMaxima one of the most popular GUIs for _Maxima_."
+msgstr ""
+"WxMaxima — графический интерфейс пользователя для системы компьютерной "
+"алгебры (СКА) _Maxima_. WxMaxima позволяет использовать все функции "
+"_Maxima_. А также предоставляет ряд удобных мастеров для работы с наиболее "
+"часто используемыми функциями. Данное руководство описывает некоторые из тех "
+"функций, которые делают wxMaxima одним из наиболее популярных графических "
+"интерфейсов для _Maxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:6
+msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
+msgstr "![Логотип wxMaxima](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:9
+#, fuzzy, no-wrap
+#| msgid "# Introduction to wxMaxima"
+msgid "Introduction to wxMaxima"
+msgstr "# Введение в wxMaxima"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:11
+#, fuzzy, no-wrap
+#| msgid "## _Maxima_ and wxMaxima"
+msgid "_Maxima_ and wxMaxima"
+msgstr "## _Maxima_ и wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:14
+msgid ""
+"In the open-source domain, big systems are normally split into smaller "
+"projects that are easier to handle for small groups of developers. For "
+"example a CD burner program will consist of a command-line tool that "
+"actually burns the CD and a graphical user interface that allows users to "
+"implement it without having to learn about all the command line switches and "
+"in fact without using the command line at all. One advantage of this "
+"approach is that the developing work that was invested into the command-line "
+"program can be shared by many programs: The same CD-burner command-line "
+"program can be used as a “send-to-CD”-plug-in for a file manager "
+"application, for the “burn to CD” function of a music player and as the CD "
+"writer for a DVD backup tool. Another advantage is that splitting one big "
+"task into smaller parts allows the developers to provide several user "
+"interfaces for the same program."
+msgstr ""
+"В области открытого программного обеспечения большие системы обычно делятся "
+"на небольшие проекты, которые проще обслуживать небольшим группам "
+"разработчиков. Например, программа записи компакт-дисков будет состоять из "
+"средства командной строки, которое фактически выполняет запись CD, и "
+"графического интерфейса пользователя, позволяющего выполнять запись без "
+"необходимости изучения всех ключей командной строки, как и вообще без "
+"необходимости использования консоли. Одним из преимуществ такого подхода "
+"является возможность применить силы и средства, вложенные в разработку "
+"консольной программы, в работе сразу нескольких программ: одна и та же "
+"программа записи компакт-дисков может использоваться и в виде модуля "
+"файлового менеджера «Отправить на CD», и в качестве функции музыкального "
+"проигрывателя «Запись на CD», и в качестве программы записи CD в составе "
+"системы резервного копирования DVD. Другим преимуществом такого подхода "
+"является разделение одной большой задачи на меньшие части, позволяющее "
+"разработчикам создавать несколько интерфейсов для одной и той же программы."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:16
+msgid ""
+"A computer algebra system (CAS) like _Maxima_ fits into this framework. A "
+"CAS can provide the logic behind an arbitrary precision calculator "
+"application or it can do automatic transforms of formulas in the background "
+"of a bigger system (e.g., [Sage](https://www.sagemath.org/)). Alternatively, "
+"it can be used directly as a free-standing system. _Maxima_ can be accessed "
+"via a command line. Often, however, an interface like _wxMaxima_ proves a "
+"more efficient way to access the software, especially for newcomers."
+msgstr ""
+"Система компьютерной алгебры (СКА) в исполнении _Maxima_ вполне вписывается "
+"в эту парадигму. СКА может выполнять роль логики калькулятора произвольной "
+"точности, либо осуществлять автоматические преобразования формул в составе "
+"более крупной системы (например, [Sage](https://www.sagemath.org/)). И при "
+"этом вполне может применяться и в качестве независимой системы. Работать с "
+"_Maxima_ можно в командной строке. Однако часто интерфейс в стиле _wxMaxima_ "
+"обеспечивает более эффективную работу с ПО, особенно новичкам."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:17
+#, fuzzy, no-wrap
+#| msgid "### _Maxima_"
+msgid "_Maxima_"
+msgstr "### _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:20
+msgid ""
+"_Maxima_ is a full-featured computer algebra system (CAS). A CAS is a "
+"program that can solve mathematical problems by rearranging formulas and "
+"finding a formula that solves the problem as opposed to just outputting the "
+"numeric value of the result. In other words, _Maxima_ can serve as a "
+"calculator that gives numerical representations of variables, and it can "
+"also provide analytical solutions. Furthermore, it offers a range of "
+"numerical methods of analysis for equations or systems of equations that "
+"cannot be solved analytically."
+msgstr ""
+"_Maxima_ является полноценной системой компьютерной алгебры (СКА). СКА "
+"представляет собой программу, которая решает математические задачи путём "
+"преобразования формул для нахождения формулы, способной решить заданную "
+"задачу, в противоположность простому выводу численного значения результата. "
+"Иными словами, _Maxima_ может служить в качестве калькулятора, выводящего "
+"численные представления переменных, и вместе с тем может выдавать и "
+"аналитические решения. Более того, она предлагает ряд численных методов "
+"анализа для уравнений или систем уравнений, которые не могут быть решены "
+"аналитически."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:22
+msgid ""
+"![Maxima screenshot, command line](./maxima_screenshot.png)"
+"{ id=img_maxima_screenshot }"
+msgstr ""
+"![Снимок экрана Maxima, командная строка](./maxima_screenshot.png)"
+"{ id=img_maxima_screenshot }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:24
+#, fuzzy, no-wrap
+#| msgid "Extensive documentation for _Maxima_ is [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor."
+msgid "Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.\n"
+msgstr "Исчерпывающая документация _Maxima_ [доступна в сети Интернет](https://maxima.sourceforge.io/documentation.html). Часть этой документации также доступна в меню справки wxMaxima. При нажатии клавиши «Справка» (в большинстве систем эту функцию выполняет клавиша <kbd>F1</kbd>) контекстно-зависимая функция справки _wxMaxima_ автоматически переходит на страницу руководства _Maxima_ с описанием команды, заданной в поле ввода."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:25
+#, fuzzy, no-wrap
+#| msgid "### WxMaxima"
+msgid "WxMaxima"
+msgstr "### WxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:28
+msgid ""
+"_WxMaxima_ is a graphical user interface that provides the full "
+"functionality and flexibility of _Maxima_. WxMaxima offers users a graphical "
+"display and many features that make working with _Maxima_ easier. For "
+"example _wxMaxima_ allows one to export any cell’s contents (or, if that is "
+"needed, any part of a formula, as well) as text, as LaTeX or as MathML "
+"specification at a simple right-click. Indeed, an entire workbook can be "
+"exported, either as a HTML file or as a LaTeX file. Documentation for "
+"_wxMaxima_, including workbooks to illustrate aspects of its use, is online "
+"at the _wxMaxima_ [help site](https://wxMaxima-developers.github.io/wxmaxima/"
+"help.html), as well as via the help menu."
+msgstr ""
+"_WxMaxima_ — это графический интерфейс пользователя, полностью сохраняющий "
+"функциональность и гибкость _Maxima_. WxMaxima предлагает пользователям "
+"графическое отображение наряду с множеством функциональных возможностей, "
+"позволяющих сделать работу с _Maxima_ более простой и приятной. Например, "
+"_wxMaxima_ может экспортировать содержимое любого поля (а при необходимости "
+"и любой части формулы) в виде текста в формате LaTeX или MathML по щелчку "
+"правой клавиши мыши. Это позволяет экспортировать целую книгу либо в виде "
+"HTML-файла, либо в виде файла LaTeX. Документация _wxMaxima_, включая "
+"рабочие книги для иллюстрации аспектов использования программы, доступна "
+"онлайн на [сайте справки](https://wxMaxima-developers.github.io/wxmaxima/"
+"help.html) _wxMaxima_, а также в меню справки программы."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:30
+msgid "![wxMaxima window](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
+msgstr "![Окно wxMaxima](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:32
+msgid ""
+"The calculations that are entered in _wxMaxima_ are performed by the "
+"_Maxima_ command-line tool in the background."
+msgstr ""
+"Введённые в _wxMaxima_ вычисления выполняются в фоновом режиме консольной "
+"программой _Maxima_."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:33
+#, fuzzy, no-wrap
+#| msgid "## Workbook basics"
+msgid "Workbook basics"
+msgstr "## Основная информация о рабочей книге"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:36
+msgid ""
+"Much of _wxMaxima_ is self-explaining, but some details require attention. "
+"[This site](https://wxMaxima-developers.github.io/wxmaxima/help.html) "
+"contains a number of workbooks that address various aspects of _wxMaxima_. "
+"Working through some of these (particularly the \"10 minute _(wx)Maxima_ "
+"tutorial\") will increase one’s familiarity with both the content of "
+"_Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. This manual "
+"concentrates on describing aspects of _wxMaxima_ that are not likely to be "
+"self-evident and that might not be covered in the online material."
+msgstr ""
+"Большая часть интерфейса _wxMaxima_ интуитивно понятна, но некоторые детали "
+"требуют особенного внимания. [Этот сайт](https://wxMaxima-developers.github."
+"io/wxmaxima/help.html) содержит несколько рабочих книг, помогающих "
+"разобраться в различных аспектах работы с _wxMaxima_. Проработка некоторых "
+"из них (особенно «_(wx)Maxima_ за 10 минут») позволит лучше ознакомиться как "
+"с содержимым _Maxima_, так и с использованием _wxMaxima_ во взаимодействии с "
+"_Maxima_. Это руководство концентрируется на описании таких аспектов "
+"_wxMaxima_, которые не будут интуитивно понятны, и описание которых может "
+"отсутствовать в материалах, доступных онлайн."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:37
+#, fuzzy, no-wrap
+#| msgid "### The workbook approach"
+msgid "The workbook approach"
+msgstr "### Метод работы с использованием рабочих книг"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:40
+msgid ""
+"One of the very few things that are not standard in _wxMaxima_ is that it "
+"organizes the data for _Maxima_ into cells that are evaluated (which means: "
+"sent to _Maxima_) only when the user requests this. When a cell is "
+"evaluated, all commands in that cell, and only that cell, are evaluated as a "
+"batch. (The preceding statement is not quite accurate: One can select a set "
+"of adjacent cells and evaluate them together. Also, one can instruct "
+"_Maxima_ to evaluate all cells in a workbook in one pass.) _WxMaxima_’s "
+"approach to submitting commands for execution might feel unfamiliar at the "
+"first sight. It does, however, drastically ease work with big documents "
+"(where the user does not want every change to automatically trigger a full "
+"re-evaluation of the whole document). Also, this approach is very handy for "
+"debugging."
+msgstr ""
+"Одним из незначительного числа нестандартных подходов, нашедших применение в "
+"_wxMaxima_, является организация данных для работы с _Maxima_ по полям, "
+"которые вычисляются (имеется в виду «отправляются в _Maxima_») только по "
+"требованию пользователя. При вычислении поля все команды в этом поле, и "
+"только в этом поле, вычисляются путём пакетной обработки. (Предыдущее "
+"высказывание не совсем точно: можно выбрать несколько смежных полей для "
+"совместного вычисления. Также _Maxima_ может вычислять сразу все поля в "
+"рабочей книге за один проход.) Принятый в _wxMaxima_ подход к отправке "
+"команд для вычисления на первый взгляд может показаться необычным. Однако он "
+"значительно упрощает работу с большими документами (где пользователю не "
+"нужно, чтобы каждое изменение автоматически запускало полный пересчёт целого "
+"документа). А также данный подход очень удобен для отладки."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:42
+msgid ""
+"If text is typed into _wxMaxima_ it automatically creates a new worksheet "
+"cell. The type of this cell can be selected in the toolbar. If a code cell "
+"is created the cell can be sent to _Maxima_, which causes the result of the "
+"calculation to be displayed below the code. A pair of such commands is shown "
+"below."
+msgstr ""
+"При вводе текста _wxMaxima_ автоматически создаёт новое поле рабочего листа. "
+"Тип этого поля можно выбрать на панели инструментов. Если создано поле кода, "
+"то его можно отправить в _Maxima_, после чего под этим кодом выводится "
+"результат вычисления. Пара таких команд показана ниже."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:44
+msgid "![Input/output cell](./InputCell.png){ id=img_InputCell }"
+msgstr "![Поле ввода/вывода](./InputCell.png){ id=img_InputCell }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:46
+msgid ""
+"On evaluation of an input cell’s contents the input cell _Maxima_ assigns a "
+"label to the input (by default shown in red and recognizable by the `%i`) by "
+"which it can be referenced later in the _wxMaxima_ session. The output that "
+"_Maxima_ generates also gets a label that begins with `%o` and by default is "
+"hidden, except if the user assigns the output a name. In this case by "
+"default the user-defined label is displayed. The `%o`-style label _Maxima_ "
+"auto-generates will also be accessible, though."
+msgstr ""
+"При вычислении содержимого, введённого в поле ввода, _Maxima_ назначает "
+"вводу метку (по умолчанию отображается красным и распознаётся по `%i`), "
+"позволяющую позднее сослаться на него в сеансе _wxMaxima_. Сгенерированный в "
+"_Maxima_ вывод также получает метку, начинающуюся с `%o` и по умолчанию "
+"скрытую, если только пользователь не назначит выводу имя. Тогда по умолчанию "
+"будет показана заданная пользователем метка. Но и автоматически создаваемая "
+"в _Maxima_ метка в виде `%o` также будет доступна."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:48
+msgid ""
+"Besides the input cells _wxMaxima_ allows for text cells for documentation, "
+"image cells, title cells, chapter cells and section cells. Every cell has "
+"its own undo buffer so debugging by changing the values of several cells and "
+"then gradually reverting the unneeded changes is rather easy. Furthermore "
+"the worksheet itself has a global undo buffer that can undo cell edits, adds "
+"and deletes."
+msgstr ""
+"Помимо полей ввода, _wxMaxima_ позволяет создавать текстовые поля для "
+"документации, поля изображений, поля заголовков, поля глав и поля разделов. "
+"Каждое поле имеет свой собственный буфер отмены действий, поэтому можно "
+"легко выполнять отладку, изменяя значения нескольких полей и затем "
+"постепенно отменяя ненужные изменения. Более того, сам рабочий лист имеет "
+"глобальный буфер отмены действий, позволяющий отменять изменение, добавление "
+"и удаление полей."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:50
+msgid ""
+"The figure below shows different cell types (title cells, section cells, "
+"subsection cells, text cells, input/output cells and image cells)."
+msgstr ""
+"На рисунке ниже показаны различные типы полей (поля заголовков, поля "
+"разделов, поля подразделов, текстовые поля, поля ввода/вывода и поля "
+"изображений)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:52
+msgid ""
+"![Example of different wxMaxima cells](./cell-example.png){ id=img_cell-"
+"example }"
+msgstr ""
+"![Пример различных полей wxMaxima](./cell-example.png){ id=img_cell-example }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:53
+#, fuzzy, no-wrap
+#| msgid "### Cells"
+msgid "Cells"
+msgstr "### Поля"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:56
+msgid ""
+"The worksheet is organized in cells. WxMaxima knows the following cell types:"
+msgstr ""
+"Рабочий лист состоит из полей. WxMaxima оперирует следующими их типами:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Math cells, containing one or more lines of _Maxima_ input."
+msgstr ""
+"Математические поля, содержащие одну или несколько строк ввода _Maxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Output of, or a question from, _Maxima_."
+msgstr "Вывод программы _Maxima_ или вопрос от неё."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Image cells."
+msgstr "Поля изображений."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Text cells, that can for example be used for documentation."
+msgstr ""
+"Текстовые поля, которые могут использоваться, например, для документации."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid ""
+"A title, section or a subsection. 6 levels of different headings are "
+"possible."
+msgstr ""
+"Заголовок, раздел или подраздел. Поддерживаются шесть уровней разных "
+"заголовков."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Page breaks."
+msgstr "Разрывы страниц."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:65
+msgid ""
+"The default behavior of _wxMaxima_ when text is entered is to automatically "
+"create a math cell. Cells of other types can be created using the Cell menu, "
+"using the hot keys shown in the menu or using the drop-down list in the "
+"toolbar. Once the non-math cell is created, whatever is typed into the file "
+"is interpreted as text."
+msgstr ""
+"По умолчанию при вводе текста в _wxMaxima_ автоматически создаётся "
+"математическое поле. Поля других типов можно создавать через меню «Поле», с "
+"помощью указанных там сочетаний клавиш или раскрывающегося списка на панели "
+"инструментов. При создании не-математического поля любой текст, введённый в "
+"файл, интерпретируется как текст."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:67
+msgid ""
+"A (C-style) [comment text](https://maxima.sourceforge.io/docs/manual/"
+"maxima_singlepage.html#Comments) can be part of a math cell as follows: `/* "
+"This comment will be ignored by Maxima */`"
+msgstr ""
+"[Текст комментария](https://maxima.sourceforge.io/docs/manual/"
+"maxima_singlepage.html#Comments) (в стиле языка C) может использоваться в "
+"математических полях следующим образом: `/* Этот комментарий будет "
+"игнорироваться Maxima */`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:69
+msgid "\"`/*`\" marks the start of the comment, \"`*/`\" the end."
+msgstr "«`/*`» указывает начало комментария, «`*/`» указывает его конец."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:70
+#, fuzzy, no-wrap
+#| msgid "### Horizontal and vertical cursors"
+msgid "Horizontal and vertical cursors"
+msgstr "### Горизонтальный и вертикальный курсоры"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:73
+msgid ""
+"If the user tries to select a complete sentence, a word processor will try "
+"to extend the selection to automatically begin and end with a word boundary. "
+"Likewise, if more than one cell is selected, _wxMaxima_ will extend the "
+"selection to whole cells."
+msgstr ""
+"Если пользователь пытается выделить предложение полностью, текстовый "
+"процессор будет автоматически пытаться расширить выделение, чтобы оно "
+"начиналось и завершалось на границе слова. Подобным образом при выборе более "
+"одного поля _wxMaxima_ расширяет выделение до целых полей."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:75
+msgid ""
+"What isn’t standard is that _wxMaxima_ provides drag-and-drop flexibility by "
+"defining two types of cursors. _WxMaxima_ will switch between them "
+"automatically when needed:"
+msgstr ""
+"Необычной возможностью _wxMaxima_ является гибкость при перетаскивании, "
+"реализованная благодаря определению двух типов курсоров. При необходимости "
+"_wxMaxima_ переключается между ними автоматически:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:78
+msgid ""
+"The cursor is drawn horizontally if it is moved in the space between two "
+"cells or by clicking there."
+msgstr ""
+"Курсор отображается горизонтально при наведении или щелчке в пространстве "
+"между двумя полями."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:78
+msgid ""
+"A vertical cursor that works inside a cell. This cursor is activated by "
+"moving the cursor inside a cell using the mouse pointer or the cursor keys "
+"and works much like the cursor in a text editor."
+msgstr ""
+"Вертикальный курсор отображается при работе внутри поля. Этот курсор "
+"активируется при помещении курсора внутрь поля указателем мыши или клавишами "
+"со стрелками и в работе очень напоминает курсор текстового редактора."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:80
+#, fuzzy, no-wrap
+#| msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`)."
+msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).\n"
+msgstr "После загрузки wxMaxima отображается только мигающий горизонтальный курсор. Если начать ввод, автоматически создаётся математическое поле и курсор принимает обычную вертикальную форму. Появится стрелка вправо — «запрос на ввод». После вычисления математического поля (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>) будут показаны метки, например: `(%i1)`, `(%o1)`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:82
+msgid ""
+"![(blinking) horizontal cursor after wxMaxima start](./horizontal-cursor-"
+"only.png){ id=img_horizontal_cursor_only }"
+msgstr ""
+"![(Мигающий) горизонтальный курсор после запуска wxMaxima](./horizontal-"
+"cursor-only.png){ id=img_horizontal_cursor_only }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:84
+msgid ""
+"You might want to create a different cell type (using the \"Cell\" menu), "
+"maybe a title cell or text cell, which describes, what will be done, when "
+"you start creating your worksheet."
+msgstr ""
+"Может понадобиться создать поле другого типа (с помощью меню «Поле»), "
+"например, поле заголовка или текстовое поле с описанием того, что будет "
+"сделано, при начале создания рабочего листа."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:86
+msgid ""
+"If you navigate between the different cells, you will also see the "
+"(blinking) horizontal cursor, where you can insert a cell into your "
+"worksheet (either a math cell, by just start typing your formula - or a "
+"different cell type using the menu)."
+msgstr ""
+"При переходе по различным полям также отображается (мигающий) горизонтальный "
+"курсор в местах, где в рабочий лист можно вставить поле (математическое поле "
+"— простым вводом формулы, поле другого типа — с помощью меню)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:88
+msgid ""
+"![(blinking) horizontal cursor between cells](./horizontal-cursor-between-"
+"cells.png){ id=img_horizontal_cursor_between_cells }"
+msgstr ""
+"![(Мигающий) горизонтальный курсор между полями](./horizontal-cursor-between-"
+"cells.png){ id=img_horizontal_cursor_between_cells }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:89
+#, fuzzy, no-wrap
+#| msgid "### Sending cells to Maxima"
+msgid "Sending cells to Maxima"
+msgstr "### Отправка полей в Maxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:92
+#, fuzzy, no-wrap
+#| msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>."
+msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.\n"
+msgstr "Команда в поле кода исполняется однократно по нажатию сочетания клавиш <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> или клавиши <kbd>ENTER</kbd> на клавиатуре. По умолчанию _wxMaxima_ вводит команды при нажатии <kbd>CTRL</kbd>+<kbd>ENTER</kbd> или <kbd>SHIFT</kbd>+<kbd>ENTER</kbd>, но после соответствующей настройки _wxMaxima_ будет выполнять команды по нажатию <kbd>ENTER</kbd>."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:93
+#, fuzzy, no-wrap
+#| msgid "### Command autocompletion"
+msgid "Command autocompletion"
+msgstr "### Автодополнение команд"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:96
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units."
+msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.\n"
+msgstr "_WxMaxima_ содержит функцию автодополнения, которая включается через меню («Поле/Завершить слово») или по нажатию сочетания клавиш <kbd>CTRL</kbd>+<kbd>ПРОБЕЛ</kbd>. Автодополнение зависит от контекста. Например, при активации внутри спецификации модулей для ezUnits будет предлагаться список применимых модулей."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:98
+msgid "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
+msgstr "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:100
+#, fuzzy, no-wrap
+#| msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template)."
+msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).\n"
+msgstr "Помимо дополнения имени файла, имени модуля, текущей команды или имени переменной, автодополнение может отображать шаблон большинства команд с указанием типа (и значения) ожидаемых программой параметров. Для включения этой функции нажмите <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>ПРОБЕЛ</kbd> или выберите соответствующий пункт меню («Поле/Показать шаблон»)."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:101
+#, fuzzy, no-wrap
+#| msgid "#### Greek characters"
+msgid "Greek characters"
+msgstr "#### Греческие символы"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:104
+msgid ""
+"Computers traditionally stored characters in 8-bit values. This allows for a "
+"maximum of 256 different characters. All letters, numbers, and control "
+"symbols (end of transmission, end of string, lines and edges for drawing "
+"rectangles for menus _etc_.) of nearly any given language can fit within "
+"that limit."
+msgstr ""
+"Компьютеры традиционно хранят символы в 8-разрядных значениях. Это позволяет "
+"создать набор из 256 различных символов. В такой набор можно включить все "
+"буквы, цифры и управляющие символы (конец передачи, конец строки, линии и "
+"углы для рисования прямоугольников меню _и т.д._.) практически любого языка."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:106
+msgid ""
+"For most countries, the codepage of 256 characters that has been chosen does "
+"not include things like Greek letters, though, that are frequently used in "
+"mathematics. To overcome this type of limitation [Unicode](https://home."
+"unicode.org/) has been invented: An encoding that makes English text work "
+"like normal, but to use much more than 256 characters."
+msgstr ""
+"Для большинства стран в кодовую страницу из выбранных 256 символов не входят "
+"греческие буквы, хотя они часто используются в математике. Для преодоления "
+"данного ограничения был разработан [Юникод](https://home.unicode.org/): "
+"кодировка, позволяющая использовать латиницу как обычно, но при этом "
+"содержащая намного больше 256 символов."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:108
+msgid ""
+"_Maxima_ allows Unicode if it was compiled using a Lisp compiler that either "
+"supports Unicode or that doesn’t care about the font encoding. As at least "
+"one of this pair of conditions is likely to be true. _WxMaxima_ provides a "
+"method of entering Greek characters using the keyboard:"
+msgstr ""
+"_Maxima_ позволяет использовать Юникод, если её сборка выполнялась "
+"компилятором Lisp, который либо поддерживает Юникод, либо не принимает во "
+"внимание кодировку шрифта. Поскольку из пары представленных условий по "
+"крайней мере одно может оказаться справедливым, _wxMaxima_ поддерживает ввод "
+"греческих символов с помощью клавиатуры:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:111
+msgid ""
+"A Greek letter can be entered by pressing the <kbd>ESC</kbd> key and then "
+"starting to type the Greek character’s name."
+msgstr ""
+"Греческую букву можно ввести путём нажатия клавиши <kbd>ESC</kbd> с "
+"последующим вводом имени греческого символа."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:111
+msgid ""
+"Alternatively it can be entered by pressing <kbd>ESC</kbd>, one letter (or "
+"two for the Greek letter omicron) and <kbd>ESC</kbd> again. In this case the "
+"following letters are supported:"
+msgstr ""
+"Также можно нажать <kbd>ESC</kbd>, ввести одну букву (или две для греческой "
+"буквы омикрон) и снова нажать <kbd>ESC</kbd>. Такой способ ввода "
+"поддерживается для следующих букв:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:130
+#, no-wrap
+msgid ""
+"| key | Greek letter | key | Greek letter | key | Greek letter |\n"
+"| :-: | :----------: | :-: | :----------: | :-: | :----------: |\n"
+"|  a  |    alpha     |  i  |     iota     |  r  |     rho      |\n"
+"|  b  |     beta     |  k  |    kappa     |  s  |    sigma     |\n"
+"|  g  |    gamma     |  l  |    lambda    |  t  |     tau      |\n"
+"|  d  |    delta     |  m  |      mu      |  u  |   upsilon    |\n"
+"|  e  |   epsilon    |  n  |      nu      |  f  |     phi      |\n"
+"|  z  |     zeta     |  x  |      xi      |  c  |     chi      |\n"
+"|  h  |     eta      | om  |   omicron    |  y  |     psi      |\n"
+"|  q  |    theta     |  p  |      pi      |  o  |    omega     |\n"
+"|  A  |    Alpha     |  I  |     Iota     |  R  |     Rho      |\n"
+"|  B  |     Beta     |  K  |    Kappa     |  S  |    Sigma     |\n"
+"|  G  |    Gamma     |  L  |    Lambda    |  T  |     Tau      |\n"
+"|  D  |    Delta     |  M  |      Mu      |  U  |   Upsilon    |\n"
+"|  E  |   Epsilon    |  N  |      Nu      |  P  |     Phi      |\n"
+"|  Z  |     Zeta     |  X  |      Xi      |  C  |     Chi      |\n"
+"|  H  |     Eta      | Om  |   Omicron    |  Y  |     Psi      |\n"
+"|  T  |    Theta     |  P  |      Pi      |  O  |    Omega     |\n"
+msgstr ""
+"| кл. | греч. буква  | кл. | греч. буква  | кл. | греч. буква  |\n"
+"| :-: | :----------: | :-: | :----------: | :-: | :----------: |\n"
+"|  a  |    альфа     |  i  |     йота     |  r  |     ро       |\n"
+"|  b  |     бета     |  k  |    каппа     |  s  |    сигма     |\n"
+"|  g  |    гамма     |  l  |    лямбда    |  t  |     тау      |\n"
+"|  d  |    дельта    |  m  |      мю      |  u  |   ипсилон    |\n"
+"|  e  |   эпсилон    |  n  |      ню      |  f  |     фи       |\n"
+"|  z  |     дзета    |  x  |      кси     |  c  |     хи     |\n"
+"|  h  |     эта      | om  |   омикрон    |  y  |     пси      |\n"
+"|  q  |    тэта      |  p  |      пи      |  o  |    омега     |\n"
+"|  A  |    Альфа     |  I  |     Йота     |  R  |     Ро       |\n"
+"|  B  |     Бета     |  K  |    Каппа     |  S  |    Сигма     |\n"
+"|  G  |    Гамма     |  L  |    Лямбда    |  T  |     Тау      |\n"
+"|  D  |    Дельта    |  M  |      Мю      |  U  |   Ипсилон    |\n"
+"|  E  |   Эпсилон    |  N  |      Ню      |  P  |     Фи       |\n"
+"|  Z  |     Дзета    |  X  |      Кси     |  C  |     Хи       |\n"
+"|  H  |     Эта      | Om  |   Омикрон    |  Y  |     Пси      |\n"
+"|  T  |    Тэта     |  P  |      Пи      |  O  |    Омега     |\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:132
+msgid ""
+"You can also use the \"Greek letters\"-sidebar to enter the Greek letters."
+msgstr ""
+"Для ввода греческих букв также можно воспользоваться боковой панелью "
+"«Греческие буквы»."
+
+#. type: Title #####
+#: ../../info/wxmaxima.md:133
+#, fuzzy, no-wrap
+#| msgid "##### Attention: Lookalike characters"
+msgid "Attention: Lookalike characters"
+msgstr "##### Внимание: похожие буквы"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:138
+msgid ""
+"Several Latin letters look like the Greek letters, e.g. the Latin letter "
+"\"A\" and the Greek letter \"Alpha\". Although they look identical, they are "
+"two different Unicode characters, represented by different Unicode code "
+"points (numbers)."
+msgstr ""
+"Несколько букв латиницы схожи с греческими буквами. Например, латинская «A» "
+"и греческая буква «Альфа». Однако, несмотря на кажущееся сходство, это два "
+"разных символа, представленных разными кодовыми точками (числами) в Юникоде."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:143
+msgid ""
+"This might be problematic, if you assign a value to the variable A and later "
+"use the Greek letter Alpha to do something with this variable, especially on "
+"printouts.  For the Greek letter my (which is also used as prefix for micro) "
+"there are also two different Unicode code points."
+msgstr ""
+"Могут возникнуть проблемы, если задать значение переменной A, но "
+"впоследствии пытаться использовать греческую букву Альфа для выполнения "
+"каких-либо операций с этой переменной, особенно при печати. Для греческой "
+"буквы Мю (которая может использоваться и в качестве приставки микро-) также "
+"есть две разных кодовых точки Юникода."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:146
+msgid ""
+"The \"Greek letters\"-sidebar therefore has the option, that lookalike "
+"characters are not available (which can be changed using a right-click menu)."
+msgstr ""
+"Поэтому на боковой панели «Греческие буквы» имеется параметр, позволяющий "
+"сделать схожие буквы недоступными (изменяется в контекстном меню)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:148
+msgid ""
+"The same mechanism also allows to enter some miscellaneous mathematical "
+"symbols:"
+msgstr "Тот же механизм позволяет вводить различные математические символы:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:199
+#, no-wrap
+msgid ""
+"| keys to enter  | mathematical symbol                                   |\n"
+"| -------------- | ----------------------------------------------------- |\n"
+"| hbar           | Planck constant: a h with a horizontal bar above it   |\n"
+"| Hbar           | a H with a horizontal bar above it                    |\n"
+"| 2              | squared                                               |\n"
+"| 3              | to the power of three                                 |\n"
+"| /2             | 1/2                                                   |\n"
+"| partial        | partial sign (the d of dx/dt)                         |\n"
+"| integral       | integral sign                                         |\n"
+"| sq             | square root                                           |\n"
+"| ii             | imaginary                                             |\n"
+"| ee             | element                                               |\n"
+"| in             | in                                                    |\n"
+"| impl implies   | implies                                               |\n"
+"| inf            | infinity                                              |\n"
+"| empty          | empty                                                 |\n"
+"| TB             | big triangle right                                    |\n"
+"| tb             | small triangle right                                  |\n"
+"| and            | and                                                   |\n"
+"| or             | or                                                    |\n"
+"| xor            | xor                                                   |\n"
+"| nand           | nand                                                  |\n"
+"| nor            | nor                                                   |\n"
+"| equiv          | equivalent to                                         |\n"
+"| not            | not                                                   |\n"
+"| union          | union                                                 |\n"
+"| inter          | intersection                                          |\n"
+"| subseteq       | subset or equal                                       |\n"
+"| subset         | subset                                                |\n"
+"| notsubseteq    | not subset or equal                                   |\n"
+"| notsubset      | not subset                                            |\n"
+"| approx         | approximately                                         |\n"
+"| propto         | proportional to                                       |\n"
+"| neq != /= or # | not equal to                                          |\n"
+"| +/- or pm      | a plus/minus sign                                     |\n"
+"| \\<= or leq     | equal or less than                                    |\n"
+"| >= or geq      | equal or greater than                                 |\n"
+"| \\<\\< or ll     | much less than                                        |\n"
+"| >> or gg       | much greater than                                     |\n"
+"| qed            | end of proof                                          |\n"
+"| nabla          | a nabla operator                                      |\n"
+"| sum            | sum sign                                              |\n"
+"| prod           | product sign                                          |\n"
+"| exists         | there exists sign                                     |\n"
+"| nexists        | there is no sign                                      |\n"
+"| parallel       | a parallel sign                                       |\n"
+"| perp           | a perpendicular sign                                  |\n"
+"| leadsto        | a leads to sign                                       |\n"
+"| ->             | a right arrow                                         |\n"
+"| -->            | a long right arrow                                    |\n"
+msgstr ""
+"| клавиши для ввода  | математический символ                                 |\n"
+"| -------------- | ----------------------------------------------------- |\n"
+"| hbar           | постоянная Планка: h с горизонтальной линией сверху |\n"
+"| Hbar           | H с горизонтальной линией сверху                      |\n"
+"| 2              | квадрат                                               |\n"
+"| 3              | куб                                                   |\n"
+"| /2             | 1/2                                                   |\n"
+"| partial        | знак частной производной (d в dx/dt)                  |\n"
+"| integral       | знак интеграла                                        |\n"
+"| sq             | квадратный корень                                     |\n"
+"| ii             | мнимая единица                                        |\n"
+"| ee             | элемент                                               |\n"
+"| in             | включается                                                  |\n"
+"| impl implies   | импликация                                            |\n"
+"| inf            | бесконечность                                         |\n"
+"| empty          | пустое множество                                      |\n"
+"| TB             | большой треугольник направо                           |\n"
+"| tb             | малый треугольник направо                             |\n"
+"| and            | и                                                     |\n"
+"| or             | или                                                   |\n"
+"| xor            | исключающее или                                       |\n"
+"| nand           | не-и                                                  |\n"
+"| nor            | не-или                                                |\n"
+"| equiv          | эквивалентно                                          |\n"
+"| not            | не                                                    |\n"
+"| union          | объединение                                           |\n"
+"| inter          | пересечение                                           |\n"
+"| subseteq       | подмножество или равно                                |\n"
+"| subset         | подмножество                                          |\n"
+"| notsubseteq    | не подмножество или равно                             |\n"
+"| notsubset      | не подмножество                                       |\n"
+"| approx         | приблизительно                                        |\n"
+"| propto         | пропорционально                                       |\n"
+"| neq != /= or # | не равно                                              |\n"
+"| +/- or pm      | знак плюс/минус                                       |\n"
+"| \\<= or leq    | меньше или равно                                    |\n"
+"| >= or geq      | больше или равно                                      |\n"
+"| \\<\\< or ll   | намного меньше                                        |\n"
+"| >> or gg       | намного меньше                                        |\n"
+"| qed            | конец доказательства                                  |\n"
+"| nabla          | оператор Лапласа                                      |\n"
+"| sum            | знак суммы                                            |\n"
+"| prod           | знак умножения                                        |\n"
+"| exists         | квантор существования                                 |\n"
+"| nexists        | квантор несуществования                               |\n"
+"| parallel       | знак параллельности                                   |\n"
+"| perp           | знак перпендикулярности                               |\n"
+"| leadsto        | знак «отсюда следует»                                 |\n"
+"| ->             | стрелка направо                                       |\n"
+"| -->            | длинная стрелка направо                               |\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:201
+msgid ""
+"You can also use the \"Symbols\"-sidebar to enter these Mathematical symbols."
+msgstr ""
+"Для ввода математических символов также можно использовать боковую панель "
+"«Математические символы»."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:203
+#, fuzzy, no-wrap
+#| msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet."
+msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.\n"
+msgstr "Если специальный символ отсутствует в списке, то произвольный символ Юникода можно ввести нажатием <kbd>ESC</kbd> \\[код символа (шестнадцатеричный)\\] <kbd>ESC</kbd>. Кроме того, с помощью контекстного меню боковой панели «Математические символы» можно отобразить список всех доступных символов Юникода, которые можно добавить на эту панель или в рабочий лист."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:205
+#, fuzzy, no-wrap
+#| msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`."
+msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.\n"
+msgstr "Таким образом комбинация <kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> позволяет ввести символ «a»."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:207
+msgid ""
+"Please note that most of these symbols (notable exceptions are the logic "
+"symbols) do not have a special meaning in _Maxima_ and therefore will be "
+"interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp "
+"that doesn’t support Unicode characters they might cause an error message."
+msgstr ""
+"Обратите внимание, что большая часть этих символов (заметным исключением "
+"являются логические символы) не имеют специального значения в _Maxima_ и "
+"поэтому будут интерпретироваться как обычные символы. Если _Maxima_ собрана "
+"в компиляторе Lisp, не имеющем поддержки символов Юникода, то при их "
+"использовании может быть выведено сообщение об ошибке."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:210
+#, fuzzy, no-wrap
+#| msgid "It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.  To solve that problem, select other fonts (using: Edit -> Configure -> Style)."
+msgid ""
+"It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.\n"
+"To solve that problem, select other fonts (using: Edit -> Configure -> Style).\n"
+msgstr "Также бывает, что греческие или математические символы отсутствуют в выбранном шрифте, из-за чего их отображение невозможно. Для решения этой проблемы необходимо выбрать другие шрифты (с помощью меню «Правка -> Настройка -> Стиль»)."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:211
+#, fuzzy, no-wrap
+#| msgid "### Unicode replacement"
+msgid "Unicode replacement"
+msgstr "### Замена символов Юникода"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:214
+msgid ""
+"wxMaxima will replace several Unicode characters with their respective "
+"Maxima expressions, e.g. `²` with `^2`, `³` with `^3`, the square root sign "
+"with the function `sqrt()`, the (mathematical) Sigma sign (which is not the "
+"same Unicode character as the corresponding Greek letter) with `sum()`, etc."
+msgstr ""
+"wxMaxima заменяет некоторые символы Юникода на соответствующие выражения "
+"Maxima, например, `²` на `^2`, `³` на `^3`, знак квадратного корня на "
+"функцию `sqrt()`, (математический) знак Сигма (отличающийся от символа "
+"Юникода для соответствующей греческой буквы) на `sum()` и так далее."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:217
+msgid ""
+"Unicode has several \"common\" fractions encoded as one Unicode code point: "
+"`¼, ½, ¾, ⅐, ⅑, ⅒, ⅓, ⅔, ⅕, ⅖, ⅗, ⅘, ⅙, ⅚, ⅛, ⅜, ⅝, ⅞`"
+msgstr ""
+"В Юникоде есть несколько «правильных» дробей, представленных в виде одной "
+"кодовой точки Юникода: `¼, ½, ¾, ⅐, ⅑, ⅒, ⅓, ⅔, ⅕, ⅖, ⅗, ⅘, ⅙, ⅚, ⅛, ⅜, ⅝, ⅞`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:219
+msgid ""
+"wxMaxima will replace them with their Maxima representations, e.g `(1/4)` "
+"before the input is sent do Maxima. There are also `⅟`, which will be "
+"replaced by `1/` and `↉` (used in baseball), which will be replaced by "
+"`(0/3)`."
+msgstr ""
+"wxMaxima заменит их соответствующими представлениями Maxima (например, "
+"`(1/4)`) перед отправкой ввода в Maxima. Кроме того, `⅟` заменяется на `1/`, "
+"а `↉` (используется в бейсболе) — на `(0/3)`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:221
+msgid ""
+"It is recommended to use **Maxima code** (not these Unicode code points) in "
+"input cells (Rationale: (a) it might be possible, that the used font for "
+"math input does not contain them; (b) if you save the document as `wxm`-"
+"file, it is usually readable by (command line) Maxima, but these changes "
+"will of course not work in command line Maxima); but they may occur, if you "
+"cut&paste a formula from another document."
+msgstr ""
+"В полях ввода рекомендуется использовать **код Maxima** (а не эти кодовые "
+"точки Юникода) (обоснование: (a) их может не быть в используемом для ввода "
+"математических данных шрифте; (b) если сохранить документ как файл `wxm`, он "
+"будет доступен для чтения (командной строкой) Maxima, но эти изменения не "
+"будут работать в командной строке Maxima); но они могут появиться при "
+"вырезании и вставке формулы из другого документа."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:222
+#, fuzzy, no-wrap
+#| msgid "### Side Panes"
+msgid "Side Panes"
+msgstr "### Боковые панели"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:225
+msgid ""
+"Shortcuts to the most important _Maxima_ commands, things like a table of "
+"contents, windows with debug messages or a history of the last issued "
+"commands can be accessed using the side panes. They can be enabled using the "
+"\"View\" menu. They all can be moved to other locations inside or outside "
+"the _wxMaxima_ window. Other useful panes is the one that allows to input "
+"Greek letters using the mouse."
+msgstr ""
+"Наиболее важные команды _Maxima_, а также содержание, окна с отладочными "
+"сообщениями и журнал последних отданных команд доступны на соответствующих "
+"боковых панелях. Их можно активировать с помощью меню «Вид» и переместить в "
+"любое место внутри или за пределами окна _wxMaxima_. Также можно открыть "
+"панель, позволяющую вводить греческие буквы с помощью мыши."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:227
+msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
+msgstr ""
+"![Пример различных боковых панелей](./SidePanes.png){ id=img_SidePanes }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:230
+msgid ""
+"In the \"table of contents\" side pane, one can increase or decrease a "
+"heading by just clicking on the heading with the right mouse button and "
+"select the next higher or lower heading type."
+msgstr ""
+"Боковая панель «Содержание» позволяет повышать или понижать уровень "
+"заголовка путём щелчка по нему правой клавишей мыши с последующим выбором "
+"ближайшего более высокого или низкого уровня."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:232
+msgid ""
+"![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-"
+"headings.png){ id=Sidepane-TOC-convert-headings }"
+msgstr ""
+"![Повышение или понижение уровня заголовков на боковой панели «Содержание»]"
+"(./Sidepane-TOC-convert-headings.png){ id=Sidepane-TOC-convert-headings}"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:233
+#, fuzzy, no-wrap
+#| msgid "### MathML output"
+msgid "MathML output"
+msgstr "### Вывод MathML"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:236
+msgid ""
+"Several word processors and similar programs either recognize [MathML]"
+"(https://www.w3.org/Math/) input and automatically insert it as an editable "
+"2D equation - or (like LibreOffice) have an equation editor that offers an "
+"“import MathML from clipboard” feature. Others support RTF maths. "
+"_WxMaxima_, therefore, offers several entries in the right-click menu."
+msgstr ""
+"Несколько текстовых процессоров и подобных им программ либо способны "
+"распознать ввод [MathML](https://www.w3.org/Math/) и автоматически вставить "
+"его в виде редактируемого двухмерного уравнения, либо (как LibreOffice) "
+"имеют редактор уравнений, позволяющий «импортировать MathML из буфера "
+"обмена». Другие поддерживают RTF maths. Поэтому в контекстном меню "
+"_wxMaxima_ доступно несколько пунктов."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:237
+#, fuzzy, no-wrap
+#| msgid "### Markdown support"
+msgid "Markdown support"
+msgstr "### Поддержка Markdown"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:240
+msgid ""
+"_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/wiki/"
+"Markdown) conventions that don’t collide with mathematical notation. One of "
+"these elements is bullet lists."
+msgstr ""
+"_WxMaxima_ поддерживает стандартные элементы форматирования [Markdown]"
+"(https://en.wikipedia.org/wiki/Markdown), которые не конфликтуют с "
+"математической записью. Одним из таких элементов являются маркированные "
+"списки."
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:241
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```text\n"
+#| "Ordinary text\n"
+#| " * One item, indentation level 1\n"
+#| " * Another item at indentation level 1\n"
+#| "   * An item at a second indentation level\n"
+#| "   * A second item at the second indentation level\n"
+#| " * A third item at the first indentation level\n"
+#| "Ordinary text\n"
+#| "```\n"
+msgid ""
+"Ordinary text\n"
+" * One item, indentation level 1\n"
+" * Another item at indentation level 1\n"
+"   * An item at a second indentation level\n"
+"   * A second item at the second indentation level\n"
+" * A third item at the first indentation level\n"
+"Ordinary text\n"
+msgstr ""
+"```text\n"
+"Обычный текст\n"
+" * Один элемент, уровень отступа 1\n"
+" * Другой элемент с уровнем отступа 1\n"
+"   * Элемент на втором уровне отступа\n"
+"   * Второй элемент на втором уровне отступа\n"
+" * Третий элемент на первом уровне отступа\n"
+"Обычный текст\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:252
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:"
+msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
+msgstr "_WxMaxima_ считает цитатой текст, начинающийся символом `>`:"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:253
+#, fuzzy, no-wrap
+#| msgid "```text Ordinary text > quote quote quote quote > quote quote quote quote > quote quote quote quote Ordinary text ```"
+msgid ""
+"Ordinary text\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"Ordinary text\n"
+msgstr "```text Обычный текст > цитата цитата цитата цитата > цитата цитата цитата цитата > цитата цитата цитата цитата Обычный текст ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:262
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:"
+msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:\n"
+msgstr "Вывод _wxMaxima_ в формате TeX и HTML также распознаёт `=>` и заменяет его на соответствующий символ Юникода:"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:263
+#, fuzzy, no-wrap
+#| msgid "```text cogito => sum.  ```"
+msgid "cogito => sum.\n"
+msgstr "```text cogito => sum.  ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:268
+#, fuzzy, no-wrap
+#| msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized."
+msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.\n"
+msgstr "Другие символы, которые распознаются при экспорте в HTML и TeX: `<=` и `>=` для сравнений, двойная двухсторонняя стрелка (`<=>`), односторонние стрелки (`<->`, `->` и `<-`) и `+/-` в качестве соответствующего знака. Для вывода TeX также распознаются `<<` и `>>`."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:269
+#, fuzzy, no-wrap
+#| msgid "### Hotkeys"
+msgid "Hotkeys"
+msgstr "### Сочетания клавиш"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:272
+msgid ""
+"Most hotkeys can be found in the text of the respective menus. Since they "
+"are actually taken from the menu text and thus can be customized by the "
+"translations of _wxMaxima_ to match the needs of users of the local "
+"keyboard, we do not document them here. A few hotkeys or hotkey aliases, "
+"though, are not documented in the menus:"
+msgstr ""
+"Большинство сочетаний клавиш можно найти в тексте соответствующих меню. "
+"Поскольку они фактически берутся из текста меню и могут быть локализованы "
+"при переводе _wxMaxima_ для использования клавиатур с соответствующими "
+"локальными настройками, мы не будем приводить их здесь. Хотя несколько "
+"сочетаний клавиш с их псевдонимами в меню отсутствуют:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid ""
+"<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
+msgstr ""
+"<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> полностью удаляет поле."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid ""
+"<kbd>CTRL</kbd>+<kbd>TAB</kbd> or <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</"
+"kbd> triggers the auto-completion mechanism."
+msgstr ""
+"<kbd>CTRL</kbd>+<kbd>TAB</kbd> или <kbd>CTRL</kbd>+<kbd>SHIFT</"
+"kbd>+<kbd>TAB</kbd> запускает механизм автодополнения."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
+msgstr "<kbd>SHIFT</kbd>+<kbd>ПРОБЕЛ</kbd> вставляет неразрывный пробел."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:277
+#, fuzzy, no-wrap
+#| msgid "### Raw TeX in the TeX export"
+msgid "Raw TeX in the TeX export"
+msgstr "### Код TeX при экспорте в TeX"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:280
+msgid ""
+"If a text cell begins with `TeX:` the TeX export contains the literal text "
+"that follows the `TeX:` marker. Using this feature allows the entry of TeX "
+"markup within the _wxMaxima_ workbook."
+msgstr ""
+"Если текстовое поле начинается с `TeX:` экспорт в TeX будет содержать "
+"дословный текст, который который следует за меткой `TeX:`. Эта функция "
+"позволяет вводить разметку TeX непосредственно в рабочую книгу _wxMaxima_."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:281
+#, fuzzy, no-wrap
+#| msgid "## File Formats"
+msgid "File Formats"
+msgstr "## Форматы файлов"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:284
+msgid ""
+"The material that is developed in a _wxMaxima_ session can be stored for "
+"later use in any of three ways:"
+msgstr ""
+"Разрабатываемые в сеансе _wxMaxima_ материалы можно сохранять для "
+"дальнейшего использования одним из трёх способов:"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:285
+#, fuzzy, no-wrap
+#| msgid "### .mac"
+msgid ".mac"
+msgstr "### .mac"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:288
+msgid ""
+"`.mac` files are ordinary text files that contain _Maxima_ commands. They "
+"can be read using _Maxima_’s `batch()` or `load()` command or _wxMaxima_’s "
+"File/Batch File menu entry."
+msgstr ""
+"Файлы `.mac` представляют собой обычные текстовые файлы, содержащие команды "
+"_Maxima_. Их можно считывать с помощью команд _Maxima_ `batch()` или "
+"`load()`, либо с помощью пункта меню _wxMaxima_ «Файл/Пакетный файл»."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:291
+msgid ""
+"One example is shown below. `Quadratic.mac` defines a function and afterward "
+"generates a plot with `wxdraw2d()`.  Afterward the contents of the file "
+"`Quadratic.mac` are printed and newly defined function `f()` is evaluated."
+msgstr ""
+"Ниже приводится один пример. `Quadratic.mac` определяет функцию, после чего "
+"генерирует график с помощью `wxdraw2d()`. Впоследствии выводится содержимое "
+"файла `Quadratic.mac` и вычисляется вновь определённая функция `f()`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:293
+msgid "![Loading a file with `batch()`](./BatchImage.png){ id=img_BatchImage }"
+msgstr ""
+"![Загрузка файла с помощью `batch()`](./BatchImage.png){ id=img_BatchImage }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:295
+msgid ""
+"Attention: Although the file `Quadratic.mac` has a usual _Maxima_ extension "
+"(`.mac`), it can only be read by _wxMaxima_, since the command `wxdraw2d()` "
+"is a wxMaxima-extension to _Maxima_. (Command line) Maxima will ignore the "
+"unknown command `wxdraw2d()` and print it as output again."
+msgstr ""
+"Внимание: несмотря на то, что файл `Quadratic.mac` имеет обычное расширение "
+"_Maxima_ (`.mac`), прочитать его сможет только _wxMaxima_, поскольку команда "
+"`wxdraw2d()` является расширением wxMaxima для _Maxima_. (Командная строка) "
+"Maxima проигнорирует неизвестную команду `wxdraw2d()`, просто продублировав "
+"её имя в выводе."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:297
+msgid ""
+"You can be use `.mac` files for writing your own library of macros. But "
+"since they don’t contain enough structural information they cannot be read "
+"back as a _wxMaxima_ session."
+msgstr ""
+"Файлы `.mac` можно использовать для создания собственной библиотеки "
+"макросов. Но, поскольку они не содержат достаточно информации по структуре, "
+"они не могут быть считаны как сеанс _wxMaxima_."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:298
+#, fuzzy, no-wrap
+#| msgid "### .wxm"
+msgid ".wxm"
+msgstr "### .wxm"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:302
+#, fuzzy, no-wrap
+#| msgid "`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files can be. With this plain-text format, it sometimes is unavoidable that worksheets that use new features are not downwards-compatible with older versions of _wxMaxima_."
+msgid ""
+"`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.\n"
+"You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.\n"
+msgstr "Файлы `.wxm` содержат рабочий лист, за исключением вывода _Maxima_. В версиях Maxima >5.38 эти файлы можно читать с помощью функции _Maxima_ `load()`, точно так же как и файлы .mac. Но неизбежной проблемой этого текстового формата является несовместимость рабочих листов, использующих новые функции, со старыми версиями _wxMaxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:304
+#, fuzzy
+#| msgid ""
+#| "`.wxm` files contain the worksheet except for _Maxima_’s output. On "
+#| "Maxima versions >5.38 they can be read using _Maxima_’s `load()` function "
+#| "just as .mac files can be. With this plain-text format, it sometimes is "
+#| "unavoidable that worksheets that use new features are not downwards-"
+#| "compatible with older versions of _wxMaxima_."
+msgid ""
+"With this plain-text format, it sometimes is unavoidable that worksheets "
+"that use new features are not downwards-compatible with older versions of "
+"_wxMaxima_."
+msgstr ""
+"Файлы `.wxm` содержат рабочий лист, за исключением вывода _Maxima_. В "
+"версиях Maxima >5.38 эти файлы можно читать с помощью функции _Maxima_ "
+"`load()`, точно так же как и файлы .mac. Но неизбежной проблемой этого "
+"текстового формата является несовместимость рабочих листов, использующих "
+"новые функции, со старыми версиями _wxMaxima_."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:305
+#, fuzzy, no-wrap
+#| msgid "#### File format of wxm files"
+msgid "File format of wxm files"
+msgstr "#### Формат файлов wxm"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:308
+msgid ""
+"This is just a plain text file (you can open it with a text editor), "
+"containing the cell contents as some special Maxima comments."
+msgstr ""
+"Это файл с обычным текстом (открывается в текстовом редакторе), в котором "
+"содержимое полей хранится в виде специальных комментариев Maxima."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:310
+msgid "It starts with the following comment:"
+msgstr "Файл начинается со следующего комментария:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:311
+#, fuzzy, no-wrap
+#| msgid "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
+msgid ""
+"/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/\n"
+"/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */\n"
+msgstr "```maxima /* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/ /* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */ ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:317
+msgid ""
+"And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
+msgstr ""
+"Затем следуют поля, записанные в виде комментариев Maxima. Например, поле "
+"раздела:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:318
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "/* [wxMaxima: section start ]\n"
+#| "Title of the section\n"
+#| "   [wxMaxima: section end   ] */\n"
+#| "```\n"
+msgid ""
+"/* [wxMaxima: section start ]\n"
+"Title of the section\n"
+"   [wxMaxima: section end   ] */\n"
+msgstr ""
+"```maxima\n"
+"/* [wxMaxima: section start ]\n"
+"Заголовок раздела\n"
+"   [wxMaxima: section end   ] */\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:325
+msgid ""
+"or (in a Math cell the input is of course *not* commented out (the output is "
+"not saved in a `wxm` file)):"
+msgstr ""
+"или (разумеется, в математическом поле ввод будет *не* закомментирован "
+"(вывод не сохраняется в файле `wxm`)):"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:326
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "/* [wxMaxima: input   start ] */\n"
+#| "f(x):=x^2+1$\n"
+#| "f(2);\n"
+#| "/* [wxMaxima: input   end   ] */\n"
+#| "```\n"
+msgid ""
+"/* [wxMaxima: input   start ] */\n"
+"f(x):=x^2+1$\n"
+"f(2);\n"
+"/* [wxMaxima: input   end   ] */\n"
+msgstr ""
+"```maxima\n"
+"/* [wxMaxima: input   start ] */\n"
+"f(x):=x^2+1$\n"
+"f(2);\n"
+"/* [wxMaxima: input   end   ] */\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:334
+msgid ""
+"Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the "
+"image type as first line):"
+msgstr ""
+"Изображения [закодированы в Base64](https://en.wikipedia.org/wiki/Base64). В "
+"первой строке находится тип изображения:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:335
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "/* [wxMaxima: image   start ]\n"
+#| "jpg\n"
+#| "[very chaotic looking character sequence]\n"
+#| "   [wxMaxima: image   end   ] */\n"
+#| "```\n"
+msgid ""
+"/* [wxMaxima: image   start ]\n"
+"jpg\n"
+"[very chaotic looking character sequence]\n"
+"   [wxMaxima: image   end   ] */\n"
+msgstr ""
+"```maxima\n"
+"/* [wxMaxima: image   start ]\n"
+"jpg\n"
+"[кажущаяся беспорядочной последовательность символов]\n"
+"   [wxMaxima: image   end   ] */\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:343
+msgid "A page break is just one line containing:"
+msgstr "Разрыв страницы представляет собой одну строку следующего содержания:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:344
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "/* [wxMaxima: page break    ] */\n"
+#| "```\n"
+msgid "/* [wxMaxima: page break    ] */\n"
+msgstr ""
+"```maxima\n"
+"/* [wxMaxima: page break    ] */\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:349
+msgid "And folded cells marked by:"
+msgstr "Свёрнутые поля обозначаются так:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:350
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "/* [wxMaxima: fold    start ] */\n"
+#| "...\n"
+#| "/* [wxMaxima: fold    end   ] */\n"
+#| "```\n"
+msgid ""
+"/* [wxMaxima: fold    start ] */\n"
+"...\n"
+"/* [wxMaxima: fold    end   ] */\n"
+msgstr ""
+"```maxima\n"
+"/* [wxMaxima: fold    start ] */\n"
+"...\n"
+"/* [wxMaxima: fold    end   ] */\n"
+"```\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:356
+#, fuzzy, no-wrap
+#| msgid "### .wxmx"
+msgid ".wxmx"
+msgstr "### .wxmx"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:359
+msgid ""
+"This XML-based file format saves the complete worksheet including things "
+"like the zoom factor and the watchlist. It is the preferred file format."
+msgstr ""
+"Этот файл на основе формата XML сохраняет рабочий лист целиком, включая "
+"такие параметры, как масштаб отображения и список отслеживания. Это "
+"рекомендуемый формат."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:360
+#, fuzzy, no-wrap
+#| msgid "#### File format of wxmx files"
+msgid "File format of wxmx files"
+msgstr "#### Формат файлов wxmx"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:364
+msgid ""
+"A `wxmx`-file seems to be a binary format, but one can handle it with tools, "
+"which are included in your OS. It is a zip file, one can decompress it with "
+"`unzip` (maybe rename it before, so that is recognized by the unzip program "
+"of your OS).  We do not use the compression function, just the possibility "
+"to merge several files into one file - images are already compressed and the "
+"rest is simple text (probably much smaller, than huge images, which are "
+"included)."
+msgstr ""
+"Файл `wxmx` похож на двоичный формат, но работать с ним можно с помощью "
+"базовых инструментов ОС. Это файл zip, который можно разархивировать с "
+"помощью программы `unzip` (рекомендуется переименовать файл, чтобы программа "
+"`unzip` могла распознать его в ОС). При создании файла используется не "
+"функция сжатия, а возможность объединять несколько файлов в один — "
+"изображения уже сжаты, а всё остальное представлено простым текстом "
+"(занимает куда меньший объём, чем громадные включаемые изображения)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:366
+msgid "It does contain the following files:"
+msgstr "Содержит следующие файлы:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-"
+"wxmathml`"
+msgstr ""
+"`mimetype`: этот файл содержит тип MIME файлов wxMaxima: `text/x-wxmathml`."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`format.txt`: a short description about wxMaxima and the wxmx file format"
+msgstr "`format.txt`: краткое описание wxMaxima и формата файлов wxmx."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima "
+"session and included images."
+msgstr ""
+"Изображения (например, png, jpeg): встроенные графики, которые были созданы "
+"в сеансе wxMaxima, и включённые изображения."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`content.xml`: a XML document, which contains the various cells of your "
+"document in XML format."
+msgstr ""
+"`content.xml`: документ XML, содержащий различные поля документа в формате "
+"XML."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:373
+msgid ""
+"So, if something goes wrong, you can unzip a wxMaxima document (maybe rename "
+"it before to a `zip`-file), maybe make changes in the `content.xml` file "
+"with a text editor, or replace an broken image, zip the files again, "
+"probably rename the `zip` to a `wxmx`-file - and you get another modified "
+"`wxmx`-file."
+msgstr ""
+"Таким образом, в случае появления ошибок можно разархивировать документ "
+"wxMaxima (рекомендуется сначала переименовать его в файл `zip`), внести "
+"изменения в файл `content.xml` в текстовом редакторе или заменить "
+"повреждённое изображение, снова добавить файлы в архив и заменить расширение "
+"`zip` на `wxmx` — и получаем отредактированный файл `wxmx`."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:374
+#, fuzzy, no-wrap
+#| msgid "## Configuration options"
+msgid "Configuration options"
+msgstr "## Параметры конфигурации"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:377
+msgid ""
+"For some common configuration variables _wxMaxima_ offers two ways of "
+"configuring:"
+msgstr ""
+"Для некоторых общих переменных конфигурации _wxMaxima_ обеспечивает два вида "
+"настройки:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:380
+msgid ""
+"The configuration dialog box below lets you change their default values for "
+"the current and subsequent sessions."
+msgstr ""
+"Диалоговое окно параметров конфигурации, представленное ниже, позволяет "
+"изменять значения параметров по умолчанию для текущего и последующих сеансов."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:380
+msgid ""
+"Also, the values for most configuration variables can be changed for the "
+"current session only by overwriting their values from the worksheet, as "
+"shown below."
+msgstr ""
+"Кроме того, для текущего сеанса возможно изменение значений большинства "
+"переменных конфигурации путём перезаписи их значений из рабочего листа, как "
+"показано ниже."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:382
+msgid ""
+"![wxMaxima configuration 1](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
+msgstr ""
+"![Конфигурация wxMaxima 1](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:383
+#, fuzzy, no-wrap
+#| msgid "### Default animation framerate"
+msgid "Default animation framerate"
+msgstr "### Частота кадров анимации по умолчанию"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:386
+msgid ""
+"The animation framerate that is used for new animations is kept in the "
+"variable `wxanimate_framerate`. The initial value this variable will contain "
+"in a new worksheet can be changed using the configuration dialogue."
+msgstr ""
+"Значение частоты кадров анимации, использующееся при создании новых "
+"анимаций, хранится в переменной `wxanimate_framerate`. Начальное значение "
+"этой переменной, которое будет содержаться в новом рабочем листе, можно "
+"изменить в диалоговом окне настройки параметров конфигурации."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:387
+#, fuzzy, no-wrap
+#| msgid "### Default plot size for new _maxima_ sessions"
+msgid "Default plot size for new _maxima_ sessions"
+msgstr "### Размер графика по умолчанию для новых сеансов _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:390
+msgid ""
+"After the next start, plots embedded into the worksheet will be created with "
+"this size if the value of `wxplot_size` isn’t changed by _maxima_."
+msgstr ""
+"Начиная со следующего запуска, указанный размер будет использоваться для "
+"создания графиков, встраиваемых в рабочий лист, если значение параметра "
+"`wxplot_size` не изменялось _Maxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:392
+msgid ""
+"In order to set the plot size of a single graph only use the following "
+"notation can be used that sets a variable’s value for one command only:"
+msgstr ""
+"Чтобы задать размер одного графика, используйте следующую запись при "
+"установке значения переменной для одной команды:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:393
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw2d(\n"
+#| "   explicit(\n"
+#| "       x^2,\n"
+#| "       x,-5,5\n"
+#| "   )\n"
+#| "), wxplot_size=[480,480]$\n"
+#| "```\n"
+msgid ""
+"wxdraw2d(\n"
+"   explicit(\n"
+"       x^2,\n"
+"       x,-5,5\n"
+"   )\n"
+"), wxplot_size=[480,480]$\n"
+msgstr ""
+"```maxima\n"
+"wxdraw2d(\n"
+"   explicit(\n"
+"       x^2,\n"
+"       x,-5,5\n"
+"   )\n"
+"), wxplot_size=[480,480]$\n"
+"```\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:402
+#, fuzzy, no-wrap
+#| msgid "### Match parenthesis in text controls"
+msgid "Match parenthesis in text controls"
+msgstr "### Проверять расстановку скобок в текстовом вводе"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:405
+msgid "This option enables two things:"
+msgstr "Этот параметр активирует сразу две функции:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:408
+msgid ""
+"If an opening parenthesis, bracket, or double quote is entered _wxMaxima_ "
+"will insert a closing one after it."
+msgstr ""
+"При вводе открывающей круглой скобки, квадратной скобки или двойной кавычки "
+"_wxMaxima_ вставляет закрывающую после неё."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:408
+msgid ""
+"If text is selected if any of these keys is pressed the selected text will "
+"be put between the matched signs."
+msgstr ""
+"При выделении текста, если нажать любую из этих клавиш, выделенный текст "
+"помещается между парой этих знаков."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:409
+#, fuzzy, no-wrap
+#| msgid "### Don’t save the worksheet automatically"
+msgid "Don’t save the worksheet automatically"
+msgstr "### Не сохранять рабочий лист автоматически"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:412
+msgid ""
+"If this option is set, the file where the worksheet is will be overwritten "
+"only the request of the user. In case of a crash/power loss/... a recent "
+"backup copy is still made available in the temp directory, though."
+msgstr ""
+"При включении этого параметра файл с рабочим листом перезаписывается только "
+"по требованию пользователя. В случае сбоя/отключении питания/... свежая "
+"резервная копия остаётся доступной во временном каталоге."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:414
+msgid ""
+"If this option isn’t set _wxMaxima_ behaves more like a modern cellphone app:"
+msgstr ""
+"Если этот параметр не включён, работа _wxMaxima_ больше напоминает "
+"современное приложение сотового телефона:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:417
+msgid "Files are saved automatically on exit"
+msgstr "Файлы автоматически сохраняются при выходе."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:417
+msgid "And the file will automatically be saved every 3 minutes."
+msgstr "Также файл автоматически сохраняется каждые 3 минуты."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:418
+#, fuzzy, no-wrap
+#| msgid "### Where is the configuration saved?"
+msgid "Where is the configuration saved?"
+msgstr "### Где сохраняется конфигурация параметров?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:422
+#, fuzzy, no-wrap
+#| msgid "If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).  (Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden)."
+msgid ""
+"If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).\n"
+"(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).\n"
+msgstr "При использовании Unix/Linux параметры конфигурации сохраняются в домашнем каталоге в файле `.wxMaxima` (если используется wxWidgets \\< 3.1.1) или в `.config/wxMaxima.conf` (XDG-Standard) (если используется wxWidgets >= 3.1.1). Версию wxWidgets можно посмотреть с помощью команды `wxbuild_info();` или в меню «Справка -> О программе». [wxWidgets](https://www.wxwidgets.org/) — кросс-платформенная библиотека для построения графического интерфейса пользователя, на которой основан интерфейс _wxMaxima_ (отсюда `wx` в имени). (Поскольку имя файла начинается с точки, `.wxMaxima` или `.config` будут скрытыми файлами.)"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:424
+msgid ""
+"If you are using Windows, the configuration will be stored in the registry. "
+"You will find the entries for _wxMaxima_ at the following position in the "
+"registry: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
+msgstr ""
+"При использовании Windows параметры конфигурации будут храниться в реестре. "
+"Расположение записей _wxMaxima_ в реестре: "
+"`HKEY_CURRENT_USER\\Software\\wxMaxima`"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:427
+#, fuzzy, no-wrap
+#| msgid "# Extensions to _Maxima_"
+msgid "Extensions to _Maxima_"
+msgstr "# Расширения _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:430
+msgid ""
+"_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
+"its main purpose is to pass along commands to _Maxima_ and to report the "
+"results of executing those commands. In some cases, however, _wxMaxima_ adds "
+"functionality to _Maxima_. _WxMaxima_’s ability to generate reports by "
+"exporting a workbook’s contents to HTML and LaTeX files has been mentioned. "
+"This section considers some ways that _wxMaxima_ enhances the inclusion of "
+"graphics in a session."
+msgstr ""
+"_WxMaxima_ является прежде всего графическим интерфейсом пользователя для "
+"_Maxima_. В этом качестве её главной целью является передача команд _Maxima_ "
+"и получение результатов выполнения этих команд. Однако в некоторых случаях "
+"_wxMaxima_ позволяет дополнить функциональные возможности _Maxima_. Уже "
+"упоминалась способность _wxMaxima_ генерировать отчёты путём экспорта "
+"содержимого рабочей книги в файлы HTML и LaTeX. Этот раздел описывает "
+"способы, которые _wxMaxima_ использует для усовершенствования использования "
+"графики в сеансе."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:431
+#, fuzzy, no-wrap
+#| msgid "## Subscripted variables"
+msgid "Subscripted variables"
+msgstr "## Переменные в нижнем индексе"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:434
+msgid ""
+"`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript "
+"variable names:"
+msgstr ""
+"Параметр `wxsubscripts` указывает, будет ли (и как) _wxMaxima_ автоматически "
+"переводить в нижний индекс имена переменных:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:436
+msgid ""
+"If it is `false`, the functionality is off, wxMaxima will not autosubscript "
+"part of variable names after an underscore."
+msgstr ""
+"При значении `false` эта функциональная возможность отключена; wxMaxima не "
+"будет автоматически переводить в нижний индекс часть имён переменных после "
+"символа подчёркивания."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:438
+msgid ""
+"If it is set to `'all`, everything after an underscore will be subscripted."
+msgstr ""
+"При значении `'all` весь текст после символа подчёркивания будет "
+"переводиться в нижний индекс."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:440
+msgid ""
+"If it is set to `true` variable names of the format `x_y` are displayed "
+"using a subscript if"
+msgstr ""
+"При значении `true` имена переменных в формате `x_y` отображаются как нижний "
+"индекс, если:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:443
+msgid "Either `x` or `y` is a single letter or"
+msgstr "Либо `x` или `y` представлены одной буквой,"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:443
+msgid "`y` is an integer (can include more than one character)."
+msgstr ""
+"либо `y` представлена целым числом (может включать более одного символа)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:445
+msgid ""
+"![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png)"
+"{ id=img_wxsubscripts }"
+msgstr ""
+"![Как переменные автоматически переводятся в нижний индекс с помощью "
+"wxsubscripts](./wxsubscripts.png){ id=img_wxsubscripts }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:447
+msgid ""
+"If the variable name doesn’t match these requirements, it can still be "
+"declared as \"to be subscripted\" using the command "
+"`wxdeclare_subscript(variable_name);` or "
+"`wxdeclare_subscript([variable_name1,variable_name2,...]);` Declaring a "
+"variable as subscripted can be reverted using the following command: "
+"`wxdeclare_subscript(variable_name,false);`"
+msgstr ""
+"Если имя переменной не соответствует этим требованиям, её всё равно можно "
+"объявить в качестве «подлежащей переводу в нижний индекс» с помощью команды "
+"`wxdeclare_subscript(variable_name);` или "
+"`wxdeclare_subscript([variable_name1,variable_name2,...]);` Объявление "
+"переменной в качестве переведённой в нижний индекс можно отменить с помощью "
+"команды: `wxdeclare_subscript(variable_name,false);`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:449
+#, fuzzy, no-wrap
+#| msgid "You can use the menu \"View->Autosubscript\" to set these values."
+msgid "You can use the menu \"View->Autosubscript\" to set these values.\n"
+msgstr "Для установки этих значений можно воспользоваться меню «Вид -> Автоперевод в нижний индекс»."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:450
+#, fuzzy, no-wrap
+#| msgid "## User feedback in the status bar"
+msgid "User feedback in the status bar"
+msgstr "## Информация в строке состояния"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:453
+msgid ""
+"Long-running commands can provide user feedback in the status bar. This user "
+"feedback is replaced by any new feedback that is placed there (allowing to "
+"use it as a progress indicator) and is deleted as soon as the current "
+"command sent to _Maxima_ is finished. It is safe to use `wxstatusbar()` even "
+"in libraries that might be used with plain _Maxima_ (as opposed to "
+"_wxMaxima_): If _wxMaxima_ isn’t present the `wxstatusbar()` command will "
+"just be left unevaluated."
+msgstr ""
+"Работающие на протяжении длительного времени команды могут выводить "
+"информацию в строку состояния. Новая информация последовательно заменяет "
+"размещённую там старую (что позволяет использовать строку состояния в "
+"качестве индикатора хода выполнения) и удаляется сразу по завершении "
+"выполнения текущей отправленной в _Maxima_ команды. Можно использовать "
+"`wxstatusbar()` даже в тех библиотеках, которые могут работать с обычной "
+"_Maxima_ (а не _wxMaxima_): при отсутствии _wxMaxima_ команда "
+"`wxstatusbar()` просто не будет обрабатываться."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:454
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "for i:1 thru 10 do (\n"
+#| "    /* Tell the user how far we got */\n"
+#| "    wxstatusbar(concat(\"Pass \",i)),\n"
+#| "    /* (sleep n) is a Lisp function, which can be used */\n"
+#| "    /* with the character \"?\" before. It delays the */\n"
+#| "    /* program execution (here: for 3 seconds) */\n"
+#| "    ?sleep(3)\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"for i:1 thru 10 do (\n"
+"    /* Tell the user how far we got */\n"
+"    wxstatusbar(concat(\"Pass \",i)),\n"
+"    /* (sleep n) is a Lisp function, which can be used */\n"
+"    /* with the character \"?\" before. It delays the */\n"
+"    /* program execution (here: for 3 seconds) */\n"
+"    ?sleep(3)\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"for i:1 thru 10 do (\n"
+"    /* Информирование о ходе выполнения */\n"
+"    wxstatusbar(concat(\"Pass \",i)),\n"
+"    /* (sleep n) — функция Lisp, которую можно вызывать */\n"
+"    /* путём предварения символом \"?\". Она откладывает */\n"
+"    /* выполнение программы (здесь: на 3 секунды) */\n"
+"    ?sleep(3)\n"
+")$\n"
+"```\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:465
+#, no-wrap
+msgid "Exporting the worksheet from within Maxima"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:468
+msgid ""
+"The command `wxworksheettohtml()` exports the current worksheet to an HTML "
+"file from within a running _Maxima_ session, which is convenient for "
+"scripted or batch export. Like `wxstatusbar()` it is safe to use in code "
+"that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present "
+"the command is simply left unevaluated."
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:469
+#, no-wrap
+msgid ""
+"wxworksheettohtml(\"report.html\")$\n"
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:475
+msgid ""
+"A relative file name is interpreted relative to _Maxima_’s working "
+"directory. The optional keyword options are:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:480
+#, no-wrap
+msgid ""
+"| option   | values                                          | meaning                                             |\n"
+"| -------- | ----------------------------------------------- | --------------------------------------------------- |\n"
+"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |\n"
+"| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:482
+msgid ""
+"The `flavor` values match the equation formats offered by the graphical "
+"**File → Export** dialog: `mathml` produces a self-contained page that needs "
+"no internet connection, `mathjax` adds a MathJaX fall-back for browsers that "
+"still lack MathML, and `svg`/`bitmap` render every equation to an image."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:484
+msgid ""
+"The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file "
+"the same way:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:485
+#, no-wrap
+msgid ""
+"wxworksheettotex(\"report.tex\")$\n"
+"wxworksheettotex(\"report.tex\", documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:494
+#, no-wrap
+msgid ""
+"| option                 | meaning                                                              |\n"
+"| ---------------------- | -------------------------------------------------------------------- |\n"
+"| `documentclass`        | overrides the LaTeX `\\documentclass` (e.g. `\"article\"`, `\"report\"`)  |\n"
+"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:496
+msgid "Support for `wxworksheettopdf()` is planned."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:497
+#, fuzzy, no-wrap
+#| msgid "## Plotting"
+msgid "Plotting"
+msgstr "## Построение графиков"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:500
+msgid ""
+"Plotting (having fundamentally to do with graphics) is a place where a "
+"graphical user interface will have to provide some extensions to the "
+"original program."
+msgstr ""
+"Построение графиков (в основном в связи с графической системой) "
+"предполагает, что графический интерфейс пользователя предоставит ряд "
+"расширений для исходной программы."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:501
+#, fuzzy, no-wrap
+#| msgid "### Embedding a plot into the worksheet"
+msgid "Embedding a plot into the worksheet"
+msgstr "### Встраивание графика в рабочий лист"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:504
+msgid ""
+"_Maxima_ normally instructs the external program _Gnuplot_ to open a "
+"separate window for every diagram it creates. Since many times it is "
+"convenient to embed graphs into the worksheet instead _wxMaxima_ provides "
+"its own set of plot functions that don’t differ from the corresponding "
+"_maxima_ functions save in their name: They are all prefixed by a “wx”."
+msgstr ""
+"Обычно _Maxima_ использует внешнюю программу _Gnuplot_, которая открывает "
+"отдельное окно для каждого создаваемого графика. Поскольку часто удобнее не "
+"делать так, а встраивать графики в рабочий лист, _wxMaxima_ предоставляет "
+"собственный набор графических функций, которые отличаются от соответствующих "
+"функций _Maxima_ только именем: все они имеют префикс “wx”."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:506
+msgid "The following plotting functions have wx-counterparts:"
+msgstr "Следующие графические функции имеют wx-аналоги:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:520
+#, no-wrap
+msgid ""
+"| wxMaxima’s plot function | Maxima’s plot function                                                                          |\n"
+"| ------------------------ | ----------------------------------------------------------------------------------------------- |\n"
+"| `wxplot2d()`             | [plot2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot2d)               |\n"
+"| `wxplot3d()`             | [plot3d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot3d)               |\n"
+"| `wxdraw2d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw2d)               |\n"
+"| `wxdraw3d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw3d)               |\n"
+"| `wxdraw()`               | [draw](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw)                   |\n"
+"| `wximplicit_plot()`      | [implicit_plot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#implicit_plot) |\n"
+"| `wxhistogram()`          | [histogram](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#histogram)         |\n"
+"| `wxscatterplot()`        | [scatterplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#scatterplot)     |\n"
+"| `wxbarsplot()`           | [barsplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#barsplot)           |\n"
+"| `wxpiechart()`           | [piechart](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#piechart)           |\n"
+"| `wxboxplot()`            | [boxplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#boxplot)             |\n"
+msgstr ""
+"|Графическая функция wxMaxima| Графическая функция Maxima                                                                          |\n"
+"| ------------------------ | ----------------------------------------------------------------------------------------------- |\n"
+"| `wxplot2d()`             | [plot2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot2d)               |\n"
+"| `wxplot3d()`             | [plot3d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot3d)               |\n"
+"| `wxdraw2d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw2d)               |\n"
+"| `wxdraw3d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw3d)               |\n"
+"| `wxdraw()`               | [draw](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw)                   |\n"
+"| `wximplicit_plot()`      | [implicit_plot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#implicit_plot) |\n"
+"| `wxhistogram()`          | [histogram](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#histogram)         |\n"
+"| `wxscatterplot()`        | [scatterplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#scatterplot)     |\n"
+"| `wxbarsplot()`           | [barsplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#barsplot)           |\n"
+"| `wxpiechart()`           | [piechart](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#piechart)           |\n"
+"| `wxboxplot()`            | [boxplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#boxplot)             |\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:522
+msgid ""
+"If a `wxm`-file is read by (console) Maxima, these functions are ignored "
+"(and printed as output, as other unknown functions in Maxima)."
+msgstr ""
+"Если Maxima прочитает файл `wxm` (в консоли), то эти функции игнорируются "
+"(печатаются в выводе, как и другие неизвестные функции в Maxima)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:524
+msgid ""
+"If you got problems with one of these functions, please check, if the "
+"problem exists in the the Maxima function too (e.g. you got an error with "
+"`wxplot2d()`, check the same plot in the Maxima command `plot2d()` (which "
+"opens the plot in a separate Window)). If the problem does not disappear, it "
+"is most likely a Maxima issue and should be reported in the [Maxima "
+"bugtracker](https://sourceforge.net/p/maxima/bugs/). Or maybe a Gnuplot "
+"issue."
+msgstr ""
+"При появлении проблем с работой одной из этих функций рекомендуется "
+"проверить, существуют ли эти проблемы также и для функции Maxima (например, "
+"если `wxplot2d()` возвращает ошибку, проверьте тот же график с помощью "
+"команды Maxima `plot2d()` (она открывает график в отдельном окне)). Если "
+"проблемы остались, вероятнее всего, что дело в ошибке Maxima; следует "
+"сообщить о ней с помощью [системы отслеживания ошибок Maxima](https://"
+"sourceforge.net/p/maxima/bugs/). Либо это может быть ошибкой Gnuplot."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:525
+#, fuzzy, no-wrap
+#| msgid "### Making embedded plots bigger or smaller"
+msgid "Making embedded plots bigger or smaller"
+msgstr "### Увеличение или уменьшение встроенных графиков"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:528
+msgid ""
+"As noted above, the configure dialog provides a way to change the default "
+"size plots created which sets the starting value of `wxplot_size`. The "
+"plotting routines of _wxMaxima_ respect this variable that specifies the "
+"size of a plot in pixels. It can always be queried or used to set the size "
+"of the following plots:"
+msgstr ""
+"Как указано выше, диалоговое окно настройки конфигурации позволяет изменять "
+"размер по умолчанию для создаваемых графиков, устанавливая начальное "
+"значение параметра `wxplot_size`. Графические процедуры _wxMaxima_ "
+"используют эту переменную для получения размера графика в пикселах. Её "
+"значение всегда можно запросить или использовать для установки размера "
+"последующих графиков:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:529
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxplot_size:[1200,800]$\n"
+#| "wxdraw2d(\n"
+#| "    explicit(\n"
+#| "        sin(x),\n"
+#| "        x,1,10\n"
+#| "    )\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"wxplot_size:[1200,800]$\n"
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"wxplot_size:[1200,800]$\n"
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:540
+msgid ""
+"If the size of only one plot is to be changed _Maxima_ provides a canonical "
+"way to change an attribute only for the current cell. In this usage the "
+"specification `wxplot_size = [value1, value2]` is appended to the "
+"`wxdraw2d( )` command, and is not part of the `wxdraw2d` command."
+msgstr ""
+"Если изменить размер необходимо только у одного графика, _Maxima_ "
+"обеспечивает канонический путь изменения атрибута только для текущего поля. "
+"В этом случае строка установки параметра `wxplot_size = [value1, value2]` "
+"добавляется к команде `wxdraw2d( )` и не является частью команды `wxdraw2d`."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:541
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw2d(\n"
+#| "    explicit(\n"
+#| "        sin(x),\n"
+#| "        x,1,10\n"
+#| "    )\n"
+#| "),wxplot_size=[1600,800]$\n"
+#| "```\n"
+msgid ""
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+"),wxplot_size=[1600,800]$\n"
+msgstr ""
+"```maxima\n"
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+"),wxplot_size=[1600,800]$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:551
+msgid ""
+"Setting the size of embedded plot with `wxplot_size` works for embedded "
+"plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` "
+"commands and for embedded animations with `with_slider_draw` and `wxanimate` "
+"commands."
+msgstr ""
+"Установка размера встроенного графика с помощью параметра `wxplot_size` "
+"работает для встроенного графика при использовании команд `wxplot`, "
+"`wxdraw`, `wxcontour_plot` и `wximplicit_plot`, а также для встроенных "
+"анимаций при использовании команд `with_slider_draw` и `wxanimate`."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:552
+#, fuzzy, no-wrap
+#| msgid "### Better quality plots"
+msgid "Better quality plots"
+msgstr "### Улучшение качества графиков"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:555
+msgid ""
+"_Gnuplot_ doesn’t seem to provide a portable way of determining whether it "
+"supports the high-quality bitmap output that the Cairo library provides. On "
+"systems where _Gnuplot_ is compiled to use this library the pngCairo option "
+"from the configuration menu (that can be overridden by the variable "
+"`wxplot_pngcairo`) enables support for antialiasing and additional line "
+"styles. If `wxplot_pngCairo` is set without _Gnuplot_ supporting this the "
+"result will be error messages instead of graphics."
+msgstr ""
+"По всей видимости в _Gnuplot_ не реализован универсальный способ определения "
+"наличия поддержки вывода растрового изображения в улучшенном качестве, "
+"реализуемого библиотекой Cairo. В системах, где _Gnuplot_ скомпилирован с "
+"поддержкой этой библиотеки, параметр pngCairo в меню настройки конфигурации "
+"(может быть переопределён переменной `wxplot_pngcairo`) включает поддержку "
+"сглаживания и дополнительные стили линий. Если включить параметр "
+"`wxplot_pngCairo` в системах без поддержки этой библиотеки в _Gnuplot_, то "
+"вместо графического изображения будут получены сообщения об ошибке."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:556
+#, fuzzy, no-wrap
+#| msgid "### Opening embedded plots in interactive _Gnuplot_ windows"
+msgid "Opening embedded plots in interactive _Gnuplot_ windows"
+msgstr "### Открытие встроенных графиков в интерактивных окнах _Gnuplot_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:559
+msgid ""
+"If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
+"`wxplot3d` isn’t supported by this feature) and the file size of the "
+"underlying _Gnuplot_ project isn’t way too high _wxMaxima_ offers a right-"
+"click menu that allows to open the plot in an interactive _Gnuplot_ window."
+msgstr ""
+"Если график был создан с помощью команд типа `wxdraw` (`wxplot2d` и "
+"`wxplot3d` в этой функции не поддерживаются) и размер файла основного "
+"проекта _Gnuplot_ не слишком велик, то можно использовать контекстное меню "
+"_wxMaxima_, которое позволяет открыть график в интерактивном окне _Gnuplot_."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:560
+#, fuzzy, no-wrap
+#| msgid "### Opening Gnuplot’s command console in `plot` windows"
+msgid "Opening Gnuplot’s command console in `plot` windows"
+msgstr "### Открытие командной строки Gnuplot в окне `plot`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:564
+msgid ""
+"On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and `wgnuplot."
+"exe`.  You can configure, which command should be used using the "
+"configuration menu. `wgnuplot.exe` offers the possibility to open a console "
+"window, where _gnuplot_ commands can be entered into, `gnuplot.exe` does not "
+"offer this possibility. Unfortunately, `wgnuplot.exe` causes _Gnuplot_ to "
+"\"steal\" the keyboard focus for a short time every time a plot is prepared."
+msgstr ""
+"В MS Windows существует две программы Gnuplot: `gnuplot.exe` и `wgnuplot."
+"exe`. Выбрать ту из них, которая будет использоваться, можно в меню "
+"настройки конфигурации. При этом `wgnuplot.exe` позволяет открыть окно "
+"командной строки для ввода команд _gnuplot_, а `gnuplot.exe` такой "
+"возможности не предоставляет. К сожалению, `wgnuplot.exe` позволяет "
+"_Gnuplot_ на некоторое время «захватывать» фокус клавиатуры каждый раз при "
+"подготовке графика."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:565
+#, fuzzy, no-wrap
+#| msgid "### Embedding animations into the spreadsheet"
+msgid "Embedding animations into the spreadsheet"
+msgstr "### Встраивание анимаций в электронную таблицу"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:568
+msgid ""
+"3D diagrams tend to make it hard to read quantitative data. A viable "
+"alternative might be to assign the 3rd parameter to the mouse wheel. The "
+"`with_slider_draw` command is a version of `wxdraw2d` that does prepare "
+"multiple plots and allows to switch between them by moving the slider on top "
+"of the screen. _WxMaxima_ allows to export this animation as an animated gif."
+msgstr ""
+"Трёхмерные графики затрудняют чтение количественных данных. В качестве "
+"возможной альтернативы можно назначить третий параметр колесу мыши. Команда "
+"`with_slider_draw` является версией команды `wxdraw2d`, позволяющей "
+"подготовить несколько графиков и переключаться между ними путём перемещения "
+"ползунка в верхней части экрана. _WxMaxima_ позволяет экспортировать эту "
+"анимацию в виде анимированного файла gif."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:570
+msgid ""
+"The first two arguments for `with_slider_draw` are the name of the variable "
+"that is stepped between the plots and a list of the values of these "
+"variable. The arguments that follow are the ordinary arguments for "
+"`wxdraw2d`:"
+msgstr ""
+"Первые два аргумента команды `with_slider_draw` представляют собой имя "
+"переменной, значение которой пошагово изменяется в графиках, и список "
+"значений этой переменной. За ними следуют обычные аргументы для `wxdraw2d`:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:571
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "with_slider_draw(\n"
+#| "    f,[1,2,3,4,5,6,7,10],\n"
+#| "    title=concat(\"f=\",f,\"Hz\"),\n"
+#| "    explicit(\n"
+#| "        sin(2*%pi*f*x),\n"
+#| "        x,0,1\n"
+#| "    ),grid=true\n"
+#| ");\n"
+#| "```\n"
+msgid ""
+"with_slider_draw(\n"
+"    f,[1,2,3,4,5,6,7,10],\n"
+"    title=concat(\"f=\",f,\"Hz\"),\n"
+"    explicit(\n"
+"        sin(2*%pi*f*x),\n"
+"        x,0,1\n"
+"    ),grid=true\n"
+");\n"
+msgstr ""
+"```maxima\n"
+"with_slider_draw(\n"
+"    f,[1,2,3,4,5,6,7,10],\n"
+"    title=concat(\"f=\",f,\"Hz\"),\n"
+"    explicit(\n"
+"        sin(2*%pi*f*x),\n"
+"        x,0,1\n"
+"    ),grid=true\n"
+");\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:583
+msgid ""
+"The same functionality for 3D plots is accessible as `with_slider_draw3d`, "
+"which allows for rotating 3d plots:"
+msgstr ""
+"Аналогичный функционал для трёхмерных графиков доступен при использовании "
+"команды `with_slider_draw3d`, которая позволяет вращать трёхмерные графики:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:584
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxanimate_autoplay:true;\n"
+#| "wxanimate_framerate:20;\n"
+#| "with_slider_draw3d(\n"
+#| "    α,makelist(i,i,1,360,3),\n"
+#| "    title=sconcat(\"α=\",α),\n"
+#| "    surface_hide=true,\n"
+#| "    contour=both,\n"
+#| "    view=[60,α],\n"
+#| "    explicit(\n"
+#| "        sin(x)*sin(y),\n"
+#| "        x,-π,π,\n"
+#| "        y,-π,π\n"
+#| "    )\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    α,makelist(i,i,1,360,3),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,α],\n"
+"    explicit(\n"
+"        sin(x)*sin(y),\n"
+"        x,-π,π,\n"
+"        y,-π,π\n"
+"    )\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    α,makelist(i,i,1,360,3),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,α],\n"
+"    explicit(\n"
+"        sin(x)*sin(y),\n"
+"        x,-π,π,\n"
+"        y,-π,π\n"
+"    )\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:602
+msgid ""
+"If the general shape of the plot is what matters it might suffice to move "
+"the plot just a little bit in order to make its 3D nature available to the "
+"intuition:"
+msgstr ""
+"Если ключевым моментом является общая форма графика, то небольшого смещения "
+"графика может быть достаточно, чтобы сделать его трёхмерную природу "
+"интуитивно узнаваемой:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:603
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxanimate_autoplay:true;\n"
+#| "wxanimate_framerate:20;\n"
+#| "with_slider_draw3d(\n"
+#| "    t,makelist(i,i,0,2*π,.05*π),\n"
+#| "    title=sconcat(\"α=\",α),\n"
+#| "    surface_hide=true,\n"
+#| "    contour=both,\n"
+#| "    view=[60,30+5*sin(t)],\n"
+#| "    explicit(\n"
+#| "        sin(x)*y^2,\n"
+#| "        x,-2*π,2*π,\n"
+#| "        y,-2*π,2*π\n"
+#| "    )\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    t,makelist(i,i,0,2*π,.05*π),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,30+5*sin(t)],\n"
+"    explicit(\n"
+"        sin(x)*y^2,\n"
+"        x,-2*π,2*π,\n"
+"        y,-2*π,2*π\n"
+"    )\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    t,makelist(i,i,0,2*π,.05*π),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,30+5*sin(t)],\n"
+"    explicit(\n"
+"        sin(x)*y^2,\n"
+"        x,-2*π,2*π,\n"
+"        y,-2*π,2*π\n"
+"    )\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:621
+msgid ""
+"For those more familiar with `plot` than with `draw`, there is a second set "
+"of functions:"
+msgstr ""
+"Для тех, кто лучше знаком с `plot`, чем с `draw`, имеется другой набор "
+"функций:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:624
+msgid "`with_slider` and"
+msgstr "`with_slider` и"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:624
+msgid "`wxanimate`."
+msgstr "`wxanimate`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:626
+msgid ""
+"Normally the animations are played back or exported with the frame rate "
+"chosen in the configuration of _wxMaxima_. To set the speed at an individual "
+"animation is played back the variable `wxanimate_framerate` can be used:"
+msgstr ""
+"Обычно анимации воспроизводятся или экспортируются с частотой кадров, "
+"заданной в конфигурации _wxMaxima_. Для установки скорости воспроизведения "
+"отдельной анимации можно воспользоваться параметром `wxanimate_framerate`:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:627
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxanimate(a, 10,\n"
+#| "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+#| "```\n"
+msgid ""
+"wxanimate(a, 10,\n"
+"    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+msgstr ""
+"```maxima\n"
+"wxanimate(a, 10,\n"
+"    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:633
+msgid ""
+"The animation functions use _Maxima_’s `makelist` command and therefore "
+"share the pitfall that the slider variable’s value is substituted into the "
+"expression only if the variable is directly visible in the expression. "
+"Therefore the following example will fail:"
+msgstr ""
+"Функции анимации используют команду _Maxima_ `makelist` и подвержены тем же "
+"недостаткам, в связи с которыми значение переменной ползунка подставляется в "
+"выражение только тогда, когда эта переменная непосредственно видима в "
+"выражении. Поэтому приведённый далее пример вызовет появление ошибки:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:634
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "f:sin(a*x);\n"
+#| "with_slider_draw(\n"
+#| "    a,makelist(i/2,i,1,10),\n"
+#| "    title=concat(\"a=\",float(a)),\n"
+#| "    grid=true,\n"
+#| "    explicit(f,x,0,10)\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    a,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(a)),\n"
+"    grid=true,\n"
+"    explicit(f,x,0,10)\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    a,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(a)),\n"
+"    grid=true,\n"
+"    explicit(f,x,0,10)\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:645
+msgid ""
+"If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
+"works fine instead:"
+msgstr ""
+"Если же отправить _Maxima_ явный запрос на подстановку значения ползунка, "
+"построение графиков работает прекрасно:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:646
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "f:sin(a*x);\n"
+#| "with_slider_draw(\n"
+#| "    b,makelist(i/2,i,1,10),\n"
+#| "    title=concat(\"a=\",float(b)),\n"
+#| "    grid=true,\n"
+#| "    explicit(\n"
+#| "        subst(a=b,f),\n"
+#| "        x,0,10\n"
+#| "    )\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    b,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(b)),\n"
+"    grid=true,\n"
+"    explicit(\n"
+"        subst(a=b,f),\n"
+"        x,0,10\n"
+"    )\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    b,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(b)),\n"
+"    grid=true,\n"
+"    explicit(\n"
+"        subst(a=b,f),\n"
+"        x,0,10\n"
+"    )\n"
+")$\n"
+"```\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:659
+#, fuzzy, no-wrap
+#| msgid "### Opening multiple plots in contemporaneous windows"
+msgid "Opening multiple plots in contemporaneous windows"
+msgstr "### Одновременное открытие нескольких графиков в нескольких окнах"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:662
+msgid ""
+"While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups "
+"that support it) sometimes comes in handily. The following example comes "
+"from a post from Mario Rodriguez to the _Maxima_ mailing list:"
+msgstr ""
+"Эта функция _Maxima_ (в системах, которые её поддерживают) не реализована в "
+"_wxMaxima_, но иногда может быть очень удобной. Следующий пример взят из "
+"письма, которое Mario Rodriguez отправил в рассылку _Maxima_:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:663
+#, no-wrap
+msgid ""
+"load(draw);\n"
+"\n"
+"/* Parabola in window #1 */\n"
+"draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Parabola in window #2 */\n"
+"draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Paraboloid in window #3 */\n"
+"draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:677
+msgid ""
+"Plotting multiple plots in the same window is possible, too (the same is "
+"possible in command line Maxima with the standard `draw()` command):"
+msgstr ""
+"Также возможно создание нескольких графиков в одном окне (то же самое "
+"возможно в командной строке Maxima при использовании стандартной команды "
+"`draw()`):"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:678
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw(\n"
+#| "  gr2d(\n"
+#| "    key=\"sin (x)\",grid=[2,2],\n"
+#| "    explicit(sin(x),x,0,2*%pi)),\n"
+#| "  gr2d(\n"
+#| "    key=\"cos (x)\",grid=[2,2],\n"
+#| "    explicit(cos(x),x,0,2*%pi))\n"
+#| ");\n"
+#| "```\n"
+msgid ""
+"wxdraw(\n"
+"  gr2d(\n"
+"    key=\"sin (x)\",grid=[2,2],\n"
+"    explicit(sin(x),x,0,2*%pi)),\n"
+"  gr2d(\n"
+"    key=\"cos (x)\",grid=[2,2],\n"
+"    explicit(cos(x),x,0,2*%pi))\n"
+");\n"
+msgstr ""
+"```maxima\n"
+"wxdraw(\n"
+"  gr2d(\n"
+"    key=\"sin (x)\",grid=[2,2],\n"
+"    explicit(sin(x),x,0,2*%pi)),\n"
+"  gr2d(\n"
+"    key=\"cos (x)\",grid=[2,2],\n"
+"    explicit(cos(x),x,0,2*%pi))\n"
+");\n"
+"```\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:689
+#, fuzzy, no-wrap
+#| msgid "### The \"Plot using draw\" side pane"
+msgid "The \"Plot using draw\" side pane"
+msgstr "### Боковая панель «График с помощью Draw»"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:692
+msgid ""
+"The \"Plot using draw\" sidebar hides a simple code generator that allows "
+"generating scenes that make use of some of the flexibility of the _draw_ "
+"package _maxima_ comes with."
+msgstr ""
+"Боковая панель «График с помощью Draw» работает как простой генератор кода, "
+"который позволяет создавать сцены, использующие гибкие возможности пакета "
+"_draw_, поставляемого с _Maxima_."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:693
+#, no-wrap
+msgid "2D"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:696
+msgid ""
+"Generates the skeleton of a `draw()` command that draws a 2D scene. This "
+"scene later has to be filled with commands that generate the scene’s "
+"contents, for example by using the buttons in the rows below the \"2D\" "
+"button."
+msgstr ""
+"Генерирует основную конструкцию команды `draw()`, которая рисует двухмерную "
+"сцену. Эту сцену далее необходимо заполнить командами, формирующими её "
+"наполнение, например, с помощью кнопок в строках под кнопкой «2D»."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:698
+msgid ""
+"One helpful feature of the 2D button is that it allows to set up the scene "
+"as an animation in which a variable (by default it is _t_) has a different "
+"value in each frame: Often a moving 2D plot allows easier interpretation "
+"than the same data in a non-moving 3D one."
+msgstr ""
+"Одной из полезных функций кнопки «2D» является возможность задать сцену в "
+"виде анимации, где переменная (по умолчанию используется _t_) имеет разное "
+"значение в каждом кадре: часто бывает проще понять анимированный двухмерный "
+"график, чем те же самые данные в неподвижной трёхмерной сцене."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:699
+#, no-wrap
+msgid "3D"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:702
+msgid ""
+"Generates the skeleton of a `draw()` command that draws a 3D scene. If "
+"neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D "
+"scene that contains the command the button generates."
+msgstr ""
+"Генерирует основную конструкцию команды `draw()`, которая рисует трёхмерную "
+"сцену. Если ни двухмерная, ни трёхмерная сцена не заданы, при нажатии всех "
+"остальных кнопок создаётся двухмерная сцена, содержащая генерируемую кнопкой "
+"команду."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:703
+#, fuzzy, no-wrap
+#| msgid "#### Expression"
+msgid "Expression"
+msgstr "#### Выражение"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:706
+msgid ""
+"Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or "
+"`x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is "
+"no draw command a 2D scene with the plot is generated. Each scene can be "
+"filled with any number of plots."
+msgstr ""
+"Добавляет стандартный график выражения, подобного `sin(x)`, `x*sin(x)` или "
+"`x^2+2*x-4`, в команду `draw()`, в которой в данный момент находится курсор. "
+"Если команда draw отсутствует, то будет создана двухмерная сцена. Каждая "
+"сцена может быть заполнена любым количеством графиков."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:707
+#, fuzzy, no-wrap
+#| msgid "#### Implicit plot"
+msgid "Implicit plot"
+msgstr "#### График неявной функции"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:710
+msgid ""
+"Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or "
+"`x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command "
+"the cursor currently is in. If there is no draw command a 2D scene with the "
+"plot is generated."
+msgstr ""
+"Пытается найти все точки, для которых истинны выражения, подобные "
+"`y=sin(x)`, `y*sin(x)=3` или `x^2+y^2=4`, и помещает итоговую кривую в "
+"команду `draw()`, в которой в данный момент находится курсор. Если команда "
+"draw отсутствует, то будет создана двухмерная сцена."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:711
+#, fuzzy, no-wrap
+#| msgid "#### Parametric plot"
+msgid "Parametric plot"
+msgstr "#### График параметрической функции"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:714
+msgid ""
+"Steps a variable from a lower limit to an upper limit and uses two "
+"expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in "
+"3D plots also z) coordinates of a curve that is put into the current draw "
+"command."
+msgstr ""
+"Проводит переменную по шагам от нижнего до верхнего предела с использованием "
+"двух выражений, подобных `t*sin(t)` и `t*cos(t)`, для генерации координат x, "
+"y (а в трёхмерных графиках ещё и z) для кривой, заданной в текущей команде "
+"draw."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:715
+#, fuzzy, no-wrap
+#| msgid "#### Points"
+msgid "Points"
+msgstr "#### Точки"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:718
+msgid ""
+"Draws many points that can optionally be joined. The coordinates of the "
+"points are taken from a list of lists, a 2D array or one list or array for "
+"each axis."
+msgstr ""
+"Рисует несколько точек, которые при необходимости можно соединить. "
+"Координаты точек берутся из списка списков, двухмерного массива, либо из "
+"одного списка или массива для каждой оси."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:719
+#, fuzzy, no-wrap
+#| msgid "#### Diagram title"
+msgid "Diagram title"
+msgstr "#### Заголовок диаграммы"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:722
+msgid "Draws a title on the upper end of the diagram,"
+msgstr "Рисует заголовок в верхней части диаграммы."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:723
+#, fuzzy, no-wrap
+#| msgid "#### Axis"
+msgid "Axis"
+msgstr "#### Ось"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:726
+msgid "Sets up the axis."
+msgstr "Задаёт ось."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:727
+#, fuzzy, no-wrap
+#| msgid "#### Contour"
+msgid "Contour"
+msgstr "#### Контур"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:730
+msgid ""
+"(Only for 3D plots): Adds contour lines similar to the ones one can find in "
+"a map of a mountain to the plot commands that follow in the current `draw()` "
+"command and/or to the ground plane of the diagram. Alternatively, this "
+"wizard allows skipping drawing the curves entirely only showing the contour "
+"plot."
+msgstr ""
+"(Только для трёхмерных графиков): добавляет отображение контурных линий, "
+"подобных изображаемым на картах гор, в команды создания графиков, которые "
+"следуют за текущей командой `draw()`, и/или на нижнюю плоскость графика. "
+"Данный мастер также позволяет полностью исключить начертание кривых, "
+"оставляя на графике только контуры."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:731
+#, fuzzy, no-wrap
+#| msgid "#### Plot name"
+msgid "Plot name"
+msgstr "#### Название графика"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:734
+msgid ""
+"Adds a legend entry showing the next plot’s name to the legend of the "
+"diagram. An empty name disables generating legend entries for the following "
+"plots."
+msgstr ""
+"Добавляет запись с отображением имени следующего графика к легенде "
+"диаграммы. Пустое имя отключает формирование записей легенды для последующих "
+"графиков."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:735
+#, fuzzy, no-wrap
+#| msgid "#### Line colour"
+msgid "Line colour"
+msgstr "#### Цвет линии"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:738
+msgid ""
+"Sets the line colour for the following plots the current draw command "
+"contains."
+msgstr ""
+"Задаёт цвет линии для последующих графиков, содержащихся в составе текущей "
+"команды draw."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:739
+#, fuzzy, no-wrap
+#| msgid "#### Fill colour"
+msgid "Fill colour"
+msgstr "#### Цвет заливки"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:742
+msgid ""
+"Sets the fill colour for the following plots the current draw command "
+"contains."
+msgstr ""
+"Задаёт цвет заливки для последующих графиков, передаваемых в составе команды "
+"draw."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:743
+#, fuzzy, no-wrap
+#| msgid "#### Grid"
+msgid "Grid"
+msgstr "#### Сетка"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:746
+msgid "Pops up a wizard that allows to set up grid lines."
+msgstr "Выводит мастер, позволяющий задать линии сетки."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:747
+#, fuzzy, no-wrap
+#| msgid "#### Accuracy"
+msgid "Accuracy"
+msgstr "#### Точность"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:750
+msgid ""
+"Allows to select an adequate point in the speed vs. accuracy tradeoff that "
+"is part of any plot program."
+msgstr ""
+"Позволяет выбрать приемлемое значение компромисса между скоростью и "
+"точностью, являющегося неотъемлемой частью любой программы формирования "
+"графиков."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:751
+#, fuzzy, no-wrap
+#| msgid "### Modify font and font size for plots"
+msgid "Modify font and font size for plots"
+msgstr "### Изменение шрифта и размера шрифта для графиков"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:754
+msgid ""
+"Especially when you use a high resolution display, the default font size "
+"might be very small. For the `draw`-based commands, you can set the font / "
+"font size using options like `font=...`, `font_size=...`, e.g.:"
+msgstr ""
+"Размер шрифта по умолчанию может оказаться слишком маленьким, особенно при "
+"использовании мониторов с высоким разрешением. Для команд на основе `draw` "
+"установка шрифта / размера шрифта выполняется с помощью таких параметров, "
+"как `font=...`, `font_size=...`, например:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:755
+#, fuzzy, no-wrap
+#| msgid ""
+#| "~~~maxima\n"
+#| "wxdraw2d(\n"
+#| "     font=\"Helvetica\",\n"
+#| "     font_size=30,\n"
+#| "     explicit(sin(x),x,1,10));\n"
+#| "~~~\n"
+msgid ""
+"wxdraw2d(\n"
+"     font=\"Helvetica\",\n"
+"     font_size=30,\n"
+"     explicit(sin(x),x,1,10));\n"
+msgstr ""
+"~~~maxima\n"
+"wxdraw2d(\n"
+"     font=\"Helvetica\",\n"
+"     font_size=30,\n"
+"     explicit(sin(x),x,1,10));\n"
+"~~~\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:763
+msgid ""
+"For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts "
+"can be set using the `gnuplot_preamble` command, e.g.:"
+msgstr ""
+"Для команд построения диаграмм (например, `wxplot2d`, `wxplot3d`) размеры "
+"шрифтов и шрифты можно задавать с помощью команды `gnuplot_preamble`, "
+"например:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:764
+#, fuzzy, no-wrap
+#| msgid ""
+#| "~~~maxima\n"
+#| "wxplot2d(sin(x),[x,1,10],\n"
+#| "         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
+#| "~~~\n"
+msgid ""
+"wxplot2d(sin(x),[x,1,10],\n"
+"         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
+msgstr ""
+"~~~maxima\n"
+"wxplot2d(sin(x),[x,1,10],\n"
+"         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
+"~~~\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:770
+msgid ""
+"This sets the font for the numbers to Arial with size 30, the size for the "
+"xlabel and ylabel font to 20 (with the default font)."
+msgstr ""
+"Это позволяет установить Arial с размером 30 в качестве шрифта для чисел. "
+"Размер шрифта для xlabel и ylabel будет равен 20 (со шрифтом по умолчанию)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:773
+msgid ""
+"Read the Maxima and Gnuplot documentation for further information.  Note: "
+"Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue "
+"1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966)."
+msgstr ""
+"Изучите документацию Maxima и Gnuplot для получения более подробной "
+"информации. Примечание: известно о наличии у Gnuplot проблем с шрифтами "
+"большого размера, смотрите [ошибку wxMaxima #1966](https://github.com/"
+"wxMaxima-developers/wxmaxima/issues/1966)."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:774
+#, fuzzy, no-wrap
+#| msgid "## Embedding graphics"
+msgid "Embedding graphics"
+msgstr "## Встраивание графики"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:777
+msgid ""
+"If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
+"project can be done as easily as per drag-and-drop. But sometimes (for "
+"example if an image’s contents might change later on in a session) it is "
+"better to tell the file to load the image on evaluation:"
+msgstr ""
+"При использовании формата файла `.wxmx` встраивание графики в проект "
+"_wxMaxima_ выполняется простым перетаскиванием. Но иногда (например, если "
+"содержимое изображения может измениться позднее во время сеанса) лучше "
+"задать загрузку файла изображения после проведения вычислений:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:778
+#, fuzzy, no-wrap
+#| msgid "```maxima show_image(\"man.png\"); ```"
+msgid "show_image(\"man.png\");\n"
+msgstr "```maxima show_image(\"man.png\"); ```"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:782
+#, fuzzy, no-wrap
+#| msgid "## Startup files"
+msgid "Startup files"
+msgstr "## Файлы запуска"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:785
+msgid ""
+"The config dialogue of _wxMaxima_ offers to edit two files with commands "
+"that are executed on startup:"
+msgstr ""
+"В диалоге настройки _wxMaxima_ можно внести изменения в два файла с "
+"командами, которые выполняются при запуске:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:788
+msgid ""
+"A file that contains commands that are executed on starting up _Maxima_: "
+"`maxima-init.mac`"
+msgstr ""
+"Файл с командами, которые выполняются при запуске _Maxima_: `maxima-init."
+"mac`."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:788
+msgid ""
+"one file of additional commands that are executed if _wxMaxima_ is starting "
+"_Maxima_: `wxmaxima-init.mac`"
+msgstr ""
+"Один файл с дополнительными командами, которые выполняются, когда _wxMaxima_ "
+"запускает _Maxima_: `wxmaxima-init.mac`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:790
+msgid ""
+"For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add "
+"`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` "
+"or any other path) to these files."
+msgstr ""
+"Например, если Gnuplot установлен в `/opt` (может быть в MacOS), в эти файлы "
+"можно добавить`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (либо `/opt/"
+"gnuplot/bin/gnuplot` или любой другой путь)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:792
+msgid ""
+"These files are in the Maxima user directory (usually `%USERPROFILE%/maxima` "
+"in Windows, `$HOME/.maxima` otherwise). The location can be found out with "
+"the command: `maxima_userdir;`"
+msgstr ""
+"Эти файлы находятся в каталоге пользователя Maxima (в Windows это обычно "
+"`%USERPROFILE%/maxima`, в других ОС — `$HOME/.maxima`). Местоположение можно "
+"выяснить с помощью команды: `maxima_userdir;`"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:793
+#, fuzzy, no-wrap
+#| msgid "## Special variables wx..."
+msgid "Special variables wx..."
+msgstr "## Специальные переменные wx…"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxsubscripts` tells _Maxima_ if it should convert variable names that "
+"contain an underscore (`R_150` or the like) into subscripted variables. See "
+"`wxdeclare_subscript` for details which variable names are automatically "
+"converted."
+msgstr ""
+"`wxsubscripts` указывает _Maxima_, следует ли преобразовать имена "
+"переменных, которые содержат символ подчёркивания (`R_150` или аналог), в "
+"переменные в нижнем индексе. Подробные сведения о том, какие имена "
+"переменных преобразуются автоматически, доступны в описании команды "
+"`wxdeclare_subscript`."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxfilename`: This variable contains the name of the file currently opened "
+"in _wxMaxima_."
+msgstr ""
+"`wxfilename`: эта переменная содержит имя файла, который в настоящее время "
+"открыт в _wxMaxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirname`: This variable contains the name the directory, in which the "
+"file currently opened in _wxMaxima_ is."
+msgstr ""
+"`wxdirname`: эта переменная содержит имя каталога, в котором находится "
+"текущий открытый в _wxMaxima_ файл."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_’s pngcairo "
+"terminal that provides more line styles and a better overall graphics "
+"quality."
+msgstr ""
+"`wxplot_pngcairo` определяет, будет ли _wxMaxima_ пытаться использовать "
+"терминал pngcairo _Gnuplot_, который предоставляет дополнительные стили "
+"линий и обеспечивает лучшее качество графики в целом."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxplot_size` defines the resolution of embedded plots."
+msgstr "`wxplot_size` определяет разрешение встроенных графиков."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
+"_Maxima_’s working directory to the directory of the current file. This "
+"allows file I/O (e.g. by `read_matrix`) to work without specifying the whole "
+"path to the file that has to be read or written. On Windows this feature "
+"sometimes causes error messages and therefore can be set to `false` from the "
+"config dialogue."
+msgstr ""
+"`wxchangedir`: в большинстве операционных систем _wxMaxima_ автоматически "
+"устанавливает в качестве рабочего каталога _Maxima_ тот каталог, где "
+"располагается текущий файл. Это позволяет файловому вводу/выводу (например, "
+"по `read_matrix`) работать без указания полного пути к файлу, который "
+"следует прочитать или записать. В Windows эта возможность иногда приводит к "
+"появлению сообщений об ошибках; её можно установить в значение `false` в "
+"диалоге настройки."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxanimate_framerate`: The number of frames per second the following "
+"animations have to be played back with."
+msgstr ""
+"`wxanimate_framerate`: количество кадров в секунду, с которым следует "
+"воспроизводить следующие анимации."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxanimate_autoplay`: Automatically play animations by default?"
+msgstr ""
+"`wxanimate_autoplay`: следует ли автоматически воспроизводить анимации по "
+"умолчанию."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
+msgstr "`wxmaximaversion`: возвращает номер версии _wxMaxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
+msgstr ""
+"`wxwidgetsversion`: возвращает версию wxWidgets, которую использует "
+"_wxMaxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these "
+"differ by maintainer, distribution and operating system:"
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@userconfdir`: The directory the user's configuration is stored in. "
+"Same directory as `maxima_userdir` (see above) - both point at the same "
+"place, `wxdirs@userconfdir` is only useful if that is more convenient to "
+"reach from a `.mac` file than the Maxima-side variable."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the built-in "
+"autocompletion list, ...) is installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@helpdir`: The directory the offline copy of this manual is installed "
+"in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@localedir`: The directory _wxMaxima_'s translation files are "
+"installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_ is "
+"configured to start."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:812
+#, fuzzy, no-wrap
+#| msgid "## Pretty-printing 2D output"
+msgid "Pretty-printing 2D output"
+msgstr "## Структурный вывод двухмерных данных"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:815
+msgid ""
+"The function `table_form()` displays a 2D list in a form that is more "
+"readable than the output from _Maxima_’s default output routine. The input "
+"is a list of one or more lists. Like the \"print\" command, this command "
+"displays output even when ended with a dollar sign. Ending the command with "
+"a semicolon results in the same table along with a \"done\" statement."
+msgstr ""
+"Функция `table_form()` отображает двухмерный список в более удобочитаемой "
+"форме, нежели при стандартном выводе процедуры _Maxima_. Ввод осуществляется "
+"в виде списка, содержащего один или нескольких списков. Как и команда "
+"«print», данная команда отображает вывод, даже когда завершается символом "
+"доллара. Завершение команды символом точки с запятой приводит к выводу такой "
+"же таблицы вместе с сообщением «done»."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:816
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "table_form(\n"
+#| "    [\n"
+#| "        [1,2],\n"
+#| "        [3,4]\n"
+#| "    ]\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"table_form(\n"
+"    [\n"
+"        [1,2],\n"
+"        [3,4]\n"
+"    ]\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"table_form(\n"
+"    [\n"
+"        [1,2],\n"
+"        [3,4]\n"
+"    ]\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:826
+msgid ""
+"As the next example shows, the lists that are assembled by the `table_form` "
+"command can be created before the command is executed."
+msgstr ""
+"Согласно примеру, представленному ниже, списки, которые собираются командой "
+"`table_form`, могут создаваться до выполнения команды."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:828
+msgid ""
+"![A third table example](./MatrixTableExample.png)"
+"{ id=img_MatrixTableExample }"
+msgstr ""
+"![Третий пример таблицы](./MatrixTableExample.png)"
+"{ id=img_MatrixTableExample }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:830
+msgid ""
+"Also, because a matrix is a list of lists, matrices can be converted to "
+"tables in a similar fashion."
+msgstr ""
+"Также, поскольку матрица является списком списков, матрицы могут схожим "
+"образом преобразовываться в таблицы."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:832
+msgid ""
+"![Another table_form example](./SecondTableExample.png)"
+"{ id=img_SecondTableExample }"
+msgstr ""
+"![Другой пример table_form](./SecondTableExample.png)"
+"{ id=img_SecondTableExample }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:834
+msgid ""
+"The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that "
+"allows for more flexible formatting of matrices in wxMaxima:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:836
+#, no-wrap
+msgid "**`wx_matrix( <matrix>, [options] )`**\n"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`lines=true`**: Draws internal separator lines between the cells. This is "
+"required to visually separate headings from data."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`rownames=true`**: Tells wxMaxima that the first column of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`colnames=true`**: Tells wxMaxima that the first row of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
+"around the matrix. Supported styles are: `round` `()`, `square` `[]`, "
+"`angled` `<>`, `straight` `||`, or `none`."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:843
+msgid "Example:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:844
+#, no-wrap
+msgid ""
+"wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
+"          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:849
+#, fuzzy, no-wrap
+#| msgid "## Bug reporting"
+msgid "Bug reporting"
+msgstr "## Отчёты об ошибках"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:852
+msgid ""
+"_WxMaxima_ provides a few functions that gather bug reporting information "
+"about the current system:"
+msgstr ""
+"_WxMaxima_ предоставляет несколько функций, которые собирают информацию о "
+"текущей системе для формирования отчёта об ошибках:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:855
+msgid ""
+"`wxbuild_info()` gathers information about the currently running version of "
+"_wxMaxima_"
+msgstr ""
+"`wxbuild_info()` собирает информацию о версии запущенной программы "
+"_wxMaxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:855
+msgid "`wxbug_report()` tells how and where to file bugs"
+msgstr "`wxbug_report()` определяет, как и куда отправлять отчёты об ошибках."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:856
+#, fuzzy, no-wrap
+#| msgid "## Marking output being drawn in red"
+msgid "Marking output being drawn in red"
+msgstr "## Выделение вывода красным цветом"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:860
+msgid ""
+"_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a "
+"red foreground, if the second argument to the command is the text "
+"`highlight`."
+msgstr ""
+"Команда _Maxima_ `box()` вызывает вывод аргументов _wxMaxima_ с выделением "
+"красным цветом, если второй аргумент команды представляет собой текст "
+"`highlight`."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:861
+#, fuzzy, no-wrap
+#| msgid "## Output rendering."
+msgid "Output rendering."
+msgstr "## Визуализация вывода"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:864
+msgid "With `set_display()` one can set, how wxMaxima will render the output."
+msgstr ""
+"`set_display()` позволяет указать, как wxMaxima следует визуализировать "
+"вывод."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:866
+msgid ""
+"`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima "
+"using an (machine readable) XML-dialect (can be seen in the \"Raw XML "
+"sidebar\") and outputs the resulting formulas nicely rendered, e.g. pretty "
+"Matrices, Square root signs, fractions, etc."
+msgstr ""
+"`set_display('xml)` — значение по умолчанию. Здесь Maxima обращается к "
+"wxMaxima с помощью (машиночитаемого) XML-диалекта (доступен для просмотра на "
+"боковой панели «Отслеживание необработанных XML-данных») и выводит "
+"получившиеся формулы в удобном для восприятия пользователем виде; например, "
+"матрицы, знаки квадратного корня, дроби и так далее."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:869
+#, fuzzy, no-wrap
+#| msgid "<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) --> `set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art."
+msgid ""
+"<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->\n"
+"`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.\n"
+msgstr "<!--- Сейчас не работает надлежащим образом; строка с меткой вывода сдвинута вправо (ошибка #2006) --> `set_display('ascii)` заставляет wxMaxima выводить формулы как в командной строке Maxima, то есть в виде символов ASCII."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:871
+msgid ""
+"`set_display('none)` causes 'one-line' ASCII results - the same as the "
+"command line Maxima command `display2d:false;` does."
+msgstr ""
+"`set_display('none)` — «однострочные» выходные данные ASCII — эта команда "
+"делает то же самое, что и команда `display2d:false;` командной строки Maxima."
+
+#. type: Title #
+#: ../../info/wxmaxima.md:872
+#, fuzzy, no-wrap
+#| msgid "# Help menu"
+msgid "Help menu"
+msgstr "# Меню справки"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:875
+msgid ""
+"WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, "
+"tips, some example worksheets and in command line Maxima included demos (the "
+"`demo()` command)."
+msgstr ""
+"Меню справки wxMaxima предоставляет доступ к руководству, подсказкам и "
+"некоторым примерам рабочих листов Maxima и wxMaxima, а также к "
+"демонстрационным примерам в командной строке Maxima (команда `demo()`)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:877
+msgid "Please notice, that the demos write:"
+msgstr "Обратите внимание на вывод демонстрационных примеров:"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:878
+#, fuzzy, no-wrap
+#| msgid "~~~text At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.  ~~~"
+msgid "At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.\n"
+msgstr "~~~text При появлении приглашения в виде ’_’ введите ’;’ и нажмите <enter> для продолжения демонстрации.  ~~~"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:883
+#, fuzzy, no-wrap
+#| msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>"
+msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>\n"
+msgstr "Это работает в командной строке Maxima, но в wxMaxima для продолжения демонстрации необходимо использовать сочетание клавиш <kbd>CTRL</kbd>+<kbd>ENTER</kbd>"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:885
+#, fuzzy, no-wrap
+#| msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)"
+msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)\n"
+msgstr "(Сочетание клавиш можно настроить в меню «Настройка -> Лист -> Комбинации клавиш для отправки команд в Maxima».)"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:888
+#, fuzzy, no-wrap
+#| msgid "# Troubleshooting"
+msgid "Troubleshooting"
+msgstr "# Устранение неполадок"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:890
+#, fuzzy, no-wrap
+#| msgid "## Cannot connect to _Maxima_"
+msgid "Cannot connect to _Maxima_"
+msgstr "## Не удаётся установить соединение с _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:893
+msgid ""
+"Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ "
+"(providing the easy-to-use user interface) are separate programs that "
+"communicate by the means of a local network connection. Therefore the most "
+"probable cause is that this connection is somehow not working. For example, "
+"a firewall could be set up in a way that it doesn’t just prevent "
+"unauthorized connections from the internet (and perhaps intercept some "
+"connections to the internet, too), but also blocks inter-process-"
+"communication inside the same computer. Note that since _Maxima_ is being "
+"run by a Lisp processor the process communication that is blocked does not "
+"necessarily have to be named \"maxima\". Common names of the program that "
+"opens the network connection would be sbcl, gcl, ccl, lisp.exe, or similar "
+"names."
+msgstr ""
+"_Maxima_ (программа, которая фактически выполняет математические расчёты) и "
+"_wxMaxima_ (предоставляет удобный интерфейс пользователя) — отдельные "
+"программы, которые обмениваются данными по локальной сети. Поэтому наиболее "
+"вероятной причиной проблемы могут быть сбои в работе соединения. Например, "
+"межсетевой экран может быть настроен таким образом, что не только "
+"предотвращает несанкционированные соединения, поступающие из сети Интернет "
+"(а возможно, и некоторые соединения в обратном направлении), но также "
+"блокирует взаимодействие между процессами на одном и том же компьютере. "
+"Поскольку _Maxima_ работает на процессоре Lisp, блокируемые процессы не "
+"обязательно будут носить имя «maxima». Сетевые соединения обычно открывают "
+"программы sbcl, gcl, ccl, lisp.exe или подобные им."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:895
+msgid ""
+"On Unix computers another possible reason would be that the loopback network "
+"that provides network connections between two programs in the same computer "
+"isn’t properly configured."
+msgstr ""
+"На компьютерах с Unix другой возможной причиной может быть неправильная "
+"конфигурация закольцованной сети, обеспечивающей сетевое соединение между "
+"двумя программами на одном компьютере."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:896
+#, fuzzy, no-wrap
+#| msgid "## How to save data from a broken .wxmx file"
+msgid "How to save data from a broken .wxmx file"
+msgstr "## Как сохранить данные из повреждённого файла .wxmx"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:899
+msgid ""
+"Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ "
+"doesn’t turn on compression, so the contents of `.wxmx` files can be viewed "
+"in any text editor."
+msgstr ""
+"Большинство современных форматов на основе XML представляют собой обычные "
+"zip-файлы. _WxMaxima_ не использует функцию сжатия, поэтому содержимое "
+"файлов `.wxmx` можно просматривать в текстовом редакторе."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:901
+msgid ""
+"If the zip signature at the end of the file is still intact after renaming a "
+"broken `.wxmx` file to `.zip` most operating systems will provide a way to "
+"extract any portion of the information that is stored inside it. This can be "
+"done when there is a need of recovering the original image files from a text "
+"processor document. If the zip signature isn’t intact that does not need to "
+"be the end of the world: If _wxMaxima_ during saving detected that something "
+"went wrong there will be a `.wxmx~` file whose contents might help."
+msgstr ""
+"Если zip-сигнатура в конце файла осталась нетронутой после переименования "
+"повреждённого файла `.wxmx` в `.zip`, то большинство операционных систем "
+"смогут обеспечить извлечение любой части находящихся в нём данных. Это может "
+"быть сделано при необходимости восстановления исходных файлов изображений из "
+"текстового документа. И даже повреждение zip-сигнатуры не означает, что всё "
+"потеряно: если во время сохранения _wxMaxima_ удалось определить, что что-то "
+"пошло не так, появится файл `.wxmx~`, содержимое которого может оказаться "
+"полезным."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:903
+#, fuzzy, no-wrap
+#| msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor)."
+msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).\n"
+msgstr "И даже если этого файла нет: формат файла `.wxmx` представляет собой контейнер, XML-содержимое в котором хранится без сжатия. Можно переименовать файл `.wxmx` в файл `.txt` и с помощью текстового редактора восстановить XML-содержимое файла (оно начинается со строки `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` и завершается строкой `</wxMaximaDocument>`, а перед этим текстом и после него в текстовом редакторе располагается нечитаемый двоичный код)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:905
+msgid ""
+"If a text file containing only these contents (e.g. copy and paste this text "
+"into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know "
+"how to recover the text from the document."
+msgstr ""
+"Если извлечь это содержимое (например, скопировать и вставить этот текст в "
+"новый файл) и сохранить полученный текстовый файл с расширением `.xml`, то "
+"_wxMaxima_ сможет восстановить текст из этого документа."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:906
+#, fuzzy, no-wrap
+#| msgid "## I want some debug info to be displayed on the screen before my command has finished"
+msgid "I want some debug info to be displayed on the screen before my command has finished"
+msgstr "## Как вывести отладочную информацию на экран до завершения работы команды"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:909
+msgid ""
+"Normally _wxMaxima_ waits for the whole 2D formula to be transferred before "
+"it begins to typeset. This saves time for making many attempts to typeset a "
+"only partially completed equation. There is a `disp` command, though, that "
+"will provide debug output immediately and without waiting for the current "
+"_Maxima_ command to finish:"
+msgstr ""
+"Обычно _wxMaxima_ начинает вёрстку только после полной передачи двухмерной "
+"формулы. Это сделано, чтобы не тратить время на выполнение нескольких "
+"попыток вёрстки частично завершённого уравнения. Тем не менее, существует "
+"команда `disp`, которая обеспечивает незамедлительный вывод отладочной "
+"информации без ожидания завершения выполнения текущей команды _Maxima_:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:910
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "for i:1 thru 10 do (\n"
+#| "   disp(i),\n"
+#| "   /* (sleep n) is a Lisp function, which can be used */\n"
+#| "   /* with the character \"?\" before. It delays the */\n"
+#| "   /* program execution (here: for 3 seconds) */\n"
+#| "   ?sleep(3)\n"
+#| ")$\n"
+#| "```\n"
+msgid ""
+"for i:1 thru 10 do (\n"
+"   disp(i),\n"
+"   /* (sleep n) is a Lisp function, which can be used */\n"
+"   /* with the character \"?\" before. It delays the */\n"
+"   /* program execution (here: for 3 seconds) */\n"
+"   ?sleep(3)\n"
+")$\n"
+msgstr ""
+"```maxima\n"
+"for i:1 thru 10 do (\n"
+"   disp(i),\n"
+"   /* (sleep n) — функция Lisp, которую можно вызывать */\n"
+"   /* путём предварения символом \"?\". Она откладывает */\n"
+"   /* выполнение программы (здесь: на 3 секунды) */\n"
+"   ?sleep(3)\n"
+")$\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:921
+msgid "Alternatively one can look for the `wxstatusbar()` command above."
+msgstr ""
+"Альтернативный вариант —  воспользоваться командой `wxstatusbar()` (её "
+"описание приводилось выше)."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:922
+#, fuzzy, no-wrap
+#| msgid "## Plotting only shows a closed empty envelope with an error message"
+msgid "Plotting only shows a closed empty envelope with an error message"
+msgstr "## Функция построения графика показывает только закрытый пустой конверт с сообщением об ошибке"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:925
+msgid ""
+"This means that _wxMaxima_ could not read the file _Maxima_ that was "
+"supposed to instruct _Gnuplot_ to create."
+msgstr ""
+"Это означает, что _wxMaxima_ не удалось прочитать файл, который должен был "
+"быть создан _Gnuplot_ по инструкции от _Maxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:927
+msgid "Possible reasons for this error are:"
+msgstr "Возможные причины ошибки:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+msgid ""
+"The plotting command is part of a third-party package like `implicit_plot` "
+"but this package was not loaded by _Maxima_’s `load()` command before trying "
+"to plot."
+msgstr ""
+"Команда построения входит в состав стороннего пакета наподобие "
+"`implicit_plot`, но этот пакет не был загружен с помощью команды `load()` "
+"_Maxima_ перед попыткой построить график."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+msgid ""
+"_Maxima_ tried to do something the currently installed version of _Gnuplot_ "
+"isn’t able to understand. In this case, a file ending in `.gnuplot` located "
+"in the directory, which _Maxima_’s variable `maxima_userdir` is pointing, "
+"contains the instructions from _Maxima_ to _Gnuplot_. Most of the time, this "
+"file’s contents therefore are helpful when debugging the problem."
+msgstr ""
+"Текущей установленной версии _Gnuplot_ не удалось распознать действие, "
+"которое пыталась выполнить _Maxima_. Файл с заканчивающимся на `.gnuplot` "
+"именем, который расположен в каталоге, указанном переменной `maxima_userdir` "
+"_Maxima_, содержит инструкции от _Maxima_ для _Gnuplot_. Чаще всего "
+"содержимое этого файла помогает при отладке."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+msgid ""
+"Gnuplot was instructed to use the pngCairo library that provides "
+"antialiasing and additional line styles, but it was not compiled to support "
+"this possibility. Solution: Uncheck the \"Use the Cairo terminal for the "
+"plot\" checkbox in the configuration dialog and don’t set `wxplot_pngcairo` "
+"to true from _Maxima_."
+msgstr ""
+"Для Gnuplot было задано использование библиотеки pngCairo, которая "
+"предоставляет сглаживание и дополнительные стили линий, но компиляция была "
+"выполнена без поддержки такой возможности. Решение: снимите флажок "
+"«Использовать Cairo для улучшения качества графиков» в диалоговом окне "
+"параметров конфигурации и не устанавливайте `wxplot_pngcairo` в значение "
+"«true» в _Maxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+msgid "Gnuplot didn’t output a valid `.png` file."
+msgstr "Вывод Gnuplot — некорректный файл `.png`."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:933
+#, fuzzy, no-wrap
+#| msgid "## Plotting an animation results in “error: undefined variable”"
+msgid "Plotting an animation results in “error: undefined variable”"
+msgstr "## При создании анимации выводится ошибка «error: undefined variable»"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:936
+msgid ""
+"The value of the slider variable by default is only substituted into the "
+"expression that is to be plotted if it is visible there. Using a `subst` "
+"command that substitutes the slider variable into the equation to plot "
+"resolves this problem. At the end of section [Embedding animations into the "
+"spreadsheet](#embedding-animations-into-the-spreadsheet), you can see an "
+"example."
+msgstr ""
+"По умолчанию значение переменной ползунка подставляется в выражение только "
+"тогда, когда эта переменная непосредственно видима в выражении. Проблему "
+"решает использование команды `subst`, которая подставляет переменную "
+"ползунка в уравнение для формирования графика. В конце раздела [Встраивание "
+"анимаций в электронную таблицу](#embedding-animations-into-the-spreadsheet) "
+"есть соответствующий пример."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:937
+#, fuzzy, no-wrap
+#| msgid "## I lost cell content and undo doesn’t remember"
+msgid "I lost cell content and undo doesn’t remember"
+msgstr "## Содержимое поля потеряно, и отмена действия не может помочь в его восстановлении"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:940
+msgid ""
+"There are separate undo functions for cell operations and for changes inside "
+"of cells so chances are low that this ever happens. If it does there are "
+"several methods to recover data:"
+msgstr ""
+"Операции с полями и действия по изменению их содержимого имеют свои "
+"отдельные функции отмены. Поэтому возникновение такой ситуации крайне "
+"маловероятно. Если же это случилось, то имеется несколько способов "
+"восстановления данных:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+msgid ""
+"_WxMaxima_ actually has two undo features: The global undo buffer that is "
+"active if no cell is selected and a per-cell undo buffer that is active if "
+"the cursor is inside a cell. It is worth trying to use both undo options in "
+"order to see if an old value can still be accessed."
+msgstr ""
+"В _wxMaxima_ есть две функции отмены: глобальный буфер отмены (активен, "
+"когда не выбрано ни одного поля) и буфер отмены для поля (активен, когда "
+"курсор находится внутри поля). Стоит попробовать воспользоваться обеими "
+"функциями, чтобы увидеть, можно ли ещё получить доступ к старому значению."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+msgid ""
+"If you still have a way to find out what label _Maxima_ has assigned to the "
+"cell just type in the cell’s label and its contents will reappear."
+msgstr ""
+"Если ещё можно узнать, какую метку _Maxima_ присвоила полю, просто введите "
+"эту метку, чтобы содержимое поля появилось вновь."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+msgid ""
+"If you don’t: Don’t panic. In the “View” menu there is a way to show a "
+"history pane that shows all _Maxima_ commands that have been issued recently."
+msgstr ""
+"Если нельзя, не переживайте. В меню «Вид» доступна панель журнала, где "
+"показаны все недавно отданные команды _Maxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+msgid "If nothing else helps _Maxima_ contains a replay feature:"
+msgstr ""
+"Если больше ничего не помогло, в _Maxima_ есть функция повторного "
+"воспроизведения:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:946
+#, no-wrap
+msgid "playback();\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:950
+#, fuzzy, no-wrap
+#| msgid "## _WxMaxima_ starts up with the message “Maxima process terminated.”"
+msgid "_WxMaxima_ starts up with the message “Maxima process terminated.”"
+msgstr "## _WxMaxima_ запускается с выводом сообщения «Процесс Maxima неожиданно завершился.»"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:953
+msgid ""
+"One possible reason is that _Maxima_ cannot be found in the location that is "
+"set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore "
+"won’t run at all. Setting the path to a working _Maxima_ binary should fix "
+"this problem."
+msgstr ""
+"Одна из возможных причин — _Maxima_ не удалось найти в расположении, которое "
+"задано на вкладке «Maxima» диалогового окна параметров конфигурации "
+"_wxMaxima_, и поэтому программа не может запуститься в принципе. Проблема "
+"решается указанием пути к рабочему исполняемому файлу _Maxima_."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:954
+#, fuzzy, no-wrap
+#| msgid "## Maxima is forever calculating and not responding to input"
+msgid "Maxima is forever calculating and not responding to input"
+msgstr "## Maxima слишком долго выполняет вычисление и не отвечает на ввод"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:957
+msgid ""
+"It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ "
+"has finished calculating and therefore never gets informed it can send new "
+"data to _Maxima_. If this is the case “Trigger evaluation” might "
+"resynchronize the two programs."
+msgstr ""
+"Теоретически возможно, что _wxMaxima_ не распознаёт, что _Maxima_ уже "
+"завершила вычисление, и поэтому не получает уведомление о том, что пора "
+"отправлять новые данные для _Maxima_. Если дело в этом, то “Trigger "
+"evaluation” может помочь повторно синхронизировать эти две программы."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:958
+#, fuzzy, no-wrap
+#| msgid "## My SBCL-based _Maxima_ runs out of memory"
+msgid "My SBCL-based _Maxima_ runs out of memory"
+msgstr "## При работе _Maxima_ на основе SBCL заканчивается свободная память"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:961
+msgid ""
+"The Lisp compiler SBCL by default comes with a memory limit that allows it "
+"to run even on low-end computers. When compiling a big software package like "
+"Lapack or dealing with extremely big lists of equations this limit might be "
+"too low. In order to extend the limits, SBCL can be provided with the "
+"command line parameter `--dynamic-space-size` that tells SBCL how many "
+"megabytes it should reserve. A 32bit Windows-SBCL can reserve up to 999 "
+"Megabytes. A 64-bit SBCL version running on Windows can be instructed to use "
+"more than the about 1280 Megabytes compiling Lapack needs."
+msgstr ""
+"Компилятор Lisp SBCL по умолчанию поставляется с ограничением памяти, "
+"которое позволяет ему работать даже на очень слабых компьютерах. В процессе "
+"компиляции такого большого программного пакета, как Lapack, или при работе с "
+"огромными списками уравнений этот лимит может оказаться слишком низким. Для "
+"увеличения лимита SBCL можно запустить с параметром командной строки `--"
+"dynamic-space-size`, который указывает SBCL сколько мегабайт нужно "
+"зарезервировать. SBCL для 32-разрядной версии Windows может зарезервировать "
+"до 999 мегабайт. 64-разрядная версия SBCL для Windows позволяет "
+"зарезервировать более 1280 мегабайт, необходимых для компилирования Lapack."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:963
+msgid ""
+"One way to provide _Maxima_ (and thus SBCL) with command line parameters is "
+"the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration "
+"dialogue."
+msgstr ""
+"Один из способов указать параметры командной строки для _Maxima_ (а значит, "
+"и для SBCL) — использовать поле «Дополнительные параметры команды Maxima» в "
+"диалоговом окне настройки параметров конфигурации _wxMaxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:965
+msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
+msgstr "![Память sbcl](./sbclMemory.png){ id=img_sbclMemory }"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:966
+#, fuzzy, no-wrap
+#| msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgstr "## Иногда ввод бывает медленным/игнорирует нажатия клавиш в Ubuntu"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:969
+msgid ""
+"Installing the package `ibus-gtk` should resolve this issue. See ([https://"
+"bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs."
+"launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) for details."
+msgstr ""
+"Установка пакета `ibus-gtk` должна решить этот вопрос. Более подробную "
+"информацию смотрите по адресу ([https://bugs.launchpad.net/ubuntu/+source/"
+"wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/"
+"wxwidgets3.0/+bug/1421558))."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:970
+#, fuzzy, no-wrap
+#| msgid "## _WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgid "_WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgstr "## _WxMaxima_ зависает, когда _Maxima_ обрабатывает греческие символы или умляуты"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:973
+msgid ""
+"If your _Maxima_ is based on SBCL the following lines have to be added to "
+"your `.sbclrc`:"
+msgstr ""
+"Если используемая версия _Maxima_ основана на SBCL, то в `.sbclrc` "
+"необходимо добавить следующие строки:"
+
+#. type: Fenced code block (commonlisp)
+#: ../../info/wxmaxima.md:974
+#, fuzzy, no-wrap
+#| msgid "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
+msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
+msgstr "```commonlisp (setf sb-impl::*default-external-format* :utf-8)  ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:979
+msgid ""
+"The folder where this file has to be placed is system- and installation-"
+"specific. But any SBCL-based _Maxima_ that already has evaluated a cell in "
+"the current session will happily tell where it can be found after getting "
+"the following command:"
+msgstr ""
+"Папка, в которой размещается этот файл, зависит от конкретной системы и "
+"установки. Но любая версия _Maxima_ на основе SBCL, в которой в текущем "
+"сеансе уже производилось вычисление поля, всегда укажет его местонахождение "
+"после получения следующей команды:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:980
+#, fuzzy, no-wrap
+#| msgid "```maxima :lisp (sb-impl::userinit-pathname)  ```"
+msgid ":lisp (sb-impl::userinit-pathname)\n"
+msgstr "```maxima :lisp (sb-impl::userinit-pathname)  ```"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:984
+#, fuzzy, no-wrap
+#| msgid "## Note concerning Wayland (recent Linux/BSD distributions)"
+msgid "Note concerning Wayland (recent Linux/BSD distributions)"
+msgstr "## Примечание касательно Wayland (свежие дистрибутивы Linux/BSD)"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:988
+msgid ""
+"There seem to be issues with the Wayland Display Server and wxWidgets.  "
+"WxMaxima may be affected, e.g. that sidebars are not moveable."
+msgstr ""
+"Возможны проблемы с работой протокола графического сервера Wayland и "
+"wxWidgets. Это может затронуть wxMaxima (например, будет невозможно "
+"перемещать боковые панели)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:992
+msgid ""
+"You can either disable Wayland and use X11 instead (globally)  or just tell, "
+"that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
+msgstr ""
+"Можно либо отключить Wayland и использовать вместо этой подсистемы X11 "
+"(глобально), либо просто указать, что wxMaxima должна использовать X Window "
+"System, установкой параметра: `GDK_BACKEND=x11`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:994
+msgid "E.g. start wxMaxima with:"
+msgstr "Например, запустить wxMaxima с параметром:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:996
+msgid "`GDK_BACKEND=x11 wxmaxima`"
+msgstr "`GDK_BACKEND=x11 wxmaxima`"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:997
+#, no-wrap
+msgid "The menu bar disappears on KDE Plasma"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1003
+msgid ""
+"On some KDE Plasma installations the global menu bar disappears when "
+"clicked.  As this is a bug in the global menu proxy, the only way to avoid "
+"it is to tell that wxMaxima should use its own menu bar instead of the "
+"global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1007
+msgid ""
+"Starting with version 26.05.0, wxMaxima attempts to set this variable "
+"automatically if it detects an affected system (KDE, Unity, or Ubuntu with "
+"older wxWidgets versions)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1009
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1011
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1012
+#, fuzzy, no-wrap
+#| msgid "## Why is the integrated manual browser not offered on my Windows PC?"
+msgid "Why is the integrated manual browser not offered on my Windows PC?"
+msgstr "## Почему встроенный браузер руководства отсутствует на ПК с Windows?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1016
+msgid ""
+"Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or "
+"Microsoft’s webview2 isn’t installed."
+msgstr ""
+"Либо компиляция wxWidgets была выполнена без поддержки webview2 от "
+"Microsoft, либо компонент webview2 от Microsoft не был установлен."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1017
+#, fuzzy, no-wrap
+#| msgid "## Why is the external manual browser not working on my Linux box?"
+msgid "Why is the external manual browser not working on my Linux box?"
+msgstr "## Почему внешний браузер руководства не работает в Linux?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1024
+msgid ""
+"The HTML browser might be a snap, flatpack or appimage version. All of these "
+"typically cannot access files that are installed on your local system. "
+"Another reason might be that maxima or wxMaxima is installed as a snap, "
+"flatpack or something else that doesn’t give the host system access to its "
+"contents. A third reason might be that the maxima HTML manual isn’t "
+"installed and the online one cannot be accessed."
+msgstr ""
+"Браузер HTML может быть реализован в виде версии пакета snap, flatpack или "
+"appimage. Все они обычно не имеют доступа к файлам, установленным локально в "
+"системе. Другая причина может заключаться в том, что Maxima или wxMaxima "
+"установлена в виде версии пакета snap, flatpack или ещё чего-то, что не "
+"предоставляет доступа к содержимому операционной системы. Третьей причиной "
+"может быть то, что HTML-руководство maxima не установлено локально, а "
+"получить доступ к онлайн-руководству не получается."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1025
+#, fuzzy, no-wrap
+#| msgid "## Can I make _wxMaxima_ output both image files and embedded plots at once?"
+msgid "Can I make _wxMaxima_ output both image files and embedded plots at once?"
+msgstr "## Можно ли сделать вывод _wxMaxima_ одновременно в виде файлов изображений и встроенных в документ графиков?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1028
+msgid ""
+"The worksheet embeds `.png files. _WxMaxima_ allows the user to specify "
+"where they should be generated:"
+msgstr ""
+"В рабочий лист встраиваются .png-файлы. _WxMaxima_ позволяет пользователю "
+"указать, где они должны генерироваться:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1029
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw2d(\n"
+#| "    file_name=\"test\",  /* extension .png automatically added */\n"
+#| "    explicit(sin(x),x,1,10)\n"
+#| ");\n"
+#| "```\n"
+msgid ""
+"wxdraw2d(\n"
+"    file_name=\"test\",  /* extension .png automatically added */\n"
+"    explicit(sin(x),x,1,10)\n"
+");\n"
+msgstr ""
+"```maxima\n"
+"wxdraw2d(\n"
+"    file_name=\"test\",  /* автоматически добавляется расширение .png */\n"
+"    explicit(sin(x),x,1,10)\n"
+");\n"
+"```\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1037
+msgid ""
+"If a different format is to be used, it is easier to generate the images and "
+"then import them into the worksheet again:"
+msgstr ""
+"Если необходимо использовать другой формат, то проще сначала сгенерировать "
+"изображения, а затем снова импортировать их в рабочий лист:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1038
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "load(\"draw\");\n"
+#| "pngdraw(name,[contents]):=\n"
+#| "(\n"
+#| "    draw(\n"
+#| "        append(\n"
+#| "            [\n"
+#| "                terminal=pngcairo,\n"
+#| "                dimensions=wxplot_size,\n"
+#| "                file_name=name\n"
+#| "            ],\n"
+#| "            contents\n"
+#| "        )\n"
+#| "    ),\n"
+#| "    show_image(printf(false,\"~a.png\",name))\n"
+#| ");\n"
+#| "pngdraw2d(name,[contents]):=\n"
+#| "    pngdraw(name,gr2d(contents));\n"
+msgid ""
+"load(\"draw\");\n"
+"pngdraw(name,[contents]):=\n"
+"(\n"
+"    draw(\n"
+"        append(\n"
+"            [\n"
+"                terminal=pngcairo,\n"
+"                dimensions=wxplot_size,\n"
+"                file_name=name\n"
+"            ],\n"
+"            contents\n"
+"        )\n"
+"    ),\n"
+"    show_image(printf(false,\"~a.png\",name))\n"
+");\n"
+"pngdraw2d(name,[contents]):=\n"
+"    pngdraw(name,gr2d(contents));\n"
+"\n"
+"pngdraw2d(\"Test\",\n"
+"        explicit(sin(x),x,1,10)\n"
+");\n"
+msgstr ""
+"```maxima\n"
+"load(\"draw\");\n"
+"pngdraw(name,[contents]):=\n"
+"(\n"
+"    draw(\n"
+"        append(\n"
+"            [\n"
+"                terminal=pngcairo,\n"
+"                dimensions=wxplot_size,\n"
+"                file_name=name\n"
+"            ],\n"
+"            contents\n"
+"        )\n"
+"    ),\n"
+"    show_image(printf(false,\"~a.png\",name))\n"
+");\n"
+"pngdraw2d(name,[contents]):=\n"
+"    pngdraw(name,gr2d(contents));\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1062
+#, fuzzy, no-wrap
+#| msgid "## Can I set the aspect ratio of an embedded plot?"
+msgid "Can I set the aspect ratio of an embedded plot?"
+msgstr "## Как задать соотношение сторон встроенного графика?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1065
+msgid "Use the variable `wxplot_size`:"
+msgstr "С помощью переменной `wxplot_size`:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1066
+#, fuzzy, no-wrap
+#| msgid ""
+#| "```maxima\n"
+#| "wxdraw2d(\n"
+#| "    explicit(sin(x),x,1,10)\n"
+#| "),wxplot_size=[1000,1000];\n"
+#| "```\n"
+msgid ""
+"wxdraw2d(\n"
+"    explicit(sin(x),x,1,10)\n"
+"),wxplot_size=[1000,1000];\n"
+msgstr ""
+"```maxima\n"
+"wxdraw2d(\n"
+"    explicit(sin(x),x,1,10)\n"
+"),wxplot_size=[1000,1000];\n"
+"```\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1072
+#, fuzzy, no-wrap
+#| msgid "## After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
+msgid "After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
+msgstr "## После обновления до MacOS 13.1 команды plot и/или draw возвращают сообщения об ошибках, например:"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:1074
+#, fuzzy, no-wrap
+#| msgid "```text 1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```"
+msgid ""
+"1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102\n"
+"2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52\n"
+"3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408\n"
+"...\n"
+msgstr "```text 1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102 2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52 3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408 ...  ```"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1082
+#, fuzzy, no-wrap
+#| msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information."
+msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.\n"
+msgstr "Эта ошибка может быть связана с операционной системой. Отключение скрытия строки меню (Системные настройки => Рабочий стол и Dock => Строка меню) может решить проблему. Более подробная информация доступна в [ошибке wxMaxima #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746)."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1083
+#, fuzzy, no-wrap
+#| msgid "## Logging"
+msgid "Logging"
+msgstr "## Журналирование"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1088
+#, fuzzy, no-wrap
+#| msgid "Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build, the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable this window using the \"View->Toggle log window\" menu entry."
+msgid ""
+"Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build,\n"
+"the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable\n"
+"this window using the \"View->Toggle log window\" menu entry.\n"
+msgstr "Сообщения журнала могут быть полезны при отладке. WxMaxima поддерживает журналирование широкого спектра событий. Большинство записей журнала пригодятся разработчикам, особенно при появлении проблем или внутренних ошибок. Если запущена сборка выпуска, журнал не отображается по умолчанию. Если же запущена сборка разработки, журнал по умолчанию отображается как второе окно. Это окно можно включать и отключать с помощью пункта меню «Вид -> Переключить окно журнала»."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1090
+msgid ""
+"Messages are not 'lost', if the log window is not shown, if you select to "
+"show the log window later, you will see past log messages (if you did not "
+"clear the messages)."
+msgstr ""
+"Сообщения не «теряются»; если окно журнала не показано, то при последующем "
+"включении его отображения будут доступны для просмотра также и прошлые "
+"сообщения журнала (если они не были очищены пользователем)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1092
+msgid ""
+"Such messages may be helpful, when you create bug reports (or trying to find "
+"a bug by yourself)."
+msgstr ""
+"Такие сообщения могут быть полезны при создании отчётов об ошибках (или при "
+"самостоятельном поиске ошибок)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1095
+msgid ""
+"Log messages can (additionally) be printed to STDERR, when using the command "
+"line option \"--logtostderr\". On Windows a separate text console will be "
+"opened, as a Windows GUI application does not have the standard IO connected."
+msgstr ""
+"Сообщения журнала можно (дополнительно) выводить в STDERR с помощью "
+"параметра командной строки «--logtostderr». В Windows будет открыта "
+"отдельная текстовая консоль, так как у приложения Windows с графическим "
+"интерфейсом пользователя не подключён стандартный ввод/вывод."
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1098
+#, fuzzy, no-wrap
+#| msgid "# FAQ"
+msgid "FAQ"
+msgstr "# Вопросы и ответы"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1100
+#, fuzzy, no-wrap
+#| msgid "## Is there a way to make more text fit on a LaTeX page?"
+msgid "Is there a way to make more text fit on a LaTeX page?"
+msgstr "## Есть ли возможность поместить больше текста на страницу LaTeX?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1103
+msgid ""
+"Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to "
+"specify the size of the borders."
+msgstr ""
+"Да. Можно использовать [пакет LaTeX «geometry»](https://ctan.org/pkg/"
+"geometry), который позволяет указать размеры границ."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1105
+#, fuzzy, no-wrap
+#| msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):"
+msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):\n"
+msgstr "Можно добавить следующую строку к преамбуле LaTeX (например, путём использования соответствующего поля в диалоге настройки («Экспорт -> Дополнительные строки для преамбулы TeX»), чтобы установить границы размером 1 см):"
+
+#. type: Fenced code block (latex)
+#: ../../info/wxmaxima.md:1106
+#, fuzzy, no-wrap
+#| msgid "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
+msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+msgstr "```latex \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry} ```"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1110
+#, fuzzy, no-wrap
+#| msgid "## Is there a dark mode?"
+msgid "Is there a dark mode?"
+msgstr "## Имеется ли тёмная тема?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1113
+msgid ""
+"If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if "
+"the rest of the operating system is. The worksheet itself is by default "
+"equipped with a bright background. But it can be configured otherwise. "
+"Alternatively, there is a `View/Invert worksheet brightness` menu entry that "
+"allows to quickly convert the worksheet from dark to bright and vice versa."
+msgstr ""
+"Если версия wxWidgets достаточно свежая, то _wxMaxima_ автоматически "
+"использует тёмную тему, когда вся остальная операционная система настроена "
+"на работу в ней. Сам по себе рабочий лист по умолчанию оснащён светлым "
+"фоном, но можно установить тёмный. Кроме того, имеется пункт меню «Вид/"
+"Инвертировать яркость рабочего листа», позволяющий быстро преобразовывать "
+"рабочий лист из тёмного в светлый и обратно."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1114
+#, fuzzy, no-wrap
+#| msgid "## _WxMaxima_ sometimes hangs for several seconds once in the first minute"
+msgid "_WxMaxima_ sometimes hangs for several seconds once in the first minute"
+msgstr "## _WxMaxima_ иногда зависает на несколько секунд в течение первой минуты"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1117
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work."
+msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.\n"
+msgstr "_WxMaxima_ делегирует ряд больших задач, таких как обработка >1000-страничного руководства _Maxima_, фоновым задачам, что обычно происходит абсолютно незаметно. Когда требуется получить результат выполнения такой задачи, _wxMaxima_ может понадобиться подождать пару секунд перед продолжением работы."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1118
+#, fuzzy, no-wrap
+#| msgid "## Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+msgid "Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+msgstr "## Часто при тестировании новых настроек локали выводится сообщение «locale ’xx_YY’ can not be set»"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1121
+msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
+msgstr "![Предупреждение локали](./locale-warning.png){ id=img_locale_warning}"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1125
+msgid ""
+"(The same problem can occur with other applications too). The translations "
+"seem okay after you click on ’OK’. WxMaxima does not only use its own "
+"translations but the translations of the wxWidgets framework too."
+msgstr ""
+"(Та же ошибка может возникать и с другими приложениями). После нажатия "
+"кнопки «ОК» никаких проблем с переводом не обнаруживается. WxMaxima "
+"использует не только свои собственные переводы, но и переводы платформы "
+"wxWidgets."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1128
+msgid ""
+"These locales maybe not present in the system. On Ubuntu/Debian systems they "
+"can be generated using: `dpkg-reconfigure locales`"
+msgstr ""
+"Указанные локали могут отсутствовать в системе. В системах Ubuntu/Debian их "
+"можно сгенерировать с помощью команды `dpkg-reconfigure locales`"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1129
+#, fuzzy, no-wrap
+#| msgid "## How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
+msgid "How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
+msgstr "## Как использовать символы для вещественных чисел, натуральных чисел (ℝ, ℕ) и так далее?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1132
+msgid ""
+"You can find these symbols in the Unicode sidebar (search for ’double-struck "
+"capital’). But the selected font must also support these symbols. If they do "
+"not display properly, select another font."
+msgstr ""
+"Эти символы доступны на боковой панели «Юникод» (выполните поиск по ’double-"
+"struck capital’). Но такие символы должен поддерживать и выбранный шрифт. "
+"Выберите другой шрифт, если символы отображаются неправильно."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1133
+#, fuzzy, no-wrap
+#| msgid "## How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
+msgid "How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
+msgstr "## Каким образом сценарий Maxima может определить, работает ли он под управлением wxMaxima или командной строки Maxima?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1136
+msgid ""
+"If wxMaxima is used, the Maxima variable `maxima_frontend` is set to "
+"`wxmaxima`. The Maxima variable `maxima_frontend_version` contains the "
+"wxMaxima version in this case."
+msgstr ""
+"Если используется wxMaxima, то переменная Maxima `maxima_frontend` "
+"установлена в значение `wxmaxima`. Переменная Maxima "
+"`maxima_frontend_version` в этом случае содержит версию wxMaxima."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1138
+msgid ""
+"If no frontend is used (you are using command line Maxima), these variables "
+"are `false`."
+msgstr ""
+"Если графический интерфейс не используется (работа выполняется в командной "
+"строке Maxima), то эти переменные имеют значение `false`."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1139
+#, no-wrap
+msgid "Help! I can not save my document!"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1142
+#, no-wrap
+msgid "If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.\n"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1145
+#, fuzzy, no-wrap
+#| msgid "# Command-line arguments"
+msgid "Command-line arguments"
+msgstr "# Аргументы командной строки"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1148
+msgid ""
+"Usually you can start programs with a graphical user interface just by "
+"clicking on a desktop icon or desktop menu entry. WxMaxima - if started from "
+"the command line - still provides some command-line switches, though."
+msgstr ""
+"Обычно программы с графическим интерфейсом пользователя можно запускать "
+"простым щелчком по значку на рабочем столе или пункту меню рабочего стола. "
+"Тем не менее, wxMaxima — при запуске из командной строки — позволяет "
+"использовать некоторые аргументы командной строки."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-v` or `--version`: Output the version information"
+msgstr "`-v` или `--version`: вывести информацию о версии."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-h` or `--help`: Output a short help text"
+msgstr "`-h` или `--help`: вывести краткую справочную информацию."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid ""
+"`-o` or `--open=<str>`: Open the filename given as an argument to this "
+"command-line switch"
+msgstr ""
+"`-o` или `--open=<str>`: открыть файл, заданный в виде аргумента к этому "
+"ключу командной строки."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-e` or `--eval`: Evaluate the file after opening it."
+msgstr "`-e` или `--eval`: выполнить вычисление файла после его открытия."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid ""
+"`-b` or `--batch`: If the command-line opens a file all cells in this file "
+"are evaluated and the file is saved afterward. This is for example useful if "
+"the session described in the file makes _Maxima_ generate output files. "
+"Batch-processing will be stopped if _wxMaxima_ detects that _Maxima_ has "
+"output an error and will pause if _Maxima_ has a question: Mathematics is "
+"somewhat interactive by nature so a completely interaction-free batch "
+"processing cannot always be guaranteed."
+msgstr ""
+"`-b` или `--batch`: если файл открывается из командной строки, то все поля в "
+"этом файле вычисляются, после чего выполняется его сохранение. Например, это "
+"полезно, когда сеанс, описанный в файле, заставляет _Maxima_ генерировать "
+"файлы вывода. Пакетная обработка будет остановлена, если _wxMaxima_ "
+"обнаруживает, что _Maxima_ вывела сообщение об ошибке, либо приостановлена, "
+"если у _Maxima_ возникает вопрос: математические вычисления по своей природе "
+"обладают некоторой интерактивностью, поэтому при пакетной обработке её "
+"полное отсутствие не всегда возможно."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1164
+#, no-wrap
+msgid ""
+"- `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
+"- `--pipe`:                        Pipe messages from Maxima to stdout.\n"
+"- `--exit-on-error`:               Close the program on any maxima error.\n"
+"- `-f` or `--ini=<str>`: Use the init file that was given as an argument to this command-line switch\n"
+"- `-u`, `--use-version=<str>`:     Use maxima version `<str>`.\n"
+"- `-l`, `--lisp=<str>`:              Use a Maxima compiled with Lisp compiler `<str>`.\n"
+"- `-X`, `--extra-args=<str>`:        Allows to specify extra Maxima arguments\n"
+"- `-m` or `--maxima=<str>`:    allows specifying the location of the _maxima_ binary\n"
+"- `--enableipc`: Lets Maxima control wxMaxima via interprocess communications. Use this option with care.\n"
+"- `--wxmathml-lisp=<str>`:   Location of wxMathML.lisp (if not the built-in should be used, mainly for developers).\n"
+msgstr ""
+"- `--logtostderr`:                 журналировать все «отладочные сообщения» из боковой панели также и в stderr.\n"
+"- `--pipe`:                        перенаправлять сообщения из Maxima в stdout.\n"
+"- `--exit-on-error`:               закрывать программу при любой ошибке Maxima.\n"
+"- `-f` or `--ini=<str>`: использовать файл init, переданный в качестве аргумента данному ключу командной строки.\n"
+"- `-u`, `--use-version=<str>`:     использовать версию Maxima `<str>`.\n"
+"- `-l`, `--lisp=<str>`:              использовать Maxima, скомпилированную компилятором Lisp`<str>`.\n"
+"- `-X`, `--extra-args=<str>`:        позволяет указать дополнительные аргументы Maxima.\n"
+"- `-m` or `--maxima=<str>`:    позволяет указать расположение двоичного файла _Maxima_.\n"
+"- `--enableipc`: позволяет Maxima использовать межпроцессное взаимодействие для управления wxMaxima. Используйте этот параметр с осторожностью.\n"
+"- `--wxmathml-lisp=<str>`:   расположение wxMathML.lisp (если необходимо использовать не встроенный файл; предназначено, главным образом, для разработчиков).\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1166
+msgid ""
+"Instead of a minus, some operating systems might use a dash in front of the "
+"command-line switches."
+msgstr ""
+"Вместо минуса в некоторых операционных системах перед ключами командной "
+"строки может использоваться тире."
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1169
+#, fuzzy, no-wrap
+#| msgid "# About the program, contributing to wxMaxima"
+msgid "About the program, contributing to wxMaxima"
+msgstr "# О программе, участие в разработке wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1172
+msgid ""
+"wxMaxima is mainly developed using the programming language C++ using the "
+"[wxWidgets framework](https://www.wxwidgets.org), as build system we use "
+"[CMake](https://www.cmake.org), a small part is written in Lisp. You can "
+"contribute to wxMaxima, join the wxMaxima project at <https://github.com/"
+"wxMaxima-developers/wxmaxima>, if you have knowledge of these programming "
+"languages and want to help and contribute to the open source project "
+"wxMaxima."
+msgstr ""
+"wxMaxima написана большей частью на языке программирования C++ с "
+"использованием [платформы wxWidgets](https://www.wxwidgets.org), в качестве "
+"системы сборки используется [CMake](https://www.cmake.org), небольшая часть "
+"написана на Lisp. Можно принять участие в разработке wxMaxima. Для этого "
+"необходимо присоединиться к проекту wxMaxima на <https://github.com/wxMaxima-"
+"developers/wxmaxima> при наличии навыков программирования на этих языках и "
+"желании внести вклад в разработку проекта wxMaxima с открытым исходным кодом."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1174
+msgid ""
+"But not only programmers are necessary! You can also contribute to wxMaxima, "
+"if you help to improve the documentation, find and report bugs (and maybe "
+"bugfixes), suggest new features, help to translate wxMaxima or the manual to "
+"your language (read the README.md in the [locale subdirectory](https://"
+"github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and "
+"the manual can be translated)."
+msgstr ""
+"Но требуются не только программисты! Внести вклад в разработку wxMaxima "
+"можно также путём улучшения документации, поиска ошибок и отправки "
+"соответствующих отчётов (а также, возможно, исправлений), предложения новых "
+"функциональных возможностей, помощи с переводом интерфейса или документации "
+"wxMaxima на другие языки (для получения информации о порядке перевода "
+"интерфейса и документации wxMaxima изучите файл README.md в [подкаталоге "
+"локализации](https://github.com/wxMaxima-developers/wxmaxima/tree/main/"
+"locales))."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1176
+msgid "Or answer questions of other users in the discussion forum."
+msgstr ""
+"Также можно отвечать на вопросы других пользователей на дискуссионном форуме."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1178
+msgid ""
+"The source code of wxMaxima is documented using Doxygen [here](https://"
+"wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+msgstr ""
+"Исходный код wxMaxima документирован с помощью Doxygen [здесь](https://"
+"wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1180
+msgid ""
+"The program is nearly self-contained, so except for system libraries (and "
+"the wxWidgets library), no external dependencies (like graphic files or the "
+"Lisp part (the `wxmathML.lisp`-file) is needed, these files are included in "
+"the executable."
+msgstr ""
+"Программа практически полностью автономна, поэтому — за исключением "
+"системных библиотек (и библиотеки wxWidgets) — для её работы не требуется "
+"внешних зависимостей (например, графических файлов или части на языке Lisp "
+"(файл `wxmathML.lisp`); эти файлы включены в исполняемый файл)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1181
+#, fuzzy, no-wrap
+#| msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one."
+msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.\n"
+msgstr "Если вы разработчик, то вы можете поработать с изменённым файлом `wxmathML.lisp` без выполнения полной перекомпиляции. Указать другой файл Lisp (нестандартный файл) можно с помощью параметра командной строки `--wxmathml-lisp=<str>`."
+
+#~ msgid "______________________________________________________________________\n"
+#~ msgstr "______________________________________________________________________\n"
+
+#~ msgid "```maxima load(draw);"
+#~ msgstr "```maxima load(draw);"
+
+#~ msgid ""
+#~ "/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
+#~ msgstr ""
+#~ "/* Парабола в окне #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
+
+#~ msgid ""
+#~ "/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
+#~ msgstr ""
+#~ "/* Парабола в окне #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
+
+#~ msgid ""
+#~ "/* Paraboloid in window #3 */ draw3d(terminal=[wxt,3],explicit(x^2+y^2,"
+#~ "x,-1,1,y,-1,1)); ```"
+#~ msgstr ""
+#~ "/* Параболоид в окне #3 */ draw3d(terminal=[wxt,3],explicit(x^2+y^2,"
+#~ "x,-1,1,y,-1,1)); ```"
+
+#~ msgid "#### 2D"
+#~ msgstr "#### Двухмерный график"
+
+#~ msgid "#### 3D"
+#~ msgstr "#### Трёхмерный график"
+
+#~ msgid "```maxima playback(); ```"
+#~ msgstr "```maxima playback(); ```"
+
+#~ msgid ""
+#~ "pngdraw2d(\"Test\",\n"
+#~ "        explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "pngdraw2d(\"Test\",\n"
+#~ "        explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+#~ "```\n"

--- a/locales/manual/tr.po
+++ b/locales/manual/tr.po
@@ -1,0 +1,4937 @@
+# This file is distributed under the same license as the PACKAGE package.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER.
+#
+# Tufan Şirin <tsirin@turgutozal.edu.tr>, November 2014.
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: wxmaxima-gui\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-04 07:28+0000\n"
+"PO-Revision-Date: 2026-08-02 11:43\n"
+"Last-Translator: \n"
+"Language-Team: Turkish\n"
+"Language: tr_TR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: wxmaxima-gui\n"
+"X-Crowdin-Project-ID: 917703\n"
+"X-Crowdin-Language: tr\n"
+"X-Crowdin-File: /main/locales/wxMaxima/wxMaxima.pot\n"
+"X-Crowdin-File-ID: 8\n"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1
+#, fuzzy, no-wrap
+#| msgid ""
+#| "The wxMaxima user manual {-}\n"
+#| "============================\n"
+msgid "The wxMaxima user manual"
+msgstr ""
+"'wxMaxima' Kullanım Kılavuzu {-}\n"
+"============================\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:4
+#, fuzzy
+#| msgid ""
+#| "wxMaxima is a graphical user interface (GUI) for the _Maxima_ computer "
+#| "algebra system (CAS). wxMaxima allows one to use all of _Maxima_’s "
+#| "functions. In addition, it provides convenient wizards for accessing the "
+#| "most commonly used features. This manual describes some of the features "
+#| "that make wxMaxima one of the most popular GUIs for _Maxima_."
+msgid ""
+"WxMaxima is a graphical user interface (GUI) for the _Maxima_ computer "
+"algebra system (CAS). WxMaxima allows one to use all of _Maxima_’s "
+"functions. In addition, it provides convenient wizards for accessing the "
+"most commonly used features. This manual describes some of the features that "
+"make wxMaxima one of the most popular GUIs for _Maxima_."
+msgstr ""
+"wxMaxima, _Maxima_ bilgisayar cebir sistemi (CAS) için bir grafiksel "
+"kullanıcı arayüzüdür (GUI). wxMaxima , _Maxima_’ın tüm işlevlerini "
+"kullanılmasına izin verir. Ayrıca, en sık kullanılan özelliklere erişmek "
+"için uygun sihirbazlar sağlar. Bu kılavuz, wxMaxima'yı _Maxima_ için en "
+"popüler GUI'lerden biri yapan bazı özellikleri açıklamaktadır."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:6
+msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
+msgstr "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:9
+#, fuzzy, no-wrap
+#| msgid ""
+#| "Introduction to wxMaxima\n"
+#| "========================\n"
+msgid "Introduction to wxMaxima"
+msgstr ""
+"'wxMaxima'ya Giriş\n"
+"========================\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:11
+#, fuzzy, no-wrap
+#| msgid "## _Maxima_ and wxMaxima"
+msgid "_Maxima_ and wxMaxima"
+msgstr "## _Maxima_ ve wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:14
+#, fuzzy
+#| msgid ""
+#| "In the open-source domain big systems are normally split into smaller "
+#| "projects that are easier to handle for small groups of developers. For "
+#| "example a CD burner program will consist of a command-line tool that "
+#| "actually burns the CD and a graphical user interface that allows users to "
+#| "implement it without having to learn about all the command line switches "
+#| "and in fact without using the command line at all. One advantage of this "
+#| "approach is that the developing work that was invested into the command-"
+#| "line program can be shared by many programs: The same CD-burner command-"
+#| "line program can be used as a “send-to-CD”-plug-in for a file manager "
+#| "application, for the “burn to CD” function of a music player and as the "
+#| "CD writer for a DVD backup tool. Another advantage is that splitting one "
+#| "big task into smaller parts allows the developers to provide several user "
+#| "interfaces for the same program."
+msgid ""
+"In the open-source domain, big systems are normally split into smaller "
+"projects that are easier to handle for small groups of developers. For "
+"example a CD burner program will consist of a command-line tool that "
+"actually burns the CD and a graphical user interface that allows users to "
+"implement it without having to learn about all the command line switches and "
+"in fact without using the command line at all. One advantage of this "
+"approach is that the developing work that was invested into the command-line "
+"program can be shared by many programs: The same CD-burner command-line "
+"program can be used as a “send-to-CD”-plug-in for a file manager "
+"application, for the “burn to CD” function of a music player and as the CD "
+"writer for a DVD backup tool. Another advantage is that splitting one big "
+"task into smaller parts allows the developers to provide several user "
+"interfaces for the same program."
+msgstr ""
+"Açık-Kaynak Açık-Kod alanında büyük sistemler normalde küçük geliştirici "
+"grupları için daha kolay işlenen daha küçük projelere ayrılır. Örneğin, bir "
+"CD yazıcı programı, CD'yi gerçekten yakan bir komut satırı aracından ve "
+"kullanıcıların tüm komut satırı anahtarları hakkında bilgi edinmek zorunda "
+"kalmadan ve aslında komut satırını kullanmadan uygulamalarını sağlayan bir "
+"grafik kullanıcı arabiriminden oluşur. . Bu yaklaşımın bir avantajı, komut "
+"satırı programına yatırım yapılan geliştirme çalışmasının birçok program "
+"tarafından paylaşılabilmesidir: Aynı CD yazıcısı komut satırı programı "
+"“CD'ye gönder” -plug- bir dosya yöneticisi uygulaması için, bir müzik "
+"çaların “CD'ye yaz” işlevi için ve bir DVD yedekleme aracı için CD yazıcı "
+"olarak. Bir başka avantaj, büyük bir görevi daha küçük parçalara bölmenin "
+"geliştiricilerin aynı program için birkaç kullanıcı arabirimi sağlamasına "
+"izin vermesidir."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:16
+#, fuzzy
+#| msgid ""
+#| "A computer algebra system (CAS) like _Maxima_ fits into this framework. A "
+#| "CAS can provide the logic behind an arbitrary precision calculator "
+#| "application or it can do automatic transforms of formulas in the "
+#| "background of a bigger system (e.g., [Sage](https://www.sagemath.org/)). "
+#| "Alternatively, it can be used directly as a free-standing system. "
+#| "_Maxima_ can be accessed via a command line. Often, however, an interface "
+#| "like wxMaxima proves a more efficient way to access the software, "
+#| "especially for newcomers."
+msgid ""
+"A computer algebra system (CAS) like _Maxima_ fits into this framework. A "
+"CAS can provide the logic behind an arbitrary precision calculator "
+"application or it can do automatic transforms of formulas in the background "
+"of a bigger system (e.g., [Sage](https://www.sagemath.org/)). Alternatively, "
+"it can be used directly as a free-standing system. _Maxima_ can be accessed "
+"via a command line. Often, however, an interface like _wxMaxima_ proves a "
+"more efficient way to access the software, especially for newcomers."
+msgstr ""
+"_Maxima_ gibi bir bilgisayar cebir sistemi (BCS) bu çerçeveye uyar. Bir BCS, "
+"çok fonksiyonlu ve kapsamlı bir hesap makinesi uygulamasının arkasındaki "
+"mantığı sağlayabilir veya daha büyük bir sistemin arka planında formüllerin "
+"otomatik dönüşümlerini yapabilir (örneğin, [Sage] (https://www.sagemath."
+"org/)). Alternatif olarak, doğrudan bağımsız bir sistem olarak "
+"kullanılabilir. _Maxima_ öğesine bir komut satırı üzerinden erişilebilir. "
+"Bununla birlikte, wxMaxima gibi bir arayüz, özellikle yeni başlayanlar için "
+"yazılıma erişmenin daha verimli bir yolunu kanıtlar."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:17
+#, fuzzy, no-wrap
+#| msgid "### _Maxima_"
+msgid "_Maxima_"
+msgstr "### _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:20
+msgid ""
+"_Maxima_ is a full-featured computer algebra system (CAS). A CAS is a "
+"program that can solve mathematical problems by rearranging formulas and "
+"finding a formula that solves the problem as opposed to just outputting the "
+"numeric value of the result. In other words, _Maxima_ can serve as a "
+"calculator that gives numerical representations of variables, and it can "
+"also provide analytical solutions. Furthermore, it offers a range of "
+"numerical methods of analysis for equations or systems of equations that "
+"cannot be solved analytically."
+msgstr ""
+"_Maxima_ tam özellikli bir 'Sembolik' olarak ta çalışabilen bir bilgisayar "
+"cebir sistemidir (BCS). Bir BCS, formülleri yeniden düzenleyerek ve sadece "
+"sonucun sayısal değerini çıkarmanın aksine problemi çözen bir formül bularak "
+"(sembolik ifadeler ile) matematiksel problemleri çözebilen bir programdır. "
+"Başka bir deyişle, _Maxima_ değişkenlerin sayısal değerlerini veren bir "
+"hesap makinesi olarak kullanılabilir ve analitik çözümler de sağlayabilir. "
+"Ayrıca, analitik olarak çözülemeyen denklemler veya denklem sistemleri için "
+"bir dizi sayısal analiz yöntemi sunar."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:22
+#, fuzzy
+#| msgid ""
+#| "![Maxima screenshot](./maxima_screenshot.png){ id=img_maxima_screenshot }"
+msgid ""
+"![Maxima screenshot, command line](./maxima_screenshot.png)"
+"{ id=img_maxima_screenshot }"
+msgstr ""
+"![Maxima screenshot](./maxima_screenshot.png){ id=img_maxima_screenshot }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:24
+#, fuzzy, no-wrap
+#| msgid "Extensive documentation for _Maxima_ is [available in the internet](http://maxima.sourceforge.net/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems that would be the F1 key) causes wxMaxima’s context-sensitive help feature will automatically jump to _Maxima_’s manual page for the command at the cursor."
+msgid "Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.\n"
+msgstr "_Maxima_ için kapsamlı belgeler [internette mevcuttur] (https://maxima.sourceforge.io/documentation.html). Bu dokümanların bir kısmı wxMaxima’nın yardım menüsünde de bulunmaktadır. Yardım tuşuna basmak (F1 tuşu olan çoğu sistemde) kullanıcıyı, wxMaxima’nın içeriğe duyarlı yardım özelliğinin imleçteki komut için otomatik olarak _Maxima_’ın kullanıcı kılavuzu sayfasına ulaştırır."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:25
+#, fuzzy, no-wrap
+#| msgid "### wxMaxima"
+msgid "WxMaxima"
+msgstr "### wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:28
+#, fuzzy
+#| msgid ""
+#| "wxMaxima is a graphical user interface that provides the full "
+#| "functionality and flexibility of _Maxima_. wxMaxima offers users a "
+#| "graphical display and many features that make working with _Maxima_ "
+#| "easier. For example wxMaxima allows one to export any cell’s contents "
+#| "(or, if that is needed, any part of a formula, as well) as text, as LaTeX "
+#| "or as MathML specification at a simple right-click. Indeed, an entire "
+#| "workbook can be exported, either as a HTML file or as a LaTeX file. "
+#| "Documentation for _wxMaxima_, including workbooks to illustrate aspects "
+#| "of its use, is online at the wxMaxima [help site](https://wxMaxima-"
+#| "developers.github.io/wxmaxima/help.html), as well as via the help menu."
+msgid ""
+"_WxMaxima_ is a graphical user interface that provides the full "
+"functionality and flexibility of _Maxima_. WxMaxima offers users a graphical "
+"display and many features that make working with _Maxima_ easier. For "
+"example _wxMaxima_ allows one to export any cell’s contents (or, if that is "
+"needed, any part of a formula, as well) as text, as LaTeX or as MathML "
+"specification at a simple right-click. Indeed, an entire workbook can be "
+"exported, either as a HTML file or as a LaTeX file. Documentation for "
+"_wxMaxima_, including workbooks to illustrate aspects of its use, is online "
+"at the _wxMaxima_ [help site](https://wxMaxima-developers.github.io/wxmaxima/"
+"help.html), as well as via the help menu."
+msgstr ""
+"wxMaxima, _Maxima_'ın tam işlevselliğini ve esnekliğini sağlayan bir grafik "
+"kullanıcı arabirimidir, gördüğünüz wxMaxima arayüzü arkada çalışan matematik "
+"motoru (math engine) ise Maximadır. wxMaxima kullanıcılara _Maxima_ ile "
+"çalışmayı kolaylaştıran bir grafiksel ekran ve birçok özellik sunar. Örneğin "
+"wxMaxima, herhangi bir hücrenin içeriğini (veya gerekirse bir formülün "
+"herhangi bir bölümünü) metin olarak, LaTeX veya MathML belirtimi olarak "
+"basit bir sağ tıklamayla dışa aktarmaya izin verir. Çalışma sayfasının "
+"tamamı HTML dosyası veya LaTeX dosyası olarak dışa aktarılabilir. wx_Maxima_ "
+"Belgelerinin, çalışma sayfaları da dahil, kullanımın özelliklerini göstermek "
+"amacıyla hazırlanan dökümanları yardım menüsü üzerinden (https://wxMaxima-"
+"developers.github.io/wxmaxima/help.html) wxMaxima [yardım sitesinde] "
+"adresinden bulabilirsiniz."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:30
+msgid "![wxMaxima window](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
+msgstr "![wxMaxima window](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:32
+msgid ""
+"The calculations that are entered in _wxMaxima_ are performed by the "
+"_Maxima_ command-line tool in the background."
+msgstr ""
+"_WxMaxima_ içine girilen hesaplamalar, arka planda _Maxima_ komut satırı "
+"aracı tarafından gerçekleştirilir."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:33
+#, fuzzy, no-wrap
+#| msgid "## Workbook basics"
+msgid "Workbook basics"
+msgstr "## Çalışma Sayfası Temel Özellikleri"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:36
+#, fuzzy
+#| msgid ""
+#| "Much of wxMaxima is self-explaining, but some details require attention. "
+#| "[This site](https://wxMaxima-developers.github.io/wxmaxima/help.html) "
+#| "contains a number of workbooks that address various aspects of wxMaxima. "
+#| "Working through some of these (particularly the \"10 minute (wx)Maxima "
+#| "tutorial\") will increase one’s familiarity with both the content of "
+#| "_Maxima_ and the use of wxMaxima to interact with _Maxima_. This manual "
+#| "concentrates on describing aspects of wxMaxima that are not likely to be "
+#| "self-evident and that might not be covered in the online material."
+msgid ""
+"Much of _wxMaxima_ is self-explaining, but some details require attention. "
+"[This site](https://wxMaxima-developers.github.io/wxmaxima/help.html) "
+"contains a number of workbooks that address various aspects of _wxMaxima_. "
+"Working through some of these (particularly the \"10 minute _(wx)Maxima_ "
+"tutorial\") will increase one’s familiarity with both the content of "
+"_Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. This manual "
+"concentrates on describing aspects of _wxMaxima_ that are not likely to be "
+"self-evident and that might not be covered in the online material."
+msgstr ""
+"WxMaxima çoğunlukla kendi kendini açıklar (imleci butonların üstüne "
+"getirdiğinizde açılan bilgi pencereleri kutucukları sayesinde), ancak bazı "
+"detaylar dikkat gerektirir. [Bu site] (https://wxMaxima-developers.github.io/"
+"wxmaxima/help.html) wxMaxima'nın çeşitli yönlerini ele alan bir dizi çalışma "
+"kitabı içerir. Bunlardan bazıları üzerinde çalışmak (özellikle \"10 "
+"dakikalık (wx) Maxima eğitimi\") kişinin _Maxima_ içeriği ve _Maxima_ ile "
+"etkileşimde bulunmak için wxMaxima kullanımını daha iyi tanıyacaktır. Bu el "
+"kitabı, wxMaxima'nın kendini açıkça göstermesi muhtemel olmayan ve çevrimiçi "
+"materyalin kapsamına girmeyen yönlerini açıklamaya odaklanmaktadır."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:37
+#, fuzzy, no-wrap
+#| msgid "### The workbook approach"
+msgid "The workbook approach"
+msgstr "### Çalışma Sayfası Yaklaşımı"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:40
+#, fuzzy
+#| msgid ""
+#| "One of the very few things that are not standard in wxMaxima is that it "
+#| "organizes the data for _Maxima_ into cells that are evaluated (which "
+#| "means: sent to _Maxima_) only when the user requests this. When a cell is "
+#| "evaluated, all commands in that cell, and only that cell, are evaluated "
+#| "as a batch. (The preceding statement is not quite accurate: One can "
+#| "select a set of adjacent cells and evaluate them together. Also, one can "
+#| "instruct _Maxima_ to evaluate all cells in a workbook in one pass.) "
+#| "_wxMaxima_'s approach to submitting commands for execution might feel "
+#| "unfamiliar at the first sight. It does, however, drastically ease work "
+#| "with big documents (where the user certainly does not want every small "
+#| "change to automatically to trigger a full re-evaluation of the whole "
+#| "document). Also, this approach is very handy for debugging."
+msgid ""
+"One of the very few things that are not standard in _wxMaxima_ is that it "
+"organizes the data for _Maxima_ into cells that are evaluated (which means: "
+"sent to _Maxima_) only when the user requests this. When a cell is "
+"evaluated, all commands in that cell, and only that cell, are evaluated as a "
+"batch. (The preceding statement is not quite accurate: One can select a set "
+"of adjacent cells and evaluate them together. Also, one can instruct "
+"_Maxima_ to evaluate all cells in a workbook in one pass.) _WxMaxima_’s "
+"approach to submitting commands for execution might feel unfamiliar at the "
+"first sight. It does, however, drastically ease work with big documents "
+"(where the user does not want every change to automatically trigger a full "
+"re-evaluation of the whole document). Also, this approach is very handy for "
+"debugging."
+msgstr ""
+"WxMaxima'da standart olmayan çok az şeyden biri, _Maxima_ için verileri "
+"yalnızca kullanıcı bunu istediğinde değerlendirilen hücrelere (yani: "
+"_Maxima_'a gönderilen) organize etmesidir. Bir hücre değerlendirildiğinde, o "
+"hücredeki ve yalnızca o hücredeki tüm komutlar toplu olarak değerlendirilir. "
+"(Önceki ifade tam olarak doğru değildir: Bir dizi bitişik hücre seçilebilir "
+"ve birlikte değerlendirilebilir. Ayrıca, _Maxima_ öğesine bir çalışma "
+"kitabındaki tüm hücreleri tek geçişte değerlendirmesi talimatı verilebilir.) "
+"_WxMaxima_'ın yürütme için komut gönderme yaklaşımı yabancı gelebilir ilk "
+"görüşte. Bununla birlikte, büyük belgelerle (kullanıcının her küçük "
+"değişikliğin otomatik olarak tüm belgenin tam olarak yeniden "
+"değerlendirilmesini tetiklemesini istemediği durumlarda) büyük ölçüde "
+"kolaylaştırır. Ayrıca, bu yaklaşım hata ayıklama için çok kullanışlıdır.\n"
+"Kısaca; bir çalışma sayfasında yazdığınız satırları/komutları geriye dönerek "
+"tek tek ya da bir kaç tanesini ya da hepsini tekrar değerlendirebilirsiniz. "
+"Matlab taki gibi sürekli aşağıya inen bir ilerleme yerine geçmiş satırlara "
+"dönüp işlem yapma olanağı sağlar."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:42
+#, fuzzy
+#| msgid ""
+#| "If text is typed into _wxMaxima_ it automatically creates a new worksheet "
+#| "cell. The type of this cell can be selected in the toolbar. If a code "
+#| "cell is created the cell can be sent to _maxima_, which causes the result "
+#| "of the calculation to be displayed below the code. A pair of such "
+#| "commands is shown below."
+msgid ""
+"If text is typed into _wxMaxima_ it automatically creates a new worksheet "
+"cell. The type of this cell can be selected in the toolbar. If a code cell "
+"is created the cell can be sent to _Maxima_, which causes the result of the "
+"calculation to be displayed below the code. A pair of such commands is shown "
+"below."
+msgstr ""
+"'wxMaxima'da iki türlü satır vardır. Metin satırı ve kod satırı. Metin ya da "
+"kod girmeye başladığınızda otomatik olarak ilgili hücre oluşur.Girilen bir "
+"matematiksel bir işlem içeren bir kod ise _Maxima'ya_ gönderilir ve alt "
+"satırda sonuç gösterilir. Bu komutların bir çifti aşağıda gösterilmiştir."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:44
+msgid "![Input/output cell](./InputCell.png){ id=img_InputCell }"
+msgstr "![Input/output cell](./InputCell.png){ id=img_InputCell }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:46
+#, fuzzy
+#| msgid ""
+#| "On evaluation of an input cell's contents the input cell _Maxima_ assigns "
+#| "a label to the input (by default shown in red and recognizable by the "
+#| "`%i`) by which it can be referenced later in the _wxMaxima_ session. The "
+#| "output that _Maxima_ generates also gets a label that begins with `%o` "
+#| "and by default is hidden, except if the user assigns the output a name. "
+#| "In this case by default the user-defined label is displayed. The `%o`\\-"
+#| "style label _Maxima_ auto-generates will also be accessible, though."
+msgid ""
+"On evaluation of an input cell’s contents the input cell _Maxima_ assigns a "
+"label to the input (by default shown in red and recognizable by the `%i`) by "
+"which it can be referenced later in the _wxMaxima_ session. The output that "
+"_Maxima_ generates also gets a label that begins with `%o` and by default is "
+"hidden, except if the user assigns the output a name. In this case by "
+"default the user-defined label is displayed. The `%o`-style label _Maxima_ "
+"auto-generates will also be accessible, though."
+msgstr ""
+"Bir girdi hücresinin içeriğinin değerlendirilmesinde, _Maxima_ her girdi "
+"hücresinin başına `% i1,% i2,% i3` şeklinde bir etiket atar (varsayılan "
+"olarak kırmızı renkte gösterilir ), daha sonraki satırlarda bu satıra `% in "
+"(n; girdi satırı numarası) ifadesiyle _wxMaxima_ oturumunda atıfta "
+"bulunulabilir ve o satırdaki ifadeyi kullanabilirsiniz.(%i ifadesindeki 'i' "
+"input yani 'girdi'yi ifade eder) _Maxima_'ın oluşturduğu çıktı ayrıca, "
+"kullanıcı çıktıya bir ad ataması dışında,% o (buradaki 'o' output yani "
+"çıktı'yı ifade eder)ile başlayan bir etiket alır. Bu durumda varsayılan "
+"olarak kullanıcı tanımlı etiket görüntülenir. Yine de% o` \\ -style _Maxima_ "
+"otomatik oluşturucu etiketine de erişilebilir. Çıktı satırları da '%on' (n; "
+"çıktı satırı numarası) sonraki satırlarda bu satıra `% on (n; girdi satırı "
+"numarası) ifadesiyle _wxMaxima_ oturumunda (geriye yönelik) atıfta "
+"bulunulabilir ve o satırdaki ifadeyi kullanabilirsiniz."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:48
+#, fuzzy
+#| msgid ""
+#| "Besides the input cells wxMaxima allows for text cells for documentation, "
+#| "image cells, title cells, chapter cells and section cells. Every cell has "
+#| "its own undo buffer so debugging by changing the values of several cells "
+#| "and then gradually reverting the unneeded changes is rather easy. "
+#| "Furthermore the worksheet itself has a global undo buffer that can undo "
+#| "cell edits, adds and deletes."
+msgid ""
+"Besides the input cells _wxMaxima_ allows for text cells for documentation, "
+"image cells, title cells, chapter cells and section cells. Every cell has "
+"its own undo buffer so debugging by changing the values of several cells and "
+"then gradually reverting the unneeded changes is rather easy. Furthermore "
+"the worksheet itself has a global undo buffer that can undo cell edits, adds "
+"and deletes."
+msgstr ""
+"'wxMaxima girdi hücrelerinin yanı sıra metin hücrelerinin belgeleme, görüntü "
+"hücreleri, başlık hücreleri, bölüm hücreleri ve alt bölüm hücreleri için "
+"kullanılmasına izin verir. Her hücrenin kendi geri alma özelliğivardır, bu "
+"nedenle birkaç hücrenin değerlerini değiştirerek ve daha sonra yavaş yavaş "
+"gereksiz değişiklikleri geri alarak düzeltme yapmak oldukça kolaydır. Ayrıca "
+"çalışma sayfasının kendisi, hücre düzenlemelerini geri alabilir, ekleyebilir "
+"ve silebilir küresel bir geri alma arabelleğine sahiptir."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:50
+#, fuzzy
+#| msgid ""
+#| "The figure below shows different cell types (Title cells, section cells, "
+#| "subsection cells, text cells, input/output cells and an image cell."
+msgid ""
+"The figure below shows different cell types (title cells, section cells, "
+"subsection cells, text cells, input/output cells and image cells)."
+msgstr ""
+"Aşağıdaki şekilde farklı hücre tipleri gösterilmektedir (Başlık hücreleri, "
+"bölüm hücreleri, alt bölüm hücreleri, metin hücreleri, giriş / çıkış "
+"hücreleri ve bir görüntü hücresi."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:52
+msgid ""
+"![Example of different wxMaxima cells](./cell-example.png){ id=img_cell-"
+"example }"
+msgstr ""
+"![Example of different wxMaxima cells](./cell-example.png){ id=img_cell-"
+"example }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:53
+#, fuzzy, no-wrap
+#| msgid "### Cells"
+msgid "Cells"
+msgstr "### Hücreler"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:56
+#, fuzzy
+#| msgid ""
+#| "The worksheet is organized in cells. Each cell can contain other cells or "
+#| "the following types of content:"
+msgid ""
+"The worksheet is organized in cells. WxMaxima knows the following cell types:"
+msgstr ""
+"Çalışma sayfası hücreler halinde düzenlenmiştir. Her hücre başka hücreler "
+"veya aşağıdaki içerik türlerini içerebilir:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+#, fuzzy
+#| msgid "one or more lines of _Maxima_ input"
+msgid "Math cells, containing one or more lines of _Maxima_ input."
+msgstr "bir veya daha fazla satır _Maxima_ girişi"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+#, fuzzy
+#| msgid "output of, or a question from, _Maxima_"
+msgid "Output of, or a question from, _Maxima_."
+msgstr "'Maxima çıktısı ya da Maxima'dan soru"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Image cells."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+#, fuzzy
+#| msgid "a text block that can for example be used for documentation"
+msgid "Text cells, that can for example be used for documentation."
+msgstr "örneğin dokümantasyon için kullanılabilecek bir metin bloğu"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid ""
+"A title, section or a subsection. 6 levels of different headings are "
+"possible."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Page breaks."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:65
+#, fuzzy
+#| msgid ""
+#| "The default behavior of _wxMaxima_ when text is entered is to "
+#| "automatically create a math cell. Cells of other types can be created "
+#| "using the Cell menu, using the hot keys shown in the menu or using the "
+#| "drop-down list in the toolbar."
+msgid ""
+"The default behavior of _wxMaxima_ when text is entered is to automatically "
+"create a math cell. Cells of other types can be created using the Cell menu, "
+"using the hot keys shown in the menu or using the drop-down list in the "
+"toolbar. Once the non-math cell is created, whatever is typed into the file "
+"is interpreted as text."
+msgstr ""
+"Metin girildiğinde varsayılan _wxMaxima_ davranışı otomatik olarak bir "
+"matematik hücresi oluşturmaktır. Diğer tür hücreler Hücre menüsü "
+"kullanılarak, menüde gösterilen kısayol tuşları veya araç çubuğundaki açılır "
+"liste (drop-down list) kullanılarak oluşturulabilir."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:67
+msgid ""
+"A (C-style) [comment text](https://maxima.sourceforge.io/docs/manual/"
+"maxima_singlepage.html#Comments) can be part of a math cell as follows: `/* "
+"This comment will be ignored by Maxima */`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:69
+msgid "\"`/*`\" marks the start of the comment, \"`*/`\" the end."
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:70
+#, fuzzy, no-wrap
+#| msgid "### Horizontal and vertical cursors"
+msgid "Horizontal and vertical cursors"
+msgstr "### Yatay ve dikey imleçler"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:73
+#, fuzzy
+#| msgid ""
+#| "If the user tries to select a complete sentence a word processor will try "
+#| "to extend the selection to automatically begin and end with a word "
+#| "boundary. Likewise _wxMaxima_ if more than one cell is selected will "
+#| "extend the selection to whole cells."
+msgid ""
+"If the user tries to select a complete sentence, a word processor will try "
+"to extend the selection to automatically begin and end with a word boundary. "
+"Likewise, if more than one cell is selected, _wxMaxima_ will extend the "
+"selection to whole cells."
+msgstr ""
+"Kullanıcı tam bir cümle seçmeye çalışırsa, bir sözcük işlemci seçimi "
+"otomatik olarak bir sözcük sınırıyla başlayıp bitecek şekilde genişletmeye "
+"çalışır. Aynı şekilde, birden fazla hücre seçilirse _wxMaxima_ seçimi tüm "
+"hücrelere genişletir."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:75
+#, fuzzy
+#| msgid ""
+#| "What isn't standard is that _wxMaxima_ provides drag-and-drop flexibility "
+#| "by defining two types of cursors. _wxMaxima_ will switch between them "
+#| "automatically when needed:"
+msgid ""
+"What isn’t standard is that _wxMaxima_ provides drag-and-drop flexibility by "
+"defining two types of cursors. _WxMaxima_ will switch between them "
+"automatically when needed:"
+msgstr ""
+"Standart olmayan, _wxMaxima_'ın iki tür imleç tanımlayarak sürükle ve bırak "
+"esnekliği sağlamasıdır. _wxMaxima_ gerektiğinde bunlar arasında otomatik "
+"olarak geçiş yapar:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:78
+msgid ""
+"The cursor is drawn horizontally if it is moved in the space between two "
+"cells or by clicking there."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:78
+#, fuzzy
+#| msgid ""
+#| "A vertical cursor that works inside a cell. This cursor is activated by "
+#| "moving the cursor inside a cell using the mouse pointer or the cursor "
+#| "keys and works much like the cursor in a text editor."
+msgid ""
+"A vertical cursor that works inside a cell. This cursor is activated by "
+"moving the cursor inside a cell using the mouse pointer or the cursor keys "
+"and works much like the cursor in a text editor."
+msgstr ""
+"Bir hücrenin içinde çalışan dikey bir imleç. Bu imleç, fare imlecini veya "
+"imleç tuşlarını kullanarak imleci bir hücrenin içinde hareket ettirerek "
+"etkinleştirilir ve bir metin düzenleyicide imleç gibi çalışır."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:80
+#, no-wrap
+msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:82
+msgid ""
+"![(blinking) horizontal cursor after wxMaxima start](./horizontal-cursor-"
+"only.png){ id=img_horizontal_cursor_only }"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:84
+msgid ""
+"You might want to create a different cell type (using the \"Cell\" menu), "
+"maybe a title cell or text cell, which describes, what will be done, when "
+"you start creating your worksheet."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:86
+msgid ""
+"If you navigate between the different cells, you will also see the "
+"(blinking) horizontal cursor, where you can insert a cell into your "
+"worksheet (either a math cell, by just start typing your formula - or a "
+"different cell type using the menu)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:88
+msgid ""
+"![(blinking) horizontal cursor between cells](./horizontal-cursor-between-"
+"cells.png){ id=img_horizontal_cursor_between_cells }"
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:89
+#, fuzzy, no-wrap
+#| msgid ""
+#| "Extensions to _Maxima_\n"
+#| "======================\n"
+msgid "Sending cells to Maxima"
+msgstr ""
+"Maxima uzantıları_\n"
+"======================\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:92
+#, no-wrap
+msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.\n"
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:93
+#, fuzzy, no-wrap
+#| msgid "### Command autocompletion"
+msgid "Command autocompletion"
+msgstr "### Otomatik komut tamamlama"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:96
+#, fuzzy, no-wrap
+#| msgid "_wxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example if activated within an unit specification for ezUnits it will offer a list of applicable units."
+msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.\n"
+msgstr "_wxMaxima_, menü (Hücre / Tam Sözcük) aracılığıyla veya alternatif olarak <kbd> CTRL </kbd> + <kbd> SPACE </kbd> tuş bileşimine basılarak tetiklenen bir otomatik tamamlama özelliği içerir. Otomatik tamamlama içeriğe duyarlıdır. Örneğin ezUnits için bir birim spesifikasyonu içinde etkinleştirilirse, uygulanabilir birimlerin bir listesini sunacaktır."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:98
+msgid "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
+msgstr "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:100
+#, fuzzy, no-wrap
+#| msgid "Besides completing a file name, an unit name or the current command’s or variable’s name the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template)."
+msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).\n"
+msgstr "Otomatik tamamlama, bir dosya adı, birim adı veya geçerli komutun veya değişkenin adını tamamlamanın yanı sıra, bu programın beklediği parametrelerin türünü (ve anlamını) belirten birçok komut için bir şablon gösterebilir. Bu özelliği etkinleştirmek için <kbd> SHIFT </kbd> + <kbd> CTRL </kbd> + <kbd> SPACE </kbd> tuşlarına basın veya ilgili menü öğesini seçin (Hücre / Şablonu Göster)."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:101
+#, fuzzy, no-wrap
+#| msgid "#### Greek characters"
+msgid "Greek characters"
+msgstr "#### Yunanca Karakterler"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:104
+#, fuzzy
+#| msgid ""
+#| "Computers traditionally store characters in 8-bit values. This allows for "
+#| "a maximum of 256 different characters. All letters, numbers, and control "
+#| "symbols (end of transmission, end of string, lines and edges for drawing "
+#| "rectangles for menus _etc_.) of nearly any given language can fit within "
+#| "that limit."
+msgid ""
+"Computers traditionally stored characters in 8-bit values. This allows for a "
+"maximum of 256 different characters. All letters, numbers, and control "
+"symbols (end of transmission, end of string, lines and edges for drawing "
+"rectangles for menus _etc_.) of nearly any given language can fit within "
+"that limit."
+msgstr ""
+"Bilgisayarlar geleneksel olarak karakterleri 8 bitlik değerlerde depolar. "
+"Bu, maksimum 256 farklı karaktere izin verir. Verilen herhangi bir dilin tüm "
+"harfleri, sayıları ve kontrol sembolleri (iletim sonu, dizi sonu, _etc_ "
+"menüleri için dikdörtgenler çizmek için çizgiler ve kenarlar) bu sınıra "
+"sığabilir."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:106
+#, fuzzy
+#| msgid ""
+#| "For most countries the codepage of 256 characters that has been chosen "
+#| "does not include things like Greek letters, though, that are frequently "
+#| "used in mathematics. To overcome this type of limitation Unicode has been "
+#| "invented: An encoding that makes english text work like normal, but to "
+#| "use characters whose keycode are more than 8 bits long."
+msgid ""
+"For most countries, the codepage of 256 characters that has been chosen does "
+"not include things like Greek letters, though, that are frequently used in "
+"mathematics. To overcome this type of limitation [Unicode](https://home."
+"unicode.org/) has been invented: An encoding that makes English text work "
+"like normal, but to use much more than 256 characters."
+msgstr ""
+"Çoğu ülke için seçilen 256 karakterlik kod sayfası, Yunan harfleri gibi "
+"matematikte sıkça kullanılan şeyleri içermez. Bu tür bir sınırlamanın "
+"üstesinden gelmek için Unicode icat edilmiştir: İngilizce metnin normal "
+"çalışmasını sağlayan bir kodlama, ancak kodu 8 bitten uzun olan karakterleri "
+"kullanmak."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:108
+#, fuzzy
+#| msgid ""
+#| "_Maxima_ allows for unicode characters if it was compiled using a Lisp "
+#| "compiler that either supports lisp or that doesn't care about the font "
+#| "encoding. As at least one of this is likely to be true _wxMaxima_ "
+#| "provides a method of entering Greek characters using the keyboard:"
+msgid ""
+"_Maxima_ allows Unicode if it was compiled using a Lisp compiler that either "
+"supports Unicode or that doesn’t care about the font encoding. As at least "
+"one of this pair of conditions is likely to be true. _WxMaxima_ provides a "
+"method of entering Greek characters using the keyboard:"
+msgstr ""
+"_Maxima_, lisp'i destekleyen veya font kodlamasını önemsemeyen bir Lisp "
+"derleyicisi kullanılarak derlenmişse unicode karakterlere izin verir. "
+"Bunlardan en az birinin doğru olması muhtemel olduğundan _wxMaxima_, "
+"klavyeyi kullanarak Yunanca karakterler girme yöntemi sağlar:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:111
+#, fuzzy
+#| msgid ""
+#| "A greek letter can be entered by pressing the <kbd>ESC</kbd> key and then "
+#| "starting to type the greek character's name."
+msgid ""
+"A Greek letter can be entered by pressing the <kbd>ESC</kbd> key and then "
+"starting to type the Greek character’s name."
+msgstr ""
+"<kbd> ESC </kbd> tuşuna basıp daha sonra Yunanca karakterin adını yazmaya "
+"başlayarak bir Yunan harfi girilebilir."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:111
+#, fuzzy
+#| msgid ""
+#| "Alternatively it can be entered by pressing <kbd>ESC</kbd>, one letter "
+#| "and <kbd>ESC</kbd> again. In this case the following letters are "
+#| "supported:"
+msgid ""
+"Alternatively it can be entered by pressing <kbd>ESC</kbd>, one letter (or "
+"two for the Greek letter omicron) and <kbd>ESC</kbd> again. In this case the "
+"following letters are supported:"
+msgstr ""
+"Alternatif olarak, <kbd> ESC </kbd>, bir harf ve <kbd> ESC </kbd> tuşlarına "
+"tekrar basılarak girilebilir. Bu durumda aşağıdaki harfler desteklenir:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:130
+#, no-wrap
+msgid ""
+"| key | Greek letter | key | Greek letter | key | Greek letter |\n"
+"| :-: | :----------: | :-: | :----------: | :-: | :----------: |\n"
+"|  a  |    alpha     |  i  |     iota     |  r  |     rho      |\n"
+"|  b  |     beta     |  k  |    kappa     |  s  |    sigma     |\n"
+"|  g  |    gamma     |  l  |    lambda    |  t  |     tau      |\n"
+"|  d  |    delta     |  m  |      mu      |  u  |   upsilon    |\n"
+"|  e  |   epsilon    |  n  |      nu      |  f  |     phi      |\n"
+"|  z  |     zeta     |  x  |      xi      |  c  |     chi      |\n"
+"|  h  |     eta      | om  |   omicron    |  y  |     psi      |\n"
+"|  q  |    theta     |  p  |      pi      |  o  |    omega     |\n"
+"|  A  |    Alpha     |  I  |     Iota     |  R  |     Rho      |\n"
+"|  B  |     Beta     |  K  |    Kappa     |  S  |    Sigma     |\n"
+"|  G  |    Gamma     |  L  |    Lambda    |  T  |     Tau      |\n"
+"|  D  |    Delta     |  M  |      Mu      |  U  |   Upsilon    |\n"
+"|  E  |   Epsilon    |  N  |      Nu      |  P  |     Phi      |\n"
+"|  Z  |     Zeta     |  X  |      Xi      |  C  |     Chi      |\n"
+"|  H  |     Eta      | Om  |   Omicron    |  Y  |     Psi      |\n"
+"|  T  |    Theta     |  P  |      Pi      |  O  |    Omega     |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:132
+msgid ""
+"You can also use the \"Greek letters\"-sidebar to enter the Greek letters."
+msgstr ""
+
+#. type: Title #####
+#: ../../info/wxmaxima.md:133
+#, no-wrap
+msgid "Attention: Lookalike characters"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:138
+msgid ""
+"Several Latin letters look like the Greek letters, e.g. the Latin letter "
+"\"A\" and the Greek letter \"Alpha\". Although they look identical, they are "
+"two different Unicode characters, represented by different Unicode code "
+"points (numbers)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:143
+msgid ""
+"This might be problematic, if you assign a value to the variable A and later "
+"use the Greek letter Alpha to do something with this variable, especially on "
+"printouts.  For the Greek letter my (which is also used as prefix for micro) "
+"there are also two different Unicode code points."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:146
+msgid ""
+"The \"Greek letters\"-sidebar therefore has the option, that lookalike "
+"characters are not available (which can be changed using a right-click menu)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:148
+msgid ""
+"The same mechanism also allows to enter some miscellaneous mathematical "
+"symbols:"
+msgstr ""
+"Aynı mekanizma ayrıca çeşitli matematiksel sembollerin girilmesine izin "
+"verir:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:199
+#, no-wrap
+msgid ""
+"| keys to enter  | mathematical symbol                                   |\n"
+"| -------------- | ----------------------------------------------------- |\n"
+"| hbar           | Planck constant: a h with a horizontal bar above it   |\n"
+"| Hbar           | a H with a horizontal bar above it                    |\n"
+"| 2              | squared                                               |\n"
+"| 3              | to the power of three                                 |\n"
+"| /2             | 1/2                                                   |\n"
+"| partial        | partial sign (the d of dx/dt)                         |\n"
+"| integral       | integral sign                                         |\n"
+"| sq             | square root                                           |\n"
+"| ii             | imaginary                                             |\n"
+"| ee             | element                                               |\n"
+"| in             | in                                                    |\n"
+"| impl implies   | implies                                               |\n"
+"| inf            | infinity                                              |\n"
+"| empty          | empty                                                 |\n"
+"| TB             | big triangle right                                    |\n"
+"| tb             | small triangle right                                  |\n"
+"| and            | and                                                   |\n"
+"| or             | or                                                    |\n"
+"| xor            | xor                                                   |\n"
+"| nand           | nand                                                  |\n"
+"| nor            | nor                                                   |\n"
+"| equiv          | equivalent to                                         |\n"
+"| not            | not                                                   |\n"
+"| union          | union                                                 |\n"
+"| inter          | intersection                                          |\n"
+"| subseteq       | subset or equal                                       |\n"
+"| subset         | subset                                                |\n"
+"| notsubseteq    | not subset or equal                                   |\n"
+"| notsubset      | not subset                                            |\n"
+"| approx         | approximately                                         |\n"
+"| propto         | proportional to                                       |\n"
+"| neq != /= or # | not equal to                                          |\n"
+"| +/- or pm      | a plus/minus sign                                     |\n"
+"| \\<= or leq     | equal or less than                                    |\n"
+"| >= or geq      | equal or greater than                                 |\n"
+"| \\<\\< or ll     | much less than                                        |\n"
+"| >> or gg       | much greater than                                     |\n"
+"| qed            | end of proof                                          |\n"
+"| nabla          | a nabla operator                                      |\n"
+"| sum            | sum sign                                              |\n"
+"| prod           | product sign                                          |\n"
+"| exists         | there exists sign                                     |\n"
+"| nexists        | there is no sign                                      |\n"
+"| parallel       | a parallel sign                                       |\n"
+"| perp           | a perpendicular sign                                  |\n"
+"| leadsto        | a leads to sign                                       |\n"
+"| ->             | a right arrow                                         |\n"
+"| -->            | a long right arrow                                    |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:201
+msgid ""
+"You can also use the \"Symbols\"-sidebar to enter these Mathematical symbols."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:203
+#, fuzzy, no-wrap
+#| msgid "If a special symbol isn’t in the list it is possible to input arbitrary unicode characters by pressing <kbd>ESC</kbd> [number of the character] <kbd>ESC</kbd>."
+msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.\n"
+msgstr "Listede özel bir sembol yoksa, <kbd> ESC </kbd> [karakterin numarası] <kbd> ESC </kbd> tuşlarına basarak rastgele unicode karakterler girmek mümkündür."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:205
+#, fuzzy, no-wrap
+#| msgid "<kbd>ESC</kbd> <kbd>61</kbd> <kbd>ESC</kbd> therefore results in an `a`."
+msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.\n"
+msgstr "<kbd> ESC </kbd> 61 </kbd> <kbd> ESC </kbd> bu nedenle bir 'a' ile sonuçlanır."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:207
+#, fuzzy
+#| msgid ""
+#| "Please note that most of these symbols (notable exceptions are the logic "
+#| "symbols) do not have a special meaning in _Maxima_ and therefore will be "
+#| "interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp "
+#| "that doesn’t support dealing with Unicode characters they might cause an "
+#| "error message instead."
+msgid ""
+"Please note that most of these symbols (notable exceptions are the logic "
+"symbols) do not have a special meaning in _Maxima_ and therefore will be "
+"interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp "
+"that doesn’t support Unicode characters they might cause an error message."
+msgstr ""
+"Bu simgelerin çoğunun (dikkate değer istisnalar mantık sembolleri olduğu) "
+"_Maxima_'da özel bir anlamı olmadığını ve bu nedenle sıradan karakterler "
+"olarak yorumlanacağını lütfen unutmayın. _Maxima_, Unicode karakterlerle "
+"uğraşmayı desteklemeyen bir Lisp kullanılarak derlenirse, bunun yerine bir "
+"hata iletisine neden olabilir."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:210
+#, no-wrap
+msgid ""
+"It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.\n"
+"To solve that problem, select other fonts (using: Edit -> Configure -> Style).\n"
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:211
+#, no-wrap
+msgid "Unicode replacement"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:214
+msgid ""
+"wxMaxima will replace several Unicode characters with their respective "
+"Maxima expressions, e.g. `²` with `^2`, `³` with `^3`, the square root sign "
+"with the function `sqrt()`, the (mathematical) Sigma sign (which is not the "
+"same Unicode character as the corresponding Greek letter) with `sum()`, etc."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:217
+msgid ""
+"Unicode has several \"common\" fractions encoded as one Unicode code point: "
+"`¼, ½, ¾, ⅐, ⅑, ⅒, ⅓, ⅔, ⅕, ⅖, ⅗, ⅘, ⅙, ⅚, ⅛, ⅜, ⅝, ⅞`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:219
+msgid ""
+"wxMaxima will replace them with their Maxima representations, e.g `(1/4)` "
+"before the input is sent do Maxima. There are also `⅟`, which will be "
+"replaced by `1/` and `↉` (used in baseball), which will be replaced by "
+"`(0/3)`."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:221
+msgid ""
+"It is recommended to use **Maxima code** (not these Unicode code points) in "
+"input cells (Rationale: (a) it might be possible, that the used font for "
+"math input does not contain them; (b) if you save the document as `wxm`-"
+"file, it is usually readable by (command line) Maxima, but these changes "
+"will of course not work in command line Maxima); but they may occur, if you "
+"cut&paste a formula from another document."
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:222
+#, fuzzy, no-wrap
+#| msgid "### Side Panes"
+msgid "Side Panes"
+msgstr "### Kenar Panelleri"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:225
+#, fuzzy
+#| msgid ""
+#| "Shortcuts to the most important _Maxima_ commands or things like a table "
+#| "of contents, windows with debug messages or a history of the last issued "
+#| "commands can be accessed using the side panes. They can be enabled using "
+#| "the \"View\" menu. They all can be moved to other locations inside or "
+#| "outside the _wxMaxima_ window. Other useful panes is the one that allows "
+#| "to input Greek letters using the mouse."
+msgid ""
+"Shortcuts to the most important _Maxima_ commands, things like a table of "
+"contents, windows with debug messages or a history of the last issued "
+"commands can be accessed using the side panes. They can be enabled using the "
+"\"View\" menu. They all can be moved to other locations inside or outside "
+"the _wxMaxima_ window. Other useful panes is the one that allows to input "
+"Greek letters using the mouse."
+msgstr ""
+"En önemli _Maxima_ komutlarının kısayollarına veya içindekiler tablosu, hata "
+"ayıklama iletilerine sahip pencereler veya son verilen komutların geçmişi "
+"gibi yan bölmeler kullanılarak erişilebilir. \"Görünüm\" menüsü kullanılarak "
+"etkinleştirilebilirler. Hepsi _wxMaxima_ penceresinin içindeki veya "
+"dışındaki diğer konumlara taşınabilir. Diğer kullanışlı bölmeler, fareyi "
+"kullanarak Yunanca harflerin girilmesine izin veren bölmelerdir."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:227
+msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
+msgstr "![Farklı Kenar Panelleri Örneği](./SidePanes.png){ id=img_SidePanes }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:230
+msgid ""
+"In the \"table of contents\" side pane, one can increase or decrease a "
+"heading by just clicking on the heading with the right mouse button and "
+"select the next higher or lower heading type."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:232
+msgid ""
+"![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-"
+"headings.png){ id=Sidepane-TOC-convert-headings }"
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:233
+#, fuzzy, no-wrap
+#| msgid "### MathML output"
+msgid "MathML output"
+msgstr "### MathML çıktısı"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:236
+#, fuzzy
+#| msgid ""
+#| "Several word processors and similar programs either recognize MathML "
+#| "input and automatically insert it as an editable 2D equation - or (like "
+#| "LibreOffice 5.1) have an equation editor that offers an “import MathML "
+#| "from clipboard” feature. Others support RTF maths. _wxMaxima_ therefore "
+#| "offers several entries in the right-click menu."
+msgid ""
+"Several word processors and similar programs either recognize [MathML]"
+"(https://www.w3.org/Math/) input and automatically insert it as an editable "
+"2D equation - or (like LibreOffice) have an equation editor that offers an "
+"“import MathML from clipboard” feature. Others support RTF maths. "
+"_WxMaxima_, therefore, offers several entries in the right-click menu."
+msgstr ""
+"Birkaç kelime işlemcisi ve benzeri programlar ya MathML girişini tanır ve "
+"otomatik olarak düzenlenebilir bir 2D denklemi olarak ekler - ya da "
+"(LibreOffice 5.1 gibi) “MathML'yi panodan içe aktar” özelliği sunan bir "
+"denklem düzenleyicisine sahiptir. Diğerleri RTF matematiğini destekler. "
+"_wxMaxima_, sağ tıklama menüsünde çeşitli girişler sunar."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:237
+#, fuzzy, no-wrap
+#| msgid "### Markdown support"
+msgid "Markdown support"
+msgstr "### İşaretleme Desteği"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:240
+#, fuzzy
+#| msgid ""
+#| "_wxMaxima_ offers a set of standard markdown conventions that don't "
+#| "collide with mathematical notation. One of this elements is bullet lists."
+msgid ""
+"_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/wiki/"
+"Markdown) conventions that don’t collide with mathematical notation. One of "
+"these elements is bullet lists."
+msgstr ""
+"_wxMaxima_, matematiksel gösterimle çarpışmayan bir dizi standart işaretleme "
+"kuralı sunar. Bu unsurlardan biri mermi (tarzındaki) listeleridir."
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:241
+#, fuzzy, no-wrap
+#| msgid ""
+#| "~~~~\n"
+#| "Ordinary text\n"
+#| " * One item, indentation level 1\n"
+#| " * Another item at indentation level 1\n"
+#| "   * An item at a second indentation level\n"
+#| "   * A second item at the second indentation level\n"
+#| " * A third item at the first indentation level\n"
+#| "Ordinary text\n"
+#| "~~~~\n"
+msgid ""
+"Ordinary text\n"
+" * One item, indentation level 1\n"
+" * Another item at indentation level 1\n"
+"   * An item at a second indentation level\n"
+"   * A second item at the second indentation level\n"
+" * A third item at the first indentation level\n"
+"Ordinary text\n"
+msgstr ""
+"~~~~\n"
+"Düz Metin\n"
+" * Bir öğe, girinti seviyesi 1\n"
+" *1. Girinti seviyesinde başka bir öge \n"
+"   * 2. Girinti seviyesinde  bir öge l\n"
+"   * 2. Girinti seviyesinde başka bir öge \n"
+" * 3. Girinti seviyesinde başka bir öge \n"
+"Düz Metin\n"
+"~~~~\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:252
+#, fuzzy, no-wrap
+#| msgid "_wxMaxima_ will recognize text starting with `>` chars as block quotes:"
+msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
+msgstr "_ wxMaxima _, `> char 'dan başlayan metni blok tırnak olarak tanır:"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:253
+#, fuzzy, no-wrap
+#| msgid "~~~~ Ordinary text > quote quote quote quote > quote quote quote quote > quote quote quote quote Ordinary text ~~~~"
+msgid ""
+"Ordinary text\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"Ordinary text\n"
+msgstr "~~~~ Düz Metin > quote quote quote quote > quote quote quote quote > quote quote quote quote Düz Metin ~~~~"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:262
+#, fuzzy, no-wrap
+#| msgid "_wxMaxima_'s TeX and html output will also recognize `=>` and replace it by the corresponding unicode sign:"
+msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:\n"
+msgstr "wxMaxima TeXT ve html çıkışı da `=>` yı tanıyor ve yerine karşılık gelen unicode işareti koyuyor:"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:263
+#, fuzzy, no-wrap
+#| msgid "~~~~ cogito => sum.  ~~~~"
+msgid "cogito => sum.\n"
+msgstr "~~~~ cogito => sum.  ~~~~"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:268
+#, fuzzy, no-wrap
+#| msgid "Other symbols the html and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single- headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized."
+msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.\n"
+msgstr "Html ve TeX dışa aktarmanın tanıyacağı diğer simgeler, karşılaştırmalar için `<=` ve `> =`, çift uçlu çift ok (`<=>`), tek başlı oklar (`<->`, `-> `ve` <-`) ve `+/- 'işaretlerini kullanın. TeX çıktısı için ayrıca `<<` ve `>>` tanınır."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:269
+#, fuzzy, no-wrap
+#| msgid "### Hotkeys"
+msgid "Hotkeys"
+msgstr "### Kısayol Tuşları"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:272
+msgid ""
+"Most hotkeys can be found in the text of the respective menus. Since they "
+"are actually taken from the menu text and thus can be customized by the "
+"translations of _wxMaxima_ to match the needs of users of the local "
+"keyboard, we do not document them here. A few hotkeys or hotkey aliases, "
+"though, are not documented in the menus:"
+msgstr ""
+"Çoğu kısayol tuşu ilgili menülerin metninde bulunabilir. Aslında menü "
+"metninden alındıklarından ve _wxMaxima_ çevirileriyle yerel klavyenin "
+"kullanıcılarının ihtiyaçlarına göre özelleştirilebildiğinden, bunları burada "
+"belgelemiyoruz. Bununla birlikte, bazı kısayol tuşları veya kısayol takma "
+"adları menülerde belgelenmemiştir:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid ""
+"<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
+msgstr ""
+"<kbd> CTRL </kbd> + <kbd> ÜST KARAKTER </kbd> + <kbd> SİL </kbd> tam bir "
+"hücreyi siler."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+#, fuzzy
+#| msgid ""
+#| "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete "
+#| "cell."
+msgid ""
+"<kbd>CTRL</kbd>+<kbd>TAB</kbd> or <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</"
+"kbd> triggers the auto-completion mechanism."
+msgstr ""
+"<kbd> CTRL </kbd> + <kbd> ÜST KARAKTER </kbd> + <kbd> SİL </kbd> tam bir "
+"hücreyi siler."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
+msgstr ""
+"<kbd> SHIFT </kbd> + <kbd> SPACE </kbd>, boşluk bırakmayan bir boşluk ekler."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:277
+#, fuzzy, no-wrap
+#| msgid "### Raw TeX in the TeX export"
+msgid "Raw TeX in the TeX export"
+msgstr "### TeX dışa aktarımında ham TeX"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:280
+msgid ""
+"If a text cell begins with `TeX:` the TeX export contains the literal text "
+"that follows the `TeX:` marker. Using this feature allows the entry of TeX "
+"markup within the _wxMaxima_ workbook."
+msgstr ""
+"Bir metin hücresi `TeX:` ile başlıyorsa, TeX dışa aktarımı `TeX:` işaretini "
+"izleyen değişmez metni içerir. Bu özelliği kullanmak _wxMaxima_ çalışma "
+"kitabına TeX işaretlemesinin girilmesini sağlar."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:281
+#, fuzzy, no-wrap
+#| msgid "## File Formats"
+msgid "File Formats"
+msgstr "## Dosya formatları"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:284
+msgid ""
+"The material that is developed in a _wxMaxima_ session can be stored for "
+"later use in any of three ways:"
+msgstr ""
+"_WxMaxima_ oturumunda geliştirilen materyal, daha sonra kullanılmak üzere üç "
+"yoldan biriyle saklanabilir:"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:285
+#, fuzzy, no-wrap
+#| msgid "### .mac"
+msgid ".mac"
+msgstr "### .mac"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:288
+#, fuzzy
+#| msgid ""
+#| ".mac files are ordinary text files that contain _Maxima_ commands. They "
+#| "can be read using _Maxima_’s read command or _wxMaxima_’s File/Batch File "
+#| "menu entry."
+msgid ""
+"`.mac` files are ordinary text files that contain _Maxima_ commands. They "
+"can be read using _Maxima_’s `batch()` or `load()` command or _wxMaxima_’s "
+"File/Batch File menu entry."
+msgstr ""
+".mac dosyaları _Maxima_ komutları içeren normal metin dosyalarıdır. "
+"_Maxima_’ın read komutu veya _wxMaxima_’ın Dosya / Toplu Dosya menü girişi "
+"kullanılarak okunabilirler."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:291
+msgid ""
+"One example is shown below. `Quadratic.mac` defines a function and afterward "
+"generates a plot with `wxdraw2d()`.  Afterward the contents of the file "
+"`Quadratic.mac` are printed and newly defined function `f()` is evaluated."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:293
+#, fuzzy
+#| msgid "![Batch image](./BatchImage.png){ id=img_BatchImage }"
+msgid "![Loading a file with `batch()`](./BatchImage.png){ id=img_BatchImage }"
+msgstr "![Batch image](./BatchImage.png){ id=img_BatchImage }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:295
+msgid ""
+"Attention: Although the file `Quadratic.mac` has a usual _Maxima_ extension "
+"(`.mac`), it can only be read by _wxMaxima_, since the command `wxdraw2d()` "
+"is a wxMaxima-extension to _Maxima_. (Command line) Maxima will ignore the "
+"unknown command `wxdraw2d()` and print it as output again."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:297
+#, fuzzy
+#| msgid ""
+#| "You can be use `.mac` files for writing own library of macros. But since "
+#| "they don’t contain enough structural information they cannot be read back "
+#| "as a _wxMaxima_ session."
+msgid ""
+"You can be use `.mac` files for writing your own library of macros. But "
+"since they don’t contain enough structural information they cannot be read "
+"back as a _wxMaxima_ session."
+msgstr ""
+"Kendi makro kütüphanesininizi yazmak için `.mac` dosyalarını "
+"kullanabilirsiniz. Ancak yeterli yapısal bilgi içermedikleri için _wxMaxima_ "
+"oturumu olarak okunamazlar."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:298
+#, fuzzy, no-wrap
+#| msgid "### .wxm"
+msgid ".wxm"
+msgstr "### .wxm"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:302
+#, fuzzy, no-wrap
+#| msgid ".wxm files contains the worksheet except _Maxima_'s output. On Maxima versions >5.38 they can be read using _Maxima_'s `load()` function just as .mac files can be. With this plain-text format it sometimes is unavoidable that worksheets that use new features are not downwards-compatible with older versions of _wxMaxima_."
+msgid ""
+"`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.\n"
+"You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.\n"
+msgstr ".wxm dosyaları _Maxima_ çıktısı dışında çalışma sayfasını içerir. Maxima> 5.38 sürümlerinde _Maxima_'ın `load ()` işlevi kullanılarak .mac dosyaları gibi okunabilirler. Bu düz metin biçimiyle, bazen yeni özellikler kullanan çalışma sayfalarının _wxMaxima_'nın eski sürümleriyle aşağı doğru uyumlu olmaması kaçınılmazdır."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:304
+#, fuzzy
+#| msgid ""
+#| ".wxm files contains the worksheet except _Maxima_'s output. On Maxima "
+#| "versions >5.38 they can be read using _Maxima_'s `load()` function just "
+#| "as .mac files can be. With this plain-text format it sometimes is "
+#| "unavoidable that worksheets that use new features are not downwards-"
+#| "compatible with older versions of _wxMaxima_."
+msgid ""
+"With this plain-text format, it sometimes is unavoidable that worksheets "
+"that use new features are not downwards-compatible with older versions of "
+"_wxMaxima_."
+msgstr ""
+".wxm dosyaları _Maxima_ çıktısı dışında çalışma sayfasını içerir. Maxima> "
+"5.38 sürümlerinde _Maxima_'ın `load ()` işlevi kullanılarak .mac dosyaları "
+"gibi okunabilirler. Bu düz metin biçimiyle, bazen yeni özellikler kullanan "
+"çalışma sayfalarının _wxMaxima_'nın eski sürümleriyle aşağı doğru uyumlu "
+"olmaması kaçınılmazdır."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:305
+#, fuzzy, no-wrap
+#| msgid "## File Formats"
+msgid "File format of wxm files"
+msgstr "## Dosya formatları"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:308
+msgid ""
+"This is just a plain text file (you can open it with a text editor), "
+"containing the cell contents as some special Maxima comments."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:310
+msgid "It starts with the following comment:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:311
+#, no-wrap
+msgid ""
+"/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/\n"
+"/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:317
+msgid ""
+"And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:318
+#, no-wrap
+msgid ""
+"/* [wxMaxima: section start ]\n"
+"Title of the section\n"
+"   [wxMaxima: section end   ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:325
+msgid ""
+"or (in a Math cell the input is of course *not* commented out (the output is "
+"not saved in a `wxm` file)):"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:326
+#, no-wrap
+msgid ""
+"/* [wxMaxima: input   start ] */\n"
+"f(x):=x^2+1$\n"
+"f(2);\n"
+"/* [wxMaxima: input   end   ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:334
+msgid ""
+"Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the "
+"image type as first line):"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:335
+#, no-wrap
+msgid ""
+"/* [wxMaxima: image   start ]\n"
+"jpg\n"
+"[very chaotic looking character sequence]\n"
+"   [wxMaxima: image   end   ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:343
+msgid "A page break is just one line containing:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:344
+#, no-wrap
+msgid "/* [wxMaxima: page break    ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:349
+msgid "And folded cells marked by:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:350
+#, no-wrap
+msgid ""
+"/* [wxMaxima: fold    start ] */\n"
+"...\n"
+"/* [wxMaxima: fold    end   ] */\n"
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:356
+#, fuzzy, no-wrap
+#| msgid "### .wxmx"
+msgid ".wxmx"
+msgstr "### .wxmx"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:359
+#, fuzzy
+#| msgid ""
+#| "This xml-based file format saves the complete worksheet including things "
+#| "like the zoom factor and the watchlist. It is the preferred file format."
+msgid ""
+"This XML-based file format saves the complete worksheet including things "
+"like the zoom factor and the watchlist. It is the preferred file format."
+msgstr ""
+"Bu xml tabanlı dosya biçimi, yakınlaştırma faktörü ve izleme listesi gibi "
+"şeyleri içeren tüm çalışma sayfasını kaydeder. Tercih edilen dosya biçimidir."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:360
+#, fuzzy, no-wrap
+#| msgid "## File Formats"
+msgid "File format of wxmx files"
+msgstr "## Dosya formatları"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:364
+msgid ""
+"A `wxmx`-file seems to be a binary format, but one can handle it with tools, "
+"which are included in your OS. It is a zip file, one can decompress it with "
+"`unzip` (maybe rename it before, so that is recognized by the unzip program "
+"of your OS).  We do not use the compression function, just the possibility "
+"to merge several files into one file - images are already compressed and the "
+"rest is simple text (probably much smaller, than huge images, which are "
+"included)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:366
+msgid "It does contain the following files:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-"
+"wxmathml`"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`format.txt`: a short description about wxMaxima and the wxmx file format"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima "
+"session and included images."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`content.xml`: a XML document, which contains the various cells of your "
+"document in XML format."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:373
+msgid ""
+"So, if something goes wrong, you can unzip a wxMaxima document (maybe rename "
+"it before to a `zip`-file), maybe make changes in the `content.xml` file "
+"with a text editor, or replace an broken image, zip the files again, "
+"probably rename the `zip` to a `wxmx`-file - and you get another modified "
+"`wxmx`-file."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:374
+#, fuzzy, no-wrap
+#| msgid "## Configuration options"
+msgid "Configuration options"
+msgstr "## Yapılandırma Seçenekleri"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:377
+msgid ""
+"For some common configuration variables _wxMaxima_ offers two ways of "
+"configuring:"
+msgstr ""
+"Bazı yaygın yapılandırma değişkenleri için _wxMaxima_ iki yapılandırma "
+"yöntemi sunar:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:380
+msgid ""
+"The configuration dialog box below lets you change their default values for "
+"the current and subsequent sessions."
+msgstr ""
+"Aşağıdaki yapılandırma iletişim kutusu, geçerli ve sonraki oturumlar için "
+"varsayılan değerlerini değiştirmenizi sağlar."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:380
+#, fuzzy
+#| msgid ""
+#| "Also, the values for most configuration variables can be changed for the "
+#| "current session only by overwriting their values from the worksheet, as "
+#| "shown below."
+msgid ""
+"Also, the values for most configuration variables can be changed for the "
+"current session only by overwriting their values from the worksheet, as "
+"shown below."
+msgstr ""
+"Ayrıca, çoğu yapılandırma değişkeninin değerleri, aşağıda gösterildiği gibi, "
+"geçerli oturum için değerlerinin yalnızca çalışma sayfasından üzerine "
+"yazılmasıyla değiştirilebilir."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:382
+msgid ""
+"![wxMaxima configuration 1](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
+msgstr ""
+"![wxMaxima configuration 1](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:383
+#, fuzzy, no-wrap
+#| msgid "### Default animation framerate"
+msgid "Default animation framerate"
+msgstr "Varsayılan animasyon kare hızı"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:386
+msgid ""
+"The animation framerate that is used for new animations is kept in the "
+"variable `wxanimate_framerate`. The initial value this variable will contain "
+"in a new worksheet can be changed using the configuration dialogue."
+msgstr ""
+"Yeni animasyonlar için kullanılan animasyon karesi `wxanimate_framerate "
+"'değişkeninde tutulur. Bu değişkenin yeni bir çalışma sayfasında içereceği "
+"ilk değer, yapılandırma iletişim kutusu kullanılarak değiştirilebilir."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:387
+#, fuzzy, no-wrap
+#| msgid "### Default plot size for new _maxima_ sessions"
+msgid "Default plot size for new _maxima_ sessions"
+msgstr "Yeni 'maxima' oturumları için varsayılan çizim boyutu"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:390
+#, fuzzy
+#| msgid ""
+#| "After the next start plots embedded into the worksheet will be created "
+#| "with this size if the value of `wxplot_size` isn't changed by _maxima_."
+msgid ""
+"After the next start, plots embedded into the worksheet will be created with "
+"this size if the value of `wxplot_size` isn’t changed by _maxima_."
+msgstr ""
+"`` wxplot_size` değeri _maxima_ tarafından değiştirilmezse, bir sonraki "
+"başlangıçtan sonra çalışma sayfasına yerleştirilen grafikler bu boyutta "
+"oluşturulacaktır."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:392
+#, fuzzy
+#| msgid ""
+#| "In order to set the plot size of a single graph only use the following "
+#| "notation can be used that sets a variable’s value for one command only:"
+msgid ""
+"In order to set the plot size of a single graph only use the following "
+"notation can be used that sets a variable’s value for one command only:"
+msgstr ""
+"Tek bir grafiğin çizim boyutunu ayarlamak için bir değişkenin değerini "
+"yalnızca bir komut için ayarlayan aşağıdaki gösterimi kullanabilirsiniz:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:393
+#, fuzzy, no-wrap
+#| msgid "    wxdraw2d( explicit(x^2,x,-5,5)), wxplot_size=[480,480]$\n"
+msgid ""
+"wxdraw2d(\n"
+"   explicit(\n"
+"       x^2,\n"
+"       x,-5,5\n"
+"   )\n"
+"), wxplot_size=[480,480]$\n"
+msgstr "    wxdraw2d( explicit(x^2,x,-5,5)), wxplot_size=[480,480]$\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:402
+#, fuzzy, no-wrap
+#| msgid "### Match parenthesis in text controls"
+msgid "Match parenthesis in text controls"
+msgstr "### Metin denetimlerinde parantezleri eşleştir"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:405
+msgid "This option enables two things:"
+msgstr "Bu seçenek iki şeyi etkinleştirir:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:408
+#, fuzzy
+#| msgid ""
+#| "If an opening parenthesis, bracket or double quote is entered _wxMaxima_ "
+#| "will insert a closing one after it."
+msgid ""
+"If an opening parenthesis, bracket, or double quote is entered _wxMaxima_ "
+"will insert a closing one after it."
+msgstr ""
+"Bir açılış parantezi, parantez veya çift tırnak girilirse _wxMaxima_, "
+"arkasından bir kapanış ekler."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:408
+msgid ""
+"If text is selected if any of these keys is pressed the selected text will "
+"be put between the matched signs."
+msgstr ""
+"Bu tuşlardan herhangi birine basıldığında metin seçilirse, seçilen metin "
+"eşleşen işaretlerin arasına yerleştirilir."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:409
+#, fuzzy, no-wrap
+#| msgid "### Don't save the worksheet automatically"
+msgid "Don’t save the worksheet automatically"
+msgstr "Çalışma sayfasını otomatik olarak kaydetme"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:412
+#, fuzzy
+#| msgid ""
+#| "If this option is set the file the worksheet is in is overwritten only on "
+#| "request of the user. In case of a crash/power loss/... a recent backup "
+#| "copy is still made available in the temp directory, though."
+msgid ""
+"If this option is set, the file where the worksheet is will be overwritten "
+"only the request of the user. In case of a crash/power loss/... a recent "
+"backup copy is still made available in the temp directory, though."
+msgstr ""
+"Bu seçenek ayarlanırsa, çalışma sayfasının bulunduğu dosya yalnızca "
+"kullanıcının isteği üzerine yazılır. Bir çökme / güç kaybı / ... durumunda, "
+"geçici dizinde yakın zamanda yedek bir kopya bulunmaya devam eder."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:414
+#, fuzzy
+#| msgid ""
+#| "If this option isn't set wxMaxima behaves more like a modern cellphone "
+#| "app:"
+msgid ""
+"If this option isn’t set _wxMaxima_ behaves more like a modern cellphone app:"
+msgstr ""
+"Bu seçenek ayarlanmazsa, wxMaxima modern bir cep telefonu uygulaması gibi "
+"davranır:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:417
+msgid "Files are saved automatically on exit"
+msgstr "Dosyalar çıkışta otomatik olarak kaydedilir"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:417
+#, fuzzy
+#| msgid "And the file will automatically be saved every 3 minutes."
+msgid "And the file will automatically be saved every 3 minutes."
+msgstr "Ve dosya her 3 dakikada bir otomatik olarak kaydedilecektir."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:418
+#, fuzzy, no-wrap
+#| msgid "### Where is the configuration saved?"
+msgid "Where is the configuration saved?"
+msgstr "### Yapılandırma nereye kaydedilir?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:422
+#, fuzzy, no-wrap
+#| msgid "If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your homedirectory (if you are using wxWidgets < 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-plattform GUI library, which is the base for wxMaxima (therefore the `wx` in the name).  (Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden)."
+msgid ""
+"If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).\n"
+"(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).\n"
+msgstr "Unix / Linux kullanıyorsanız, yapılandırma bilgileri, ana dizininizdeki bir .wxMaxima` dosyasına kaydedilir (wxWidgets <3.1.1 kullanıyorsanız) veya `.config / wxMaxima.conf` ((XDG-Standard) ) wxWidgets> = 3.1.1 kullanılıyorsa). WxWidgets sürümünü `wxbuild_info ();` komutundan ya da Yardım-> Hakkında menü seçeneğini kullanarak alabilirsiniz. [wxWidgets] (https://www.wxwidgets.org/), wxMaxima (bu nedenle adındaki \"wx\") için temel olan çapraz platform GUI kütüphanesidir. (Dosya adı bir nokta ile başladığından, “.wxMaxima` veya“ .config` gizlenecektir)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:424
+#, fuzzy
+#| msgid ""
+#| "If you are using Windows, the configuration will be stored in the "
+#| "registry. You will find the entries for wxMaxima at the following "
+#| "position in the registry: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
+msgid ""
+"If you are using Windows, the configuration will be stored in the registry. "
+"You will find the entries for _wxMaxima_ at the following position in the "
+"registry: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
+msgstr ""
+"Windows kullanıyorsanız, yapılandırma kayıt defterinde saklanır. WxMaxima "
+"girişlerini kayıt defterinde aşağıdaki konumda bulabilirsiniz: "
+"`HKEY_CURRENT_USER \\ Software \\ wxMaxima`"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:427
+#, fuzzy, no-wrap
+#| msgid ""
+#| "Extensions to _Maxima_\n"
+#| "======================\n"
+msgid "Extensions to _Maxima_"
+msgstr ""
+"Maxima uzantıları_\n"
+"======================\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:430
+#, fuzzy
+#| msgid ""
+#| "_wxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
+#| "its main purpose is to pass along commands to _Maxima_ and to report the "
+#| "results of executing those commands. In some cases, however, _wxMaxima_ "
+#| "adds functionality to _Maxima_. _wxMaxima_’s ability to generate reports "
+#| "by exporting a workbook’s contents to HTML and LaTeX files has been "
+#| "mentioned. This section considers some ways that _wxMaxima_ enhances the "
+#| "inclusion of graphics into a session. described here."
+msgid ""
+"_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
+"its main purpose is to pass along commands to _Maxima_ and to report the "
+"results of executing those commands. In some cases, however, _wxMaxima_ adds "
+"functionality to _Maxima_. _WxMaxima_’s ability to generate reports by "
+"exporting a workbook’s contents to HTML and LaTeX files has been mentioned. "
+"This section considers some ways that _wxMaxima_ enhances the inclusion of "
+"graphics in a session."
+msgstr ""
+"_wxMaxima_ öncelikle _Maxima_ için bir grafik kullanıcı arayüzüdür. Bu "
+"nedenle, asıl amacı, komutları _Maxima_ öğesine iletmek ve bu komutların "
+"yürütülmesinin sonuçlarını bildirmektir. Ancak bazı durumlarda _wxMaxima_, "
+"_Maxima_ işlevine işlevsellik katar. _wxMaxima_’nin çalışma kitabının "
+"içeriğini HTML ve LaTeX dosyalarına aktararak rapor üretme yeteneğinden "
+"bahsedildi. Bu bölüm _wxMaxima_'ın grafiklerin bir oturuma dahil edilmesini "
+"geliştirmesinin bazı yollarını ele almaktadır. burada açıklanmıştır."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:431
+#, fuzzy, no-wrap
+#| msgid "## Subscripted variables"
+msgid "Subscripted variables"
+msgstr "## Alt indisli değişkenler"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:434
+msgid ""
+"`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript "
+"variable names:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:436
+msgid ""
+"If it is `false`, the functionality is off, wxMaxima will not autosubscript "
+"part of variable names after an underscore."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:438
+msgid ""
+"If it is set to `'all`, everything after an underscore will be subscripted."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:440
+#, fuzzy
+#| msgid ""
+#| "if `wxsubscripts` is set to true variable names of the format `x_y` are "
+#| "displayed using a subscript if"
+msgid ""
+"If it is set to `true` variable names of the format `x_y` are displayed "
+"using a subscript if"
+msgstr ""
+"`wxsubscripts`, true olarak seçilirse 'x_y' biçimindeki değişken isimleri "
+"bir alt simge kullanılarak görüntülenir, eğer"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:443
+#, fuzzy
+#| msgid "`y` is a single letter"
+msgid "Either `x` or `y` is a single letter or"
+msgstr "\"y\" tek bir harftir"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:443
+msgid "`y` is an integer (can include more than one character)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:445
+msgid ""
+"![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png)"
+"{ id=img_wxsubscripts }"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:447
+#, fuzzy
+#| msgid ""
+#| "If the variable name doesn’t match these requirements it can still be "
+#| "declared as \"to be subscripted\" using the command "
+#| "`wxdeclare_subscript(variable_name);` or "
+#| "`wxdeclare_subscript([variable_name1,variable_name2,...]);` Declaring a "
+#| "variable as subscripted can be reverted using the following command: "
+#| "`wxdeclare_subscript(variable_name,false);`"
+msgid ""
+"If the variable name doesn’t match these requirements, it can still be "
+"declared as \"to be subscripted\" using the command "
+"`wxdeclare_subscript(variable_name);` or "
+"`wxdeclare_subscript([variable_name1,variable_name2,...]);` Declaring a "
+"variable as subscripted can be reverted using the following command: "
+"`wxdeclare_subscript(variable_name,false);`"
+msgstr ""
+"Değişken adı bu gereksinimlere uymuyorsa, hala wxdeclare_subscript "
+"(değişken_adı); `veya` wxdeclare_subscript ([değişken_adı1, "
+"değişken_adı2, ...]) komutu kullanılarak \"alt indisli\" olarak "
+"bildirilebilir; alt indis  şu komut kullanılarak geri alınabilir: "
+"`wxdeclare_subscript (değişken_adı, yanlış);`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:449
+#, no-wrap
+msgid "You can use the menu \"View->Autosubscript\" to set these values.\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:450
+#, fuzzy, no-wrap
+#| msgid "## User feedback in the statusbar"
+msgid "User feedback in the status bar"
+msgstr "## Durum çubuğundaki kullanıcı geri bildirimi"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:453
+#, fuzzy
+#| msgid ""
+#| "Long-running commands can provide user-feedback in the status bar. This "
+#| "user feedback is replaced by any new feedback that is placed there "
+#| "(allowing to use it as a progress indicator) and is deleted as soon as "
+#| "the current command sent to _maxima_ is finished. It is safe to use "
+#| "`wxstatusbar()` even in libraries that might be used with plain _Maxima_ "
+#| "(as opposed to _wxMaxima_): If _wxMaxima_ isn't present the "
+#| "`wxstatusbar()` command will just be left unevaluated."
+msgid ""
+"Long-running commands can provide user feedback in the status bar. This user "
+"feedback is replaced by any new feedback that is placed there (allowing to "
+"use it as a progress indicator) and is deleted as soon as the current "
+"command sent to _Maxima_ is finished. It is safe to use `wxstatusbar()` even "
+"in libraries that might be used with plain _Maxima_ (as opposed to "
+"_wxMaxima_): If _wxMaxima_ isn’t present the `wxstatusbar()` command will "
+"just be left unevaluated."
+msgstr ""
+"Uzun süren komutlar, durum çubuğunda kullanıcı geri bildirimi sağlayabilir. "
+"Bu kullanıcı geri bildirimi, yeni bir geri bildirim ile değiştirilir "
+"(ilerleme göstergesi olarak kullanılmasına izin verilir) ve _maxima_'a "
+"gönderilen geçerli komut tamamlanır tamamlanmaz silinir. Düz _Maxima_ ile "
+"kullanılabilen (_wxMaxima_ yerine) kütüphanelerde bile `wxstatusbar ()` "
+"kullanmak güvenlidir: _wxMaxima_ yoksa, `wxstatusbar ()` komutu "
+"değerlendirilmeden bırakılır."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:454
+#, fuzzy, no-wrap
+#| msgid ""
+#| "    for i:1 thru 10 do (\n"
+#| "        /* Tell the user how far we got */\n"
+#| "        wxstatusbar(concat(\"Pass \",i)),\n"
+#| "        /* (sleep n) is a Lisp function, which can be used */\n"
+#| "        /* with the character \"?\" before. It delays the */\n"
+#| "        /* program execution (here: for 3 seconds) */\n"
+#| "        ?sleep(3)\n"
+#| "    )$\n"
+msgid ""
+"for i:1 thru 10 do (\n"
+"    /* Tell the user how far we got */\n"
+"    wxstatusbar(concat(\"Pass \",i)),\n"
+"    /* (sleep n) is a Lisp function, which can be used */\n"
+"    /* with the character \"?\" before. It delays the */\n"
+"    /* program execution (here: for 3 seconds) */\n"
+"    ?sleep(3)\n"
+")$\n"
+msgstr ""
+"    for i:1 thru 10 do (\n"
+"        /* Tell the user how far we got */\n"
+"        wxstatusbar(concat(\"Pass \",i)),\n"
+"        /* (sleep n) is a Lisp function, which can be used */\n"
+"        /* with the character \"?\" before. It delays the */\n"
+"        /* program execution (here: for 3 seconds) */\n"
+"        ?sleep(3)\n"
+"    )$\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:465
+#, no-wrap
+msgid "Exporting the worksheet from within Maxima"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:468
+msgid ""
+"The command `wxworksheettohtml()` exports the current worksheet to an HTML "
+"file from within a running _Maxima_ session, which is convenient for "
+"scripted or batch export. Like `wxstatusbar()` it is safe to use in code "
+"that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present "
+"the command is simply left unevaluated."
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:469
+#, no-wrap
+msgid ""
+"wxworksheettohtml(\"report.html\")$\n"
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:475
+msgid ""
+"A relative file name is interpreted relative to _Maxima_’s working "
+"directory. The optional keyword options are:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:480
+#, no-wrap
+msgid ""
+"| option   | values                                          | meaning                                             |\n"
+"| -------- | ----------------------------------------------- | --------------------------------------------------- |\n"
+"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |\n"
+"| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:482
+msgid ""
+"The `flavor` values match the equation formats offered by the graphical "
+"**File → Export** dialog: `mathml` produces a self-contained page that needs "
+"no internet connection, `mathjax` adds a MathJaX fall-back for browsers that "
+"still lack MathML, and `svg`/`bitmap` render every equation to an image."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:484
+msgid ""
+"The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file "
+"the same way:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:485
+#, no-wrap
+msgid ""
+"wxworksheettotex(\"report.tex\")$\n"
+"wxworksheettotex(\"report.tex\", documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:494
+#, no-wrap
+msgid ""
+"| option                 | meaning                                                              |\n"
+"| ---------------------- | -------------------------------------------------------------------- |\n"
+"| `documentclass`        | overrides the LaTeX `\\documentclass` (e.g. `\"article\"`, `\"report\"`)  |\n"
+"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:496
+msgid "Support for `wxworksheettopdf()` is planned."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:497
+#, fuzzy, no-wrap
+#| msgid "## Plotting"
+msgid "Plotting"
+msgstr "##Grafik çizmek"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:500
+msgid ""
+"Plotting (having fundamentally to do with graphics) is a place where a "
+"graphical user interface will have to provide some extensions to the "
+"original program."
+msgstr ""
+"Çizim (temel olarak grafiklerle ilgili çalışmak), grafik kullanıcı "
+"arayüzünün orijinal programa bazı uzantılar sağlamak zorunda kalacağı bir "
+"yerdir."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:501
+#, fuzzy, no-wrap
+#| msgid "### Embedding a plot into the work sheet"
+msgid "Embedding a plot into the worksheet"
+msgstr "### Bir taslağı çalışma sayfasına gömme"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:504
+#, fuzzy
+#| msgid ""
+#| "_Maxima_ normally instructs the external program gnuplot to open a "
+#| "separate window for every diagram it creates. Since many times it is "
+#| "convenient to embed graphs into the work sheet instead _wxMaxima_ "
+#| "provides its own set of plot functions that don’t differ from the "
+#| "corresponding _maxima_ functions save in their name: They are all "
+#| "prefixed by a “wx”. For example `wxplot2d` corresponds to `plot2d`, "
+#| "`wxplot3d` corresponds to `plot3d`, `wxdraw` corresponds to `draw` and "
+#| "`wxhistogram` corresponds to `histogram`."
+msgid ""
+"_Maxima_ normally instructs the external program _Gnuplot_ to open a "
+"separate window for every diagram it creates. Since many times it is "
+"convenient to embed graphs into the worksheet instead _wxMaxima_ provides "
+"its own set of plot functions that don’t differ from the corresponding "
+"_maxima_ functions save in their name: They are all prefixed by a “wx”."
+msgstr ""
+"_Maxima_ normalde harici program gnuplot'a oluşturduğu her diyagram için "
+"ayrı bir pencere açmasını söyler. Çoğu zaman grafikleri çalışma sayfasına "
+"gömmek uygun olduğu için _wxMaxima_, kendi adına kaydedilen karşılık gelen "
+"_maxima_ işlevlerinden farklı olmayan kendi çizim işlevlerini sağlar: "
+"Hepsinin önüne \"wx\" eklenir. Örneğin \"wxplot2d\", \"plot2d\" ye, "
+"\"wxplot3d\", \"plot3d\" ye, \"wxdraw\", \"draw\" a ve \"wxhistogram\", "
+"\"histogram\" a karşılık gelir."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:506
+msgid "The following plotting functions have wx-counterparts:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:520
+#, no-wrap
+msgid ""
+"| wxMaxima’s plot function | Maxima’s plot function                                                                          |\n"
+"| ------------------------ | ----------------------------------------------------------------------------------------------- |\n"
+"| `wxplot2d()`             | [plot2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot2d)               |\n"
+"| `wxplot3d()`             | [plot3d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot3d)               |\n"
+"| `wxdraw2d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw2d)               |\n"
+"| `wxdraw3d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw3d)               |\n"
+"| `wxdraw()`               | [draw](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw)                   |\n"
+"| `wximplicit_plot()`      | [implicit_plot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#implicit_plot) |\n"
+"| `wxhistogram()`          | [histogram](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#histogram)         |\n"
+"| `wxscatterplot()`        | [scatterplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#scatterplot)     |\n"
+"| `wxbarsplot()`           | [barsplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#barsplot)           |\n"
+"| `wxpiechart()`           | [piechart](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#piechart)           |\n"
+"| `wxboxplot()`            | [boxplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#boxplot)             |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:522
+msgid ""
+"If a `wxm`-file is read by (console) Maxima, these functions are ignored "
+"(and printed as output, as other unknown functions in Maxima)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:524
+msgid ""
+"If you got problems with one of these functions, please check, if the "
+"problem exists in the the Maxima function too (e.g. you got an error with "
+"`wxplot2d()`, check the same plot in the Maxima command `plot2d()` (which "
+"opens the plot in a separate Window)). If the problem does not disappear, it "
+"is most likely a Maxima issue and should be reported in the [Maxima "
+"bugtracker](https://sourceforge.net/p/maxima/bugs/). Or maybe a Gnuplot "
+"issue."
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:525
+#, fuzzy, no-wrap
+#| msgid "### Making embedded plots bigger or smaller"
+msgid "Making embedded plots bigger or smaller"
+msgstr "### Gömülü grafikleri daha büyük veya daha küçük yapma"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:528
+#, fuzzy
+#| msgid ""
+#| "As noted above, the configure dialog provides a way to change the default "
+#| "size plots are created with which sets the starting value of "
+#| "`wxplot_size`. The plotting routines of _wxMaxima_ respect this variable "
+#| "that specifies the size of a plot in pixels. It can always be queried or "
+#| "used to set the size of the following plots:"
+msgid ""
+"As noted above, the configure dialog provides a way to change the default "
+"size plots created which sets the starting value of `wxplot_size`. The "
+"plotting routines of _wxMaxima_ respect this variable that specifies the "
+"size of a plot in pixels. It can always be queried or used to set the size "
+"of the following plots:"
+msgstr ""
+"Yukarıda belirtildiği gibi, yapılandırma iletişim kutusu, varsayılan değer "
+"grafiklerinin, wxplot_size `nin başlangıç değerini ayarlayan "
+"değiştirilmesinin bir yolunu sağlar. _WxMaxima_'nın çizim yordamları, bir "
+"grafiğin piksel cinsinden boyutunu belirleyen bu değişkene uyar. Aşağıdaki "
+"grafiklerin boyutunu ayarlamak için her zaman sorgulanabilir veya "
+"kullanılabilir:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:529
+#, fuzzy, no-wrap
+#| msgid ""
+#| "    wxplot_size:[1200,800]$\n"
+#| "    wxdraw2d(\n"
+#| "        explicit(\n"
+#| "            sin(x),\n"
+#| "            x,1,10\n"
+#| "        )\n"
+#| "    )$\n"
+msgid ""
+"wxplot_size:[1200,800]$\n"
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+")$\n"
+msgstr ""
+"    wxplot_size:[1200,800]$\n"
+"    wxdraw2d(\n"
+"        explicit(\n"
+"            sin(x),\n"
+"            x,1,10\n"
+"        )\n"
+"    )$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:540
+#, fuzzy
+#| msgid ""
+#| "If the size of only one plot is to be changed _Maxima_ provides a "
+#| "canonical way to change an attribute only for the current cell."
+msgid ""
+"If the size of only one plot is to be changed _Maxima_ provides a canonical "
+"way to change an attribute only for the current cell. In this usage the "
+"specification `wxplot_size = [value1, value2]` is appended to the "
+"`wxdraw2d( )` command, and is not part of the `wxdraw2d` command."
+msgstr ""
+"Yalnızca bir grafiğin boyutu değiştirilecekse _Maxima_, yalnızca geçerli "
+"hücre için bir özniteliği değiştirmek için standart bir yol sağlar."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:541
+#, fuzzy, no-wrap
+#| msgid ""
+#| "     wxdraw2d(\n"
+#| "        explicit(\n"
+#| "            sin(x),\n"
+#| "            x,1,10\n"
+#| "        )\n"
+#| "     ),wxplot_size=[1600,800]$\n"
+msgid ""
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+"),wxplot_size=[1600,800]$\n"
+msgstr ""
+"     wxdraw2d(\n"
+"        explicit(\n"
+"            sin(x),\n"
+"            x,1,10\n"
+"        )\n"
+"     ),wxplot_size=[1600,800]$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:551
+msgid ""
+"Setting the size of embedded plot with `wxplot_size` works for embedded "
+"plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` "
+"commands and for embedded animations with `with_slider_draw` and `wxanimate` "
+"commands."
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:552
+#, fuzzy, no-wrap
+#| msgid "### Better quality plots"
+msgid "Better quality plots"
+msgstr "### Daha kaliteli grafik çizimleri"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:555
+#, fuzzy
+#| msgid ""
+#| "Gnuplot doesn’t seem to provide a portable way of determining whether it "
+#| "supports the high-quality bitmap output the cairo library provides. On "
+#| "systems where gnuplot is compiled to use this library the pngcairo option "
+#| "from the configuration menu (that can be overridden by the variable "
+#| "`wxplot_pngcairo`) enables support for antialiasing and additional line "
+#| "styles. If `wxplot_pngcairo` is set without gnuplot supporting this the "
+#| "result will be error messages instead of graphics."
+msgid ""
+"_Gnuplot_ doesn’t seem to provide a portable way of determining whether it "
+"supports the high-quality bitmap output that the Cairo library provides. On "
+"systems where _Gnuplot_ is compiled to use this library the pngCairo option "
+"from the configuration menu (that can be overridden by the variable "
+"`wxplot_pngcairo`) enables support for antialiasing and additional line "
+"styles. If `wxplot_pngCairo` is set without _Gnuplot_ supporting this the "
+"result will be error messages instead of graphics."
+msgstr ""
+"Gnuplot, cairo kütüphanesinin sağladığı yüksek kaliteli bitmap çıktısını "
+"destekleyip desteklemediğini belirlemenin taşınabilir bir yolu gibi "
+"görünmüyor. Bu kütüphaneyi kullanmak için gnuplot'un derlendiği sistemlerde, "
+"yapılandırma menüsünden (wxplot_pngcairo` değişkeni tarafından geçersiz "
+"kılınabilir) pngcairo seçeneği kenar yumuşatma ve ek çizgi stilleri için "
+"destek sağlar. `Wxplot_pngcairo` bunu destekleyici gnuplot olmadan "
+"ayarlanırsa, sonuç grafik yerine hata mesajları olur."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:556
+#, fuzzy, no-wrap
+#| msgid "### Opening embedded plots in interactive gnuplot windows"
+msgid "Opening embedded plots in interactive _Gnuplot_ windows"
+msgstr "### İnteraktif gnuplot pencerelerinde gömülü grafikleri açma"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:559
+#, fuzzy
+#| msgid ""
+#| "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
+#| "`wxplot3d` isn't supported by this feature) and the file size of the "
+#| "underlying gnuplot project isn't way too high _wxMaxima_ offers a right-"
+#| "click menu that allows to open the plot in an interactive gnuplot window."
+msgid ""
+"If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
+"`wxplot3d` isn’t supported by this feature) and the file size of the "
+"underlying _Gnuplot_ project isn’t way too high _wxMaxima_ offers a right-"
+"click menu that allows to open the plot in an interactive _Gnuplot_ window."
+msgstr ""
+"`Wxdraw` tipi komutlar kullanılarak bir çizim oluşturulduysa (` wxplot2d` ve "
+"`wxplot3d` bu özellik tarafından desteklenmiyorsa) ve alttaki gnuplot "
+"projesinin dosya boyutu çok yüksek değilse _wxMaxima_ sağ tıklama  "
+"etkileşimli bir gnuplot penceresinde çizimin açılmasını sağlayan menü sunar."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:560
+#, fuzzy, no-wrap
+#| msgid "### Opening gnuplot's command console in `plot` windows"
+msgid "Opening Gnuplot’s command console in `plot` windows"
+msgstr "### gnuplot'un komut konsolunu `plot` pencerelerinde açma"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:564
+#, fuzzy
+#| msgid ""
+#| "On MS Windows, if in _Maxima_'s variable `gnuplot_command` \"gnuplot\" is "
+#| "replaced by \"wgnuplot\", gnuplot offers the possibility to open a "
+#| "console window, where gnuplot commands can be entered into. Unfortunately "
+#| "enabling this feature causes gnuplot to \"steal\" the keyboard focus for "
+#| "a short time every time a plot is prepared."
+msgid ""
+"On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and `wgnuplot."
+"exe`.  You can configure, which command should be used using the "
+"configuration menu. `wgnuplot.exe` offers the possibility to open a console "
+"window, where _gnuplot_ commands can be entered into, `gnuplot.exe` does not "
+"offer this possibility. Unfortunately, `wgnuplot.exe` causes _Gnuplot_ to "
+"\"steal\" the keyboard focus for a short time every time a plot is prepared."
+msgstr ""
+"MS Windows'ta, _Maxima_ değişkenindeki \"gnuplot_command`\" gnuplot "
+"\"yerine\" wgnuplot \"yazılırsa, gnuplot, gnuplot komutlarının "
+"girilebileceği bir konsol penceresi açma olanağı sunar. Ne yazık ki bu "
+"özelliğin etkinleştirilmesi, gnuplot'un her çizim hazırlandığında klavye "
+"odağını kısa bir süre \"çalmasına\" neden olur."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:565
+#, fuzzy, no-wrap
+#| msgid "### Embedding animations into the spreadsheet"
+msgid "Embedding animations into the spreadsheet"
+msgstr "### Animasyonları düz bir sayfaya gömme"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:568
+#, fuzzy
+#| msgid ""
+#| "3D diagrams tend to make it hard to read quantitative data. A viable "
+#| "alternative might be to assign the 3rd parameter to the mouse wheel. The "
+#| "`with_slider_draw` command is a version of `wxdraw2d` that does prepare "
+#| "multiple plots and allows to switch between them by moving the slider on "
+#| "top of the screen. _wxMaxima_ allows to export this animation as an "
+#| "animated gif."
+msgid ""
+"3D diagrams tend to make it hard to read quantitative data. A viable "
+"alternative might be to assign the 3rd parameter to the mouse wheel. The "
+"`with_slider_draw` command is a version of `wxdraw2d` that does prepare "
+"multiple plots and allows to switch between them by moving the slider on top "
+"of the screen. _WxMaxima_ allows to export this animation as an animated gif."
+msgstr ""
+"3B diyagramlar nicel verilerin okunmasını zorlaştırma eğilimindedir. Uygun "
+"bir alternatif, 3. parametreyi fare tekerleğine atamak olabilir. "
+"`With_slider_draw` komutu, birden fazla grafik hazırlayan ve kaydırıcıyı "
+"ekranın üstüne getirerek aralarında geçiş yapmayı sağlayan bir 'wxdraw2d` "
+"sürümüdür. _wxMaxima_, bu animasyonu hareketli bir gif olarak dışa aktarmaya "
+"izin verir."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:570
+msgid ""
+"The first two arguments for `with_slider_draw` are the name of the variable "
+"that is stepped between the plots and a list of the values of these "
+"variable. The arguments that follow are the ordinary arguments for "
+"`wxdraw2d`:"
+msgstr ""
+"`With_slider_draw` için ilk iki argüman, grafikler arasında basamaklanan "
+"değişkenin adı ve bu değişkenin değerlerinin bir listesidir. Aşağıdaki "
+"argümanlar \"wxdraw2d\" için sıradan argümanlardır:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:571
+#, fuzzy, no-wrap
+#| msgid ""
+#| "    with_slider_draw(\n"
+#| "        f,[1,2,3,4,5,6,7,10],\n"
+#| "        title=concat(\"f=\",f,\"Hz\"),\n"
+#| "        explicit(\n"
+#| "            sin(2*%pi*f*x),\n"
+#| "            x,0,1\n"
+#| "        ),grid=true\n"
+#| "    );\n"
+msgid ""
+"with_slider_draw(\n"
+"    f,[1,2,3,4,5,6,7,10],\n"
+"    title=concat(\"f=\",f,\"Hz\"),\n"
+"    explicit(\n"
+"        sin(2*%pi*f*x),\n"
+"        x,0,1\n"
+"    ),grid=true\n"
+");\n"
+msgstr ""
+"    with_slider_draw(\n"
+"        f,[1,2,3,4,5,6,7,10],\n"
+"        title=concat(\"f=\",f,\"Hz\"),\n"
+"        explicit(\n"
+"            sin(2*%pi*f*x),\n"
+"            x,0,1\n"
+"        ),grid=true\n"
+"    );\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:583
+msgid ""
+"The same functionality for 3D plots is accessible as `with_slider_draw3d`, "
+"which allows for rotating 3d plots:"
+msgstr ""
+"3D grafikler için aynı işleve, 3d grafikleri döndürmeye izin veren `` "
+"with_slider_draw3d` ile erişilebilir:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:584
+#, fuzzy, no-wrap
+#| msgid ""
+#| "    wxanimate_autoplay:true;\n"
+#| "    wxanimate_framerate:20;\n"
+#| "    with_slider_draw3d(\n"
+#| "        α,makelist(i,i,1,360,3),\n"
+#| "        title=sconcat(\"α=\",α),\n"
+#| "        surface_hide=true,\n"
+#| "        contour=both,\n"
+#| "        view=[60,α],\n"
+#| "        explicit(\n"
+#| "            sin(x)*sin(y),\n"
+#| "            x,-π,π,\n"
+#| "            y,-π,π\n"
+#| "        )\n"
+#| "    )$\n"
+msgid ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    α,makelist(i,i,1,360,3),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,α],\n"
+"    explicit(\n"
+"        sin(x)*sin(y),\n"
+"        x,-π,π,\n"
+"        y,-π,π\n"
+"    )\n"
+")$\n"
+msgstr ""
+"    wxanimate_autoplay:true;\n"
+"    wxanimate_framerate:20;\n"
+"    with_slider_draw3d(\n"
+"        α,makelist(i,i,1,360,3),\n"
+"        title=sconcat(\"α=\",α),\n"
+"        surface_hide=true,\n"
+"        contour=both,\n"
+"        view=[60,α],\n"
+"        explicit(\n"
+"            sin(x)*sin(y),\n"
+"            x,-π,π,\n"
+"            y,-π,π\n"
+"        )\n"
+"    )$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:602
+#, fuzzy
+#| msgid ""
+#| "If the general shape of the plot is what matters it might suffice to move "
+#| "the plot just a little bit in order to make it's 3D nature available to "
+#| "the intuition:"
+msgid ""
+"If the general shape of the plot is what matters it might suffice to move "
+"the plot just a little bit in order to make its 3D nature available to the "
+"intuition:"
+msgstr ""
+"Grafiğin genel şekli önemliyse, 3D doğasını sezginin kullanımına sunmak için "
+"çizimi biraz hareket ettirmek yeterli olabilir:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:603
+#, fuzzy, no-wrap
+#| msgid ""
+#| "    wxanimate_autoplay:true;\n"
+#| "    wxanimate_framerate:20;\n"
+#| "    with_slider_draw3d(\n"
+#| "        t,makelist(i,i,0,2*π,.05*π),\n"
+#| "        title=sconcat(\"α=\",α),\n"
+#| "        surface_hide=true,\n"
+#| "        contour=both,\n"
+#| "        view=[60,30+5*sin(t)],\n"
+#| "        explicit(\n"
+#| "            sin(x)*y^2,\n"
+#| "            x,-2*π,2*π,\n"
+#| "            y,-2*π,2*π\n"
+#| "        )\n"
+#| "    )$\n"
+msgid ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    t,makelist(i,i,0,2*π,.05*π),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,30+5*sin(t)],\n"
+"    explicit(\n"
+"        sin(x)*y^2,\n"
+"        x,-2*π,2*π,\n"
+"        y,-2*π,2*π\n"
+"    )\n"
+")$\n"
+msgstr ""
+"    wxanimate_autoplay:true;\n"
+"    wxanimate_framerate:20;\n"
+"    with_slider_draw3d(\n"
+"        t,makelist(i,i,0,2*π,.05*π),\n"
+"        title=sconcat(\"α=\",α),\n"
+"        surface_hide=true,\n"
+"        contour=both,\n"
+"        view=[60,30+5*sin(t)],\n"
+"        explicit(\n"
+"            sin(x)*y^2,\n"
+"            x,-2*π,2*π,\n"
+"            y,-2*π,2*π\n"
+"        )\n"
+"    )$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:621
+#, fuzzy
+#| msgid ""
+#| "For those more familiar with `plot` than with `draw` there is a second "
+#| "set of functions:"
+msgid ""
+"For those more familiar with `plot` than with `draw`, there is a second set "
+"of functions:"
+msgstr ""
+"\"Çizim\" e daha çok \"çizim\" ile aşina olanlar için ikinci bir işlev grubu "
+"vardır:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:624
+#, fuzzy
+#| msgid "`with_slider` and"
+msgid "`with_slider` and"
+msgstr "`with_slider` ve"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:624
+msgid "`wxanimate`."
+msgstr "`wxanimate`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:626
+#, fuzzy
+#| msgid ""
+#| "Normally the animations are played back or exported with the frame rate "
+#| "chosen in the configuration of _wxMaxima_. To set the speed an individual "
+#| "animation is played back the variable `wxanimate_framerate` can be used:"
+msgid ""
+"Normally the animations are played back or exported with the frame rate "
+"chosen in the configuration of _wxMaxima_. To set the speed at an individual "
+"animation is played back the variable `wxanimate_framerate` can be used:"
+msgstr ""
+"Normalde animasyonlar _wxMaxima_ yapılandırmasında seçilen kare hızıyla "
+"oynatılır veya dışa aktarılır. Tek bir animasyonun oynatıldığı hızı "
+"ayarlamak için `wxanimate_framerate 'değişkeni kullanılabilir:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:627
+#, fuzzy, no-wrap
+#| msgid ""
+#| "    wxanimate(a, 10,\n"
+#| "        sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+msgid ""
+"wxanimate(a, 10,\n"
+"    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+msgstr ""
+"    wxanimate(a, 10,\n"
+"        sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:633
+#, fuzzy
+#| msgid ""
+#| "The animation functions use _maxima_'s `makelist` command and therefore "
+#| "shares the pitfall that the slider variable's value is substituted into "
+#| "the expression only if the variable is directly visible in the "
+#| "expression. Therefore the following example will fail:"
+msgid ""
+"The animation functions use _Maxima_’s `makelist` command and therefore "
+"share the pitfall that the slider variable’s value is substituted into the "
+"expression only if the variable is directly visible in the expression. "
+"Therefore the following example will fail:"
+msgstr ""
+"Animasyon işlevleri _maxima_'ın `makelist` komutunu kullanır ve bu nedenle, "
+"kaydırıcı değişkeninin değerinin, yalnızca değişken ifadede doğrudan "
+"görülebiliyorsa ifadeye ikame edilmesiyle ilgili tuzakları paylaşır. Bu "
+"nedenle aşağıdaki örnek başarısız olacaktır:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:634
+#, fuzzy, no-wrap
+#| msgid ""
+#| "    f:sin(a*x);\n"
+#| "    with_slider_draw(\n"
+#| "        a,makelist(i/2,i,1,10),\n"
+#| "        title=concat(\"a=\",float(a)),\n"
+#| "        grid=true,\n"
+#| "        explicit(f,x,0,10)\n"
+#| "    )$\n"
+msgid ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    a,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(a)),\n"
+"    grid=true,\n"
+"    explicit(f,x,0,10)\n"
+")$\n"
+msgstr ""
+"    f:sin(a*x);\n"
+"    with_slider_draw(\n"
+"        a,makelist(i/2,i,1,10),\n"
+"        title=concat(\"a=\",float(a)),\n"
+"        grid=true,\n"
+"        explicit(f,x,0,10)\n"
+"    )$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:645
+#, fuzzy
+#| msgid ""
+#| "If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
+#| "works fine instead:"
+msgid ""
+"If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
+"works fine instead:"
+msgstr ""
+"_Maxima_'dan açıkça kaydırıcının yerine değer girmesi istenirse bunun yerine "
+"değer grafiği işe yarar:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:646
+#, fuzzy, no-wrap
+#| msgid ""
+#| "    f:sin(a*x);\n"
+#| "    with_slider_draw(\n"
+#| "        b,makelist(i/2,i,1,10),\n"
+#| "        title=concat(\"a=\",float(b)),\n"
+#| "        grid=true,\n"
+#| "        explicit(\n"
+#| "            subst(a=b,f),\n"
+#| "            x,0,10\n"
+#| "        )\n"
+#| "    )$\n"
+msgid ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    b,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(b)),\n"
+"    grid=true,\n"
+"    explicit(\n"
+"        subst(a=b,f),\n"
+"        x,0,10\n"
+"    )\n"
+")$\n"
+msgstr ""
+"    f:sin(a*x);\n"
+"    with_slider_draw(\n"
+"        b,makelist(i/2,i,1,10),\n"
+"        title=concat(\"a=\",float(b)),\n"
+"        grid=true,\n"
+"        explicit(\n"
+"            subst(a=b,f),\n"
+"            x,0,10\n"
+"        )\n"
+"    )$\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:659
+#, fuzzy, no-wrap
+#| msgid "### Opening multiple plots in contemporaneous windows"
+msgid "Opening multiple plots in contemporaneous windows"
+msgstr "### Eşzamanlı olmayan pencerelerde birden fazla çizim açma"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:662
+#, fuzzy
+#| msgid ""
+#| "While not being a provided by _wxMaxima_ this feature of _Maxima_ (on "
+#| "setups that support it) sometimes comes in handily. The following example "
+#| "comes from a post from Mario Rodriguez to the _Maxima_ mailing list:"
+msgid ""
+"While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups "
+"that support it) sometimes comes in handily. The following example comes "
+"from a post from Mario Rodriguez to the _Maxima_ mailing list:"
+msgstr ""
+"_WxMaxima_ tarafından sağlanmasa da, _Maxima_'ın bu özelliği (bunu "
+"destekleyen kurulumlarda) bazen kolayca elde edilebilir. Aşağıdaki örnek, "
+"Mario Rodriguez'in _Maxima_ posta listesine bir gönderiden geliyor:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:663
+#, no-wrap
+msgid ""
+"load(draw);\n"
+"\n"
+"/* Parabola in window #1 */\n"
+"draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Parabola in window #2 */\n"
+"draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Paraboloid in window #3 */\n"
+"draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:677
+msgid ""
+"Plotting multiple plots in the same window is possible, too (the same is "
+"possible in command line Maxima with the standard `draw()` command):"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:678
+#, no-wrap
+msgid ""
+"wxdraw(\n"
+"  gr2d(\n"
+"    key=\"sin (x)\",grid=[2,2],\n"
+"    explicit(sin(x),x,0,2*%pi)),\n"
+"  gr2d(\n"
+"    key=\"cos (x)\",grid=[2,2],\n"
+"    explicit(cos(x),x,0,2*%pi))\n"
+");\n"
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:689
+#, fuzzy, no-wrap
+#| msgid "### The \"Plot using draw\" sidepane"
+msgid "The \"Plot using draw\" side pane"
+msgstr "Draw  kullanarak grafik çiz### \"draw komutu ile grafik çizme'' yan paneli"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:692
+#, fuzzy
+#| msgid ""
+#| "The \"Plot using draw\" sidebar hides a simple code generator that allows "
+#| "to generate scenes that make use of some of the flexibility of the _draw_ "
+#| "package _maxima_ comes with."
+msgid ""
+"The \"Plot using draw\" sidebar hides a simple code generator that allows "
+"generating scenes that make use of some of the flexibility of the _draw_ "
+"package _maxima_ comes with."
+msgstr ""
+"\"Çizim kullanarak çizim\" kenar çubuğu, _maxima_ ile birlikte gelen _draw_ "
+"paketinin esnekliğinden bazılarını kullanan sahneler oluşturmaya izin veren "
+"basit bir kod oluşturucuyu gizler."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:693
+#, no-wrap
+msgid "2D"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:696
+#, fuzzy
+#| msgid ""
+#| "Generates the skeleton of a `draw()` command that draws a 2D scene. This "
+#| "scene later has to be filled with commands that generate the scene's "
+#| "contents, for example by using the buttons in the rows below the \"2D\" "
+#| "button."
+msgid ""
+"Generates the skeleton of a `draw()` command that draws a 2D scene. This "
+"scene later has to be filled with commands that generate the scene’s "
+"contents, for example by using the buttons in the rows below the \"2D\" "
+"button."
+msgstr ""
+"2B sahne çizen bir draw () komutunun iskeletini oluşturur. Bu sahne daha "
+"sonra, örneğin \"2B\" düğmesinin altındaki satırlardaki düğmeleri "
+"kullanarak, sahnenin içeriğini oluşturan komutlarla doldurulmalıdır."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:698
+#, fuzzy
+#| msgid ""
+#| "One helpful feature of the 2D button is that it allows to setup the scene "
+#| "as an animation in which a variable (by default it is _t_ has a different "
+#| "value in each frame: Often an moving 2D plot allows easier interpretation "
+#| "than the same data in a non-moving 3D one."
+msgid ""
+"One helpful feature of the 2D button is that it allows to set up the scene "
+"as an animation in which a variable (by default it is _t_) has a different "
+"value in each frame: Often a moving 2D plot allows easier interpretation "
+"than the same data in a non-moving 3D one."
+msgstr ""
+"2B düğmesinin yararlı bir özelliği, sahneyi bir değişkenin (varsayılan "
+"olarak _t_ her karede farklı bir değere sahip olduğu) bir animasyon olarak "
+"ayarlamasına izin vermesidir: Genellikle hareketli bir 2B çizim, aynı "
+"veriden daha kolay yorumlamaya izin verir hareketsiz 3D bir."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:699
+#, no-wrap
+msgid "3D"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:702
+#, fuzzy
+#| msgid ""
+#| "Generates the skeleton of a `draw()` command that draws a 3D scene. If "
+#| "neither a 2D or a 3D scene are set up all of the other buttons set up a "
+#| "2D scene that contains the command the button generates."
+msgid ""
+"Generates the skeleton of a `draw()` command that draws a 3D scene. If "
+"neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D "
+"scene that contains the command the button generates."
+msgstr ""
+"3B sahne çizen bir draw () komutunun iskeletini oluşturur. Bir 2B veya 3B "
+"sahne ayarlanmamışsa, diğer tüm butonlar butonun oluşturduğu komutu içeren "
+"bir 2B sahne ayarlayın."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:703
+#, fuzzy, no-wrap
+#| msgid "#### Expression"
+msgid "Expression"
+msgstr "#### İfade"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:706
+msgid ""
+"Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or "
+"`x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is "
+"no draw command a 2D scene with the plot is generated. Each scene can be "
+"filled with any number of plots."
+msgstr ""
+"İmlecin içinde bulunduğu `draw ()` komutuna `sin (x)`, `x * sin (x)` veya `x "
+"^ 2 + 2 * x-4` gibi bir ifadenin standart grafiğini ekler. çizim ile bir 2D "
+"sahne oluşturulur çizme komutu yoktur. Her sahne herhangi bir sayıda çizim "
+"ile doldurulabilir."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:707
+#, fuzzy, no-wrap
+#| msgid "#### Implicit plot"
+msgid "Implicit plot"
+msgstr "#### Kapalı çizim"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:710
+msgid ""
+"Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or "
+"`x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command "
+"the cursor currently is in. If there is no draw command a 2D scene with the "
+"plot is generated."
+msgstr ""
+"`Y = sin (x)`, `y * sin (x) = 3` veya` x ^ 2 + y ^ 2 = 4` gibi bir ifadenin "
+"tüm noktalarını bulmaya çalışır ve sonuçtaki eğriyi `` imlecin içinde "
+"bulunduğu draw () `komutu. Draw komutu yoksa çizim içeren bir 2D sahne "
+"oluşturulur."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:711
+#, fuzzy, no-wrap
+#| msgid "#### Parametric plot"
+msgid "Parametric plot"
+msgstr "#### Parametrik Grafik çizimi"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:714
+msgid ""
+"Steps a variable from a lower limit to an upper limit and uses two "
+"expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in "
+"3D plots also z) coordinates of a curve that is put into the current draw "
+"command."
+msgstr ""
+"Bir değişkeni alt sınırdan üst sınıra çevirir ve a'nın x, y (ve 3B "
+"grafiklerde de z) koordinatlarını oluşturmak için `t * sin (t)` ve `t * cos "
+"(t)` gibi iki ifade kullanır geçerli çizim komutuna konan eğri."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:715
+#, fuzzy, no-wrap
+#| msgid "#### Points"
+msgid "Points"
+msgstr "#### Noktalar"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:718
+msgid ""
+"Draws many points that can optionally be joined. The coordinates of the "
+"points are taken from a list of lists, a 2D array or one list or array for "
+"each axis."
+msgstr ""
+"İsteğe bağlı olarak birleştirilebilen birçok nokta çizer. Noktaların "
+"koordinatları bir liste listesinden, bir 2D diziden veya her eksen için bir "
+"listeden veya diziden alınır."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:719
+#, fuzzy, no-wrap
+#| msgid "#### Diagram title"
+msgid "Diagram title"
+msgstr "#### Diyagram başlığı"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:722
+msgid "Draws a title on the upper end of the diagram,"
+msgstr "Diyagramın üst ucuna bir başlık çizer,"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:723
+#, fuzzy, no-wrap
+#| msgid "#### 2D"
+msgid "Axis"
+msgstr "#### 2B"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:726
+msgid "Sets up the axis."
+msgstr "Ekseni ayarlar."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:727
+#, fuzzy, no-wrap
+#| msgid "#### Contour"
+msgid "Contour"
+msgstr "#### Eşyükselti eğrisi"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:730
+#, fuzzy
+#| msgid ""
+#| "(Only for 3D plots): Adds contour lines similar to the ones one can find "
+#| "in a map of a mountain to the plot commands that follow in the current "
+#| "draw() command and/or to the ground plane of the diagram. Alternatively "
+#| "this wizard allows skipping drawing the curves entirely only showing the "
+#| "contour plot."
+msgid ""
+"(Only for 3D plots): Adds contour lines similar to the ones one can find in "
+"a map of a mountain to the plot commands that follow in the current `draw()` "
+"command and/or to the ground plane of the diagram. Alternatively, this "
+"wizard allows skipping drawing the curves entirely only showing the contour "
+"plot."
+msgstr ""
+"(Yalnızca 3B grafikler için): Geçerli draw () komutunda ve / veya diyagramın "
+"zemin düzleminde izlenen çizim komutlarına bir dağ haritasında bulanlara "
+"benzer kontur çizgileri ekler. Alternatif olarak, bu sihirbaz eğrileri "
+"tamamen atlayarak sadece kontur grafiğini göstermeyi sağlar."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:731
+#, fuzzy, no-wrap
+#| msgid "#### Plot name"
+msgid "Plot name"
+msgstr "#### Çizim Adı"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:734
+#, fuzzy
+#| msgid ""
+#| "Adds a legend entry showing the next plot's name to the legend of the "
+#| "diagram. An empty name disables generating legend entries for the "
+#| "following plots."
+msgid ""
+"Adds a legend entry showing the next plot’s name to the legend of the "
+"diagram. An empty name disables generating legend entries for the following "
+"plots."
+msgstr ""
+"Diyagramın göstergesine bir sonraki grafiğin adını gösteren bir gösterge "
+"girişi ekler. Boş bir ad, aşağıdaki grafikler için açıklama girişi "
+"oluşturulmasını devre dışı bırakır."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:735
+#, fuzzy, no-wrap
+#| msgid "#### Line color"
+msgid "Line colour"
+msgstr "#### Çizgi Rengi"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:738
+#, fuzzy
+#| msgid ""
+#| "Sets the line color for the following plots the current draw command "
+#| "contains."
+msgid ""
+"Sets the line colour for the following plots the current draw command "
+"contains."
+msgstr ""
+"Geçerli çizim komutunun içerdiği aşağıdaki çizimler için çizgi rengini "
+"ayarlar."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:739
+#, fuzzy, no-wrap
+#| msgid "#### Fill color"
+msgid "Fill colour"
+msgstr "#### Renk doldur"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:742
+#, fuzzy
+#| msgid ""
+#| "Sets the fill color for the following plots the current draw command "
+#| "contains."
+msgid ""
+"Sets the fill colour for the following plots the current draw command "
+"contains."
+msgstr ""
+"Geçerli çizim komutunun içerdiği aşağıdaki çizimler için dolgu rengini "
+"ayarlar."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:743
+#, fuzzy, no-wrap
+#| msgid "#### 2D"
+msgid "Grid"
+msgstr "#### 2B"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:746
+msgid "Pops up a wizard that allows to set up grid lines."
+msgstr "Izgara çizgilerini ayarlamaya izin veren bir sihirbaz açar."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:747
+#, fuzzy, no-wrap
+#| msgid "#### Accuracy"
+msgid "Accuracy"
+msgstr "#### Doğruluk"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:750
+msgid ""
+"Allows to select an adequate point in the speed vs. accuracy tradeoff that "
+"is part of any plot program."
+msgstr ""
+"Herhangi bir çizim programının parçası olan hız ve doğruluk dengesinde "
+"yeterli bir noktanın seçilmesini sağlar."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:751
+#, no-wrap
+msgid "Modify font and font size for plots"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:754
+msgid ""
+"Especially when you use a high resolution display, the default font size "
+"might be very small. For the `draw`-based commands, you can set the font / "
+"font size using options like `font=...`, `font_size=...`, e.g.:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:755
+#, fuzzy, no-wrap
+#| msgid ""
+#| "pngdraw2d(\"Test\",\n"
+#| "        explicit(sin(x),x,1,10)\n"
+#| ");\n"
+#| "~~~~\n"
+msgid ""
+"wxdraw2d(\n"
+"     font=\"Helvetica\",\n"
+"     font_size=30,\n"
+"     explicit(sin(x),x,1,10));\n"
+msgstr ""
+"pngdraw2d(\"Test\",\n"
+"        explicit(sin(x),x,1,10)\n"
+");\n"
+"~~~~\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:763
+msgid ""
+"For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts "
+"can be set using the `gnuplot_preamble` command, e.g.:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:764
+#, no-wrap
+msgid ""
+"wxplot2d(sin(x),[x,1,10],\n"
+"         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:770
+msgid ""
+"This sets the font for the numbers to Arial with size 30, the size for the "
+"xlabel and ylabel font to 20 (with the default font)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:773
+msgid ""
+"Read the Maxima and Gnuplot documentation for further information.  Note: "
+"Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue "
+"1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966)."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:774
+#, fuzzy, no-wrap
+#| msgid "## Embedding graphics"
+msgid "Embedding graphics"
+msgstr "## Grafikleri gömme"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:777
+#, fuzzy
+#| msgid ""
+#| "if the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
+#| "project can be done as easily as per drag-and-drop. But sometimes (for "
+#| "example if an image’s contents might change later on in a session) it is "
+#| "better to tell the file to load the image on evaluation:"
+msgid ""
+"If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
+"project can be done as easily as per drag-and-drop. But sometimes (for "
+"example if an image’s contents might change later on in a session) it is "
+"better to tell the file to load the image on evaluation:"
+msgstr ""
+"\".wxmx\" dosya biçimi kullanılıyorsa, dosyaları _wxMaxima_ projesine gömmek "
+"sürükle ve bırak yöntemiyle kolayca yapılabilir. Ancak bazen (örneğin bir "
+"görüntünün içeriği bir oturumda daha sonra değişebilirse), dosyaya görüntüyü "
+"değerlendirme sırasında yüklemesini söylemek daha iyidir:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:778
+#, fuzzy, no-wrap
+#| msgid "    show_image(\"man.png\");\n"
+msgid "show_image(\"man.png\");\n"
+msgstr "    show_image(\"man.png\");\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:782
+#, fuzzy, no-wrap
+#| msgid "## Startup files"
+msgid "Startup files"
+msgstr "## Başlangıç dosyaları"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:785
+msgid ""
+"The config dialogue of _wxMaxima_ offers to edit two files with commands "
+"that are executed on startup:"
+msgstr ""
+"_WxMaxima_'ın yapılandırma iletişim kutusu, başlangıçta yürütülen komutlarla "
+"iki dosyayı düzenlemeyi önerir:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:788
+#, fuzzy
+#| msgid ""
+#| "A file that contains commands that are executed on starting up _Maxima_: "
+#| "`~/.maxima/maxima-init.mac`"
+msgid ""
+"A file that contains commands that are executed on starting up _Maxima_: "
+"`maxima-init.mac`"
+msgstr ""
+"_Maxima_: `~ / .maxima / maxima-init.mac` başlatılırken yürütülen komutları "
+"içeren bir dosya"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:788
+#, fuzzy
+#| msgid ""
+#| "A file that contains commands that are executed on starting up _Maxima_: "
+#| "`~/.maxima/maxima-init.mac`"
+msgid ""
+"one file of additional commands that are executed if _wxMaxima_ is starting "
+"_Maxima_: `wxmaxima-init.mac`"
+msgstr ""
+"_Maxima_: `~ / .maxima / maxima-init.mac` başlatılırken yürütülen komutları "
+"içeren bir dosya"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:790
+msgid ""
+"For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add "
+"`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` "
+"or any other path) to these files."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:792
+#, fuzzy
+#| msgid ""
+#| "These files are in the Maxima user directory, usually `.maxima/` in the "
+#| "user's home directory, the location can be found out with the command: "
+#| "`maxima_userdir;`"
+msgid ""
+"These files are in the Maxima user directory (usually `%USERPROFILE%/maxima` "
+"in Windows, `$HOME/.maxima` otherwise). The location can be found out with "
+"the command: `maxima_userdir;`"
+msgstr ""
+"Bu dosyalar Maxima kullanıcı dizinindedir, genellikle kullanıcının ana "
+"dizinindeki `.maxima /`, konum şu komutla bulunabilir: `maxima_userdir;`"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:793
+#, fuzzy, no-wrap
+#| msgid "## Special variables wx..."
+msgid "Special variables wx..."
+msgstr "## Özel değişkenler wx ..."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxsubscripts` tells _Maxima_ if it should convert variable names that "
+"contain an underscore (`R_150` or the like) into subscripted variables. See "
+"`wxdeclare_subscript` for details which variable names are automatically "
+"converted."
+msgstr ""
+"`wxsubscripts`, _Maxima_ öğesine alt çizgi (` R_150` veya benzeri) içeren "
+"değişken adlarını abone değişkenlere dönüştürüp dönüştürmeyeceğini bildirir. "
+"Hangi değişken adlarının otomatik olarak dönüştürüldüğünü öğrenmek için "
+"`wxdeclare_subscript'e bakınız."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxfilename`: This variable contains the name of the file currently opened "
+"in _wxMaxima_."
+msgstr ""
+"`wxfilename`: Bu değişken, şu anda _wxMaxima_ içinde açılmış olan dosyanın "
+"adını içerir."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+#, fuzzy
+#| msgid ""
+#| "`wxfilename`: This variable contains the name of the file currently "
+#| "opened in _wxMaxima_."
+msgid ""
+"`wxdirname`: This variable contains the name the directory, in which the "
+"file currently opened in _wxMaxima_ is."
+msgstr ""
+"`wxfilename`: Bu değişken, şu anda _wxMaxima_ içinde açılmış olan dosyanın "
+"adını içerir."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+#, fuzzy
+#| msgid ""
+#| "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _gnuplot_’s "
+#| "pngcairo terminal that provides more line styles and a better overall "
+#| "graphics quality."
+msgid ""
+"`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_’s pngcairo "
+"terminal that provides more line styles and a better overall graphics "
+"quality."
+msgstr ""
+"`wxplot_pngcairo`, _wxMaxima_'nın _gnuplot_’ın daha fazla çizgi stili ve "
+"daha iyi bir genel grafik kalitesi sağlayan pngcairo terminali kullanmaya "
+"çalışıp çalışmadığını söyler."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxplot_size` defines the resolution of embedded plots."
+msgstr "\"wxplot_size`, katıştırılmış grafiklerin çözünürlüğünü tanımlar."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+#, fuzzy
+#| msgid ""
+#| "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
+#| "_Maxima_’s working directory to the directory of the current file. This "
+#| "allows file I/O (e.g. by `read_matrix`) to work without specifying the "
+#| "whole path to the file that has to be read or written. On Windows this "
+#| "feature sometimes causes error messages and therefore can be set to "
+#| "`false` from the config dialogue."
+msgid ""
+"`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
+"_Maxima_’s working directory to the directory of the current file. This "
+"allows file I/O (e.g. by `read_matrix`) to work without specifying the whole "
+"path to the file that has to be read or written. On Windows this feature "
+"sometimes causes error messages and therefore can be set to `false` from the "
+"config dialogue."
+msgstr ""
+"`wxchangedir`: Çoğu işletim sisteminde _wxMaxima_ _Maxima_’ın çalışma "
+"dizinini geçerli dosyanın dizinine otomatik olarak ayarlar. Bu, dosya G / "
+"Ç'sinin (ör. `Read_matrix` ile) okunması veya yazılması gereken dosyanın tam "
+"yolunu belirtmeden çalışmasını sağlar. Windows'ta bu özellik bazen hata "
+"mesajlarına neden olur ve bu nedenle yapılandırma iletişim kutusundan "
+"\"false\" olarak ayarlanabilir."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxanimate_framerate`: The number of frames per second the following "
+"animations have to be played back with."
+msgstr ""
+"\"wxanimate_framerate\": Aşağıdaki animasyonların oynatılması gereken saniye "
+"başına kare sayısı."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxanimate_autoplay`: Automatically play animations by default?"
+msgstr ""
+"\"wxanimate_autoplay`: Animasyonlar varsayılan olarak otomatik olarak "
+"oynatılsın mı?"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these "
+"differ by maintainer, distribution and operating system:"
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@userconfdir`: The directory the user's configuration is stored in. "
+"Same directory as `maxima_userdir` (see above) - both point at the same "
+"place, `wxdirs@userconfdir` is only useful if that is more convenient to "
+"reach from a `.mac` file than the Maxima-side variable."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the built-in "
+"autocompletion list, ...) is installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@helpdir`: The directory the offline copy of this manual is installed "
+"in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@localedir`: The directory _wxMaxima_'s translation files are "
+"installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_ is "
+"configured to start."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:812
+#, fuzzy, no-wrap
+#| msgid "## Pretty-printing 2D output"
+msgid "Pretty-printing 2D output"
+msgstr "## Güzel-baskı 2D çıktı"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:815
+#, fuzzy
+#| msgid ""
+#| "The function `table_form()` displays a 2D list in a form that is more "
+#| "readable than the output _Maxima_’s default output routine. The input is "
+#| "a list of one or more lists. Like the print command, this command "
+#| "displays output even when ended with a dollar sign. Ending the command "
+#| "with a semicolon results in the same table along with a \"done\" "
+#| "statement."
+msgid ""
+"The function `table_form()` displays a 2D list in a form that is more "
+"readable than the output from _Maxima_’s default output routine. The input "
+"is a list of one or more lists. Like the \"print\" command, this command "
+"displays output even when ended with a dollar sign. Ending the command with "
+"a semicolon results in the same table along with a \"done\" statement."
+msgstr ""
+"`table_form ()` işlevi, _Maxima_’ın varsayılan çıktı yordamından daha "
+"okunabilir bir biçimde bir 2D liste görüntüler. Girdi, bir veya daha fazla "
+"listenin listesidir. Print komutu gibi, bu komut dolar işareti ile bitse "
+"bile çıktı görüntüler. Komutu noktalı virgülle bitirmek, \"done\" deyimi ile "
+"birlikte aynı tabloda sonuçlanır."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:816
+#, fuzzy, no-wrap
+#| msgid ""
+#| "    table_form(\n"
+#| "        [\n"
+#| "            [1,2],\n"
+#| "            [3,4]\n"
+#| "        ]\n"
+#| "    )$\n"
+msgid ""
+"table_form(\n"
+"    [\n"
+"        [1,2],\n"
+"        [3,4]\n"
+"    ]\n"
+")$\n"
+msgstr ""
+"    table_form(\n"
+"        [\n"
+"            [1,2],\n"
+"            [3,4]\n"
+"        ]\n"
+"    )$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:826
+msgid ""
+"As the next example shows, the lists that are assembled by the `table_form` "
+"command can be created before the command is executed."
+msgstr ""
+"Bir sonraki örnekte gösterildiği gibi, `table_form` komutu ile birleştirilen "
+"listeler komut yürütülmeden önce oluşturulabilir."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:828
+msgid ""
+"![A third table example](./MatrixTableExample.png)"
+"{ id=img_MatrixTableExample }"
+msgstr ""
+"![Bir üçüncü tablo örneği](./MatrixTableExample.png)"
+"{ id=img_MatrisTabloÖrneği }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:830
+msgid ""
+"Also, because a matrix is a list of lists, matrices can be converted to "
+"tables in a similar fashion."
+msgstr ""
+"Ayrıca, bir matris bir liste listesi olduğundan, matrisler benzer şekilde "
+"tablolara dönüştürülebilir."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:832
+msgid ""
+"![Another table_form example](./SecondTableExample.png)"
+"{ id=img_SecondTableExample }"
+msgstr ""
+"![Bir başkar table_form Örneüi](./SecondTableExample.png)"
+"{ id=img_İkinciTabloÖrneği }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:834
+msgid ""
+"The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that "
+"allows for more flexible formatting of matrices in wxMaxima:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:836
+#, no-wrap
+msgid "**`wx_matrix( <matrix>, [options] )`**\n"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`lines=true`**: Draws internal separator lines between the cells. This is "
+"required to visually separate headings from data."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`rownames=true`**: Tells wxMaxima that the first column of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`colnames=true`**: Tells wxMaxima that the first row of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
+"around the matrix. Supported styles are: `round` `()`, `square` `[]`, "
+"`angled` `<>`, `straight` `||`, or `none`."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:843
+#, fuzzy
+#| msgid "One Example:"
+msgid "Example:"
+msgstr "Bir Örnek:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:844
+#, no-wrap
+msgid ""
+"wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
+"          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:849
+#, fuzzy, no-wrap
+#| msgid "## Bug reporting"
+msgid "Bug reporting"
+msgstr "## Hata Raporlama"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:852
+#, fuzzy
+#| msgid ""
+#| "_wxMaxima_ provides a few functions that gather bug reporting information "
+#| "about the current system:"
+msgid ""
+"_WxMaxima_ provides a few functions that gather bug reporting information "
+"about the current system:"
+msgstr ""
+"_wxMaxima_, mevcut sistem hakkında hata raporlama bilgileri toplayan birkaç "
+"işlev sunar:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:855
+#, fuzzy
+#| msgid ""
+#| "`wxbuild_info()` gathers information about the currently running version "
+#| "of _wxMaxima_"
+msgid ""
+"`wxbuild_info()` gathers information about the currently running version of "
+"_wxMaxima_"
+msgstr ""
+"`wxbuild_info ()` şu anda çalışan _wxMaxima_ sürümü hakkında bilgi toplar"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:855
+msgid "`wxbug_report()` tells how and where to file bugs"
+msgstr "`wxbug_report ()`, hataların nasıl ve nerede dosyalanacağını söyler"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:856
+#, fuzzy, no-wrap
+#| msgid "## Marking output being drawn in red"
+msgid "Marking output being drawn in red"
+msgstr "## İşaretleme çıktısı kırmızıyla çizilir"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:860
+#, fuzzy
+#| msgid ""
+#| "_Maxima_'s `box()` command causes _wxMaxima_ to print its argument with a "
+#| "red foreground."
+msgid ""
+"_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a "
+"red foreground, if the second argument to the command is the text "
+"`highlight`."
+msgstr ""
+"_Maxima_'ın `box ()` komutu, wxMaxima'nın argümanını kırmızı bir ön plan ile "
+"yazdırmasına neden olur."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:861
+#, no-wrap
+msgid "Output rendering."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:864
+msgid "With `set_display()` one can set, how wxMaxima will render the output."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:866
+msgid ""
+"`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima "
+"using an (machine readable) XML-dialect (can be seen in the \"Raw XML "
+"sidebar\") and outputs the resulting formulas nicely rendered, e.g. pretty "
+"Matrices, Square root signs, fractions, etc."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:869
+#, no-wrap
+msgid ""
+"<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->\n"
+"`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:871
+msgid ""
+"`set_display('none)` causes 'one-line' ASCII results - the same as the "
+"command line Maxima command `display2d:false;` does."
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:872
+#, no-wrap
+msgid "Help menu"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:875
+msgid ""
+"WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, "
+"tips, some example worksheets and in command line Maxima included demos (the "
+"`demo()` command)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:877
+msgid "Please notice, that the demos write:"
+msgstr ""
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:878
+#, no-wrap
+msgid "At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:883
+#, no-wrap
+msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:885
+#, no-wrap
+msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)\n"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:888
+#, fuzzy, no-wrap
+#| msgid ""
+#| "Troubleshooting\n"
+#| "===============\n"
+msgid "Troubleshooting"
+msgstr ""
+"Sorun Giderme\n"
+"===============\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:890
+#, fuzzy, no-wrap
+#| msgid "## Cannot connect to _Maxima_"
+msgid "Cannot connect to _Maxima_"
+msgstr "## _Maxima_ 'ya bağlanılamıyor"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:893
+#, fuzzy
+#| msgid ""
+#| "Since _Maxima_ (the program that does the actual mathematics) and "
+#| "_wxMaxima_ (providing the easy-to-use user interface) are separate "
+#| "programs that communicate by the means of a local network connection. "
+#| "Therefore the most probable cause is that this connection is somehow not "
+#| "working. For example a firewall could be set up in a way that it doesn’t "
+#| "just prevent against unauthorized connections from the internet (and "
+#| "perhaps to intercept some connections to the internet, too), but it also "
+#| "to blocks inter-process-communication inside the same computer. Note that "
+#| "since _Maxima_ is being run by a Lisp processor the process communication "
+#| "that is blocked from does not necessarily have to be named \"maxima\". "
+#| "Common names of the program that opens the network connection would be "
+#| "sbcl, gcl, ccl, lisp.exe or similar names."
+msgid ""
+"Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ "
+"(providing the easy-to-use user interface) are separate programs that "
+"communicate by the means of a local network connection. Therefore the most "
+"probable cause is that this connection is somehow not working. For example, "
+"a firewall could be set up in a way that it doesn’t just prevent "
+"unauthorized connections from the internet (and perhaps intercept some "
+"connections to the internet, too), but also blocks inter-process-"
+"communication inside the same computer. Note that since _Maxima_ is being "
+"run by a Lisp processor the process communication that is blocked does not "
+"necessarily have to be named \"maxima\". Common names of the program that "
+"opens the network connection would be sbcl, gcl, ccl, lisp.exe, or similar "
+"names."
+msgstr ""
+"_Maxima_ (gerçek matematiği yapan program) ve _wxMaxima_ (kullanımı kolay "
+"kullanıcı arabirimi sağlayan), yerel bir ağ bağlantısı aracılığıyla iletişim "
+"kuran ayrı programlardır. Bu nedenle en olası neden, bu bağlantının bir "
+"şekilde çalışmamasıdır. Örneğin, bir güvenlik duvarı, yalnızca internetten "
+"izinsiz bağlantılara karşı (ve belki de bazı internet bağlantılarını da "
+"kesmek için) önleyecek şekilde değil, aynı zamanda internetin içindeki "
+"süreçler arası iletişimi de engelleyecek şekilde kurulabilir. aynı "
+"bilgisayar. _Maxima_ bir Lisp işlemcisi tarafından çalıştırıldığından, "
+"engellenen işlem iletişiminin \"maxima\" olarak adlandırılması gerekmediğini "
+"unutmayın. Ağ bağlantısını açan programın genel adları sbcl, gcl, ccl, lisp."
+"exe veya benzer adlardır."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:895
+#, fuzzy
+#| msgid ""
+#| "On Un\\*x computers another possible reason would be that the loopback "
+#| "network that provides network connections between two programs in the "
+#| "same computer isn’t properly configured."
+msgid ""
+"On Unix computers another possible reason would be that the loopback network "
+"that provides network connections between two programs in the same computer "
+"isn’t properly configured."
+msgstr ""
+"Un \\ * x bilgisayarlarda başka bir olası neden, aynı bilgisayardaki iki "
+"program arasında ağ bağlantısı sağlayan geri döngü ağının düzgün "
+"yapılandırılmamış olması olabilir."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:896
+#, fuzzy, no-wrap
+#| msgid "## How to save data from a broken .wxmx file"
+msgid "How to save data from a broken .wxmx file"
+msgstr "## Bozuk bir .wxmx dosyasından veri nasıl kaydedilir"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:899
+#, fuzzy
+#| msgid ""
+#| "Internally most modern xml-based formats are ordinary zip-files. wxMaxima "
+#| "doesn't turn on compression which makes the contents of .wxmx files "
+#| "viewable in any text editor."
+msgid ""
+"Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ "
+"doesn’t turn on compression, so the contents of `.wxmx` files can be viewed "
+"in any text editor."
+msgstr ""
+"Dahili olarak çoğu modern xml tabanlı formatlar sıradan zip dosyalarıdır. "
+"wxMaxima, .wxmx dosyalarının içeriğini herhangi bir metin düzenleyicisinde "
+"görüntülenebilir hale getiren sıkıştırmayı açmaz."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:901
+#, fuzzy
+#| msgid ""
+#| "If the zip signature at the end of the file is still intact after "
+#| "renaming a broken .wxmx file to .zip most operating systems will provide "
+#| "a way to extract any portion of information that is stored inside it. The "
+#| "can be done when there is the need of recovering the original image files "
+#| "from a text processor document. If the zip signature isn’t intact that "
+#| "does not need to be the end of the world: If _wxMaxima_ during saving "
+#| "detected that something went wrong there will be a wxmx~ file whose "
+#| "contents might help and even if there isn’t such a file: If the "
+#| "configuration option is set that .wxmx files have to be optimized for "
+#| "version control it is possible to rename the .wxmx file to a .txt file "
+#| "and to use a text editor to recover the XML portion of the file's "
+#| "contents."
+msgid ""
+"If the zip signature at the end of the file is still intact after renaming a "
+"broken `.wxmx` file to `.zip` most operating systems will provide a way to "
+"extract any portion of the information that is stored inside it. This can be "
+"done when there is a need of recovering the original image files from a text "
+"processor document. If the zip signature isn’t intact that does not need to "
+"be the end of the world: If _wxMaxima_ during saving detected that something "
+"went wrong there will be a `.wxmx~` file whose contents might help."
+msgstr ""
+"Dosyanın sonundaki zip imzası, bozuk bir .wxmx dosyasını .zip olarak yeniden "
+"adlandırdıktan sonra hala bozulmamışsa, çoğu işletim sistemi içinde saklanan "
+"bilgilerin herhangi bir bölümünü ayıklamak için bir yol sağlar. Bir metin "
+"işlemci belgesinden orijinal görüntü dosyalarının kurtarılması gerektiğinde "
+"yapılabilir. Zip imzası bozulmamışsa, dünyanın sonu olması gerekmez: "
+"Kaydetme sırasında _wxMaxima_ bir şeylerin yanlış gittiğini tespit ederse, "
+"içeriği yardımcı olabilecek ve böyle bir dosya olmasa bile bir wxmx ~ "
+"dosyası olacaktır. : Yapılandırma seçeneği, .wxmx dosyalarının sürüm "
+"denetimi için en iyi duruma getirilmesi gerektiği olarak ayarlanmışsa, .wxmx "
+"dosyasını bir .txt dosyasına yeniden adlandırmak ve dosya içeriğinin XML "
+"bölümünü kurtarmak için bir metin düzenleyicisi kullanmak mümkündür."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:903
+#, no-wrap
+msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:905
+#, fuzzy
+#| msgid ""
+#| "If the text file containing this contents is saved as a file ending in ."
+#| "xml _wxMaxima_ will know how to recover the text of the document from it."
+msgid ""
+"If a text file containing only these contents (e.g. copy and paste this text "
+"into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know "
+"how to recover the text from the document."
+msgstr ""
+"Bu içeriği içeren metin dosyası, .xml _ wxMaxima _ ile biten bir dosya "
+"olarak kaydedilirse, belgenin metnini ondan nasıl kurtaracağını bilir."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:906
+#, fuzzy, no-wrap
+#| msgid "## I want some debug info to be displayed on the screen before my command has finished"
+msgid "I want some debug info to be displayed on the screen before my command has finished"
+msgstr "## Komutum bitmeden ekranda bazı hata ayıklama bilgilerinin görüntülenmesini istiyorum"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:909
+msgid ""
+"Normally _wxMaxima_ waits for the whole 2D formula to be transferred before "
+"it begins to typeset. This saves time for making many attempts to typeset a "
+"only partially completed equation. There is a `disp` command, though, that "
+"will provide debug output immediately and without waiting for the current "
+"_Maxima_ command to finish:"
+msgstr ""
+"Normalde _wxMaxima_, 2B formülün tamamının dizilmeye başlamadan önce "
+"aktarılmasını bekler. Bu, sadece kısmen tamamlanmış bir denklemi dizmek için "
+"birçok girişimde bulunmak için zaman kazandırır. Bununla birlikte, geçerli "
+"_Maxima_ komutunun bitmesini beklemeden hemen hata ayıklama çıktısı "
+"sağlayacak bir 'disp` komutu vardır:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:910
+#, fuzzy, no-wrap
+#| msgid ""
+#| "    for i:1 thru 10 do (\n"
+#| "       disp(i),\n"
+#| "       /* (sleep n) is a Lisp function, which can be used */\n"
+#| "       /* with the character \"?\" before. It delays the */\n"
+#| "       /* program execution (here: for 3 seconds) */\n"
+#| "       ?sleep(3)\n"
+#| "    )$\n"
+msgid ""
+"for i:1 thru 10 do (\n"
+"   disp(i),\n"
+"   /* (sleep n) is a Lisp function, which can be used */\n"
+"   /* with the character \"?\" before. It delays the */\n"
+"   /* program execution (here: for 3 seconds) */\n"
+"   ?sleep(3)\n"
+")$\n"
+msgstr ""
+"    for i:1 thru 10 do (\n"
+"       disp(i),\n"
+"       /* (sleep n) is a Lisp function, which can be used */\n"
+"       /* with the character \"?\" before. It delays the */\n"
+"       /* program execution (here: for 3 seconds) */\n"
+"       ?sleep(3)\n"
+"    )$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:921
+msgid "Alternatively one can look for the `wxstatusbar()` command above."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:922
+#, fuzzy, no-wrap
+#| msgid "## Plotting only shows a closed empty envelope with an error message"
+msgid "Plotting only shows a closed empty envelope with an error message"
+msgstr "## Çizim yalnızca hata mesajı içeren kapalı bir boş zarf gösteriyor"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:925
+#, fuzzy
+#| msgid ""
+#| "This means that _wxMaxima_ could not read the file _Maxima_ that was "
+#| "supposed to instruct gnuplot to create."
+msgid ""
+"This means that _wxMaxima_ could not read the file _Maxima_ that was "
+"supposed to instruct _Gnuplot_ to create."
+msgstr ""
+"Bu, _wxMaxima_ uygulamasının, gnuplot'a oluşturma talimatı vermesi gereken "
+"_Maxima_ dosyasını okuyamadığı anlamına gelir."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:927
+msgid "Possible reasons for this error are:"
+msgstr "Bu hatanın olası nedenleri:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+#, fuzzy
+#| msgid ""
+#| "The plotting command is part of a third-party package like "
+#| "`implicit_plot` but this package was not loaded by _Maxima_’s `load()` "
+#| "command before trying to plot."
+msgid ""
+"The plotting command is part of a third-party package like `implicit_plot` "
+"but this package was not loaded by _Maxima_’s `load()` command before trying "
+"to plot."
+msgstr ""
+"Çizim komutu, \"implicit_plot\" gibi üçüncü taraf bir paketin parçasıdır, "
+"ancak bu paket, çizmeye çalışmadan önce _Maxima_’ın `load ()` komutu "
+"tarafından yüklenmedi."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+#, fuzzy
+#| msgid ""
+#| "_Maxima_ tried to do something the currently installed version of gnuplot "
+#| "isn’t able to understand. In this case a file ending in .gnuplot in the "
+#| "directory _Maxima_’s variable maxima\\_userdir points to contains the "
+#| "instructions from _Maxima_ to gnuplot. Most of the time this file’s "
+#| "contents therefore are helpful when debugging the problem."
+msgid ""
+"_Maxima_ tried to do something the currently installed version of _Gnuplot_ "
+"isn’t able to understand. In this case, a file ending in `.gnuplot` located "
+"in the directory, which _Maxima_’s variable `maxima_userdir` is pointing, "
+"contains the instructions from _Maxima_ to _Gnuplot_. Most of the time, this "
+"file’s contents therefore are helpful when debugging the problem."
+msgstr ""
+"_Maxima_, şu anda yüklü olan gnuplot sürümünün anlayamadığı bir şey yapmaya "
+"çalıştı. Bu durumda _Maxima_’ın maxima \\ _userdir dizinindeki .gnuplot ile "
+"biten bir dosya, _Maxima_ 'dan gnuplot' a kadar olan talimatları içerir. Bu "
+"nedenle, bu dosyanın içeriği çoğu zaman sorunu ayıklarken faydalıdır."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+#, fuzzy
+#| msgid ""
+#| "Gnuplot was instructed to use the pngcairo library that provides "
+#| "antialiasing and additional line styles, but it was not compiled to "
+#| "support this possibility. Solution: Uncheck the \"Use the cairo terminal "
+#| "for plot\" checkbox in the configuration dialog and don’t set "
+#| "`wxplot_pngcairo` to true from _Maxima_."
+msgid ""
+"Gnuplot was instructed to use the pngCairo library that provides "
+"antialiasing and additional line styles, but it was not compiled to support "
+"this possibility. Solution: Uncheck the \"Use the Cairo terminal for the "
+"plot\" checkbox in the configuration dialog and don’t set `wxplot_pngcairo` "
+"to true from _Maxima_."
+msgstr ""
+"Gnuplot'a kenar yumuşatma ve ek çizgi stilleri sağlayan pngcairo "
+"kütüphanesini kullanması söylendi, ancak bu olasılığı desteklemek için "
+"derlenmedi. Çözüm: Yapılandırma iletişim kutusundaki \"Çizim için cairo "
+"terminalini kullan\" onay kutusunun işaretini kaldırın ve _Maxima_'dan "
+"`wxplot_pngcairo` değerini true olarak ayarlamayın."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+#, fuzzy
+#| msgid "Gnuplot didn’t output a valid .png file."
+msgid "Gnuplot didn’t output a valid `.png` file."
+msgstr "Gnuplot geçerli bir .png dosyası vermedi."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:933
+#, fuzzy, no-wrap
+#| msgid "## Plotting an animation results in “error: undefined variable”"
+msgid "Plotting an animation results in “error: undefined variable”"
+msgstr "## Bir animasyonun çizilmesi “hata: tanımsız değişken” ile sonuçlanır"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:936
+#, fuzzy
+#| msgid ""
+#| "The value of the slider variable by default is only substituted into the "
+#| "expression that is to be plotted if it is visible there. Using a `subst` "
+#| "command that substitutes the slider variable into the equation to plot "
+#| "(there should be an example of this in this manual) resolves this problem."
+msgid ""
+"The value of the slider variable by default is only substituted into the "
+"expression that is to be plotted if it is visible there. Using a `subst` "
+"command that substitutes the slider variable into the equation to plot "
+"resolves this problem. At the end of section [Embedding animations into the "
+"spreadsheet](#embedding-animations-into-the-spreadsheet), you can see an "
+"example."
+msgstr ""
+"Varsayılan olarak kaydırıcı değişkeninin değeri, yalnızca orada görünürse "
+"çizilecek ifadenin yerine kullanılır. Kaydırıcı değişkeni çizilecek denkleme "
+"yerleştiren bir `subst 'komutu kullanmak (bu kılavuzda buna bir örnek olması "
+"gerekir) bu sorunu çözer."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:937
+#, fuzzy, no-wrap
+#| msgid "## I lost a cell contents and undo doesn’t remember"
+msgid "I lost cell content and undo doesn’t remember"
+msgstr "## Bir hücre içeriğini kaybettim ve geri almayı hatırlamıyorum"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:940
+msgid ""
+"There are separate undo functions for cell operations and for changes inside "
+"of cells so chances are low that this ever happens. If it does there are "
+"several methods to recover data:"
+msgstr ""
+"Hücre işlemleri ve hücrelerin içindeki değişiklikler için ayrı geri alma "
+"işlevleri vardır, bu nedenle bunun gerçekleşme ihtimali düşüktür. Varsa, "
+"verileri kurtarmak için birkaç yöntem vardır:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+#, fuzzy
+#| msgid ""
+#| "_wxMaxima_ actually has two undo features: The global undo buffer that is "
+#| "active if no cell is selected and a per-cell undo buffer that is active "
+#| "if the cursor is inside a cell. It is worth trying to use both undo "
+#| "options in order to see if an old value can still be accessed."
+msgid ""
+"_WxMaxima_ actually has two undo features: The global undo buffer that is "
+"active if no cell is selected and a per-cell undo buffer that is active if "
+"the cursor is inside a cell. It is worth trying to use both undo options in "
+"order to see if an old value can still be accessed."
+msgstr ""
+"_wxMaxima_ aslında iki geri alma özelliğine sahiptir: Hiçbir hücre "
+"seçilmezse etkin olan genel geri alma arabelleği ve imleç bir hücrenin "
+"içindeyse etkin olan hücre başına geri alma arabelleği. Eski bir değere hala "
+"erişilip erişilemeyeceğini görmek için her iki geri alma seçeneğini "
+"kullanmaya değer."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+#, fuzzy
+#| msgid ""
+#| "If you still have a way to find out what label _Maxima_ has assigned to "
+#| "the cell just type in the cell’s label and its contents will reappear."
+msgid ""
+"If you still have a way to find out what label _Maxima_ has assigned to the "
+"cell just type in the cell’s label and its contents will reappear."
+msgstr ""
+"Hücreye _Maxima_ etiketinin hangi etiketi atadığını bulmak için hala bir "
+"yolunuz varsa, hücrenin etiketini yazmanız yeterlidir ve içeriği yeniden "
+"görünür."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+#, fuzzy
+#| msgid ""
+#| "If you don’t: Don’t panic. In the “View” menu there is a way to show a "
+#| "history pane that shows all _Maxima_ commands that have been issued "
+#| "recently."
+msgid ""
+"If you don’t: Don’t panic. In the “View” menu there is a way to show a "
+"history pane that shows all _Maxima_ commands that have been issued recently."
+msgstr ""
+"Yapmazsanız: Panik yapmayın. “Görünüm” menüsünde, son zamanlarda verilen tüm "
+"_Maxima_ komutlarını gösteren bir geçmiş bölmesi göstermenin bir yolu vardır."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+msgid "If nothing else helps _Maxima_ contains a replay feature:"
+msgstr ""
+"Başka bir şey yardımcı olmazsa _Maxima_ bir yeniden oynatma özelliği içerir:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:946
+#, no-wrap
+msgid "playback();\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:950
+#, fuzzy, no-wrap
+#| msgid "## _wxMaxima_ starts up with the message “Maxima process terminated.”"
+msgid "_WxMaxima_ starts up with the message “Maxima process terminated.”"
+msgstr "## _ wxMaxima _ “Maxima işlemi sonlandırıldı” mesajı ile başlar."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:953
+#, fuzzy
+#| msgid ""
+#| "One possible reason is that _Maxima_ cannot be found in the location that "
+#| "is set in the “Maxima” tab of _wxMaxima_’s configuration dialog and "
+#| "therefore won’t run at all. Setting the path to a working _Maxima_ binary "
+#| "should fix this problem."
+msgid ""
+"One possible reason is that _Maxima_ cannot be found in the location that is "
+"set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore "
+"won’t run at all. Setting the path to a working _Maxima_ binary should fix "
+"this problem."
+msgstr ""
+"Olası nedenlerden biri, _Maxima_'ın _wxMaxima_’ın yapılandırma iletişim "
+"kutusunun “Maxima” sekmesinde ayarlanan konumda bulunamaması ve bu nedenle "
+"hiç çalışmaz. Çalışan bir _Maxima_ ikili dosyasının yolunu ayarlamak bu "
+"sorunu gidermelidir."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:954
+#, fuzzy, no-wrap
+#| msgid "## Maxima is forever calculating and not responding to input"
+msgid "Maxima is forever calculating and not responding to input"
+msgstr "## Maxima sonsuza kadar hesaplıyor ve girdiye yanıt vermiyor"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:957
+#, fuzzy
+#| msgid ""
+#| "It is theoretically possible that _wxMaxima_ doesn’t realize that "
+#| "_Maxima_ has finished calculating and therefore never gets informed it "
+#| "can send new data to _Maxima_. If this is the case “Trigger evaluation” "
+#| "might resynchronize the two programs."
+msgid ""
+"It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ "
+"has finished calculating and therefore never gets informed it can send new "
+"data to _Maxima_. If this is the case “Trigger evaluation” might "
+"resynchronize the two programs."
+msgstr ""
+"_WxMaxima_'nın _Maxima_'ın hesaplamayı bitirdiğini ve bu nedenle asla "
+"_Maxima_'a yeni veri gönderebileceğini bilmemesi teorik olarak mümkündür. Bu "
+"durumda “Tetikleyici değerlendirmesi” iki programı yeniden senkronize "
+"edebilir."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:958
+#, fuzzy, no-wrap
+#| msgid "## My SBCL-based _Maxima_ runs out of memory"
+msgid "My SBCL-based _Maxima_ runs out of memory"
+msgstr "## SBCL tabanlı _Maxima_'ımın belleği yetersiz"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:961
+#, fuzzy
+#| msgid ""
+#| "The Lisp compiler SBCL by default comes with a memory limit that allows "
+#| "it to run even on low-end computers. When compiling a big software "
+#| "package like lapack or dealing with extremely big lists or equations this "
+#| "limit might be too low. In order to extend the limits sbcl can be "
+#| "provided with the command line parameter `--dynamic-space-size` that "
+#| "tells SBCL how many megabytes it should reserve. A 32bit Windows-SBCL can "
+#| "reserve up to 999 Megabytes. A 64-bit SBCL version running on Windows can "
+#| "be instructed to use more than the about 1280 Megabytes compiling lapack "
+#| "needs."
+msgid ""
+"The Lisp compiler SBCL by default comes with a memory limit that allows it "
+"to run even on low-end computers. When compiling a big software package like "
+"Lapack or dealing with extremely big lists of equations this limit might be "
+"too low. In order to extend the limits, SBCL can be provided with the "
+"command line parameter `--dynamic-space-size` that tells SBCL how many "
+"megabytes it should reserve. A 32bit Windows-SBCL can reserve up to 999 "
+"Megabytes. A 64-bit SBCL version running on Windows can be instructed to use "
+"more than the about 1280 Megabytes compiling Lapack needs."
+msgstr ""
+"Lisp derleyici SBCL, varsayılan olarak düşük kaliteli bilgisayarlarda bile "
+"çalışmasına izin veren bir bellek sınırıyla birlikte gelir. Lapack gibi "
+"büyük bir yazılım paketi derlerken veya aşırı büyük listeler veya "
+"denklemlerle uğraşırken bu sınır çok düşük olabilir. Sınırları genişletmek "
+"için sbcl, SBCL'ye kaç megabayt ayırması gerektiğini bildiren komut satırı "
+"parametresi olan \"--dinamik-alan-boyutu\" ile sağlanabilir. 32bit Windows-"
+"SBCL, 999 Megabayta kadar ayırabilir. Windows üzerinde çalışan 64 bit SBCL "
+"sürümüne, yaklaşık 1280 Megabayt derleme lapack ihtiyacından fazlasını "
+"kullanma talimatı verilebilir."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:963
+#, fuzzy
+#| msgid ""
+#| "One way to provide _Maxima_ (and thus SBCL) with command line parameters "
+#| "is the \"Additional parameters for Maxima\" field of _wxMaxima_’s "
+#| "configuration dialogue."
+msgid ""
+"One way to provide _Maxima_ (and thus SBCL) with command line parameters is "
+"the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration "
+"dialogue."
+msgstr ""
+"_Maxima_ (ve dolayısıyla SBCL) komut satırı parametrelerini sağlamanın bir "
+"yolu, _wxMaxima_’ın yapılandırma iletişim kutusunun \"Maxima için ek "
+"parametreler\" alanıdır."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:965
+msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
+msgstr "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:966
+#, fuzzy, no-wrap
+#| msgid "## Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgstr "## Girdi bazen Ubuntu'daki anahtarları yavaş / yok sayılıyor"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:969
+msgid ""
+"Installing the package `ibus-gtk` should resolve this issue. See ([https://"
+"bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs."
+"launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) for details."
+msgstr ""
+"`İbus-gtk` paketinin yüklenmesi bu sorunu çözmelidir. Bkz. ([Https://bugs."
+"launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558 yetersiz(https://bugs."
+"launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/ 1421558))."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:970
+#, fuzzy, no-wrap
+#| msgid "## _wxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgid "_WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgstr "## _wxMaxima_, _Maxima_ Yunan karakterlerini veya Umlauts'u işlediğinde durur"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:973
+msgid ""
+"If your _Maxima_ is based on SBCL the following lines have to be added to "
+"your `.sbclrc`:"
+msgstr ""
+"_Maxima_'nız SBCL'ye dayanıyorsa, aşağıdaki satırların .sbclrc`inize "
+"eklenmesi gerekir:"
+
+#. type: Fenced code block (commonlisp)
+#: ../../info/wxmaxima.md:974
+#, fuzzy, no-wrap
+#| msgid "    (setf sb-impl::*default-external-format* :utf-8)\n"
+msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
+msgstr "    (setf sb-impl::*default-external-format* :utf-8)\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:979
+#, fuzzy
+#| msgid ""
+#| "The folder this file has to be placed in is system- and installation-"
+#| "specific. But any sbcl-based _Maxima_ that already has evaluated a cell "
+#| "in the current session will happily tell where it can be found after "
+#| "getting the following command:"
+msgid ""
+"The folder where this file has to be placed is system- and installation-"
+"specific. But any SBCL-based _Maxima_ that already has evaluated a cell in "
+"the current session will happily tell where it can be found after getting "
+"the following command:"
+msgstr ""
+"Bu dosyanın yerleştirilmesi gereken klasör sisteme ve kuruluma özeldir. "
+"Ancak, geçerli oturumda zaten bir hücreyi değerlendiren sbcl tabanlı "
+"_Maxima_, aşağıdaki komutu aldıktan sonra nerede bulunabileceğini "
+"memnuniyetle söyleyecektir:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:980
+#, fuzzy, no-wrap
+#| msgid "    :lisp (sb-impl::userinit-pathname)\n"
+msgid ":lisp (sb-impl::userinit-pathname)\n"
+msgstr "    :lisp (sb-impl::userinit-pathname)\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:984
+#, no-wrap
+msgid "Note concerning Wayland (recent Linux/BSD distributions)"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:988
+msgid ""
+"There seem to be issues with the Wayland Display Server and wxWidgets.  "
+"WxMaxima may be affected, e.g. that sidebars are not moveable."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:992
+msgid ""
+"You can either disable Wayland and use X11 instead (globally)  or just tell, "
+"that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:994
+msgid "E.g. start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:996
+msgid "`GDK_BACKEND=x11 wxmaxima`"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:997
+#, no-wrap
+msgid "The menu bar disappears on KDE Plasma"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1003
+msgid ""
+"On some KDE Plasma installations the global menu bar disappears when "
+"clicked.  As this is a bug in the global menu proxy, the only way to avoid "
+"it is to tell that wxMaxima should use its own menu bar instead of the "
+"global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1007
+msgid ""
+"Starting with version 26.05.0, wxMaxima attempts to set this variable "
+"automatically if it detects an affected system (KDE, Unity, or Ubuntu with "
+"older wxWidgets versions)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1009
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1011
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1012
+#, no-wrap
+msgid "Why is the integrated manual browser not offered on my Windows PC?"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1016
+msgid ""
+"Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or "
+"Microsoft’s webview2 isn’t installed."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1017
+#, no-wrap
+msgid "Why is the external manual browser not working on my Linux box?"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1024
+msgid ""
+"The HTML browser might be a snap, flatpack or appimage version. All of these "
+"typically cannot access files that are installed on your local system. "
+"Another reason might be that maxima or wxMaxima is installed as a snap, "
+"flatpack or something else that doesn’t give the host system access to its "
+"contents. A third reason might be that the maxima HTML manual isn’t "
+"installed and the online one cannot be accessed."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1025
+#, fuzzy, no-wrap
+#| msgid "### Can I make _wxMaxima_ output both image files and embedded plots at once?"
+msgid "Can I make _wxMaxima_ output both image files and embedded plots at once?"
+msgstr "### _wxMaxima_ çıktısını aynı anda hem görüntü dosyaları hem de gömülü grafikler yapabilir miyim?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1028
+#, fuzzy
+#| msgid ""
+#| "The worksheet embeds .png files. wxMaxima allows the user to specify "
+#| "where they should be generated:"
+msgid ""
+"The worksheet embeds `.png files. _WxMaxima_ allows the user to specify "
+"where they should be generated:"
+msgstr ""
+"Çalışma sayfası .png dosyalarını gömer. wxMaxima kullanıcının nerede "
+"üretilmesi gerektiğini belirtmesini sağlar:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1029
+#, fuzzy, no-wrap
+#| msgid ""
+#| "~~~~\n"
+#| "wxdraw2d(\n"
+#| "    file_name=\"test\",\n"
+#| "    explicit(sin(x),x,1,10)\n"
+#| ");\n"
+#| "~~~~\n"
+msgid ""
+"wxdraw2d(\n"
+"    file_name=\"test\",  /* extension .png automatically added */\n"
+"    explicit(sin(x),x,1,10)\n"
+");\n"
+msgstr ""
+"~~~~\n"
+"wxdraw2d(\n"
+"    file_name=\"test\",\n"
+"    explicit(sin(x),x,1,10)\n"
+");\n"
+"~~~~\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1037
+#, fuzzy
+#| msgid ""
+#| "If a different format is to be used it is easier to generate the images "
+#| "and then to import them into the worksheet again:"
+msgid ""
+"If a different format is to be used, it is easier to generate the images and "
+"then import them into the worksheet again:"
+msgstr ""
+"Farklı bir biçim kullanılacaksa, görüntüleri oluşturmak ve daha sonra tekrar "
+"çalışma sayfasına almak daha kolaydır:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1038
+#, fuzzy, no-wrap
+#| msgid ""
+#| "~~~~\n"
+#| "load(\"draw\");\n"
+#| "pngdraw(name,[contents]):=\n"
+#| "(\n"
+#| "    draw(\n"
+#| "        append(\n"
+#| "            [\n"
+#| "                terminal=pngcairo,\n"
+#| "                dimensions=wxplot_size,\n"
+#| "                file_name=name\n"
+#| "            ],\n"
+#| "            contents\n"
+#| "        )\n"
+#| "    ),\n"
+#| "    show_image(printf(false,\"~a.png\",name))\n"
+#| ");\n"
+#| "pngdraw2d(name,[contents]):=\n"
+#| "    pngdraw(name,gr2d(contents));\n"
+msgid ""
+"load(\"draw\");\n"
+"pngdraw(name,[contents]):=\n"
+"(\n"
+"    draw(\n"
+"        append(\n"
+"            [\n"
+"                terminal=pngcairo,\n"
+"                dimensions=wxplot_size,\n"
+"                file_name=name\n"
+"            ],\n"
+"            contents\n"
+"        )\n"
+"    ),\n"
+"    show_image(printf(false,\"~a.png\",name))\n"
+");\n"
+"pngdraw2d(name,[contents]):=\n"
+"    pngdraw(name,gr2d(contents));\n"
+"\n"
+"pngdraw2d(\"Test\",\n"
+"        explicit(sin(x),x,1,10)\n"
+");\n"
+msgstr ""
+"~~~~\n"
+"load(\"draw\");\n"
+"pngdraw(name,[contents]):=\n"
+"(\n"
+"    draw(\n"
+"        append(\n"
+"            [\n"
+"                terminal=pngcairo,\n"
+"                dimensions=wxplot_size,\n"
+"                file_name=name\n"
+"            ],\n"
+"            contents\n"
+"        )\n"
+"    ),\n"
+"    show_image(printf(false,\"~a.png\",name))\n"
+");\n"
+"pngdraw2d(name,[contents]):=\n"
+"    pngdraw(name,gr2d(contents));\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1062
+#, fuzzy, no-wrap
+#| msgid "### Can I set the aspect ratio of a plot?"
+msgid "Can I set the aspect ratio of an embedded plot?"
+msgstr "### Bir grafiğin en boy oranını ayarlayabilir miyim?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1065
+msgid "Use the variable `wxplot_size`:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1066
+#, fuzzy, no-wrap
+#| msgid ""
+#| "     wxdraw2d(\n"
+#| "         proportional_axis=xy,\n"
+#| "         explicit(sin(x),x,1,10)\n"
+#| "     ),wxplot_size=[1000,1000];\n"
+msgid ""
+"wxdraw2d(\n"
+"    explicit(sin(x),x,1,10)\n"
+"),wxplot_size=[1000,1000];\n"
+msgstr ""
+"     wxdraw2d(\n"
+"         proportional_axis=xy,\n"
+"         explicit(sin(x),x,1,10)\n"
+"     ),wxplot_size=[1000,1000];\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1072
+#, no-wrap
+msgid "After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
+msgstr ""
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:1074
+#, no-wrap
+msgid ""
+"1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102\n"
+"2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52\n"
+"3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408\n"
+"...\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1082
+#, no-wrap
+msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1083
+#, no-wrap
+msgid "Logging"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1088
+#, no-wrap
+msgid ""
+"Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build,\n"
+"the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable\n"
+"this window using the \"View->Toggle log window\" menu entry.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1090
+msgid ""
+"Messages are not 'lost', if the log window is not shown, if you select to "
+"show the log window later, you will see past log messages (if you did not "
+"clear the messages)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1092
+msgid ""
+"Such messages may be helpful, when you create bug reports (or trying to find "
+"a bug by yourself)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1095
+msgid ""
+"Log messages can (additionally) be printed to STDERR, when using the command "
+"line option \"--logtostderr\". On Windows a separate text console will be "
+"opened, as a Windows GUI application does not have the standard IO connected."
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1098
+#, no-wrap
+msgid "FAQ"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1100
+#, fuzzy, no-wrap
+#| msgid "## Is there a way to make more text fit on a pdfLaTeX page?"
+msgid "Is there a way to make more text fit on a LaTeX page?"
+msgstr "## Bir pdfLaTeX sayfasına daha fazla metin sığdırmanın bir yolu var mı?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1103
+msgid ""
+"Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to "
+"specify the size of the borders."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1105
+#, fuzzy, no-wrap
+#| msgid "There is: Just add the following lines to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"):"
+msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):\n"
+msgstr "Var: LaTeX başlangıç ekine aşağıdaki satırları ekleyin (örneğin, yapılandırma iletişim kutusundaki ilgili alanı kullanarak (\"Dışa Aktar\" -> \"TeX başlangıç eki için ek satırlar\"):"
+
+#. type: Fenced code block (latex)
+#: ../../info/wxmaxima.md:1106
+#, fuzzy, no-wrap
+#| msgid "    \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+msgstr "    \\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1110
+#, fuzzy, no-wrap
+#| msgid "## Is there a dark mode?"
+msgid "Is there a dark mode?"
+msgstr "## Koyu bir mod var mı?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1113
+#, fuzzy
+#| msgid ""
+#| "If wxWidgets is new enough wxMaxima will automatically be in dark mode if "
+#| "the rest of the operating system is. The worksheet itself is by default "
+#| "equipped with a bright background. But it can be configured otherwise. "
+#| "Alternatively there is a `View/Invert worksheet brightness` menu entry "
+#| "that allows to quickly convert the worksheet from dark to bright and vice "
+#| "versa."
+msgid ""
+"If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if "
+"the rest of the operating system is. The worksheet itself is by default "
+"equipped with a bright background. But it can be configured otherwise. "
+"Alternatively, there is a `View/Invert worksheet brightness` menu entry that "
+"allows to quickly convert the worksheet from dark to bright and vice versa."
+msgstr ""
+"WxWidgets yeterince yeniyse, işletim sisteminin geri kalan kısmı ise "
+"wxMaxima otomatik olarak koyu modda olacaktır. Çalışma sayfasının kendisi "
+"varsayılan olarak parlak bir arka planla donatılmıştır. Ancak başka şekilde "
+"yapılandırılabilir. Alternatif olarak, çalışma sayfasını hızla karanlıktan "
+"aydınlığa veya tersine hızlı bir şekilde dönüştürmeye izin veren bir `` "
+"Çalışma sayfası parlaklığını görüntüle / tersine çevir '' menü girişi vardır."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1114
+#, fuzzy, no-wrap
+#| msgid "## wxMaxima sometimes hangs for a several seconds once in the first minute"
+msgid "_WxMaxima_ sometimes hangs for several seconds once in the first minute"
+msgstr "## wxMaxima bazen ilk dakikada bir kaç saniye takılır"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1117
+#, fuzzy, no-wrap
+#| msgid "wxMaxima delegates some big tasks like parsing maxima's >1000-page-manual to background tasks, which normally goes totally unnoticed. In the moment the result of such a task is needed, though, it is possible that wxMaxima needs to wait a couple of seconds before it can continue its work."
+msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.\n"
+msgstr "wxMaxima, maxima'nın> 1000 sayfalık kullanım kılavuzunu, normalde tamamen fark edilmeyen arka plan görevlerine ayrıştırma gibi bazı büyük görevleri devreder. Bununla birlikte, böyle bir görevin sonucuna ihtiyaç duyulduğu anda, wxMaxima'nın çalışmasına devam edebilmesi için birkaç saniye beklemesi gerekebilir."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1118
+#, no-wrap
+msgid "Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1121
+msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1125
+msgid ""
+"(The same problem can occur with other applications too). The translations "
+"seem okay after you click on ’OK’. WxMaxima does not only use its own "
+"translations but the translations of the wxWidgets framework too."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1128
+msgid ""
+"These locales maybe not present in the system. On Ubuntu/Debian systems they "
+"can be generated using: `dpkg-reconfigure locales`"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1129
+#, no-wrap
+msgid "How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1132
+msgid ""
+"You can find these symbols in the Unicode sidebar (search for ’double-struck "
+"capital’). But the selected font must also support these symbols. If they do "
+"not display properly, select another font."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1133
+#, no-wrap
+msgid "How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1136
+msgid ""
+"If wxMaxima is used, the Maxima variable `maxima_frontend` is set to "
+"`wxmaxima`. The Maxima variable `maxima_frontend_version` contains the "
+"wxMaxima version in this case."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1138
+msgid ""
+"If no frontend is used (you are using command line Maxima), these variables "
+"are `false`."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1139
+#, no-wrap
+msgid "Help! I can not save my document!"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1142
+#, no-wrap
+msgid "If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.\n"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1145
+#, fuzzy, no-wrap
+#| msgid ""
+#| "Command-line arguments\n"
+#| "======================\n"
+msgid "Command-line arguments"
+msgstr ""
+"Komut-satırı argümanları\n"
+"======================\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1148
+msgid ""
+"Usually you can start programs with a graphical user interface just by "
+"clicking on a desktop icon or desktop menu entry. WxMaxima - if started from "
+"the command line - still provides some command-line switches, though."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-v` or `--version`: Output the version information"
+msgstr "`-v` veya` --version`: Sürüm bilgisini çıktılar"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-h` or `--help`: Output a short help text"
+msgstr "`-h` veya` --help`: Kısa bir yardım metni çıkarır"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+#, fuzzy
+#| msgid ""
+#| "`-o` or `--open=<str>`: Open the filename given as argument to this "
+#| "command-line switch"
+msgid ""
+"`-o` or `--open=<str>`: Open the filename given as an argument to this "
+"command-line switch"
+msgstr ""
+"`-o` veya` --open = <str> `: Bu komut satırı anahtarına bağımsız değişken "
+"olarak verilen dosya adını açın"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-e` or `--eval`: Evaluate the file after opening it."
+msgstr "`-e` veya` --eval`: Dosyayı açtıktan sonra değerlendirin."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+#, fuzzy
+#| msgid ""
+#| "`-b` or `--batch`: If the command-line opens a file all cells in this "
+#| "file are evaluated and the file is saved afterwards. This is for example "
+#| "useful if the session described in the file makes _Maxima_ generate "
+#| "output files. Batch-processing will be stopped if _wxMaxima_ detects that "
+#| "_Maxima_ has output an error and will pause if _Maxima_ has a question: "
+#| "Mathematics is somewhat interactive by nature so a completely interaction-"
+#| "free batch processing cannot always be guaranteed."
+msgid ""
+"`-b` or `--batch`: If the command-line opens a file all cells in this file "
+"are evaluated and the file is saved afterward. This is for example useful if "
+"the session described in the file makes _Maxima_ generate output files. "
+"Batch-processing will be stopped if _wxMaxima_ detects that _Maxima_ has "
+"output an error and will pause if _Maxima_ has a question: Mathematics is "
+"somewhat interactive by nature so a completely interaction-free batch "
+"processing cannot always be guaranteed."
+msgstr ""
+"`-b` veya` --batch`: Komut satırı bir dosyayı açarsa, bu dosyadaki tüm "
+"hücreler değerlendirilir ve daha sonra dosya kaydedilir. Bu, örneğin, "
+"dosyada açıklanan oturum _Maxima_ çıktı dosyaları oluşturuyorsa yararlıdır. "
+"_WxMaxima_, _Maxima_ öğesinin bir hata verdiğini algılarsa ve _Maxima_'ın "
+"bir sorusu varsa duraklatılırsa, toplu işlem durdurulur: Matematik, doğası "
+"gereği biraz etkileşimlidir, bu nedenle tamamen etkileşimsiz bir toplu işlem "
+"her zaman garanti edilemez."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1164
+#, fuzzy, no-wrap
+#| msgid ""
+#| "* `--logtostdout`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
+#| "* `--pipe`:                        Pipe messages from Maxima to stdout.\n"
+#| "* `--exit-on-error`:               Close the program on any maxima error.\n"
+#| "* `-f` or `--ini=<str>`: Use the init file that was given as argument to this command-line switch\n"
+#| "* `-u`, `--use-version=<str>`:     Use maxima version `<str>`.\n"
+#| "* `-l`, `--lisp=<str>`:              Use a Maxima compiled with Lisp compiler `<str>`.\n"
+#| "* `-X`, `--extra-args=<str>`:        Allows to specify extra Maxima arguments\n"
+#| "* `-m` or `--maxima=<str>`:    allows to specify the location of the _maxima_ binary\n"
+msgid ""
+"- `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
+"- `--pipe`:                        Pipe messages from Maxima to stdout.\n"
+"- `--exit-on-error`:               Close the program on any maxima error.\n"
+"- `-f` or `--ini=<str>`: Use the init file that was given as an argument to this command-line switch\n"
+"- `-u`, `--use-version=<str>`:     Use maxima version `<str>`.\n"
+"- `-l`, `--lisp=<str>`:              Use a Maxima compiled with Lisp compiler `<str>`.\n"
+"- `-X`, `--extra-args=<str>`:        Allows to specify extra Maxima arguments\n"
+"- `-m` or `--maxima=<str>`:    allows specifying the location of the _maxima_ binary\n"
+"- `--enableipc`: Lets Maxima control wxMaxima via interprocess communications. Use this option with care.\n"
+"- `--wxmathml-lisp=<str>`:   Location of wxMathML.lisp (if not the built-in should be used, mainly for developers).\n"
+msgstr ""
+"* `--logtostdout`:                 Tüm \"hata ayıklama iletileri\" kenar çubuğu iletilerini stderr'e de günlüğe kaydet.\n"
+"* `--pipe`:                        İletileri Maxima'dan stdout'a ilet.\n"
+"* `--exit-on-error`:               Herhangi bir maxima hatasında programı kapat.\n"
+"* `-f` or `--ini=<str>`: Bu komut satırı anahtarına bağımsız değişken olarak verilen init dosyasını kullanın\n"
+"* `-u`, `--use-version=<str>`:     Maxima sürümü kullan `<str>`.\n"
+"* `-l`, `--lisp=<str>`:              Lisp derleyicisiyle derlenmiş bir Maxima kullanın `<str>`.\n"
+"* `-X`, `--extra-args=<str>`:        Ekstra Maxima bağımsız değişkenleri belirtmeye izin verir\n"
+"* `-m` or `--maxima=<str>`:    _maxima_ ikili dosyasının konumunu belirtmenize izin verir\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1166
+#, fuzzy
+#| msgid ""
+#| "Instead of a minus some operating systems might use a dash in front of "
+#| "the command-line switches."
+msgid ""
+"Instead of a minus, some operating systems might use a dash in front of the "
+"command-line switches."
+msgstr ""
+"Eksi yerine bazı işletim sistemleri komut satırı anahtarlarının önünde bir "
+"tire kullanabilir."
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1169
+#, no-wrap
+msgid "About the program, contributing to wxMaxima"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1172
+msgid ""
+"wxMaxima is mainly developed using the programming language C++ using the "
+"[wxWidgets framework](https://www.wxwidgets.org), as build system we use "
+"[CMake](https://www.cmake.org), a small part is written in Lisp. You can "
+"contribute to wxMaxima, join the wxMaxima project at <https://github.com/"
+"wxMaxima-developers/wxmaxima>, if you have knowledge of these programming "
+"languages and want to help and contribute to the open source project "
+"wxMaxima."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1174
+msgid ""
+"But not only programmers are necessary! You can also contribute to wxMaxima, "
+"if you help to improve the documentation, find and report bugs (and maybe "
+"bugfixes), suggest new features, help to translate wxMaxima or the manual to "
+"your language (read the README.md in the [locale subdirectory](https://"
+"github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and "
+"the manual can be translated)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1176
+msgid "Or answer questions of other users in the discussion forum."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1178
+msgid ""
+"The source code of wxMaxima is documented using Doxygen [here](https://"
+"wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1180
+msgid ""
+"The program is nearly self-contained, so except for system libraries (and "
+"the wxWidgets library), no external dependencies (like graphic files or the "
+"Lisp part (the `wxmathML.lisp`-file) is needed, these files are included in "
+"the executable."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1181
+#, no-wrap
+msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.\n"
+msgstr ""
+
+#, fuzzy
+#~| msgid "    load(draw);\n"
+#~ msgid "```maxima load(draw);"
+#~ msgstr "    load(draw);\n"
+
+#, fuzzy
+#~| msgid ""
+#~| "    /* Parabola in window #1 */\n"
+#~| "    draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+#~ msgid ""
+#~ "/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
+#~ msgstr ""
+#~ "    /* Parabola in window #1 */\n"
+#~ "    draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+
+#, fuzzy
+#~| msgid ""
+#~| "    /* Parabola in window #2 */\n"
+#~| "    draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+#~ msgid ""
+#~ "/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
+#~ msgstr ""
+#~ "    /* Parabola in window #2 */\n"
+#~ "    draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+
+#, fuzzy
+#~| msgid ""
+#~| "    /* Paraboloid in window #3 */\n"
+#~| "    draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
+#~ msgid ""
+#~ "/* Paraboloid in window #3 */ draw3d(terminal=[wxt,3],explicit(x^2+y^2,"
+#~ "x,-1,1,y,-1,1)); ```"
+#~ msgstr ""
+#~ "    /* Paraboloid in window #3 */\n"
+#~ "    draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
+
+#~ msgid "#### 2D"
+#~ msgstr "#### 2B"
+
+#~ msgid "#### 3D"
+#~ msgstr "#### 3B"
+
+#, fuzzy
+#~| msgid ""
+#~| "pngdraw2d(\"Test\",\n"
+#~| "        explicit(sin(x),x,1,10)\n"
+#~| ");\n"
+#~| "~~~~\n"
+#~ msgid ""
+#~ "pngdraw2d(\"Test\",\n"
+#~ "        explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "pngdraw2d(\"Test\",\n"
+#~ "        explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+#~ "~~~~\n"

--- a/locales/manual/uk.po
+++ b/locales/manual/uk.po
@@ -1,0 +1,5010 @@
+# Copyright (C) 2020 Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Yuri Chornoivan <yurchor@ukr.net>, 2020, 2021, 2022, 2023.
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: wxmaxima-gui\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-04 07:28+0000\n"
+"PO-Revision-Date: 2026-08-02 11:43\n"
+"Last-Translator: \n"
+"Language-Team: Ukrainian\n"
+"Language: uk_UA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=((n%10==1 && n%100!=11) ? 0 : ((n%10 >= 2 "
+"&& n%10 <=4 && (n%100 < 12 || n%100 > 14)) ? 1 : ((n%10 == 0 || (n%10 >= 5 "
+"&& n%10 <=9)) || (n%100 >= 11 && n%100 <= 14)) ? 2 : 3));\n"
+"X-Crowdin-Project: wxmaxima-gui\n"
+"X-Crowdin-Project-ID: 917703\n"
+"X-Crowdin-Language: uk\n"
+"X-Crowdin-File: /main/locales/wxMaxima/wxMaxima.pot\n"
+"X-Crowdin-File-ID: 8\n"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1
+#, fuzzy, no-wrap
+#| msgid "The wxMaxima user manual {-}"
+msgid "The wxMaxima user manual"
+msgstr "Підручник користувача wxMaxima {-}"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:4
+#, fuzzy
+#| msgid ""
+#| "WxMaxima is a graphical user interface (GUI) for the _Maxima_ computer "
+#| "algebra system (CAS). WxMaxima allows one to use all of _Maxima_’s "
+#| "functions. In addition, it provides convenient wizards for accessing the "
+#| "most commonly used features. This manual describes some of the features "
+#| "that make wxMaxima one of the most popular GUIs for _Maxima_."
+msgid ""
+"WxMaxima is a graphical user interface (GUI) for the _Maxima_ computer "
+"algebra system (CAS). WxMaxima allows one to use all of _Maxima_’s "
+"functions. In addition, it provides convenient wizards for accessing the "
+"most commonly used features. This manual describes some of the features that "
+"make wxMaxima one of the most popular GUIs for _Maxima_."
+msgstr ""
+"WxMaxima — графічний інтерфейс користувача до системи комп'ютерної алгебри "
+"(СКА) _Maxima_. За допомогою WxMaxima можна користуватися усіма функціями "
+"_Maxima_. Крім того, у програмі передбачено зручні допоміжні програми для "
+"доступу до найпоширеніших можливостей СКА. У цьому підручнику наведено опис "
+"деяких можливостей, які роблять WxMaxima одним із найпопулярніших графічних "
+"інтерфейсів _Maxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:6
+msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
+msgstr "![Логотип wxMaxima](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:9
+#, fuzzy, no-wrap
+#| msgid "Introduction to wxMaxima"
+msgid "Introduction to wxMaxima"
+msgstr "Вступ до wxMaxima"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:11
+#, fuzzy, no-wrap
+#| msgid "_Maxima_ and wxMaxima"
+msgid "_Maxima_ and wxMaxima"
+msgstr "_Maxima_ і wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:14
+#, fuzzy
+#| msgid ""
+#| "In the open-source domain, big systems are normally split into smaller "
+#| "projects that are easier to handle for small groups of developers. For "
+#| "example a CD burner program will consist of a command-line tool that "
+#| "actually burns the CD and a graphical user interface that allows users to "
+#| "implement it without having to learn about all the command line switches "
+#| "and in fact without using the command line at all. One advantage of this "
+#| "approach is that the developing work that was invested into the command-"
+#| "line program can be shared by many programs: The same CD-burner command-"
+#| "line program can be used as a “send-to-CD”-plug-in for a file manager "
+#| "application, for the “burn to CD” function of a music player and as the "
+#| "CD writer for a DVD backup tool. Another advantage is that splitting one "
+#| "big task into smaller parts allows the developers to provide several user "
+#| "interfaces for the same program."
+msgid ""
+"In the open-source domain, big systems are normally split into smaller "
+"projects that are easier to handle for small groups of developers. For "
+"example a CD burner program will consist of a command-line tool that "
+"actually burns the CD and a graphical user interface that allows users to "
+"implement it without having to learn about all the command line switches and "
+"in fact without using the command line at all. One advantage of this "
+"approach is that the developing work that was invested into the command-line "
+"program can be shared by many programs: The same CD-burner command-line "
+"program can be used as a “send-to-CD”-plug-in for a file manager "
+"application, for the “burn to CD” function of a music player and as the CD "
+"writer for a DVD backup tool. Another advantage is that splitting one big "
+"task into smaller parts allows the developers to provide several user "
+"interfaces for the same program."
+msgstr ""
+"У системі програмного забезпечення з відкритим кодом великі системи, "
+"зазвичай, діляться на менші проєкти, з якими простіше працювати невеликим "
+"групам розробників. Наприклад, програма для запису компакт-дисків "
+"складається з засобу командного рядка, який, власне, виконує запис компакт-"
+"диска, і графічного інтерфейсу користувача, за допомогою користувачі можуть "
+"виконати потрібні їм дії, не запам'ятовуючи параметрів командного рядка і, "
+"загалом, взагалі не маючи справи із командним рядком. Однією із переваг "
+"цього підходу є те, що робота з розробки засобу командного рядка може бути "
+"використана багатьма програмами: той самий засіб командного рядка для запису "
+"компакт-дисків можна використати у додатку надсилання даних на компакт-диск "
+"у програмі для керування файлами, для функції «записати на компакт-диск» у "
+"музичному програвачі та для запису компакт-диска у програмі для резервного "
+"копіювання на DVD. Ще однією перевагою є поділ одного великого завдання на "
+"менші частини, що надає змогу розробникам надавати декілька інтерфейсів "
+"користувача для однієї програми."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:16
+msgid ""
+"A computer algebra system (CAS) like _Maxima_ fits into this framework. A "
+"CAS can provide the logic behind an arbitrary precision calculator "
+"application or it can do automatic transforms of formulas in the background "
+"of a bigger system (e.g., [Sage](https://www.sagemath.org/)). Alternatively, "
+"it can be used directly as a free-standing system. _Maxima_ can be accessed "
+"via a command line. Often, however, an interface like _wxMaxima_ proves a "
+"more efficient way to access the software, especially for newcomers."
+msgstr ""
+"Система комп'ютерної алгебри (СКА), подібна до _Maxima_, дуже добре "
+"вкладається у цю схему. СКА може надавати логіку до програми-калькулятора із "
+"довільною точністю обчислень або може виконувати автоматичні перетворення "
+"форму у фоновому режимі для більших систем (наприклад, [Sage](https://www."
+"sagemath.org/)). Крім того, нею можна користуватися і безпосередньо, як "
+"самостійною системою. Доступ до _Maxima_ можна отримати з командного рядка. "
+"Втім, часто інтерфейси, подібні до _wxMaxima_, є набагато ефективнішим "
+"способом доступу до програмного забезпечення, особливо для початківців."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:17
+#, fuzzy, no-wrap
+#| msgid "_Maxima_"
+msgid "_Maxima_"
+msgstr "_Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:20
+msgid ""
+"_Maxima_ is a full-featured computer algebra system (CAS). A CAS is a "
+"program that can solve mathematical problems by rearranging formulas and "
+"finding a formula that solves the problem as opposed to just outputting the "
+"numeric value of the result. In other words, _Maxima_ can serve as a "
+"calculator that gives numerical representations of variables, and it can "
+"also provide analytical solutions. Furthermore, it offers a range of "
+"numerical methods of analysis for equations or systems of equations that "
+"cannot be solved analytically."
+msgstr ""
+"_Maxima_ є повноцінною системою комп'ютерної алгебри (СКА). СКА — програма, "
+"яка може розв'язувати математичні задачі перетворенням формул і визначенням "
+"формули, яка розв'язує задачу, замість простого виведення числової форми "
+"результату. Іншими словами, _Maxima_ може слугувати калькулятором, який "
+"визначає числові значення змінних, а може давати аналітичні розв'язки. Крім "
+"того, у програмі передбачено багато обчислювальних методів для аналізу "
+"рівнянь і систем рівнянь, які не може бути розв'язано аналітично."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:22
+msgid ""
+"![Maxima screenshot, command line](./maxima_screenshot.png)"
+"{ id=img_maxima_screenshot }"
+msgstr ""
+"![Знімок вікна Maxima, командний рядок](./maxima_screenshot.png)"
+"{ id=img_maxima_screenshot }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:24
+#, fuzzy, no-wrap
+#| msgid "Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.\n"
+msgid "Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.\n"
+msgstr "Із докладною документацією до _Maxima_ можна [ознайомитися у інтернеті](https://maxima.sourceforge.io/documentation.html). Доступ до частини цієї документації можна отримати з меню «Довідка» у wxMaxima. Якщо ви натиснете клавішу довідки (у більшості систем це клавіша <kbd>F1</kbd>), використання контекстної довідки _wxMaxima_ відкриє для вас сторінку підручника з _Maxima_ із довідкою щодо команди, у якій перебуває курсор.\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:25
+#, fuzzy, no-wrap
+#| msgid "WxMaxima"
+msgid "WxMaxima"
+msgstr "WxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:28
+#, fuzzy
+#| msgid ""
+#| "_WxMaxima_ is a graphical user interface that provides the full "
+#| "functionality and flexibility of _Maxima_. WxMaxima offers users a "
+#| "graphical display and many features that make working with _Maxima_ "
+#| "easier. For example _wxMaxima_ allows one to export any cell’s contents "
+#| "(or, if that is needed, any part of a formula, as well) as text, as LaTeX "
+#| "or as MathML specification at a simple right-click. Indeed, an entire "
+#| "workbook can be exported, either as a HTML file or as a LaTeX file. "
+#| "Documentation for _wxMaxima_, including workbooks to illustrate aspects "
+#| "of its use, is online at the _wxMaxima_ [help site](https://wxMaxima-"
+#| "developers.github.io/wxmaxima/help.html), as well as via the help menu."
+msgid ""
+"_WxMaxima_ is a graphical user interface that provides the full "
+"functionality and flexibility of _Maxima_. WxMaxima offers users a graphical "
+"display and many features that make working with _Maxima_ easier. For "
+"example _wxMaxima_ allows one to export any cell’s contents (or, if that is "
+"needed, any part of a formula, as well) as text, as LaTeX or as MathML "
+"specification at a simple right-click. Indeed, an entire workbook can be "
+"exported, either as a HTML file or as a LaTeX file. Documentation for "
+"_wxMaxima_, including workbooks to illustrate aspects of its use, is online "
+"at the _wxMaxima_ [help site](https://wxMaxima-developers.github.io/wxmaxima/"
+"help.html), as well as via the help menu."
+msgstr ""
+"_wxMaxima_ — графічний інтерфейс користувача, який надає доступ до усіх "
+"функціональних можливостей і гнучкості _Maxima_. _wxMaxima_ надає у "
+"розпорядження користувачам графічні засоби роботи та можливості, які значно "
+"спрощують роботу з _Maxima_. Наприклад, у wxMaxima передбачено можливість "
+"експортування вмісту будь-якої комірки (або, якщо це потрібно, будь-якої "
+"частини формули) у форматі тексту, коду LaTeX або специфікації MathML "
+"простим клацанням правою кнопкою миші. Насправді, можна експортувати увесь "
+"робочий аркуш у форматі HTML або коду LaTeX. Із документацією до _wxMaxima_, "
+"зокрема робочими книгами для ілюстрації аспектів користування, можна "
+"ознайомитися на [сайті довідки](https://wxMaxima-developers.github.io/"
+"wxmaxima/help.html) _wxMaxima_, а також за допомогою меню «Довідка»."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:30
+msgid "![wxMaxima window](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
+msgstr "![Вікно wxMaxima](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:32
+msgid ""
+"The calculations that are entered in _wxMaxima_ are performed by the "
+"_Maxima_ command-line tool in the background."
+msgstr ""
+"Обчислення, які ви наказуєте виконати _wxMaxima_ у фоновому режимі "
+"передаються інструментам командного рядка _Maxima_."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:33
+#, fuzzy, no-wrap
+#| msgid "Workbook basics"
+msgid "Workbook basics"
+msgstr "Основи роботи із книгою"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:36
+#, fuzzy
+#| msgid ""
+#| "Much of _wxMaxima_ is self-explaining, but some details require "
+#| "attention. [This site](https://wxMaxima-developers.github.io/wxmaxima/"
+#| "help.html) contains a number of workbooks that address various aspects of "
+#| "_wxMaxima_. Working through some of these (particularly the \"10 minute "
+#| "_(wx)Maxima_ tutorial\") will increase one’s familiarity with both the "
+#| "content of _Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. "
+#| "This manual concentrates on describing aspects of _wxMaxima_ that are not "
+#| "likely to be self-evident and that might not be covered in the online "
+#| "material."
+msgid ""
+"Much of _wxMaxima_ is self-explaining, but some details require attention. "
+"[This site](https://wxMaxima-developers.github.io/wxmaxima/help.html) "
+"contains a number of workbooks that address various aspects of _wxMaxima_. "
+"Working through some of these (particularly the \"10 minute _(wx)Maxima_ "
+"tutorial\") will increase one’s familiarity with both the content of "
+"_Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. This manual "
+"concentrates on describing aspects of _wxMaxima_ that are not likely to be "
+"self-evident and that might not be covered in the online material."
+msgstr ""
+"Призначення більшої частини інтерфейсу _wxMaxima_ є очевидним, але деякі "
+"речі потребують більшої уваги. На [цьому сайті](https://wxMaxima-developers."
+"github.io/wxmaxima/help.html) можна знайти декілька робочих книг, які "
+"присвячено різноманітним аспектами роботи у _wxMaxima_. Опрацювання деяких з "
+"цих зразків (зокрема «Десятихвилинного підручника з _(wx)Maxima_») надасть "
+"змогу краще ознайомитися із роботою _Maxima_ і використанням _wxMaxima_ для "
+"взаємодії із _Maxima_. У цьому ж підручнику ми зосередимо увагу на описі тих "
+"аспектів _wxMaxima_, які, ймовірно, є неочевидними і про які немає "
+"відомостей у інтернет-підручнику."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:37
+#, fuzzy, no-wrap
+#| msgid "The workbook approach"
+msgid "The workbook approach"
+msgstr "Використання робочих книг"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:40
+#, fuzzy
+#| msgid ""
+#| "One of the very few things that are not standard in _wxMaxima_ is that it "
+#| "organizes the data for _Maxima_ into cells that are evaluated (which "
+#| "means: sent to _Maxima_) only when the user requests this. When a cell is "
+#| "evaluated, all commands in that cell, and only that cell, are evaluated "
+#| "as a batch. (The preceding statement is not quite accurate: One can "
+#| "select a set of adjacent cells and evaluate them together. Also, one can "
+#| "instruct _Maxima_ to evaluate all cells in a workbook in one pass.) "
+#| "_WxMaxima_'s approach to submitting commands for execution might feel "
+#| "unfamiliar at the first sight. It does, however, drastically ease work "
+#| "with big documents (where the user does not want every change to "
+#| "automatically trigger a full re-evaluation of the whole document). Also, "
+#| "this approach is very handy for debugging."
+msgid ""
+"One of the very few things that are not standard in _wxMaxima_ is that it "
+"organizes the data for _Maxima_ into cells that are evaluated (which means: "
+"sent to _Maxima_) only when the user requests this. When a cell is "
+"evaluated, all commands in that cell, and only that cell, are evaluated as a "
+"batch. (The preceding statement is not quite accurate: One can select a set "
+"of adjacent cells and evaluate them together. Also, one can instruct "
+"_Maxima_ to evaluate all cells in a workbook in one pass.) _WxMaxima_’s "
+"approach to submitting commands for execution might feel unfamiliar at the "
+"first sight. It does, however, drastically ease work with big documents "
+"(where the user does not want every change to automatically trigger a full "
+"re-evaluation of the whole document). Also, this approach is very handy for "
+"debugging."
+msgstr ""
+"Однією із дуже небагатьох речей, які є нестандартними у _wxMaxima_ є те, що "
+"дані для _Maxima_ у програмі впорядковано за комірками, які обчислюються "
+"(тобто надсилаються до _Maxima_) лише на запит користувача. При обчисленні "
+"комірки усі команди у ній, і лише у ній, обчислюються пакетно. (Попереднє "
+"твердження є не зовсім точним: можна позначити набір сусідніх комірок і "
+"обчислити їх разом. Крім того, можна наказати _Maxima_ обчислити усі комірки "
+"у робочій книзі одразу.) Підхід _wxMaxima_ до надсилання команд на виконання "
+"може спочатку видатися незвичним. Втім, він значно спрощує роботу із "
+"великими документами (у яких користувач не хоче, щоб програма автоматично "
+"вмикала повне переобчислення усього документа у відповідь на будь-яку "
+"зміну). Крім того, такий підхід є дуже зручним для усування вад."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:42
+msgid ""
+"If text is typed into _wxMaxima_ it automatically creates a new worksheet "
+"cell. The type of this cell can be selected in the toolbar. If a code cell "
+"is created the cell can be sent to _Maxima_, which causes the result of the "
+"calculation to be displayed below the code. A pair of such commands is shown "
+"below."
+msgstr ""
+"Якщо ви почнете вводити якийсь текст у вікні _wxMaxima_, програма "
+"автоматично створить нову комірку робочого аркуша. Тип цієї комірки можна "
+"вибрати за допомогою панелі інструментів. Якщо створено комірку з кодом, її "
+"вміст може бути надіслано до _Maxima_. Результат обчислень буде показано під "
+"рядком коду. Пару таких команд показано нижче."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:44
+msgid "![Input/output cell](./InputCell.png){ id=img_InputCell }"
+msgstr "![Комірка введення-виведення](./InputCell.png){ id=img_InputCell }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:46
+#, fuzzy
+#| msgid ""
+#| "On evaluation of an input cell's contents the input cell _Maxima_ assigns "
+#| "a label to the input (by default shown in red and recognizable by the "
+#| "`%i`) by which it can be referenced later in the _wxMaxima_ session. The "
+#| "output that _Maxima_ generates also gets a label that begins with `%o` "
+#| "and by default is hidden, except if the user assigns the output a name. "
+#| "In this case by default the user-defined label is displayed. The `%o`\\-"
+#| "style label _Maxima_ auto-generates will also be accessible, though."
+msgid ""
+"On evaluation of an input cell’s contents the input cell _Maxima_ assigns a "
+"label to the input (by default shown in red and recognizable by the `%i`) by "
+"which it can be referenced later in the _wxMaxima_ session. The output that "
+"_Maxima_ generates also gets a label that begins with `%o` and by default is "
+"hidden, except if the user assigns the output a name. In this case by "
+"default the user-defined label is displayed. The `%o`-style label _Maxima_ "
+"auto-generates will also be accessible, though."
+msgstr ""
+"При обчисленні вмісту комірки вхідних даних _Maxima_ призначає мітку для "
+"вхідних даних (типово, таку мітку буде показано червоним кольором, вона "
+"матиме формат `%i`). За цією міткою можна посилатися на вміст далі у сеансі "
+"роботи з _wxMaxima_. Виведені _Maxima_ дані також отримають мітку, яка "
+"починається з `%o`, і яку типово буде приховано, хіба що користувач надасть "
+"назву виведеними даним. Якщо надано назву, буде показано визначену "
+"користувачем мітку. Втім, можна буде користуватися і автоматично створеною "
+"_Maxima_ міткою у стилі `%o`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:48
+msgid ""
+"Besides the input cells _wxMaxima_ allows for text cells for documentation, "
+"image cells, title cells, chapter cells and section cells. Every cell has "
+"its own undo buffer so debugging by changing the values of several cells and "
+"then gradually reverting the unneeded changes is rather easy. Furthermore "
+"the worksheet itself has a global undo buffer that can undo cell edits, adds "
+"and deletes."
+msgstr ""
+"Окрім комірок для вхідних даних, у _wxMaxima_ передбачено комірки для "
+"документації, комірки зображень, комірки заголовків, комірки глав та комірки "
+"розділів. У кожної комірки є власний буфер скасовування дій, тому дуже "
+"просто діагностувати проблеми, змінюючи значення у комірках і поступово "
+"скасовуючи внесені зміни у різних комірках. Крім того, у самого робочого "
+"аркуша також є власний буфер скасовування дій, яким може скористатися для "
+"скасовування редагувань у комірках, додавання і вилучення комірок."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:50
+msgid ""
+"The figure below shows different cell types (title cells, section cells, "
+"subsection cells, text cells, input/output cells and image cells)."
+msgstr ""
+"На рисунку нижче показано різні типи комірок (комірки заголовків, комірки "
+"розділів, комірки підрозділів, текстові комірки, комірки введення-виведення "
+"та комірки зображення)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:52
+msgid ""
+"![Example of different wxMaxima cells](./cell-example.png){ id=img_cell-"
+"example }"
+msgstr ""
+"![Приклад різних комірок wxMaxima](./cell-example.png){ id=img_cell-example }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:53
+#, fuzzy, no-wrap
+#| msgid "Cells"
+msgid "Cells"
+msgstr "Комірки"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:56
+msgid ""
+"The worksheet is organized in cells. WxMaxima knows the following cell types:"
+msgstr ""
+"Робочий аркуш складається з комірок. У wxMaxima передбачено такі типи "
+"комірок:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Math cells, containing one or more lines of _Maxima_ input."
+msgstr ""
+"Математичні комірки, у яких міститься один або декілька рядків вхідних даних "
+"_Maxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Output of, or a question from, _Maxima_."
+msgstr "Виведені дані або питання від _Maxima_"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Image cells."
+msgstr "Комірки зображень."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Text cells, that can for example be used for documentation."
+msgstr "Текстові комірки, які можуть бути, наприклад, документацією"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid ""
+"A title, section or a subsection. 6 levels of different headings are "
+"possible."
+msgstr ""
+"Заголовок, розділ або підрозділ. Передбачено 6 різних рівнів заголовків."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Page breaks."
+msgstr "Межі сторінок."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:65
+msgid ""
+"The default behavior of _wxMaxima_ when text is entered is to automatically "
+"create a math cell. Cells of other types can be created using the Cell menu, "
+"using the hot keys shown in the menu or using the drop-down list in the "
+"toolbar. Once the non-math cell is created, whatever is typed into the file "
+"is interpreted as text."
+msgstr ""
+"Типовою поведінкою _wxMaxima_ при введенні тексту є автоматичне створення "
+"комірки формули. Комірки інших типів можна створити за допомогою меню "
+"«Комірка», натискання клавіатурних скорочень для пунктів з цього меню або за "
+"допомогою спадного списку на панелі інструментів. Після створення "
+"нематематичної комірки усе, що введено у файл, вважатиметься текстом."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:67
+msgid ""
+"A (C-style) [comment text](https://maxima.sourceforge.io/docs/manual/"
+"maxima_singlepage.html#Comments) can be part of a math cell as follows: `/* "
+"This comment will be ignored by Maxima */`"
+msgstr ""
+"[Текст коментаря](https://maxima.sourceforge.io/docs/manual/"
+"maxima_singlepage.html#Comments) (у стилі C) може бути частиною математичної "
+"комірки ось так: `/* Цей коментар буде проігноровано Maxima */`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:69
+msgid "\"`/*`\" marks the start of the comment, \"`*/`\" the end."
+msgstr "«`/*`» позначає початок коментаря, «`*/`» — його кінець."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:70
+#, fuzzy, no-wrap
+#| msgid "Horizontal and vertical cursors"
+msgid "Horizontal and vertical cursors"
+msgstr "Горизонтальний і вертикальний курсори"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:73
+msgid ""
+"If the user tries to select a complete sentence, a word processor will try "
+"to extend the selection to automatically begin and end with a word boundary. "
+"Likewise, if more than one cell is selected, _wxMaxima_ will extend the "
+"selection to whole cells."
+msgstr ""
+"Якщо користувач намагається позначити ціле речення, текстовий процесор "
+"намагається розширити позначений фрагмент так, щоб він автоматично "
+"завершувався на початку і наприкінці слів. Так само, _wxMaxima_, якщо "
+"позначено декілька комірок, доповнюватиме позначений фрагмент до меж комірок."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:75
+#, fuzzy
+#| msgid ""
+#| "What isn't standard is that _wxMaxima_ provides drag-and-drop flexibility "
+#| "by defining two types of cursors. _WxMaxima_ will switch between them "
+#| "automatically when needed:"
+msgid ""
+"What isn’t standard is that _wxMaxima_ provides drag-and-drop flexibility by "
+"defining two types of cursors. _WxMaxima_ will switch between them "
+"automatically when needed:"
+msgstr ""
+"Нестандартною особливістю є те, що у _wxMaxima_ передбачено гнучку систему "
+"перетягування зі скиданням, у якій визначено два типи курсорів. _wxMaxima_ "
+"автоматично перемикатиметься між ними, коли у цьому виникатиме потреба:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:78
+msgid ""
+"The cursor is drawn horizontally if it is moved in the space between two "
+"cells or by clicking there."
+msgstr ""
+"Курсор буде намальовано горизонтально, якщо його пересунуто до проміжку між "
+"двома комірками, або якщо користувач клацнув кнопкою миші у проміжку між "
+"двома комірками."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:78
+#, fuzzy
+#| msgid ""
+#| "A vertical cursor that works inside a cell. This cursor is activated by "
+#| "moving the cursor inside a cell using the mouse pointer or the cursor "
+#| "keys and works much like the cursor in a text editor."
+msgid ""
+"A vertical cursor that works inside a cell. This cursor is activated by "
+"moving the cursor inside a cell using the mouse pointer or the cursor keys "
+"and works much like the cursor in a text editor."
+msgstr ""
+"Вертикальний курсор, який працює у комірці. Цей курсор активується "
+"пересуванням курсора всередину комірки за допомогою вказівника миші або "
+"клавіш зі стрілками. Цей курсор працює подібно до курсора у текстовому "
+"редакторі."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:80
+#, fuzzy, no-wrap
+#| msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL+ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).\n"
+msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).\n"
+msgstr "Після запуску wxMaxima, ви побачите лише горизонтальний курсор, який блиматиме. Якщо ви почнете щось вводити, буде автоматично створено математичну комірку, а курсор буде замінено на звичайний вертикальний (ви побачите стрілку праворуч як «запит», а після обчислення вмісту математичної комірки (<kbd>Ctrl+Enter</kbd>) ви побачите мітки, наприклад `(%i1)`, `(%o1)`).\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:82
+msgid ""
+"![(blinking) horizontal cursor after wxMaxima start](./horizontal-cursor-"
+"only.png){ id=img_horizontal_cursor_only }"
+msgstr ""
+"![Горизонтальний курсор після запуску wxMaxima](./horizontal-cursor-only.png)"
+"{ id=img_horizontal_cursor_only }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:84
+msgid ""
+"You might want to create a different cell type (using the \"Cell\" menu), "
+"maybe a title cell or text cell, which describes, what will be done, when "
+"you start creating your worksheet."
+msgstr ""
+"Ви можете створити комірки іншого типу (за допомогою меню «Комірка»), "
+"можливо, комірку заголовка та текстову комірку, яка описуватиме виконану "
+"математичну дію, коли почнете створення вашого робочого аркуша."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:86
+msgid ""
+"If you navigate between the different cells, you will also see the "
+"(blinking) horizontal cursor, where you can insert a cell into your "
+"worksheet (either a math cell, by just start typing your formula - or a "
+"different cell type using the menu)."
+msgstr ""
+"Якщо ви переходитимете між різними комірками програма також показуватиме "
+"горизонтальний курсор, що блиматиме. На місці курсора ви можете вставити "
+"комірку до робочого аркуша (математичну комірку простим введенням формули "
+"або комірку іншого типу за допомогою меню)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:88
+msgid ""
+"![(blinking) horizontal cursor between cells](./horizontal-cursor-between-"
+"cells.png){ id=img_horizontal_cursor_between_cells }"
+msgstr ""
+"![Горизонтальний курсор між комірками](./horizontal-cursor-between-cells.png)"
+"{ id=img_horizontal_cursor_between_cells }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:89
+#, fuzzy, no-wrap
+#| msgid "Sending cells to Maxima"
+msgid "Sending cells to Maxima"
+msgstr "Надсилання комірок для обчислення у Maxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:92
+#, fuzzy, no-wrap
+#| msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL+ENTER</kbd> or <kbd>SHIFT+ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.\n"
+msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.\n"
+msgstr "Команду у комірці буде виконано одразу після натискання комбінацій клавіш <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> або клавіші <kbd>ENTER</kbd> на клавіатурі. Типовим для _wxMaxima_ є введення команд за допомогою <kbd>CTRL+ENTER</kbd> або <kbd>SHIFT+ENTER</kbd>, але _wxMaxima_ можна налаштувати на виконання команд у відповідь на натискання <kbd>ENTER</kbd>.\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:93
+#, fuzzy, no-wrap
+#| msgid "Command autocompletion"
+msgid "Command autocompletion"
+msgstr "Автоматичне доповнення команд"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:96
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.\n"
+msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.\n"
+msgstr "У _wxMaxima_ реалізовано можливість автоматичного доповнення коду, якою можна скористатися за допомогою меню (Комірка/Доповнити слово) або натисканням комбінації клавіш <kbd>CTRL</kbd>+<kbd>Пробіл</kbd>. Автоматичне доповнення є чутливим до регістру символів. Наприклад, якщо його активувати зі специфікацією модулів для ezUnits, воно запропонує список відповідних модулів.\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:98
+msgid "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
+msgstr "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:100
+#, fuzzy, no-wrap
+#| msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).\n"
+msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).\n"
+msgstr "Окрім доповнення, назви файла, назви модуля або назви поточної команди чи змінної, засіб автоматичного доповнення може показувати шаблони для більшості команд, вказуючи тип (і значення) параметрів, які очікує отримати відповідна програма. Щоб задіяти цю можливість, натисніть комбінацію клавіш <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>ПРОБІЛ</kbd> або виберіть відповідний пункт меню (Комірка/Показати шаблон).\n"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:101
+#, fuzzy, no-wrap
+#| msgid "Greek characters"
+msgid "Greek characters"
+msgstr "Грецькі літери"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:104
+msgid ""
+"Computers traditionally stored characters in 8-bit values. This allows for a "
+"maximum of 256 different characters. All letters, numbers, and control "
+"symbols (end of transmission, end of string, lines and edges for drawing "
+"rectangles for menus _etc_.) of nearly any given language can fit within "
+"that limit."
+msgstr ""
+"Комп'ютери традиційно зберігають символи у форматі 8-бітових значень. Це "
+"уможливлює існування наборів, що складаються лише із 256 різних символів. У "
+"такий набір може бути включено усі літери, цифри та символи керування "
+"(завершення передавання, кінець рядка, лінії та кутики для малювання меню "
+"_тощо_) майже будь-якої європейської мови."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:106
+msgid ""
+"For most countries, the codepage of 256 characters that has been chosen does "
+"not include things like Greek letters, though, that are frequently used in "
+"mathematics. To overcome this type of limitation [Unicode](https://home."
+"unicode.org/) has been invented: An encoding that makes English text work "
+"like normal, but to use much more than 256 characters."
+msgstr ""
+"Втім, у більшості мов до вибраної кодової сторінки із 256 символів не можна "
+"включити додаткові символи, зокрема літери грецької абетки, які широко "
+"використовуються у математичних формулах. Щоб подолати обмеження подібного "
+"типу, було винайдено [Юнікод](https://home.unicode.org/) — кодування, яке "
+"працює для латиниці, але використовує набагато більше за 256 символів."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:108
+#, fuzzy
+#| msgid ""
+#| "_Maxima_ allows Unicode if it was compiled using a Lisp compiler that "
+#| "either supports Unicode or that doesn't care about the font encoding. As "
+#| "at least one of this pair of conditions is likely to be true. _WxMaxima_ "
+#| "provides a method of entering Greek characters using the keyboard:"
+msgid ""
+"_Maxima_ allows Unicode if it was compiled using a Lisp compiler that either "
+"supports Unicode or that doesn’t care about the font encoding. As at least "
+"one of this pair of conditions is likely to be true. _WxMaxima_ provides a "
+"method of entering Greek characters using the keyboard:"
+msgstr ""
+"_Maxima_ уможливлює використання символів Юнікоду, якщо програму було "
+"зібрано за допомогою компілятора Lisp, у якому передбачено підтримку Юнікоду "
+"або такого, який є нейтральним щодо кодування символів. Оскільки, хоча б "
+"одна з цих вимог, зазвичай, справджується, у _wxMaxima_ реалізовано спосіб "
+"введення грецьких символів з клавіатури:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:111
+#, fuzzy
+#| msgid ""
+#| "A Greek letter can be entered by pressing the <kbd>ESC</kbd> key and then "
+#| "starting to type the Greek character's name."
+msgid ""
+"A Greek letter can be entered by pressing the <kbd>ESC</kbd> key and then "
+"starting to type the Greek character’s name."
+msgstr ""
+"Грецьку літеру можна ввести натисканням клавіші <kbd>ESC</kbd> з наступним "
+"введенням назви символу грецької абетки."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:111
+#, fuzzy
+#| msgid ""
+#| "Alternatively it can be entered by pressing <kbd>ESC</kbd>, one letter "
+#| "(or two for the Greek letter omicron) and <kbd>ESC</kbd> again. In this "
+#| "case the following letters are supported:"
+msgid ""
+"Alternatively it can be entered by pressing <kbd>ESC</kbd>, one letter (or "
+"two for the Greek letter omicron) and <kbd>ESC</kbd> again. In this case the "
+"following letters are supported:"
+msgstr ""
+"Крім того, можна натиснути <kbd>ESC</kbd>, ввести одну літеру (чи дві літери "
+"для грецької літери «омікрон») і натиснути <kbd>ESC</kbd> ще раз. У цьому "
+"випадку прив'язка до літер є такою:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:130
+#, fuzzy, no-wrap
+#| msgid ""
+#| "| key | Greek letter | key | Greek letter | key | Greek letter |\n"
+#| "|:---:|:------------:|:---:|:------------:|:---:|:------------:|\n"
+#| "|  a  |     alpha    |  i  |     iota     |  r  |      rho     |\n"
+#| "|  b  |     beta     |  k  |     kappa    |  s  |     sigma    |\n"
+#| "|  g  |     gamma    |  l  |    lambda    |  t  |      tau     |\n"
+#| "|  d  |     delta    |  m  |      mu      |  u  |    upsilon   |\n"
+#| "|  e  |    epsilon   |  n  |      nu      |  f  |      phi     |\n"
+#| "|  z  |     zeta     |  x  |      xi      |  c  |      chi     |\n"
+#| "|  h  |      eta     |  om |    omicron   |  y  |      psi     |\n"
+#| "|  q  |     theta    |  p  |      pi      |  o  |     omega    |\n"
+#| "|  A  |     Alpha    |  I  |     Iota     |  R  |      Rho     |\n"
+#| "|  B  |     Beta     |  K  |     Kappa    |  S  |     Sigma    |\n"
+#| "|  G  |     Gamma    |  L  |    Lambda    |  T  |      Tau     |\n"
+#| "|  D  |     Delta    |  M  |      Mu      |  U  |    Upsilon   |\n"
+#| "|  E  |    Epsilon   |  N  |      Nu      |  P  |      Phi     |\n"
+#| "|  Z  |     Zeta     |  X  |      Xi      |  C  |      Chi     |\n"
+#| "|  H  |      Eta     |  Om |    Omicron   |  Y  |      Psi     |\n"
+#| "|  T  |     Theta    |  P  |      Pi      |  O  |     Omega    |\n"
+msgid ""
+"| key | Greek letter | key | Greek letter | key | Greek letter |\n"
+"| :-: | :----------: | :-: | :----------: | :-: | :----------: |\n"
+"|  a  |    alpha     |  i  |     iota     |  r  |     rho      |\n"
+"|  b  |     beta     |  k  |    kappa     |  s  |    sigma     |\n"
+"|  g  |    gamma     |  l  |    lambda    |  t  |     tau      |\n"
+"|  d  |    delta     |  m  |      mu      |  u  |   upsilon    |\n"
+"|  e  |   epsilon    |  n  |      nu      |  f  |     phi      |\n"
+"|  z  |     zeta     |  x  |      xi      |  c  |     chi      |\n"
+"|  h  |     eta      | om  |   omicron    |  y  |     psi      |\n"
+"|  q  |    theta     |  p  |      pi      |  o  |    omega     |\n"
+"|  A  |    Alpha     |  I  |     Iota     |  R  |     Rho      |\n"
+"|  B  |     Beta     |  K  |    Kappa     |  S  |    Sigma     |\n"
+"|  G  |    Gamma     |  L  |    Lambda    |  T  |     Tau      |\n"
+"|  D  |    Delta     |  M  |      Mu      |  U  |   Upsilon    |\n"
+"|  E  |   Epsilon    |  N  |      Nu      |  P  |     Phi      |\n"
+"|  Z  |     Zeta     |  X  |      Xi      |  C  |     Chi      |\n"
+"|  H  |     Eta      | Om  |   Omicron    |  Y  |     Psi      |\n"
+"|  T  |    Theta     |  P  |      Pi      |  O  |    Omega     |\n"
+msgstr ""
+"| key | greek letter | key | greek letter | key | greek letter |\n"
+"|:---:|:------------:|:---:|:------------:|:---:|:------------:|\n"
+"|  a  |     альфа    |  i  |     йота     |  r  |      ро      |\n"
+"|  b  |     бета     |  k  |     каппа    |  s  |     сигма    |\n"
+"|  g  |     гамма    |  l  |    лямбда    |  t  |      тау     |\n"
+"|  d  |     дельта   |  m  |      мю      |  u  |    упсилоn   |\n"
+"|  e  |    епсилон   |  n  |      ню      |  f  |      фі      |\n"
+"|  z  |     дзета    |  x  |      ксі     |  c  |      хі      |\n"
+"|  h  |      ета     |  om |    омікрон   |  y  |      псі     |\n"
+"|  q  |     тета     |  p  |      пі      |  o  |     омега    |\n"
+"|  A  |     Альфа    |  I  |     Йота     |  R  |      Ро      |\n"
+"|  B  |     Бета     |  K  |     Каппа    |  S  |     Сигма    |\n"
+"|  G  |     Гамма    |  L  |    Лямбда    |  T  |      Тау     |\n"
+"|  D  |     Дельта   |  M  |      Мю      |  U  |    Упсилон   |\n"
+"|  E  |    Епсилон   |  N  |      Ню      |  P  |      Фі      |\n"
+"|  Z  |     Дзета    |  X  |      Ксі     |  C  |      Хі      |\n"
+"|  H  |      Ета     |  Om |    Омікрон   |  Y  |      Псі     |\n"
+"|  T  |     Тета     |  P  |      Пі      |  O  |     Омега    |\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:132
+msgid ""
+"You can also use the \"Greek letters\"-sidebar to enter the Greek letters."
+msgstr ""
+
+#. type: Title #####
+#: ../../info/wxmaxima.md:133
+#, no-wrap
+msgid "Attention: Lookalike characters"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:138
+msgid ""
+"Several Latin letters look like the Greek letters, e.g. the Latin letter "
+"\"A\" and the Greek letter \"Alpha\". Although they look identical, they are "
+"two different Unicode characters, represented by different Unicode code "
+"points (numbers)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:143
+msgid ""
+"This might be problematic, if you assign a value to the variable A and later "
+"use the Greek letter Alpha to do something with this variable, especially on "
+"printouts.  For the Greek letter my (which is also used as prefix for micro) "
+"there are also two different Unicode code points."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:146
+msgid ""
+"The \"Greek letters\"-sidebar therefore has the option, that lookalike "
+"characters are not available (which can be changed using a right-click menu)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:148
+msgid ""
+"The same mechanism also allows to enter some miscellaneous mathematical "
+"symbols:"
+msgstr "У той самий спосіб можна вводити різноманітні математичні символи:"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:199
+#, fuzzy, no-wrap
+#| msgid ""
+#| "| keys to enter  | mathematical symbol                                   |\n"
+#| "|----------------|-------------------------------------------------------|\n"
+#| "| hbar           | Planck constant: a h with a horizontal bar above it   |\n"
+#| "| Hbar           | a H with a horizontal bar above it                    |\n"
+#| "| 2              | squared                                               |\n"
+#| "| 3              | to the power of three                                 |\n"
+#| "| /2             | 1/2                                                   |\n"
+#| "| partial        | partial sign (the d of dx/dt)                         |\n"
+#| "| integral       | integral sign                                         |\n"
+#| "| sq             | square root                                           |\n"
+#| "| ii             | imaginary                                             |\n"
+#| "| ee             | element                                               |\n"
+#| "| in             | in                                                    |\n"
+#| "| impl implies   | implies                                               |\n"
+#| "| inf            | infinity                                              |\n"
+#| "| empty          | empty                                                 |\n"
+#| "| TB             | big triangle right                                    |\n"
+#| "| tb             | small triangle right                                  |\n"
+#| "| and            | and                                                   |\n"
+#| "| or             | or                                                    |\n"
+#| "| xor            | xor                                                   |\n"
+#| "| nand           | nand                                                  |\n"
+#| "| nor            | nor                                                   |\n"
+#| "| equiv          | equivalent to                                         |\n"
+#| "| not            | not                                                   |\n"
+#| "| union          | union                                                 |\n"
+#| "| inter          | intersection                                          |\n"
+#| "| subseteq       | subset or equal                                       |\n"
+#| "| subset         | subset                                                |\n"
+#| "| notsubseteq    | not subset or equal                                   |\n"
+#| "| notsubset      | not subset                                            |\n"
+#| "| approx         | approximately                                         |\n"
+#| "| propto         | proportional to                                       |\n"
+#| "| neq != /= or # | not equal to                                          |\n"
+#| "| +/- or pm      | a plus/minus sign                                     |\n"
+#| "| <= or leq      | equal or less than                                    |\n"
+#| "| >= or geq      | equal or greater than                                 |\n"
+#| "| << or ll       | much less than                                        |\n"
+#| "| >> or gg       | much greater than                                     |\n"
+#| "| qed            | end of proof                                          |\n"
+#| "| nabla          | a nabla operator                                      |\n"
+#| "| sum            | sum sign                                              |\n"
+#| "| prod           | product sign                                          |\n"
+#| "| exists         | there exists sign                                     |\n"
+#| "| nexists        | there is no sign                                      |\n"
+#| "| parallel       | a parallel sign                                       |\n"
+#| "| perp           | a perpendicular sign                                  |\n"
+#| "| leadsto        | a leads to sign                                       |\n"
+#| "| ->             | a right arrow                                         |\n"
+#| "| -->            | a long right arrow                                    |\n"
+msgid ""
+"| keys to enter  | mathematical symbol                                   |\n"
+"| -------------- | ----------------------------------------------------- |\n"
+"| hbar           | Planck constant: a h with a horizontal bar above it   |\n"
+"| Hbar           | a H with a horizontal bar above it                    |\n"
+"| 2              | squared                                               |\n"
+"| 3              | to the power of three                                 |\n"
+"| /2             | 1/2                                                   |\n"
+"| partial        | partial sign (the d of dx/dt)                         |\n"
+"| integral       | integral sign                                         |\n"
+"| sq             | square root                                           |\n"
+"| ii             | imaginary                                             |\n"
+"| ee             | element                                               |\n"
+"| in             | in                                                    |\n"
+"| impl implies   | implies                                               |\n"
+"| inf            | infinity                                              |\n"
+"| empty          | empty                                                 |\n"
+"| TB             | big triangle right                                    |\n"
+"| tb             | small triangle right                                  |\n"
+"| and            | and                                                   |\n"
+"| or             | or                                                    |\n"
+"| xor            | xor                                                   |\n"
+"| nand           | nand                                                  |\n"
+"| nor            | nor                                                   |\n"
+"| equiv          | equivalent to                                         |\n"
+"| not            | not                                                   |\n"
+"| union          | union                                                 |\n"
+"| inter          | intersection                                          |\n"
+"| subseteq       | subset or equal                                       |\n"
+"| subset         | subset                                                |\n"
+"| notsubseteq    | not subset or equal                                   |\n"
+"| notsubset      | not subset                                            |\n"
+"| approx         | approximately                                         |\n"
+"| propto         | proportional to                                       |\n"
+"| neq != /= or # | not equal to                                          |\n"
+"| +/- or pm      | a plus/minus sign                                     |\n"
+"| \\<= or leq     | equal or less than                                    |\n"
+"| >= or geq      | equal or greater than                                 |\n"
+"| \\<\\< or ll     | much less than                                        |\n"
+"| >> or gg       | much greater than                                     |\n"
+"| qed            | end of proof                                          |\n"
+"| nabla          | a nabla operator                                      |\n"
+"| sum            | sum sign                                              |\n"
+"| prod           | product sign                                          |\n"
+"| exists         | there exists sign                                     |\n"
+"| nexists        | there is no sign                                      |\n"
+"| parallel       | a parallel sign                                       |\n"
+"| perp           | a perpendicular sign                                  |\n"
+"| leadsto        | a leads to sign                                       |\n"
+"| ->             | a right arrow                                         |\n"
+"| -->            | a long right arrow                                    |\n"
+msgstr ""
+"| введений рядок | математичний символ                                   |\n"
+"|----------------|-------------------------------------------------------|\n"
+"| hbar           | стала Планка: h із горизонтальною рискою згори        |\n"
+"| Hbar           | H із горизонтальною рискою згори                      |\n"
+"| 2              |   квадрат                                             |\n"
+"| 3              |   куб                                                 |\n"
+"| /2             | 1/2                                                   |\n"
+"| partial        | знак частинної похідної (d у dx/dt)                   |\n"
+"| integral       | символ інтеграла                                      |\n"
+"| sq             | квадратний корінь                                     |\n"
+"| ii             | уявна одиниця                                         |\n"
+"| ee             | елемент                                               |\n"
+"| in             | включається                                           |\n"
+"| impl implies   | випливає                                              |\n"
+"| inf            | нескінченність                                        |\n"
+"| empty          | порожня множина                                       |\n"
+"| TB             | великий трикутник праворуч                            |\n"
+"| tb             | малий трикутник праворуч                              |\n"
+"| and            | і                                                     |\n"
+"| or             | або                                                   |\n"
+"| xor            | виключне або                                          |\n"
+"| nand           | ні-і                                                  |\n"
+"| nor            | ні-або                                                |\n"
+"| equiv          | еквівалентний                                         |\n"
+"| not            | ні                                                    |\n"
+"| union          | об'єднання                                            |\n"
+"| inter          | перетин                                               |\n"
+"| subseteq       | підмножина або рівна множина                          |\n"
+"| subset         | підмножина                                            |\n"
+"| notsubseteq    | не підмножина або рівна множина                       |\n"
+"| notsubset      | не підмножина                                         |\n"
+"| approx         | приблизно                                             |\n"
+"| propto         | пропорційне до                                        |\n"
+"| neq != /= або # |не рівне                                              |\n"
+"| +/- або pm     | плюс-мінус                                            |\n"
+"| <= або leq     | менше або дорівнює                                    |\n"
+"| >= або geq     | більше або дорівнює                                   |\n"
+"| << або ll      | набагато менше                                        |\n"
+"| >> або gg      | набагато більше                                       |\n"
+"| qed            | що і слід було довести                                |\n"
+"| nabla          | набла-оператор                                        |\n"
+"| sum            | знак суми                                             |\n"
+"| prod           | знак добутку                                          |\n"
+"| exists         | знак «існує»                                          |\n"
+"| nexists        | знак «не існує»                                       |\n"
+"| parallel       | знак «паралельно»                                     |\n"
+"| perp           | знак «перпендикулярно»                                |\n"
+"| leadsto        | знак «випливає»                                       |\n"
+"| ->             | стрілка праворуч                                      |\n"
+"| -->            | довга стрілка праворуч                                |\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:201
+msgid ""
+"You can also use the \"Symbols\"-sidebar to enter these Mathematical symbols."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:203
+#, fuzzy, no-wrap
+#| msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> [number of the character (hexadecimal)] <kbd>ESC</kbd>.\n"
+msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.\n"
+msgstr "Якщо спеціального символу немає у списку, ви можете ввести його як довільний символ Юнікод натисканням послідовності клавіш <kbd>ESC</kbd> [номер символу (шістнадцятковий)] <kbd>ESC</kbd>.\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:205
+#, fuzzy, no-wrap
+#| msgid "<kbd>ESC</kbd> <kbd>61</kbd> <kbd>ESC</kbd> therefore results in an `a`.\n"
+msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.\n"
+msgstr "Отже, <kbd>ESC</kbd> <kbd>61</kbd> <kbd>ESC</kbd> дасть «a».\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:207
+#, fuzzy
+#| msgid ""
+#| "Please note that most of these symbols (notable exceptions are the logic "
+#| "symbols) do not have a special meaning in _Maxima_ and therefore will be "
+#| "interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp "
+#| "that doesn’t support Unicode characters they might cause an error message."
+msgid ""
+"Please note that most of these symbols (notable exceptions are the logic "
+"symbols) do not have a special meaning in _Maxima_ and therefore will be "
+"interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp "
+"that doesn’t support Unicode characters they might cause an error message."
+msgstr ""
+"Будь ласка, зауважте, що більшість цих символів (виключеннями є логічні "
+"символи) не мають спеціального значення у _Maxima_ і тому можуть бути "
+"оброблені як звичайні символи. Якщо _Maxima_ зібрано із Lisp, у якому не "
+"передбачено обробки символів Юнікоду, використання цих символів може "
+"призвести до показу повідомлення про помилку."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:210
+#, fuzzy, no-wrap
+#| msgid ""
+#| "It may be the case that e.g. greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.\n"
+#| "To solve that problem, select other fonts (using: Edit -> Configure -> Style).\n"
+msgid ""
+"It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.\n"
+"To solve that problem, select other fonts (using: Edit -> Configure -> Style).\n"
+msgstr ""
+"Може так статися, що у вибраному шрифті не буде символів грецької абетки або математичних символів. Тоді програма не зможе показати ці символи.\n"
+"Щоб усунути проблему, виберіть інші шрифти (за допомогою пункту меню «Зміни -> Налаштувати -> Стиль»).\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:211
+#, no-wrap
+msgid "Unicode replacement"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:214
+msgid ""
+"wxMaxima will replace several Unicode characters with their respective "
+"Maxima expressions, e.g. `²` with `^2`, `³` with `^3`, the square root sign "
+"with the function `sqrt()`, the (mathematical) Sigma sign (which is not the "
+"same Unicode character as the corresponding Greek letter) with `sum()`, etc."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:217
+msgid ""
+"Unicode has several \"common\" fractions encoded as one Unicode code point: "
+"`¼, ½, ¾, ⅐, ⅑, ⅒, ⅓, ⅔, ⅕, ⅖, ⅗, ⅘, ⅙, ⅚, ⅛, ⅜, ⅝, ⅞`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:219
+msgid ""
+"wxMaxima will replace them with their Maxima representations, e.g `(1/4)` "
+"before the input is sent do Maxima. There are also `⅟`, which will be "
+"replaced by `1/` and `↉` (used in baseball), which will be replaced by "
+"`(0/3)`."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:221
+msgid ""
+"It is recommended to use **Maxima code** (not these Unicode code points) in "
+"input cells (Rationale: (a) it might be possible, that the used font for "
+"math input does not contain them; (b) if you save the document as `wxm`-"
+"file, it is usually readable by (command line) Maxima, but these changes "
+"will of course not work in command line Maxima); but they may occur, if you "
+"cut&paste a formula from another document."
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:222
+#, fuzzy, no-wrap
+#| msgid "Side Panes"
+msgid "Side Panes"
+msgstr "Бічні панелі"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:225
+msgid ""
+"Shortcuts to the most important _Maxima_ commands, things like a table of "
+"contents, windows with debug messages or a history of the last issued "
+"commands can be accessed using the side panes. They can be enabled using the "
+"\"View\" menu. They all can be moved to other locations inside or outside "
+"the _wxMaxima_ window. Other useful panes is the one that allows to input "
+"Greek letters using the mouse."
+msgstr ""
+"Доступ до найважливіших команд _Maxima_ або речей, подібних до таблиці "
+"змісту, вікон із діагностичними повідомленнями або журналу останніх виданих "
+"команд можна отримати за допомогою бічних панелей. Увімкнути бічні панелі "
+"можна за допомогою меню «Перегляд». Панелі можна пересувати як всередині "
+"вікна _wxMaxima_, так і ззовні. Ще однією корисною панеллю є панель введення "
+"грецьких літер за допомогою вказівника миші."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:227
+msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
+msgstr "![Приклад різних бічних панелей](./SidePanes.png){ id=img_SidePanes }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:230
+msgid ""
+"In the \"table of contents\" side pane, one can increase or decrease a "
+"heading by just clicking on the heading with the right mouse button and "
+"select the next higher or lower heading type."
+msgstr ""
+"За допомогою бічної панелі «Зміст» можна збільшити або зменшити рівень "
+"заголовка: просто клацніть на заголовку правою кнопкою миші і виберіть "
+"наступний більший або менший рівень заголовка."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:232
+msgid ""
+"![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-"
+"headings.png){ id=Sidepane-TOC-convert-headings }"
+msgstr ""
+"![Збільшення або зменшення рівня заголовка за допомогою бічної панелі "
+"«Зміст»](./Sidepane-TOC-convert-headings.png){ id=Sidepane-TOC-convert-"
+"headings }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:233
+#, fuzzy, no-wrap
+#| msgid "MathML output"
+msgid "MathML output"
+msgstr "Виведення коду MathML"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:236
+#, fuzzy
+#| msgid ""
+#| "Several word processors and similar programs either recognize [MathML]"
+#| "(https://www.w3.org/Math/) input and automatically insert it as an "
+#| "editable 2D equation - or (like LibreOffice 5.1) have an equation editor "
+#| "that offers an “import MathML from clipboard” feature. Others support RTF "
+#| "maths. _WxMaxima_, therefore, offers several entries in the right-click "
+#| "menu."
+msgid ""
+"Several word processors and similar programs either recognize [MathML]"
+"(https://www.w3.org/Math/) input and automatically insert it as an editable "
+"2D equation - or (like LibreOffice) have an equation editor that offers an "
+"“import MathML from clipboard” feature. Others support RTF maths. "
+"_WxMaxima_, therefore, offers several entries in the right-click menu."
+msgstr ""
+"Деякі текстові процесори і подібні програми або розпізнають вхідні дані "
+"[MathML](https://www.w3.org/Math/) і автоматично вставляють їх до придатного "
+"для редагування рівняння, або (подібно до LibreOffice 5.1) мають у складі "
+"редактор рівнянь, у якому передбачено можливість імпортування даних MathML з "
+"буфера обміну даними. У інших редакторах передбачено підтримку формул у RTF. "
+"Через це у _wxMaxima_ передбачено декілька відповідних пунктів у "
+"контекстному меню."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:237
+#, fuzzy, no-wrap
+#| msgid "Markdown support"
+msgid "Markdown support"
+msgstr "Підтримка Markdown"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:240
+#, fuzzy
+#| msgid ""
+#| "_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/"
+#| "wiki/Markdown) conventions that don't collide with mathematical notation. "
+#| "One of these elements is bullet lists."
+msgid ""
+"_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/wiki/"
+"Markdown) conventions that don’t collide with mathematical notation. One of "
+"these elements is bullet lists."
+msgstr ""
+"У _wxMaxima_ ви зможете скористатися стандартними варіантами [Markdown]"
+"(https://en.wikipedia.org/wiki/Markdown), які не суперечать математичним "
+"позначенням. Одним із елементів розмітки є невпорядковані списки."
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:241
+#, fuzzy, no-wrap
+#| msgid ""
+#| "Ordinary text\n"
+#| " * One item, indentation level 1\n"
+#| " * Another item at indentation level 1\n"
+#| "   * An item at a second indentation level\n"
+#| "   * A second item at the second indentation level\n"
+#| " * A third item at the first indentation level\n"
+#| "Ordinary text\n"
+msgid ""
+"Ordinary text\n"
+" * One item, indentation level 1\n"
+" * Another item at indentation level 1\n"
+"   * An item at a second indentation level\n"
+"   * A second item at the second indentation level\n"
+" * A third item at the first indentation level\n"
+"Ordinary text\n"
+msgstr ""
+"Звичайний текст\n"
+" * Один пункт, рівень відступу 1\n"
+" * Інший пункт на рівні відступу 1\n"
+"   * Пункт на другому рівні відступу\n"
+"   * Другий пункт на другому рівні відступу\n"
+" * Третій пункт на першому рівні відступу\n"
+"Звичайний текст\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:252
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
+msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
+msgstr "У _wxMaxima_ фрагменти тексту, які розпочинаються з символів `>` вважаються блоками цитат:\n"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:253
+#, fuzzy, no-wrap
+#| msgid ""
+#| "Ordinary text\n"
+#| "> quote quote quote quote\n"
+#| "> quote quote quote quote\n"
+#| "> quote quote quote quote\n"
+#| "Ordinary text\n"
+msgid ""
+"Ordinary text\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"Ordinary text\n"
+msgstr ""
+"Звичайний текст\n"
+"> цитата цитата цитата цитата\n"
+"> цитата цитата цитата цитата\n"
+"> цитата цитата цитата цитата\n"
+"Звичайний текст\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:262
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_'s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:\n"
+msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:\n"
+msgstr "У коді TeX та HTML _wxMaxima_ також розпізнається рядок `=>`, який програма замінює на відповідний символ Юнікод:\n"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:263
+#, fuzzy, no-wrap
+#| msgid "cogito => sum.\n"
+msgid "cogito => sum.\n"
+msgstr "cogito => sum.\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:268
+#, fuzzy, no-wrap
+#| msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.\n"
+msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.\n"
+msgstr "Іншими символами, які буде розпізнано під час експортування до HTML або TeX, є `<=` і `>=` для порівнянь, двобічна стрілка (`<=>`), одинарні стрілки (`<->`, `->` і `<-`), а також `+/-` як відповідний знак. Для експортування у код TeX передбачено також підтримку перетворення `<<` і `>>`.\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:269
+#, fuzzy, no-wrap
+#| msgid "Hotkeys"
+msgid "Hotkeys"
+msgstr "Клавіатурні скорочення"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:272
+msgid ""
+"Most hotkeys can be found in the text of the respective menus. Since they "
+"are actually taken from the menu text and thus can be customized by the "
+"translations of _wxMaxima_ to match the needs of users of the local "
+"keyboard, we do not document them here. A few hotkeys or hotkey aliases, "
+"though, are not documented in the menus:"
+msgstr ""
+"Більшість клавіатурних скорочень можна знайти у тексті відповідних меню. "
+"Оскільки їх взято з тексту меню і, отже, може бути змінено під час перекладу "
+"_wxMaxima_ так, щоб вони відповідали потребам користувачів локалізованих "
+"клавіатур, ми не наводимо їх у цьому підручнику. Втім, декілька клавіатурних "
+"скорочень все ж не документовано у меню:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid ""
+"<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
+msgstr ""
+"<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> вилучає увесь вміст "
+"комірки."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+#, fuzzy
+#| msgid ""
+#| "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete "
+#| "cell."
+msgid ""
+"<kbd>CTRL</kbd>+<kbd>TAB</kbd> or <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</"
+"kbd> triggers the auto-completion mechanism."
+msgstr ""
+"<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> вилучає увесь вміст "
+"комірки."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
+msgstr "<kbd>SHIFT</kbd>+<kbd>ПРОБІЛ</kbd> вставляє нерозривний пробіл."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:277
+#, fuzzy, no-wrap
+#| msgid "Raw TeX in the TeX export"
+msgid "Raw TeX in the TeX export"
+msgstr "Код TeX у експортованому TeX"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:280
+msgid ""
+"If a text cell begins with `TeX:` the TeX export contains the literal text "
+"that follows the `TeX:` marker. Using this feature allows the entry of TeX "
+"markup within the _wxMaxima_ workbook."
+msgstr ""
+"Якщо текстову комірку буде розпочато з `TeX:` у експортованих у форматі TeX "
+"даних буде буквально відтворено текст, який вказано після позначки `TeX:`. "
+"За допомогою цієї можливості можна використовувати розмітку TeX у робочій "
+"книзі _wxMaxima_."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:281
+#, fuzzy, no-wrap
+#| msgid "File Formats"
+msgid "File Formats"
+msgstr "Формати файлів"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:284
+msgid ""
+"The material that is developed in a _wxMaxima_ session can be stored for "
+"later use in any of three ways:"
+msgstr ""
+"Матеріал, який було отримано під час сеансу роботи у _wxMaxima_ може бути "
+"збережено для наступного використання у три способи:"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:285
+#, fuzzy, no-wrap
+#| msgid ".mac"
+msgid ".mac"
+msgstr ".mac"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:288
+#, fuzzy
+#| msgid ""
+#| "`.mac` files are ordinary text files that contain _Maxima_ commands. They "
+#| "can be read using _Maxima_’s `batch()` or `load()` command or "
+#| "_wxMaxima_’s File/Batch File menu entry."
+msgid ""
+"`.mac` files are ordinary text files that contain _Maxima_ commands. They "
+"can be read using _Maxima_’s `batch()` or `load()` command or _wxMaxima_’s "
+"File/Batch File menu entry."
+msgstr ""
+"Файли `.mac` є звичайними текстовими файлами, які містять команди _Maxima_. "
+"Їх можна прочитати за допомогою команди `batch()` або `load()` _Maxima_ або "
+"пункту меню «Файл/Пакетний файл»."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:291
+msgid ""
+"One example is shown below. `Quadratic.mac` defines a function and afterward "
+"generates a plot with `wxdraw2d()`.  Afterward the contents of the file "
+"`Quadratic.mac` are printed and newly defined function `f()` is evaluated."
+msgstr ""
+"Один з прикладів наведено нижче. `Quadratic.mac` визначає функцію і після "
+"цього створює креслення за допомогою `wxdraw2d()`. Далі, буде виведено вміст "
+"файла `Quadratic.mac` і виконано обчислення нової визначеної функції `f()`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:293
+#, fuzzy
+#| msgid ""
+#| "![Loading a `.mac` file with `batch()`](./BatchImage.png)"
+#| "{ id=img_BatchImage }"
+msgid "![Loading a file with `batch()`](./BatchImage.png){ id=img_BatchImage }"
+msgstr ""
+"![Завантаження файла `.mac` за допомогою `batch()`](./BatchImage.png)"
+"{ id=img_BatchImage }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:295
+#, fuzzy
+#| msgid ""
+#| "Attention: Although the file `Quadratic.mac` has a usual _Maxima_ "
+#| "extension (`.mac`), it can only be read by _wxMaxima_, since the command "
+#| "`wxdraw2d()` is a wxMaxima-extension to _Maxima_."
+msgid ""
+"Attention: Although the file `Quadratic.mac` has a usual _Maxima_ extension "
+"(`.mac`), it can only be read by _wxMaxima_, since the command `wxdraw2d()` "
+"is a wxMaxima-extension to _Maxima_. (Command line) Maxima will ignore the "
+"unknown command `wxdraw2d()` and print it as output again."
+msgstr ""
+"Увага! Хоча назва файла `Quadratic.mac` містить звичайний для _Maxima_ "
+"суфікс (`.mac`), прочитати дані з нього зможе лише _wxMaxima_, оскільки "
+"команда `wxdraw2d()` є wxMaxima-розширенням до _Maxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:297
+#, fuzzy
+#| msgid ""
+#| "You can be use `.mac` files for writing your own library of macros. But "
+#| "since they don’t contain enough structural information they cannot be "
+#| "read back as a _wxMaxima_ session."
+msgid ""
+"You can be use `.mac` files for writing your own library of macros. But "
+"since they don’t contain enough structural information they cannot be read "
+"back as a _wxMaxima_ session."
+msgstr ""
+"Ви можете використовувати файли `.mac` для написання власної бібліотеки "
+"макросів. Але оскільки у них не міститься достатніх даних щодо структури, їх "
+"не можна читати як сеанс _wxMaxima_."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:298
+#, fuzzy, no-wrap
+#| msgid ".wxm"
+msgid ".wxm"
+msgstr ".wxm"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:302
+#, fuzzy, no-wrap
+#| msgid ".wxm files contain the worksheet except for _Maxima_'s output. On Maxima versions >5.38 they can be read using _Maxima_'s `load()` function just as .mac files can be. With this plain-text format, it sometimes is unavoidable that worksheets that use new features are not downwards-compatible with older versions of _wxMaxima_.\n"
+msgid ""
+"`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.\n"
+"You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.\n"
+msgstr "Файли .wxm містять дані робочого аркуша, окрім виведених даних _Maxima_. У версіях Maxima >5.38 їх можна прочитати за допомогою функції `load()` _Maxima_, так само, як можна прочитати файли .mac. У цьому текстовому форматі іноді є неусувна проблема — робочі аркуші із новими можливостями не є зворотно сумісними із застарілими версіями _wxMaxima_.\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:304
+#, fuzzy
+#| msgid ""
+#| ".wxm files contain the worksheet except for _Maxima_'s output. On Maxima "
+#| "versions >5.38 they can be read using _Maxima_'s `load()` function just "
+#| "as .mac files can be. With this plain-text format, it sometimes is "
+#| "unavoidable that worksheets that use new features are not downwards-"
+#| "compatible with older versions of _wxMaxima_.\n"
+msgid ""
+"With this plain-text format, it sometimes is unavoidable that worksheets "
+"that use new features are not downwards-compatible with older versions of "
+"_wxMaxima_."
+msgstr ""
+"Файли .wxm містять дані робочого аркуша, окрім виведених даних _Maxima_. У "
+"версіях Maxima >5.38 їх можна прочитати за допомогою функції `load()` "
+"_Maxima_, так само, як можна прочитати файли .mac. У цьому текстовому "
+"форматі іноді є неусувна проблема — робочі аркуші із новими можливостями не "
+"є зворотно сумісними із застарілими версіями _wxMaxima_.\n"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:305
+#, fuzzy, no-wrap
+#| msgid "File Formats"
+msgid "File format of wxm files"
+msgstr "Формати файлів"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:308
+msgid ""
+"This is just a plain text file (you can open it with a text editor), "
+"containing the cell contents as some special Maxima comments."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:310
+msgid "It starts with the following comment:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:311
+#, no-wrap
+msgid ""
+"/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/\n"
+"/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:317
+msgid ""
+"And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:318
+#, no-wrap
+msgid ""
+"/* [wxMaxima: section start ]\n"
+"Title of the section\n"
+"   [wxMaxima: section end   ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:325
+msgid ""
+"or (in a Math cell the input is of course *not* commented out (the output is "
+"not saved in a `wxm` file)):"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:326
+#, no-wrap
+msgid ""
+"/* [wxMaxima: input   start ] */\n"
+"f(x):=x^2+1$\n"
+"f(2);\n"
+"/* [wxMaxima: input   end   ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:334
+msgid ""
+"Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the "
+"image type as first line):"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:335
+#, no-wrap
+msgid ""
+"/* [wxMaxima: image   start ]\n"
+"jpg\n"
+"[very chaotic looking character sequence]\n"
+"   [wxMaxima: image   end   ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:343
+msgid "A page break is just one line containing:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:344
+#, no-wrap
+msgid "/* [wxMaxima: page break    ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:349
+msgid "And folded cells marked by:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:350
+#, no-wrap
+msgid ""
+"/* [wxMaxima: fold    start ] */\n"
+"...\n"
+"/* [wxMaxima: fold    end   ] */\n"
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:356
+#, fuzzy, no-wrap
+#| msgid ".wxmx"
+msgid ".wxmx"
+msgstr ".wxmx"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:359
+msgid ""
+"This XML-based file format saves the complete worksheet including things "
+"like the zoom factor and the watchlist. It is the preferred file format."
+msgstr ""
+"У цьому заснованому на XML форматі файлів зберігається увесь робочий аркуш, "
+"включно із даними щодо масштабу та списком спостереження. Цей формат файлів "
+"є рекомендованим."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:360
+#, fuzzy, no-wrap
+#| msgid "File Formats"
+msgid "File format of wxmx files"
+msgstr "Формати файлів"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:364
+msgid ""
+"A `wxmx`-file seems to be a binary format, but one can handle it with tools, "
+"which are included in your OS. It is a zip file, one can decompress it with "
+"`unzip` (maybe rename it before, so that is recognized by the unzip program "
+"of your OS).  We do not use the compression function, just the possibility "
+"to merge several files into one file - images are already compressed and the "
+"rest is simple text (probably much smaller, than huge images, which are "
+"included)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:366
+msgid "It does contain the following files:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-"
+"wxmathml`"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`format.txt`: a short description about wxMaxima and the wxmx file format"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima "
+"session and included images."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`content.xml`: a XML document, which contains the various cells of your "
+"document in XML format."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:373
+msgid ""
+"So, if something goes wrong, you can unzip a wxMaxima document (maybe rename "
+"it before to a `zip`-file), maybe make changes in the `content.xml` file "
+"with a text editor, or replace an broken image, zip the files again, "
+"probably rename the `zip` to a `wxmx`-file - and you get another modified "
+"`wxmx`-file."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:374
+#, fuzzy, no-wrap
+#| msgid "Configuration options"
+msgid "Configuration options"
+msgstr "Параметри налаштування"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:377
+msgid ""
+"For some common configuration variables _wxMaxima_ offers two ways of "
+"configuring:"
+msgstr ""
+"Для деяких типових змінних налаштувань у _wxMaxima_ передбачено два способи "
+"налаштовування:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:380
+msgid ""
+"The configuration dialog box below lets you change their default values for "
+"the current and subsequent sessions."
+msgstr ""
+"За допомогою діалогової панелі налаштовування, знімок якої наведено нижче, "
+"ви можете змінити типові значення для поточного і наступних сеансі роботи "
+"програми."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:380
+#, fuzzy
+#| msgid ""
+#| "Also, the values for most configuration variables can be changed for the "
+#| "current session only by overwriting their values from the worksheet, as "
+#| "shown below."
+msgid ""
+"Also, the values for most configuration variables can be changed for the "
+"current session only by overwriting their values from the worksheet, as "
+"shown below."
+msgstr ""
+"Крім того, значення більшості змінних налаштувань може бути змінено лише для "
+"поточного сеансу перезаписуванням їхніх значень з робочого аркуша, як це "
+"показано нижче."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:382
+msgid ""
+"![wxMaxima configuration 1](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
+msgstr ""
+"![Налаштування wxMaxima 1](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:383
+#, fuzzy, no-wrap
+#| msgid "Default animation framerate"
+msgid "Default animation framerate"
+msgstr "Типова частота кадрів анімації"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:386
+msgid ""
+"The animation framerate that is used for new animations is kept in the "
+"variable `wxanimate_framerate`. The initial value this variable will contain "
+"in a new worksheet can be changed using the configuration dialogue."
+msgstr ""
+"Частота кадрів анімації, яка використовуватиметься для нових анімацій, "
+"зберігається у змінній `wxanimate_framerate`. Початкове значення цієї "
+"змінної, яке міститиметься у новому робочому аркуші, можна змінити за "
+"допомогою діалогового вікна налаштовування."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:387
+#, fuzzy, no-wrap
+#| msgid "Default plot size for new _maxima_ sessions"
+msgid "Default plot size for new _maxima_ sessions"
+msgstr "Типовий розмір креслення для нових сеансів _maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:390
+#, fuzzy
+#| msgid ""
+#| "After the next start, plots embedded into the worksheet will be created "
+#| "with this size if the value of `wxplot_size` isn't changed by _maxima_."
+msgid ""
+"After the next start, plots embedded into the worksheet will be created with "
+"this size if the value of `wxplot_size` isn’t changed by _maxima_."
+msgstr ""
+"Після наступного запуску креслення, які вбудовано до робочого аркуша, буде "
+"створено з цим розміром, якщо значення `wxplot_size` не було змінено "
+"_maxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:392
+#, fuzzy
+#| msgid ""
+#| "In order to set the plot size of a single graph only use the following "
+#| "notation can be used that sets a variable’s value for one command only:"
+msgid ""
+"In order to set the plot size of a single graph only use the following "
+"notation can be used that sets a variable’s value for one command only:"
+msgstr ""
+"Щоб встановити розмір графіка для окремого графіка, можна скористатися "
+"наведеною нижче конструкцією, яка встановить значення змінної лише для одної "
+"команди:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:393
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxdraw2d(\n"
+#| "   explicit(\n"
+#| "       x^2,\n"
+#| "\t   x,-5,5\n"
+#| "   )\n"
+#| "), wxplot_size=[480,480]$\n"
+msgid ""
+"wxdraw2d(\n"
+"   explicit(\n"
+"       x^2,\n"
+"       x,-5,5\n"
+"   )\n"
+"), wxplot_size=[480,480]$\n"
+msgstr ""
+"wxdraw2d(\n"
+"   explicit(\n"
+"       x^2,\n"
+"\t   x,-5,5\n"
+"   )\n"
+"), wxplot_size=[480,480]$\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:402
+#, fuzzy, no-wrap
+#| msgid "Match parenthesis in text controls"
+msgid "Match parenthesis in text controls"
+msgstr "Перевіряти баланс дужок у тексті"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:405
+msgid "This option enables two things:"
+msgstr "За допомогою цього пункту можна увімкнути дві речі:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:408
+#, fuzzy
+#| msgid ""
+#| "If an opening parenthesis, bracket, or double quote is entered _wxMaxima_ "
+#| "will insert a closing one after it."
+msgid ""
+"If an opening parenthesis, bracket, or double quote is entered _wxMaxima_ "
+"will insert a closing one after it."
+msgstr ""
+"Якщо ви введете у _wxMaxima_ початкову круглу або квадратну дужку або "
+"подвійні лапки, програма автоматично вставить завершальну дужку або лапки за "
+"нею."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:408
+msgid ""
+"If text is selected if any of these keys is pressed the selected text will "
+"be put between the matched signs."
+msgstr ""
+"Якщо при натисканні якоїсь із цих комбінацій клавіш було позначено фрагмент "
+"тексту, цей текст буде вставлено між відповідними символами."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:409
+#, fuzzy, no-wrap
+#| msgid "Don't save the worksheet automatically"
+msgid "Don’t save the worksheet automatically"
+msgstr "Не зберігати робочий аркуш автоматично"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:412
+msgid ""
+"If this option is set, the file where the worksheet is will be overwritten "
+"only the request of the user. In case of a crash/power loss/... a recent "
+"backup copy is still made available in the temp directory, though."
+msgstr ""
+"Якщо позначено цей пункт, файл, у якому зберігається робочий аркуш, буде "
+"перезаписано лише за запит користувача. Втім, у випадку аварії, втрати "
+"живлення тощо, у каталозі тимчасових даних завжди лишатиметься резервна "
+"копія."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:414
+#, fuzzy
+#| msgid ""
+#| "If this option isn't set _wxMaxima_ behaves more like a modern cellphone "
+#| "app:"
+msgid ""
+"If this option isn’t set _wxMaxima_ behaves more like a modern cellphone app:"
+msgstr ""
+"Якщо не встановлено цей параметр, _wxMaxima_ поводиться подібно до сучасної "
+"програми для мобільних телефонів:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:417
+msgid "Files are saved automatically on exit"
+msgstr "Файли автоматично зберігаються під час виходу з програми"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:417
+#, fuzzy
+#| msgid "And the file will automatically be saved every 3 minutes."
+msgid "And the file will automatically be saved every 3 minutes."
+msgstr "І файл буде автоматично збережено кожні 3 хвилини."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:418
+#, fuzzy, no-wrap
+#| msgid "Where is the configuration saved?"
+msgid "Where is the configuration saved?"
+msgstr "Де зберігаються налаштування?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:422
+#, fuzzy, no-wrap
+#| msgid ""
+#| "If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets < 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).\n"
+#| "(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).\n"
+msgid ""
+"If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).\n"
+"(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).\n"
+msgstr ""
+"Якщо ви користуєтеся Unix/Linux, дані налаштувань буде збережено до файла `.wxMaxima` у вашому домашньому каталозі (якщо ви користуєтеся wxWidgets < 3.1.1), або `.config/wxMaxima.conf` ((стандартний каталог XDG), якщо використано wxWidgets >= 3.1.1). Визначити версію wxWidgets можна за допомогою команди `wxbuild_info();` або пункту меню «Довідка -> Про програму». [wxWidgets](https://www.wxwidgets.org/) є бібліотекою графічного інтерфейсу користувача, яка працює на багатьох платформах і є основою _wxMaxima_ (звідси `wx` у назві програми).\n"
+"(Оскільки назви файлів починається з крапки, файл `.wxMaxima` і  каталог`.config` є прихованими).\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:424
+msgid ""
+"If you are using Windows, the configuration will be stored in the registry. "
+"You will find the entries for _wxMaxima_ at the following position in the "
+"registry: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
+msgstr ""
+"Якщо ви користуєтеся Windows, налаштування буде збережено у реєстрі. Записи "
+"_wxMaxima_ можна знайти у цій гілці: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:427
+#, fuzzy, no-wrap
+#| msgid "Extensions to _Maxima_"
+msgid "Extensions to _Maxima_"
+msgstr "Розширення _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:430
+#, fuzzy
+#| msgid ""
+#| "_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
+#| "its main purpose is to pass along commands to _Maxima_ and to report the "
+#| "results of executing those commands. In some cases, however, _wxMaxima_ "
+#| "adds functionality to _Maxima_. _WxMaxima_’s ability to generate reports "
+#| "by exporting a workbook’s contents to HTML and LaTeX files has been "
+#| "mentioned. This section considers some ways that _wxMaxima_ enhances the "
+#| "inclusion of graphics in a session."
+msgid ""
+"_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
+"its main purpose is to pass along commands to _Maxima_ and to report the "
+"results of executing those commands. In some cases, however, _wxMaxima_ adds "
+"functionality to _Maxima_. _WxMaxima_’s ability to generate reports by "
+"exporting a workbook’s contents to HTML and LaTeX files has been mentioned. "
+"This section considers some ways that _wxMaxima_ enhances the inclusion of "
+"graphics in a session."
+msgstr ""
+"Основним призначенням _wxMaxima_ є забезпечення графічного інтерфейсу до "
+"_Maxima_. Отже, основним завданням програми є передавання команд до _Maxima_ "
+"і сповіщення користувача про результат виконання цих команд. Втім, у деяких "
+"випадках, _wxMaxima_ розширює функціональні можливості _Maxima_. Ми вже "
+"згадували про здатність _wxMaxima_ створювати звіти експортуванням вмісту "
+"робочої книги до файлів HTML і LaTeX. У цьому розділі ми розглянемо деякі "
+"способи, у які _wxMaxima_ удосконалює включення графіки до сеансу."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:431
+#, fuzzy, no-wrap
+#| msgid "Subscripted variables"
+msgid "Subscripted variables"
+msgstr "Змінні із індексами"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:434
+msgid ""
+"`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript "
+"variable names:"
+msgstr ""
+"`wxsubscripts` визначає, чи _wxMaxima_ виконуватиме автоматичне перетворення "
+"нижніх індексів у назвах змінних (і як вона це робитиме):"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:436
+msgid ""
+"If it is `false`, the functionality is off, wxMaxima will not autosubscript "
+"part of variable names after an underscore."
+msgstr ""
+"Якщо має значення `false`, функціональну можливість буде вимкнено, wxMaxima "
+"не виконуватиме автоматичного перетворення частини назв змінної після "
+"символу підкреслення."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:438
+#, fuzzy
+#| msgid ""
+#| "If it is set to `'all`, everything after an underscore will be "
+#| "subscripted."
+msgid ""
+"If it is set to `'all`, everything after an underscore will be subscripted."
+msgstr ""
+"Якщо встановлено значення `all`, усе після символу підкреслення буде "
+"перетворено на нижній індекс."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:440
+msgid ""
+"If it is set to `true` variable names of the format `x_y` are displayed "
+"using a subscript if"
+msgstr ""
+"Якщо встановлено значення `true` для `wxsubscripts`, назви змінних у форматі "
+"`x_y` буде показано як літеру із нижнім індексом, якщо"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:443
+msgid "Either `x` or `y` is a single letter or"
+msgstr "`x` або `y` є одинарною літерою або"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:443
+#, fuzzy
+#| msgid "`y` is an integer (can include more than one character)."
+msgid "`y` is an integer (can include more than one character)."
+msgstr "`y` є цілим числом (може складатися з декількох символів)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:445
+msgid ""
+"![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png)"
+"{ id=img_wxsubscripts }"
+msgstr ""
+"![Автоматичне перетворення нижніх індексів з використанням wxsubscripts](./"
+"wxsubscripts.png){ id=img_wxsubscripts }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:447
+#, fuzzy
+#| msgid ""
+#| "If the variable name doesn’t match these requirements, it can still be "
+#| "declared as \"to be subscripted\" using the command "
+#| "`wxdeclare_subscript(variable_name);` or "
+#| "`wxdeclare_subscript([variable_name1,variable_name2,...]);` Declaring a "
+#| "variable as subscripted can be reverted using the following command: "
+#| "`wxdeclare_subscript(variable_name,false);`"
+msgid ""
+"If the variable name doesn’t match these requirements, it can still be "
+"declared as \"to be subscripted\" using the command "
+"`wxdeclare_subscript(variable_name);` or "
+"`wxdeclare_subscript([variable_name1,variable_name2,...]);` Declaring a "
+"variable as subscripted can be reverted using the following command: "
+"`wxdeclare_subscript(variable_name,false);`"
+msgstr ""
+"Якщо назва змінної не задовольняє ці вимоги, змінну все одно можна оголосити "
+"як змінну із нижнім індексом, за допомогою команди "
+"`wxdeclare_subscript(назва_змінної);` або "
+"`wxdeclare_subscript([назва_змінної1,назва_змінної2,...]);` Оголошення "
+"змінної як змінної із нижнім індексом можна скасувати за допомогою такої "
+"команди: `wxdeclare_subscript(назва_змінної,false);`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:449
+#, fuzzy, no-wrap
+#| msgid "You can use the menu \"View->Autosubscript\" to set these values.\n"
+msgid "You can use the menu \"View->Autosubscript\" to set these values.\n"
+msgstr "Для встановлення цих значень ви можете скористатися меню «Перегляд->Автоматичне переведення у нижній індекс».\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:450
+#, fuzzy, no-wrap
+#| msgid "User feedback in the status bar"
+msgid "User feedback in the status bar"
+msgstr "Візуальний супровід дій користувача у смужці стану"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:453
+#, fuzzy
+#| msgid ""
+#| "Long-running commands can provide user feedback in the status bar. This "
+#| "user feedback is replaced by any new feedback that is placed there "
+#| "(allowing to use it as a progress indicator) and is deleted as soon as "
+#| "the current command sent to _Maxima_ is finished. It is safe to use "
+#| "`wxstatusbar()` even in libraries that might be used with plain _Maxima_ "
+#| "(as opposed to _wxMaxima_): If _wxMaxima_ isn't present the "
+#| "`wxstatusbar()` command will just be left unevaluated."
+msgid ""
+"Long-running commands can provide user feedback in the status bar. This user "
+"feedback is replaced by any new feedback that is placed there (allowing to "
+"use it as a progress indicator) and is deleted as soon as the current "
+"command sent to _Maxima_ is finished. It is safe to use `wxstatusbar()` even "
+"in libraries that might be used with plain _Maxima_ (as opposed to "
+"_wxMaxima_): If _wxMaxima_ isn’t present the `wxstatusbar()` command will "
+"just be left unevaluated."
+msgstr ""
+"Команди, які виконуються довго, можуть надавати користувачам інформацію на "
+"смужці стану. Цю інформацію буде замінено на будь-яку нову інформацію, яку "
+"програма надсилатиме туди (це надає змогу використовувати смужку стану як "
+"індикатор поступу), і буде вилучено, щойно буде завершено виконання поточної "
+"команди, яку надіслано до _Maxima_. Команду `wxstatusbar()` можна безпечно "
+"використовувати навіть у бібліотеках, які може бути використано у звичайній "
+"_Maxima_ (без _wxMaxima_): якщо _wxMaxima_ немає, команда `wxstatusbar()` "
+"просто не оброблятиметься."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:454
+#, fuzzy, no-wrap
+#| msgid ""
+#| "for i:1 thru 10 do (\n"
+#| "    /* Tell the user how far we got */\n"
+#| "    wxstatusbar(concat(\"Pass \",i)),\n"
+#| "    /* (sleep n) is a Lisp function, which can be used */\n"
+#| "    /* with the character \"?\" before. It delays the */\n"
+#| "    /* program execution (here: for 3 seconds) */\n"
+#| "    ?sleep(3)\n"
+#| ")$\n"
+msgid ""
+"for i:1 thru 10 do (\n"
+"    /* Tell the user how far we got */\n"
+"    wxstatusbar(concat(\"Pass \",i)),\n"
+"    /* (sleep n) is a Lisp function, which can be used */\n"
+"    /* with the character \"?\" before. It delays the */\n"
+"    /* program execution (here: for 3 seconds) */\n"
+"    ?sleep(3)\n"
+")$\n"
+msgstr ""
+"for i:1 thru 10 do (\n"
+"    /* Повідомляємо користувачу, наскільки далеко зайшли */\n"
+"    wxstatusbar(concat(\"Pass \",i)),\n"
+"    /* (sleep n) — функція Lisp, якою можна скористатися */\n"
+"    /* із додаванням перед нею символу «?». Команда затримує */\n"
+"    /* виконання програми (у нашому прикладі, на 3 секунди) */\n"
+"    ?sleep(3)\n"
+")$\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:465
+#, no-wrap
+msgid "Exporting the worksheet from within Maxima"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:468
+msgid ""
+"The command `wxworksheettohtml()` exports the current worksheet to an HTML "
+"file from within a running _Maxima_ session, which is convenient for "
+"scripted or batch export. Like `wxstatusbar()` it is safe to use in code "
+"that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present "
+"the command is simply left unevaluated."
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:469
+#, no-wrap
+msgid ""
+"wxworksheettohtml(\"report.html\")$\n"
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:475
+msgid ""
+"A relative file name is interpreted relative to _Maxima_’s working "
+"directory. The optional keyword options are:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:480
+#, no-wrap
+msgid ""
+"| option   | values                                          | meaning                                             |\n"
+"| -------- | ----------------------------------------------- | --------------------------------------------------- |\n"
+"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |\n"
+"| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:482
+msgid ""
+"The `flavor` values match the equation formats offered by the graphical "
+"**File → Export** dialog: `mathml` produces a self-contained page that needs "
+"no internet connection, `mathjax` adds a MathJaX fall-back for browsers that "
+"still lack MathML, and `svg`/`bitmap` render every equation to an image."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:484
+msgid ""
+"The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file "
+"the same way:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:485
+#, no-wrap
+msgid ""
+"wxworksheettotex(\"report.tex\")$\n"
+"wxworksheettotex(\"report.tex\", documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:494
+#, no-wrap
+msgid ""
+"| option                 | meaning                                                              |\n"
+"| ---------------------- | -------------------------------------------------------------------- |\n"
+"| `documentclass`        | overrides the LaTeX `\\documentclass` (e.g. `\"article\"`, `\"report\"`)  |\n"
+"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:496
+msgid "Support for `wxworksheettopdf()` is planned."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:497
+#, fuzzy, no-wrap
+#| msgid "Plotting"
+msgid "Plotting"
+msgstr "Креслення"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:500
+msgid ""
+"Plotting (having fundamentally to do with graphics) is a place where a "
+"graphical user interface will have to provide some extensions to the "
+"original program."
+msgstr ""
+"Креслення (яке фундаментально пов'язано із графікою) є місцем, де графічний "
+"інтерфейс користувача має надавати якісь додаткові можливості до "
+"оригінальної програми."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:501
+#, fuzzy, no-wrap
+#| msgid "Embedding a plot into the worksheet"
+msgid "Embedding a plot into the worksheet"
+msgstr "Вбудовування креслення до робочого аркуша"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:504
+#, fuzzy
+#| msgid ""
+#| "_Maxima_ normally instructs the external program _gnuplot_ to open a "
+#| "separate window for every diagram it creates. Since many times it is "
+#| "convenient to embed graphs into the worksheet instead _wxMaxima_ provides "
+#| "its own set of plot functions that don’t differ from the corresponding "
+#| "_maxima_ functions save in their name: They are all prefixed by a “wx”. "
+#| "For example `wxplot2d` corresponds to `plot2d`, `wxplot3d` corresponds to "
+#| "`plot3d`, `wxdraw` corresponds to `draw` and `wxhistogram` corresponds to "
+#| "`histogram`."
+msgid ""
+"_Maxima_ normally instructs the external program _Gnuplot_ to open a "
+"separate window for every diagram it creates. Since many times it is "
+"convenient to embed graphs into the worksheet instead _wxMaxima_ provides "
+"its own set of plot functions that don’t differ from the corresponding "
+"_maxima_ functions save in their name: They are all prefixed by a “wx”."
+msgstr ""
+"Зазвичай, _Maxima_ наказує зовнішній програмі _gnuplot_ відкривати окреме "
+"вікно для кожної створеної програмою діаграми. Оскільки набагато зручніше "
+"вбудовувати графіки безпосередньо до робочого аркуша, у _wxMaxima_ "
+"передбачено власний набір команд для креслення, які не відрізняються від "
+"відповідних функцій _maxima_ майже нічим, окрім назви: в усіх цих командах "
+"використано префікс «wx». Наприклад, команда `wxplot2d` відповідає команді "
+"`plot2d`, команда `wxplot3d` — команді `plot3d`, команда `wxdraw` — команді "
+"`draw`, а команда `wxhistogram` — команді `histogram`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:506
+msgid "The following plotting functions have wx-counterparts:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:520
+#, no-wrap
+msgid ""
+"| wxMaxima’s plot function | Maxima’s plot function                                                                          |\n"
+"| ------------------------ | ----------------------------------------------------------------------------------------------- |\n"
+"| `wxplot2d()`             | [plot2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot2d)               |\n"
+"| `wxplot3d()`             | [plot3d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot3d)               |\n"
+"| `wxdraw2d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw2d)               |\n"
+"| `wxdraw3d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw3d)               |\n"
+"| `wxdraw()`               | [draw](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw)                   |\n"
+"| `wximplicit_plot()`      | [implicit_plot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#implicit_plot) |\n"
+"| `wxhistogram()`          | [histogram](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#histogram)         |\n"
+"| `wxscatterplot()`        | [scatterplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#scatterplot)     |\n"
+"| `wxbarsplot()`           | [barsplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#barsplot)           |\n"
+"| `wxpiechart()`           | [piechart](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#piechart)           |\n"
+"| `wxboxplot()`            | [boxplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#boxplot)             |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:522
+msgid ""
+"If a `wxm`-file is read by (console) Maxima, these functions are ignored "
+"(and printed as output, as other unknown functions in Maxima)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:524
+msgid ""
+"If you got problems with one of these functions, please check, if the "
+"problem exists in the the Maxima function too (e.g. you got an error with "
+"`wxplot2d()`, check the same plot in the Maxima command `plot2d()` (which "
+"opens the plot in a separate Window)). If the problem does not disappear, it "
+"is most likely a Maxima issue and should be reported in the [Maxima "
+"bugtracker](https://sourceforge.net/p/maxima/bugs/). Or maybe a Gnuplot "
+"issue."
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:525
+#, fuzzy, no-wrap
+#| msgid "Making embedded plots bigger or smaller"
+msgid "Making embedded plots bigger or smaller"
+msgstr "Збільшення або зменшення вбудованих креслень"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:528
+msgid ""
+"As noted above, the configure dialog provides a way to change the default "
+"size plots created which sets the starting value of `wxplot_size`. The "
+"plotting routines of _wxMaxima_ respect this variable that specifies the "
+"size of a plot in pixels. It can always be queried or used to set the size "
+"of the following plots:"
+msgstr ""
+"Як ми вже згадували вище, діалогове вікно налаштовування надає змогу змінити "
+"типові розміри креслень. Унаслідок застосування цього способу змінюється "
+"початкове значення `wxplot_size`. Підпрограми створення креслень _wxMaxima_ "
+"враховують це значення, яке визначає розмір креслення у пікселях. Це "
+"значення завжди можна отримати або використати для встановлення розмірів "
+"наступних креслень:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:529
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxplot_size:[1200,800]$\n"
+#| "wxdraw2d(\n"
+#| "    explicit(\n"
+#| "        sin(x),\n"
+#| "        x,1,10\n"
+#| "    )\n"
+#| ")$\n"
+msgid ""
+"wxplot_size:[1200,800]$\n"
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+")$\n"
+msgstr ""
+"wxplot_size:[1200,800]$\n"
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+")$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:540
+msgid ""
+"If the size of only one plot is to be changed _Maxima_ provides a canonical "
+"way to change an attribute only for the current cell. In this usage the "
+"specification `wxplot_size = [value1, value2]` is appended to the "
+"`wxdraw2d( )` command, and is not part of the `wxdraw2d` command."
+msgstr ""
+"Якщо потрібно змінити розміри лише одного креслення, у _Maxima_ передбачено "
+"канонічний спосіб зміни атрибута лише для поточної комірки. У цьому випадку "
+"до команди wxdraw2d( ) додається специфікація wxplot_size = [значення1, "
+"значення2], яка не є частиною команди wxdraw2d."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:541
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxdraw2d(\n"
+#| "    explicit(\n"
+#| "        sin(x),\n"
+#| "        x,1,10\n"
+#| "    )\n"
+#| "),wxplot_size=[1600,800]$\n"
+msgid ""
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+"),wxplot_size=[1600,800]$\n"
+msgstr ""
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+"),wxplot_size=[1600,800]$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:551
+msgid ""
+"Setting the size of embedded plot with `wxplot_size` works for embedded "
+"plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` "
+"commands and for embedded animations with `with_slider_draw` and `wxanimate` "
+"commands."
+msgstr ""
+"Встановлення розміру вбудованого креслення за допомогою `wxplot_size` працює "
+"для вбудованих креслень, які використовують, наприклад, команди `wxplot`, "
+"`wxdraw`, `wxcontour_plot` і `wximplicit_plot`, і для вбудованих анімацій, "
+"які використовують команди `with_slider_draw` і `wxanimate`."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:552
+#, fuzzy, no-wrap
+#| msgid "Better quality plots"
+msgid "Better quality plots"
+msgstr "Креслення кращої якості"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:555
+#, fuzzy
+#| msgid ""
+#| "_Gnuplot_ doesn’t seem to provide a portable way of determining whether "
+#| "it supports the high-quality bitmap output that the Cairo library "
+#| "provides. On systems where _gnuplot_ is compiled to use this library the "
+#| "pngCairo option from the configuration menu (that can be overridden by "
+#| "the variable `wxplot_pngcairo`) enables support for antialiasing and "
+#| "additional line styles. If `wxplot_pngCairo` is set without _gnuplot_ "
+#| "supporting this the result will be error messages instead of graphics."
+msgid ""
+"_Gnuplot_ doesn’t seem to provide a portable way of determining whether it "
+"supports the high-quality bitmap output that the Cairo library provides. On "
+"systems where _Gnuplot_ is compiled to use this library the pngCairo option "
+"from the configuration menu (that can be overridden by the variable "
+"`wxplot_pngcairo`) enables support for antialiasing and additional line "
+"styles. If `wxplot_pngCairo` is set without _Gnuplot_ supporting this the "
+"result will be error messages instead of graphics."
+msgstr ""
+"_Gnuplot_, здається, не надає придатного до портування на різні платформи "
+"способу визначення, чи передбачено у програмі підтримку виведення даних у "
+"форматі високоякісного растрового зображення з використанням бібліотеки "
+"cairo. У системах, де _gnuplot_ зібрано з використанням відповідної "
+"бібліотеки, пункт pngCairo у меню налаштовування (який може бути "
+"перевизначено за допомогою змінної `wxplot_pngcairo`) вмикає підтримку "
+"згладжування та додаткових стилів ліній. Якщо встановлено `wxplot_pngCairo` "
+"без підтримки у _gnuplot_, результатом буде повідомлення про помилку замість "
+"графіка."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:556
+#, fuzzy, no-wrap
+#| msgid "Opening embedded plots in interactive _gnuplot_ windows"
+msgid "Opening embedded plots in interactive _Gnuplot_ windows"
+msgstr "Відкриття вбудованих креслень в інтерактивних вікнах _gnuplot_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:559
+#, fuzzy
+#| msgid ""
+#| "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
+#| "`wxplot3d` isn't supported by this feature) and the file size of the "
+#| "underlying _gnuplot_ project isn't way too high _wxMaxima_ offers a right-"
+#| "click menu that allows to open the plot in an interactive _gnuplot_ "
+#| "window."
+msgid ""
+"If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
+"`wxplot3d` isn’t supported by this feature) and the file size of the "
+"underlying _Gnuplot_ project isn’t way too high _wxMaxima_ offers a right-"
+"click menu that allows to open the plot in an interactive _Gnuplot_ window."
+msgstr ""
+"Якщо креслення було створено за допомогою команд типу `wxdraw` (у `wxplot2d` "
+"і `wxplot3d` підтримки цієї можливості не передбачено), і розмір файла "
+"базового проєкту _gnuplot_ не є надто великим, _wxMaxima_ пропонує "
+"контекстне меню, за допомогою якого можна відкрити креслення у "
+"інтерактивному вікні _gnuplot_."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:560
+#, fuzzy, no-wrap
+#| msgid "Opening gnuplot's command console in `plot` windows"
+msgid "Opening Gnuplot’s command console in `plot` windows"
+msgstr "Відкриття консолі команд gnuplot у вікнах `plot`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:564
+#, fuzzy
+#| msgid ""
+#| "On MS Windows, if in _Maxima_'s variable `gnuplot_command` \"gnuplot\" is "
+#| "replaced by \"wgnuplot\", _gnuplot_ offers the possibility to open a "
+#| "console window, where _gnuplot_ commands can be entered into. "
+#| "Unfortunately, enabling this feature causes _gnuplot_ to \"steal\" the "
+#| "keyboard focus for a short time every time a plot is prepared."
+msgid ""
+"On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and `wgnuplot."
+"exe`.  You can configure, which command should be used using the "
+"configuration menu. `wgnuplot.exe` offers the possibility to open a console "
+"window, where _gnuplot_ commands can be entered into, `gnuplot.exe` does not "
+"offer this possibility. Unfortunately, `wgnuplot.exe` causes _Gnuplot_ to "
+"\"steal\" the keyboard focus for a short time every time a plot is prepared."
+msgstr ""
+"У MS Windows, якщо у змінній _Maxima_ `gnuplot_command` замінити «gnuplot» "
+"на «wgnuplot», _gnuplot_ запропонує можливість відкрити вікно консолі, у "
+"якому ви зможете вводити команди _gnuplot_. На жаль, вмикання цієї "
+"можливості призводить до того, що _gnuplot_ на короткий період «викрадає» "
+"фокусування клавіатури кожного разу, коли готується креслення."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:565
+#, fuzzy, no-wrap
+#| msgid "Embedding animations into the spreadsheet"
+msgid "Embedding animations into the spreadsheet"
+msgstr "Вбудовування анімацій до робочого аркуша"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:568
+msgid ""
+"3D diagrams tend to make it hard to read quantitative data. A viable "
+"alternative might be to assign the 3rd parameter to the mouse wheel. The "
+"`with_slider_draw` command is a version of `wxdraw2d` that does prepare "
+"multiple plots and allows to switch between them by moving the slider on top "
+"of the screen. _WxMaxima_ allows to export this animation as an animated gif."
+msgstr ""
+"На просторових креслення доволі важко читати кількісні дані. Альтернативним "
+"рішенням є прив'язка третього параметра до коліщатка миші. Команда "
+"`with_slider_draw` є версією `wxdraw2d`, яка готує декілька креслень і надає "
+"змогу перемикатися між ними пересуванням повзунка у верхній частині вікна. "
+"_WxMaxima_ надає змогу експортувати анімацію у форматі анімації gif."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:570
+msgid ""
+"The first two arguments for `with_slider_draw` are the name of the variable "
+"that is stepped between the plots and a list of the values of these "
+"variable. The arguments that follow are the ordinary arguments for "
+"`wxdraw2d`:"
+msgstr ""
+"Першими двома аргументами `with_slider_draw` є назва змінної, яка покроково "
+"змінюватиметься між кресленнями, і список значень цієї змінної. Наступними "
+"аргументами є звичайні аргументи `wxdraw2d`:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:571
+#, fuzzy, no-wrap
+#| msgid ""
+#| "with_slider_draw(\n"
+#| "    f,[1,2,3,4,5,6,7,10],\n"
+#| "    title=concat(\"f=\",f,\"Hz\"),\n"
+#| "    explicit(\n"
+#| "        sin(2*%pi*f*x),\n"
+#| "        x,0,1\n"
+#| "    ),grid=true\n"
+#| ");\n"
+msgid ""
+"with_slider_draw(\n"
+"    f,[1,2,3,4,5,6,7,10],\n"
+"    title=concat(\"f=\",f,\"Hz\"),\n"
+"    explicit(\n"
+"        sin(2*%pi*f*x),\n"
+"        x,0,1\n"
+"    ),grid=true\n"
+");\n"
+msgstr ""
+"with_slider_draw(\n"
+"    f,[1,2,3,4,5,6,7,10],\n"
+"    title=concat(\"f=\",f,\"Hz\"),\n"
+"    explicit(\n"
+"        sin(2*%pi*f*x),\n"
+"        x,0,1\n"
+"    ),grid=true\n"
+");\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:583
+msgid ""
+"The same functionality for 3D plots is accessible as `with_slider_draw3d`, "
+"which allows for rotating 3d plots:"
+msgstr ""
+"Доступ до тих самих можливостей для просторових креслень можна отримати за "
+"допомогою функції `with_slider_draw3d`, яка надає можливість обертати "
+"просторові креслення:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:584
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxanimate_autoplay:true;\n"
+#| "wxanimate_framerate:20;\n"
+#| "with_slider_draw3d(\n"
+#| "    α,makelist(i,i,1,360,3),\n"
+#| "    title=sconcat(\"α=\",α),\n"
+#| "    surface_hide=true,\n"
+#| "    contour=both,\n"
+#| "    view=[60,α],\n"
+#| "    explicit(\n"
+#| "        sin(x)*sin(y),\n"
+#| "        x,-π,π,\n"
+#| "        y,-π,π\n"
+#| "    )\n"
+#| ")$\n"
+msgid ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    α,makelist(i,i,1,360,3),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,α],\n"
+"    explicit(\n"
+"        sin(x)*sin(y),\n"
+"        x,-π,π,\n"
+"        y,-π,π\n"
+"    )\n"
+")$\n"
+msgstr ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    α,makelist(i,i,1,360,3),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,α],\n"
+"    explicit(\n"
+"        sin(x)*sin(y),\n"
+"        x,-π,π,\n"
+"        y,-π,π\n"
+"    )\n"
+")$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:602
+msgid ""
+"If the general shape of the plot is what matters it might suffice to move "
+"the plot just a little bit in order to make its 3D nature available to the "
+"intuition:"
+msgstr ""
+"Якщо важливою є загальна форма креслення, може бути достатнім трошки "
+"пересунути креслення з метою зробити його просторову природу інтуїтивно "
+"зрозумілою:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:603
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxanimate_autoplay:true;\n"
+#| "wxanimate_framerate:20;\n"
+#| "with_slider_draw3d(\n"
+#| "    t,makelist(i,i,0,2*π,.05*π),\n"
+#| "    title=sconcat(\"α=\",α),\n"
+#| "    surface_hide=true,\n"
+#| "    contour=both,\n"
+#| "    view=[60,30+5*sin(t)],\n"
+#| "    explicit(\n"
+#| "        sin(x)*y^2,\n"
+#| "        x,-2*π,2*π,\n"
+#| "        y,-2*π,2*π\n"
+#| "    )\n"
+#| ")$\n"
+msgid ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    t,makelist(i,i,0,2*π,.05*π),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,30+5*sin(t)],\n"
+"    explicit(\n"
+"        sin(x)*y^2,\n"
+"        x,-2*π,2*π,\n"
+"        y,-2*π,2*π\n"
+"    )\n"
+")$\n"
+msgstr ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    t,makelist(i,i,0,2*π,.05*π),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,30+5*sin(t)],\n"
+"    explicit(\n"
+"        sin(x)*y^2,\n"
+"        x,-2*π,2*π,\n"
+"        y,-2*π,2*π\n"
+"    )\n"
+")$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:621
+msgid ""
+"For those more familiar with `plot` than with `draw`, there is a second set "
+"of functions:"
+msgstr ""
+"Для тих, хто знайомий більше з `plot`, аніж з `draw`, другий набір функцій:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:624
+#, fuzzy
+#| msgid "`with_slider` and"
+msgid "`with_slider` and"
+msgstr "`with_slider` і"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:624
+msgid "`wxanimate`."
+msgstr "`wxanimate`."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:626
+msgid ""
+"Normally the animations are played back or exported with the frame rate "
+"chosen in the configuration of _wxMaxima_. To set the speed at an individual "
+"animation is played back the variable `wxanimate_framerate` can be used:"
+msgstr ""
+"Зазвичай, анімації відтворюються і експортуються із частотою кадрів, яку "
+"можна вибрати у налаштуваннях _wxMaxima_. Щоб встановити швидкість "
+"відтворення окремої анімації, можна скористатися змінною "
+"`wxanimate_framerate`:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:627
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxanimate(a, 10,\n"
+#| "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+msgid ""
+"wxanimate(a, 10,\n"
+"    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+msgstr ""
+"wxanimate(a, 10,\n"
+"    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:633
+#, fuzzy
+#| msgid ""
+#| "The animation functions use _Maxima_'s `makelist` command and therefore "
+#| "share the pitfall that the slider variable's value is substituted into "
+#| "the expression only if the variable is directly visible in the "
+#| "expression. Therefore the following example will fail:"
+msgid ""
+"The animation functions use _Maxima_’s `makelist` command and therefore "
+"share the pitfall that the slider variable’s value is substituted into the "
+"expression only if the variable is directly visible in the expression. "
+"Therefore the following example will fail:"
+msgstr ""
+"Функції анімації використовують команду _maxima_ `makelist` і тому мають "
+"спільну ваду — значення змінної повзунка замінюється на вираз, лише якщо "
+"змінна є безпосередньо видимою у виразі. Тому такий приклад не працюватиме:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:634
+#, fuzzy, no-wrap
+#| msgid ""
+#| "f:sin(a*x);\n"
+#| "with_slider_draw(\n"
+#| "    a,makelist(i/2,i,1,10),\n"
+#| "    title=concat(\"a=\",float(a)),\n"
+#| "    grid=true,\n"
+#| "    explicit(f,x,0,10)\n"
+#| ")$\n"
+msgid ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    a,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(a)),\n"
+"    grid=true,\n"
+"    explicit(f,x,0,10)\n"
+")$\n"
+msgstr ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    a,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(a)),\n"
+"    grid=true,\n"
+"    explicit(f,x,0,10)\n"
+")$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:645
+#, fuzzy
+#| msgid ""
+#| "If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
+#| "works fine instead:"
+msgid ""
+"If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
+"works fine instead:"
+msgstr ""
+"А якщо _Maxima_ явно попросити підставити значення повзунка, креслення "
+"працюватиме як слід:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:646
+#, fuzzy, no-wrap
+#| msgid ""
+#| "f:sin(a*x);\n"
+#| "with_slider_draw(\n"
+#| "    b,makelist(i/2,i,1,10),\n"
+#| "    title=concat(\"a=\",float(b)),\n"
+#| "    grid=true,\n"
+#| "    explicit(\n"
+#| "        subst(a=b,f),\n"
+#| "        x,0,10\n"
+#| "    )\n"
+#| ")$\n"
+msgid ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    b,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(b)),\n"
+"    grid=true,\n"
+"    explicit(\n"
+"        subst(a=b,f),\n"
+"        x,0,10\n"
+"    )\n"
+")$\n"
+msgstr ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    b,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(b)),\n"
+"    grid=true,\n"
+"    explicit(\n"
+"        subst(a=b,f),\n"
+"        x,0,10\n"
+"    )\n"
+")$\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:659
+#, fuzzy, no-wrap
+#| msgid "Opening multiple plots in contemporaneous windows"
+msgid "Opening multiple plots in contemporaneous windows"
+msgstr "Відкриття декількох креслень у вікнах одночасно"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:662
+msgid ""
+"While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups "
+"that support it) sometimes comes in handily. The following example comes "
+"from a post from Mario Rodriguez to the _Maxima_ mailing list:"
+msgstr ""
+"Хоча _wxMaxima_ не надає доступу до цієї можливості, ця функція _Maxima_ (у "
+"конфігураціях, де передбачено її підтримку) іноді є дуже зручною. Наведений "
+"нижче приклад походить із допису Маріо Родрігеса (Mario Rodriguez) у списку "
+"листування _Maxima_:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:663
+#, no-wrap
+msgid ""
+"load(draw);\n"
+"\n"
+"/* Parabola in window #1 */\n"
+"draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Parabola in window #2 */\n"
+"draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Paraboloid in window #3 */\n"
+"draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:677
+msgid ""
+"Plotting multiple plots in the same window is possible, too (the same is "
+"possible in command line Maxima with the standard `draw()` command):"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:678
+#, fuzzy, no-wrap
+#| msgid ""
+#| "\twxdraw(\n"
+#| "\t\tgr2d(\n"
+#| "\t    \tkey=\"sin (x)\",grid=[2,2],\n"
+#| "\t    \texplicit(sin(x),x,0,2*%pi)),\n"
+#| "\t\tgr2d(\n"
+#| "\t   \tkey=\"cos (x)\",grid=[2,2],\n"
+#| "\t   \texplicit(cos(x),x,0,2*%pi))\n"
+#| "\t );\n"
+msgid ""
+"wxdraw(\n"
+"  gr2d(\n"
+"    key=\"sin (x)\",grid=[2,2],\n"
+"    explicit(sin(x),x,0,2*%pi)),\n"
+"  gr2d(\n"
+"    key=\"cos (x)\",grid=[2,2],\n"
+"    explicit(cos(x),x,0,2*%pi))\n"
+");\n"
+msgstr ""
+"\twxdraw(\n"
+"\t\tgr2d(\n"
+"\t    \tkey=\"sin (x)\",grid=[2,2],\n"
+"\t    \texplicit(sin(x),x,0,2*%pi)),\n"
+"\t\tgr2d(\n"
+"\t   \tkey=\"cos (x)\",grid=[2,2],\n"
+"\t   \texplicit(cos(x),x,0,2*%pi))\n"
+"\t );\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:689
+#, fuzzy, no-wrap
+#| msgid "The \"Plot using draw\" side pane"
+msgid "The \"Plot using draw\" side pane"
+msgstr "Бічна панель «Накреслити за допомогою Draw»"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:692
+msgid ""
+"The \"Plot using draw\" sidebar hides a simple code generator that allows "
+"generating scenes that make use of some of the flexibility of the _draw_ "
+"package _maxima_ comes with."
+msgstr ""
+"Бічна панель «Накреслити за допомогою Draw» приховує простий генератор коду, "
+"який уможливлює створення сцен, які використовують певну гнучкість пакунка "
+"_draw_, з яким постачається _maxima_."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:693
+#, no-wrap
+msgid "2D"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:696
+#, fuzzy
+#| msgid ""
+#| "Generates the skeleton of a `draw()` command that draws a 2D scene. This "
+#| "scene later has to be filled with commands that generate the scene's "
+#| "contents, for example by using the buttons in the rows below the \"2D\" "
+#| "button."
+msgid ""
+"Generates the skeleton of a `draw()` command that draws a 2D scene. This "
+"scene later has to be filled with commands that generate the scene’s "
+"contents, for example by using the buttons in the rows below the \"2D\" "
+"button."
+msgstr ""
+"Створює каркас команди `draw()`, яка малює плоску сцену. Цю сцену пізніше "
+"може бути заповнено за допомогою команд, які створюють вміст сцени, "
+"наприклад, за допомогою кнопок у рядках під кнопкою «Плоский»."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:698
+msgid ""
+"One helpful feature of the 2D button is that it allows to set up the scene "
+"as an animation in which a variable (by default it is _t_) has a different "
+"value in each frame: Often a moving 2D plot allows easier interpretation "
+"than the same data in a non-moving 3D one."
+msgstr ""
+"Однією з корисних можливостей кнопки «Плоский» є те, що вона надає змогу "
+"налаштувати сцену як анімацію, у якій змінна (типовою змінною є _t_) має "
+"різне значення для кожного з кадрів: часто динамічне плоске креслення надає "
+"змогу простіше інтерпретувати дані за ті самі у формі нерухомого "
+"просторового креслення."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:699
+#, no-wrap
+msgid "3D"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:702
+msgid ""
+"Generates the skeleton of a `draw()` command that draws a 3D scene. If "
+"neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D "
+"scene that contains the command the button generates."
+msgstr ""
+"Створює каркас команди `draw()`, яка малює просторову сцену. Якщо не "
+"налаштовано ні двовимірну, ні тривимірну сцену, усі інші кнопки "
+"налаштовуватимуть двовимірну сцену, яка містить команду, яку створює кнопка."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:703
+#, fuzzy, no-wrap
+#| msgid "Expression"
+msgid "Expression"
+msgstr "Вираз"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:706
+msgid ""
+"Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or "
+"`x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is "
+"no draw command a 2D scene with the plot is generated. Each scene can be "
+"filled with any number of plots."
+msgstr ""
+"Додає стандартне креслення виразу, подібного до `sin(x)`, `x*sin(x)` або "
+"`x^2+2*x-4` до команди `draw()`, у якій зараз перебуває курсор. Якщо команди "
+"draw немає, буде створено двовимірну сцену із кресленням. Кожну сцену можна "
+"заповнити довільною кількістю креслень."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:707
+#, fuzzy, no-wrap
+#| msgid "Implicit plot"
+msgid "Implicit plot"
+msgstr "Графік неявної функції"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:710
+msgid ""
+"Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or "
+"`x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command "
+"the cursor currently is in. If there is no draw command a 2D scene with the "
+"plot is generated."
+msgstr ""
+"Спробувати знайти усі точки, у яких справджуються вирази, подібні до "
+"`y=sin(x)`, `y*sin(x)=3` або `x^2+y^2=4`, і накреслити криву-результат за "
+"допомогою команди `draw()` у поточній позиції курсора. Якщо команди draw "
+"виявлено не буде, буде створено плоску сцену із кресленням."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:711
+#, fuzzy, no-wrap
+#| msgid "Parametric plot"
+msgid "Parametric plot"
+msgstr "Графік параметричної функції"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:714
+msgid ""
+"Steps a variable from a lower limit to an upper limit and uses two "
+"expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in "
+"3D plots also z) coordinates of a curve that is put into the current draw "
+"command."
+msgstr ""
+"Покроково проходить змінну від нижньої межі до верхньої межі і використовує "
+"два виразу, подібні до `t*sin(t)` і `t*cos(t)` для створення координат точок "
+"x, y (у просторових кресленнях використовується і z) кривої, які буде "
+"передано до поточної команди draw."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:715
+#, fuzzy, no-wrap
+#| msgid "Points"
+msgid "Points"
+msgstr "Точки"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:718
+msgid ""
+"Draws many points that can optionally be joined. The coordinates of the "
+"points are taken from a list of lists, a 2D array or one list or array for "
+"each axis."
+msgstr ""
+"Малює точки, які, якщо вказано, буде з'єднано. Координати точок буде взято "
+"зі списку списків, двовимірного масиву або списку масивів для кожної з осей."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:719
+#, fuzzy, no-wrap
+#| msgid "Diagram title"
+msgid "Diagram title"
+msgstr "Заголовок діаграми"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:722
+msgid "Draws a title on the upper end of the diagram,"
+msgstr "Малює заголовок у верхній частині діаграми,"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:723
+#, fuzzy, no-wrap
+#| msgid "Axis"
+msgid "Axis"
+msgstr "Вісь"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:726
+msgid "Sets up the axis."
+msgstr "Налаштовує вісі."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:727
+#, fuzzy, no-wrap
+#| msgid "Contour"
+msgid "Contour"
+msgstr "Контур"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:730
+msgid ""
+"(Only for 3D plots): Adds contour lines similar to the ones one can find in "
+"a map of a mountain to the plot commands that follow in the current `draw()` "
+"command and/or to the ground plane of the diagram. Alternatively, this "
+"wizard allows skipping drawing the curves entirely only showing the contour "
+"plot."
+msgstr ""
+"(Лише для просторових креслень) Додає контурні лінії, подібні до тих, які "
+"можна знайти на карті висот, до команд креслення, які йдуть за нею у "
+"поточній команді «draw()» і/або до площини основи діаграми. Крім того, цей "
+"майстер надає змогу повністю пропустити малювання кривих і показати лише "
+"контурне креслення."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:731
+#, fuzzy, no-wrap
+#| msgid "Plot name"
+msgid "Plot name"
+msgstr "Назва графіка"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:734
+#, fuzzy
+#| msgid ""
+#| "Adds a legend entry showing the next plot's name to the legend of the "
+#| "diagram. An empty name disables generating legend entries for the "
+#| "following plots."
+msgid ""
+"Adds a legend entry showing the next plot’s name to the legend of the "
+"diagram. An empty name disables generating legend entries for the following "
+"plots."
+msgstr ""
+"Додає запис умовних позначень із назвою наступного креслення на панель "
+"умовних позначень діаграми. Порожнє значення назви вимикає створення записів "
+"умовних позначень для наступних креслень."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:735
+#, fuzzy, no-wrap
+#| msgid "Line colour"
+msgid "Line colour"
+msgstr "Колір лінії"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:738
+msgid ""
+"Sets the line colour for the following plots the current draw command "
+"contains."
+msgstr ""
+"Встановлює колір лінії для наступних креслень у поточній команді малювання."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:739
+#, fuzzy, no-wrap
+#| msgid "Fill colour"
+msgid "Fill colour"
+msgstr "Колір заповнення"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:742
+msgid ""
+"Sets the fill colour for the following plots the current draw command "
+"contains."
+msgstr ""
+"Встановлює колір заповнення для наступних креслень у поточній команді "
+"малювання."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:743
+#, fuzzy, no-wrap
+#| msgid "Grid"
+msgid "Grid"
+msgstr "Сітка"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:746
+msgid "Pops up a wizard that allows to set up grid lines."
+msgstr ""
+"Відкриває допоміжне вікно, за допомогою якого можна налаштувати лінії сітки."
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:747
+#, fuzzy, no-wrap
+#| msgid "Accuracy"
+msgid "Accuracy"
+msgstr "Точність"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:750
+msgid ""
+"Allows to select an adequate point in the speed vs. accuracy tradeoff that "
+"is part of any plot program."
+msgstr ""
+"Надає змогу вибрати адекватну позицію у компромісному питанні «швидкість чи "
+"точність?», яке є частиною будь-якої програми для креслення."
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:751
+#, no-wrap
+msgid "Modify font and font size for plots"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:754
+msgid ""
+"Especially when you use a high resolution display, the default font size "
+"might be very small. For the `draw`-based commands, you can set the font / "
+"font size using options like `font=...`, `font_size=...`, e.g.:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:755
+#, fuzzy, no-wrap
+#| msgid ""
+#| "pngdraw2d(\"Test\",\n"
+#| "        explicit(sin(x),x,1,10)\n"
+#| ");\n"
+#| "~~~\n"
+msgid ""
+"wxdraw2d(\n"
+"     font=\"Helvetica\",\n"
+"     font_size=30,\n"
+"     explicit(sin(x),x,1,10));\n"
+msgstr ""
+"wxdraw2d(\n"
+"    file_name=\"test\",\n"
+"    explicit(sin(x),x,1,10)\n"
+");\n"
+"~~~\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:763
+msgid ""
+"For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts "
+"can be set using the `gnuplot_preamble` command, e.g.:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:764
+#, no-wrap
+msgid ""
+"wxplot2d(sin(x),[x,1,10],\n"
+"         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:770
+msgid ""
+"This sets the font for the numbers to Arial with size 30, the size for the "
+"xlabel and ylabel font to 20 (with the default font)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:773
+msgid ""
+"Read the Maxima and Gnuplot documentation for further information.  Note: "
+"Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue "
+"1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966)."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:774
+#, fuzzy, no-wrap
+#| msgid "Embedding graphics"
+msgid "Embedding graphics"
+msgstr "Вбудовування графіків"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:777
+#, fuzzy
+#| msgid ""
+#| "If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
+#| "project can be done as easily as per drag-and-drop. But sometimes (for "
+#| "example if an image’s contents might change later on in a session) it is "
+#| "better to tell the file to load the image on evaluation:"
+msgid ""
+"If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
+"project can be done as easily as per drag-and-drop. But sometimes (for "
+"example if an image’s contents might change later on in a session) it is "
+"better to tell the file to load the image on evaluation:"
+msgstr ""
+"Якщо використано формат файлів `.wxmx`, вбудовування файлів до проєкту "
+"_wxMaxima_ можна виконати простим перетягуванням зі скиданням. Але іноді "
+"(наприклад, якщо вміст зображення може бути змінено згодом протягом роботи у "
+"сеансі), краще наказати програмі завантажувати файл зображення при обробці "
+"команд:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:778
+#, fuzzy, no-wrap
+#| msgid "show_image(\"man.png\");\n"
+msgid "show_image(\"man.png\");\n"
+msgstr "show_image(\"man.png\");\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:782
+#, fuzzy, no-wrap
+#| msgid "Startup files"
+msgid "Startup files"
+msgstr "Файли запуску"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:785
+msgid ""
+"The config dialogue of _wxMaxima_ offers to edit two files with commands "
+"that are executed on startup:"
+msgstr ""
+"У діалоговому вікні налаштовування _wxMaxima_ передбачено можливість "
+"редагування двох файлів із командами, які виконуються під час запуску "
+"програми:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:788
+msgid ""
+"A file that contains commands that are executed on starting up _Maxima_: "
+"`maxima-init.mac`"
+msgstr ""
+"Файла, у якому містяться команди, які виконуються під час запуску _Maxima_: "
+"`maxima-init.mac`"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:788
+#, fuzzy
+#| msgid ""
+#| "A file that contains commands that are executed on starting up _Maxima_: "
+#| "`maxima-init.mac`"
+msgid ""
+"one file of additional commands that are executed if _wxMaxima_ is starting "
+"_Maxima_: `wxmaxima-init.mac`"
+msgstr ""
+"Файла, у якому містяться команди, які виконуються під час запуску _Maxima_: "
+"`maxima-init.mac`"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:790
+msgid ""
+"For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add "
+"`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` "
+"or any other path) to these files."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:792
+#, fuzzy
+#| msgid ""
+#| "These files are in the Maxima user directory (usually `maxima` in "
+#| "Windows, `.maxima` otherwise) in the user's home directory / user profile "
+#| "directory. The location can be found out with the command: "
+#| "`maxima_userdir;`"
+msgid ""
+"These files are in the Maxima user directory (usually `%USERPROFILE%/maxima` "
+"in Windows, `$HOME/.maxima` otherwise). The location can be found out with "
+"the command: `maxima_userdir;`"
+msgstr ""
+"Ці файли зберігаються у каталозі користувача Maxima (зазвичай, каталозі "
+"`maxima` у Windows, `.maxima/` у інших системах) у домашній теці "
+"користувача. Розташування файлів можна визначити за допомогою такої команди: "
+"`maxima_userdir;`"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:793
+#, fuzzy, no-wrap
+#| msgid "Special variables wx..."
+msgid "Special variables wx..."
+msgstr "Спеціальні змінні wx..."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxsubscripts` tells _Maxima_ if it should convert variable names that "
+"contain an underscore (`R_150` or the like) into subscripted variables. See "
+"`wxdeclare_subscript` for details which variable names are automatically "
+"converted."
+msgstr ""
+"`wxsubscripts` вказує _Maxima_, чи слід перетворювати назви змінних, які "
+"містять символ підкреслювання (`R_150` або подібні змінні) на змінні із "
+"нижніми індексами. Див. `wxdeclare_subscript`, щоб дізнатися більше про те, "
+"які саме назви змінних буде перетворено автоматично."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxfilename`: This variable contains the name of the file currently opened "
+"in _wxMaxima_."
+msgstr ""
+"`wxfilename`: у цій змінній зберігається назва файла, який зараз відкрито у "
+"_wxMaxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirname`: This variable contains the name the directory, in which the "
+"file currently opened in _wxMaxima_ is."
+msgstr ""
+"`wxdirname`: у цій змінній зберігається назва каталогу, у якому зберігається "
+"поточний відкритий _wxMaxima_ файл."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+#, fuzzy
+#| msgid ""
+#| "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _gnuplot_’s "
+#| "pngcairo terminal that provides more line styles and a better overall "
+#| "graphics quality."
+msgid ""
+"`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_’s pngcairo "
+"terminal that provides more line styles and a better overall graphics "
+"quality."
+msgstr ""
+"`wxplot_pngcairo` визначає те, чи намагатиметься _wxMaxima_ скористатися "
+"терміналом pngcairo _gnuplot_, який надає доступ до ширшого вибору стилів "
+"ліній та кращої якості зображення."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxplot_size` defines the resolution of embedded plots."
+msgstr "`wxplot_size` визначає роздільну здатність для вбудованих креслень."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+#, fuzzy
+#| msgid ""
+#| "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
+#| "_Maxima_’s working directory to the directory of the current file. This "
+#| "allows file I/O (e.g. by `read_matrix`) to work without specifying the "
+#| "whole path to the file that has to be read or written. On Windows this "
+#| "feature sometimes causes error messages and therefore can be set to "
+#| "`false` from the config dialogue."
+msgid ""
+"`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
+"_Maxima_’s working directory to the directory of the current file. This "
+"allows file I/O (e.g. by `read_matrix`) to work without specifying the whole "
+"path to the file that has to be read or written. On Windows this feature "
+"sometimes causes error messages and therefore can be set to `false` from the "
+"config dialogue."
+msgstr ""
+"`wxchangedir`: у більшості операційних систем _wxMaxima_ автоматично "
+"встановлює для робочого каталогу _Maxima_ каталог поточного файла. Це "
+"уможливлює роботу введення-виведення до файла (наприклад, за допомогою "
+"`read_matrix`) без визначення усього шляху до файла, який має бути прочитано "
+"або записано. У Windows ця можливість іноді спричиняє повідомлення про "
+"помилку, тому варто встановити для цього параметра значення `false` у "
+"діалоговому вікні налаштовування."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxanimate_framerate`: The number of frames per second the following "
+"animations have to be played back with."
+msgstr ""
+"`wxanimate_framerate`: частота у кадрах на секунду, із якою "
+"відтворюватимуться наступі анімації."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxanimate_autoplay`: Automatically play animations by default?"
+msgstr "`wxanimate_autoplay`: типово автоматично відтворювати анімації?"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
+msgstr "`wxmaximaversion`: повертає номер версії _wxMaxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
+msgstr ""
+"`wxwidgetsversion`: повертає версію wxWidgets, яку використано у _wxMaxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these "
+"differ by maintainer, distribution and operating system:"
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@userconfdir`: The directory the user's configuration is stored in. "
+"Same directory as `maxima_userdir` (see above) - both point at the same "
+"place, `wxdirs@userconfdir` is only useful if that is more convenient to "
+"reach from a `.mac` file than the Maxima-side variable."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the built-in "
+"autocompletion list, ...) is installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@helpdir`: The directory the offline copy of this manual is installed "
+"in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@localedir`: The directory _wxMaxima_'s translation files are "
+"installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_ is "
+"configured to start."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:812
+#, fuzzy, no-wrap
+#| msgid "Pretty-printing 2D output"
+msgid "Pretty-printing 2D output"
+msgstr "Структурний друк двовимірних даних"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:815
+#, fuzzy
+#| msgid ""
+#| "The function `table_form()` displays a 2D list in a form that is more "
+#| "readable than the output from _Maxima_’s default output routine. The "
+#| "input is a list of one or more lists. Like the \"print\" command, this "
+#| "command displays output even when ended with a dollar sign. Ending the "
+#| "command with a semicolon results in the same table along with a \"done\" "
+#| "statement."
+msgid ""
+"The function `table_form()` displays a 2D list in a form that is more "
+"readable than the output from _Maxima_’s default output routine. The input "
+"is a list of one or more lists. Like the \"print\" command, this command "
+"displays output even when ended with a dollar sign. Ending the command with "
+"a semicolon results in the same table along with a \"done\" statement."
+msgstr ""
+"Функція `table_form()` показує двовимірний список у формі, яка є зручнішою "
+"для читання, за виведені дані типової підпрограми виведення даних _Maxima_. "
+"Вхідними даними є список одного або декількох списків. Подібно до команди "
+"друку, ця команда виводить дані, навіть якщо її завершити символом долара. "
+"Завершення команди символом крапки з комою призводить до виведення тієї "
+"самої таблиці разом із інструкцією «done»."
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:816
+#, fuzzy, no-wrap
+#| msgid ""
+#| "table_form(\n"
+#| "    [\n"
+#| "        [1,2],\n"
+#| "        [3,4]\n"
+#| "    ]\n"
+#| ")$\n"
+msgid ""
+"table_form(\n"
+"    [\n"
+"        [1,2],\n"
+"        [3,4]\n"
+"    ]\n"
+")$\n"
+msgstr ""
+"table_form(\n"
+"    [\n"
+"        [1,2],\n"
+"        [3,4]\n"
+"    ]\n"
+")$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:826
+msgid ""
+"As the next example shows, the lists that are assembled by the `table_form` "
+"command can be created before the command is executed."
+msgstr ""
+"Як показує наступний приклад, списки, які зібрано командою `table_form`, "
+"можна створювати до виконання команди."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:828
+msgid ""
+"![A third table example](./MatrixTableExample.png)"
+"{ id=img_MatrixTableExample }"
+msgstr ""
+"![Третій приклад таблиці](./MatrixTableExample.png)"
+"{ id=img_MatrixTableExample }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:830
+msgid ""
+"Also, because a matrix is a list of lists, matrices can be converted to "
+"tables in a similar fashion."
+msgstr ""
+"Крім того, оскільки матриця — список списків, матриці можна перетворювати на "
+"таблиці у подібний же спосіб."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:832
+msgid ""
+"![Another table_form example](./SecondTableExample.png)"
+"{ id=img_SecondTableExample }"
+msgstr ""
+"![Ще один приклад table_form](./SecondTableExample.png)"
+"{ id=img_SecondTableExample }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:834
+msgid ""
+"The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that "
+"allows for more flexible formatting of matrices in wxMaxima:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:836
+#, no-wrap
+msgid "**`wx_matrix( <matrix>, [options] )`**\n"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`lines=true`**: Draws internal separator lines between the cells. This is "
+"required to visually separate headings from data."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`rownames=true`**: Tells wxMaxima that the first column of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`colnames=true`**: Tells wxMaxima that the first row of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
+"around the matrix. Supported styles are: `round` `()`, `square` `[]`, "
+"`angled` `<>`, `straight` `||`, or `none`."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:843
+#, fuzzy
+#| msgid "One Example:"
+msgid "Example:"
+msgstr "Один приклад:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:844
+#, no-wrap
+msgid ""
+"wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
+"          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:849
+#, fuzzy, no-wrap
+#| msgid "Bug reporting"
+msgid "Bug reporting"
+msgstr "Звітування про вади"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:852
+msgid ""
+"_WxMaxima_ provides a few functions that gather bug reporting information "
+"about the current system:"
+msgstr ""
+"У _wxMaxima_ передбачено декілька функцій, які збирають дані щодо поточної "
+"системи для звітування щодо вад:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:855
+#, fuzzy
+#| msgid ""
+#| "`wxbuild_info()` gathers information about the currently running version "
+#| "of _wxMaxima_"
+msgid ""
+"`wxbuild_info()` gathers information about the currently running version of "
+"_wxMaxima_"
+msgstr ""
+"`wxbuild_info()` збирає відомості щодо поточної запущеної версії _wxMaxima_"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:855
+msgid "`wxbug_report()` tells how and where to file bugs"
+msgstr ""
+"`wxbug_report()` надає відомості щодо того, як і де слід повідомляти про вади"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:856
+#, fuzzy, no-wrap
+#| msgid "Marking output being drawn in red"
+msgid "Marking output being drawn in red"
+msgstr "Як зробити так, щоб виведені дані було показано червоним кольором?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:860
+#, fuzzy
+#| msgid ""
+#| "_Maxima_'s `box()` command causes _wxMaxima_ to print its argument with a "
+#| "red foreground, if the second argument to the command is the text "
+#| "`highlight`."
+msgid ""
+"_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a "
+"red foreground, if the second argument to the command is the text "
+"`highlight`."
+msgstr ""
+"Команда `box()` _Maxima_ призводити до того, що _wxMaxima_ виводить її "
+"аргумент червоним кольором, якщо другим аргументом команди є текст "
+"`highlight`."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:861
+#, no-wrap
+msgid "Output rendering."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:864
+msgid "With `set_display()` one can set, how wxMaxima will render the output."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:866
+msgid ""
+"`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima "
+"using an (machine readable) XML-dialect (can be seen in the \"Raw XML "
+"sidebar\") and outputs the resulting formulas nicely rendered, e.g. pretty "
+"Matrices, Square root signs, fractions, etc."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:869
+#, no-wrap
+msgid ""
+"<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->\n"
+"`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:871
+msgid ""
+"`set_display('none)` causes 'one-line' ASCII results - the same as the "
+"command line Maxima command `display2d:false;` does."
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:872
+#, no-wrap
+msgid "Help menu"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:875
+msgid ""
+"WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, "
+"tips, some example worksheets and in command line Maxima included demos (the "
+"`demo()` command)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:877
+msgid "Please notice, that the demos write:"
+msgstr ""
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:878
+#, no-wrap
+msgid "At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:883
+#, no-wrap
+msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:885
+#, no-wrap
+msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)\n"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:888
+#, fuzzy, no-wrap
+#| msgid "Troubleshooting"
+msgid "Troubleshooting"
+msgstr "Вирішення проблем"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:890
+#, fuzzy, no-wrap
+#| msgid "Cannot connect to _Maxima_"
+msgid "Cannot connect to _Maxima_"
+msgstr "Не вдається з'єднатися із _Maxima_"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:893
+#, fuzzy
+#| msgid ""
+#| "Since _Maxima_ (the program that does the actual mathematics) and "
+#| "_wxMaxima_ (providing the easy-to-use user interface) are separate "
+#| "programs that communicate by the means of a local network connection. "
+#| "Therefore the most probable cause is that this connection is somehow not "
+#| "working. For example, a firewall could be set up in a way that it doesn’t "
+#| "just prevent unauthorized connections from the internet (and perhaps "
+#| "intercept some connections to the internet, too), but also blocks inter-"
+#| "process-communication inside the same computer. Note that since _Maxima_ "
+#| "is being run by a Lisp processor the process communication that is "
+#| "blocked does not necessarily have to be named \"maxima\". Common names of "
+#| "the program that opens the network connection would be sbcl, gcl, ccl, "
+#| "lisp.exe, or similar names."
+msgid ""
+"Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ "
+"(providing the easy-to-use user interface) are separate programs that "
+"communicate by the means of a local network connection. Therefore the most "
+"probable cause is that this connection is somehow not working. For example, "
+"a firewall could be set up in a way that it doesn’t just prevent "
+"unauthorized connections from the internet (and perhaps intercept some "
+"connections to the internet, too), but also blocks inter-process-"
+"communication inside the same computer. Note that since _Maxima_ is being "
+"run by a Lisp processor the process communication that is blocked does not "
+"necessarily have to be named \"maxima\". Common names of the program that "
+"opens the network connection would be sbcl, gcl, ccl, lisp.exe, or similar "
+"names."
+msgstr ""
+"Оскільки _Maxima_ (програма, яка виконує самі обчислення) і _wxMaxima_ "
+"(програма, яка надає простий у користуванні інтерфейс користувача) є "
+"окремими програмами, які обмінюються даними за допомогою з'єднання локальною "
+"мережею. Тому найімовірнішою причиною є те, що це з'єднання чомусь не "
+"працює. Наприклад, брандмауер може бути налаштовано таким чином, що він не "
+"просто запобігає неуповноваженим з'єднання з інтернету (і, можливо, також "
+"перехоплює з'єднання із інтернетом), але і блокує обмін даними між процесами "
+"на тому самому комп'ютері. Зауважте, що оскільки _Maxima_ виконується "
+"процесором Lisp, процес. із яким блокується обмін даними, не обов'язково "
+"називається «maxima». Типовими назвами програм, які відкривають з'єднання "
+"мережі, можуть бути sbcl, gcl, ccl, lisp.exe або щось подібне."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:895
+#, fuzzy
+#| msgid ""
+#| "On Unix computers another possible reason would be that the loopback "
+#| "network that provides network connections between two programs in the "
+#| "same computer isn’t properly configured."
+msgid ""
+"On Unix computers another possible reason would be that the loopback network "
+"that provides network connections between two programs in the same computer "
+"isn’t properly configured."
+msgstr ""
+"У системах Unix іншою можливою причиною є те, що петльову мережу, яка "
+"забезпечує з'єднання мережі між двома програмам, які працюють на одному "
+"комп'ютері, не налаштовано належним чином."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:896
+#, fuzzy, no-wrap
+#| msgid "How to save data from a broken .wxmx file"
+msgid "How to save data from a broken .wxmx file"
+msgstr "Як зберегти дані із пошкодженого файла .wxmx"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:899
+#, fuzzy
+#| msgid ""
+#| "Internally most modern XML-based formats are ordinary zip files. "
+#| "_WxMaxima_ doesn't turn on compression, so the contents of `.wxmx` files "
+#| "can be viewed in any text editor."
+msgid ""
+"Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ "
+"doesn’t turn on compression, so the contents of `.wxmx` files can be viewed "
+"in any text editor."
+msgstr ""
+"На внутрішньому рівні більшість сучасних форматів на основі XML є звичайними "
+"файлами zip. _wxMaxima_ не увімкнула стискання, що робить вміст файлів `."
+"wxmx` придатним до перекладу у будь-якому текстовому редакторі."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:901
+#, fuzzy
+#| msgid ""
+#| "If the zip signature at the end of the file is still intact after "
+#| "renaming a broken `.wxmx` file to `.zip` most operating systems will "
+#| "provide a way to extract any portion of the information that is stored "
+#| "inside it. This can be done when there is a need of recovering the "
+#| "original image files from a text processor document. If the zip signature "
+#| "isn’t intact that does not need to be the end of the world: If _wxMaxima_ "
+#| "during saving detected that something went wrong there will be a `.wxmx~` "
+#| "file whose contents might help."
+msgid ""
+"If the zip signature at the end of the file is still intact after renaming a "
+"broken `.wxmx` file to `.zip` most operating systems will provide a way to "
+"extract any portion of the information that is stored inside it. This can be "
+"done when there is a need of recovering the original image files from a text "
+"processor document. If the zip signature isn’t intact that does not need to "
+"be the end of the world: If _wxMaxima_ during saving detected that something "
+"went wrong there will be a `.wxmx~` file whose contents might help."
+msgstr ""
+"Якщо підпис zip наприкінці файла є неушкодженим після перейменовування "
+"пошкодженого файла `.wxmx` на `.zip`, у більшості операційних систем "
+"передбачено спосіб видобування будь-якої частини даних, яка у ньому "
+"зберігається. Виконати таке видобування можна, якщо потрібно відновити "
+"початкові файли зображень з документа текстового процесора. Якщо підпис zip "
+"пошкоджено, це ще не кінець світу: якщо _wxMaxima_ під час збереження "
+"виявила якусь помилку, має ще бути файл `.wxmx~`, чий вміст може допомогти у "
+"відновленні даних."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:903
+#, fuzzy, no-wrap
+#| msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file's contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).\n"
+msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).\n"
+msgstr " І навіть якщо такого файла не існує — якщо встановлено параметр налаштування для оптимізації файлів .wxmx для системи керування версіями, можна перейменувати файл .wxmx на файл .txt і скористатися текстовим редактором для відновлення частини XML із вмісту файла (він починається з `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` і завершується `</wxMaximaDocument>`. До і після цього фрагмента тексту у текстовому редакторі ви побачите непридатні до читання двійкові дані).\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:905
+msgid ""
+"If a text file containing only these contents (e.g. copy and paste this text "
+"into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know "
+"how to recover the text from the document."
+msgstr ""
+"Якщо текстовий файл, що містить ці дані (наприклад скопійовані і вставлені "
+"як текст до звичайного файла), збережено як файл із суфіксом назви .xml, "
+"_wxMaxima_ відомий спосіб відновлення тексту документа з цього файла."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:906
+#, fuzzy, no-wrap
+#| msgid "I want some debug info to be displayed on the screen before my command has finished"
+msgid "I want some debug info to be displayed on the screen before my command has finished"
+msgstr "Хочу бачити діагностичні відомості на екрані, перш ніж команда завершить свою роботу"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:909
+msgid ""
+"Normally _wxMaxima_ waits for the whole 2D formula to be transferred before "
+"it begins to typeset. This saves time for making many attempts to typeset a "
+"only partially completed equation. There is a `disp` command, though, that "
+"will provide debug output immediately and without waiting for the current "
+"_Maxima_ command to finish:"
+msgstr ""
+"Зазвичай, _wxMaxima_ очікує, доки буде передано усю двовимірну формулу, перш "
+"ніж починає виводити дані. Таким чином заощаджується час, який могло б бути "
+"витрачено на постійні спроби вивести незавершену формулу. Втім, існує "
+"команда `disp`, яка може виводити діагностичні дані негайно, не очікуючи на "
+"завершення поточної команди _Maxima_:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:910
+#, fuzzy, no-wrap
+#| msgid ""
+#| "for i:1 thru 10 do (\n"
+#| "   disp(i),\n"
+#| "   /* (sleep n) is a Lisp function, which can be used */\n"
+#| "   /* with the character \"?\" before. It delays the */\n"
+#| "   /* program execution (here: for 3 seconds) */\n"
+#| "   ?sleep(3)\n"
+#| ")$\n"
+msgid ""
+"for i:1 thru 10 do (\n"
+"   disp(i),\n"
+"   /* (sleep n) is a Lisp function, which can be used */\n"
+"   /* with the character \"?\" before. It delays the */\n"
+"   /* program execution (here: for 3 seconds) */\n"
+"   ?sleep(3)\n"
+")$\n"
+msgstr ""
+"for i:1 thru 10 do (\n"
+"   disp(i),\n"
+"   /* (sleep n) — функція Lisp, якою можна скористатися */\n"
+"   /* із додаванням перед нею символу «?». Команда затримує */\n"
+"   /* виконання програми (у нашому прикладі, на 3 секунди) */\n"
+"   ?sleep(3)\n"
+")$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:921
+msgid "Alternatively one can look for the `wxstatusbar()` command above."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:922
+#, fuzzy, no-wrap
+#| msgid "Plotting only shows a closed empty envelope with an error message"
+msgid "Plotting only shows a closed empty envelope with an error message"
+msgstr "На кресленні показано лише закриту порожню обгортку із повідомленням про помилку"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:925
+#, fuzzy
+#| msgid ""
+#| "This means that _wxMaxima_ could not read the file _Maxima_ that was "
+#| "supposed to instruct _gnuplot_ to create."
+msgid ""
+"This means that _wxMaxima_ could not read the file _Maxima_ that was "
+"supposed to instruct _Gnuplot_ to create."
+msgstr ""
+"Це означає, що _wxMaxima_ не вдалося прочитати файл, який _Maxima_ мала "
+"наказати створити _gnuplot_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:927
+msgid "Possible reasons for this error are:"
+msgstr "Можливими причинами цієї помилки є такі:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+#, fuzzy
+#| msgid ""
+#| "The plotting command is part of a third-party package like "
+#| "`implicit_plot` but this package was not loaded by _Maxima_’s `load()` "
+#| "command before trying to plot."
+msgid ""
+"The plotting command is part of a third-party package like `implicit_plot` "
+"but this package was not loaded by _Maxima_’s `load()` command before trying "
+"to plot."
+msgstr ""
+"Команда креслення є частиною стороннього пакунка, наприклад `implicit_plot`, "
+"але цей пакунок не було завантажено командою `load()` _Maxima_ до того, як "
+"команду було передано на виконання."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+#, fuzzy
+#| msgid ""
+#| "_Maxima_ tried to do something the currently installed version of "
+#| "_gnuplot_ isn’t able to understand. In this case, a file ending in `."
+#| "gnuplot` located in the directory, which _Maxima_’s variable "
+#| "`maxima_userdir` is pointing, contains the instructions from _Maxima_ to "
+#| "_gnuplot_. Most of the time, this file’s contents therefore are helpful "
+#| "when debugging the problem."
+msgid ""
+"_Maxima_ tried to do something the currently installed version of _Gnuplot_ "
+"isn’t able to understand. In this case, a file ending in `.gnuplot` located "
+"in the directory, which _Maxima_’s variable `maxima_userdir` is pointing, "
+"contains the instructions from _Maxima_ to _Gnuplot_. Most of the time, this "
+"file’s contents therefore are helpful when debugging the problem."
+msgstr ""
+"_Maxima_ спробувала зробити щось, що не змогла обробити поточна встановлена "
+"версія _gnuplot_. У цьому випадку, файл із суфіксом назви `.gnuplot` у "
+"каталозі, на який вказує змінна _Maxima_ `maxima_userdir`, містить команди, "
+"які _Maxima_ передавала _gnuplot_. Здебільшого, вміст цього файла є дуже "
+"корисним для діагностування проблеми."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+#, fuzzy
+#| msgid ""
+#| "Gnuplot was instructed to use the pngCairo library that provides "
+#| "antialiasing and additional line styles, but it was not compiled to "
+#| "support this possibility. Solution: Uncheck the \"Use the Cairo terminal "
+#| "for the plot\" checkbox in the configuration dialog and don’t set "
+#| "`wxplot_pngCairo` to true from _Maxima_."
+msgid ""
+"Gnuplot was instructed to use the pngCairo library that provides "
+"antialiasing and additional line styles, but it was not compiled to support "
+"this possibility. Solution: Uncheck the \"Use the Cairo terminal for the "
+"plot\" checkbox in the configuration dialog and don’t set `wxplot_pngcairo` "
+"to true from _Maxima_."
+msgstr ""
+"Gnuplot було наказано використовувати бібліотеку pngcairo, яка надає "
+"можливості згладжування зображення та додаткових стилів ліній, але саму "
+"програму не було зібрано із підтримкою цієї бібліотеки. Вирішення: зніміть "
+"позначку з пункту «Використовувати термінал cairo для креслення» у "
+"діалоговому вікні налаштувань і не встановлюйте для `wxplot_pngcairo` "
+"значення true з коду _Maxima_."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+#, fuzzy
+#| msgid "Gnuplot didn’t output a valid `.png` file."
+msgid "Gnuplot didn’t output a valid `.png` file."
+msgstr "Gnuplot не вивів коректного файла `.png`."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:933
+#, fuzzy, no-wrap
+#| msgid "Plotting an animation results in “error: undefined variable”"
+msgid "Plotting an animation results in “error: undefined variable”"
+msgstr "Спроба накреслити анімацію призводить до повідомлення «помилка: невизначена змінна»"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:936
+msgid ""
+"The value of the slider variable by default is only substituted into the "
+"expression that is to be plotted if it is visible there. Using a `subst` "
+"command that substitutes the slider variable into the equation to plot "
+"resolves this problem. At the end of section [Embedding animations into the "
+"spreadsheet](#embedding-animations-into-the-spreadsheet), you can see an "
+"example."
+msgstr ""
+"Значення змінної повзунка, типово, буде підставлено до виразу для креслення, "
+"лише якщо воно є видимим у цьому виразі. Використання команди `subst`, яка "
+"підставляє змінну повзунка до рівняння, яке слід накреслити, має усунути "
+"проблему. Наприкінці розділу [Вбудовування анімацій до робочого аркуша]"
+"(#embedding-animations-into-the-spreadsheet) наведено приклад."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:937
+#, fuzzy, no-wrap
+#| msgid "I lost cell content and undo doesn’t remember"
+msgid "I lost cell content and undo doesn’t remember"
+msgstr "Втрачено вміст комірок і скасовування дій не допомагає"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:940
+msgid ""
+"There are separate undo functions for cell operations and for changes inside "
+"of cells so chances are low that this ever happens. If it does there are "
+"several methods to recover data:"
+msgstr ""
+"У програмі передбачено окремі функції скасовування дій для дій з комірками і "
+"для дій усередині комірок, тому така подія має бути дуже рідкісною. Якщо "
+"таке все ж сталося, існує декілька способів відновити дані:"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+msgid ""
+"_WxMaxima_ actually has two undo features: The global undo buffer that is "
+"active if no cell is selected and a per-cell undo buffer that is active if "
+"the cursor is inside a cell. It is worth trying to use both undo options in "
+"order to see if an old value can still be accessed."
+msgstr ""
+"У _wxMaxima_ є два списки скасовування дій: загальний буфер скасовування, "
+"який є активним, якщо не позначено жодної комірки, та окремі буфери комірок, "
+"які є активним, якщо курсор перебуває у відповідній комірці. Варто "
+"спробувати скористатися обома варіантами скасовування, щоб спробувати "
+"дістатися потрібного вам попереднього значення."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+#, fuzzy
+#| msgid ""
+#| "If you still have a way to find out what label _Maxima_ has assigned to "
+#| "the cell just type in the cell’s label and its contents will reappear."
+msgid ""
+"If you still have a way to find out what label _Maxima_ has assigned to the "
+"cell just type in the cell’s label and its contents will reappear."
+msgstr ""
+"Якщо у вас лишився доступ до мітки, яку _Maxima_ призначила комірці, просто "
+"введіть до комірки цю мітку, і програма покаже її вміст."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+#, fuzzy
+#| msgid ""
+#| "If you don’t: Don’t panic. In the “View” menu there is a way to show a "
+#| "history pane that shows all _Maxima_ commands that have been issued "
+#| "recently."
+msgid ""
+"If you don’t: Don’t panic. In the “View” menu there is a way to show a "
+"history pane that shows all _Maxima_ commands that have been issued recently."
+msgstr ""
+"Якщо доступу не лишилося, не панікуйте. У меню «Перегляд» є пункт для показу "
+"панелі журналу, на якій буде показано усі команди _Maxima_, які було "
+"нещодавно віддано."
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+msgid "If nothing else helps _Maxima_ contains a replay feature:"
+msgstr ""
+"Якщо ніщо інше не допомагає, у _Maxima_ є функція для відтворення усіх "
+"команд:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:946
+#, no-wrap
+msgid "playback();\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:950
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ starts up with the message “Maxima process terminated.”"
+msgid "_WxMaxima_ starts up with the message “Maxima process terminated.”"
+msgstr "_wxMaxima_ запускається із повідомленням «Процес Maxima несподівано перервав роботу.»"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:953
+#, fuzzy
+#| msgid ""
+#| "One possible reason is that _Maxima_ cannot be found in the location that "
+#| "is set in the “Maxima” tab of _wxMaxima_’s configuration dialog and "
+#| "therefore won’t run at all. Setting the path to a working _Maxima_ binary "
+#| "should fix this problem."
+msgid ""
+"One possible reason is that _Maxima_ cannot be found in the location that is "
+"set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore "
+"won’t run at all. Setting the path to a working _Maxima_ binary should fix "
+"this problem."
+msgstr ""
+"Однією з можливих причин є те, що _Maxima_ не вдалося знайти у каталозі, "
+"який вказано на сторінці «Maxima» діалогового вікна налаштовування "
+"_wxMaxima_, а отже, програму взагалі не запущено. Встановлення адреси "
+"коректного виконуваного файла _Maxima_ має виправити цю проблему."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:954
+#, fuzzy, no-wrap
+#| msgid "Maxima is forever calculating and not responding to input"
+msgid "Maxima is forever calculating and not responding to input"
+msgstr "Maxima висне при обчислення і не відповідає на команди"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:957
+#, fuzzy
+#| msgid ""
+#| "It is theoretically possible that _wxMaxima_ doesn’t realize that "
+#| "_Maxima_ has finished calculating and therefore never gets informed it "
+#| "can send new data to _Maxima_. If this is the case “Trigger evaluation” "
+#| "might resynchronize the two programs."
+msgid ""
+"It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ "
+"has finished calculating and therefore never gets informed it can send new "
+"data to _Maxima_. If this is the case “Trigger evaluation” might "
+"resynchronize the two programs."
+msgstr ""
+"Теоретично можливий випадок, коли _wxMaxima_ не може розпізнати момент "
+"завершення обчислень у _Maxima_ і тому ніколи не дізнається про те, що може "
+"надсилати нові дані до _Maxima_. У цьому випадку команда виконання "
+"обчислення може відновити синхронізацію між двома програмами."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:958
+#, fuzzy, no-wrap
+#| msgid "My SBCL-based _Maxima_ runs out of memory"
+msgid "My SBCL-based _Maxima_ runs out of memory"
+msgstr "Версії _Maxima_ на основі SBCL не вистачає оперативної пам'яті"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:961
+msgid ""
+"The Lisp compiler SBCL by default comes with a memory limit that allows it "
+"to run even on low-end computers. When compiling a big software package like "
+"Lapack or dealing with extremely big lists of equations this limit might be "
+"too low. In order to extend the limits, SBCL can be provided with the "
+"command line parameter `--dynamic-space-size` that tells SBCL how many "
+"megabytes it should reserve. A 32bit Windows-SBCL can reserve up to 999 "
+"Megabytes. A 64-bit SBCL version running on Windows can be instructed to use "
+"more than the about 1280 Megabytes compiling Lapack needs."
+msgstr ""
+"Компілятор Lisp SBCL типово позначається із обмеженням на використання "
+"пам'яті, яке надає змогу запускати його на слабких комп'ютерах. При "
+"компіляції великих пакунків програмного забезпечення, зокрема lapack, або "
+"роботі з великими списками або формулами це обмеження може заважати "
+"нормальній роботі. Щоб зняти обмеження, SBCL можна передати параметр `--"
+"dynamic-space-size`, який вказуватиме SBCL, скільки мегабайтів пам'яті слід "
+"зарезервувати. У 32-бітовому Windows-SBCL можна зарезервувати до 999 "
+"мегабайтів. У 64-бітовій версії SBCL, яку запущено у Windows, можна наказати "
+"програмі використовувати понад близько 1280 мегабайтів, чого має бути "
+"достатньо для збирання lapack."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:963
+#, fuzzy
+#| msgid ""
+#| "One way to provide _Maxima_ (and thus SBCL) with command line parameters "
+#| "is the \"Additional parameters for Maxima\" field of _wxMaxima_’s "
+#| "configuration dialogue."
+msgid ""
+"One way to provide _Maxima_ (and thus SBCL) with command line parameters is "
+"the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration "
+"dialogue."
+msgstr ""
+"Одним зі способів передати _Maxima_ (а отже, SBCL) параметри командного "
+"рядка є поле «Додаткові параметри для Maxima» вікна налаштовування "
+"_wxMaxima_."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:965
+msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
+msgstr "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:966
+#, fuzzy, no-wrap
+#| msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgstr "При введенні даних програма уповільнюється або пропускає символи в Ubuntu"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:969
+msgid ""
+"Installing the package `ibus-gtk` should resolve this issue. See ([https://"
+"bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs."
+"launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) for details."
+msgstr ""
+"Встановлення пакунка `ibus-gtk` має усунути проблему. Докладніше про це на "
+"сторінці ([https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/"
+"+bug/1421558](https://bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/"
+"+bug/1421558))."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:970
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgid "_WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgstr "_wxMaxima_ припиняє роботу, коли _Maxima_ обробляє грецькі символи або умляути"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:973
+msgid ""
+"If your _Maxima_ is based on SBCL the following lines have to be added to "
+"your `.sbclrc`:"
+msgstr ""
+"Якщо вашу _Maxima_ засновано на SBCL, слід додати такі рядки до вашого файла "
+"`.sbclrc`:"
+
+#. type: Fenced code block (commonlisp)
+#: ../../info/wxmaxima.md:974
+#, fuzzy, no-wrap
+#| msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
+msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
+msgstr "(setf sb-impl::*default-external-format* :utf-8)\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:979
+msgid ""
+"The folder where this file has to be placed is system- and installation-"
+"specific. But any SBCL-based _Maxima_ that already has evaluated a cell in "
+"the current session will happily tell where it can be found after getting "
+"the following command:"
+msgstr ""
+"Тека, у якій має бути розташовано цей файл залежить від системи та способу "
+"встановлення. Втім, будь-яка _Maxima_ на основі SBCL, яка вже виконала "
+"обчислення у якійсь комірці протягом поточного сеансу, без проблем "
+"повідомить, де його можна знайти, у відповідь на таку команду:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:980
+#, fuzzy, no-wrap
+#| msgid "    :lisp (sb-impl::userinit-pathname)\n"
+msgid ":lisp (sb-impl::userinit-pathname)\n"
+msgstr "    :lisp (sb-impl::userinit-pathname)\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:984
+#, no-wrap
+msgid "Note concerning Wayland (recent Linux/BSD distributions)"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:988
+msgid ""
+"There seem to be issues with the Wayland Display Server and wxWidgets.  "
+"WxMaxima may be affected, e.g. that sidebars are not moveable."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:992
+msgid ""
+"You can either disable Wayland and use X11 instead (globally)  or just tell, "
+"that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:994
+msgid "E.g. start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:996
+msgid "`GDK_BACKEND=x11 wxmaxima`"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:997
+#, no-wrap
+msgid "The menu bar disappears on KDE Plasma"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1003
+msgid ""
+"On some KDE Plasma installations the global menu bar disappears when "
+"clicked.  As this is a bug in the global menu proxy, the only way to avoid "
+"it is to tell that wxMaxima should use its own menu bar instead of the "
+"global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1007
+msgid ""
+"Starting with version 26.05.0, wxMaxima attempts to set this variable "
+"automatically if it detects an affected system (KDE, Unity, or Ubuntu with "
+"older wxWidgets versions)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1009
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1011
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1012
+#, no-wrap
+msgid "Why is the integrated manual browser not offered on my Windows PC?"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1016
+msgid ""
+"Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or "
+"Microsoft’s webview2 isn’t installed."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1017
+#, no-wrap
+msgid "Why is the external manual browser not working on my Linux box?"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1024
+msgid ""
+"The HTML browser might be a snap, flatpack or appimage version. All of these "
+"typically cannot access files that are installed on your local system. "
+"Another reason might be that maxima or wxMaxima is installed as a snap, "
+"flatpack or something else that doesn’t give the host system access to its "
+"contents. A third reason might be that the maxima HTML manual isn’t "
+"installed and the online one cannot be accessed."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1025
+#, fuzzy, no-wrap
+#| msgid "Can I make _wxMaxima_ output both image files and embedded plots at once?"
+msgid "Can I make _wxMaxima_ output both image files and embedded plots at once?"
+msgstr "Чи можна зробити так, щоб _wxMaxima_ виводила дані одразу до файлів зображень і до вбудованих до аркуша креслень?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1028
+#, fuzzy
+#| msgid ""
+#| "The worksheet embeds .png files. _WxMaxima_ allows the user to specify "
+#| "where they should be generated:"
+msgid ""
+"The worksheet embeds `.png files. _WxMaxima_ allows the user to specify "
+"where they should be generated:"
+msgstr ""
+"До робочого аркуша вбудовуються файли .png. _wxMaxima_ дозволяє користувачу "
+"вказати, де має бути створено ці файли:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1029
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxdraw2d(\n"
+#| "    file_name=\"test\",\n"
+#| "    explicit(sin(x),x,1,10)\n"
+#| ");\n"
+msgid ""
+"wxdraw2d(\n"
+"    file_name=\"test\",  /* extension .png automatically added */\n"
+"    explicit(sin(x),x,1,10)\n"
+");\n"
+msgstr ""
+"wxdraw2d(\n"
+"    file_name=\"test\",\n"
+"    explicit(sin(x),x,1,10)\n"
+");\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1037
+msgid ""
+"If a different format is to be used, it is easier to generate the images and "
+"then import them into the worksheet again:"
+msgstr ""
+"Якщо має бути використано якийсь інший формат зображень, простіше створити "
+"зображення окремо, а потім імпортувати їх до робочого аркуша:"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1038
+#, fuzzy, no-wrap
+#| msgid ""
+#| "load(\"draw\");\n"
+#| "pngdraw(name,[contents]):=\n"
+#| "(\n"
+#| "    draw(\n"
+#| "        append(\n"
+#| "            [\n"
+#| "                terminal=pngcairo,\n"
+#| "                dimensions=wxplot_size,\n"
+#| "                file_name=name\n"
+#| "            ],\n"
+#| "            contents\n"
+#| "        )\n"
+#| "    ),\n"
+#| "    show_image(printf(false,\"~a.png\",name))\n"
+#| ");\n"
+#| "pngdraw2d(name,[contents]):=\n"
+#| "    pngdraw(name,gr2d(contents));\n"
+#| "\n"
+#| "pngdraw2d(\"Test\",\n"
+#| "        explicit(sin(x),x,1,10)\n"
+#| ");\n"
+msgid ""
+"load(\"draw\");\n"
+"pngdraw(name,[contents]):=\n"
+"(\n"
+"    draw(\n"
+"        append(\n"
+"            [\n"
+"                terminal=pngcairo,\n"
+"                dimensions=wxplot_size,\n"
+"                file_name=name\n"
+"            ],\n"
+"            contents\n"
+"        )\n"
+"    ),\n"
+"    show_image(printf(false,\"~a.png\",name))\n"
+");\n"
+"pngdraw2d(name,[contents]):=\n"
+"    pngdraw(name,gr2d(contents));\n"
+"\n"
+"pngdraw2d(\"Test\",\n"
+"        explicit(sin(x),x,1,10)\n"
+");\n"
+msgstr ""
+"load(\"draw\");\n"
+"pngdraw(name,[contents]):=\n"
+"(\n"
+"    draw(\n"
+"        append(\n"
+"            [\n"
+"                terminal=pngcairo,\n"
+"                dimensions=wxplot_size,\n"
+"                file_name=name\n"
+"            ],\n"
+"            contents\n"
+"        )\n"
+"    ),\n"
+"    show_image(printf(false,\"~a.png\",name))\n"
+");\n"
+"pngdraw2d(name,[contents]):=\n"
+"    pngdraw(name,gr2d(contents));\n"
+"\n"
+"pngdraw2d(\"Test\",\n"
+"        explicit(sin(x),x,1,10)\n"
+");\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1062
+#, fuzzy, no-wrap
+#| msgid "Can I set the aspect ratio of a plot?"
+msgid "Can I set the aspect ratio of an embedded plot?"
+msgstr "Чи можна встановити співвідношення розмірів зображення креслення?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1065
+msgid "Use the variable `wxplot_size`:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1066
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxdraw2d(\n"
+#| "    proportional_axis=xy,\n"
+#| "    explicit(sin(x),x,1,10)\n"
+#| "),wxplot_size=[1000,1000];\n"
+msgid ""
+"wxdraw2d(\n"
+"    explicit(sin(x),x,1,10)\n"
+"),wxplot_size=[1000,1000];\n"
+msgstr ""
+"wxdraw2d(\n"
+"    proportional_axis=xy,\n"
+"    explicit(sin(x),x,1,10)\n"
+"),wxplot_size=[1000,1000];\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1072
+#, fuzzy, no-wrap
+#| msgid "After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
+msgid "After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
+msgstr "Після оновлення до MacOS 13.1 у відповідь на команди plot і/або draw програма виводить повідомлення про помилки, подібні до таких:"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:1074
+#, fuzzy, no-wrap
+#| msgid ""
+#| "\n"
+#| "1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102\n"
+#| "2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52\n"
+#| "3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408\n"
+#| "...\n"
+msgid ""
+"1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102\n"
+"2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52\n"
+"3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408\n"
+"...\n"
+msgstr ""
+"\n"
+"1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102\n"
+"2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52\n"
+"3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408\n"
+"...\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1082
+#, fuzzy, no-wrap
+#| msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.\n"
+msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.\n"
+msgstr "Це може бути проблемою операційної системи. Вимикання приховування смужки меню (SystemSettings => Стільниця і панель => Смужка меню) може усунути проблему. Див. [вада у wxMaxima 1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1083
+#, no-wrap
+msgid "Logging"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1088
+#, no-wrap
+msgid ""
+"Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build,\n"
+"the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable\n"
+"this window using the \"View->Toggle log window\" menu entry.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1090
+msgid ""
+"Messages are not 'lost', if the log window is not shown, if you select to "
+"show the log window later, you will see past log messages (if you did not "
+"clear the messages)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1092
+msgid ""
+"Such messages may be helpful, when you create bug reports (or trying to find "
+"a bug by yourself)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1095
+msgid ""
+"Log messages can (additionally) be printed to STDERR, when using the command "
+"line option \"--logtostderr\". On Windows a separate text console will be "
+"opened, as a Windows GUI application does not have the standard IO connected."
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1098
+#, no-wrap
+msgid "FAQ"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1100
+#, fuzzy, no-wrap
+#| msgid "Is there a way to make more text fit on a LaTeX page?"
+msgid "Is there a way to make more text fit on a LaTeX page?"
+msgstr "Чи є якийсь спосіб умістити більше тексту на сторінку LaTeX?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1103
+msgid ""
+"Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to "
+"specify the size of the borders."
+msgstr ""
+"Так. Скористайтеся [пакунком LaTeX «geometry»](https://ctan.org/pkg/"
+"geometry) для визначення розмірів полів."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1105
+#, fuzzy, no-wrap
+#| msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):\n"
+msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):\n"
+msgstr "Ви можете додати такий рядок до преамбули LaTeX (наприклад, за допомогою відповідного поля у діалоговому вікні налаштовування («Експорт->Додаткові рядки до преамбули TeX») для встановлення розміру полів у 1 см):\n"
+
+#. type: Fenced code block (latex)
+#: ../../info/wxmaxima.md:1106
+#, fuzzy, no-wrap
+#| msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+msgstr "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1110
+#, fuzzy, no-wrap
+#| msgid "Is there a dark mode?"
+msgid "Is there a dark mode?"
+msgstr "Чи передбачено у програмі «темний» режим?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1113
+msgid ""
+"If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if "
+"the rest of the operating system is. The worksheet itself is by default "
+"equipped with a bright background. But it can be configured otherwise. "
+"Alternatively, there is a `View/Invert worksheet brightness` menu entry that "
+"allows to quickly convert the worksheet from dark to bright and vice versa."
+msgstr ""
+"Якщо бібліотека wxWidgets є достатньо новою, _wxMaxima_ автоматично "
+"працюватиме у темному режимі, якщо у ньому працює решта операційної системи. "
+"Сам робочий аркуш типово має світле тло. Втім, колір тла можна змінити. Крім "
+"того, ви можете скористатися пунктом меню «Перегляд/Інвертувати яскравість "
+"робочого аркуша», за допомогою якого можна швидко перетворити робочий аркуш "
+"з темного на світлий, і навпаки."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1114
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ sometimes hangs for several seconds once in the first minute"
+msgid "_WxMaxima_ sometimes hangs for several seconds once in the first minute"
+msgstr "_wxMaxima_ іноді повисає на декілька секунд під час першої хвилини роботи"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1117
+#, fuzzy, no-wrap
+#| msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_'s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.\n"
+msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.\n"
+msgstr "_wxMaxima_ передає певні складні завдання, зокрема завдання з обробки підручника з _Maxima_, який складається з понад 1000 сторінок, фоновим завданням, що, зазвичай, відбувається зовсім непомітно. Втім, у момент, коли може знадобитися результат виконання такого завдання, _wxMaxima_ може знадобитися декілька секунд для відновлення нормальної роботи.\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1118
+#, fuzzy, no-wrap
+#| msgid "Especially when testing new locale settings, a message box \"locale 'xx_YY' can not be set\" occurs"
+msgid "Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+msgstr "З'являється повідомлення «Неможливо встановити локаль \"xx_YY\"», особливо під час тестування параметрів нової локалі"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1121
+msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
+msgstr ""
+"![Попередження про локаль](./locale-warning.png){ id=img_locale_warning}"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1125
+#, fuzzy
+#| msgid ""
+#| "(The same problem can occur with other applications too). The "
+#| "translations seem okay after you click on 'OK'. WxMaxima does not only "
+#| "use its own translations but the translations of the wxWidgets framework "
+#| "too."
+msgid ""
+"(The same problem can occur with other applications too). The translations "
+"seem okay after you click on ’OK’. WxMaxima does not only use its own "
+"translations but the translations of the wxWidgets framework too."
+msgstr ""
+"(Таке саме може статися із іншими програмами.) Переклад може працювати після "
+"натискання кнопки «Гаразд». wxMaxima не просто використовує власні "
+"переклади, але і переклади з бібліотеки wxWidgets."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1128
+msgid ""
+"These locales maybe not present in the system. On Ubuntu/Debian systems they "
+"can be generated using: `dpkg-reconfigure locales`"
+msgstr ""
+"Локалі може не бути у системі. У системах Ubuntu/Debian локалі можна "
+"створити за допомогою такої команди: `dpkg-reconfigure locales`"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1129
+#, fuzzy, no-wrap
+#| msgid "How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
+msgid "How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
+msgstr "Якщо скористатися символами множин дійсних чисел, натуральних чисел (ℝ, ℕ) тощо?"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1132
+#, fuzzy
+#| msgid ""
+#| "You can find these symbols in the Unicode sidebar (search for 'double-"
+#| "struck capital'). But the selected font must also support these symbols. "
+#| "If they do not display properly, select another font."
+msgid ""
+"You can find these symbols in the Unicode sidebar (search for ’double-struck "
+"capital’). But the selected font must also support these symbols. If they do "
+"not display properly, select another font."
+msgstr ""
+"Ці символи можна знайти на бічній панелі Unicode (пошукайте «великі літери "
+"із подвійним контуром»). Втім, підтримку цих символів має бути передбачено у "
+"вибраному шрифті. Якщо програма не показує символи належним чином, виберіть "
+"інший шрифт."
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1133
+#, no-wrap
+msgid "How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1136
+msgid ""
+"If wxMaxima is used, the Maxima variable `maxima_frontend` is set to "
+"`wxmaxima`. The Maxima variable `maxima_frontend_version` contains the "
+"wxMaxima version in this case."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1138
+msgid ""
+"If no frontend is used (you are using command line Maxima), these variables "
+"are `false`."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1139
+#, no-wrap
+msgid "Help! I can not save my document!"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1142
+#, no-wrap
+msgid "If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.\n"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1145
+#, fuzzy, no-wrap
+#| msgid "Command-line arguments"
+msgid "Command-line arguments"
+msgstr "Параметри командного рядка"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1148
+msgid ""
+"Usually you can start programs with a graphical user interface just by "
+"clicking on a desktop icon or desktop menu entry. WxMaxima - if started from "
+"the command line - still provides some command-line switches, though."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-v` or `--version`: Output the version information"
+msgstr "`-v` або `--version`: вивести дані щодо версії програми"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-h` or `--help`: Output a short help text"
+msgstr "`-h` або `--help`: вивести короткий довідковий текст"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid ""
+"`-o` or `--open=<str>`: Open the filename given as an argument to this "
+"command-line switch"
+msgstr ""
+"`-o` або `--open=<рядок>`: відкрити файл, який передано як аргумент до цього "
+"параметра командного рядка"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-e` or `--eval`: Evaluate the file after opening it."
+msgstr "`-e` або `--eval`: обробити файл після його відкриття"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid ""
+"`-b` or `--batch`: If the command-line opens a file all cells in this file "
+"are evaluated and the file is saved afterward. This is for example useful if "
+"the session described in the file makes _Maxima_ generate output files. "
+"Batch-processing will be stopped if _wxMaxima_ detects that _Maxima_ has "
+"output an error and will pause if _Maxima_ has a question: Mathematics is "
+"somewhat interactive by nature so a completely interaction-free batch "
+"processing cannot always be guaranteed."
+msgstr ""
+"`-b` або `--batch`: якщо ви відкриваєте файл з командного рядка, усі комірки "
+"у цьому файлі обчислюються, а потім програма виконує збереження файла. Це, "
+"наприклад, корисно, якщо сеанс, який описано у файлі, призводить до того, що "
+"_Maxima_ щось виводить до файлів. Пакетну обробку буде зупинено, якщо "
+"_wxMaxima_ виявить, що _Maxima_ вивела повідомлення про помилку, і "
+"призупинить обробку, якщо _Maxima_ задасть питання: математика є дещо "
+"інтерактивною за природою, тому повністю автономна пакетна обробка можлива "
+"далеко не завжди."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1164
+#, fuzzy, no-wrap
+#| msgid ""
+#| "* `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
+#| "* `--pipe`:                        Pipe messages from Maxima to stdout.\n"
+#| "* `--exit-on-error`:               Close the program on any maxima error.\n"
+#| "* `-f` or `--ini=<str>`: Use the init file that was given as an argument to this command-line switch\n"
+#| "* `-u`, `--use-version=<str>`:     Use maxima version `<str>`.\n"
+#| "* `-l`, `--lisp=<str>`:              Use a Maxima compiled with Lisp compiler `<str>`.\n"
+#| "* `-X`, `--extra-args=<str>`:        Allows to specify extra Maxima arguments\n"
+#| "* `-m` or `--maxima=<str>`:    allows specifying the location of the _maxima_ binary\n"
+#| "* `--enableipc`: Lets Maxima control wxMaxima via interprocess communications. Use this option with care.\n"
+#| "* `--wxmathml-lisp=<str>`:   Location of wxMathML.lisp (if not the built-in should be used, mainly for developers).\n"
+msgid ""
+"- `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
+"- `--pipe`:                        Pipe messages from Maxima to stdout.\n"
+"- `--exit-on-error`:               Close the program on any maxima error.\n"
+"- `-f` or `--ini=<str>`: Use the init file that was given as an argument to this command-line switch\n"
+"- `-u`, `--use-version=<str>`:     Use maxima version `<str>`.\n"
+"- `-l`, `--lisp=<str>`:              Use a Maxima compiled with Lisp compiler `<str>`.\n"
+"- `-X`, `--extra-args=<str>`:        Allows to specify extra Maxima arguments\n"
+"- `-m` or `--maxima=<str>`:    allows specifying the location of the _maxima_ binary\n"
+"- `--enableipc`: Lets Maxima control wxMaxima via interprocess communications. Use this option with care.\n"
+"- `--wxmathml-lisp=<str>`:   Location of wxMathML.lisp (if not the built-in should be used, mainly for developers).\n"
+msgstr ""
+"* `--logtostderr`:                 записувати до stderr і усі «діагностичні повідомлення» бічної панелі.\n"
+"* `--pipe`:                        передавати каналом повідомлення від Maxima до stdout.\n"
+"* `--exit-on-error`:               завершити роботу програми за будь-якої помилки maxima.\n"
+"* `-f` або `--ini=<рядок>`: скористатися файлом init, який передано як аргумент цього параметра командного рядка\n"
+"* `-u`, `--use-version=<рядок>`:   скористатися версією maxima `<рядок>`.\n"
+"* `-l`, `--lisp=<рядок>`:          скористатися Maxima, яку зібрано за допомогою компілятора Lisp `<рядок>`.\n"
+"* `-X`, `--extra-args=<рядок>`:    надає змогу вказати додаткові аргументи Maxima\n"
+"* `-m` або `--maxima=<рядок>`:     надає змогу вказати розташування виконуваного файла _maxima_\n"
+"* `--enableipc`: дозволяє Maxima керувати wxMaxima шляхом міжпроцесорної взаємодії. Будьте обережні із використанням цього параметра.\n"
+"* `--wxmathml-lisp=<str>`:   розташування wxMathML.lisp (якщо слід використовувати відмінний від вбудованого, в основному, для розробників).\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1166
+msgid ""
+"Instead of a minus, some operating systems might use a dash in front of the "
+"command-line switches."
+msgstr ""
+"Замість символу мінуса у деяких операційних системах перед перемикачами "
+"командного рядка використовується тире."
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1169
+#, fuzzy, no-wrap
+#| msgid "About the program, contributing to wxMaxima"
+msgid "About the program, contributing to wxMaxima"
+msgstr "Про програму, участь у розробці wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1172
+#, fuzzy
+#| msgid ""
+#| "wxMaxima is mainly developed using the program language C++ using the "
+#| "wxWidgets framework, as build system we use CMake, a small part is "
+#| "written in Lisp. You can contribute to wxMaxima, join the wxMaxima "
+#| "project at <https://github.com/wxMaxima-developers/wxmaxima>, if you have "
+#| "knowledge of these programming languages and want to help and contribute "
+#| "to the open source project wxMaxima."
+msgid ""
+"wxMaxima is mainly developed using the programming language C++ using the "
+"[wxWidgets framework](https://www.wxwidgets.org), as build system we use "
+"[CMake](https://www.cmake.org), a small part is written in Lisp. You can "
+"contribute to wxMaxima, join the wxMaxima project at <https://github.com/"
+"wxMaxima-developers/wxmaxima>, if you have knowledge of these programming "
+"languages and want to help and contribute to the open source project "
+"wxMaxima."
+msgstr ""
+"Основна розробка wxMaxima виконується мовою програмування C++ з "
+"використанням бібліотек wxWidgets. Як систему збирання, ми використовуємо "
+"CMake. Невеличку частину написано мовою програмування Lisp. Ви можете взяти "
+"участь у розробці wxMaxima, долучитися до проєкту wxMaxima на <https://"
+"github.com/wxMaxima-developers/wxmaxima>, якщо знаєте ці мови програмування "
+"і хочете допомогти і удосконалити проєкт з відкрити кодом wxMaxima."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1174
+msgid ""
+"But not only programmers are necessary! You can also contribute to wxMaxima, "
+"if you help to improve the documentation, find and report bugs (and maybe "
+"bugfixes), suggest new features, help to translate wxMaxima or the manual to "
+"your language (read the README.md in the [locale subdirectory](https://"
+"github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and "
+"the manual can be translated)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1176
+msgid "Or answer questions of other users in the discussion forum."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1178
+msgid ""
+"The source code of wxMaxima is documented using Doxygen [here](https://"
+"wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+msgstr ""
+"Початковий код wxMaxima документовано за допомогою системи Doxygen [тут]"
+"(https://wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1180
+msgid ""
+"The program is nearly self-contained, so except for system libraries (and "
+"the wxWidgets library), no external dependencies (like graphic files or the "
+"Lisp part (the `wxmathML.lisp`-file) is needed, these files are included in "
+"the executable."
+msgstr ""
+"Програма є майже самодостатньою, тому, окрім системних бібліотек (та "
+"бібліотеки wxWidgets), ніяких зовнішніх залежностей (зокрема графічних "
+"файлів або частини Lisp (файла `wxmathML.lisp`) не потрібно, ці файли "
+"включено до виконуваного файла програми."
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1181
+#, fuzzy, no-wrap
+#| msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.\n"
+msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.\n"
+msgstr "Якщо ви є розробником, можете спробувати внести зміни до `wxmathML.lisp` без перезбирання усього. Можна скористатися параметром командного рядка `--wxmathml-lisp=<рядок>`, щоб наказати програмі використати інший файл Lisp, замість включеного до її складу.\n"
+
+#, fuzzy
+#~| msgid "~~~maxima load(draw);"
+#~ msgid "```maxima load(draw);"
+#~ msgstr "~~~maxima load(draw);"
+
+#, fuzzy
+#~| msgid ""
+#~| "/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,"
+#~| "x,-1,1));"
+#~ msgid ""
+#~ "/* Parabola in window #1 */ draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));"
+#~ msgstr ""
+#~ "    /* Парабола у вікні 1 */ draw1d(terminal=[wxt,1],explicit(x^2,"
+#~ "x,-1,1));"
+
+#, fuzzy
+#~| msgid ""
+#~| "/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,"
+#~| "x,-1,1));"
+#~ msgid ""
+#~ "/* Parabola in window #2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
+#~ msgstr ""
+#~ "/* Парабола у вікні 2 */ draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));"
+
+#, fuzzy
+#~| msgid ""
+#~| "/* Paraboloid in window #3 */ draw3d(terminal=[wxt,3],explicit(x^2+y^2,"
+#~| "x,-1,1,y,-1,1)); ~~~"
+#~ msgid ""
+#~ "/* Paraboloid in window #3 */ draw3d(terminal=[wxt,3],explicit(x^2+y^2,"
+#~ "x,-1,1,y,-1,1)); ```"
+#~ msgstr ""
+#~ "/* Параболоїд у вікні 3 */ draw3d(terminal=[wxt,3],explicit(x^2+y^2,"
+#~ "x,-1,1,y,-1,1)); ~~~"
+
+#, fuzzy
+#~| msgid ""
+#~| "pngdraw2d(\"Test\",\n"
+#~| "        explicit(sin(x),x,1,10)\n"
+#~| ");\n"
+#~| "~~~\n"
+#~ msgid ""
+#~ "pngdraw2d(\"Test\",\n"
+#~ "        explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "wxdraw2d(\n"
+#~ "    file_name=\"test\",\n"
+#~ "    explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+#~ "~~~\n"

--- a/locales/manual/zh_CN.po
+++ b/locales/manual/zh_CN.po
@@ -1,0 +1,4780 @@
+# This file is distributed under the same license as the wxMaxima package.
+# 注意：翻译此文件时，需根据上下文，而非字面意思（有些文字的原文有误或不准确）。
+# Liu Rong, <rong.liu@mail.bnu.edu.cn>, 2020.
+# crickzhang1, <crickzhang1@gmail.com>, 2013.
+# Some strings in this Simplified Chinese translation have their roots
+# in the Tranditional Chinese translation (`zh_TW.po`).
+# Copyright (C) 2020 Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Liu Rong <rong.liu@mail.bnu.edu.cn>, 2020.
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: wxMaxima HEAD\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-04 07:28+0000\n"
+"PO-Revision-Date: 2021-01-20 20:14+0800\n"
+"Last-Translator: Liu Rong <rong.liu@mail.bnu.edu.cn>\n"
+"Language-Team: amateur\n"
+"Language: zh\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.4.1\n"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1
+#, fuzzy, no-wrap
+#| msgid "The wxMaxima user manual {-}"
+msgid "The wxMaxima user manual"
+msgstr "wxMaxima 用户手册 {-}"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:4
+#, fuzzy
+#| msgid ""
+#| "wxMaxima is a graphical user interface (GUI) for the _Maxima_ computer "
+#| "algebra system (CAS). wxMaxima allows one to use all of _Maxima_’s "
+#| "functions. In addition, it provides convenient wizards for accessing the "
+#| "most commonly used features. This manual describes some of the features "
+#| "that make wxMaxima one of the most popular GUIs for _Maxima_."
+msgid ""
+"WxMaxima is a graphical user interface (GUI) for the _Maxima_ computer "
+"algebra system (CAS). WxMaxima allows one to use all of _Maxima_’s "
+"functions. In addition, it provides convenient wizards for accessing the "
+"most commonly used features. This manual describes some of the features that "
+"make wxMaxima one of the most popular GUIs for _Maxima_."
+msgstr ""
+"wxMaxima 是计算机代数系统（CAS，computer algebra system）Maxima 的图形用户界"
+"面（GUI，graphical user interface）。在 wxMaxima 中，用户可以使用 Maxima 所有"
+"的命令。此外，wxMaxima 还提供了一些向导以方便用户使用最常用的功能。本手册描述"
+"了一些 wxMaxima 的特性，这些特性使其成为最流行的 Maxima 图形用户界面之一。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:6
+msgid "![wxMaxima logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
+msgstr "![wxMaxima 的 logo](./wxMaximaLogo.png){ id=img_wxMaximaLogo }"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:9
+#, fuzzy, no-wrap
+#| msgid "Introduction to wxMaxima"
+msgid "Introduction to wxMaxima"
+msgstr "wxMaxima 简介"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:11
+#, fuzzy, no-wrap
+#| msgid "_Maxima_ and wxMaxima"
+msgid "_Maxima_ and wxMaxima"
+msgstr "Maxima 和 wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:14
+#, fuzzy
+#| msgid ""
+#| "In the open-source domain, big systems are normally split into smaller "
+#| "projects that are easier to handle for small groups of developers. For "
+#| "example a CD burner program will consist of a command-line tool that "
+#| "actually burns the CD and a graphical user interface that allows users to "
+#| "implement it without having to learn about all the command line switches "
+#| "and in fact without using the command line at all. One advantage of this "
+#| "approach is that the developing work that was invested into the command-"
+#| "line program can be shared by many programs: The same CD-burner command-"
+#| "line program can be used as a “send-to-CD”-plug-in for a file manager "
+#| "application, for the “burn to CD” function of a music player and as the "
+#| "CD writer for a DVD backup tool. Another advantage is that splitting one "
+#| "big task into smaller parts allows the developers to provide several user "
+#| "interfaces for the same program."
+msgid ""
+"In the open-source domain, big systems are normally split into smaller "
+"projects that are easier to handle for small groups of developers. For "
+"example a CD burner program will consist of a command-line tool that "
+"actually burns the CD and a graphical user interface that allows users to "
+"implement it without having to learn about all the command line switches and "
+"in fact without using the command line at all. One advantage of this "
+"approach is that the developing work that was invested into the command-line "
+"program can be shared by many programs: The same CD-burner command-line "
+"program can be used as a “send-to-CD”-plug-in for a file manager "
+"application, for the “burn to CD” function of a music player and as the CD "
+"writer for a DVD backup tool. Another advantage is that splitting one big "
+"task into smaller parts allows the developers to provide several user "
+"interfaces for the same program."
+msgstr ""
+"在开源领域，大型项目通常被分割成小型项目，后者对于小规模开发组来说更容易处"
+"理。例如，一个 CD 刻录机程序会包括一个实际刻录 CD 的命令行程序和一个图形用户"
+"界面，该界面使得用户不必了解所有的命令行参数就能刻录 CD，从而实际上避开了使用"
+"命令行。这种方法的一个优点是，投入到命令行程序中的开发工作可以被许多程序共"
+"享：同一个刻录 CD 的命令行程序可以用作文件管理器应用程序的“发送到 CD”插件、音"
+"乐播放器的“刻录到 CD”功能以及 DVD 备份工具的刻录 CD 功能。另一个优点是将一个"
+"大型任务分解成更小的部分时，开发人员就可以为同一个程序提供多个用户界面。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:16
+msgid ""
+"A computer algebra system (CAS) like _Maxima_ fits into this framework. A "
+"CAS can provide the logic behind an arbitrary precision calculator "
+"application or it can do automatic transforms of formulas in the background "
+"of a bigger system (e.g., [Sage](https://www.sagemath.org/)). Alternatively, "
+"it can be used directly as a free-standing system. _Maxima_ can be accessed "
+"via a command line. Often, however, an interface like _wxMaxima_ proves a "
+"more efficient way to access the software, especially for newcomers."
+msgstr ""
+"一个像 Maxima 这样的计算机代数系统（CAS，computer algebra system）也适合前述"
+"框架。Maxima 可以用作任意精度计算器程序的底层软件，也可以在更大计算系统中作为"
+"公式转换程序来帮助计算（例如 [Sage](https://www.sagemath.org/)）。Maxima 也可"
+"以直接作为独立的计算系统使用，它可以通过命令行来访问。然而，在通常情况下，像 "
+"wxMaxima 这样的用户界面是使用 Maxima 的一种更有效的方法，特别是对于新手而言更"
+"是如此。"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:17
+#, fuzzy, no-wrap
+#| msgid "_Maxima_"
+msgid "_Maxima_"
+msgstr "Maxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:20
+msgid ""
+"_Maxima_ is a full-featured computer algebra system (CAS). A CAS is a "
+"program that can solve mathematical problems by rearranging formulas and "
+"finding a formula that solves the problem as opposed to just outputting the "
+"numeric value of the result. In other words, _Maxima_ can serve as a "
+"calculator that gives numerical representations of variables, and it can "
+"also provide analytical solutions. Furthermore, it offers a range of "
+"numerical methods of analysis for equations or systems of equations that "
+"cannot be solved analytically."
+msgstr ""
+"Maxima 是一个功能齐全的计算机代数系统（CAS）。CAS 是一个程序，它可以通过对公"
+"式变形并找到问题的解来求解数学问题，而不是仅仅输出结果的数值。换言之，Maxima "
+"可以作为一个计算器，给出变量的数值表示，也可以提供解析解。此外，它还提供了一"
+"系列数值分析方法，用于求解没有解析解的方程或方程组。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:22
+msgid ""
+"![Maxima screenshot, command line](./maxima_screenshot.png)"
+"{ id=img_maxima_screenshot }"
+msgstr ""
+"![Maxima 截图，命令行](./maxima_screenshot.png){ id=img_maxima_screenshot }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:24
+#, fuzzy, no-wrap
+#| msgid "Extensive documentation for _Maxima_ is [available in the internet](http://maxima.sourceforge.net/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the F1 key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor."
+msgid "Extensive documentation for _Maxima_ is  [available in the internet](https://maxima.sourceforge.io/documentation.html). Part of this documentation is also available in wxMaxima’s help menu. Pressing the Help key (on most systems the <kbd>F1</kbd> key) causes _wxMaxima_’s context-sensitive help feature to automatically jump to _Maxima_’s manual page for the command at the cursor.\n"
+msgstr "大量关于 Maxima 的文档[可在互联网上获得](https://maxima.sourceforge.io/documentation.html)。wxMaxima 的“帮助”菜单中也提供了部分文档。按下帮助键（在大多数系统上是按 F1 键）后，wxMaxima 的上下文相关帮助功能会自动打开 Maxima 的手册页，并跳转到光标处命令对应的内容。"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:25
+#, fuzzy, no-wrap
+#| msgid "wxMaxima"
+msgid "WxMaxima"
+msgstr "wxMaxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:28
+#, fuzzy
+#| msgid ""
+#| "_wxMaxima_ is a graphical user interface that provides the full "
+#| "functionality and flexibility of _Maxima_. wxMaxima offers users a "
+#| "graphical display and many features that make working with _Maxima_ "
+#| "easier. For example _wxMaxima_ allows one to export any cell’s contents "
+#| "(or, if that is needed, any part of a formula, as well) as text, as LaTeX "
+#| "or as MathML specification at a simple right-click. Indeed, an entire "
+#| "workbook can be exported, either as a HTML file or as a LaTeX file. "
+#| "Documentation for _wxMaxima_, including workbooks to illustrate aspects "
+#| "of its use, is online at the _wxMaxima_ [help site](https://wxMaxima-"
+#| "developers.github.io/wxmaxima/help.html), as well as via the help menu."
+msgid ""
+"_WxMaxima_ is a graphical user interface that provides the full "
+"functionality and flexibility of _Maxima_. WxMaxima offers users a graphical "
+"display and many features that make working with _Maxima_ easier. For "
+"example _wxMaxima_ allows one to export any cell’s contents (or, if that is "
+"needed, any part of a formula, as well) as text, as LaTeX or as MathML "
+"specification at a simple right-click. Indeed, an entire workbook can be "
+"exported, either as a HTML file or as a LaTeX file. Documentation for "
+"_wxMaxima_, including workbooks to illustrate aspects of its use, is online "
+"at the _wxMaxima_ [help site](https://wxMaxima-developers.github.io/wxmaxima/"
+"help.html), as well as via the help menu."
+msgstr ""
+"wxMaxima 是一个图形用户界面，它提供了 Maxima 的全部功能和灵活性。wxMaxima 为"
+"用户提供了图形显示和许多其他功能，使得 Maxima 更易于使用。例如，wxMaxima 允许"
+"用户通过右键单击将任何单元格的内容（或者，如果需要，也可以导出公式的任何部"
+"分）作为文本、LaTeX 代码或 MathML 代码导出。实际上，用户可以将整个工作簿"
+"（workbook）导出为 HTML 文件或 LaTeX 文件。有关 wxMaxima 的文档，包括说明其各"
+"种使用方法的工作簿，都可以在 wxMaxima 的[帮助站点](https://wxMaxima-"
+"developers.github.io/wxMaxima/help.html)上找到，也可以通过“帮助”菜单查看相关"
+"说明。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:30
+msgid "![wxMaxima window](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
+msgstr "![wxMaxima 界面](./wxMaximaWindow.png){ id=img_wxMaximaWindow }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:32
+msgid ""
+"The calculations that are entered in _wxMaxima_ are performed by the "
+"_Maxima_ command-line tool in the background."
+msgstr "在 wxMaxima 中输入的计算式是由 Maxima 命令行工具在后台执行的。"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:33
+#, fuzzy, no-wrap
+#| msgid "Workbook basics"
+msgid "Workbook basics"
+msgstr "工作簿（Workbook）基础"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:36
+#, fuzzy
+#| msgid ""
+#| "Much of _wxMaxima_ is self-explaining, but some details require "
+#| "attention. [This site](https://wxMaxima-developers.github.io/wxmaxima/"
+#| "help.html) contains a number of workbooks that address various aspects of "
+#| "_wxMaxima_. Working through some of these (particularly the \"10 minute "
+#| "_(wx)Maxima_ tutorial\") will increase one’s familiarity with both the "
+#| "content of _Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. "
+#| "This manual concentrates on describing aspects of _wxMaxima_ that are not "
+#| "likely to be self-evident and that might not be covered in the online "
+#| "material."
+msgid ""
+"Much of _wxMaxima_ is self-explaining, but some details require attention. "
+"[This site](https://wxMaxima-developers.github.io/wxmaxima/help.html) "
+"contains a number of workbooks that address various aspects of _wxMaxima_. "
+"Working through some of these (particularly the \"10 minute _(wx)Maxima_ "
+"tutorial\") will increase one’s familiarity with both the content of "
+"_Maxima_ and the use of _wxMaxima_ to interact with _Maxima_. This manual "
+"concentrates on describing aspects of _wxMaxima_ that are not likely to be "
+"self-evident and that might not be covered in the online material."
+msgstr ""
+"大部分 wxMaxima 功能是不言自明的，但有些细节需要注意。[这个网站](https://"
+"wxMaxima-developers.github.io/wxMaxima/help.html)包含多个工作簿，这些工作簿涉"
+"及 wxMaxima 的各个方面。学习其中的一些（特别是“10 minute _(wx)Maxima_ "
+"tutorial”，即“十分钟 (wx)Maxima 教程”）将增加用户对 Maxima 的内容和 wxMaxima "
+"与 Maxima 交互过程的熟悉度。本手册集中描述 wxMaxima 的某些功能，这些功能可能"
+"并非不言而喻的，也可能不会被在线文档涵盖。"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:37
+#, fuzzy, no-wrap
+#| msgid "The workbook approach"
+msgid "The workbook approach"
+msgstr "工作簿的使用"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:40
+#, fuzzy
+#| msgid ""
+#| "One of the very few things that are not standard in _wxMaxima_ is that it "
+#| "organizes the data for _Maxima_ into cells that are evaluated (which "
+#| "means: sent to _Maxima_) only when the user requests this. When a cell is "
+#| "evaluated, all commands in that cell, and only that cell, are evaluated "
+#| "as a batch. (The preceding statement is not quite accurate: One can "
+#| "select a set of adjacent cells and evaluate them together. Also, one can "
+#| "instruct _Maxima_ to evaluate all cells in a workbook in one pass.) "
+#| "_wxMaxima_'s approach to submitting commands for execution might feel "
+#| "unfamiliar at the first sight. It does, however, drastically ease work "
+#| "with big documents (where the user does not want every change to "
+#| "automatically trigger a full re-evaluation of the whole document). Also, "
+#| "this approach is very handy for debugging."
+msgid ""
+"One of the very few things that are not standard in _wxMaxima_ is that it "
+"organizes the data for _Maxima_ into cells that are evaluated (which means: "
+"sent to _Maxima_) only when the user requests this. When a cell is "
+"evaluated, all commands in that cell, and only that cell, are evaluated as a "
+"batch. (The preceding statement is not quite accurate: One can select a set "
+"of adjacent cells and evaluate them together. Also, one can instruct "
+"_Maxima_ to evaluate all cells in a workbook in one pass.) _WxMaxima_’s "
+"approach to submitting commands for execution might feel unfamiliar at the "
+"first sight. It does, however, drastically ease work with big documents "
+"(where the user does not want every change to automatically trigger a full "
+"re-evaluation of the whole document). Also, this approach is very handy for "
+"debugging."
+msgstr ""
+"wxMaxima 的特性之一是可以将发送给 Maxima 的命令提前组织到单元格中，这些单元格"
+"只在用户请求时才被处理（这意味着：把命令发送给 Maxima）。在处理单元格时，该单"
+"元格（且仅该单元格）中的所有命令将作为批处理进行计算。（前面的语句并不十分准"
+"确，因为可以选择一组相邻的单元格并且一起计算它们，或者让 Maxima 一次性算完工"
+"作簿中的所有单元格。）wxMaxima 提交命令的方法乍一看可能会觉得陌生。但是，这种"
+"做法确实大大简化了处理大型文档的工作（用户不希望每次更改都自动触发对整个文档"
+"的重新计算）。而且，该方法用于调试命令时非常方便。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:42
+msgid ""
+"If text is typed into _wxMaxima_ it automatically creates a new worksheet "
+"cell. The type of this cell can be selected in the toolbar. If a code cell "
+"is created the cell can be sent to _Maxima_, which causes the result of the "
+"calculation to be displayed below the code. A pair of such commands is shown "
+"below."
+msgstr ""
+"如果输入文本到 wxMaxima 中，则会自动创建一个新的工作簿单元格。可以在工具栏中"
+"选择此单元格的类型。如果创建了一个（数学）代码单元格，则可以将该单元格发送到 "
+"Maxima，这将使得计算结果显示在代码下方。下面显示了一对这样的命令："
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:44
+msgid "![Input/output cell](./InputCell.png){ id=img_InputCell }"
+msgstr "![输入、输出单元格](./InputCell.png){ id=img_InputCell }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:46
+#, fuzzy
+#| msgid ""
+#| "On evaluation of an input cell's contents the input cell _Maxima_ assigns "
+#| "a label to the input (by default shown in red and recognizable by the "
+#| "`%i`) by which it can be referenced later in the _wxMaxima_ session. The "
+#| "output that _Maxima_ generates also gets a label that begins with `%o` "
+#| "and by default is hidden, except if the user assigns the output a name. "
+#| "In this case by default the user-defined label is displayed. The `%o`\\-"
+#| "style label _Maxima_ auto-generates will also be accessible, though."
+msgid ""
+"On evaluation of an input cell’s contents the input cell _Maxima_ assigns a "
+"label to the input (by default shown in red and recognizable by the `%i`) by "
+"which it can be referenced later in the _wxMaxima_ session. The output that "
+"_Maxima_ generates also gets a label that begins with `%o` and by default is "
+"hidden, except if the user assigns the output a name. In this case by "
+"default the user-defined label is displayed. The `%o`-style label _Maxima_ "
+"auto-generates will also be accessible, though."
+msgstr ""
+"在计算（数学）输入单元格的内容时，Maxima 会为该输入指定一个标签（默认情况下以"
+"红色显示，并且可以由“%i”加数字识别），以便在 wxMaxima 会话的后续内容中引用该"
+"标签。Maxima 生成的输出也会获得以“%o”开头的标签，而当用户为输出指定了名称（如"
+"变量名）时，该标签是隐藏的。在后一种情况下，默认显示用户定义的名称。不过，此"
+"时仍可以访问 Maxima 自动生成的“%o”型标签。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:48
+msgid ""
+"Besides the input cells _wxMaxima_ allows for text cells for documentation, "
+"image cells, title cells, chapter cells and section cells. Every cell has "
+"its own undo buffer so debugging by changing the values of several cells and "
+"then gradually reverting the unneeded changes is rather easy. Furthermore "
+"the worksheet itself has a global undo buffer that can undo cell edits, adds "
+"and deletes."
+msgstr ""
+"除了（数学）输入单元格外，wxMaxima 中还可以使用文本单元格、图片单元格、标题单"
+"元格、节单元格和小节单元格等。每个单元格都有独立的撤消缓冲区，因此通过更改多"
+"个单元格的内容，然后逐步撤销不需要的更改来进行调试，是非常容易的。此外，工作"
+"簿本身有一个全局撤消缓冲区，可以撤消单元格编辑、添加和删除操作。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:50
+msgid ""
+"The figure below shows different cell types (title cells, section cells, "
+"subsection cells, text cells, input/output cells and image cells)."
+msgstr ""
+"下图显示了不同的单元格类型（标题单元格、节单元格、小节单元格、文本单元格、输"
+"入/输出单元格和图片单元格）："
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:52
+msgid ""
+"![Example of different wxMaxima cells](./cell-example.png){ id=img_cell-"
+"example }"
+msgstr ""
+"![wxMaxima 的不同类型单元格](./cell-example.png){ id=img_cell-example }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:53
+#, fuzzy, no-wrap
+#| msgid "Cells"
+msgid "Cells"
+msgstr "单元格"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:56
+#, fuzzy
+#| msgid ""
+#| "The worksheet is organized in cells. Each cell can contain other cells or "
+#| "the following types of content:"
+msgid ""
+"The worksheet is organized in cells. WxMaxima knows the following cell types:"
+msgstr "工作簿由单元格组成。每个单元格可以包含以下类型的内容："
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+#, fuzzy
+#| msgid "one or more lines of _Maxima_ input"
+msgid "Math cells, containing one or more lines of _Maxima_ input."
+msgstr "一行或多行 Maxima 命令；"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+#, fuzzy
+#| msgid "output of, or a question from, _Maxima_"
+msgid "Output of, or a question from, _Maxima_."
+msgstr "Maxima 的输出（含提问、报错信息）；"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Image cells."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+#, fuzzy
+#| msgid "a text block that can for example be used for documentation"
+msgid "Text cells, that can for example be used for documentation."
+msgstr "文本块，例如可用于组成文档的段落；"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid ""
+"A title, section or a subsection. 6 levels of different headings are "
+"possible."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:63
+msgid "Page breaks."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:65
+msgid ""
+"The default behavior of _wxMaxima_ when text is entered is to automatically "
+"create a math cell. Cells of other types can be created using the Cell menu, "
+"using the hot keys shown in the menu or using the drop-down list in the "
+"toolbar. Once the non-math cell is created, whatever is typed into the file "
+"is interpreted as text."
+msgstr ""
+"当输入文本时，wxMaxima 的默认行为是自动创建一个数学单元格。可以使用“单元格”菜"
+"单、菜单中显示的热键或工具栏中的下拉列表创建其他类型的单元格。一旦创建了非数"
+"学单元格，输入到文档的任何内容都将被解释为文本。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:67
+#, fuzzy
+#| msgid ""
+#| "Additional comment text can be entered into a math cell if bracketed as "
+#| "follows: `/*This comment will not be sent to Maxima for evaluation*/`."
+msgid ""
+"A (C-style) [comment text](https://maxima.sourceforge.io/docs/manual/"
+"maxima_singlepage.html#Comments) can be part of a math cell as follows: `/* "
+"This comment will be ignored by Maxima */`"
+msgstr ""
+"额外的注释文本可以输入到一个数学单元格中，格式为：`/*此注释将不会发送到 "
+"Maxima 中进行计算*/`。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:69
+msgid "\"`/*`\" marks the start of the comment, \"`*/`\" the end."
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:70
+#, fuzzy, no-wrap
+#| msgid "Horizontal and vertical cursors"
+msgid "Horizontal and vertical cursors"
+msgstr "水平光标和竖直光标"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:73
+#, fuzzy
+#| msgid ""
+#| "If the user tries to select a complete sentence a word processor will try "
+#| "to extend the selection to automatically begin and end with a word "
+#| "boundary. Likewise _wxMaxima_ if more than one cell is selected will "
+#| "extend the selection to whole cells."
+msgid ""
+"If the user tries to select a complete sentence, a word processor will try "
+"to extend the selection to automatically begin and end with a word boundary. "
+"Likewise, if more than one cell is selected, _wxMaxima_ will extend the "
+"selection to whole cells."
+msgstr ""
+"在一般的文字处理程序中，如果用户试图选择多个行，该程序将尝试扩展选择范围，使"
+"其自动包括这些行的所有内容。类似地，在 wxMaxima 中，如果同时选择了多个单元"
+"格，则 wxMaxima 会将选择范围扩展到所有这些单元格的内容。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:75
+#, fuzzy
+#| msgid ""
+#| "What isn't standard is that _wxMaxima_ provides drag-and-drop flexibility "
+#| "by defining two types of cursors. _wxMaxima_ will switch between them "
+#| "automatically when needed:"
+msgid ""
+"What isn’t standard is that _wxMaxima_ provides drag-and-drop flexibility by "
+"defining two types of cursors. _WxMaxima_ will switch between them "
+"automatically when needed:"
+msgstr ""
+"与一般程序不同的是，wxMaxima 通过定义两种类型的光标，提供了操作灵活性。"
+"wxMaxima 将在需要时自动在它们之间切换："
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:78
+msgid ""
+"The cursor is drawn horizontally if it is moved in the space between two "
+"cells or by clicking there."
+msgstr "如果光标在两个单元格之间移动或单击，则会使用水平光标；"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:78
+#, fuzzy
+#| msgid ""
+#| "A vertical cursor that works inside a cell. This cursor is activated by "
+#| "moving the cursor inside a cell using the mouse pointer or the cursor "
+#| "keys and works much like the cursor in a text editor."
+msgid ""
+"A vertical cursor that works inside a cell. This cursor is activated by "
+"moving the cursor inside a cell using the mouse pointer or the cursor keys "
+"and works much like the cursor in a text editor."
+msgstr ""
+"如果在单元格内输入时，则会使用垂直光标。此种光标是当使用鼠标指针或方向键在单"
+"元格内移动光标时被激活的，与文本编辑器中光标的激活方式非常相似。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:80
+#, no-wrap
+msgid "When you start wxMaxima, you will only see the blinking horizontal cursor. If you start typing, a math cell will be automatically created and the cursor will change to a regular vertical one (you will see a right arrow as \"prompt\", after the Math cell is evaluated (<kbd>CTRL</kbd>+<kbd>ENTER</kbd>), you will see the labels, e.g. `(%i1)`, `(%o1)`).\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:82
+msgid ""
+"![(blinking) horizontal cursor after wxMaxima start](./horizontal-cursor-"
+"only.png){ id=img_horizontal_cursor_only }"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:84
+msgid ""
+"You might want to create a different cell type (using the \"Cell\" menu), "
+"maybe a title cell or text cell, which describes, what will be done, when "
+"you start creating your worksheet."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:86
+msgid ""
+"If you navigate between the different cells, you will also see the "
+"(blinking) horizontal cursor, where you can insert a cell into your "
+"worksheet (either a math cell, by just start typing your formula - or a "
+"different cell type using the menu)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:88
+msgid ""
+"![(blinking) horizontal cursor between cells](./horizontal-cursor-between-"
+"cells.png){ id=img_horizontal_cursor_between_cells }"
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:89
+#, fuzzy, no-wrap
+#| msgid "Sending cells to Maxima"
+msgid "Sending cells to Maxima"
+msgstr "向 Maxima 发送单元格"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:92
+#, fuzzy, no-wrap
+#| msgid "The command in a code cell are executed once <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad is pressed. The _wxMaxima_ default is to enter commands when either <kbd>CTRL+ENTER</kbd> or <kbd>SHIFT+ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.\n"
+msgid "The command in a code cell is executed once by pressing <kbd>CTRL</kbd>+<kbd>ENTER</kbd>, <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> or the <kbd>ENTER</kbd> key on the keypad. The _wxMaxima_ default is to enter commands when either <kbd>CTRL</kbd>+<kbd>ENTER</kbd> or <kbd>SHIFT</kbd>+<kbd>ENTER</kbd> is entered, but _wxMaxima_ can be configured to execute commands in response to <kbd>ENTER</kbd>.\n"
+msgstr "只要按下键盘上的 <kbd>CTRL</kbd>+<kbd>ENTER</kbd>、<kbd>SHIFT</kbd>+<kbd>ENTER</kbd> 或 <kbd>ENTER</kbd> 键，（数学）代码单元格中的命令就会执行。wxMaxima 的默认设置是 <kbd>CTRL</kbd>+<kbd>ENTER</kbd> 或 <kbd>SHIFT</kbd>+ENTER</kbd> 键会使得命令由 Maxima 执行，但也可以设置为按下 <kbd>ENTER</kbd> 键执行命令。\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:93
+#, fuzzy, no-wrap
+#| msgid "Command autocompletion"
+msgid "Command autocompletion"
+msgstr "命令自动补全"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:96
+#, fuzzy, no-wrap
+#| msgid "_wxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example if activated within an unit specification for ezUnits it will offer a list of applicable units.\n"
+msgid "_WxMaxima_ contains an autocompletion feature that is triggered via the menu (Cell/Complete Word) or alternatively by pressing the key combination <kbd>CTRL</kbd>+<kbd>SPACE</kbd>. The autocompletion is context-sensitive. For example, if activated within a unit specification for ezUnits it will offer a list of applicable units.\n"
+msgstr "wxMaxima 包含自动补全功能，该功能可以通过菜单“单元格->自动补全”（Cell->Complete Word）或按组合键 <kbd>CTRL</kbd>+<kbd>K</kbd> 来触发。自动补全是上下文相关的。例如，如果在使用 ezUnits （单位换算包）的单元格中激活，它将提供适用的单位列表。\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:98
+msgid "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
+msgstr "![ezUnits](./ezUnits.png){ id=img_ezUnits }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:100
+#, fuzzy, no-wrap
+#| msgid "Besides completing a file name, a unit name or the current command’s or variable’s name the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).\n"
+msgid "Besides completing a file name, a unit name, or the current command or variable name, the autocompletion is able to show a template for most of the commands indicating the type (and meaning) of the parameters this program expects. To activate this feature press <kbd>SHIFT</kbd>+<kbd>CTRL</kbd>+<kbd>SPACE</kbd> or select the respective menu item (Cell/Show Template).\n"
+msgstr "除了补全文件名、单位名、当前命令或变量的名称之外，自动补全功能还可以显示大多数命令的模板，指示该命令所需参数的类型（和含义）。要激活此功能，可按下 <kbd>SHIFT</kbd> +<kbd>CTRL</kbd> +<kbd>K</kbd> 或选择相应的菜单项（“单元格->显示模板”，Cell->Show Template）。\n"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:101
+#, fuzzy, no-wrap
+#| msgid "Greek characters"
+msgid "Greek characters"
+msgstr "希腊字母"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:104
+msgid ""
+"Computers traditionally stored characters in 8-bit values. This allows for a "
+"maximum of 256 different characters. All letters, numbers, and control "
+"symbols (end of transmission, end of string, lines and edges for drawing "
+"rectangles for menus _etc_.) of nearly any given language can fit within "
+"that limit."
+msgstr ""
+"计算机一般以 8 位值（8-bit）存储字符，所以最多可以储存 256 个不同字符。大部分"
+"语言中的所有字母、数字和控制符号（传输结束、字符串结束、为菜单绘制矩形的线条"
+"和边缘等）都符合该限制。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:106
+#, fuzzy
+#| msgid ""
+#| "For most countries the codepage of 256 characters that has been chosen "
+#| "does not include things like Greek letters, though, that are frequently "
+#| "used in mathematics. To overcome this type of limitation [Unicode]"
+#| "(https://home.unicode.org/) has been invented: An encoding that makes "
+#| "English text work like normal, but to use much more than 256 characters."
+msgid ""
+"For most countries, the codepage of 256 characters that has been chosen does "
+"not include things like Greek letters, though, that are frequently used in "
+"mathematics. To overcome this type of limitation [Unicode](https://home."
+"unicode.org/) has been invented: An encoding that makes English text work "
+"like normal, but to use much more than 256 characters."
+msgstr ""
+"不过，对于大多数国家来说，256 个字符的代码页并没有包括希腊字母，而这些字母是"
+"数学上常用的。为了克服这种限制，[Unicode](https://home.unicode.org/)被发明"
+"了：一种使英文文本储存方式不变的编码，可使用的字符数远超 256 个。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:108
+#, fuzzy
+#| msgid ""
+#| "_Maxima_ allows Unicode, if it was compiled using a Lisp compiler that "
+#| "either supports Unicode or that doesn't care about the font encoding. As "
+#| "at least one of this pair of conditions is likely to be true. _wxMaxima_ "
+#| "provides a method of entering Greek characters using the keyboard:"
+msgid ""
+"_Maxima_ allows Unicode if it was compiled using a Lisp compiler that either "
+"supports Unicode or that doesn’t care about the font encoding. As at least "
+"one of this pair of conditions is likely to be true. _WxMaxima_ provides a "
+"method of entering Greek characters using the keyboard:"
+msgstr ""
+"如果使用支持 Unicode 或不关心字体编码的 Lisp 编译器来编译 Maxima，则在 "
+"Maxima 中可以使用 Unicode。前述两种情况中一般至少有一种是真的。wxMaxima 提供"
+"了一种使用键盘输入希腊字母的方法："
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:111
+#, fuzzy
+#| msgid ""
+#| "A Greek letter can be entered by pressing the <kbd>ESC</kbd> key and then "
+#| "starting to type the Greek character's name."
+msgid ""
+"A Greek letter can be entered by pressing the <kbd>ESC</kbd> key and then "
+"starting to type the Greek character’s name."
+msgstr ""
+"可以通过按下 <kbd>ESC</kbd> 键，然后开始键入希腊字母的英文名称来输入该字母。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:111
+#, fuzzy
+#| msgid ""
+#| "Alternatively it can be entered by pressing <kbd>ESC</kbd>, one letter "
+#| "(or two for the Greek letter omicron) and <kbd>ESC</kbd> again. In this "
+#| "case the following letters are supported:"
+msgid ""
+"Alternatively it can be entered by pressing <kbd>ESC</kbd>, one letter (or "
+"two for the Greek letter omicron) and <kbd>ESC</kbd> again. In this case the "
+"following letters are supported:"
+msgstr ""
+"或者，也可以通过按下 <kbd>ESC</kbd>、一个英文字母（对希腊字母 omicron 而言是"
+"两个）并再次按下 <kbd>ESC</kbd> 来输入。在这种情况下，支持以下字母："
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:130
+#, fuzzy, no-wrap
+#| msgid ""
+#| "| key | Greek letter | key | Greek letter | key | Greek letter |\n"
+#| "|:---:|:------------:|:---:|:------------:|:---:|:------------:|\n"
+#| "|  a  |     alpha    |  i  |     iota     |  r  |      rho     |\n"
+#| "|  b  |     beta     |  k  |     kappa    |  s  |     sigma    |\n"
+#| "|  g  |     gamma    |  l  |    lambda    |  t  |      tau     |\n"
+#| "|  d  |     delta    |  m  |      mu      |  u  |    upsilon   |\n"
+#| "|  e  |    epsilon   |  n  |      nu      |  f  |      phi     |\n"
+#| "|  z  |     zeta     |  x  |      xi      |  c  |      chi     |\n"
+#| "|  h  |      eta     |  om |    omicron   |  y  |      psi     |\n"
+#| "|  q  |     theta    |  p  |      pi      |  o  |     omega    |\n"
+#| "|  A  |     Alpha    |  I  |     Iota     |  R  |      Rho     |\n"
+#| "|  B  |     Beta     |  K  |     Kappa    |  S  |     Sigma    |\n"
+#| "|  G  |     Gamma    |  L  |    Lambda    |  T  |      Tau     |\n"
+#| "|  D  |     Delta    |  M  |      Mu      |  U  |    Upsilon   |\n"
+#| "|  E  |    Epsilon   |  N  |      Nu      |  P  |      Phi     |\n"
+#| "|  Z  |     Zeta     |  X  |      Xi      |  C  |      Chi     |\n"
+#| "|  H  |      Eta     |  Om |    Omicron   |  Y  |      Psi     |\n"
+#| "|  T  |     Theta    |  P  |      Pi      |  O  |     Omega    |\n"
+msgid ""
+"| key | Greek letter | key | Greek letter | key | Greek letter |\n"
+"| :-: | :----------: | :-: | :----------: | :-: | :----------: |\n"
+"|  a  |    alpha     |  i  |     iota     |  r  |     rho      |\n"
+"|  b  |     beta     |  k  |    kappa     |  s  |    sigma     |\n"
+"|  g  |    gamma     |  l  |    lambda    |  t  |     tau      |\n"
+"|  d  |    delta     |  m  |      mu      |  u  |   upsilon    |\n"
+"|  e  |   epsilon    |  n  |      nu      |  f  |     phi      |\n"
+"|  z  |     zeta     |  x  |      xi      |  c  |     chi      |\n"
+"|  h  |     eta      | om  |   omicron    |  y  |     psi      |\n"
+"|  q  |    theta     |  p  |      pi      |  o  |    omega     |\n"
+"|  A  |    Alpha     |  I  |     Iota     |  R  |     Rho      |\n"
+"|  B  |     Beta     |  K  |    Kappa     |  S  |    Sigma     |\n"
+"|  G  |    Gamma     |  L  |    Lambda    |  T  |     Tau      |\n"
+"|  D  |    Delta     |  M  |      Mu      |  U  |   Upsilon    |\n"
+"|  E  |   Epsilon    |  N  |      Nu      |  P  |     Phi      |\n"
+"|  Z  |     Zeta     |  X  |      Xi      |  C  |     Chi      |\n"
+"|  H  |     Eta      | Om  |   Omicron    |  Y  |     Psi      |\n"
+"|  T  |    Theta     |  P  |      Pi      |  O  |    Omega     |\n"
+msgstr ""
+"| 按键 | 希腊字母 | 按键 | 希腊字母 | 按键 | 希腊字母 |\n"
+"|:---:|:------------:|:---:|:------------:|:---:|:------------:|\n"
+"|  a  |     alpha    |  i  |     iota     |  r  |      rho     |\n"
+"|  b  |     beta     |  k  |     kappa    |  s  |     sigma    |\n"
+"|  g  |     gamma    |  l  |    lambda    |  t  |      tau     |\n"
+"|  d  |     delta    |  m  |      mu      |  u  |    upsilon   |\n"
+"|  e  |    epsilon   |  n  |      nu      |  f  |      phi     |\n"
+"|  z  |     zeta     |  x  |      xi      |  c  |      chi     |\n"
+"|  h  |      eta     |  om |    omicron   |  y  |      psi     |\n"
+"|  q  |     theta    |  p  |      pi      |  o  |     omega    |\n"
+"|  A  |     Alpha    |  I  |     Iota     |  R  |      Rho     |\n"
+"|  B  |     Beta     |  K  |     Kappa    |  S  |     Sigma    |\n"
+"|  G  |     Gamma    |  L  |    Lambda    |  T  |      Tau     |\n"
+"|  D  |     Delta    |  M  |      Mu      |  U  |    Upsilon   |\n"
+"|  E  |    Epsilon   |  N  |      Nu      |  P  |      Phi     |\n"
+"|  Z  |     Zeta     |  X  |      Xi      |  C  |      Chi     |\n"
+"|  H  |      Eta     |  Om |    Omicron   |  Y  |      Psi     |\n"
+"|  T  |     Theta    |  P  |      Pi      |  O  |     Omega    |\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:132
+msgid ""
+"You can also use the \"Greek letters\"-sidebar to enter the Greek letters."
+msgstr ""
+
+#. type: Title #####
+#: ../../info/wxmaxima.md:133
+#, no-wrap
+msgid "Attention: Lookalike characters"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:138
+msgid ""
+"Several Latin letters look like the Greek letters, e.g. the Latin letter "
+"\"A\" and the Greek letter \"Alpha\". Although they look identical, they are "
+"two different Unicode characters, represented by different Unicode code "
+"points (numbers)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:143
+msgid ""
+"This might be problematic, if you assign a value to the variable A and later "
+"use the Greek letter Alpha to do something with this variable, especially on "
+"printouts.  For the Greek letter my (which is also used as prefix for micro) "
+"there are also two different Unicode code points."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:146
+msgid ""
+"The \"Greek letters\"-sidebar therefore has the option, that lookalike "
+"characters are not available (which can be changed using a right-click menu)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:148
+msgid ""
+"The same mechanism also allows to enter some miscellaneous mathematical "
+"symbols:"
+msgstr "用同样的方法还可以输入一些其他的数学符号："
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:199
+#, fuzzy, no-wrap
+#| msgid ""
+#| "| keys to enter  | mathematical symbol                                   |\n"
+#| "|----------------|-------------------------------------------------------|\n"
+#| "| hbar           | Planck constant: a h with a horizontal bar above it   |\n"
+#| "| Hbar           | a H with a horizontal bar above it                    |\n"
+#| "| 2              | squared                                               |\n"
+#| "| 3              | to the power of three                                 |\n"
+#| "| /2             | 1/2                                                   |\n"
+#| "| partial        | partial sign (the d of dx/dt)                         |\n"
+#| "| integral       | integral sign                                         |\n"
+#| "| sq             | root                                                  |\n"
+#| "| ii             | imaginary                                             |\n"
+#| "| ee             | element                                               |\n"
+#| "| in             | in                                                    |\n"
+#| "| impl implies   | implies                                               |\n"
+#| "| inf            | infinity                                              |\n"
+#| "| empty          | empty                                                 |\n"
+#| "| TB             | Big triangle right                                    |\n"
+#| "| tb             | small triangle right                                  |\n"
+#| "| and            | and                                                   |\n"
+#| "| or             | or                                                    |\n"
+#| "| xor            | xor                                                   |\n"
+#| "| nand           | nand                                                  |\n"
+#| "| nor            | nor                                                   |\n"
+#| "| equiv          | equivalent                                            |\n"
+#| "| not            | not                                                   |\n"
+#| "| union          | union                                                 |\n"
+#| "| inter          | intersection                                          |\n"
+#| "| subseteq       | subset or equal                                       |\n"
+#| "| subset         | subset                                                |\n"
+#| "| notsubseteq    | not subset or equal                                   |\n"
+#| "| notsubset      | not subset                                            |\n"
+#| "| approx         | approximately                                         |\n"
+#| "| propto         | proportional to                                       |\n"
+#| "| neq != /= or # | not equal to                                          |\n"
+#| "| +/- or pm      | a plus/minus sign                                     |\n"
+#| "| <= or leq      | equal or less than                                    |\n"
+#| "| >= or geq      | equal or greater than                                 |\n"
+#| "| << or ll       | much less than                                        |\n"
+#| "| >> or gg       | much greater than                                     |\n"
+#| "| equiv          | equivalent to                                         |\n"
+#| "| qed            | end of proof                                          |\n"
+#| "| nabla          | a nabla operator                                      |\n"
+#| "| sum            | sum sign                                              |\n"
+#| "| prod           | product sign                                          |\n"
+#| "| exists         | there exists sign                                     |\n"
+#| "| nexists        | there is no sign                                      |\n"
+#| "| parallel       | a parallel sign                                       |\n"
+#| "| perp           | a perpendicular sign                                  |\n"
+#| "| leadsto        | a leads to sign                                       |\n"
+#| "| ->             | a right arrow                                         |\n"
+#| "| -->            | a long right arrow                                    |\n"
+msgid ""
+"| keys to enter  | mathematical symbol                                   |\n"
+"| -------------- | ----------------------------------------------------- |\n"
+"| hbar           | Planck constant: a h with a horizontal bar above it   |\n"
+"| Hbar           | a H with a horizontal bar above it                    |\n"
+"| 2              | squared                                               |\n"
+"| 3              | to the power of three                                 |\n"
+"| /2             | 1/2                                                   |\n"
+"| partial        | partial sign (the d of dx/dt)                         |\n"
+"| integral       | integral sign                                         |\n"
+"| sq             | square root                                           |\n"
+"| ii             | imaginary                                             |\n"
+"| ee             | element                                               |\n"
+"| in             | in                                                    |\n"
+"| impl implies   | implies                                               |\n"
+"| inf            | infinity                                              |\n"
+"| empty          | empty                                                 |\n"
+"| TB             | big triangle right                                    |\n"
+"| tb             | small triangle right                                  |\n"
+"| and            | and                                                   |\n"
+"| or             | or                                                    |\n"
+"| xor            | xor                                                   |\n"
+"| nand           | nand                                                  |\n"
+"| nor            | nor                                                   |\n"
+"| equiv          | equivalent to                                         |\n"
+"| not            | not                                                   |\n"
+"| union          | union                                                 |\n"
+"| inter          | intersection                                          |\n"
+"| subseteq       | subset or equal                                       |\n"
+"| subset         | subset                                                |\n"
+"| notsubseteq    | not subset or equal                                   |\n"
+"| notsubset      | not subset                                            |\n"
+"| approx         | approximately                                         |\n"
+"| propto         | proportional to                                       |\n"
+"| neq != /= or # | not equal to                                          |\n"
+"| +/- or pm      | a plus/minus sign                                     |\n"
+"| \\<= or leq     | equal or less than                                    |\n"
+"| >= or geq      | equal or greater than                                 |\n"
+"| \\<\\< or ll     | much less than                                        |\n"
+"| >> or gg       | much greater than                                     |\n"
+"| qed            | end of proof                                          |\n"
+"| nabla          | a nabla operator                                      |\n"
+"| sum            | sum sign                                              |\n"
+"| prod           | product sign                                          |\n"
+"| exists         | there exists sign                                     |\n"
+"| nexists        | there is no sign                                      |\n"
+"| parallel       | a parallel sign                                       |\n"
+"| perp           | a perpendicular sign                                  |\n"
+"| leadsto        | a leads to sign                                       |\n"
+"| ->             | a right arrow                                         |\n"
+"| -->            | a long right arrow                                    |\n"
+msgstr ""
+"| 按键  | 数学符号                                   |\n"
+"|----------------|-------------------------------------------------------|\n"
+"| hbar           | ħ，普朗克常数 |\n"
+"| Hbar           | Ħ，“H”上带一个短横                    |\n"
+"| 2              | ²，平方                                               |\n"
+"| 3              | ³，三次方                                 |\n"
+"| /2             | ½，二分之一                                           |\n"
+"| partial        | ∂，偏微分号                        |\n"
+"| integral       | ∫，积分号                                         |\n"
+"| sq             | √，根号                                                 |\n"
+"| ii             | ⅈ，虚部                                            |\n"
+"| ee             | ⅇ，元素                                               |\n"
+"| in             | ∈，属于                                                    |\n"
+"| impl，implies   | ⇒，可推出                                               |\n"
+"| inf            | ∞，无穷                                              |\n"
+"| empty          | ∅，空集                                                 |\n"
+"| TB             | ▶，向右的大三角形                                    |\n"
+"| tb             | ▸，向右的小三角形                                  |\n"
+"| and            | ⋀，且                                                  |\n"
+"| or             | ⋁，或                                                    |\n"
+"| xor            | ⊻，异或                                                   |\n"
+"| nand           | ⊼，且非                                                  |\n"
+"| nor            | ⊽，或非                                                   |\n"
+"| equiv          | ⇔，等价                                            |\n"
+"| not            | ¬，非                                                   |\n"
+"| union          | ⋃，并                                                 |\n"
+"| inter          | ⋂，交                                          |\n"
+"| subseteq       | ⊆，（可相等）子集                                      |\n"
+"| subset         | ⊂，子集                                                |\n"
+"| notsubseteq    | ⊈，非（可相等）子集                               |\n"
+"| notsubset      | ⊄，非子集                                            |\n"
+"| approx         | ≅，约等于                                         |\n"
+"| propto         | ∝，成比例                                       |\n"
+"| neq，!=，/= 或 # | ≠，不等于                                  |\n"
+"| +/- 或 pm      | ±，加减号                                     |\n"
+"| <= 或 leq      | ≤，小于等于                                    |\n"
+"| >= 或 geq      | ≥，大于等于                                 |\n"
+"| << 或 ll       | ≪，远小于                                        |\n"
+"| >> 或 gg       | ≫，远大于                                     |\n"
+"| equiv          | ≣，等价于                                         |\n"
+"| qed            | ∎，证毕                                          |\n"
+"| nabla          | ∇，nabla 算符                                      |\n"
+"| sum            | ∑，求和号                                              |\n"
+"| prod           | ∏，求积号                                          |\n"
+"| exists         | ∃，存在                                     |\n"
+"| nexists        | ∄，不存在                                      |\n"
+"| parallel       | ∥，平行                                       |\n"
+"| perp           | ⟂，垂直                                  |\n"
+"| leadsto        | ↝，导出                                       |\n"
+"| ->             | →，向右箭头                                         |\n"
+"| -->            | ⟶，向右长箭头                                   |\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:201
+msgid ""
+"You can also use the \"Symbols\"-sidebar to enter these Mathematical symbols."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:203
+#, fuzzy, no-wrap
+#| msgid "If a special symbol isn’t in the list it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> [number of the character (hexadecimal)] <kbd>ESC</kbd>.\n"
+msgid "If a special symbol isn’t in the list, it is possible to input arbitrary Unicode characters by pressing <kbd>ESC</kbd> \\[number of the character (hexadecimal)\\] <kbd>ESC</kbd>. Additionally the \"symbols\" sidebar has a right-click menu that allow to display a list of all available Unicode symbols one can add to this toolbar or to the worksheet.\n"
+msgstr "如果某个特殊的 Unicode 字符不在上表中，则可以用如下方式输入：按下 <kbd>ESC</kbd> 后，输入该字符的 16 进制编码，再按下 <kbd>ESC</kbd>。\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:205
+#, fuzzy, no-wrap
+#| msgid "<kbd>ESC</kbd> <kbd>61</kbd> <kbd>ESC</kbd> therefore results in an `a`.\n"
+msgid "<kbd>ESC</kbd><kbd>6</kbd><kbd>1</kbd><kbd>ESC</kbd> therefore results in an `a`.\n"
+msgstr "因此 <kbd>ESC</kbd> <kbd>61</kbd> <kbd>ESC</kbd> 输入了字符 `a`.\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:207
+#, fuzzy
+#| msgid ""
+#| "Please note that most of these symbols (notable exceptions are the logic "
+#| "symbols) do not have a special meaning in _Maxima_ and therefore will be "
+#| "interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp "
+#| "that doesn’t support dealing with Unicode characters they might cause an "
+#| "error message instead."
+msgid ""
+"Please note that most of these symbols (notable exceptions are the logic "
+"symbols) do not have a special meaning in _Maxima_ and therefore will be "
+"interpreted as ordinary characters. If _Maxima_ is compiled using a Lisp "
+"that doesn’t support Unicode characters they might cause an error message."
+msgstr ""
+"请注意，这些符号中的大多数（逻辑符号除外）在 Maxima 中没有特殊含义，因此将被"
+"解释为普通字符。如果使用不支持 Unicode 字符的 Lisp 编译器编译出 Maxima，则这"
+"些符号可能会导致输出错误消息。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:210
+#, no-wrap
+msgid ""
+"It may be the case that e.g. Greek characters or mathematical symbols are not included in the selected font, then they can not be displayed.\n"
+"To solve that problem, select other fonts (using: Edit -> Configure -> Style).\n"
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:211
+#, no-wrap
+msgid "Unicode replacement"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:214
+msgid ""
+"wxMaxima will replace several Unicode characters with their respective "
+"Maxima expressions, e.g. `²` with `^2`, `³` with `^3`, the square root sign "
+"with the function `sqrt()`, the (mathematical) Sigma sign (which is not the "
+"same Unicode character as the corresponding Greek letter) with `sum()`, etc."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:217
+msgid ""
+"Unicode has several \"common\" fractions encoded as one Unicode code point: "
+"`¼, ½, ¾, ⅐, ⅑, ⅒, ⅓, ⅔, ⅕, ⅖, ⅗, ⅘, ⅙, ⅚, ⅛, ⅜, ⅝, ⅞`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:219
+msgid ""
+"wxMaxima will replace them with their Maxima representations, e.g `(1/4)` "
+"before the input is sent do Maxima. There are also `⅟`, which will be "
+"replaced by `1/` and `↉` (used in baseball), which will be replaced by "
+"`(0/3)`."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:221
+msgid ""
+"It is recommended to use **Maxima code** (not these Unicode code points) in "
+"input cells (Rationale: (a) it might be possible, that the used font for "
+"math input does not contain them; (b) if you save the document as `wxm`-"
+"file, it is usually readable by (command line) Maxima, but these changes "
+"will of course not work in command line Maxima); but they may occur, if you "
+"cut&paste a formula from another document."
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:222
+#, fuzzy, no-wrap
+#| msgid "Side Panes"
+msgid "Side Panes"
+msgstr "侧边栏"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:225
+#, fuzzy
+#| msgid ""
+#| "Shortcuts to the most important _Maxima_ commands or things like a table "
+#| "of contents, windows with debug messages or a history of the last issued "
+#| "commands can be accessed using the side panes. They can be enabled using "
+#| "the \"View\" menu. They all can be moved to other locations inside or "
+#| "outside the _wxMaxima_ window. Other useful panes is the one that allows "
+#| "to input Greek letters using the mouse."
+msgid ""
+"Shortcuts to the most important _Maxima_ commands, things like a table of "
+"contents, windows with debug messages or a history of the last issued "
+"commands can be accessed using the side panes. They can be enabled using the "
+"\"View\" menu. They all can be moved to other locations inside or outside "
+"the _wxMaxima_ window. Other useful panes is the one that allows to input "
+"Greek letters using the mouse."
+msgstr ""
+"侧边栏可以用来访问一些常用的 Maxima 命令快捷方式、目录、包含调试消息的窗口或"
+"已执行命令的历史记录等。使用\"查看\"菜单可以启用这些侧边栏。它们都可以移动到 "
+"wxMaxima 窗口内部或外部。其中一个常用的是可用鼠标点选输入希腊字母的侧边栏。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:227
+msgid "![Example of different side panes](./SidePanes.png){ id=img_SidePanes }"
+msgstr "![各种类型的侧边栏](./SidePanes.png){ id=img_SidePanes }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:230
+msgid ""
+"In the \"table of contents\" side pane, one can increase or decrease a "
+"heading by just clicking on the heading with the right mouse button and "
+"select the next higher or lower heading type."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:232
+msgid ""
+"![Increase or decrease headings in the TOC side pane](./Sidepane-TOC-convert-"
+"headings.png){ id=Sidepane-TOC-convert-headings }"
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:233
+#, fuzzy, no-wrap
+#| msgid "MathML output"
+msgid "MathML output"
+msgstr "MathML 输出"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:236
+#, fuzzy
+#| msgid ""
+#| "Several word processors and similar programs either recognize MathML "
+#| "input and automatically insert it as an editable 2D equation - or (like "
+#| "LibreOffice 5.1) have an equation editor that offers an “import MathML "
+#| "from clipboard” feature. Others support RTF maths. _wxMaxima_ therefore "
+#| "offers several entries in the right-click menu."
+msgid ""
+"Several word processors and similar programs either recognize [MathML]"
+"(https://www.w3.org/Math/) input and automatically insert it as an editable "
+"2D equation - or (like LibreOffice) have an equation editor that offers an "
+"“import MathML from clipboard” feature. Others support RTF maths. "
+"_WxMaxima_, therefore, offers several entries in the right-click menu."
+msgstr ""
+"一些文字处理程序可以识别 MathML 输入并自动将其作为可编辑的数学公式插入，或者"
+"（像 LibreOffice 7.1 那样）有一个提供“从剪贴板导入 MathML”功能的公式编辑器。"
+"有些程序也支持 RTF 公式。因此，wxMaxima 在右键单击菜单中提供了多种复制公式的"
+"方法。"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:237
+#, fuzzy, no-wrap
+#| msgid "Markdown support"
+msgid "Markdown support"
+msgstr "标记语言（Markdown）支持"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:240
+#, fuzzy
+#| msgid ""
+#| "_wxMaxima_ offers a set of standard markdown conventions that don't "
+#| "collide with mathematical notation. One of this elements is bullet lists."
+msgid ""
+"_WxMaxima_ offers a set of standard [Markdown](https://en.wikipedia.org/wiki/"
+"Markdown) conventions that don’t collide with mathematical notation. One of "
+"these elements is bullet lists."
+msgstr ""
+"wxMaxima 提供了一些标准的标记（markdown）语言支持，而这些记号不会与数学符号相"
+"冲突。其中一个支持是项目符号列表。"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:241
+#, fuzzy, no-wrap
+#| msgid ""
+#| "Ordinary text\n"
+#| " * One item, indentation level 1\n"
+#| " * Another item at indentation level 1\n"
+#| "   * An item at a second indentation level\n"
+#| "   * A second item at the second indentation level\n"
+#| " * A third item at the first indentation level\n"
+#| "Ordinary text\n"
+msgid ""
+"Ordinary text\n"
+" * One item, indentation level 1\n"
+" * Another item at indentation level 1\n"
+"   * An item at a second indentation level\n"
+"   * A second item at the second indentation level\n"
+" * A third item at the first indentation level\n"
+"Ordinary text\n"
+msgstr ""
+"普通文本\n"
+" *一个条目，缩进级别为 1\n"
+" *另一个条目，缩进级别为 1\n"
+"   *一个条目，缩进级别为 2\n"
+"   *另一个条目，缩进级别为 2\n"
+"*第三个条目，缩进级别为 1\n"
+"普通文本\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:252
+#, fuzzy, no-wrap
+#| msgid "_wxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
+msgid "_WxMaxima_ will recognize text starting with `>` chars as block quotes:\n"
+msgstr "wxMaxima 也能将以 `>` 字符开头的文本识别为引用块：\n"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:253
+#, fuzzy, no-wrap
+#| msgid ""
+#| "Ordinary text\n"
+#| "> quote quote quote quote\n"
+#| "> quote quote quote quote\n"
+#| "> quote quote quote quote\n"
+#| "Ordinary text\n"
+msgid ""
+"Ordinary text\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"> quote quote quote quote\n"
+"Ordinary text\n"
+msgstr ""
+"普通文本\n"
+">引用文字\n"
+">引用文字\n"
+">引用文字\n"
+"普通文本\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:262
+#, fuzzy, no-wrap
+#| msgid "_wxMaxima_'s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:\n"
+msgid "_WxMaxima_’s TeX and HTML output will also recognize `=>` and replace it by the corresponding Unicode sign:\n"
+msgstr "wxMaxima 的 TeX 和 HTML 输出也能识别 `=>`，并将其替换为相应的 Unicode 符号：\n"
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:263
+#, fuzzy, no-wrap
+#| msgid "cogito => sum.\n"
+msgid "cogito => sum.\n"
+msgstr "cogito => sum.\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:268
+#, fuzzy, no-wrap
+#| msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single- headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.\n"
+msgid "Other symbols the HTML and TeX export will recognize are `<=` and `>=` for comparisons, a double-pointed double arrow (`<=>`), single-headed arrows (`<->`, `->` and `<-`) and `+/-` as the respective sign. For TeX output also `<<` and `>>` are recognized.\n"
+msgstr "导出 TeX 和 HTML 文件时将识别的其他符号还有不等号（`<=` 和 `>=`）、双线箭头（`<=>`）、单线箭头（`<->`、`->` 和 `<-`）以及 `+/-`。对于 TeX 输出，还可以识别 `<<` 和 `>>`。\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:269
+#, fuzzy, no-wrap
+#| msgid "Hotkeys"
+msgid "Hotkeys"
+msgstr "快捷键"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:272
+msgid ""
+"Most hotkeys can be found in the text of the respective menus. Since they "
+"are actually taken from the menu text and thus can be customized by the "
+"translations of _wxMaxima_ to match the needs of users of the local "
+"keyboard, we do not document them here. A few hotkeys or hotkey aliases, "
+"though, are not documented in the menus:"
+msgstr ""
+"大多数快捷键可以在相应菜单的文本中找到。由于它们实际上是从菜单文本中获取的，"
+"所以可以通过 wxMaxima 的翻译文本进行定制，以满足本地用户的需求，因此我们不在"
+"这里记录它们。但是，一些快捷键或其别名并没有记录在菜单中："
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid ""
+"<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete cell."
+msgstr "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> 删除一个单元格。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+#, fuzzy
+#| msgid ""
+#| "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> deletes a complete "
+#| "cell."
+msgid ""
+"<kbd>CTRL</kbd>+<kbd>TAB</kbd> or <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>TAB</"
+"kbd> triggers the auto-completion mechanism."
+msgstr "<kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>DELETE</kbd> 删除一个单元格。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:276
+msgid "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> inserts a non-breaking space."
+msgstr "<kbd>SHIFT</kbd>+<kbd>SPACE</kbd> 插入一个不可断行的空格。"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:277
+#, fuzzy, no-wrap
+#| msgid "Raw TeX in the TeX export"
+msgid "Raw TeX in the TeX export"
+msgstr "导出 TeX 时的原始 TeX 代码"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:280
+msgid ""
+"If a text cell begins with `TeX:` the TeX export contains the literal text "
+"that follows the `TeX:` marker. Using this feature allows the entry of TeX "
+"markup within the _wxMaxima_ workbook."
+msgstr ""
+"如果文本单元格以 `TeX: ` 开头，则导出 TeX 时，文件将包含 `TeX: ` 标记后面的文"
+"本。使用此功能可以在 wxMaxima 工作簿中输入 TeX 代码。"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:281
+#, fuzzy, no-wrap
+#| msgid "File Formats"
+msgid "File Formats"
+msgstr "文件格式"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:284
+msgid ""
+"The material that is developed in a _wxMaxima_ session can be stored for "
+"later use in any of three ways:"
+msgstr "在 wxMaxima 中输入的内容可以存为以下三种文件格式之一，以供以后使用："
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:285
+#, fuzzy, no-wrap
+#| msgid ".mac"
+msgid ".mac"
+msgstr ".mac"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:288
+#, fuzzy
+#| msgid ""
+#| ".mac files are ordinary text files that contain _Maxima_ commands. They "
+#| "can be read using _Maxima_’s read command or _wxMaxima_’s File/Batch File "
+#| "menu entry."
+msgid ""
+"`.mac` files are ordinary text files that contain _Maxima_ commands. They "
+"can be read using _Maxima_’s `batch()` or `load()` command or _wxMaxima_’s "
+"File/Batch File menu entry."
+msgstr ""
+"`.mac` 文件是包含 Maxima 命令的普通文本文件，该文件可以使用 Maxima 的 read 命"
+"令或 wxMaxima 的\"文件->批处理\"（File->Batch）菜单项来读取它们。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:291
+msgid ""
+"One example is shown below. `Quadratic.mac` defines a function and afterward "
+"generates a plot with `wxdraw2d()`.  Afterward the contents of the file "
+"`Quadratic.mac` are printed and newly defined function `f()` is evaluated."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:293
+#, fuzzy
+#| msgid "![Batch image](./BatchImage.png){ id=img_BatchImage }"
+msgid "![Loading a file with `batch()`](./BatchImage.png){ id=img_BatchImage }"
+msgstr "![批处理](./BatchImage.png){ id=img_BatchImage }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:295
+msgid ""
+"Attention: Although the file `Quadratic.mac` has a usual _Maxima_ extension "
+"(`.mac`), it can only be read by _wxMaxima_, since the command `wxdraw2d()` "
+"is a wxMaxima-extension to _Maxima_. (Command line) Maxima will ignore the "
+"unknown command `wxdraw2d()` and print it as output again."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:297
+#, fuzzy
+#| msgid ""
+#| "You can be use `.mac` files for writing your own library of macros. But "
+#| "since they don’t contain enough structural information they cannot be "
+#| "read back as a _wxMaxima_ session."
+msgid ""
+"You can be use `.mac` files for writing your own library of macros. But "
+"since they don’t contain enough structural information they cannot be read "
+"back as a _wxMaxima_ session."
+msgstr ""
+"用户可以使用 `.mac` 文件编写自己的程序包。但是由于它们没有包含足够的结构信"
+"息，因此不能作为一个 wxMaxima 工作簿来读取。"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:298
+#, fuzzy, no-wrap
+#| msgid ".wxm"
+msgid ".wxm"
+msgstr ".wxm"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:302
+#, fuzzy, no-wrap
+#| msgid ".wxm files contain the worksheet except _Maxima_'s output. On Maxima versions >5.38 they can be read using _Maxima_'s `load()` function just as .mac files can be. With this plain-text format it sometimes is unavoidable that worksheets that use new features are not downwards-compatible with older versions of _wxMaxima_.\n"
+msgid ""
+"`.wxm` files contain the worksheet except for _Maxima_’s output. On Maxima versions >5.38 they can be read using _Maxima_’s `load()` function just as .mac files. Well - mostly. Questions (like `asksign(x)`) are problematic, as the answer is written in the `.wxm` file (so that it can be suggested after loading), but that can Maxima not evaluate.\n"
+"You can prevent Maxima from asking questions by using `assume()` to declare some properties, Maxima wants to know.\n"
+msgstr "`.wxm` 文件包含除 Maxima 输出之外的工作簿内容。在版本号大于 5.38 的 Maxima 上，可以像 `.mac` 文件一样，使用 Maxima 的 `load()` 函数来读取。如果采用这种文本格式，使用含新功能的工作簿时会不可避免地与旧版本的 wxMaxima 不兼容。\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:304
+#, fuzzy
+#| msgid ""
+#| ".wxm files contain the worksheet except _Maxima_'s output. On Maxima "
+#| "versions >5.38 they can be read using _Maxima_'s `load()` function just "
+#| "as .mac files can be. With this plain-text format it sometimes is "
+#| "unavoidable that worksheets that use new features are not downwards-"
+#| "compatible with older versions of _wxMaxima_.\n"
+msgid ""
+"With this plain-text format, it sometimes is unavoidable that worksheets "
+"that use new features are not downwards-compatible with older versions of "
+"_wxMaxima_."
+msgstr ""
+"`.wxm` 文件包含除 Maxima 输出之外的工作簿内容。在版本号大于 5.38 的 Maxima "
+"上，可以像 `.mac` 文件一样，使用 Maxima 的 `load()` 函数来读取。如果采用这种"
+"文本格式，使用含新功能的工作簿时会不可避免地与旧版本的 wxMaxima 不兼容。\n"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:305
+#, fuzzy, no-wrap
+#| msgid "File Formats"
+msgid "File format of wxm files"
+msgstr "文件格式"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:308
+msgid ""
+"This is just a plain text file (you can open it with a text editor), "
+"containing the cell contents as some special Maxima comments."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:310
+msgid "It starts with the following comment:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:311
+#, no-wrap
+msgid ""
+"/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/\n"
+"/* [ Created with wxMaxima version 24.02.2_DevelopmentSnapshot ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:317
+msgid ""
+"And then the cells follow, encoded as Maxima comments, e.g. a section cell:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:318
+#, no-wrap
+msgid ""
+"/* [wxMaxima: section start ]\n"
+"Title of the section\n"
+"   [wxMaxima: section end   ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:325
+msgid ""
+"or (in a Math cell the input is of course *not* commented out (the output is "
+"not saved in a `wxm` file)):"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:326
+#, no-wrap
+msgid ""
+"/* [wxMaxima: input   start ] */\n"
+"f(x):=x^2+1$\n"
+"f(2);\n"
+"/* [wxMaxima: input   end   ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:334
+msgid ""
+"Images are [Base64 encoded](https://en.wikipedia.org/wiki/Base64) with the "
+"image type as first line):"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:335
+#, no-wrap
+msgid ""
+"/* [wxMaxima: image   start ]\n"
+"jpg\n"
+"[very chaotic looking character sequence]\n"
+"   [wxMaxima: image   end   ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:343
+msgid "A page break is just one line containing:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:344
+#, no-wrap
+msgid "/* [wxMaxima: page break    ] */\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:349
+msgid "And folded cells marked by:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:350
+#, no-wrap
+msgid ""
+"/* [wxMaxima: fold    start ] */\n"
+"...\n"
+"/* [wxMaxima: fold    end   ] */\n"
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:356
+#, fuzzy, no-wrap
+#| msgid ".wxmx"
+msgid ".wxmx"
+msgstr ".wxmx"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:359
+msgid ""
+"This XML-based file format saves the complete worksheet including things "
+"like the zoom factor and the watchlist. It is the preferred file format."
+msgstr ""
+"这种基于 XML 的文件格式保存了完整的工作簿内容，包括缩放因子和观察列表等内容。"
+"它是首选的文件格式。"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:360
+#, fuzzy, no-wrap
+#| msgid "File Formats"
+msgid "File format of wxmx files"
+msgstr "文件格式"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:364
+msgid ""
+"A `wxmx`-file seems to be a binary format, but one can handle it with tools, "
+"which are included in your OS. It is a zip file, one can decompress it with "
+"`unzip` (maybe rename it before, so that is recognized by the unzip program "
+"of your OS).  We do not use the compression function, just the possibility "
+"to merge several files into one file - images are already compressed and the "
+"rest is simple text (probably much smaller, than huge images, which are "
+"included)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:366
+msgid "It does contain the following files:"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`mimetype`: this file does contain the mimetype of wxMaxima files: `text/x-"
+"wxmathml`"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`format.txt`: a short description about wxMaxima and the wxmx file format"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"Images (e.g. png, jpeg): inline plots which were produced in the wxMaxima "
+"session and included images."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:371
+msgid ""
+"`content.xml`: a XML document, which contains the various cells of your "
+"document in XML format."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:373
+msgid ""
+"So, if something goes wrong, you can unzip a wxMaxima document (maybe rename "
+"it before to a `zip`-file), maybe make changes in the `content.xml` file "
+"with a text editor, or replace an broken image, zip the files again, "
+"probably rename the `zip` to a `wxmx`-file - and you get another modified "
+"`wxmx`-file."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:374
+#, fuzzy, no-wrap
+#| msgid "Configuration options"
+msgid "Configuration options"
+msgstr "设置选项"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:377
+msgid ""
+"For some common configuration variables _wxMaxima_ offers two ways of "
+"configuring:"
+msgstr "对于一些常见的可设置变量，wxMaxima提供了两种设置方法："
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:380
+msgid ""
+"The configuration dialog box below lets you change their default values for "
+"the current and subsequent sessions."
+msgstr "下面的设置对话框允许用户更改当前和后续会话的默认值。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:380
+#, fuzzy
+#| msgid ""
+#| "Also, the values for most configuration variables can be changed for the "
+#| "current session only by overwriting their values from the worksheet, as "
+#| "shown below."
+msgid ""
+"Also, the values for most configuration variables can be changed for the "
+"current session only by overwriting their values from the worksheet, as "
+"shown below."
+msgstr ""
+"对于当前会话，要变更大多数可设置变量的值只能通过从工作簿添加相应的命令，见后"
+"续说明。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:382
+msgid ""
+"![wxMaxima configuration 1](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
+msgstr ""
+"![wxMaxima 设置对话框](./wxMaxima_configuration_001.png)"
+"{ id=img_wxMaxima_configuration_001 }"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:383
+#, fuzzy, no-wrap
+#| msgid "Default animation framerate"
+msgid "Default animation framerate"
+msgstr "默认动图帧率"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:386
+msgid ""
+"The animation framerate that is used for new animations is kept in the "
+"variable `wxanimate_framerate`. The initial value this variable will contain "
+"in a new worksheet can be changed using the configuration dialogue."
+msgstr ""
+"用于新生成动图的帧率保存在变量 `wxanimate_framerate` 中，可以使用设置对话框更"
+"改此变量在新工作簿中的初始值。"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:387
+#, fuzzy, no-wrap
+#| msgid "Default plot size for new _maxima_ sessions"
+msgid "Default plot size for new _maxima_ sessions"
+msgstr "新 Maxima 会话的默认绘图尺寸"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:390
+#, fuzzy
+#| msgid ""
+#| "After the next start plots embedded into the worksheet will be created "
+#| "with this size if the value of `wxplot_size` isn't changed by _maxima_."
+msgid ""
+"After the next start, plots embedded into the worksheet will be created with "
+"this size if the value of `wxplot_size` isn’t changed by _maxima_."
+msgstr ""
+"如果 `wxplot_size` 的值没有被 Maxima 更改，则使用此大小创建绘图并嵌入工作簿。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:392
+#, fuzzy
+#| msgid ""
+#| "In order to set the plot size of a single graph only use the following "
+#| "notation can be used that sets a variable’s value for one command only:"
+msgid ""
+"In order to set the plot size of a single graph only use the following "
+"notation can be used that sets a variable’s value for one command only:"
+msgstr "为了仅对单个绘图命令设置绘制图形的大小，可以使用以下代码："
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:393
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxdraw2d( \n"
+#| "   explicit(\n"
+#| "       x^2,\n"
+#| "\t   x,-5,5\n"
+#| "   )\n"
+#| "), wxplot_size=[480,480]$\n"
+msgid ""
+"wxdraw2d(\n"
+"   explicit(\n"
+"       x^2,\n"
+"       x,-5,5\n"
+"   )\n"
+"), wxplot_size=[480,480]$\n"
+msgstr ""
+"wxdraw2d( \n"
+"   explicit(\n"
+"       x^2,\n"
+"\t   x,-5,5\n"
+"   )\n"
+"), wxplot_size=[480,480]$\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:402
+#, fuzzy, no-wrap
+#| msgid "Match parenthesis in text controls"
+msgid "Match parenthesis in text controls"
+msgstr "在文本中匹配括号"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:405
+msgid "This option enables two things:"
+msgstr "该选项使以下两个功能生效："
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:408
+#, fuzzy
+#| msgid ""
+#| "If an opening parenthesis, bracket or double quote is entered _wxMaxima_ "
+#| "will insert a closing one after it."
+msgid ""
+"If an opening parenthesis, bracket, or double quote is entered _wxMaxima_ "
+"will insert a closing one after it."
+msgstr ""
+"如果输入了左括号、左方括号或左双引号，wxMaxima 将自动在其后插入与之配对的右括"
+"号、右方括号或右双引号。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:408
+msgid ""
+"If text is selected if any of these keys is pressed the selected text will "
+"be put between the matched signs."
+msgstr ""
+"如果在输入前述字符中的任何一个时选择了文本，则所选文本将被放在配对的两个字符"
+"之间。"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:409
+#, fuzzy, no-wrap
+#| msgid "Don't save the worksheet automatically"
+msgid "Don’t save the worksheet automatically"
+msgstr "不自动保存工作簿"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:412
+#, fuzzy
+#| msgid ""
+#| "If this option is set the file the worksheet is in is overwritten only on "
+#| "request of the user. In case of a crash/power loss/... a recent backup "
+#| "copy is still made available in the temp directory, though."
+msgid ""
+"If this option is set, the file where the worksheet is will be overwritten "
+"only the request of the user. In case of a crash/power loss/... a recent "
+"backup copy is still made available in the temp directory, though."
+msgstr ""
+"如果设置了此选项，则只有在用户请求时才会覆盖工作簿所在的文件。为了防止发生碰"
+"撞、断电等突发情况，临时目录（temp）中仍保留了一个最近的备份文件。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:414
+#, fuzzy
+#| msgid ""
+#| "If this option isn't set _wxMaxima_ behaves more like a modern cellphone "
+#| "app:"
+msgid ""
+"If this option isn’t set _wxMaxima_ behaves more like a modern cellphone app:"
+msgstr "如果未设置此选项，则 wxMaxima 的行为更像现代手机软件："
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:417
+msgid "Files are saved automatically on exit"
+msgstr "文件在退出时被自动保存；"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:417
+#, fuzzy
+#| msgid "And the file will automatically be saved every 3 minutes."
+msgid "And the file will automatically be saved every 3 minutes."
+msgstr "每 3 分钟文件被自动保存一次；"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:418
+#, fuzzy, no-wrap
+#| msgid "Where is the configuration saved?"
+msgid "Where is the configuration saved?"
+msgstr "设置信息保存的位置"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:422
+#, fuzzy, no-wrap
+#| msgid ""
+#| "If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets < 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).\n"
+#| "(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).\n"
+msgid ""
+"If you are using Unix/Linux, the configuration information will be saved in a file `.wxMaxima` in your home directory (if you are using wxWidgets \\< 3.1.1), or `.config/wxMaxima.conf` ((XDG-Standard) if wxWidgets >= 3.1.1 is used). You can retrieve the wxWidgets version from the command `wxbuild_info();` or by using the menu option Help->About. [wxWidgets](https://www.wxwidgets.org/) is the cross-platform GUI library, which is the base for _wxMaxima_ (therefore the `wx` in the name).\n"
+"(Since the filename starts with a dot, `.wxMaxima` or `.config` will be hidden).\n"
+msgstr ""
+"当使用 Unix/Linux 系统时，设置信息将保存在主目录中的 `.wxMaxima` 文件里（如果 wxWidgets 版本号小于 3.1.1）或 `.config/wxMaxima.conf` 文件里（如果 wxWidgets 的版本号大于等于 3.1.1（XDG标准））。用户可以通过命令 `wxbuild_info();` 或使用菜单选项 \"帮助->关于\"（Help->About）来检索 wxWidgets 版本号。[wxWidgets](https://www.wxwidgets.org/) 是跨平台的 GUI 库，也是 wxMaxima 的底层库（因此 wxMaxima 的名称中带“wx”）。\n"
+"（由于文件名以点“.”开头，文件 `.wxMaxima` 或 `.config` 将被隐藏）。\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:424
+msgid ""
+"If you are using Windows, the configuration will be stored in the registry. "
+"You will find the entries for _wxMaxima_ at the following position in the "
+"registry: `HKEY_CURRENT_USER\\Software\\wxMaxima`"
+msgstr ""
+"当使用 Windows 系统时，配置信息将存储在注册表中。在注册表中的以下位置可以找"
+"到 wxMaxima 的相关条目：`HKEY_CURRENT_USER\\Software\\wxMaxima`。"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:427
+#, fuzzy, no-wrap
+#| msgid "Extensions to _Maxima_"
+msgid "Extensions to _Maxima_"
+msgstr "对 Maxima 功能的扩充"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:430
+#, fuzzy
+#| msgid ""
+#| "_wxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
+#| "its main purpose is to pass along commands to _Maxima_ and to report the "
+#| "results of executing those commands. In some cases, however, _wxMaxima_ "
+#| "adds functionality to _Maxima_. _wxMaxima_’s ability to generate reports "
+#| "by exporting a workbook’s contents to HTML and LaTeX files has been "
+#| "mentioned. This section considers some ways that _wxMaxima_ enhances the "
+#| "inclusion of graphics into a session."
+msgid ""
+"_WxMaxima_ is primarily a graphical user interface for _Maxima_. As such, "
+"its main purpose is to pass along commands to _Maxima_ and to report the "
+"results of executing those commands. In some cases, however, _wxMaxima_ adds "
+"functionality to _Maxima_. _WxMaxima_’s ability to generate reports by "
+"exporting a workbook’s contents to HTML and LaTeX files has been mentioned. "
+"This section considers some ways that _wxMaxima_ enhances the inclusion of "
+"graphics in a session."
+msgstr ""
+"wxMaxima 是 Maxima 的图形用户界面，因此它的主要目的是将命令传递给 Maxima，并"
+"输出执行这些命令的结果。但是，在某些情况下，wxMaxima 会为 Maxima 添加新的功"
+"能。前面已提到 wxMaxima 可以将工作簿的内容导出为 HTML 和 LaTeX 文件。本节将讨"
+"论另外一些增强功能，以及在工作簿中包含图形的方法。"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:431
+#, fuzzy, no-wrap
+#| msgid "Subscripted variables"
+msgid "Subscripted variables"
+msgstr "为变量添加下标"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:434
+msgid ""
+"`wxsubscripts` specifies, if (and how) _wxMaxima_ will autosubscript "
+"variable names:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:436
+msgid ""
+"If it is `false`, the functionality is off, wxMaxima will not autosubscript "
+"part of variable names after an underscore."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:438
+msgid ""
+"If it is set to `'all`, everything after an underscore will be subscripted."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:440
+#, fuzzy
+#| msgid ""
+#| "if `wxsubscripts` is set to true variable names of the format `x_y` are "
+#| "displayed using a subscript if"
+msgid ""
+"If it is set to `true` variable names of the format `x_y` are displayed "
+"using a subscript if"
+msgstr ""
+"如果 `wxsubscripts` 设置为 true，则当以下条件满足时，将使用下标来显示格式为 "
+"`x_y` 的变量名："
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:443
+#, fuzzy
+#| msgid "`y` is a single letter"
+msgid "Either `x` or `y` is a single letter or"
+msgstr "`y` 是一个字母；"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:443
+msgid "`y` is an integer (can include more than one character)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:445
+msgid ""
+"![How variables are autosubscripted using wxsubscripts](./wxsubscripts.png)"
+"{ id=img_wxsubscripts }"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:447
+#, fuzzy
+#| msgid ""
+#| "If the variable name doesn’t match these requirements it can still be "
+#| "declared as \"to be subscripted\" using the command "
+#| "`wxdeclare_subscript(variable_name);` or "
+#| "`wxdeclare_subscript([variable_name1,variable_name2,...]);` Declaring a "
+#| "variable as subscripted can be reverted using the following command: "
+#| "`wxdeclare_subscript(variable_name,false);`"
+msgid ""
+"If the variable name doesn’t match these requirements, it can still be "
+"declared as \"to be subscripted\" using the command "
+"`wxdeclare_subscript(variable_name);` or "
+"`wxdeclare_subscript([variable_name1,variable_name2,...]);` Declaring a "
+"variable as subscripted can be reverted using the following command: "
+"`wxdeclare_subscript(variable_name,false);`"
+msgstr ""
+"如果变量格式与上述条件不匹配，仍可以使用命令"
+"`wxdeclare_subscript(variable_name);` 或 "
+"`wxdeclare_subscript([variable_name1,variable_name2,...]);`来显示下标。声明为"
+"下标的变量可以使用以下命令还原格式：`wxdeclare_subscript(variable_name,"
+"false);`。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:449
+#, no-wrap
+msgid "You can use the menu \"View->Autosubscript\" to set these values.\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:450
+#, fuzzy, no-wrap
+#| msgid "User feedback in the status bar"
+msgid "User feedback in the status bar"
+msgstr "在状态栏中提供反馈信息"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:453
+#, fuzzy
+#| msgid ""
+#| "Long-running commands can provide user-feedback in the status bar. This "
+#| "user feedback is replaced by any new feedback that is placed there "
+#| "(allowing to use it as a progress indicator) and is deleted as soon as "
+#| "the current command sent to _Maxima_ is finished. It is safe to use "
+#| "`wxstatusbar()` even in libraries that might be used with plain _Maxima_ "
+#| "(as opposed to _wxMaxima_): If _wxMaxima_ isn't present the "
+#| "`wxstatusbar()` command will just be left unevaluated."
+msgid ""
+"Long-running commands can provide user feedback in the status bar. This user "
+"feedback is replaced by any new feedback that is placed there (allowing to "
+"use it as a progress indicator) and is deleted as soon as the current "
+"command sent to _Maxima_ is finished. It is safe to use `wxstatusbar()` even "
+"in libraries that might be used with plain _Maxima_ (as opposed to "
+"_wxMaxima_): If _wxMaxima_ isn’t present the `wxstatusbar()` command will "
+"just be left unevaluated."
+msgstr ""
+"长时间运行的命令中可以包含 `wxstatusbar()`，以用于在状态栏中向用户提供反馈信"
+"息。此反馈信息将被任何新生成的反馈信息覆盖（从而可以将其用作运行进度指示"
+"器），并在发送到 Maxima 的命令运行结束后立即被删除。即使在只与 Maxima（而非 "
+"wxMaxima）一起使用的库中包含命令 `wxstatusbar()` 也是可行的：如果没有运行 "
+"wxMaxima，那么命令 `wxstatusbar()` 也不会被执行。"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:454
+#, fuzzy, no-wrap
+#| msgid ""
+#| "for i:1 thru 10 do (\n"
+#| "    /* Tell the user how far we got */\n"
+#| "    wxstatusbar(concat(\"Pass \",i)),\n"
+#| "    /* (sleep n) is a Lisp function, which can be used */\n"
+#| "    /* with the character \"?\" before. It delays the */\n"
+#| "    /* program execution (here: for 3 seconds) */\n"
+#| "    ?sleep(3)\n"
+#| ")$\n"
+msgid ""
+"for i:1 thru 10 do (\n"
+"    /* Tell the user how far we got */\n"
+"    wxstatusbar(concat(\"Pass \",i)),\n"
+"    /* (sleep n) is a Lisp function, which can be used */\n"
+"    /* with the character \"?\" before. It delays the */\n"
+"    /* program execution (here: for 3 seconds) */\n"
+"    ?sleep(3)\n"
+")$\n"
+msgstr ""
+"for i:1 thru 10 do (\n"
+"    /* 告诉用户目前的运行位置 */\n"
+"    wxstatusbar(concat(\"Pass \",i)),\n"
+"    /* (sleep n) 是可接在字符\"?\"后使用的 Lisp 函数 */\n"
+"    /* 它推迟了程序的运行，此处是 3 秒 */\n"
+"    ?sleep(3)\n"
+")$\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:465
+#, no-wrap
+msgid "Exporting the worksheet from within Maxima"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:468
+msgid ""
+"The command `wxworksheettohtml()` exports the current worksheet to an HTML "
+"file from within a running _Maxima_ session, which is convenient for "
+"scripted or batch export. Like `wxstatusbar()` it is safe to use in code "
+"that might also run in plain (console) _Maxima_: if _wxMaxima_ isn’t present "
+"the command is simply left unevaluated."
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:469
+#, no-wrap
+msgid ""
+"wxworksheettohtml(\"report.html\")$\n"
+"wxworksheettohtml(\"report.html\", flavor=\"svg\", wxmx=true)$\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:475
+msgid ""
+"A relative file name is interpreted relative to _Maxima_’s working "
+"directory. The optional keyword options are:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:480
+#, no-wrap
+msgid ""
+"| option   | values                                          | meaning                                             |\n"
+"| -------- | ----------------------------------------------- | --------------------------------------------------- |\n"
+"| `flavor` | `mathml` (default), `mathjax`, `svg`, `bitmap`  | how the equations are rendered in the exported page |\n"
+"| `wxmx`   | `false` (default), `true`                       | embed a downloadable `.wxmx` copy of the session    |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:482
+msgid ""
+"The `flavor` values match the equation formats offered by the graphical "
+"**File → Export** dialog: `mathml` produces a self-contained page that needs "
+"no internet connection, `mathjax` adds a MathJaX fall-back for browsers that "
+"still lack MathML, and `svg`/`bitmap` render every equation to an image."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:484
+msgid ""
+"The companion command `wxworksheettotex()` exports to a LaTeX (`.tex`) file "
+"the same way:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:485
+#, no-wrap
+msgid ""
+"wxworksheettotex(\"report.tex\")$\n"
+"wxworksheettotex(\"report.tex\", documentclass=\"report\", documentclassoptions=\"12pt,a4paper\")$\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:494
+#, no-wrap
+msgid ""
+"| option                 | meaning                                                              |\n"
+"| ---------------------- | -------------------------------------------------------------------- |\n"
+"| `documentclass`        | overrides the LaTeX `\\documentclass` (e.g. `\"article\"`, `\"report\"`)  |\n"
+"| `documentclassoptions` | overrides its options (e.g. `\"12pt,a4paper\"`)                        |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:496
+msgid "Support for `wxworksheettopdf()` is planned."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:497
+#, fuzzy, no-wrap
+#| msgid "Plotting"
+msgid "Plotting"
+msgstr "绘图"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:500
+msgid ""
+"Plotting (having fundamentally to do with graphics) is a place where a "
+"graphical user interface will have to provide some extensions to the "
+"original program."
+msgstr ""
+"因为绘图功能与图形密切相关，所以图形用户界面理应为原始程序的绘图功能提供一些"
+"扩充内容。"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:501
+#, fuzzy, no-wrap
+#| msgid "Embedding a plot into the work sheet"
+msgid "Embedding a plot into the worksheet"
+msgstr "将绘制的图形嵌入工作簿"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:504
+#, fuzzy
+#| msgid ""
+#| "_Maxima_ normally instructs the external program _gnuplot_ to open a "
+#| "separate window for every diagram it creates. Since many times it is "
+#| "convenient to embed graphs into the work sheet instead _wxMaxima_ "
+#| "provides its own set of plot functions that don’t differ from the "
+#| "corresponding _maxima_ functions save in their name: They are all "
+#| "prefixed by a “wx”. For example `wxplot2d` corresponds to `plot2d`, "
+#| "`wxplot3d` corresponds to `plot3d`, `wxdraw` corresponds to `draw` and "
+#| "`wxhistogram` corresponds to `histogram`."
+msgid ""
+"_Maxima_ normally instructs the external program _Gnuplot_ to open a "
+"separate window for every diagram it creates. Since many times it is "
+"convenient to embed graphs into the worksheet instead _wxMaxima_ provides "
+"its own set of plot functions that don’t differ from the corresponding "
+"_maxima_ functions save in their name: They are all prefixed by a “wx”."
+msgstr ""
+"Maxima 在创建图形时，通常会指示外部程序 gnuplot 用单独的窗口展示每个图形。因"
+"为在工作簿中嵌入图形通常会更方便，所以 wxMaxima 提供了自己的一组绘图函数。这"
+"些函数与其名称所对应的 Maxima 函数在使用时没有区别，但是都以“wx”为前缀。例"
+"如，`wxplot2d` 对应于 `plot2d`，`wxplot3d` 对应于 `plot3d`，`wxdraw` 对应于 "
+"`draw`，`wxhistogram` 对应于 `histogram`。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:506
+msgid "The following plotting functions have wx-counterparts:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:520
+#, no-wrap
+msgid ""
+"| wxMaxima’s plot function | Maxima’s plot function                                                                          |\n"
+"| ------------------------ | ----------------------------------------------------------------------------------------------- |\n"
+"| `wxplot2d()`             | [plot2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot2d)               |\n"
+"| `wxplot3d()`             | [plot3d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#plot3d)               |\n"
+"| `wxdraw2d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw2d)               |\n"
+"| `wxdraw3d()`             | [draw2d](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw3d)               |\n"
+"| `wxdraw()`               | [draw](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#draw)                   |\n"
+"| `wximplicit_plot()`      | [implicit_plot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#implicit_plot) |\n"
+"| `wxhistogram()`          | [histogram](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#histogram)         |\n"
+"| `wxscatterplot()`        | [scatterplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#scatterplot)     |\n"
+"| `wxbarsplot()`           | [barsplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#barsplot)           |\n"
+"| `wxpiechart()`           | [piechart](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#piechart)           |\n"
+"| `wxboxplot()`            | [boxplot](https://maxima.sourceforge.io/docs/manual/maxima_singlepage.html#boxplot)             |\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:522
+msgid ""
+"If a `wxm`-file is read by (console) Maxima, these functions are ignored "
+"(and printed as output, as other unknown functions in Maxima)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:524
+msgid ""
+"If you got problems with one of these functions, please check, if the "
+"problem exists in the the Maxima function too (e.g. you got an error with "
+"`wxplot2d()`, check the same plot in the Maxima command `plot2d()` (which "
+"opens the plot in a separate Window)). If the problem does not disappear, it "
+"is most likely a Maxima issue and should be reported in the [Maxima "
+"bugtracker](https://sourceforge.net/p/maxima/bugs/). Or maybe a Gnuplot "
+"issue."
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:525
+#, fuzzy, no-wrap
+#| msgid "Making embedded plots bigger or smaller"
+msgid "Making embedded plots bigger or smaller"
+msgstr "设置嵌入图形的大小"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:528
+#, fuzzy
+#| msgid ""
+#| "As noted above, the configure dialog provides a way to change the default "
+#| "size plots are created with which sets the starting value of "
+#| "`wxplot_size`. The plotting routines of _wxMaxima_ respect this variable "
+#| "that specifies the size of a plot in pixels. It can always be queried or "
+#| "used to set the size of the following plots:"
+msgid ""
+"As noted above, the configure dialog provides a way to change the default "
+"size plots created which sets the starting value of `wxplot_size`. The "
+"plotting routines of _wxMaxima_ respect this variable that specifies the "
+"size of a plot in pixels. It can always be queried or used to set the size "
+"of the following plots:"
+msgstr ""
+"如前面所述，设置对话框提供了一种更改默认绘图大小的方法，该方法设置了 "
+"`wxplot_size` 的默认值。绘图时，wxMaxima 将该变量识别为图片尺寸（以像素为单"
+"位）。可以查询该变量，或以如下方式设置所绘制图片的大小："
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:529
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxplot_size:[1200,800]$\n"
+#| "wxdraw2d(\n"
+#| "    explicit(\n"
+#| "        sin(x),\n"
+#| "        x,1,10\n"
+#| "    )\n"
+#| ")$\n"
+msgid ""
+"wxplot_size:[1200,800]$\n"
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+")$\n"
+msgstr ""
+"wxplot_size:[1200,800]$\n"
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+")$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:540
+msgid ""
+"If the size of only one plot is to be changed _Maxima_ provides a canonical "
+"way to change an attribute only for the current cell. In this usage the "
+"specification `wxplot_size = [value1, value2]` is appended to the "
+"`wxdraw2d( )` command, and is not part of the `wxdraw2d` command."
+msgstr ""
+"如果只更改一个绘制图片的大小，wxMaxima 提供了一种只为当前单元格更改属性的方"
+"法。具体用法为，将 `wxplot_size=[value1,value2]` 附加到 `wxdraw2d()` 命令结"
+"尾，而不是作为该命令的一部分："
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:541
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxdraw2d(\n"
+#| "    explicit(\n"
+#| "        sin(x),\n"
+#| "        x,1,10\n"
+#| "    )\n"
+#| "),wxplot_size=[1600,800]$\n"
+msgid ""
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+"),wxplot_size=[1600,800]$\n"
+msgstr ""
+"wxdraw2d(\n"
+"    explicit(\n"
+"        sin(x),\n"
+"        x,1,10\n"
+"    )\n"
+"),wxplot_size=[1600,800]$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:551
+msgid ""
+"Setting the size of embedded plot with `wxplot_size` works for embedded "
+"plots using e.g. `wxplot`, `wxdraw`, `wxcontour_plot` and `wximplicit_plot` "
+"commands and for embedded animations with `with_slider_draw` and `wxanimate` "
+"commands."
+msgstr ""
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:552
+#, fuzzy, no-wrap
+#| msgid "Better quality plots"
+msgid "Better quality plots"
+msgstr "更好的绘图质量"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:555
+#, fuzzy
+#| msgid ""
+#| "_Gnuplot_ doesn’t seem to provide a portable way of determining whether "
+#| "it supports the high-quality bitmap output that the cairo library "
+#| "provides. On systems where _gnuplot_ is compiled to use this library the "
+#| "pngcairo option from the configuration menu (that can be overridden by "
+#| "the variable `wxplot_pngcairo`) enables support for antialiasing and "
+#| "additional line styles. If `wxplot_pngcairo` is set without _gnuplot_ "
+#| "supporting this the result will be error messages instead of graphics."
+msgid ""
+"_Gnuplot_ doesn’t seem to provide a portable way of determining whether it "
+"supports the high-quality bitmap output that the Cairo library provides. On "
+"systems where _Gnuplot_ is compiled to use this library the pngCairo option "
+"from the configuration menu (that can be overridden by the variable "
+"`wxplot_pngcairo`) enables support for antialiasing and additional line "
+"styles. If `wxplot_pngCairo` is set without _Gnuplot_ supporting this the "
+"result will be error messages instead of graphics."
+msgstr ""
+"Gnuplot 似乎没有提供一种通用的方法来确定它是否支持 cairo 库提供的高质量位图输"
+"出。如果所编译的 gnuplot 使用了 cairo 库，勾选设置菜单中的 pngcairo 选项（可"
+"被变量 `wxplot_pngcairo` 覆盖）可以提供抗锯齿和其他线条样式支持。如果设置了 "
+"`wxplot_pngcairo`，而 gnuplot 并未使用 cairo 库，则绘图将会失败并给出错误消"
+"息。"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:556
+#, fuzzy, no-wrap
+#| msgid "Opening embedded plots in interactive _gnuplot_ windows"
+msgid "Opening embedded plots in interactive _Gnuplot_ windows"
+msgstr "在交互式 gnuplot 窗口中打开嵌入的绘图"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:559
+#, fuzzy
+#| msgid ""
+#| "If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
+#| "`wxplot3d` isn't supported by this feature) and the file size of the "
+#| "underlying _gnuplot_ project isn't way too high _wxMaxima_ offers a right-"
+#| "click menu that allows to open the plot in an interactive _gnuplot_ "
+#| "window."
+msgid ""
+"If a plot was generated using the `wxdraw`-type commands (`wxplot2d` and "
+"`wxplot3d` isn’t supported by this feature) and the file size of the "
+"underlying _Gnuplot_ project isn’t way too high _wxMaxima_ offers a right-"
+"click menu that allows to open the plot in an interactive _Gnuplot_ window."
+msgstr ""
+"如果绘图时使用 `wxdraw` 类型的命令（不含 `wxplot2d` 和 `wxplot3d`），并且底层"
+"的 `gnuplot` 项目文件不是太大，则 wxMaxima 提供了一个右键单击菜单，允许在交互"
+"式的 gnuplot 窗口中打开绘制的图形。"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:560
+#, fuzzy, no-wrap
+#| msgid "Opening gnuplot's command console in `plot` windows"
+msgid "Opening Gnuplot’s command console in `plot` windows"
+msgstr "在绘图窗口中打开 gnuplot 控制台"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:564
+#, fuzzy
+#| msgid ""
+#| "On MS Windows, if in _Maxima_'s variable `gnuplot_command` \"gnuplot\" is "
+#| "replaced by \"wgnuplot\", _gnuplot_ offers the possibility to open a "
+#| "console window, where _gnuplot_ commands can be entered into. "
+#| "Unfortunately, enabling this feature causes _gnuplot_ to \"steal\" the "
+#| "keyboard focus for a short time every time a plot is prepared."
+msgid ""
+"On MS Windows, there are two Gnuplot programs, `gnuplot.exe` and `wgnuplot."
+"exe`.  You can configure, which command should be used using the "
+"configuration menu. `wgnuplot.exe` offers the possibility to open a console "
+"window, where _gnuplot_ commands can be entered into, `gnuplot.exe` does not "
+"offer this possibility. Unfortunately, `wgnuplot.exe` causes _Gnuplot_ to "
+"\"steal\" the keyboard focus for a short time every time a plot is prepared."
+msgstr ""
+"在 Windows 系统上，如果 Maxima 的变量 `gnuplot_command` 的值 “gnuplot” 被换"
+"为 “wgnuplot”，则 gnuplot 会打开一个控制台窗口，在该窗口中可以输入 gnuplot 的"
+"命令。但是，启用此功能会使得每次绘图时 gnuplot 短时间内独占键盘。"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:565
+#, fuzzy, no-wrap
+#| msgid "Embedding animations into the spreadsheet"
+msgid "Embedding animations into the spreadsheet"
+msgstr "在工作簿中嵌入动图"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:568
+#, fuzzy
+#| msgid ""
+#| "3D diagrams tend to make it hard to read quantitative data. A viable "
+#| "alternative might be to assign the 3rd parameter to the mouse wheel. The "
+#| "`with_slider_draw` command is a version of `wxdraw2d` that does prepare "
+#| "multiple plots and allows to switch between them by moving the slider on "
+#| "top of the screen. _wxMaxima_ allows to export this animation as an "
+#| "animated gif."
+msgid ""
+"3D diagrams tend to make it hard to read quantitative data. A viable "
+"alternative might be to assign the 3rd parameter to the mouse wheel. The "
+"`with_slider_draw` command is a version of `wxdraw2d` that does prepare "
+"multiple plots and allows to switch between them by moving the slider on top "
+"of the screen. _WxMaxima_ allows to export this animation as an animated gif."
+msgstr ""
+"在三维图形中，点的坐标往往难以读取。一个可行的替代方法是将第三个参数指定给鼠"
+"标滚轮（即绘制多个二维图形）。`with_slider_draw` 命令是 `wxdraw2d` 的一个版"
+"本，它可以绘制多幅图片，使用户可以通过移动菜单栏中的滑块（或滚动鼠标滚轮）在"
+"这些图片之间切换。wxMaxima 支持将此动图导出为 gif 格式的图片。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:570
+msgid ""
+"The first two arguments for `with_slider_draw` are the name of the variable "
+"that is stepped between the plots and a list of the values of these "
+"variable. The arguments that follow are the ordinary arguments for "
+"`wxdraw2d`:"
+msgstr ""
+"`with_slider_draw` 命令的前两个参数是用于控制绘图的变量名称和变量值的列表，接"
+"下来的参数与 `wxdraw2d` 命令的参数相同："
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:571
+#, fuzzy, no-wrap
+#| msgid ""
+#| "with_slider_draw(\n"
+#| "    f,[1,2,3,4,5,6,7,10],\n"
+#| "    title=concat(\"f=\",f,\"Hz\"),\n"
+#| "    explicit(\n"
+#| "        sin(2*%pi*f*x),\n"
+#| "        x,0,1\n"
+#| "    ),grid=true\n"
+#| ");\n"
+msgid ""
+"with_slider_draw(\n"
+"    f,[1,2,3,4,5,6,7,10],\n"
+"    title=concat(\"f=\",f,\"Hz\"),\n"
+"    explicit(\n"
+"        sin(2*%pi*f*x),\n"
+"        x,0,1\n"
+"    ),grid=true\n"
+");\n"
+msgstr ""
+"with_slider_draw(\n"
+"    f,[1,2,3,4,5,6,7,10],\n"
+"    title=concat(\"f=\",f,\"Hz\"),\n"
+"    explicit(\n"
+"        sin(2*%pi*f*x),\n"
+"        x,0,1\n"
+"    ),grid=true\n"
+");\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:583
+msgid ""
+"The same functionality for 3D plots is accessible as `with_slider_draw3d`, "
+"which allows for rotating 3d plots:"
+msgstr ""
+"对三维绘图而言，类似的功能由命令 `with_slider_draw3d` 提供，可用参数来旋转三"
+"维图形："
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:584
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxanimate_autoplay:true;\n"
+#| "wxanimate_framerate:20;\n"
+#| "with_slider_draw3d(\n"
+#| "    α,makelist(i,i,1,360,3),\n"
+#| "    title=sconcat(\"α=\",α),\n"
+#| "    surface_hide=true,\n"
+#| "    contour=both,\n"
+#| "    view=[60,α],\n"
+#| "    explicit(\n"
+#| "        sin(x)*sin(y),\n"
+#| "        x,-π,π,\n"
+#| "        y,-π,π\n"
+#| "    )\n"
+#| ")$\n"
+msgid ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    α,makelist(i,i,1,360,3),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,α],\n"
+"    explicit(\n"
+"        sin(x)*sin(y),\n"
+"        x,-π,π,\n"
+"        y,-π,π\n"
+"    )\n"
+")$\n"
+msgstr ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    α,makelist(i,i,1,360,3),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,α],\n"
+"    explicit(\n"
+"        sin(x)*sin(y),\n"
+"        x,-π,π,\n"
+"        y,-π,π\n"
+"    )\n"
+")$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:602
+msgid ""
+"If the general shape of the plot is what matters it might suffice to move "
+"the plot just a little bit in order to make its 3D nature available to the "
+"intuition:"
+msgstr ""
+"如果重要的是图的大致形状，那么只要稍微移动一点，就可以直观地看出它的三维特"
+"征："
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:603
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxanimate_autoplay:true;\n"
+#| "wxanimate_framerate:20;\n"
+#| "with_slider_draw3d(\n"
+#| "    t,makelist(i,i,0,2*π,.05*π),\n"
+#| "    title=sconcat(\"α=\",α),\n"
+#| "    surface_hide=true,\n"
+#| "    contour=both,\n"
+#| "    view=[60,30+5*sin(t)],\n"
+#| "    explicit(\n"
+#| "        sin(x)*y^2,\n"
+#| "        x,-2*π,2*π,\n"
+#| "        y,-2*π,2*π\n"
+#| "    )\n"
+#| ")$\n"
+msgid ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    t,makelist(i,i,0,2*π,.05*π),\n"
+"    title=sconcat(\"α=\",α),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,30+5*sin(t)],\n"
+"    explicit(\n"
+"        sin(x)*y^2,\n"
+"        x,-2*π,2*π,\n"
+"        y,-2*π,2*π\n"
+"    )\n"
+")$\n"
+msgstr ""
+"wxanimate_autoplay:true;\n"
+"wxanimate_framerate:20;\n"
+"with_slider_draw3d(\n"
+"    t,makelist(i,i,0,2*π,.05*π),\n"
+"    title=sconcat(\"t=\",t),\n"
+"    surface_hide=true,\n"
+"    contour=both,\n"
+"    view=[60,30+5*sin(t)],\n"
+"    explicit(\n"
+"        sin(x)*y^2,\n"
+"        x,-2*π,2*π,\n"
+"        y,-2*π,2*π\n"
+"    )\n"
+")$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:621
+#, fuzzy
+#| msgid ""
+#| "For those more familiar with `plot` than with `draw` there is a second "
+#| "set of functions:"
+msgid ""
+"For those more familiar with `plot` than with `draw`, there is a second set "
+"of functions:"
+msgstr "对于更熟悉 `plot` 而不是 `draw` 的用户来说，还有一组函数："
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:624
+#, fuzzy
+#| msgid "`with_slider` and"
+msgid "`with_slider` and"
+msgstr "`with_slider`；"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:624
+msgid "`wxanimate`."
+msgstr "`wxanimate`。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:626
+#, fuzzy
+#| msgid ""
+#| "Normally the animations are played back or exported with the frame rate "
+#| "chosen in the configuration of _wxMaxima_. To set the speed an individual "
+#| "animation is played back the variable `wxanimate_framerate` can be used:"
+msgid ""
+"Normally the animations are played back or exported with the frame rate "
+"chosen in the configuration of _wxMaxima_. To set the speed at an individual "
+"animation is played back the variable `wxanimate_framerate` can be used:"
+msgstr ""
+"在通常情况下，动图会以设置中选择的帧率回放或导出。要设置回放单个动图的速度，"
+"可以修改变量 `wxanimate_framerate`："
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:627
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxanimate(a, 10,\n"
+#| "    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+msgid ""
+"wxanimate(a, 10,\n"
+"    sin(a*x), [x,-5,5]), wxanimate_framerate=6$\n"
+msgstr ""
+"wxanimate(a, 10, sin(a*x), [x,-5,5]),\n"
+"     wxanimate_framerate=6$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:633
+#, fuzzy
+#| msgid ""
+#| "The animation functions use _Maxima_'s `makelist` command and therefore "
+#| "shares the pitfall that the slider variable's value is substituted into "
+#| "the expression only if the variable is directly visible in the "
+#| "expression. Therefore the following example will fail:"
+msgid ""
+"The animation functions use _Maxima_’s `makelist` command and therefore "
+"share the pitfall that the slider variable’s value is substituted into the "
+"expression only if the variable is directly visible in the expression. "
+"Therefore the following example will fail:"
+msgstr ""
+"动图函数使用 Maxima 的 `makelist` 命令，因此存在如下缺陷：只有当滑块变量在绘"
+"图表达式中直接可见时，才会将该变量的值替换到表达式中。因此，执行以下例子将显"
+"示错误信息："
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:634
+#, fuzzy, no-wrap
+#| msgid ""
+#| "f:sin(a*x);\n"
+#| "with_slider_draw(\n"
+#| "    a,makelist(i/2,i,1,10),\n"
+#| "    title=concat(\"a=\",float(a)),\n"
+#| "    grid=true,\n"
+#| "    explicit(f,x,0,10)\n"
+#| ")$\n"
+msgid ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    a,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(a)),\n"
+"    grid=true,\n"
+"    explicit(f,x,0,10)\n"
+")$\n"
+msgstr ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    a,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(a)),\n"
+"    grid=true,\n"
+"    explicit(f,x,0,10)\n"
+")$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:645
+#, fuzzy
+#| msgid ""
+#| "If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
+#| "works fine instead:"
+msgid ""
+"If _Maxima_ is explicitly asked to substitute the slider’s value plotting "
+"works fine instead:"
+msgstr ""
+"如果修改为明确要求 Maxima 代入滑块变量的值，则修改后的代码可用于绘制动图："
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:646
+#, fuzzy, no-wrap
+#| msgid ""
+#| "f:sin(a*x);\n"
+#| "with_slider_draw(\n"
+#| "    b,makelist(i/2,i,1,10),\n"
+#| "    title=concat(\"a=\",float(b)),\n"
+#| "    grid=true,\n"
+#| "    explicit(\n"
+#| "        subst(a=b,f),\n"
+#| "        x,0,10\n"
+#| "    )\n"
+#| ")$\n"
+msgid ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    b,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(b)),\n"
+"    grid=true,\n"
+"    explicit(\n"
+"        subst(a=b,f),\n"
+"        x,0,10\n"
+"    )\n"
+")$\n"
+msgstr ""
+"f:sin(a*x);\n"
+"with_slider_draw(\n"
+"    b,makelist(i/2,i,1,10),\n"
+"    title=concat(\"a=\",float(b)),\n"
+"    grid=true,\n"
+"    explicit(\n"
+"        subst(a=b,f),\n"
+"        x,0,10\n"
+"    )\n"
+")$\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:659
+#, fuzzy, no-wrap
+#| msgid "Opening multiple plots in contemporaneous windows"
+msgid "Opening multiple plots in contemporaneous windows"
+msgstr "同时打开多个绘图窗口"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:662
+#, fuzzy
+#| msgid ""
+#| "While not being a provided by _wxMaxima_ this feature of _Maxima_ (on "
+#| "setups that support it) sometimes comes in handily. The following example "
+#| "comes from a post from Mario Rodriguez to the _Maxima_ mailing list:"
+msgid ""
+"While not being provided by _wxMaxima_ this feature of _Maxima_ (on setups "
+"that support it) sometimes comes in handily. The following example comes "
+"from a post from Mario Rodriguez to the _Maxima_ mailing list:"
+msgstr ""
+"虽然这个 Maxima 特性不是由 wxMaxima 提供的，但是（如果安装的 Maxima 支持此特"
+"性）有时使用起来会很方便。以下例子来自 Mario Rodriguez 在 Maxima 邮件列表中的"
+"一篇帖子："
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:663
+#, no-wrap
+msgid ""
+"load(draw);\n"
+"\n"
+"/* Parabola in window #1 */\n"
+"draw2d(terminal=[wxt,1],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Parabola in window #2 */\n"
+"draw2d(terminal=[wxt,2],explicit(x^2,x,-1,1));\n"
+"\n"
+"/* Paraboloid in window #3 */\n"
+"draw3d(terminal=[wxt,3],explicit(x^2+y^2,x,-1,1,y,-1,1));\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:677
+msgid ""
+"Plotting multiple plots in the same window is possible, too (the same is "
+"possible in command line Maxima with the standard `draw()` command):"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:678
+#, fuzzy, no-wrap
+#| msgid ""
+#| "\twxdraw(\n"
+#| "\t\tgr2d(\n"
+#| "\t    \tkey=\"sin (x)\",grid=[2,2],\n"
+#| "\t    \texplicit(sin(x),x,0,2*%pi)),\n"
+#| "\t\tgr2d(\n"
+#| "\t   \tkey=\"cos (x)\",grid=[2,2],\n"
+#| "\t   \texplicit(cos(x),x,0,2*%pi))\n"
+#| "\t );\n"
+msgid ""
+"wxdraw(\n"
+"  gr2d(\n"
+"    key=\"sin (x)\",grid=[2,2],\n"
+"    explicit(sin(x),x,0,2*%pi)),\n"
+"  gr2d(\n"
+"    key=\"cos (x)\",grid=[2,2],\n"
+"    explicit(cos(x),x,0,2*%pi))\n"
+");\n"
+msgstr ""
+"\twxdraw(\n"
+"\t\tgr2d(\n"
+"\t    \tkey=\"sin (x)\",grid=[2,2],\n"
+"\t    \texplicit(sin(x),x,0,2*%pi)),\n"
+"\t\tgr2d(\n"
+"\t   \tkey=\"cos (x)\",grid=[2,2],\n"
+"\t   \texplicit(cos(x),x,0,2*%pi))\n"
+"\t );\n"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:689
+#, fuzzy, no-wrap
+#| msgid "The \"Plot using draw\" side pane"
+msgid "The \"Plot using draw\" side pane"
+msgstr "“用 draw 函数绘图”侧边栏"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:692
+#, fuzzy
+#| msgid ""
+#| "The \"Plot using draw\" sidebar hides a simple code generator that allows "
+#| "to generate scenes that make use of some of the flexibility of the _draw_ "
+#| "package _maxima_ comes with."
+msgid ""
+"The \"Plot using draw\" sidebar hides a simple code generator that allows "
+"generating scenes that make use of some of the flexibility of the _draw_ "
+"package _maxima_ comes with."
+msgstr ""
+"“用 draw 函数绘图”侧边栏暗含一个简单的代码生成器，使用它可以利用 Maxima 的 "
+"draw 程序包方便灵活地生成一些图形绘制命令模板。"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:693
+#, no-wrap
+msgid "2D"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:696
+#, fuzzy
+#| msgid ""
+#| "Generates the skeleton of a `draw()` command that draws a 2D scene. This "
+#| "scene later has to be filled with commands that generate the scene's "
+#| "contents, for example by using the buttons in the rows below the \"2D\" "
+#| "button."
+msgid ""
+"Generates the skeleton of a `draw()` command that draws a 2D scene. This "
+"scene later has to be filled with commands that generate the scene’s "
+"contents, for example by using the buttons in the rows below the \"2D\" "
+"button."
+msgstr ""
+"提供绘制二维图形的 `draw()` 命令的简单模板。然后可以使用具体的绘图命令填充该"
+"模板，例如利用“二维图形”按钮下方的其他按钮导入绘图命令。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:698
+#, fuzzy
+#| msgid ""
+#| "One helpful feature of the 2D button is that it allows to setup the scene "
+#| "as an animation in which a variable (by default it is _t_) has a "
+#| "different value in each frame: Often an moving 2D plot allows easier "
+#| "interpretation than the same data in a non-moving 3D one."
+msgid ""
+"One helpful feature of the 2D button is that it allows to set up the scene "
+"as an animation in which a variable (by default it is _t_) has a different "
+"value in each frame: Often a moving 2D plot allows easier interpretation "
+"than the same data in a non-moving 3D one."
+msgstr ""
+"“二维图形”按钮的一个有用的功能是，用它可以设置一个生成动画的模板，其中一个变"
+"量（默认情况下是 t）在每一帧中都有不同的值。通常动态的二维图形比静态的三维图"
+"形中的相同数据更容易理解。"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:699
+#, no-wrap
+msgid "3D"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:702
+#, fuzzy
+#| msgid ""
+#| "Generates the skeleton of a `draw()` command that draws a 3D scene. If "
+#| "neither a 2D or a 3D scene are set up all of the other buttons set up a "
+#| "2D scene that contains the command the button generates."
+msgid ""
+"Generates the skeleton of a `draw()` command that draws a 3D scene. If "
+"neither a 2D nor a 3D scene is set up, all of the other buttons set up a 2D "
+"scene that contains the command the button generates."
+msgstr ""
+"提供绘制三维图形的 `draw()` 命令的简单模板。如果没有主动使用此功能和上一功"
+"能，则所有其他按钮都将自动提前调用上一功能中的绘制二维图形模板。"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:703
+#, fuzzy, no-wrap
+#| msgid "Expression"
+msgid "Expression"
+msgstr "表达式"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:706
+msgid ""
+"Appends a standard plot of an expression like `sin(x)`, `x*sin(x)` or "
+"`x^2+2*x-4` to the `draw()` command the cursor currently is in. If there is "
+"no draw command a 2D scene with the plot is generated. Each scene can be "
+"filled with any number of plots."
+msgstr ""
+"在光标当前所在的 `draw()` 命令中添加绘图函数表达式，如 `sin(x)`, `x*sin(x)` "
+"或者 `x^2+2*x-4` 等 。每个图中可以绘制任意数量的图形。如果没有 `draw()` 命"
+"令，将调用绘制二维图形的模板。"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:707
+#, fuzzy, no-wrap
+#| msgid "Implicit plot"
+msgid "Implicit plot"
+msgstr "隐式图形"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:710
+msgid ""
+"Tries to find all points an expression like `y=sin(x)`, `y*sin(x)=3` or "
+"`x^2+y^2=4` is true at and plots the resulting curve in the `draw()` command "
+"the cursor currently is in. If there is no draw command a 2D scene with the "
+"plot is generated."
+msgstr ""
+"尝试寻找满足 `y=sin(x)`，`y*sin(x)=3` 或 `x^2+y^2=4` 之类的表达式的所有解，并"
+"在光标当前所在的 `draw()` 命令中绘制对应曲线。如果没有 `draw()` 命令，将调用"
+"绘制二维图形的模板。"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:711
+#, fuzzy, no-wrap
+#| msgid "Parametric plot"
+msgid "Parametric plot"
+msgstr "参数式图形"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:714
+msgid ""
+"Steps a variable from a lower limit to an upper limit and uses two "
+"expressions like `t*sin(t)` and `t*cos(t)` for generating the x, y (and in "
+"3D plots also z) coordinates of a curve that is put into the current draw "
+"command."
+msgstr ""
+"将变量（如 t）从下限变化到上限，并在当前绘图命令中使用两个表达式（如 "
+"`t*sin(t)` 和 `t*cos(t)`），以生成曲线上点的横、纵坐标 (x,y)（在三维图形中，"
+"第三个表达式生成竖坐标 z）。"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:715
+#, fuzzy, no-wrap
+#| msgid "Points"
+msgid "Points"
+msgstr "点"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:718
+msgid ""
+"Draws many points that can optionally be joined. The coordinates of the "
+"points are taken from a list of lists, a 2D array or one list or array for "
+"each axis."
+msgstr ""
+"绘制多个点，并且可以选择顺次连接它们。点的坐标取自列表的列表、二维数组或为每"
+"个轴指定的一个列表或数组。"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:719
+#, fuzzy, no-wrap
+#| msgid "Diagram title"
+msgid "Diagram title"
+msgstr "图形标题"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:722
+msgid "Draws a title on the upper end of the diagram,"
+msgstr "在图形上方绘制标题。"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:723
+#, fuzzy, no-wrap
+#| msgid "Axis"
+msgid "Axis"
+msgstr "坐标轴"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:726
+msgid "Sets up the axis."
+msgstr "设置坐标轴。"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:727
+#, fuzzy, no-wrap
+#| msgid "Contour"
+msgid "Contour"
+msgstr "等高线"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:730
+#, fuzzy
+#| msgid ""
+#| "(Only for 3D plots): Adds contour lines similar to the ones one can find "
+#| "in a map of a mountain to the plot commands that follow in the current "
+#| "`draw()` command and/or to the ground plane of the diagram. Alternatively "
+#| "this wizard allows skipping drawing the curves entirely only showing the "
+#| "contour plot."
+msgid ""
+"(Only for 3D plots): Adds contour lines similar to the ones one can find in "
+"a map of a mountain to the plot commands that follow in the current `draw()` "
+"command and/or to the ground plane of the diagram. Alternatively, this "
+"wizard allows skipping drawing the curves entirely only showing the contour "
+"plot."
+msgstr ""
+"（仅适用于三维绘图）将类似于山地图中的等高线添加到当前 `draw()` 命令绘制的三"
+"维图形中，或图形在坐标面的二维投影上。另外，此向导也可以用来不绘制曲面而只显"
+"示等高线。"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:731
+#, fuzzy, no-wrap
+#| msgid "Plot name"
+msgid "Plot name"
+msgstr "图形名称"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:734
+#, fuzzy
+#| msgid ""
+#| "Adds a legend entry showing the next plot's name to the legend of the "
+#| "diagram. An empty name disables generating legend entries for the "
+#| "following plots."
+msgid ""
+"Adds a legend entry showing the next plot’s name to the legend of the "
+"diagram. An empty name disables generating legend entries for the following "
+"plots."
+msgstr ""
+"在图例中增加下一个图形对应的图例项。空名称将阻止为下一个图形生成图例项。"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:735
+#, fuzzy, no-wrap
+#| msgid "Line colour"
+msgid "Line colour"
+msgstr "线条颜色"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:738
+msgid ""
+"Sets the line colour for the following plots the current draw command "
+"contains."
+msgstr "为当前 `draw()` 命令所绘图形设置线条颜色。"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:739
+#, fuzzy, no-wrap
+#| msgid "Fill colour"
+msgid "Fill colour"
+msgstr "填充颜色"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:742
+msgid ""
+"Sets the fill colour for the following plots the current draw command "
+"contains."
+msgstr "为当前 `draw()` 命令所绘图形设置填充颜色。"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:743
+#, fuzzy, no-wrap
+#| msgid "Grid"
+msgid "Grid"
+msgstr "网格"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:746
+msgid "Pops up a wizard that allows to set up grid lines."
+msgstr "弹出设置网格线的向导。"
+
+#. type: Title ####
+#: ../../info/wxmaxima.md:747
+#, fuzzy, no-wrap
+#| msgid "Accuracy"
+msgid "Accuracy"
+msgstr "精度"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:750
+msgid ""
+"Allows to select an adequate point in the speed vs. accuracy tradeoff that "
+"is part of any plot program."
+msgstr "允许选择适当数目的点，以兼顾速度与精度（任何绘图程序都会权衡两者）。"
+
+#. type: Title ###
+#: ../../info/wxmaxima.md:751
+#, no-wrap
+msgid "Modify font and font size for plots"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:754
+msgid ""
+"Especially when you use a high resolution display, the default font size "
+"might be very small. For the `draw`-based commands, you can set the font / "
+"font size using options like `font=...`, `font_size=...`, e.g.:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:755
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxdraw2d(\n"
+#| "    file_name=\"test\",\n"
+#| "    explicit(sin(x),x,1,10)\n"
+#| ");\n"
+msgid ""
+"wxdraw2d(\n"
+"     font=\"Helvetica\",\n"
+"     font_size=30,\n"
+"     explicit(sin(x),x,1,10));\n"
+msgstr ""
+"wxdraw2d(\n"
+"    file_name=\"test\",\n"
+"    explicit(sin(x),x,1,10)\n"
+");\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:763
+msgid ""
+"For the `plot`-commands (e.g. `wxplot2d`, `wxplot3d`) font sizes and fonts "
+"can be set using the `gnuplot_preamble` command, e.g.:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:764
+#, no-wrap
+msgid ""
+"wxplot2d(sin(x),[x,1,10],\n"
+"         [gnuplot_preamble, \"set tics font \\\"Arial, 30\\\"; set xlabel font \\\",20\\\"; set ylabel font \\\",20\\\";\"]);\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:770
+msgid ""
+"This sets the font for the numbers to Arial with size 30, the size for the "
+"xlabel and ylabel font to 20 (with the default font)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:773
+msgid ""
+"Read the Maxima and Gnuplot documentation for further information.  Note: "
+"Gnuplot seems to have issues with larger font sizes, see [wxMaxima issue "
+"1966](https://github.com/wxMaxima-developers/wxmaxima/issues/1966)."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:774
+#, fuzzy, no-wrap
+#| msgid "Embedding graphics"
+msgid "Embedding graphics"
+msgstr "嵌入图片"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:777
+#, fuzzy
+#| msgid ""
+#| "If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
+#| "project can be done as easily as per drag-and-drop. But sometimes (for "
+#| "example if an image’s contents might change later on in a session) it is "
+#| "better to tell the file to load the image on evaluation:"
+msgid ""
+"If the `.wxmx` file format is being used embedding files in a _wxMaxima_ "
+"project can be done as easily as per drag-and-drop. But sometimes (for "
+"example if an image’s contents might change later on in a session) it is "
+"better to tell the file to load the image on evaluation:"
+msgstr ""
+"如果使用的是 `.wxmx` 文件格式，则可以通过拖放将图片文件嵌入 wxMaxima 文档中。"
+"但有时（例如某个图像的内容可能在稍后发生更改）最好指明在计算时加载图像："
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:778
+#, fuzzy, no-wrap
+#| msgid "show_image(\"man.png\");\n"
+msgid "show_image(\"man.png\");\n"
+msgstr "show_image(\"man.png\");\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:782
+#, fuzzy, no-wrap
+#| msgid "Startup files"
+msgid "Startup files"
+msgstr "启动时读取的文件"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:785
+msgid ""
+"The config dialogue of _wxMaxima_ offers to edit two files with commands "
+"that are executed on startup:"
+msgstr ""
+"在 wxMaxima 的设置对话框中可以编辑两个文件的命令，这些命令在启动时被执行："
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:788
+msgid ""
+"A file that contains commands that are executed on starting up _Maxima_: "
+"`maxima-init.mac`"
+msgstr "文件 `maxima-init.mac` 中包含每次启动 Maxima 时被执行的命令；"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:788
+#, fuzzy
+#| msgid ""
+#| "A file that contains commands that are executed on starting up _Maxima_: "
+#| "`maxima-init.mac`"
+msgid ""
+"one file of additional commands that are executed if _wxMaxima_ is starting "
+"_Maxima_: `wxmaxima-init.mac`"
+msgstr "文件 `maxima-init.mac` 中包含每次启动 Maxima 时被执行的命令；"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:790
+msgid ""
+"For example, if Gnuplot is installed in `/opt` (maybe on MacOS), you can add "
+"`gnuplot_command:\"/opt/local/bin/gnuplot\"$` (or `/opt/gnuplot/bin/gnuplot` "
+"or any other path) to these files."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:792
+#, fuzzy
+#| msgid ""
+#| "These files are in the Maxima user directory (usually `maxima` in "
+#| "Windows, `.maxima` otherwise) in the user's home directory / user profile "
+#| "directory. The location can be found out with the command: "
+#| "`maxima_userdir;`"
+msgid ""
+"These files are in the Maxima user directory (usually `%USERPROFILE%/maxima` "
+"in Windows, `$HOME/.maxima` otherwise). The location can be found out with "
+"the command: `maxima_userdir;`"
+msgstr ""
+"这些文件位于用户的主目录或配置文件目录中的 Maxima 用户目录（在 Windows 系统中"
+"通常为 maxima，在其他系统中为 .maxima）。使用命令 `maxima_userdir;` 可以确定"
+"该目录。"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:793
+#, fuzzy, no-wrap
+#| msgid "Special variables wx..."
+msgid "Special variables wx..."
+msgstr "以 wx 开头的特殊变量"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxsubscripts` tells _Maxima_ if it should convert variable names that "
+"contain an underscore (`R_150` or the like) into subscripted variables. See "
+"`wxdeclare_subscript` for details which variable names are automatically "
+"converted."
+msgstr ""
+"`wxsubscripts` ：告诉 Maxima 是否应将包含下划线的变量名（例如 `R_150`）转换为"
+"带下标的变量名。有关自动转换哪些变量名的详细信息，请参见 "
+"`wxdeclare_subscript`。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxfilename`: This variable contains the name of the file currently opened "
+"in _wxMaxima_."
+msgstr "`wxfilename`：此变量包含当前在 wxMaxima 中打开的文件的名称。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+#, fuzzy
+#| msgid ""
+#| "`wxfilename`: This variable contains the name of the file currently "
+#| "opened in _wxMaxima_."
+msgid ""
+"`wxdirname`: This variable contains the name the directory, in which the "
+"file currently opened in _wxMaxima_ is."
+msgstr "`wxfilename`：此变量包含当前在 wxMaxima 中打开的文件的名称。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+#, fuzzy
+#| msgid ""
+#| "`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _gnuplot_’s "
+#| "pngcairo terminal that provides more line styles and a better overall "
+#| "graphics quality."
+msgid ""
+"`wxplot_pngcairo` tells whether _wxMaxima_ tries to use _Gnuplot_’s pngcairo "
+"terminal that provides more line styles and a better overall graphics "
+"quality."
+msgstr ""
+"`wxplot_pngcairo`：表明 wxMaxima 是否尝试使用 gnuplot 的 pngcairo 功能，以提"
+"供更多的线条样式和更好的整体图形质量。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxplot_size` defines the resolution of embedded plots."
+msgstr "`wxplot_size`：定义嵌入绘图的分辨率。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+#, fuzzy
+#| msgid ""
+#| "`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
+#| "_Maxima_’s working directory to the directory of the current file. This "
+#| "allows file I/O (e.g. by `read_matrix`) to work without specifying the "
+#| "whole path to the file that has to be read or written. On Windows this "
+#| "feature sometimes causes error messages and therefore can be set to "
+#| "`false` from the config dialogue."
+msgid ""
+"`wxchangedir`: On most operating systems _wxMaxima_ automatically sets "
+"_Maxima_’s working directory to the directory of the current file. This "
+"allows file I/O (e.g. by `read_matrix`) to work without specifying the whole "
+"path to the file that has to be read or written. On Windows this feature "
+"sometimes causes error messages and therefore can be set to `false` from the "
+"config dialogue."
+msgstr ""
+"`wxchangedir`：在大多数操作系统上，wxMaxima 自动将 Maxima 的工作目录设置为当"
+"前文件的目录。这允许文件 I/O（例如通过 `read_matrix`）工作，而无需指定必须读"
+"或写的文件的整个路径。在 Windows 操作系统上，此功能有时会导致错误消息，因此可"
+"以在设置对话框中将其设置为 `false`。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxanimate_framerate`: The number of frames per second the following "
+"animations have to be played back with."
+msgstr "`wxanimate_framerate`：下一个动图回放的帧率。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxanimate_autoplay`: Automatically play animations by default?"
+msgstr "`wxanimate_autoplay`：是否在默认情况下自动播放动图。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxmaximaversion`: Returns the version number of _wxMaxima_."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid "`wxwidgetsversion`: Returns the wxWidgets version _wxMaxima_ is using."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs`: A struct holding the paths _wxMaxima_ itself uses, since these "
+"differ by maintainer, distribution and operating system:"
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@userconfdir`: The directory the user's configuration is stored in. "
+"Same directory as `maxima_userdir` (see above) - both point at the same "
+"place, `wxdirs@userconfdir` is only useful if that is more convenient to "
+"reach from a `.mac` file than the Maxima-side variable."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@datadir`: The directory _wxMaxima_'s own data (icons, the built-in "
+"autocompletion list, ...) is installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@helpdir`: The directory the offline copy of this manual is installed "
+"in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@localedir`: The directory _wxMaxima_'s translation files are "
+"installed in."
+msgstr ""
+
+#. type: Bullet: '  - '
+#: ../../info/wxmaxima.md:811
+msgid ""
+"`wxdirs@maximalocation`: The path to the _Maxima_ executable _wxMaxima_ is "
+"configured to start."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:812
+#, fuzzy, no-wrap
+#| msgid "Pretty-printing 2D output"
+msgid "Pretty-printing 2D output"
+msgstr "输出美观的二维公式"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:815
+#, fuzzy
+#| msgid ""
+#| "The function `table_form()` displays a 2D list in a form that is more "
+#| "readable than the output from _Maxima_’s default output routine. The "
+#| "input is a list of one or more lists. Like the \"print\" command, this "
+#| "command displays output even when ended with a dollar sign. Ending the "
+#| "command with a semicolon results in the same table along with a \"done\" "
+#| "statement."
+msgid ""
+"The function `table_form()` displays a 2D list in a form that is more "
+"readable than the output from _Maxima_’s default output routine. The input "
+"is a list of one or more lists. Like the \"print\" command, this command "
+"displays output even when ended with a dollar sign. Ending the command with "
+"a semicolon results in the same table along with a \"done\" statement."
+msgstr ""
+"函数 `table_form()` 显示的二维列表比 Maxima 的默认输出更具可读性。该函数的输"
+"入是一个列表，其中含一个或多个列表。与 `print` 命令类似，此命令即使以符号 "
+"`$` 结尾也会显示输出。以分号 `;` 结束命令时，除了得到列表，还会有“done”语句。"
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:816
+#, fuzzy, no-wrap
+#| msgid ""
+#| "table_form(\n"
+#| "    [\n"
+#| "        [1,2],\n"
+#| "        [3,4]\n"
+#| "    ]\n"
+#| ")$\n"
+msgid ""
+"table_form(\n"
+"    [\n"
+"        [1,2],\n"
+"        [3,4]\n"
+"    ]\n"
+")$\n"
+msgstr ""
+"table_form(\n"
+"    [\n"
+"        [1,2],\n"
+"        [3,4]\n"
+"    ]\n"
+")$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:826
+msgid ""
+"As the next example shows, the lists that are assembled by the `table_form` "
+"command can be created before the command is executed."
+msgstr ""
+"正如下一个例子所示，可以在执行 `table_form` 命令之前创建需要显示的列表。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:828
+msgid ""
+"![A third table example](./MatrixTableExample.png)"
+"{ id=img_MatrixTableExample }"
+msgstr ""
+"![一个三行表的例子](./MatrixTableExample.png){ id=img_MatrixTableExample }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:830
+msgid ""
+"Also, because a matrix is a list of lists, matrices can be converted to "
+"tables in a similar fashion."
+msgstr "此外，由于矩阵是含列表的列表，它也可以用类似的方式转换为表格。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:832
+msgid ""
+"![Another table_form example](./SecondTableExample.png)"
+"{ id=img_SecondTableExample }"
+msgstr ""
+"![另一个 table_form 的例子](./SecondTableExample.png)"
+"{ id=img_SecondTableExample }"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:834
+msgid ""
+"The function `wx_matrix()` is a wrapper for Maxima's `matrix()` command that "
+"allows for more flexible formatting of matrices in wxMaxima:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:836
+#, no-wrap
+msgid "**`wx_matrix( <matrix>, [options] )`**\n"
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`lines=true`**: Draws internal separator lines between the cells. This is "
+"required to visually separate headings from data."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`rownames=true`**: Tells wxMaxima that the first column of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`colnames=true`**: Tells wxMaxima that the first row of the matrix "
+"contains labels."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:841
+msgid ""
+"**`parenstyle=<style>`**: Sets the type of parenthesis or brackets to draw "
+"around the matrix. Supported styles are: `round` `()`, `square` `[]`, "
+"`angled` `<>`, `straight` `||`, or `none`."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:843
+#, fuzzy
+#| msgid "One Example:"
+msgid "Example:"
+msgstr "例如："
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:844
+#, no-wrap
+msgid ""
+"wx_matrix(matrix([\"Name\", \"Value\"], [\"X\", 10], [\"Y\", 20]),\n"
+"          lines=true, rownames=true, colnames=true, parenstyle=square);\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:849
+#, fuzzy, no-wrap
+#| msgid "Bug reporting"
+msgid "Bug reporting"
+msgstr "错误（bug）报告"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:852
+#, fuzzy
+#| msgid ""
+#| "_wxMaxima_ provides a few functions that gather bug reporting information "
+#| "about the current system:"
+msgid ""
+"_WxMaxima_ provides a few functions that gather bug reporting information "
+"about the current system:"
+msgstr "wxMaxima 提供了一些函数，用于收集当前系统的错误报告信息："
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:855
+#, fuzzy
+#| msgid ""
+#| "`wxbuild_info()` gathers information about the currently running version "
+#| "of _wxMaxima_"
+msgid ""
+"`wxbuild_info()` gathers information about the currently running version of "
+"_wxMaxima_"
+msgstr "`wxbuild_info()` 收集当前运行的 wxMaxima 的版本信息；"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:855
+msgid "`wxbug_report()` tells how and where to file bugs"
+msgstr "`wxbug_report()` 说明如何以及在何处提交错误报告。"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:856
+#, fuzzy, no-wrap
+#| msgid "Marking output being drawn in red"
+msgid "Marking output being drawn in red"
+msgstr "让输出显示为红色"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:860
+#, fuzzy
+#| msgid ""
+#| "_Maxima_'s `box()` command causes _wxMaxima_ to print its argument with a "
+#| "red foreground."
+msgid ""
+"_Maxima_’s `box()` command causes _wxMaxima_ to print its argument with a "
+"red foreground, if the second argument to the command is the text "
+"`highlight`."
+msgstr "Maxima 的 `box()` 命令使 wxMaxima 以红色输出其参数。"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:861
+#, no-wrap
+msgid "Output rendering."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:864
+msgid "With `set_display()` one can set, how wxMaxima will render the output."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:866
+msgid ""
+"`set_display('xml)` is the default value. Here Maxima speaks to wxMaxima "
+"using an (machine readable) XML-dialect (can be seen in the \"Raw XML "
+"sidebar\") and outputs the resulting formulas nicely rendered, e.g. pretty "
+"Matrices, Square root signs, fractions, etc."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:869
+#, no-wrap
+msgid ""
+"<!--- Currently that does not work as it should, the line with the output label is shifted right (issue: #2006) -->\n"
+"`set_display('ascii)` causes wxMaxima to output formulas as in command line Maxima - as ASCII-Art.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:871
+msgid ""
+"`set_display('none)` causes 'one-line' ASCII results - the same as the "
+"command line Maxima command `display2d:false;` does."
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:872
+#, no-wrap
+msgid "Help menu"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:875
+msgid ""
+"WxMaxima’s help menu provides access to the Maxima and wxMaxima manual, "
+"tips, some example worksheets and in command line Maxima included demos (the "
+"`demo()` command)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:877
+msgid "Please notice, that the demos write:"
+msgstr ""
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:878
+#, no-wrap
+msgid "At the ’_’ prompt, type ’;’ and <enter> to proceed with the demonstration.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:883
+#, no-wrap
+msgid "That is valid for command-line Maxima, however in wxMaxima by default it is necessary to continue the demonstration with: <kbd>CTRL</kbd>+<kbd>ENTER</kbd>\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:885
+#, no-wrap
+msgid "(That can be configured in the Configure->Worksheet->\"Hotkeys for sending commands to Maxima\" menu.)\n"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:888
+#, fuzzy, no-wrap
+#| msgid "Troubleshooting"
+msgid "Troubleshooting"
+msgstr "疑难解答"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:890
+#, fuzzy, no-wrap
+#| msgid "Cannot connect to _Maxima_"
+msgid "Cannot connect to _Maxima_"
+msgstr "无法连接到 Maxima"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:893
+#, fuzzy
+#| msgid ""
+#| "Since _Maxima_ (the program that does the actual mathematics) and "
+#| "_wxMaxima_ (providing the easy-to-use user interface) are separate "
+#| "programs that communicate by the means of a local network connection. "
+#| "Therefore the most probable cause is that this connection is somehow not "
+#| "working. For example a firewall could be set up in a way that it doesn’t "
+#| "just prevent unauthorized connections from the internet (and perhaps to "
+#| "intercept some connections to the internet, too), but it also to blocks "
+#| "inter-process-communication inside the same computer. Note that since "
+#| "_Maxima_ is being run by a Lisp processor the process communication that "
+#| "is blocked from does not necessarily have to be named \"maxima\". Common "
+#| "names of the program that opens the network connection would be sbcl, "
+#| "gcl, ccl, lisp.exe or similar names."
+msgid ""
+"Since _Maxima_ (the program that does the actual mathematics) and _wxMaxima_ "
+"(providing the easy-to-use user interface) are separate programs that "
+"communicate by the means of a local network connection. Therefore the most "
+"probable cause is that this connection is somehow not working. For example, "
+"a firewall could be set up in a way that it doesn’t just prevent "
+"unauthorized connections from the internet (and perhaps intercept some "
+"connections to the internet, too), but also blocks inter-process-"
+"communication inside the same computer. Note that since _Maxima_ is being "
+"run by a Lisp processor the process communication that is blocked does not "
+"necessarily have to be named \"maxima\". Common names of the program that "
+"opens the network connection would be sbcl, gcl, ccl, lisp.exe, or similar "
+"names."
+msgstr ""
+"由于 Maxima（进行实际数学运算的程序）和 wxMaxima（提供易于使用的用户界面的程"
+"序）是通过本地网络连接进行通信的独立程序，因此，最有可能的原因是这种连接不起"
+"作用。例如，可能设置了防火墙不仅可以阻止来自互联网的未经授权的连接（也许还会"
+"拦截一些通向互联网的连接），而且可以阻止同一台计算机内部的进程间通信。注意，"
+"由于 Maxima 由 Lisp 语言处理程序运行，因此被阻止的通信进程不一定命名"
+"为“Maxima”。此时打开网络连接的程序名称可能是 sbcl、gcl、ccl、lisp.exe 或者类"
+"似的名字。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:895
+#, fuzzy
+#| msgid ""
+#| "On Un\\*x computers another possible reason would be that the loopback "
+#| "network that provides network connections between two programs in the "
+#| "same computer isn’t properly configured."
+msgid ""
+"On Unix computers another possible reason would be that the loopback network "
+"that provides network connections between two programs in the same computer "
+"isn’t properly configured."
+msgstr ""
+"在 Un\\*x 系统上，另一个可能的原因是在同一台计算机上的两个程序之间提供网络连"
+"接的环回（loopback）网络配置不正确。"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:896
+#, fuzzy, no-wrap
+#| msgid "How to save data from a broken .wxmx file"
+msgid "How to save data from a broken .wxmx file"
+msgstr "从损坏的 .wxmx 文件中取回信息的方法"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:899
+#, fuzzy
+#| msgid ""
+#| "Internally most modern XML-based formats are ordinary zip-files. "
+#| "_wxMaxima_ doesn't turn on compression, so the contents of .wxmx files "
+#| "can be viewed in any text editor."
+msgid ""
+"Internally most modern XML-based formats are ordinary zip files. _WxMaxima_ "
+"doesn’t turn on compression, so the contents of `.wxmx` files can be viewed "
+"in any text editor."
+msgstr ""
+"大多数现代的、基于 XML 格式的文件其实都是普通的压缩（zip）文件。wxMaxima 没有"
+"启用压缩，因此可以在任何文本编辑器中查看 `.wxmx` 文件的内容。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:901
+#, fuzzy
+#| msgid ""
+#| "If the zip signature at the end of the file is still intact after "
+#| "renaming a broken .wxmx file to .zip most operating systems will provide "
+#| "a way to extract any portion of information that is stored inside it. "
+#| "This can be done when there is the need of recovering the original image "
+#| "files from a text processor document. If the zip signature isn’t intact "
+#| "that does not need to be the end of the world: If _wxMaxima_ during "
+#| "saving detected that something went wrong there will be a `wxmx~` file "
+#| "whose contents might help."
+msgid ""
+"If the zip signature at the end of the file is still intact after renaming a "
+"broken `.wxmx` file to `.zip` most operating systems will provide a way to "
+"extract any portion of the information that is stored inside it. This can be "
+"done when there is a need of recovering the original image files from a text "
+"processor document. If the zip signature isn’t intact that does not need to "
+"be the end of the world: If _wxMaxima_ during saving detected that something "
+"went wrong there will be a `.wxmx~` file whose contents might help."
+msgstr ""
+"如果文件末尾的 zip 签名仍然完整，那么将损坏的 `.wxmx` 文件重命名为 `.zip` 文"
+"件后，大多数操作系统都提供了提取存储在其中的信息的方法。当需要从该文件中恢复"
+"原始图像文件时，可以执行此操作。当 zip 签名不完整时，也不是毫无办法：如果 "
+"wxMaxima 在保存文件时检测到错误，那么还会有一个 `.wxmx~` 文件，其内容可能会有"
+"所帮助。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:903
+#, fuzzy, no-wrap
+#| msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file's contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).\n"
+msgid "And even if there isn’t such a file: The `.wxmx` file is a container format and the XML portion is stored uncompressed. It it is possible to rename the `.wxmx` file to a `.txt` file and to use a text editor to recover the XML portion of the file’s contents (it starts with `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` and ends with `</wxMaximaDocument>`. Before and after that text you will see some unreadable binary contents in the text editor).\n"
+msgstr "即使没有 `.wxmx~` 文件，`.wxmx` 文件中 XML 部分是未压缩的，可以将该文件重命名为 `.txt` 文件，并使用文本编辑器恢复文件中的 XML 部分（以 `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` 开头，并以 `</wxMaximaDocument>` 结尾（在 XML 部分的前后，可在文本编辑器中看到一些不可读的二进制内容）。\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:905
+#, fuzzy
+#| msgid ""
+#| "If a text file containing only this contents (e.g. copy and paste this "
+#| "text into a new file) is saved as a file ending in `.xml`, _wxMaxima_ "
+#| "will know how to recover the text of the document from it."
+msgid ""
+"If a text file containing only these contents (e.g. copy and paste this text "
+"into a new file) is saved as a file ending in `.xml`, _wxMaxima_ will know "
+"how to recover the text from the document."
+msgstr ""
+"如果将只包含 XML 部分的文本文件（例如，将这一部分复制并粘贴到新文件中）保存为"
+"以 `.xml` 结尾的文件，则 wxMaxima 可以从中恢复原始文档的文本。"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:906
+#, fuzzy, no-wrap
+#| msgid "I want some debug info to be displayed on the screen before my command has finished"
+msgid "I want some debug info to be displayed on the screen before my command has finished"
+msgstr "在命令完成前显示一些调试信息"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:909
+msgid ""
+"Normally _wxMaxima_ waits for the whole 2D formula to be transferred before "
+"it begins to typeset. This saves time for making many attempts to typeset a "
+"only partially completed equation. There is a `disp` command, though, that "
+"will provide debug output immediately and without waiting for the current "
+"_Maxima_ command to finish:"
+msgstr ""
+"通常 wxMaxima 会等待最后的公式形成后才开始输出，这节省了多次尝试输出部分公式"
+"的时间。不过， `disp()` 命令可以立即输出调试信息，而不必等待当前的 Maxima 命"
+"令完成："
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:910
+#, fuzzy, no-wrap
+#| msgid ""
+#| "for i:1 thru 10 do (\n"
+#| "   disp(i),\n"
+#| "   /* (sleep n) is a Lisp function, which can be used */\n"
+#| "   /* with the character \"?\" before. It delays the */\n"
+#| "   /* program execution (here: for 3 seconds) */\n"
+#| "   ?sleep(3)\n"
+#| ")$\n"
+msgid ""
+"for i:1 thru 10 do (\n"
+"   disp(i),\n"
+"   /* (sleep n) is a Lisp function, which can be used */\n"
+"   /* with the character \"?\" before. It delays the */\n"
+"   /* program execution (here: for 3 seconds) */\n"
+"   ?sleep(3)\n"
+")$\n"
+msgstr ""
+"for i:1 thru 10 do (\n"
+"   disp(i),\n"
+"   /* (sleep n) 是可接在字符\"?\"后使用的 Lisp 函数 */\n"
+"   /* 它推迟了程序的运行，此处是 3 秒 */\n"
+"   ?sleep(3)\n"
+")$\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:921
+msgid "Alternatively one can look for the `wxstatusbar()` command above."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:922
+#, fuzzy, no-wrap
+#| msgid "Plotting only shows a closed empty envelope with an error message"
+msgid "Plotting only shows a closed empty envelope with an error message"
+msgstr "绘图结果是空的绘图框和错误信息"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:925
+#, fuzzy
+#| msgid ""
+#| "This means that _wxMaxima_ could not read the file _Maxima_ that was "
+#| "supposed to instruct _gnuplot_ to create."
+msgid ""
+"This means that _wxMaxima_ could not read the file _Maxima_ that was "
+"supposed to instruct _Gnuplot_ to create."
+msgstr "这意味着 wxMaxima 无法读取由 Maxima 指示 gnuplot 创建的文件。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:927
+msgid "Possible reasons for this error are:"
+msgstr "这个错误的可能原因如下："
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+#, fuzzy
+#| msgid ""
+#| "The plotting command is part of a third-party package like "
+#| "`implicit_plot` but this package was not loaded by _Maxima_’s `load()` "
+#| "command before trying to plot."
+msgid ""
+"The plotting command is part of a third-party package like `implicit_plot` "
+"but this package was not loaded by _Maxima_’s `load()` command before trying "
+"to plot."
+msgstr ""
+"绘图命令是第三方程序包（如 `implicit_plot`）的一部分，但在尝试绘图之前，没有"
+"调用 Maxima 的 `load()` 命令加载此包。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+#, fuzzy
+#| msgid ""
+#| "_Maxima_ tried to do something the currently installed version of "
+#| "_gnuplot_ isn’t able to understand. In this case, a file ending in `."
+#| "gnuplot` located in the directory, which _Maxima_’s variable "
+#| "`maxima_userdir` is pointing, contains the instructions from _Maxima_ to "
+#| "_gnuplot_. Most of the time, this file’s contents therefore are helpful "
+#| "when debugging the problem."
+msgid ""
+"_Maxima_ tried to do something the currently installed version of _Gnuplot_ "
+"isn’t able to understand. In this case, a file ending in `.gnuplot` located "
+"in the directory, which _Maxima_’s variable `maxima_userdir` is pointing, "
+"contains the instructions from _Maxima_ to _Gnuplot_. Most of the time, this "
+"file’s contents therefore are helpful when debugging the problem."
+msgstr ""
+"Maxima 试图做一些当前版本的 gnuplot 无法理解的事情。此时，在由 Maxima 的变量 "
+"`maxima_userdir` 确定的目录中，以 `.gnuplot` 结尾的文件包含了 Maxima 给 "
+"gnuplot 的指令。在调试问题时，此文件的内容在大多数情况下都是有帮助的。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+#, fuzzy
+#| msgid ""
+#| "Gnuplot was instructed to use the pngcairo library that provides "
+#| "antialiasing and additional line styles, but it was not compiled to "
+#| "support this possibility. Solution: Uncheck the \"Use the cairo terminal "
+#| "for plot\" checkbox in the configuration dialog and don’t set "
+#| "`wxplot_pngcairo` to true from _Maxima_."
+msgid ""
+"Gnuplot was instructed to use the pngCairo library that provides "
+"antialiasing and additional line styles, but it was not compiled to support "
+"this possibility. Solution: Uncheck the \"Use the Cairo terminal for the "
+"plot\" checkbox in the configuration dialog and don’t set `wxplot_pngcairo` "
+"to true from _Maxima_."
+msgstr ""
+"Gnuplot 被设置为使用 pngcairo 库以提供抗锯齿功能和更多线条样式，但是在编译时"
+"没有开启此项功能支持。解决方案：取消选中设置对话框中的“使用 cairo 终端进行绘"
+"图”复选框，并且不要在 Maxima 中将 `wxplot_pngcairo` 设置为true。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:932
+#, fuzzy
+#| msgid "Gnuplot didn’t output a valid `.png` file."
+msgid "Gnuplot didn’t output a valid `.png` file."
+msgstr "Gnuplot 没有生成有效的 .png 文件。"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:933
+#, fuzzy, no-wrap
+#| msgid "Plotting an animation results in “error: undefined variable”"
+msgid "Plotting an animation results in “error: undefined variable”"
+msgstr "绘制动图时得到“error: undefined variable（错误：未定义的变量）”"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:936
+#, fuzzy
+#| msgid ""
+#| "The value of the slider variable by default is only substituted into the "
+#| "expression that is to be plotted if it is visible there. Using a `subst` "
+#| "command that substitutes the slider variable into the equation to plot "
+#| "resolves this problem. At the end of section [Embedding animations into "
+#| "the spreadsheet](#embedding-animations-into-the-spreadsheet) you can see "
+#| "an example."
+msgid ""
+"The value of the slider variable by default is only substituted into the "
+"expression that is to be plotted if it is visible there. Using a `subst` "
+"command that substitutes the slider variable into the equation to plot "
+"resolves this problem. At the end of section [Embedding animations into the "
+"spreadsheet](#embedding-animations-into-the-spreadsheet), you can see an "
+"example."
+msgstr ""
+"在默认情况下，滑块变量的值需要被替换到要绘制图形的表达式中，即该变量在表达式"
+"中可见。使用 `subst()` 命令将滑块变量替换到要绘制图形的方程中可以解决此问题。"
+"[在工作簿中嵌入动图](#embedding-animations-into-the-spreadsheet)一节的末尾有"
+"一个例子。"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:937
+#, fuzzy, no-wrap
+#| msgid "I lost a cell contents and undo doesn’t remember"
+msgid "I lost cell content and undo doesn’t remember"
+msgstr "删除了一个单元格，而撤销操作不起作用"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:940
+msgid ""
+"There are separate undo functions for cell operations and for changes inside "
+"of cells so chances are low that this ever happens. If it does there are "
+"several methods to recover data:"
+msgstr ""
+"对单元格的操作和单元格内部的更改均有单独的撤消函数，因此发生这种情况的可能性"
+"很低。如果确实是这样，有如下方法可以恢复数据："
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+#, fuzzy
+#| msgid ""
+#| "_wxMaxima_ actually has two undo features: The global undo buffer that is "
+#| "active if no cell is selected and a per-cell undo buffer that is active "
+#| "if the cursor is inside a cell. It is worth trying to use both undo "
+#| "options in order to see if an old value can still be accessed."
+msgid ""
+"_WxMaxima_ actually has two undo features: The global undo buffer that is "
+"active if no cell is selected and a per-cell undo buffer that is active if "
+"the cursor is inside a cell. It is worth trying to use both undo options in "
+"order to see if an old value can still be accessed."
+msgstr ""
+"wxMaxima 实际上有两个撤消功能：全局撤消（如果未选择单元格）和单元格内撤消（如"
+"果光标在单元格内）。可以尝试使用这两个撤消选项，以查看是否可以恢复内容。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+#, fuzzy
+#| msgid ""
+#| "If you still have a way to find out what label _Maxima_ has assigned to "
+#| "the cell just type in the cell’s label and its contents will reappear."
+msgid ""
+"If you still have a way to find out what label _Maxima_ has assigned to the "
+"cell just type in the cell’s label and its contents will reappear."
+msgstr ""
+"如果有办法确定 Maxima 分配给该单元格的标签，只需键入此标签，单元格的内容就会"
+"重新出现。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+#, fuzzy
+#| msgid ""
+#| "If you don’t: Don’t panic. In the “View” menu there is a way to show a "
+#| "history pane that shows all _Maxima_ commands that have been issued "
+#| "recently."
+msgid ""
+"If you don’t: Don’t panic. In the “View” menu there is a way to show a "
+"history pane that shows all _Maxima_ commands that have been issued recently."
+msgstr ""
+"如果忘了单元格的标签，也无需惊慌。在“查看”菜单中，可以勾选显示“历史命令”侧边"
+"栏，其中显示了最近使用的所有 Maxima 命令。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:945
+msgid "If nothing else helps _Maxima_ contains a replay feature:"
+msgstr "如果以上都没有帮助，可以调用 Maxima 的回放功能："
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:946
+#, no-wrap
+msgid "playback();\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:950
+#, fuzzy, no-wrap
+#| msgid "_wxMaxima_ starts up with the message “Maxima process terminated.”"
+msgid "_WxMaxima_ starts up with the message “Maxima process terminated.”"
+msgstr "wxMaxima 启动时显示信息“Maxima process terminated（Maxima 进程已终止）。”"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:953
+#, fuzzy
+#| msgid ""
+#| "One possible reason is that _Maxima_ cannot be found in the location that "
+#| "is set in the “Maxima” tab of _wxMaxima_’s configuration dialog and "
+#| "therefore won’t run at all. Setting the path to a working _Maxima_ binary "
+#| "should fix this problem."
+msgid ""
+"One possible reason is that _Maxima_ cannot be found in the location that is "
+"set in the “Maxima” tab of _wxMaxima_’s configuration dialog and therefore "
+"won’t run at all. Setting the path to a working _Maxima_ binary should fix "
+"this problem."
+msgstr ""
+"一个可能的原因是，在设置对话框的“Maxima”选项卡中设置的位置找不到 Maxima 程"
+"序，因此根本无法运行 Maxima。将路径设置为有效的 Maxima 二进制文件所在文件夹应"
+"该可以解决此问题。"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:954
+#, fuzzy, no-wrap
+#| msgid "Maxima is forever calculating and not responding to input"
+msgid "Maxima is forever calculating and not responding to input"
+msgstr "Maxima 永远在计算中而不响应输入"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:957
+#, fuzzy
+#| msgid ""
+#| "It is theoretically possible that _wxMaxima_ doesn’t realize that "
+#| "_Maxima_ has finished calculating and therefore never gets informed it "
+#| "can send new data to _Maxima_. If this is the case “Trigger evaluation” "
+#| "might resynchronize the two programs."
+msgid ""
+"It is theoretically possible that _wxMaxima_ doesn’t realize that _Maxima_ "
+"has finished calculating and therefore never gets informed it can send new "
+"data to _Maxima_. If this is the case “Trigger evaluation” might "
+"resynchronize the two programs."
+msgstr ""
+"理论上讲，有可能是 wxMaxima 没有意识到 Maxima 已经完成了计算，因此没有得到通"
+"知，以告知它可以向 Maxima 发送新的数据。如果是这种情况，重新求值可能会使两个"
+"程序同步。"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:958
+#, fuzzy, no-wrap
+#| msgid "My SBCL-based _Maxima_ runs out of memory"
+msgid "My SBCL-based _Maxima_ runs out of memory"
+msgstr "基于 SBCL 的 Maxima 耗尽内存"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:961
+#, fuzzy
+#| msgid ""
+#| "The Lisp compiler SBCL by default comes with a memory limit that allows "
+#| "it to run even on low-end computers. When compiling a big software "
+#| "package like Lapack or dealing with extremely big lists or equations this "
+#| "limit might be too low. In order to extend the limits SBCL can be "
+#| "provided with the command line parameter `--dynamic-space-size` that "
+#| "tells SBCL how many megabytes it should reserve. A 32bit Windows-SBCL can "
+#| "reserve up to 999 Megabytes. A 64-bit SBCL version running on Windows can "
+#| "be instructed to use more than the about 1280 Megabytes compiling Lapack "
+#| "needs."
+msgid ""
+"The Lisp compiler SBCL by default comes with a memory limit that allows it "
+"to run even on low-end computers. When compiling a big software package like "
+"Lapack or dealing with extremely big lists of equations this limit might be "
+"too low. In order to extend the limits, SBCL can be provided with the "
+"command line parameter `--dynamic-space-size` that tells SBCL how many "
+"megabytes it should reserve. A 32bit Windows-SBCL can reserve up to 999 "
+"Megabytes. A 64-bit SBCL version running on Windows can be instructed to use "
+"more than the about 1280 Megabytes compiling Lapack needs."
+msgstr ""
+"默认情况下，Lisp 编译器 SBCL 有一个内存限制，以使得它能在低端计算机上运行。当"
+"编译一个大型软件包（如 Lapack）或处理特别大的列表和方程时，该限制值可能太低。"
+"为了扩展内存限制，可以向 SBCL 提供命令行参数 `--dynamic-space-size`，该参数告"
+"诉 SBCL 应该使用多少兆字节的内存。32位 Windows 系统版本的 SBCL 最多可使用 "
+"999 兆字节，64位 Windows 系统版本的 SBCL 可以被设置为使用更大的内存（例如超过"
+"编译 Lapack 所需的约 1280 兆字节）。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:963
+#, fuzzy
+#| msgid ""
+#| "One way to provide _Maxima_ (and thus SBCL) with command line parameters "
+#| "is the \"Additional parameters for Maxima\" field of _wxMaxima_’s "
+#| "configuration dialogue."
+msgid ""
+"One way to provide _Maxima_ (and thus SBCL) with command line parameters is "
+"the \"Additional parameters for Maxima\" field of _wxMaxima_’s configuration "
+"dialogue."
+msgstr ""
+"为 Maxima（因此也为 SBCL）提供命令行参数的一种方法是利用 wxMaxima 设置对话框"
+"的“额外的 Maxima 参数（Additional parameters for Maxima）”字段。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:965
+msgid "![sbcl memory](./sbclMemory.png){ id=img_sbclMemory }"
+msgstr "![SBCL 内存](./sbclMemory.png){ id=img_sbclMemory }"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:966
+#, fuzzy, no-wrap
+#| msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgid "Input sometimes is sluggish/ignoring keys on Ubuntu"
+msgstr "在 Ubuntu 系统上，有时输入无响应或响应迟缓"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:969
+msgid ""
+"Installing the package `ibus-gtk` should resolve this issue. See ([https://"
+"bugs.launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs."
+"launchpad.net/ubuntu/+source/wxwidgets3.0/+bug/1421558)) for details."
+msgstr ""
+"安装软件包 `ibus-gtk` 应该可以解决此问题. 详情见 [https://bugs.launchpad.net/"
+"ubuntu/+source/wxwidgets3.0/+bug/1421558](https://bugs.launchpad.net/ubuntu/"
+"+source/wxwidgets3.0/+bug/1421558)。"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:970
+#, fuzzy, no-wrap
+#| msgid "_wxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgid "_WxMaxima_ halts when _Maxima_ processes Greek characters or Umlauts"
+msgstr "wxMaxima 在处理希腊字符或元音变音符时停止"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:973
+msgid ""
+"If your _Maxima_ is based on SBCL the following lines have to be added to "
+"your `.sbclrc`:"
+msgstr "如果所使用的 Maxima 基于SBCL，则必须将以下行添加到 `.sbclrc` 文件中："
+
+#. type: Fenced code block (commonlisp)
+#: ../../info/wxmaxima.md:974
+#, fuzzy, no-wrap
+#| msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
+msgid "(setf sb-impl::*default-external-format* :utf-8)\n"
+msgstr "(setf sb-impl::*default-external-format* :utf-8)\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:979
+#, fuzzy
+#| msgid ""
+#| "The folder this file has to be placed in is system- and installation-"
+#| "specific. But any SBCL-based _Maxima_ that already has evaluated a cell "
+#| "in the current session will happily tell where it can be found after "
+#| "getting the following command:"
+msgid ""
+"The folder where this file has to be placed is system- and installation-"
+"specific. But any SBCL-based _Maxima_ that already has evaluated a cell in "
+"the current session will happily tell where it can be found after getting "
+"the following command:"
+msgstr ""
+"`.sbclrc` 文件应放入特定的文件夹。任何基于 SBCL 的 Maxima 如果已经在当前会话"
+"中计算了一个单元格，那么在获得如下命令后，都会显示该文件的位置："
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:980
+#, fuzzy, no-wrap
+#| msgid "    :lisp (sb-impl::userinit-pathname)\n"
+msgid ":lisp (sb-impl::userinit-pathname)\n"
+msgstr "    :lisp (sb-impl::userinit-pathname)\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:984
+#, no-wrap
+msgid "Note concerning Wayland (recent Linux/BSD distributions)"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:988
+msgid ""
+"There seem to be issues with the Wayland Display Server and wxWidgets.  "
+"WxMaxima may be affected, e.g. that sidebars are not moveable."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:992
+msgid ""
+"You can either disable Wayland and use X11 instead (globally)  or just tell, "
+"that wxMaxima should use the X Window System by setting: `GDK_BACKEND=x11`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:994
+msgid "E.g. start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:996
+msgid "`GDK_BACKEND=x11 wxmaxima`"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:997
+#, no-wrap
+msgid "The menu bar disappears on KDE Plasma"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1003
+msgid ""
+"On some KDE Plasma installations the global menu bar disappears when "
+"clicked.  As this is a bug in the global menu proxy, the only way to avoid "
+"it is to tell that wxMaxima should use its own menu bar instead of the "
+"global one.  This is done by setting: `UBUNTU_MENUPROXY=0`"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1007
+msgid ""
+"Starting with version 26.05.0, wxMaxima attempts to set this variable "
+"automatically if it detects an affected system (KDE, Unity, or Ubuntu with "
+"older wxWidgets versions)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1009
+msgid "If the automatic fix fails, you can manually start wxMaxima with:"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1011
+msgid "`UBUNTU_MENUPROXY=0 wxmaxima`"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1012
+#, no-wrap
+msgid "Why is the integrated manual browser not offered on my Windows PC?"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1016
+msgid ""
+"Either wxWidgets wasn’t compiled with support for Microsoft’s webview2 or "
+"Microsoft’s webview2 isn’t installed."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1017
+#, no-wrap
+msgid "Why is the external manual browser not working on my Linux box?"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1024
+msgid ""
+"The HTML browser might be a snap, flatpack or appimage version. All of these "
+"typically cannot access files that are installed on your local system. "
+"Another reason might be that maxima or wxMaxima is installed as a snap, "
+"flatpack or something else that doesn’t give the host system access to its "
+"contents. A third reason might be that the maxima HTML manual isn’t "
+"installed and the online one cannot be accessed."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1025
+#, fuzzy, no-wrap
+#| msgid "Can I make _wxMaxima_ output both image files and embedded plots at once?"
+msgid "Can I make _wxMaxima_ output both image files and embedded plots at once?"
+msgstr "是否可以同时输出和嵌入绘图文件？"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1028
+#, fuzzy
+#| msgid ""
+#| "The worksheet embeds .png files. _wxMaxima_ allows the user to specify "
+#| "where they should be generated:"
+msgid ""
+"The worksheet embeds `.png files. _WxMaxima_ allows the user to specify "
+"where they should be generated:"
+msgstr "工作簿可嵌入 `.png` 文件。wxMaxima 允许用户指定它们的生成位置："
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1029
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxdraw2d(\n"
+#| "    file_name=\"test\",\n"
+#| "    explicit(sin(x),x,1,10)\n"
+#| ");\n"
+msgid ""
+"wxdraw2d(\n"
+"    file_name=\"test\",  /* extension .png automatically added */\n"
+"    explicit(sin(x),x,1,10)\n"
+");\n"
+msgstr ""
+"wxdraw2d(\n"
+"    file_name=\"test\",\n"
+"    explicit(sin(x),x,1,10)\n"
+");\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1037
+#, fuzzy
+#| msgid ""
+#| "If a different format is to be used it is easier to generate the images "
+#| "and then to import them into the worksheet again:"
+msgid ""
+"If a different format is to be used, it is easier to generate the images and "
+"then import them into the worksheet again:"
+msgstr "如果要使用不同的格式，则可以先生成图像，然后再将其导入工作簿："
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1038
+#, fuzzy, no-wrap
+#| msgid ""
+#| "load(\"draw\");\n"
+#| "pngdraw(name,[contents]):=\n"
+#| "(\n"
+#| "    draw(\n"
+#| "        append(\n"
+#| "            [\n"
+#| "                terminal=pngcairo,\n"
+#| "                dimensions=wxplot_size,\n"
+#| "                file_name=name\n"
+#| "            ],\n"
+#| "            contents\n"
+#| "        )\n"
+#| "    ),\n"
+#| "    show_image(printf(false,\"~a.png\",name))\n"
+#| ");\n"
+#| "pngdraw2d(name,[contents]):=\n"
+#| "    pngdraw(name,gr2d(contents));\n"
+#| "\n"
+#| "pngdraw2d(\"Test\",\n"
+#| "        explicit(sin(x),x,1,10)\n"
+#| ");\n"
+msgid ""
+"load(\"draw\");\n"
+"pngdraw(name,[contents]):=\n"
+"(\n"
+"    draw(\n"
+"        append(\n"
+"            [\n"
+"                terminal=pngcairo,\n"
+"                dimensions=wxplot_size,\n"
+"                file_name=name\n"
+"            ],\n"
+"            contents\n"
+"        )\n"
+"    ),\n"
+"    show_image(printf(false,\"~a.png\",name))\n"
+");\n"
+"pngdraw2d(name,[contents]):=\n"
+"    pngdraw(name,gr2d(contents));\n"
+"\n"
+"pngdraw2d(\"Test\",\n"
+"        explicit(sin(x),x,1,10)\n"
+");\n"
+msgstr ""
+"load(\"draw\");\n"
+"pngdraw(name,[contents]):=\n"
+"(\n"
+"    draw(\n"
+"        append(\n"
+"            [\n"
+"                terminal=pngcairo,\n"
+"                dimensions=wxplot_size,\n"
+"                file_name=name\n"
+"            ],\n"
+"            contents\n"
+"        )\n"
+"    ),\n"
+"    show_image(printf(false,\"~a.png\",name))\n"
+");\n"
+"pngdraw2d(name,[contents]):=\n"
+"    pngdraw(name,gr2d(contents));\n"
+"\n"
+"pngdraw2d(\"Test\",\n"
+"        explicit(sin(x),x,1,10)\n"
+");\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1062
+#, fuzzy, no-wrap
+#| msgid "Can I set the aspect ratio of a plot?"
+msgid "Can I set the aspect ratio of an embedded plot?"
+msgstr "是否可以指定绘制图形的相对比例？"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1065
+msgid "Use the variable `wxplot_size`:"
+msgstr ""
+
+#. type: Fenced code block (maxima)
+#: ../../info/wxmaxima.md:1066
+#, fuzzy, no-wrap
+#| msgid ""
+#| "wxdraw2d(\n"
+#| "    proportional_axis=xy,\n"
+#| "    explicit(sin(x),x,1,10)\n"
+#| "),wxplot_size=[1000,1000];\n"
+msgid ""
+"wxdraw2d(\n"
+"    explicit(sin(x),x,1,10)\n"
+"),wxplot_size=[1000,1000];\n"
+msgstr ""
+"wxdraw2d(\n"
+"    proportional_axis=xy,\n"
+"    explicit(sin(x),x,1,10)\n"
+"),wxplot_size=[1000,1000];\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1072
+#, no-wrap
+msgid "After upgrading to MacOS 13.1 plot and/or draw commands output error messages like"
+msgstr ""
+
+#. type: Fenced code block (text)
+#: ../../info/wxmaxima.md:1074
+#, no-wrap
+msgid ""
+"1 HIToolbox 0x00007ff80cd91726 _ZN15MenuBarInstance22EnsureAutoShowObserverEv + 102\n"
+"2 HIToolbox 0x00007ff80cd912b8 _ZN15MenuBarInstance14EnableAutoShowEv + 52\n"
+"3 HIToolbox 0x00007ff80cd35908 SetMenuBarObscured + 408\n"
+"...\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1082
+#, no-wrap
+msgid "This might be an issue with the operating system. Disable the hiding of the menu bar (SystemSettings => Desktop & Dock => Menu Bar) might solve the issue. See [wxMaxima issue #1746](https://github.com/wxMaxima-developers/wxmaxima/issues/1746) for more information.\n"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1083
+#, no-wrap
+msgid "Logging"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1088
+#, no-wrap
+msgid ""
+"Log messages might be helpful to debug problems. WxMaxima can log many events. Most log entries will be helpful for developers, especially in case of problems or bugs. If you run a \"Release\"-Build,\n"
+"the log windows is not shown by default, if you run a development version, it is shown by default as a second window. You can enable and disable\n"
+"this window using the \"View->Toggle log window\" menu entry.\n"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1090
+msgid ""
+"Messages are not 'lost', if the log window is not shown, if you select to "
+"show the log window later, you will see past log messages (if you did not "
+"clear the messages)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1092
+msgid ""
+"Such messages may be helpful, when you create bug reports (or trying to find "
+"a bug by yourself)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1095
+msgid ""
+"Log messages can (additionally) be printed to STDERR, when using the command "
+"line option \"--logtostderr\". On Windows a separate text console will be "
+"opened, as a Windows GUI application does not have the standard IO connected."
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1098
+#, no-wrap
+msgid "FAQ"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1100
+#, fuzzy, no-wrap
+#| msgid "Is there a way to make more text fit on a LaTeX page?"
+msgid "Is there a way to make more text fit on a LaTeX page?"
+msgstr "有没有办法在 LaTeX 页面中显示更多的文字？"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1103
+msgid ""
+"Yes. Use the [LaTeX package \"geometry\"](https://ctan.org/pkg/geometry) to "
+"specify the size of the borders."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1105
+#, fuzzy, no-wrap
+#| msgid "There is: Just add the following lines to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"):\n"
+msgid "You can add the following line to the LaTeX preamble (for example by using the respective field in the config dialogue (\"Export\"->\"Additional lines for the TeX preamble\"), to set borders of 1cm):\n"
+msgstr "有，只需将以下文字添加到 LaTeX 文件的导言区，例如通过修改设置对话框中的相应字段（导出->在 TeX 导言区中添加额外的内容（Export->Additional lines for the TeX preamble））：\n"
+
+#. type: Fenced code block (latex)
+#: ../../info/wxmaxima.md:1106
+#, fuzzy, no-wrap
+#| msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+msgid "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+msgstr "\\usepackage[left=1cm,right=1cm,top=1cm,bottom=1cm]{geometry}\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1110
+#, fuzzy, no-wrap
+#| msgid "Is there a dark mode?"
+msgid "Is there a dark mode?"
+msgstr "是否有深色模式？"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1113
+#, fuzzy
+#| msgid ""
+#| "If wxWidgets is new enough _wxMaxima_ will automatically be in dark mode "
+#| "if the rest of the operating system is. The worksheet itself is by "
+#| "default equipped with a bright background. But it can be configured "
+#| "otherwise. Alternatively there is a `View/Invert worksheet brightness` "
+#| "menu entry that allows to quickly convert the worksheet from dark to "
+#| "bright and vice versa."
+msgid ""
+"If wxWidgets is new enough, _wxMaxima_ will automatically be in dark mode if "
+"the rest of the operating system is. The worksheet itself is by default "
+"equipped with a bright background. But it can be configured otherwise. "
+"Alternatively, there is a `View/Invert worksheet brightness` menu entry that "
+"allows to quickly convert the worksheet from dark to bright and vice versa."
+msgstr ""
+"如果 wxWidgets 版本足够新，那么当系统设置了深色主题时，wxMaxima 将自动处于深"
+"色模式。在默认情况下，工作簿本身具有浅色背景。但也可以进行其他配置：利用菜"
+"单“查看->反转工作簿亮度”，可以快速将工作簿在浅色模式和深色模式中转换。"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1114
+#, fuzzy, no-wrap
+#| msgid "_wxMaxima_ sometimes hangs for a several seconds once in the first minute"
+msgid "_WxMaxima_ sometimes hangs for several seconds once in the first minute"
+msgstr "wxMaxima 有时在启动后的一段时间内无响应"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1117
+#, fuzzy, no-wrap
+#| msgid "_wxMaxima_ delegates some big tasks like parsing _Maxima_'s >1000-page-manual to background tasks, which normally goes totally unnoticed. In the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.\n"
+msgid "_WxMaxima_ delegates some big tasks like parsing _Maxima_’s >1000-page-manual to background tasks, which normally goes totally unnoticed. At the moment the result of such a task is needed, though, it is possible that _wxMaxima_ needs to wait a couple of seconds before it can continue its work.\n"
+msgstr "wxMaxima 将一些大型任务（如解析 Maxima 的超过 1000 页的手册）委托给后台任务，而这些任务通常不会被执行。然而，当需要执行这样一个任务时，可能需要等待几秒钟才能继续工作。\n"
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1118
+#, no-wrap
+msgid "Especially when testing new locale settings, a message box \"locale ’xx_YY’ can not be set\" occurs"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1121
+msgid "![Locale warning](./locale-warning.png){ id=img_locale_warning}"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1125
+msgid ""
+"(The same problem can occur with other applications too). The translations "
+"seem okay after you click on ’OK’. WxMaxima does not only use its own "
+"translations but the translations of the wxWidgets framework too."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1128
+msgid ""
+"These locales maybe not present in the system. On Ubuntu/Debian systems they "
+"can be generated using: `dpkg-reconfigure locales`"
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1129
+#, no-wrap
+msgid "How can I use symbols for real numbers, natural numbers (ℝ, ℕ), etc.?"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1132
+msgid ""
+"You can find these symbols in the Unicode sidebar (search for ’double-struck "
+"capital’). But the selected font must also support these symbols. If they do "
+"not display properly, select another font."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1133
+#, no-wrap
+msgid "How can a Maxima script determine, if it is running under wxMaxima or command line Maxima?"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1136
+msgid ""
+"If wxMaxima is used, the Maxima variable `maxima_frontend` is set to "
+"`wxmaxima`. The Maxima variable `maxima_frontend_version` contains the "
+"wxMaxima version in this case."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1138
+msgid ""
+"If no frontend is used (you are using command line Maxima), these variables "
+"are `false`."
+msgstr ""
+
+#. type: Title ##
+#: ../../info/wxmaxima.md:1139
+#, no-wrap
+msgid "Help! I can not save my document!"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1142
+#, no-wrap
+msgid "If saving as wxmx file does not work, try saving the document as wxm file (and vice versa). And you can also try to remove all output (Menu Cell->Remove all output) and save that file, maybe some unexpected output causes issues during the save process.\n"
+msgstr ""
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1145
+#, fuzzy, no-wrap
+#| msgid "Command-line arguments"
+msgid "Command-line arguments"
+msgstr "命令行参数"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1148
+msgid ""
+"Usually you can start programs with a graphical user interface just by "
+"clicking on a desktop icon or desktop menu entry. WxMaxima - if started from "
+"the command line - still provides some command-line switches, though."
+msgstr ""
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-v` or `--version`: Output the version information"
+msgstr "`-v` 或 `--version`：输出版本信息。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-h` or `--help`: Output a short help text"
+msgstr "`-h` 或 `--help`: 输出简短的帮助文本。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+#, fuzzy
+#| msgid ""
+#| "`-o` or `--open=<str>`: Open the filename given as argument to this "
+#| "command-line switch"
+msgid ""
+"`-o` or `--open=<str>`: Open the filename given as an argument to this "
+"command-line switch"
+msgstr "`-o` 或 `--open=<str>`：打开作为此命令行参数的文件名。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+msgid "`-e` or `--eval`: Evaluate the file after opening it."
+msgstr "`-e` 或 `--eval`：打开文件后对公式单元格求值。"
+
+#. type: Bullet: '- '
+#: ../../info/wxmaxima.md:1164
+#, fuzzy
+#| msgid ""
+#| "`-b` or `--batch`: If the command-line opens a file all cells in this "
+#| "file are evaluated and the file is saved afterwards. This is for example "
+#| "useful if the session described in the file makes _Maxima_ generate "
+#| "output files. Batch-processing will be stopped if _wxMaxima_ detects that "
+#| "_Maxima_ has output an error and will pause if _Maxima_ has a question: "
+#| "Mathematics is somewhat interactive by nature so a completely interaction-"
+#| "free batch processing cannot always be guaranteed."
+msgid ""
+"`-b` or `--batch`: If the command-line opens a file all cells in this file "
+"are evaluated and the file is saved afterward. This is for example useful if "
+"the session described in the file makes _Maxima_ generate output files. "
+"Batch-processing will be stopped if _wxMaxima_ detects that _Maxima_ has "
+"output an error and will pause if _Maxima_ has a question: Mathematics is "
+"somewhat interactive by nature so a completely interaction-free batch "
+"processing cannot always be guaranteed."
+msgstr ""
+"`-b` 或 `--batch`：如果用命令行打开一个文件，则计算该文件中的所有单元格，然后"
+"保存文件。例如，如果文件中描述的会话使 Maxima 生成输出文件，则这一参数会很有"
+"用。如果 wxMaxima 检测到 Maxima 输出了错误信息，则批处理将停止；如果检测到 "
+"Maxima 有疑问，则批处理将暂停。Maxima 的计算过程有一定的交互性，因此无法保证"
+"完全无交互的批处理。"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1164
+#, fuzzy, no-wrap
+#| msgid ""
+#| "* `--logtostdout`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
+#| "* `--pipe`:                        Pipe messages from Maxima to stdout.\n"
+#| "* `--exit-on-error`:               Close the program on any maxima error.\n"
+#| "* `-f` or `--ini=<str>`: Use the init file that was given as argument to this command-line switch\n"
+#| "* `-u`, `--use-version=<str>`:     Use maxima version `<str>`.\n"
+#| "* `-l`, `--lisp=<str>`:              Use a Maxima compiled with Lisp compiler `<str>`.\n"
+#| "* `-X`, `--extra-args=<str>`:        Allows to specify extra Maxima arguments\n"
+#| "* `-m` or `--maxima=<str>`:    allows to specify the location of the _maxima_ binary\n"
+#| "* `--enableipc`: Lets Maxima control wxMaxima via interprocess communications. Use this option with care.\n"
+msgid ""
+"- `--logtostderr`:                 Log all \"debug messages\" sidebar messages to stderr, too.\n"
+"- `--pipe`:                        Pipe messages from Maxima to stdout.\n"
+"- `--exit-on-error`:               Close the program on any maxima error.\n"
+"- `-f` or `--ini=<str>`: Use the init file that was given as an argument to this command-line switch\n"
+"- `-u`, `--use-version=<str>`:     Use maxima version `<str>`.\n"
+"- `-l`, `--lisp=<str>`:              Use a Maxima compiled with Lisp compiler `<str>`.\n"
+"- `-X`, `--extra-args=<str>`:        Allows to specify extra Maxima arguments\n"
+"- `-m` or `--maxima=<str>`:    allows specifying the location of the _maxima_ binary\n"
+"- `--enableipc`: Lets Maxima control wxMaxima via interprocess communications. Use this option with care.\n"
+"- `--wxmathml-lisp=<str>`:   Location of wxMathML.lisp (if not the built-in should be used, mainly for developers).\n"
+msgstr ""
+"* `--logtostdout`：将所有“调试信息”侧边栏里的信息也输出到标准错误文件（stderr）。\n"
+"* `--pipe`：将 Maxima 的信息通过管道（pipe）输出到标准输出文件（stdout）。\n"
+"* `--exit-on-error`：在遇到任何 Maxima 错误时关闭程序。\n"
+"* `-f` 或 `--ini=<str>`： 指定要使用的初始设定文件。\n"
+"* `-u` 或 `--use-version=<str>`：指定要使用的 Maxima 的版本。\n"
+"* `-l` 或 `--lisp=<str>`：指定 Maxima 使用的 Lisp 解释器。\n"
+"* `-X` 或 `--extra-args=<str>`：指定额外的 Maxima 参数。\n"
+"* `-m` 或 `--maxima=<str>`：指定 Maxima 程序的位置。\n"
+"* `--enableipc`：使 Maxima 通过内部进程通讯来控制 wxMaxima （应谨慎使用此选项）。\n"
+"\n"
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1166
+#, fuzzy
+#| msgid ""
+#| "Instead of a minus some operating systems might use a dash in front of "
+#| "the command-line switches."
+msgid ""
+"Instead of a minus, some operating systems might use a dash in front of the "
+"command-line switches."
+msgstr "一些操作系统可能在命令行选项前面使用连字符（-，dash），而不是减号。"
+
+#. type: Title #
+#: ../../info/wxmaxima.md:1169
+#, no-wrap
+msgid "About the program, contributing to wxMaxima"
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1172
+msgid ""
+"wxMaxima is mainly developed using the programming language C++ using the "
+"[wxWidgets framework](https://www.wxwidgets.org), as build system we use "
+"[CMake](https://www.cmake.org), a small part is written in Lisp. You can "
+"contribute to wxMaxima, join the wxMaxima project at <https://github.com/"
+"wxMaxima-developers/wxmaxima>, if you have knowledge of these programming "
+"languages and want to help and contribute to the open source project "
+"wxMaxima."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1174
+msgid ""
+"But not only programmers are necessary! You can also contribute to wxMaxima, "
+"if you help to improve the documentation, find and report bugs (and maybe "
+"bugfixes), suggest new features, help to translate wxMaxima or the manual to "
+"your language (read the README.md in the [locale subdirectory](https://"
+"github.com/wxMaxima-developers/wxmaxima/tree/main/locales) how wxMaxima and "
+"the manual can be translated)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1176
+msgid "Or answer questions of other users in the discussion forum."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1178
+msgid ""
+"The source code of wxMaxima is documented using Doxygen [here](https://"
+"wxmaxima-developers.github.io/wxmaxima/Doxygen-documentation/)."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1180
+msgid ""
+"The program is nearly self-contained, so except for system libraries (and "
+"the wxWidgets library), no external dependencies (like graphic files or the "
+"Lisp part (the `wxmathML.lisp`-file) is needed, these files are included in "
+"the executable."
+msgstr ""
+
+#. type: Plain text
+#: ../../info/wxmaxima.md:1181
+#, no-wrap
+msgid "If you are a developer, you might want to try out a modified `wxmathML.lisp`-file without recompiling everything, one can use the command line option `--wxmathml-lisp=<str>` to use another Lisp file, not the included one.\n"
+msgstr ""
+
+#, fuzzy
+#~| msgid ""
+#~| "wxdraw2d(\n"
+#~| "    file_name=\"test\",\n"
+#~| "    explicit(sin(x),x,1,10)\n"
+#~| ");\n"
+#~ msgid ""
+#~ "pngdraw2d(\"Test\",\n"
+#~ "        explicit(sin(x),x,1,10)\n"
+#~ ");\n"
+#~ "```\n"
+#~ msgstr ""
+#~ "wxdraw2d(\n"
+#~ "    file_name=\"test\",\n"
+#~ "    explicit(sin(x),x,1,10)\n"
+#~ ");\n"

--- a/locales/wxMaxima/CMakeLists.txt
+++ b/locales/wxMaxima/CMakeLists.txt
@@ -65,7 +65,7 @@ if(GETTEXT_FOUND AND GETTEXT_MSGFMT_EXECUTABLE AND GETTEXT_MSGMERGE_EXECUTABLE)
 
 	add_custom_target(
 	    ${LANG}_po
-	    DEPENDS ${LANG}.po)
+	    DEPENDS ${LANG}.po wxMaxima.pot)
 	add_custom_command(
 	    TARGET ${LANG}_po
 	    PRE_BUILD
@@ -79,6 +79,15 @@ if(GETTEXT_FOUND AND GETTEXT_MSGFMT_EXECUTABLE AND GETTEXT_MSGMERGE_EXECUTABLE)
 	    # real ones without reading a word of it. The catalogues currently
 	    # hold ~9400 fuzzy entries and not one of them says what it used to
 	    # be; this stops that from being true of the next ones.
+	    # Fold locales/manual/${LANG}.po's translations (if any - po4a keeps
+	    # writing its own file there, see merge_manual_po.cmake for why) into
+	    # this file BEFORE msgmerge, so the combined catalog picks up the
+	    # manual's current translations too.
+	    COMMAND "${CMAKE_COMMAND}"
+		"-DLANG_PO=${CMAKE_CURRENT_SOURCE_DIR}/${LANG}.po"
+		"-DMANUAL_PO=${CMAKE_SOURCE_DIR}/locales/manual/${LANG}.po"
+		"-DMSGCAT=${MSGCAT}"
+		-P "${CMAKE_CURRENT_SOURCE_DIR}/merge_manual_po.cmake"
 	    COMMAND "${GETTEXT_MSGMERGE_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/${LANG}.po" "${CMAKE_CURRENT_SOURCE_DIR}/wxMaxima.pot" -U --previous
 	    COMMAND "${GETTEXT_MSGFMT_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/${LANG}.po" -o "${CMAKE_CURRENT_BINARY_DIR}/${LANG}.gmo"
 	    COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_BINARY_DIR}/${LANG}.gmo" "${CMAKE_BINARY_DIR}/locale/${LANG}/LC_MESSAGES/wxMaxima.mo")

--- a/locales/wxMaxima/CMakeLists.txt
+++ b/locales/wxMaxima/CMakeLists.txt
@@ -39,6 +39,16 @@ if(GETTEXT_FOUND AND GETTEXT_MSGFMT_EXECUTABLE AND GETTEXT_MSGMERGE_EXECUTABLE)
 	COMMAND ${MSGCAT} --use-first --no-wrap "${CMAKE_CURRENT_BINARY_DIR}/wxMaxima_sourcecode.pot" "${CMAKE_SOURCE_DIR}/locales/manual/wxmaxima.md.pot" -o "${CMAKE_CURRENT_BINARY_DIR}/wxMaxima.pot"
 	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/wxMaxima.pot" "${CMAKE_CURRENT_SOURCE_DIR}/wxMaxima.pot"
 	COMMENT "Updating the POT-file from the current sourcecode and the manual")
+    # A plain file (as opposed to a target) can only be a custom command's
+    # OUTPUT for one "owner" target under Xcode's build system - having all
+    # ${LANG}_po targets below list wxMaxima.pot itself in their DEPENDS
+    # made CMake's Xcode generator refuse to configure ("is attached to
+    # multiple targets ... none of these is a common dependency of the
+    # other(s)", confirmed by CI). Routing every language's dependency
+    # through this one shared target instead avoids that: many targets can
+    # depend on the same target, just not the same bare custom-command
+    # output file.
+    add_custom_target(wxMaxima_pot DEPENDS wxMaxima.pot)
 
     foreach(POFILE ${TRANSLATION_FILES})
 	string(REGEX REPLACE ".*locales/wxMaxima/(.*).po$" "\\1" LANG ${POFILE})
@@ -65,7 +75,7 @@ if(GETTEXT_FOUND AND GETTEXT_MSGFMT_EXECUTABLE AND GETTEXT_MSGMERGE_EXECUTABLE)
 
 	add_custom_target(
 	    ${LANG}_po
-	    DEPENDS ${LANG}.po wxMaxima.pot)
+	    DEPENDS ${LANG}.po wxMaxima_pot)
 	add_custom_command(
 	    TARGET ${LANG}_po
 	    PRE_BUILD

--- a/locales/wxMaxima/merge_manual_po.cmake
+++ b/locales/wxMaxima/merge_manual_po.cmake
@@ -1,0 +1,37 @@
+# -*- mode: CMake; cmake-tab-width: 4; -*-
+#
+# Combines locales/manual/<lang>.po's translations into
+# locales/wxMaxima/<lang>.po (if a manual translation for that language
+# exists) before wxMaxima's own msgmerge -U picks up the result.
+#
+# po4a treats the po file it is pointed at as its own: running po4a on a
+# file that also holds wxMaxima's own UI strings does not just add/update
+# the manual's entries, it *rewrites the whole file to contain only the
+# entries po4a itself extracted from info/wxmaxima.md* - silently dropping
+# every UI string in it (confirmed live: a language with 1000 translated UI
+# strings and 69 translated manual strings dropped to 69 after one po4a
+# run). So po4a must keep writing its own separate locales/manual/<lang>.po
+# (as it always did), and this script is the *only* place that folds that
+# content into the combined locales/wxMaxima/<lang>.po - never let po4a
+# write directly into the shared file.
+#
+# --use-first prefers locales/wxMaxima/<lang>.po's own header (Crowdin
+# metadata, more current) over the manual po's; there is no msgid overlap
+# between the two catalogs (confirmed empirically) for this to have to
+# arbitrate beyond that.
+#
+# Required variables (-D on the cmake -P invocation):
+#   LANG_PO    - path to locales/wxMaxima/<lang>.po (updated in place)
+#   MANUAL_PO  - path to locales/manual/<lang>.po (read-only; may not exist)
+#   MSGCAT     - path to the msgcat executable
+
+if(EXISTS "${MANUAL_PO}")
+    execute_process(
+        COMMAND "${MSGCAT}" --use-first --no-wrap "${LANG_PO}" "${MANUAL_PO}" -o "${LANG_PO}.merging"
+        RESULT_VARIABLE _result
+    )
+    if(NOT _result EQUAL 0)
+        message(FATAL_ERROR "msgcat failed to merge ${MANUAL_PO} into ${LANG_PO}")
+    endif()
+    file(RENAME "${LANG_PO}.merging" "${LANG_PO}")
+endif()


### PR DESCRIPTION
## Summary

- **Critical fix**: the previously-merged translation-catalog merge (#2185) pointed `po4a`'s `$lang:` path directly at the combined `locales/wxMaxima/<lang>.po`. `po4a` doesn't add/update entries in a `.po` file it's pointed at — it treats it as *its own* and rewrites it wholesale to contain only what it itself extracted from `info/wxmaxima.md`, silently discarding everything else. Confirmed live with a real `po4a` 0.74: a language with 1000+ translated UI strings dropped to its ~69 manual-only strings after one run of `make update-locale-manual-in-source`. This bug is live on `main` right now — nobody had run that target with a `po4a` >= 0.70 yet (this sandbox's `apt` only has 0.69, which `CheckPo4aVersion.cmake` already refuses for unrelated corruption reasons), so it hadn't been triggered for real before this.
  - Fix: `po4a` goes back to writing its own `locales/manual/<lang>.po` (restored here for the 8 languages that have one), and a new `merge_manual_po.cmake` step folds that into `locales/wxMaxima/<lang>.po` via `msgcat` *before* `msgmerge` runs. Translators still only need to edit one file per language.
- **Fixes #2047** ("Translated manuals with po4a not formatted as the input"): `po4a`'s `[type: text]` mode needs `-o markdown` passed explicitly to recognize Markdown headings/lists/code blocks as their own no-wrap constructs — its own internal default for that option doesn't take effect through this invocation path. Without it, a translated heading could get a literal newline inserted mid-text when `po4a` wrapped it like an ordinary paragraph.
  - Regenerated `locales/manual/*.po`, `wxmaxima.md.pot` and the 8 translated `info/wxmaxima.<lang>.md` files with a real `po4a` 0.74 to verify the fix. Headings/lists/code blocks whose extraction shape changed are marked fuzzy (translation preserved in the `.po`, but excluded from the generated manual until a translator re-confirms it — mostly a mechanical "drop the now-redundant leading `#`" for headings) rather than silently dropped.
- Also fixes `locales/wxMaxima/CMakeLists.txt`'s `${LANG}_po` custom target missing `wxMaxima.pot` in its `DEPENDS`, so a stale `wxMaxima.pot` on disk could survive a `make update-locale` run untouched.

Deliberately **out of scope**: `locales/wxMaxima/*.po`/`wxMaxima.pot` also drifted against the current C++ source (~1100 UI strings added since the catalog was last regenerated) — that's real but unrelated, and bundling it in would bury this fix under noise across 24 languages. Left for a separate `make update-locale` follow-up.

## Test plan

- [x] Verified live with a real `po4a` 0.74 (this sandbox's `apt` only has 0.69): `make update-locale-manual-in-source` followed by `make update-locale` no longer drops UI translations from any of the 8 combined catalogs.
- [x] `msgfmt -c` validates all 8 regenerated `locales/manual/<lang>.po` files.
- [x] Confirmed the previously-reported heading-wrapping bug is gone from the regenerated `info/wxmaxima.<lang>.md` files.
- [x] Full project rebuild (`make -j$(nproc)`) succeeds cleanly.
- [ ] Full `ctest` suite run (in progress at the time of this PR; will report back if anything regresses — locale files aren't exercised by any existing test besides the Markdown lint, which explicitly excludes translated manuals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDdgx8DR7G9w9B5hBZAo9R

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDdgx8DR7G9w9B5hBZAo9R)_