### PR TITLE
Document GH #1335 (non-contiguous cell allocation) as still open

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -457,6 +457,30 @@ next" style work.
 - **Real tab handling in `EditorCell`:** tabs are currently just replaced by
   spaces on input instead of being handled as their own character/column-stop
   concept.
+- **GH #1335 -- cell allocations are non-local (still open, unstarted):**
+  `Cell`s are still individually heap-allocated and linked via each cell's own
+  `m_previous`/`m_next`, not stored contiguously. `CellList.h`'s own header
+  comment already says "the eventual plan is to have a list of cells be a
+  dedicated lightweight class working together with an arena allocator", but
+  `CellListBuilderBase` still just holds a `std::unique_ptr<Cell> m_head` --
+  that plan was never implemented. The issue's three proposed moves are all
+  still open: (1) drop `m_previous`/`m_next` from `Cell` in favor of a
+  `CellList` that owns contiguous storage, (2) hoist `m_group` from `Cell` to
+  `CellList` (one owner per list), (3) hoist the per-line-geometry caches --
+  the issue calls them `m_fullWidth`/`m_maxCenter`/`m_maxDrop`, renamed since
+  to `m_cachedSumOfWidths`/`m_cachedCenterList`/`m_cachedMaxDrop`/
+  `m_cachedLineWidth` -- from `Cell` to `CellList` too. Confirmed `sizeof(Cell)`
+  is 224 bytes on the current tree (checked directly, post-#1445), not the 112
+  the issue was measured against in 2020 -- `Cell` has grown substantially
+  since (accessibility support, config-change-tracking atomics, UUID string,
+  extra-XML-attributes map, ...), so the issue's "112 -> 76 bytes" estimate is
+  stale, but the underlying proposal is still real. This is a bigger
+  undertaking than #1445: it changes the core list *storage model*
+  (`m_next`/`m_previous` becoming array-relative instead of pointer-based),
+  touching every list-manipulation site in `CellList.cpp` plus anything
+  walking `GetNext()`/`GetPrevious()` directly -- scope it out carefully
+  before starting, don't assume it's a small follow-on to #1445 just because
+  they're adjacent/both filed by KubaO in 2020.
 
 ## Error resilience
 


### PR DESCRIPTION
## Summary

While working on #1445 (removing `m_nextToDraw`), checked whether the related #1335 ("cell allocations are non-local") had made any progress since 2020. It hasn't — this is a docs-only note recording that in `AGENTS.md`'s Backlog section for future reference, so the next agent or contributor picking this up doesn't have to re-derive it.

Findings, checked directly against the current tree rather than assumed:
- `CellList.h`'s own header comment already states the intended design ("a dedicated lightweight class working together with an arena allocator"), but `CellListBuilderBase` still just holds a `std::unique_ptr<Cell> m_head` — cells are still individually heap-allocated and linked via each cell's own `m_previous`/`m_next`.
- `m_group` is still per-`Cell`, not hoisted to a single list-level owner.
- The per-line-geometry caches (`m_fullWidth`/`m_maxCenter`/`m_maxDrop` in the issue, renamed since to `m_cachedSumOfWidths`/`m_cachedCenterList`/`m_cachedMaxDrop`/`m_cachedLineWidth`) are still per-`Cell` too.
- `sizeof(Cell)` is 224 bytes on the current tree (compiled and measured directly, post-#1445), not the 112 bytes the issue was measured against in 2020 — `Cell` has grown a fair amount since then, so the issue's "112 → 76 bytes" estimate is stale even though the underlying proposal is still valid.

No code changes — this only updates `AGENTS.md`.

## Test plan

- N/A (documentation only)

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_