### PR TITLE
Remove m_nextToDraw: compute the draw list instead of storing it (#1445)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,61 @@ a local TCP socket.
   - `Maxima` (`src/Maxima.cpp`): Owns the TCP socket to the Maxima process and emits `EVT_MAXIMA` events carrying incoming data.
   - `Variablespane`: Manages the list of defined variables and their values.
   - `AutoComplete`: Handles the autocomplete logic for commands, variables, and files.
+- **The draw list is computed, not stored (2026-08, closes GH #1445):** `Cell`
+  used to carry a `mutable CellPtr<Cell> m_nextToDraw` member -- a second
+  always-present `CellPtr` on *every* cell, threaded by hand via a virtual
+  `SetNextToDraw()` override on each 2D-capable compound cell (`FracCell`,
+  `ParenCell`, `SqrtCell`, `AbsCell`, `BoxCell`, `ConjugateCell`, `ListCell`,
+  `ExptCell`, `SumCell`, `IntCell`, `LimitCell`, `IntervalCell`, `DiffCell`,
+  `FunCell`, `NamedBoxCell`, `LongNumberCell`) whenever `BreakUp()`/`Unbreak()`
+  ran. `CellDrawListIterator` (`src/cells/CellIterators.h`) now computes the
+  same flattened "line" sequence on the fly instead: it walks `GetNext()` for
+  ordinary siblings, and when a cell `IsBrokenIntoLines()` it descends into
+  `GetBrokenCellCount()`/`GetBrokenCell()` (an explicit stack in the iterator
+  remembers where to resume once a nested expansion is exhausted -- normal
+  documents nest only a few levels deep, so this stays empty, with zero
+  allocation, for any line containing no broken cell). `GetBrokenCellCount()`/
+  `GetBrokenCell()` default to the existing `GetInnerCellCount()`/
+  `GetInnerCell()` (the *semantic*-children interface, previously used only
+  for `ResetSize_Recursively()`/`CollectWideCells()`/tooltip fallback), which
+  turned out to already match the draw sequence exactly for 11 of the 15
+  classes above (confirmed by direct comparison against each `BreakUp()`,
+  not assumed). **Four classes needed a real, separate override**, because
+  their structural inner-cell set and their actual linear draw sequence
+  diverge under runtime conditions: `IntCell` (the linear form omits the
+  lower/upper limit slots entirely when `HasLimits()`), `SumCell` (shows
+  `Base()` -- the bare, unwrapped content -- instead of the `ParenCell`
+  wrapper `GetInnerCell()` reports, and conditionally omits the upper-limit
+  pieces when `over` is empty), `IntervalCell` and `LimitCell` (both have
+  structural slots -- bracket glyphs, the "lim" name label -- that exist only
+  for the 2D form and are never part of the linear one). Getting one of
+  these four wrong is a real rendering bug, not just a wrong tree-shape for
+  an unrelated recursive walk, since there is no longer a separate
+  hand-threaded pointer chain to cross-check the sequence against -- treat
+  any future change to a class's `GetInnerCellCount()`/`GetInnerCell()` (or
+  `GetBrokenCellCount()`/`GetBrokenCell()` override) as a rendering-order
+  change and re-verify it against that class's actual `BreakUp()` logic.
+  A 2020 attempt at this same removal (branch
+  `feature/KubaO/remove-nexttodraw`, never merged) shipped visible
+  regressions in exactly this class of nested-breaking scenario (a broken
+  fraction inside a broken fraction/paren/diff cell) because it didn't
+  account for this divergence; this attempt was verified against it
+  directly -- both with a dedicated nested-broken-cell unit test
+  (`test/unit_tests/test_CellPtr.cpp`, `SCENARIO("DrawListIterator works")`)
+  and by running the real batch tests (`absCells`, `boxCells`, `diffCells`,
+  `conjugateCells`, `exptCells`, `fracCells`, `intCells`, `intervals`,
+  `limitCells`, `matrixCells`, `parenthesisCells`, `sumCells`) against a real
+  Maxima, plus a manual Xvfb+ImageMagick screenshot of
+  `diff(abs(f(x)/g(x)),x)` at a narrow width (a broken `diff` containing a
+  broken `abs` containing a broken nested fraction, all at once) to visually
+  confirm correct rendering -- this sandbox can install `maxima`/`maxima-doc`
+  (see the sandbox note under Build System for the doc-stripping workaround)
+  and `Xvfb`/`xdotool`/`imagemagick` for exactly this kind of check when a
+  change is rendering-sensitive and the automated test suite's XML/structural
+  assertions aren't enough on their own. `CellList.cpp`'s `SetNext()`/
+  `AppendCell()`/`SpliceInAfter()`/`TearOut()` no longer need any
+  draw-list-mirroring bookkeeping, since there's nothing stored to keep in
+  sync.
 
 ### Communication with Maxima
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Current development version
 
+- Reduced the memory footprint of every cell on the worksheet by removing
+  `m_nextToDraw`, a per-cell pointer used only by fractions, parentheses and
+  similar 2D-capable cells when line-wrapped; the same information is now
+  computed on demand instead of stored on every cell (closes #1445).
 - Fixed a critical bug in the translation merge above: `po4a` treats the `.po`
   file it is pointed at as its own and rewrites it wholesale on every run, so
   pointing it directly at the combined `locales/wxMaxima/<lang>.po` (as the

--- a/src/cells/AbsCell.cpp
+++ b/src/cells/AbsCell.cpp
@@ -164,16 +164,5 @@ bool AbsCell::BreakUp() const {
     return false;
 
   Cell::BreakUpAndMark();
-  m_open->SetNextToDraw(m_innerCell);
-  m_innerCell->last()->SetNextToDraw(m_close);
-  m_close->SetNextToDraw(m_nextToDraw);
-  m_nextToDraw = m_open;
   return true;
-}
-
-void AbsCell::SetNextToDraw(Cell *next) const {
-  if (IsBrokenIntoLines())
-    m_close->SetNextToDraw(next);
-  else
-    m_nextToDraw = next;
 }

--- a/src/cells/AbsCell.h
+++ b/src/cells/AbsCell.h
@@ -41,16 +41,13 @@
 
 /*! A cell that represents an abs(x) block
 
-  In the case that this cell is broken into multiple lines, it is
-  represented by the following cells in the draw order:
+  Once IsBrokenIntoLines(), the draw list (see GetBrokenCellCount()/
+  GetBrokenCell()) expands this cell into the following individual cells
+  instead of drawing it as a single 2D object:
 
-  - The AbsCell itself
   - The opening "abs("
   - The contents
   - The closing ")".
-
-  If it isn't broken into multiple cells, then m_nextToDraw points to the
-  cell that follows this AbsCell.
 */
 class AbsCell final : public Cell
 {
@@ -61,6 +58,9 @@ public:
   std::unique_ptr<Cell> Copy(GroupCell *group) const override;
   const CellTypeInfo &GetInfo() override;
 
+  //! ORDER MATTERS: also used, via the default GetBrokenCellCount()/
+  //! GetBrokenCell(), as this cell's broken/linear draw sequence -- "abs(",
+  //! then the (possibly multi-cell) contents, then ")", unconditionally.
   size_t GetInnerCellCount() const override { return 3; }
   Cell *GetInnerCell(size_t index) const override {
     switch (index) {
@@ -91,7 +91,6 @@ public:
   wxString ToTeX() const override;
   wxString ToXML() const override;
 
-  void SetNextToDraw(Cell *next) const override;
 private:
   void MakeBreakupCells();
 

--- a/src/cells/BoxCell.cpp
+++ b/src/cells/BoxCell.cpp
@@ -168,16 +168,5 @@ bool BoxCell::BreakUp() const {
     return false;
 
   Cell::BreakUpAndMark();
-  m_open->SetNextToDraw(m_innerCell);
-  m_innerCell->last()->SetNextToDraw(m_close);
-  m_close->SetNextToDraw(m_nextToDraw);
-  m_nextToDraw = m_open;
   return true;
-}
-
-void BoxCell::SetNextToDraw(Cell *next) const {
-  if (IsBrokenIntoLines())
-    m_close->SetNextToDraw(next);
-  else
-    m_nextToDraw = next;
 }

--- a/src/cells/BoxCell.h
+++ b/src/cells/BoxCell.h
@@ -35,17 +35,13 @@
 
 /*! A cell that represents a box(x) block
 
-  In the case that this cell is broken into two lines in the order of
-  m_nextToDraw this cell is represented by the following individual
-  cells:
+  Once IsBrokenIntoLines(), the draw list (see GetBrokenCellCount()/
+  GetBrokenCell()) expands this cell into the following individual cells
+  instead of drawing it as a single 2D object:
 
-  - The BoxCell itself
   - The opening "box("
   - The contents
   - The closing ")".
-
-  If it isn't broken into multiple cells m_nextToDraw points to the
-  cell that follows this Cell.
 */
 class BoxCell final : public Cell
 {
@@ -56,6 +52,9 @@ public:
   std::unique_ptr<Cell> Copy(GroupCell *group) const override;
   const CellTypeInfo &GetInfo() override;
 
+  //! ORDER MATTERS: also used, via the default GetBrokenCellCount()/
+  //! GetBrokenCell(), as this cell's broken/linear draw sequence -- "box(",
+  //! then the (possibly multi-cell) contents, then ")", unconditionally.
   size_t GetInnerCellCount() const override { return 3; }
   Cell *GetInnerCell(size_t index) const override {
     switch (index) {
@@ -71,8 +70,6 @@ public:
   }
 
   bool BreakUp() const override;
-
-  void SetNextToDraw(Cell *next) const override;
 
 private:
   void MakeBreakupCells();

--- a/src/cells/Cell.cpp
+++ b/src/cells/Cell.cpp
@@ -1389,7 +1389,6 @@ void Cell::Unbreak() const {
     m_isBrokenIntoLines = false;
   }
   SoftLineBreak(false);
-  SetNextToDraw(GetNext());
 }
 
 void Cell::UnbreakList() const {

--- a/src/cells/Cell.h
+++ b/src/cells/Cell.h
@@ -103,15 +103,21 @@ public:
 /*!
   The base class all cell types the worksheet can consist of are derived from
 
-  Every Cell is part of two double-linked lists:
-  - A Cell does have a member m_previous that points to the previous item
-  (or contains a NULL for the head node of the list) and a member named m_next
-  that points to the next cell (or contains a NULL if this is the end node of a list).
-  - And there is m_nextToDraw that contain fractions and similar
-  items as one element if they are drawn as a single 2D object that isn't divided by
-  a line break, but will contain every single element of a fraction as a separate
-  object if the fraction is broken into several lines and therefore displayed in its
-  a linear form.
+  Every Cell is part of a double-linked list: a Cell has a member m_previous
+  that points to the previous item (or contains a NULL for the head node of
+  the list) and a member named m_next that points to the next cell (or
+  contains a NULL if this is the end node of a list).
+
+  On top of that, the "draw list" (see OnDrawList() and GetBrokenCellCount()/
+  GetBrokenCell()) is a flattened view of that same tree along which cells
+  are actually measured/drawn/hit-tested: it treats a compound cell (a
+  fraction and similar) as a single 2D object as long as it isn't divided by
+  a line break, but expands it into every one of its individual pieces once
+  it IsBrokenIntoLines() and is therefore displayed in its linear form. Unlike
+  m_previous/m_next, the draw list isn't a stored pointer -- it's computed on
+  the fly by CellDrawListIterator from GetNext() plus GetBrokenCellCount()/
+  GetBrokenCell(), since which cells belong to it depends on that runtime
+  broken/unbroken state.
 
   Also every list of Cells can be a branch of a tree since every math cell contains
   a pointer to its parent group cell.
@@ -765,32 +771,32 @@ public:
 
   //! Get the next cell in the list.
   Cell *GetNext() const { return m_next.get(); }
-  /*! Get the next cell that needs to be drawn
 
-    In case of potential 2d objects like fractions either the fraction needs to be
-    drawn as a single 2D object or the nominator, the cell containing the "/" and
-    the denominator are pointed to by GetNextToDraw() as single separate objects.
+  /*! The number of pieces this cell is displayed as once it IsBrokenIntoLines(),
+    and in what order -- see GetBrokenCell().
+
+    Defaults to GetInnerCellCount()/GetInnerCell(), which is correct for every
+    compound cell whose broken (linear/1D) form shows exactly its structural
+    inner cells, in the same order, unconditionally (e.g. ParenCell: "(",
+    contents, ")"). A handful of cells (IntCell, SumCell, IntervalCell,
+    LimitCell) show a runtime-conditional subset or a different substitute
+    object (e.g. IntCell omits the limits unless HasLimits(); SumCell displays
+    Base() instead of the ParenCell wrapper) and override both this and
+    GetBrokenCell() to match their BreakUp() logic exactly.
+
+    ORDER IS LOAD-BEARING: this pair is the sole source of the on-screen,
+    left-to-right sequence the draw list (CellDrawListIterator, i.e.
+    OnDrawList()) expands a broken cell into -- Draw(), the width/height/line
+    caches (UpdateListCaches() and friends) and hit-testing/selection
+    (GetCellsInOutputRect() and friends) all walk it. There is no longer a
+    separate, hand-threaded pointer chain to cross-check it against, so
+    getting the index-to-piece mapping (or which indices exist, for the
+    classes that override this) wrong directly produces wrong rendering, not
+    just a wrong tree-shape for an unrelated recursive walk.
   */
-  Cell *GetNextToDraw() const { return m_nextToDraw; }
-
-  /*! Tells this cell which one should be the next cell to be drawn
-
-    If the cell is displayed as 2d object this sets the pointer to the next cell.
-
-    If the cell is broken into lines this sets the pointer of the last of the
-    list of cells this cell is displayed as.
-  */
-  virtual void SetNextToDraw(Cell *next) const { m_nextToDraw = next; }
-  template <typename T, typename Del,
-            typename std::enable_if<std::is_base_of<Cell, T>::value, bool>::type = true>
-  /*! Tells this cell which one should be the next cell to be drawn
-
-    If the cell is displayed as 2d object this sets the pointer to the next cell.
-
-    If the cell is broken into lines this sets the pointer of the last of the
-    list of cells this cell is displayed as.
-  */
-  void SetNextToDraw(const std::unique_ptr<T, Del> &ptr) { SetNextToDraw(ptr.get()); }
+  virtual size_t GetBrokenCellCount() const { return GetInnerCellCount(); }
+  //! Retrieve a piece of this cell's broken (linear/1D) display; see GetBrokenCellCount().
+  virtual Cell *GetBrokenCell(size_t index) const { return GetInnerCell(index); }
 
   /*! Determine if this cell contains text that isn't code
 
@@ -1097,9 +1103,6 @@ public:
 protected:
   /*! The GroupCell this list of cells belongs to. */
   CellPtr<GroupCell> m_group;
-  //! The next cell in the draw list. This has been factored into Cell temporarily to
-  //! reduce the change "noise" when it will be subsequently removed.
-  mutable CellPtr<Cell> m_nextToDraw;
 
   //! A pointer to the configuration responsible for this worksheet
   Configuration *m_configuration;

--- a/src/cells/CellIterators.h
+++ b/src/cells/CellIterators.h
@@ -88,10 +88,30 @@ public:
   static constexpr const_iterator cend() { return {}; }
 };
 
+/*! Walks the "draw list": the flattened sequence of cells that make up one
+  displayed line, in the order they should be measured/drawn/hit-tested.
+
+  This used to be a stored `m_nextToDraw` pointer on every `Cell`, threaded by
+  hand (via virtual `SetNextToDraw()` overrides) whenever a compound cell's
+  `BreakUp()`/`Unbreak()` ran. It is now computed on the fly instead: a cell
+  that `IsBrokenIntoLines()` is expanded into its `GetBrokenCellCount()`/
+  `GetBrokenCell()` pieces (each of which may itself have further siblings via
+  `GetNext()`, and may itself be broken, recursively) instead of being treated
+  as a single opaque node. The explicit stack below remembers, for each
+  broken cell currently being expanded, which piece to resume at once its
+  current piece's own chain is exhausted -- normal documents nest only a few
+  levels deep, so this stays small (and empty, with no allocation at all,
+  for any line that contains no broken cell).
+*/
 template <typename Cell>
 class CellDrawListIterator final {
   static_assert(std::is_class<Cell>::value, "The type argument must be a class");
+  struct Frame {
+    Cell *parent;
+    size_t nextIndex;
+  };
   Cell *m_ptr = {};
+  std::vector<Frame> m_stack;
 
 public:
   using iterator_category = std::forward_iterator_tag;
@@ -100,33 +120,58 @@ public:
   using pointer = Cell *;
   using reference = Cell &;
 
-  constexpr CellDrawListIterator() = default;
-  constexpr explicit CellDrawListIterator(const std::unique_ptr<Cell> &p) : m_ptr(p.get()) {}
-  constexpr explicit CellDrawListIterator(Cell *p) : m_ptr(p) {}
-  constexpr CellDrawListIterator(const CellDrawListIterator &o) = default;
-  constexpr CellDrawListIterator &operator=(const CellDrawListIterator &o) = default;
-  constexpr CellDrawListIterator operator++(int) {
+  CellDrawListIterator() = default;
+  explicit CellDrawListIterator(const std::unique_ptr<Cell> &p) : m_ptr(p.get()) {}
+  explicit CellDrawListIterator(Cell *p) : m_ptr(p) {}
+  CellDrawListIterator(const CellDrawListIterator &o) = default;
+  CellDrawListIterator &operator=(const CellDrawListIterator &o) = default;
+  CellDrawListIterator operator++(int) {
     auto ret = *this;
     return operator++(), ret;
   }
-  // constexpr fails if wxASSERT contains assembler code, which is true on MinGW
   CellDrawListIterator &operator++()
     {
-      if (m_ptr)
-      {
-        const auto *const prev = m_ptr;
-        m_ptr = m_ptr->GetNextToDraw();
-        wxASSERT(prev != m_ptr);
+      if (!m_ptr)
+        return *this;
+
+      const auto *const prev = m_ptr;
+      Cell *next = {};
+
+      if (prev->IsBrokenIntoLines() && prev->GetBrokenCellCount() > 0) {
+        // Descend into this cell's broken-form pieces. Once piece 0's own
+        // chain (and anything nested inside it) is exhausted, resume here
+        // at index 1.
+        m_stack.push_back(Frame{const_cast<Cell *>(prev), 1});
+        next = prev->GetBrokenCell(0);
+      } else {
+        next = prev->GetNext();
+        while (!next && !m_stack.empty()) {
+          Frame &frame = m_stack.back();
+          if (frame.nextIndex < frame.parent->GetBrokenCellCount()) {
+            next = frame.parent->GetBrokenCell(frame.nextIndex++);
+            continue;
+          }
+          // This broken cell's pieces are all done: resume with whatever
+          // originally followed it, or -- if it has no successor of its
+          // own -- keep unwinding into whatever enclosing broken cell (if
+          // any) we're nested inside of.
+          Cell *const afterParent = frame.parent->GetNext();
+          m_stack.pop_back();
+          next = afterParent;
+        }
       }
+
+      m_ptr = next;
+      wxASSERT(prev != m_ptr);
       return *this;
     }
-  constexpr bool operator==(const CellDrawListIterator &o) const
+  bool operator==(const CellDrawListIterator &o) const
     { return m_ptr == o.m_ptr; }
-  constexpr bool operator!=(const CellDrawListIterator &o) const
+  bool operator!=(const CellDrawListIterator &o) const
     { return m_ptr != o.m_ptr; }
-  constexpr operator bool() const { return m_ptr; }
-  constexpr operator Cell*() const { return m_ptr; }
-  constexpr Cell *operator->() const { return m_ptr; }
+  operator bool() const { return m_ptr; }
+  operator Cell*() const { return m_ptr; }
+  Cell *operator->() const { return m_ptr; }
 };
 
 template <typename Cell> class CellDrawListAdapter final

--- a/src/cells/CellList.cpp
+++ b/src/cells/CellList.cpp
@@ -74,7 +74,6 @@ std::unique_ptr<Cell> CellList::SetNext(Cell *cell, std::unique_ptr<Cell> &&next
   // Set the previous pointer for our successor
   if (cell->m_next)
     cell->m_next->m_previous = cell;
-  cell->SetNextToDraw(cell->m_next);
   cell->InvalidateListCache();
 
   Check(cell);
@@ -101,23 +100,8 @@ void CellList::AppendCell(Cell *cell, std::unique_ptr<Cell> &&tail) {
     // above would be inappropriate.
     cell->GetGroup()->ResetSize_Recursively();
 
-  auto *const next = tail.get();
   auto *const last = cell->last();
-
-  // We want to append to the draw list as well
-  // Get the end of the draw list
-  auto *lastToDraw = last->GetNextToDraw();
-  if (lastToDraw && lastToDraw->GetNextToDraw()) {
-    while (lastToDraw->GetNextToDraw())
-      lastToDraw = lastToDraw->GetNextToDraw();
-  }
-
-  // Append the cell
   SetNext(last, std::move(tail));
-
-  // Restore the draw list, and append the cell to it
-  if (lastToDraw)
-    lastToDraw->SetNextToDraw(next);
 }
 
 CellList::SplicedIn
@@ -136,13 +120,8 @@ CellList::SpliceInAfter(Cell *where, std::unique_ptr<Cell> &&head, Cell *last) {
       wxASSERT_MSG(!last->m_next,
                    "Bug: SpliceIn::last has a successor, it will be deleted.");
 
-      // We're explicitly splicing into the draw list as well
-      // - preserve the draw list.
-      auto *const nextToDraw = where->GetNextToDraw();
-
       // Insert the cells into the cell list
       SetNext(last, std::move(where->m_next));
-      last->SetNextToDraw(nextToDraw);
     }
   SetNext(where, std::move(head));
 
@@ -173,7 +152,6 @@ CellList::TornOut CellList::TearOut(Cell *first, Cell *last) {
     Check(retval.tailOwner.get());
   }
 
-  wxASSERT(!last->GetNextToDraw());
   wxASSERT(!first->m_previous);
   Check(first);
   Check(last);

--- a/src/cells/CellPtr.h
+++ b/src/cells/CellPtr.h
@@ -411,10 +411,13 @@ protected:
       // Warning: This function is CRITICAL to the performance of wxMaxima
       // as a whole!
       //
-      // The common hot path that iterates cells via the m_nextToDraw uses
-      // this function and is intimately tied to its performance. Small
+      // Every Cell's m_group is a CellPtr<GroupCell>, and GetGroup() -- called
+      // throughout layout, drawing and hit-testing -- goes through this
+      // function, so it is intimately tied to overall performance. Small
       // changes here can cause performance regressions - or small performance
-      // improvements.
+      // improvements. (The draw list used to be a second CellPtr, m_nextToDraw,
+      // present on every cell; it's computed on the fly now instead, see
+      // CellIterators.h, so this is no longer its hot path too.)
       //
       // If you change anything, do before- and after- measurements to verify
       // that whatever improvement you sought is in fact achieved. Changes that
@@ -484,8 +487,10 @@ static_assert(alignof(CellPtrBase) >= 4, "CellPtrBase doesn't have minimum viabl
  * abstraction!**
  *
  * **Warning:** To maintain performance, most cells should have at most one CellPtr
- * pointing at them. Currently, this is the m_nextToDraw - it uses up our "CellPtr
- * budget". The remaining CellPtrs are in CellPointers, and there is very few cells
+ * pointing at them. This is m_group - every Cell has one. (The draw list used to be
+ * a second CellPtr, m_nextToDraw, present on every cell; it's computed on the fly
+ * now instead - see CellIterators.h - so it no longer spends any of our "CellPtr
+ * budget".) The remaining CellPtrs are in CellPointers, and there is very few cells
  * at any given time that are pointed-to by those pointers, and thus the performance
  * impact is minimal.
  *

--- a/src/cells/ConjugateCell.cpp
+++ b/src/cells/ConjugateCell.cpp
@@ -150,16 +150,5 @@ bool ConjugateCell::BreakUp() const {
     return false;
 
   Cell::BreakUpAndMark();
-  m_open->SetNextToDraw(m_innerCell);
-  m_innerCell->last()->SetNextToDraw(m_close);
-  m_close->SetNextToDraw(m_nextToDraw);
-  m_nextToDraw = m_open;
   return true;
-}
-
-void ConjugateCell::SetNextToDraw(Cell *next) const {
-  if (IsBrokenIntoLines())
-    m_close->SetNextToDraw(next);
-  else
-    m_nextToDraw = next;
 }

--- a/src/cells/ConjugateCell.h
+++ b/src/cells/ConjugateCell.h
@@ -35,17 +35,13 @@
 
 /*! A cell that represents a conjugate(x) block
 
-  In the case that this cell is broken into two lines in the order of
-  m_nextToDraw this cell is represented by the following individual
-  cells:
+  Once IsBrokenIntoLines(), the draw list (see GetBrokenCellCount()/
+  GetBrokenCell()) expands this cell into the following individual cells
+  instead of drawing it as a single 2D object:
 
-  - The ConjugateCell itself
   - The opening "conjugate("
   - The contents
   - The closing ")".
-
-  If it isn't broken into multiple cells m_nextToDraw points to the
-  cell that follows this Cell.
 */
 class ConjugateCell final : public Cell
 {
@@ -56,6 +52,10 @@ public:
   std::unique_ptr<Cell> Copy(GroupCell *group) const override;
   const CellTypeInfo &GetInfo() override;
 
+  //! ORDER MATTERS: also used, via the default GetBrokenCellCount()/
+  //! GetBrokenCell(), as this cell's broken/linear draw sequence --
+  //! "conjugate(", then the (possibly multi-cell) contents, then ")",
+  //! unconditionally.
   size_t GetInnerCellCount() const override { return 3; }
   Cell *GetInnerCell(size_t index) const override {
     switch (index) {
@@ -71,8 +71,6 @@ public:
   }
 
   bool BreakUp() const override;
-
-  void SetNextToDraw(Cell *next) const override;
 
 private:
   void MakeBreakupCells();

--- a/src/cells/DiffCell.cpp
+++ b/src/cells/DiffCell.cpp
@@ -190,18 +190,5 @@ bool DiffCell::BreakUp() const {
     return false;
 
   Cell::BreakUpAndMark();
-  m_open->SetNextToDraw(m_baseCell);
-  m_baseCell->last()->SetNextToDraw(m_comma);
-  m_comma->SetNextToDraw(m_diffCell);
-  m_diffCell->last()->SetNextToDraw(m_close);
-  m_close->SetNextToDraw(m_nextToDraw);
-  m_nextToDraw = m_open;
   return true;
-}
-
-void DiffCell::SetNextToDraw(Cell *next) const {
-  if (IsBrokenIntoLines())
-    m_close->SetNextToDraw(next);
-  else
-    m_nextToDraw = next;
 }

--- a/src/cells/DiffCell.h
+++ b/src/cells/DiffCell.h
@@ -39,6 +39,9 @@ public:
   std::unique_ptr<Cell> Copy(GroupCell *group) const override;
   const CellTypeInfo &GetInfo() override;
 
+  //! ORDER MATTERS: also used, via the default GetBrokenCellCount()/
+  //! GetBrokenCell(), as this cell's broken/linear draw sequence -- "diff(",
+  //! the base, ",", the diff variable(s), ")", unconditionally.
   size_t GetInnerCellCount() const override { return 5; }
   Cell *GetInnerCell(size_t index) const override {
     switch (index) {
@@ -69,8 +72,6 @@ public:
   wxString ToString() const override;
   wxString ToTeX() const override;
   wxString ToXML() const override;
-
-  void SetNextToDraw(Cell *next) const override;
 
   bool BreakUp() const override;
 

--- a/src/cells/ExptCell.cpp
+++ b/src/cells/ExptCell.cpp
@@ -208,11 +208,5 @@ bool ExptCell::BreakUp() const {
     return false;
 
   Cell::BreakUpAndMark();
-  m_baseCell->last()->SetNextToDraw(m_exp);
-  m_exp->SetNextToDraw(m_open);
-  m_open->SetNextToDraw(m_exptCell);
-  m_exptCell->last()->SetNextToDraw(m_close);
-  m_close->SetNextToDraw(m_nextToDraw);
-  m_nextToDraw = m_baseCell;
   return true;
 }

--- a/src/cells/ExptCell.h
+++ b/src/cells/ExptCell.h
@@ -35,17 +35,16 @@
 
 /*! This cell represents a exp() or %e^x-construct.
 
-  In the case that this cell is broken into two lines in the order of
-  m_nextToDraw this cell is represented by the following individual
-  cells:
+  Once IsBrokenIntoLines(), the draw list (see GetBrokenCellCount()/
+  GetBrokenCell(), which here is simply GetInnerCellCount()/GetInnerCell())
+  expands this cell into the following individual cells instead of drawing
+  it as a single 2D object:
 
-  - The ExptCell itself
-  - The opening "exp("
-  - The contents
+  - The base
+  - "^"
+  - The opening "("
+  - The exponent
   - The closing ")".
-
-  If it isn't broken into multiple cells m_nextToDraw points to the
-  cell that follows this Cell.
 */
 class ExptCell final : public Cell
 {
@@ -56,6 +55,9 @@ public:
   std::unique_ptr<Cell> Copy(GroupCell *group) const override;
   const CellTypeInfo &GetInfo() override;
 
+  //! ORDER MATTERS: also used, via the default GetBrokenCellCount()/
+  //! GetBrokenCell(), as this cell's broken/linear draw sequence -- the
+  //! base, "^", "(", the exponent, ")", unconditionally.
   size_t GetInnerCellCount() const override { return 5; }
   Cell *GetInnerCell(size_t index) const override {
     switch (index) {

--- a/src/cells/FracCell.cpp
+++ b/src/cells/FracCell.cpp
@@ -370,17 +370,5 @@ bool FracCell::BreakUp() const {
     m_displayedNum = m_numParenthesis.get();
   if (Denom() && Denom()->GetNext())
     m_displayedDenom = m_denomParenthesis.get();
-  // Note: Yes, we don't want m_displayedNum->last() here.
-  m_displayedNum->SetNextToDraw(m_divide);
-  m_divide->SetNextToDraw(m_displayedDenom);
-  m_displayedDenom->SetNextToDraw(m_nextToDraw);
-  m_nextToDraw = m_displayedNum;
   return true;
-}
-
-void FracCell::SetNextToDraw(Cell *next) const {
-  if (IsBrokenIntoLines())
-    m_displayedDenom->SetNextToDraw(next);
-  else
-    m_nextToDraw = next;
 }

--- a/src/cells/FracCell.h
+++ b/src/cells/FracCell.h
@@ -53,6 +53,14 @@ public:
   std::unique_ptr<Cell> Copy(GroupCell *group) const override;
   const CellTypeInfo &GetInfo() override;
 
+  //! ORDER MATTERS: also used, via the default GetBrokenCellCount()/
+  //! GetBrokenCell(), as this cell's broken/linear draw sequence -- unlike
+  //! most compound cells, no separate override is needed here, because
+  //! m_displayedNum/m_displayedDenom are ALREADY the dynamically-aliased
+  //! "what's currently shown" slots (see SetupBreakUps()/BreakUp(): they
+  //! point at the bare numerator/denominator, or at their ParenCell wrapper
+  //! when one is needed), so this same sequence is correct whether the
+  //! fraction IsBrokenIntoLines() or not.
   size_t GetInnerCellCount() const override { return 3; }
   Cell *GetInnerCell(size_t index) const override {
     switch (index) {
@@ -105,7 +113,6 @@ public:
 
   void SetupBreakUps() const;
 
-  void SetNextToDraw(Cell *next) const override;
 private:
   //! Makes the division sign cell, used in linear form - whether when broken
   //! into lines, or when the exponent flag is set.

--- a/src/cells/FunCell.cpp
+++ b/src/cells/FunCell.cpp
@@ -164,15 +164,5 @@ bool FunCell::BreakUp() const {
     return false;
 
   Cell::BreakUpAndMark();
-  m_nameCell->last()->SetNextToDraw(m_argCell);
-  m_argCell->last()->SetNextToDraw(m_nextToDraw);
-  m_nextToDraw = m_nameCell;
   return true;
-}
-
-void FunCell::SetNextToDraw(Cell *next) const {
-  if (IsBrokenIntoLines())
-    m_argCell->last()->SetNextToDraw(next);
-  else
-    m_nextToDraw = next;
 }

--- a/src/cells/FunCell.h
+++ b/src/cells/FunCell.h
@@ -38,17 +38,13 @@
   - AbsCell
   - ConjugateCell
 
-  In the case that this cell is broken into two lines in the order of
-  m_nextToDraw this cell is represented by the following individual
-  cells:
+  Once IsBrokenIntoLines(), the draw list (see GetBrokenCellCount()/
+  GetBrokenCell(), which here is simply GetInnerCellCount()/GetInnerCell())
+  expands this cell into the following individual cells instead of drawing
+  it as a single 2D object:
 
-  - The FunCell itself
-  - The function name"
-  - The ParenCell containing its contents
-  - The closing ")".
-
-  If it isn't broken into multiple cells m_nextToDraw points to the
-  cell that follows this Cell.
+  - The function name
+  - The ParenCell containing its contents.
 */
 class FunCell final : public Cell
 {
@@ -60,6 +56,9 @@ public:
   std::unique_ptr<Cell> Copy(GroupCell *group) const override;
   const CellTypeInfo &GetInfo() override;
 
+  //! ORDER MATTERS: also used, via the default GetBrokenCellCount()/
+  //! GetBrokenCell(), as this cell's broken/linear draw sequence -- the
+  //! function name, then its (parenthesized) argument, unconditionally.
   size_t GetInnerCellCount() const override { return 2; }
   Cell *GetInnerCell(size_t index) const override {
     switch (index) {
@@ -89,8 +88,6 @@ public:
   const wxString &GetAltCopyText() const override { return m_altCopyText; }
 
   bool BreakUp() const override;
-
-  void SetNextToDraw(Cell *next) const override;
 
 private:
   //! Text that should end up on the clipboard if this cell is copied as text.

--- a/src/cells/GroupCell.cpp
+++ b/src/cells/GroupCell.cpp
@@ -285,7 +285,6 @@ void GroupCell::AppendInput(std::unique_ptr<Cell> &&cell) {
       // m_group->ResetSize_Recursively. Perhaps we can decide that SetNext alone could do
       // something like that, as long as it wouldn't cause quadratic behavior.
       CellList::SetNext(m_inputLabel.get(), nullptr);
-      wxASSERT(!m_inputLabel->GetNextToDraw());
       CellList::AppendCell(m_inputLabel, std::move(cell));
     } else {
       AppendOutput(std::move(cell));
@@ -1380,7 +1379,10 @@ wxString GroupCell::ToTeXCodeCell(const wxString &imgDir, const wxString &filena
     bool mathMode = false;
     bool asciiArt = false;
 
-    for (const Cell &tmp : OnDrawList(m_output.get())) {
+    auto const outputDrawList = OnDrawList(m_output.get());
+    for (auto it = outputDrawList.begin(), listEnd = outputDrawList.end();
+         it != listEnd; ++it) {
+      const Cell &tmp = *it;
       // 2-D ASCII-art maths -- what maxima prints when it isn't asked for XML,
       // e.g. from the Lisp side or with display2d in its plain-text mode --
       // draws fraction bars, roots and matrices out of characters, so it only
@@ -1428,7 +1430,9 @@ wxString GroupCell::ToTeXCodeCell(const wxString &imgDir, const wxString &filena
           // A label in front of ASCII art must not open math mode: the art is
           // about to leave it again, and all that would be left of the equation
           // is an empty, numbered \[...\]. Emit the label as text instead.
-          const Cell *const next = tmp.GetNextToDraw();
+          auto peek = it;
+          ++peek;
+          const Cell *const next = peek;
           if (next && (next->GetTextStyle() == TS_ASCIIMATHS)) {
             if (mathMode) {
               str += wxS("\\mbox{}\n\\]");

--- a/src/cells/IntCell.cpp
+++ b/src/cells/IntCell.cpp
@@ -350,32 +350,7 @@ bool IntCell::BreakUp() const {
     return false;
 
   Cell::BreakUpAndMark();
-  m_close->SetNextToDraw(m_nextToDraw);
-  m_nextToDraw = m_open;
-  m_open->last()->SetNextToDraw(m_base);
-  m_base->last()->SetNextToDraw(m_comma1);
-  // The first cell of m_var should normally be a "d"
-  if (m_var->GetNext() != NULL)
-    m_comma1->last()->SetNextToDraw(m_var->GetNext());
-  else
-    m_comma1->last()->SetNextToDraw(m_var);
-  if (HasLimits())
-    m_var->last()->SetNextToDraw(m_close);
-  else {
-    m_var->last()->SetNextToDraw(m_comma2);
-    m_comma2->last()->SetNextToDraw(m_lowerLimit);
-    m_lowerLimit->last()->SetNextToDraw(m_comma3);
-    m_comma3->last()->SetNextToDraw(m_upperLimit);
-    m_upperLimit->last()->SetNextToDraw(m_close);
-  }
   return true;
-}
-
-void IntCell::SetNextToDraw(Cell *next) const {
-  if (IsBrokenIntoLines())
-    m_close->SetNextToDraw(next);
-  else
-    m_nextToDraw = next;
 }
 
 const wxString IntCell::m_svgIntegralSign(reinterpret_cast<const char*>(INTSIGN));

--- a/src/cells/IntCell.h
+++ b/src/cells/IntCell.h
@@ -98,7 +98,60 @@ public:
   wxString ToXML() const override;
 
   bool BreakUp() const override;
-  void SetNextToDraw(Cell *next) const override;
+
+  /*! ORDER MATTERS, and this is a runtime-conditional SUBSET of
+    GetInnerCellCount()/GetInnerCell() above, not the same fixed 9 slots:
+    when HasLimits(), the linear form omits the lower/upper limit entirely
+    (just "integrate(base,var)"); otherwise it includes them (see BreakUp()
+    for the exact rationale -- this mirrors it precisely, don't derive it
+    independently). Also: if the integration variable cell m_var itself
+    starts with a leading "d" sibling (the usual case), that leading piece
+    is skipped and the chain starts at m_var->GetNext() instead -- returning
+    that as the "head" is enough, since GetNext() from there still reaches
+    the same tail.
+  */
+  size_t GetBrokenCellCount() const override { return HasLimits() ? 5 : 9; }
+  Cell *GetBrokenCell(size_t index) const override {
+    Cell *const varHead = m_var->GetNext() ? m_var->GetNext() : m_var.get();
+    if (HasLimits()) {
+      switch (index) {
+      case 0:
+        return m_open.get();
+      case 1:
+        return m_base.get();
+      case 2:
+        return m_comma1.get();
+      case 3:
+        return varHead;
+      case 4:
+        return m_close.get();
+      default:
+        return nullptr;
+      }
+    }
+    switch (index) {
+    case 0:
+      return m_open.get();
+    case 1:
+      return m_base.get();
+    case 2:
+      return m_comma1.get();
+    case 3:
+      return varHead;
+    case 4:
+      return m_comma2.get();
+    case 5:
+      return m_lowerLimit.get();
+    case 6:
+      return m_comma3.get();
+    case 7:
+      return m_upperLimit.get();
+    case 8:
+      return m_close.get();
+    default:
+      return nullptr;
+    }
+  }
 
   //! Does this integral have limits?
   bool HasLimits() const {return (m_intStyle == INT_DEF) &&

--- a/src/cells/IntervalCell.cpp
+++ b/src/cells/IntervalCell.cpp
@@ -263,18 +263,5 @@ bool IntervalCell::BreakUp() const {
     return false;
 
   Cell::BreakUpAndMark();
-  m_stop->last()->SetNextToDraw(m_close);
-  m_comma->SetNextToDraw(m_stop);
-  m_start->last()->SetNextToDraw(m_comma);
-  m_open->SetNextToDraw(m_start);
-  m_close->SetNextToDraw(m_nextToDraw);
-  m_nextToDraw = m_open;
   return true;
-}
-
-void IntervalCell::SetNextToDraw(Cell *next) const {
-  if (IsBrokenIntoLines())
-    m_close->SetNextToDraw(next);
-  else
-    m_nextToDraw = next;
 }

--- a/src/cells/IntervalCell.h
+++ b/src/cells/IntervalCell.h
@@ -34,17 +34,17 @@
 
 /*! The class that represents parenthesis that are wrapped around text
 
-  In the case that this cell is broken into two lines in the order of
-  m_nextToDraw this cell is represented by the following individual
-  cells:
+  Once IsBrokenIntoLines(), the draw list (see GetBrokenCellCount()/
+  GetBrokenCell(), a proper SUBSET of GetInnerCellCount()/GetInnerCell() --
+  the bracket glyphs and ellipsis are only ever part of the 2D form) expands
+  this cell into the following individual cells instead of drawing it as a
+  single 2D object:
 
-  - The IntervalCell itself
-  - The opening "["
-  - The contents
-  - The closing "]".
-
-  If it isn't broken into multiple cells m_nextToDraw points to the
-  cell that follows this Cell.
+  - The opening "interval("
+  - The start value
+  - ","
+  - The stop value
+  - The closing ")".
 */
 class IntervalCell : public Cell
 {
@@ -81,6 +81,30 @@ public:
     }
   }
 
+  /*! ORDER MATTERS, and this is NOT the same set as GetInnerCellCount()/
+    GetInnerCell() above: m_openBracket, m_ellipsis and m_closeBracket are
+    only ever drawn directly by Draw() as part of the 2D bracket/ellipsis
+    rendering and never appear in the broken/linear draw sequence, which is
+    "interval(", the start value, ",", the stop value, ")", unconditionally.
+  */
+  size_t GetBrokenCellCount() const override { return 5; }
+  Cell *GetBrokenCell(size_t index) const override {
+    switch (index) {
+    case 0:
+      return m_open.get();
+    case 1:
+      return m_start.get();
+    case 2:
+      return m_comma.get();
+    case 3:
+      return m_stop.get();
+    case 4:
+      return m_close.get();
+    default:
+      return nullptr;
+    }
+  }
+
   void Recalculate(const AFontSize fontsize) const override;
 
   using Cell::SetCurrentPoint;
@@ -95,8 +119,6 @@ public:
   virtual wxString ToString() const override;
   virtual wxString ToTeX() const override;
   virtual wxString ToXML() const override;
-
-  void SetNextToDraw(Cell *next) const override;
 
 protected:
   void DrawBigLeftOpenBracket(wxDC *dc, wxPoint point) const;

--- a/src/cells/LimitCell.cpp
+++ b/src/cells/LimitCell.cpp
@@ -174,18 +174,5 @@ bool LimitCell::BreakUp() const {
     return false;
 
   BreakUpAndMark();
-  m_open->SetNextToDraw(m_base.get());
-  m_base->last()->SetNextToDraw(m_comma.get());
-  m_comma->SetNextToDraw(m_under.get());
-  m_under->last()->SetNextToDraw(m_close.get());
-  m_close->SetNextToDraw(m_nextToDraw);
-  m_nextToDraw = m_open.get();
   return true;
-}
-
-void LimitCell::SetNextToDraw(Cell *next) const {
-  if (IsBrokenIntoLines()) {
-    m_close->SetNextToDraw(next);
-  } else
-    m_nextToDraw = next;
 }

--- a/src/cells/LimitCell.h
+++ b/src/cells/LimitCell.h
@@ -68,6 +68,30 @@ public:
     }
   }
 
+  /*! ORDER MATTERS, and this is NOT the same set as GetInnerCellCount()/
+    GetInnerCell() above: m_name (the "lim" label, index 0 there) is never
+    part of the broken/linear draw sequence -- it's only ever drawn directly
+    by Draw() as part of the 2D "lim" + subscript rendering. The linear form
+    is "limit(", the base, ",", the "var->to" condition, ")", unconditionally.
+  */
+  size_t GetBrokenCellCount() const override { return 5; }
+  Cell *GetBrokenCell(size_t index) const override {
+    switch (index) {
+    case 0:
+      return m_open.get();
+    case 1:
+      return m_base.get();
+    case 2:
+      return m_comma.get();
+    case 3:
+      return m_under.get();
+    case 4:
+      return m_close.get();
+    default:
+      return nullptr;
+    }
+  }
+
   void Recalculate(const AFontSize fontsize) const override;
 
   using Cell::SetCurrentPoint;
@@ -83,7 +107,6 @@ public:
 
   bool BreakUp() const override;
 
-  void SetNextToDraw(Cell *next) const override;
 private:
   void MakeBreakUpCells();
 

--- a/src/cells/ListCell.cpp
+++ b/src/cells/ListCell.cpp
@@ -210,16 +210,5 @@ bool ListCell::BreakUp() const {
     return false;
 
   Cell::BreakUpAndMark();
-  m_open->SetNextToDraw(m_innerCell);
-  m_innerCell->last()->SetNextToDraw(m_close);
-  m_close->SetNextToDraw(m_nextToDraw);
-  m_nextToDraw = m_open;
   return true;
-}
-
-void ListCell::SetNextToDraw(Cell *next) const {
-  if (IsBrokenIntoLines())
-    m_close->SetNextToDraw(next);
-  else
-    m_nextToDraw = next;
 }

--- a/src/cells/ListCell.h
+++ b/src/cells/ListCell.h
@@ -34,17 +34,13 @@
 
 /*! The class that represents parenthesis that are wrapped around text
 
-  In the case that this cell is broken into two lines in the order of
-  m_nextToDraw this cell is represented by the following individual
-  cells:
+  Once IsBrokenIntoLines(), the draw list (see GetBrokenCellCount()/
+  GetBrokenCell()) expands this cell into the following individual cells
+  instead of drawing it as a single 2D object:
 
-  - The ListCell itself
   - The opening "["
   - The contents
   - The closing "]".
-
-  If it isn't broken into multiple cells m_nextToDraw points to the
-  cell that follows this Cell.
 */
 class ListCell : public Cell
 {
@@ -56,6 +52,9 @@ public:
   virtual std::unique_ptr<Cell> Copy(GroupCell *group) const override;
   virtual const CellTypeInfo &GetInfo() override;
 
+  //! ORDER MATTERS: also used, via the default GetBrokenCellCount()/
+  //! GetBrokenCell(), as this cell's broken/linear draw sequence -- "[",
+  //! then the (possibly multi-cell) contents, then "]", unconditionally.
   size_t GetInnerCellCount() const override { return 3; }
   Cell *GetInnerCell(size_t index) const override {
     switch (index) {
@@ -84,8 +83,6 @@ public:
   virtual wxString ToString() const override;
   virtual wxString ToTeX() const override;
   virtual wxString ToXML() const override;
-
-  void SetNextToDraw(Cell *next) const override;
 
 protected:
   // The pointers below point to inner cells and must be kept contiguous.

--- a/src/cells/LongNumberCell.cpp
+++ b/src/cells/LongNumberCell.cpp
@@ -265,15 +265,6 @@ bool LongNumberCell::BreakUp() const {
       }
     }
   }
-  m_innerCell->last()->SetNextToDraw(m_nextToDraw);
-  m_nextToDraw = m_innerCell;
   Cell::BreakUpAndMark();
   return true;
-}
-
-void LongNumberCell::SetNextToDraw(Cell *next) const {
-  if (IsBrokenIntoLines())
-    m_innerCell->last()->SetNextToDraw(next);
-  else
-    m_nextToDraw = next;
 }

--- a/src/cells/LongNumberCell.h
+++ b/src/cells/LongNumberCell.h
@@ -54,7 +54,12 @@ public:
   void SetCurrentPoint(wxPoint point) const override;
   void Draw(wxDC *dc, wxDC *antialiassingDC) override;
   bool BreakUp() const override;
-  void SetNextToDraw(Cell *next) const override;
+  //! ORDER MATTERS: also used, via the default GetBrokenCellCount()/
+  //! GetBrokenCell(), as this cell's broken/linear draw sequence. There is
+  //! only ever this one slot -- BreakUp() builds the whole grouped-digit
+  //! chain as m_innerCell's own GetNext() siblings, so the draw-list
+  //! iterator walks all of them by following that chain, not by iterating
+  //! further indices here.
   size_t GetInnerCellCount() const override { if(m_innerCell) return 1; else return 0; }
   // cppcheck-suppress objectIndex
   Cell *GetInnerCell(size_t index) const override;

--- a/src/cells/NamedBoxCell.cpp
+++ b/src/cells/NamedBoxCell.cpp
@@ -204,18 +204,5 @@ bool NamedBoxCell::BreakUp() const {
     return false;
 
   Cell::BreakUpAndMark();
-  m_open->SetNextToDraw(m_innerCell);
-  m_innerCell->last()->SetNextToDraw(m_comma);
-  m_comma->last()->SetNextToDraw(m_boxname);
-  m_boxname->last()->SetNextToDraw(m_close);
-  m_close->SetNextToDraw(m_nextToDraw);
-  m_nextToDraw = m_open;
   return true;
-}
-
-void NamedBoxCell::SetNextToDraw(Cell *next) const {
-  if (IsBrokenIntoLines())
-    m_close->SetNextToDraw(next);
-  else
-    m_nextToDraw = next;
 }

--- a/src/cells/NamedBoxCell.h
+++ b/src/cells/NamedBoxCell.h
@@ -35,17 +35,15 @@
 
 /*! A cell that represents a box(x) block
 
-  In the case that this cell is broken into two lines in the order of
-  m_nextToDraw this cell is represented by the following individual
-  cells:
+  Once IsBrokenIntoLines(), the draw list (see GetBrokenCellCount()/
+  GetBrokenCell()) expands this cell into the following individual cells
+  instead of drawing it as a single 2D object:
 
-  - The NamedBoxCell itself
   - The opening "box("
   - The contents
+  - ","
+  - The box name
   - The closing ")".
-
-  If it isn't broken into multiple cells m_nextToDraw points to the
-  cell that follows this Cell.
 */
 class NamedBoxCell final : public Cell
 {
@@ -57,6 +55,9 @@ public:
   std::unique_ptr<Cell> Copy(GroupCell *group) const override;
   const CellTypeInfo &GetInfo() override;
 
+  //! ORDER MATTERS: also used, via the default GetBrokenCellCount()/
+  //! GetBrokenCell(), as this cell's broken/linear draw sequence -- "box(",
+  //! the contents, ",", the box name, ")", unconditionally.
   size_t GetInnerCellCount() const override { return 5; }
   Cell *GetInnerCell(size_t index) const override {
     switch (index) {
@@ -76,8 +77,6 @@ public:
   }
 
   bool BreakUp() const override;
-
-  void SetNextToDraw(Cell *next) const override;
 
 private:
   void MakeBreakupCells();

--- a/src/cells/ParenCell.cpp
+++ b/src/cells/ParenCell.cpp
@@ -347,21 +347,5 @@ bool ParenCell::BreakUp() const {
     return false;
 
   Cell::BreakUpAndMark();
-  if(m_innerCell)
-    {
-      m_open->SetNextToDraw(m_innerCell);
-      m_innerCell->last()->SetNextToDraw(m_close);
-    }
-  else
-    m_open->SetNextToDraw(m_close);
-  m_close->SetNextToDraw(m_nextToDraw);
-  m_nextToDraw = m_open;
   return true;
-}
-
-void ParenCell::SetNextToDraw(Cell *next) const {
-  if (IsBrokenIntoLines())
-    m_close->SetNextToDraw(next);
-  else
-    m_nextToDraw = next;
 }

--- a/src/cells/ParenCell.h
+++ b/src/cells/ParenCell.h
@@ -34,17 +34,13 @@
 
 /*! The class that represents parenthesis that are wrapped around text
 
-  In the case that this cell is broken into two lines in the order of
-  m_nextToDraw this cell is represented by the following individual
-  cells:
+  Once IsBrokenIntoLines(), the draw list (see GetBrokenCellCount()/
+  GetBrokenCell()) expands this cell into the following individual cells
+  instead of drawing it as a single 2D object:
 
-  - The ParenCell itself
   - The opening "("
   - The contents
   - The closing ")".
-
-  If it isn't broken into multiple cells m_nextToDraw points to the
-  cell that follows this Cell.
 */
 class ParenCell final : public Cell
 {
@@ -57,6 +53,9 @@ public:
   const CellTypeInfo &GetInfo() override;
   std::unique_ptr<Cell> Copy(GroupCell *group) const override;
 
+  //! ORDER MATTERS: also used, via the default GetBrokenCellCount()/
+  //! GetBrokenCell(), as this cell's broken/linear draw sequence -- "(",
+  //! then the (possibly multi-cell) contents, then ")", unconditionally.
   size_t GetInnerCellCount() const override { return 3; }
   Cell *GetInnerCell(size_t index) const override {
     switch (index) {
@@ -92,8 +91,6 @@ public:
   wxString ToString() const override;
   wxString ToTeX() const override;
   wxString ToXML() const override;
-
-  void SetNextToDraw(Cell *next) const override;
 
 private:
   // The pointers below point to inner cells and must be kept contiguous.

--- a/src/cells/SetCell.h
+++ b/src/cells/SetCell.h
@@ -35,17 +35,13 @@
 
 /*! The class that represents parenthesis that are wrapped around text
 
-  In the case that this cell is broken into two lines in the order of
-  m_nextToDraw this cell is represented by the following individual
-  cells:
+  Once IsBrokenIntoLines(), the draw list (see GetBrokenCellCount()/
+  GetBrokenCell(), inherited unchanged from ListCell) expands this cell into
+  the following individual cells instead of drawing it as a single 2D object:
 
-  - The SetCell itself
   - The opening "["
   - The contents
   - The closing "]".
-
-  If it isn't broken into multiple cells m_nextToDraw points to the
-  cell that follows this Cell.
 */
 class SetCell final : public ListCell
 {

--- a/src/cells/SqrtCell.cpp
+++ b/src/cells/SqrtCell.cpp
@@ -167,16 +167,5 @@ bool SqrtCell::BreakUp() const {
     return false;
 
   Cell::BreakUpAndMark();
-  m_open->SetNextToDraw(m_innerCell);
-  m_innerCell->last()->SetNextToDraw(m_close);
-  m_close->SetNextToDraw(m_nextToDraw);
-  m_nextToDraw = m_open;
   return true;
-}
-
-void SqrtCell::SetNextToDraw(Cell *next) const {
-  if (IsBrokenIntoLines())
-    m_close->SetNextToDraw(next);
-  else
-    m_nextToDraw = next;
 }

--- a/src/cells/SqrtCell.h
+++ b/src/cells/SqrtCell.h
@@ -33,17 +33,13 @@
 
 /*! This class represents a square root
 
-  In the case that this cell is broken into two lines in the order of
-  m_nextToDraw this cell is represented by the following individual
-  cells:
+  Once IsBrokenIntoLines(), the draw list (see GetBrokenCellCount()/
+  GetBrokenCell()) expands this cell into the following individual cells
+  instead of drawing it as a single 2D object:
 
-  - The SqrtCell itself
   - The opening "sqrt("
   - The contents
   - The closing ")".
-
-  If it isn't broken into multiple cells m_nextToDraw points to the
-  cell that follows this Cell.
 */
 class SqrtCell final : public Cell
 {
@@ -54,6 +50,9 @@ public:
   std::unique_ptr<Cell> Copy(GroupCell *group) const override;
   const CellTypeInfo &GetInfo() override;
 
+  //! ORDER MATTERS: also used, via the default GetBrokenCellCount()/
+  //! GetBrokenCell(), as this cell's broken/linear draw sequence -- "sqrt(",
+  //! then the (possibly multi-cell) contents, then ")", unconditionally.
   size_t GetInnerCellCount() const override { return 3; }
   Cell *GetInnerCell(size_t index) const override {
     switch (index) {
@@ -82,8 +81,6 @@ public:
   wxString ToString() const override;
   wxString ToTeX() const override;
   wxString ToXML() const override;
-
-  void SetNextToDraw(Cell *next) const override;
 
 private:
   void MakeBreakUpCells();

--- a/src/cells/SumCell.cpp
+++ b/src/cells/SumCell.cpp
@@ -363,30 +363,7 @@ bool SumCell::BreakUp() const {
 
   Cell::BreakUpAndMark();
   m_displayParen = false;
-
-  m_close->SetNextToDraw(m_nextToDraw);
-  m_nextToDraw = m_open;
-  m_open->last()->SetNextToDraw(DisplayedBase());
-  DisplayedBase()->last()->SetNextToDraw(m_comma1);
-  m_comma1->last()->SetNextToDraw(m_var);
-  m_var->last()->SetNextToDraw(m_comma2);
-  m_comma2->last()->SetNextToDraw(m_start);
-  // The first cell of m_var should normally be a "d"
-  if (m_over->ToString().IsEmpty())
-    m_start->last()->SetNextToDraw(m_close);
-  else {
-    m_start->last()->SetNextToDraw(m_comma3);
-    m_comma3->last()->SetNextToDraw(m_over);
-    m_over->last()->SetNextToDraw(m_close);
-  }
   return true;
-}
-
-void SumCell::SetNextToDraw(Cell *next) const {
-  if (IsBrokenIntoLines())
-    m_close->SetNextToDraw(next);
-  else
-    m_nextToDraw = next;
 }
 
 const wxString SumCell::m_svgSumSign(reinterpret_cast<const char*>(SUMSIGN));

--- a/src/cells/SumCell.h
+++ b/src/cells/SumCell.h
@@ -95,7 +95,46 @@ public:
   const wxString &GetAltCopyText() const override { return m_altCopyText; }
 
   bool BreakUp() const override;
-  void SetNextToDraw(Cell *next) const override;
+
+  /*! ORDER MATTERS, and this is NOT the same set as GetInnerCellCount()/
+    GetInnerCell() above: index 1 there is m_paren (the ParenCell wrapper),
+    but the linear form shows Base() -- the wrapper's bare inner content,
+    parenthesis-free -- since BreakUp() clears m_displayParen before
+    building this sequence. m_under (index 9 above) never appears at all;
+    m_start (derived from m_under at construction) is shown instead. The
+    upper-limit pieces (comma3, over) are only present when m_over actually
+    has content (mirrors BreakUp()'s own `m_over->ToString().IsEmpty()`
+    check precisely -- don't derive this independently).
+  */
+  size_t GetBrokenCellCount() const override {
+    return m_over->ToString().IsEmpty() ? 7 : 9;
+  }
+  Cell *GetBrokenCell(size_t index) const override {
+    const bool hasOver = !m_over->ToString().IsEmpty();
+    switch (index) {
+    case 0:
+      return m_open.get();
+    case 1:
+      return Base();
+    case 2:
+      return m_comma1.get();
+    case 3:
+      return m_var.get();
+    case 4:
+      return m_comma2.get();
+    case 5:
+      return m_start.get();
+    case 6:
+      return hasOver ? m_comma3.get() : m_close.get();
+    case 7:
+      return hasOver ? m_over.get() : nullptr;
+    case 8:
+      return hasOver ? m_close.get() : nullptr;
+    default:
+      return nullptr;
+    }
+  }
+
   void Unbreak() const override final;
 
 protected:

--- a/test/unit_tests/test_CellPtr.cpp
+++ b/test/unit_tests/test_CellPtr.cpp
@@ -703,12 +703,12 @@ SCENARIO("DrawListIterator works") {
   GIVEN("A broken-up cell with two inner cells") {
     IterArrayCell<2> cell;
     cell.MockBreakUp();
-    Cell *prevCell = &cell;
-    for (auto &inner : cell.inner) {
+    // GetBrokenCellCount()/GetBrokenCell() default to GetInnerCellCount()/
+    // GetInnerCell(), which IterArrayCell already overrides to expose
+    // `inner` -- so once the cell IsBrokenIntoLines(), the draw list
+    // iterator descends into `inner` on its own; no manual linking needed.
+    for (auto &inner : cell.inner)
       inner = std::make_unique<FullTestCell>();
-      prevCell->SetNextToDraw(inner.get());
-      prevCell = inner.get();
-    }
     THEN("A range-for loop over the draw list iterates over the cell and its inner cells")
     {
       std::vector<Cell *> trace;
@@ -717,6 +717,40 @@ SCENARIO("DrawListIterator works") {
       REQUIRE(trace[0] == &cell);
       REQUIRE(trace[1] == cell.inner[0].get());
       REQUIRE(trace[2] == cell.inner[1].get());
+    }
+  }
+  GIVEN("A broken-up cell whose first inner cell is itself broken up") {
+    // Regression guard: this is the exact shape (a broken compound cell
+    // nested inside another broken compound cell -- e.g. a broken fraction
+    // in a broken fraction's numerator, or a broken parenthesis inside a
+    // broken parenthesis) that a 2020 attempt at removing the m_nextToDraw
+    // pointer got wrong, breaking nested line-breaking. The draw list must
+    // descend into the inner broken cell's own pieces before resuming the
+    // outer cell's remaining pieces.
+    auto outerCell = std::make_unique<IterArrayCell<2>>();
+    outerCell->MockBreakUp();
+
+    auto innerBroken = std::make_unique<IterArrayCell<2>>();
+    innerBroken->MockBreakUp();
+    for (auto &leaf : innerBroken->inner)
+      leaf = std::make_unique<FullTestCell>();
+
+    IterArrayCell<2> *const innerBrokenPtr = innerBroken.get();
+    outerCell->inner[0] = std::move(innerBroken);
+    outerCell->inner[1] = std::make_unique<FullTestCell>();
+
+    THEN("A range-for loop over the draw list visits the nested cell's own "
+         "pieces before the outer cell's remaining piece")
+    {
+      std::vector<Cell *> trace;
+      for (auto &tmp : OnDrawList(static_cast<Cell*>(outerCell.get())))
+        trace.push_back(&tmp);
+      REQUIRE(trace.size() == 5);
+      REQUIRE(trace[0] == outerCell.get());
+      REQUIRE(trace[1] == innerBrokenPtr);
+      REQUIRE(trace[2] == innerBrokenPtr->inner[0].get());
+      REQUIRE(trace[3] == innerBrokenPtr->inner[1].get());
+      REQUIRE(trace[4] == outerCell->inner[1].get());
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes #1445.

Every `Cell` carried a `mutable CellPtr<Cell> m_nextToDraw` — a second always-present `CellPtr` on *every* cell, threaded by hand via a virtual `SetNextToDraw()` override on each 2D-capable compound cell (`FracCell`, `ParenCell`, `SqrtCell`, `AbsCell`, `BoxCell`, `ConjugateCell`, `ListCell`, `ExptCell`, `SumCell`, `IntCell`, `LimitCell`, `IntervalCell`, `DiffCell`, `FunCell`, `NamedBoxCell`, `LongNumberCell`) whenever `BreakUp()`/`Unbreak()` ran.

`CellDrawListIterator` (`src/cells/CellIterators.h`) now computes the same flattened "line" sequence on the fly instead:
- Walks `GetNext()` for ordinary siblings.
- When a cell `IsBrokenIntoLines()`, descends into `GetBrokenCellCount()`/`GetBrokenCell()` (new virtuals) instead of treating it as one atomic node.
- An explicit stack in the iterator remembers where to resume once a nested expansion is exhausted — normal documents nest only a few levels deep, so this stays empty, with zero allocation, for any line containing no broken cell.

`GetBrokenCellCount()`/`GetBrokenCell()` default to the existing `GetInnerCellCount()`/`GetInnerCell()` (the semantic-children interface, previously used only for `ResetSize_Recursively()`/`CollectWideCells()`/tooltip fallback). That default turned out to already match the real draw sequence exactly for 11 of the 15 classes above — confirmed by direct comparison against each `BreakUp()`, not assumed.

**Four classes needed a real, separate override**, because their structural inner-cell set and their actual linear draw sequence diverge under runtime conditions:
- `IntCell` — the linear form omits the lower/upper limit slots entirely when `HasLimits()`.
- `SumCell` — shows `Base()` (the bare, unwrapped content) instead of the `ParenCell` wrapper `GetInnerCell()` reports, and conditionally omits the upper-limit pieces when `over` is empty.
- `IntervalCell` / `LimitCell` — both have structural slots (bracket glyphs, the "lim" name label) that exist only for the 2D form and are never part of the linear one.

Also fixed a latent bug found along the way: `ExptCell` never had a `SetNextToDraw()` override at all, so if its sibling pointer changed while broken, the default implementation would silently clobber its "descend into my own content" link. That whole bug class is now structurally impossible, since there's no stored pointer left to clobber.

`CellList.cpp`'s `SetNext()`/`AppendCell()`/`SpliceInAfter()`/`TearOut()` no longer need any draw-list-mirroring bookkeeping, since there's nothing stored to keep in sync.

## Why this is safe despite the history

A 2020 attempt at this exact removal (`feature/KubaO/remove-nexttodraw`, never merged) shipped visible regressions in exactly this class of nested-breaking scenario (a broken fraction inside a broken fraction/paren/diff cell), traced to the inner-cell list and draw list falling out of sync for nested compounds. This attempt was verified against that specific failure mode:

- A new nested-broken-cell unit test (`test/unit_tests/test_CellPtr.cpp`, `SCENARIO("DrawListIterator works")`) exercising a broken cell whose own inner cell is itself broken.
- The full unit suite (39/39 passing).
- The real Maxima batch tests for every touched cell type: `absCells`, `boxCells`, `diffCells`, `conjugateCells`, `exptCells`, `fracCells`, `intCells`, `intervals`, `limitCells`, `matrixCells`, `parenthesisCells`, `sumCells` (41/41 passing, including `_cmdline`/`_wxmathml` variants).
- A manual Xvfb + ImageMagick screenshot of `diff(abs(f(x)/g(x)),x)` at a narrow width — a broken `diff` containing a broken `abs` containing a broken nested fraction, all at once — to visually confirm correct rendering.

## Test plan

- [x] `ninja -C build` — clean, no warnings on touched files
- [x] `xvfb-run ctest --test-dir build -L unittest` — 39/39 passing
- [x] `xvfb-run ctest --test-dir build -R 'absCells|boxCells|diffCells|conjugateCells|exptCells|fracCells|intCells|intervals|limitCells|matrixCells|parenthesisCells|sumCells'` (real Maxima) — 41/41 passing
- [x] Manual visual check of nested broken cells via Xvfb screenshot

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_