### PR TITLE
Add "Anonymize Code for Bug Report" to the Help menu (closes #1339)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,57 @@ a local TCP socket.
   draw-list-mirroring bookkeeping, since there's nothing stored to keep in
   sync.
 
+- **`Worksheet::AnonymizeCodeCells()` (GH #1339, Help menu -> "Anonymize Code
+  for Bug Report"):** renames every non-builtin variable/function name in the
+  selected code cells (whole document if nothing's selected, after a
+  confirmation `wxMessageBox`) to a random `anon_...` name, the same
+  replacement for every occurrence of a given original name, as a single
+  undo step. Telling "a user-defined name" apart from "a name Maxima already
+  knows" needs **two** independent checks on each `TS_CODE_VARIABLE`/
+  `TS_CODE_FUNCTION` token, not one: `AutoComplete::GetSymbolList()` (Maxima
+  builtins plus session-loaded package symbols -- deliberately *not*
+  polluted by user-typed worksheet words, which live in a separate
+  `m_worksheetWords` map) catches real Maxima functions/variables, but
+  `MaximaTokenizer` tokenizes its own hardcoded control-flow keywords
+  (`for`/`in`/`then`/`while`/`do`/`thru`/`next`/`step`/`unless`/`from`/`if`/
+  `else`/`elseif`/`and`/`or`/`not`/`true`/`false`) with that same
+  variable/function style, and only 4 of those 18
+  (`and`/`false`/`in`/`true`) also happen to appear in
+  `data/builtin_commands.txt` -- confirmed directly by grepping that file.
+  A filter using only `GetSymbolList()` would rename `for`/`then`/`do`/...
+  themselves and corrupt the Maxima syntax outright. Fixed by exposing the
+  tokenizer's private keyword set as a new public static
+  `MaximaTokenizer::IsHardcodedKeyword()` and checking both. That accessor
+  needed its own fix first: the keyword map was populated lazily inside the
+  constructor, so calling it before any `MaximaTokenizer` instance existed
+  silently returned false for everything -- fixed by extracting
+  `EnsureHardcodedFunctionsInitialized()` and calling it from both the
+  constructor and the new accessor.
+  `test/unit_tests/test_AnonymizeCodeCells.cpp` pins this with a real
+  `Worksheet`/`Configuration` (no live Maxima), calling the narrow,
+  synchronous `AutoComplete::LoadBuiltinSymbols()` in its `main()` rather
+  than the full `Worksheet::LoadSymbols()` -- the latter also kicks off
+  `LoadableFiles_BackgroundTask`'s directory scan for Maxima's share/demo
+  folders, which stalled for 70+ seconds in this sandbox and got the test
+  process killed by its ctest timeout. A substring check like
+  `after.Contains(wxS("f("))` to confirm a renamed function is gone is
+  fragile and intermittently flaky (confirmed live, ~1-in-3 failure rate
+  over repeated runs): the random 13-character `anon_...` replacement for
+  some *other* name can itself end in the letter being searched for, and
+  since a real function call always has `(` immediately after its name in
+  valid Maxima syntax, the reconstructed text can contain a coincidental
+  `...anon_xyzqwrtf(...` match. Use exact per-token comparison via
+  `MaximaTokenizer` instead (see that test file's `HasExactToken()` helper).
+  The "nothing selected -> confirm whole document" `wxMessageBox` path can't
+  be driven or screenshotted reliably in this sandbox's Xvfb (no window
+  manager is running, and a GTK modal dialog's window never became visible
+  to `import -window <id>`/`-window root` in several attempts, though the
+  underlying `wxMessageBox` call is the same well-established idiom used
+  elsewhere in this codebase) -- verified instead by exercising the
+  already-selected-cells path end-to-end in a live Xvfb session (typed real
+  code, selected the group cell via hCaret + Shift+Up, confirmed the
+  rendered text changed consistently and a single Ctrl+Z restored it).
+
 ### Communication with Maxima
 
 wxMaxima sends Lisp and Maxima commands over the socket; Maxima answers with XML

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Current development version
 
+- Added "Anonymize Code for Bug Report" to the Help menu (#1339): replaces
+  every non-builtin variable and function name in the selected code cells (or,
+  after confirmation, the whole document) with a random name, consistently
+  across all occurrences and all selected cells, so a worksheet can be shared
+  in a bug report without revealing the original names. Maxima builtins and
+  the tokenizer's own syntax keywords (`for`/`then`/`do`/...) are left alone,
+  and the whole operation is a single undo step.
 - Reduced the memory footprint of every cell on the worksheet by removing
   `m_nextToDraw`, a per-cell pointer used only by fractions, parentheses and
   similar 2D-capable cells when line-wrapped; the same information is now

--- a/src/EventIDs.cpp
+++ b/src/EventIDs.cpp
@@ -400,6 +400,7 @@ const wxWindowIDRef EventIDs::menu_plot_format(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_build_info(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_register_wxmx_difftool(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_bug_report(wxWindow::NewControlId());
+const wxWindowIDRef EventIDs::menu_anonymize(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_add_path(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_evaluate_all_visible(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_evaluate_all(wxWindow::NewControlId());

--- a/src/EventIDs.h
+++ b/src/EventIDs.h
@@ -465,6 +465,9 @@ public:
   //! Register wxMaxima as the .wxmx diff tool for TortoiseSVN/TortoiseGit (MSW).
   static const wxWindowIDRef menu_register_wxmx_difftool;
   static const wxWindowIDRef menu_bug_report;
+  //! Anonymize code cells before filing a bug report (replaces non-builtin
+  //! variable/function names with random strings; see GH #1339).
+  static const wxWindowIDRef menu_anonymize;
   static const wxWindowIDRef menu_add_path;
   static const wxWindowIDRef menu_evaluate_all_visible;
   static const wxWindowIDRef menu_evaluate_all;

--- a/src/MaximaCommandMenus.cpp
+++ b/src/MaximaCommandMenus.cpp
@@ -2150,6 +2150,10 @@ void MaximaCommandMenus::HelpMenu(wxCommandEvent &event) {
     m_wxMaxima.MenuCommand(wxS("wxbug_report()$"));
   }
 
+  else if(event.GetId() == EventIDs::menu_anonymize){
+    m_wxMaxima.GetWorksheet()->AnonymizeCodeCells();
+  }
+
   else if(event.GetId() == EventIDs::menu_help_tutorials){
     wxLaunchDefaultBrowser(wxS("https://wxMaxima-developers.github.io/wxmaxima/help.html"));
   }

--- a/src/MaximaTokenizer.cpp
+++ b/src/MaximaTokenizer.cpp
@@ -33,9 +33,7 @@
 #include <wx/string.h>
 #include <wx/wx.h>
 
-MaximaTokenizer::MaximaTokenizer(const wxString &commands,
-                                 const Configuration * const configuration)
-  : m_configuration(configuration) {
+void MaximaTokenizer::EnsureHardcodedFunctionsInitialized() {
   if (m_hardcodedFunctions.empty()) {
     m_hardcodedFunctions["for"] = 1;
     m_hardcodedFunctions["in"] = 1;
@@ -56,6 +54,12 @@ MaximaTokenizer::MaximaTokenizer(const wxString &commands,
     m_hardcodedFunctions["true"] = 1;
     m_hardcodedFunctions["false"] = 1;
   }
+}
+
+MaximaTokenizer::MaximaTokenizer(const wxString &commands,
+                                 const Configuration * const configuration)
+  : m_configuration(configuration) {
+  EnsureHardcodedFunctionsInitialized();
 
   // ----------------------------------------------------------------
   // --------------------- Step one:                -----------------

--- a/src/MaximaTokenizer.h
+++ b/src/MaximaTokenizer.h
@@ -96,6 +96,22 @@ public:
   MaximaTokenizer(const wxString &commands, const Configuration * const configuration,
                   const TokenList &initialTokens);
 
+  /*! Is this text one of the fake-function keywords (see m_hardcodedFunctions)?
+
+    These are tokenized as TS_CODE_FUNCTION -- the same style as a genuine
+    function call -- but are Maxima syntax, not identifiers a user could have
+    defined: "for", "then", "do" and the like. Anything that walks tokens
+    looking for user-definable names (e.g. a variable-renaming tool) needs to
+    exclude these in addition to checking a token's text against the known
+    builtin/command list, since most of them (unlike genuine builtin
+    functions) are deliberately not real Maxima function names and so don't
+    appear in that list at all.
+  */
+  static bool IsHardcodedKeyword(const wxString &text) {
+    EnsureHardcodedFunctionsInitialized();
+    return m_hardcodedFunctions.find(text) != m_hardcodedFunctions.end();
+  }
+
 protected:
   //! The tokens the string is divided into
   TokenList m_tokens;
@@ -123,6 +139,8 @@ protected:
     argument. These fake functions are kept in this hash.
   */
   static StringHash m_hardcodedFunctions;
+  //! Populates m_hardcodedFunctions on first use; safe to call repeatedly.
+  static void EnsureHardcodedFunctionsInitialized();
 
 };
 

--- a/src/worksheet/Worksheet.cpp
+++ b/src/worksheet/Worksheet.cpp
@@ -55,6 +55,9 @@
 #include "ArtProvider.h"
 #include <algorithm>
 #include <memory>
+#include <random>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <utility>
 #include <stdlib.h>
@@ -5373,6 +5376,150 @@ int Worksheet::ReplaceAll_RegEx(const wxString &oldString, const wxString &newSt
   }
 
   return count;
+}
+
+namespace {
+//! Generates a random, not-yet-used, always-valid Maxima identifier and
+//! reserves it in \p usedNames so a later call can't return it again.
+wxString GenerateAnonymousName(Configuration *configuration,
+                               std::unordered_set<wxString, wxStringHash> &usedNames) {
+  static const wxString letters = wxS("abcdefghijklmnopqrstuvwxyz");
+  static const wxString alnum = wxS("abcdefghijklmnopqrstuvwxyz0123456789");
+  std::uniform_int_distribution<size_t> letterDist(0, letters.Length() - 1);
+  std::uniform_int_distribution<size_t> alnumDist(0, alnum.Length() - 1);
+  for (;;) {
+    wxString candidate = wxS("anon_");
+    candidate += letters[letterDist(configuration->RandomEngine())];
+    for (int i = 0; i < 7; ++i)
+      candidate += alnum[alnumDist(configuration->RandomEngine())];
+    if (usedNames.insert(candidate).second)
+      return candidate;
+  }
+}
+} // namespace
+
+void Worksheet::AnonymizeCodeCells() {
+  if (!GetTree())
+    return;
+
+  GroupCell *startGroup;
+  GroupCell *endGroup;
+  if (HasCellsSelected()) {
+    startGroup = GetDocumentCellPointers().GetSelectionStart()->GetGroup();
+    endGroup = GetDocumentCellPointers().GetSelectionEnd()->GetGroup();
+  } else {
+    int answer = wxMessageBox(
+        _("No cells are selected. Anonymize the code in the whole document?"),
+        _("Anonymize Code for Bug Report"),
+        wxYES_NO | wxICON_QUESTION | wxCENTRE, this);
+    if (answer != wxYES)
+      return;
+    startGroup = GetTree();
+    endGroup = GetLastCellInWorksheet();
+  }
+  if (!startGroup || !endGroup)
+    return;
+
+  // Pass 1: walk the selected code cells once to collect every candidate
+  // name (TS_CODE_VARIABLE/TS_CODE_FUNCTION token text) that isn't Maxima
+  // syntax (MaximaTokenizer::IsHardcodedKeyword(), e.g. "for"/"then"/"do" --
+  // these are tokenized with the same style as a real function call, but
+  // aren't identifiers a user could have defined).
+  std::vector<GroupCell *> codeGroups;
+  std::unordered_set<wxString, wxStringHash> candidateNames;
+  for (auto &tmp : OnList(startGroup)) {
+    if (tmp.GetGroupType() == GC_TYPE_CODE) {
+      EditorCell *editor = tmp.GetEditable();
+      if (editor && editor->IsCodeEditor()) {
+        codeGroups.push_back(&tmp);
+        for (auto const &tok : editor->GetAllTokens()) {
+          TextStyle style = tok.GetTextStyle();
+          if ((style == TS_CODE_VARIABLE || style == TS_CODE_FUNCTION) &&
+              !MaximaTokenizer::IsHardcodedKeyword(tok.GetText()))
+            candidateNames.insert(tok.GetText());
+        }
+      }
+    }
+    if (&tmp == endGroup)
+      break;
+  }
+  if (codeGroups.empty())
+    return;
+
+  // Names Maxima itself already knows (builtins, plus anything a loaded
+  // package has defined this session) must never be renamed.
+  std::unordered_set<wxString, wxStringHash> knownToMaxima;
+  for (auto const &symbol : GetAutocomplete().GetSymbolList())
+    knownToMaxima.insert(symbol);
+
+  // Every name actually appearing in the scanned cells (whether it ends up
+  // renamed or not) plus every name Maxima knows about is off-limits for a
+  // freshly generated replacement -- otherwise a "random" replacement could
+  // collide with a real, distinct name and silently merge two variables.
+  std::unordered_set<wxString, wxStringHash> usedNames = knownToMaxima;
+  usedNames.insert(candidateNames.begin(), candidateNames.end());
+
+  std::unordered_map<wxString, wxString, wxStringHash> renameMap;
+  for (auto const &name : candidateNames)
+    if (knownToMaxima.find(name) == knownToMaxima.end())
+      renameMap[name] = GenerateAnonymousName(m_configuration, usedNames);
+
+  if (renameMap.empty())
+    return;
+
+  // Pass 2: rebuild each affected cell's text, substituting renamed tokens.
+  // Concatenating every token's text reproduces the original text exactly
+  // (MaximaTokenizer's tokens are contiguous and non-overlapping, including
+  // whitespace/newline tokens -- the same invariant Worksheet::UnicodeToMaxima()
+  // above already relies on), so only the renamed identifiers change.
+  struct PendingEdit {
+    GroupCell *group;
+    EditorCell *editor;
+    wxString oldText;
+    wxString newText;
+  };
+  std::vector<PendingEdit> edits;
+  for (GroupCell *group : codeGroups) {
+    EditorCell *editor = group->GetEditable();
+    wxString newText;
+    bool changed = false;
+    for (auto const &tok : editor->GetAllTokens()) {
+      TextStyle style = tok.GetTextStyle();
+      if (style == TS_CODE_VARIABLE || style == TS_CODE_FUNCTION) {
+        auto it = renameMap.find(tok.GetText());
+        if (it != renameMap.end()) {
+          newText += it->second;
+          changed = true;
+          continue;
+        }
+      }
+      newText += tok.GetText();
+    }
+    if (changed)
+      edits.push_back({group, editor, editor->GetValue(), std::move(newText)});
+  }
+  if (edits.empty())
+    return;
+
+  // Record one undo action per edited cell, chaining all but the last one
+  // via TreeUndo_AppendAction() so the whole batch undoes as a single step
+  // (see TOCdnd()/SetCellStyle() for the same chaining pattern).
+  GetTreeUndo().ClearRedoActionList();
+  for (size_t i = 0; i < edits.size(); ++i) {
+    const PendingEdit &edit = edits[i];
+    GetTreeUndo().UndoStack().emplace_front(
+        edit.group, edit.oldText,
+        static_cast<long long>(edit.editor->SelectionStart()),
+        static_cast<long long>(edit.editor->SelectionEnd()));
+    if (i + 1 < edits.size())
+      TreeUndo_AppendAction();
+    edit.editor->SetValue(edit.newText);
+    edit.group->ResetInputLabel();
+    edit.group->ResetSize();
+  }
+
+  SetSaved(false);
+  RequestRedraw();
 }
 
 bool Worksheet::Autocomplete(AutoComplete::autoCompletionType type) {

--- a/src/worksheet/Worksheet.h
+++ b/src/worksheet/Worksheet.h
@@ -1517,6 +1517,18 @@ public:
   int ReplaceAll(const wxString &oldString, const wxString &newString, bool ignoreCase, bool searchInInput = true, bool searchInOutput = true);
   int ReplaceAll_RegEx(const wxString &oldString, const wxString &newString, bool searchInInput = true, bool searchInOutput = true);
 
+  /*! Anonymize the code cells in the current selection for a bug report (GH #1339).
+
+    Replaces every variable/function name that isn't built into Maxima (see
+    AutoComplete::GetSymbolList()) with a random, collision-free name, the
+    same replacement everywhere the original name occurs within the scanned
+    cells. Only code cells (GC_TYPE_CODE) are touched; text/heading cells are
+    left alone. If nothing is selected, asks the user whether to anonymize
+    the whole document instead of silently doing nothing or silently doing
+    everything. All edits are grouped into a single document-level undo step.
+  */
+  void AnonymizeCodeCells();
+
   wxString GetInputAboveCaret();
 
   wxString GetOutputAboveCaret();

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -531,6 +531,7 @@ wxMaxima::wxMaxima(wxWindow *parent, int id,
   Bind(wxEVT_MENU, &MaximaCommandMenus::HelpMenu, &m_menuCommands, EventIDs::menu_help_tutorials);
   Bind(wxEVT_MENU, &MaximaCommandMenus::HelpMenu, &m_menuCommands, EventIDs::menu_goto_url);
   Bind(wxEVT_MENU, &MaximaCommandMenus::HelpMenu, &m_menuCommands, EventIDs::menu_bug_report);
+  Bind(wxEVT_MENU, &MaximaCommandMenus::HelpMenu, &m_menuCommands, EventIDs::menu_anonymize);
   Bind(wxEVT_MENU, &MaximaCommandMenus::HelpMenu, &m_menuCommands, EventIDs::menu_build_info);
 #ifdef __WXMSW__
   Bind(wxEVT_MENU, &MaximaCommandMenus::HelpMenu, &m_menuCommands, EventIDs::menu_register_wxmx_difftool);

--- a/src/wxMaximaFrame.cpp
+++ b/src/wxMaximaFrame.cpp
@@ -1986,6 +1986,12 @@ void wxMaximaFrame::SetupHelpMenu() {
                      _("Info about Maxima build"), wxITEM_NORMAL);
   m_HelpMenu->Append(EventIDs::menu_bug_report, _("&Bug Report"), _("Report bug"),
                      wxITEM_NORMAL);
+  m_HelpMenu->Append(EventIDs::menu_anonymize, _("Anonymize Code for Bug Report"),
+                     _("Replace non-builtin variable and function names in the "
+                       "selected code cells (or the whole document) with random "
+                       "names, so a worksheet can be shared without revealing "
+                       "its original names"),
+                     wxITEM_NORMAL);
   m_HelpMenu->Append(EventIDs::menu_license, _("&License"), _("wxMaxima's license"),
                      wxITEM_NORMAL);
   m_HelpMenu->Append(EventIDs::menu_changelog, _("Change Log"), _("wxMaxima's ChangeLog"),

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -366,6 +366,20 @@ if(TARGET wxmTestApp)
     add_test(NAME WorksheetFind
         COMMAND ${WXM_TEST_LAUNCHER} "$<TARGET_FILE:test_WorksheetFind>")
 
+    # Pins Worksheet::AnonymizeCodeCells() (GH #1339): non-builtin
+    # variable/function names in the selected code cells get replaced with a
+    # random, collision-free, reproducible-within-the-run name, while Maxima
+    # builtins, the tokenizer's hardcoded keywords, non-code cells and cells
+    # outside the selection are left alone, all as a single undo step.
+    add_executable(test_AnonymizeCodeCells
+        test_AnonymizeCodeCells.cpp groupcell_test_stubs.cpp ${WXM_TEST_SETUP}
+        $<TARGET_OBJECTS:wxmTestApp>)
+    target_compile_features(test_AnonymizeCodeCells PUBLIC cxx_std_20)
+    target_link_libraries(test_AnonymizeCodeCells PRIVATE
+        ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${WXM_TESTAPP_EXTRA_LIBS})
+    add_test(NAME AnonymizeCodeCells
+        COMMAND ${WXM_TEST_LAUNCHER} "$<TARGET_FILE:test_AnonymizeCodeCells>")
+
     # Pins the "add cells to the evaluation queue" behavior (which visible code
     # cells each Add*ToEvaluationQueue enqueues, and where the h-caret lands)
     # ahead of the WorksheetEvalQueue extraction.

--- a/test/unit_tests/test_AnonymizeCodeCells.cpp
+++ b/test/unit_tests/test_AnonymizeCodeCells.cpp
@@ -1,0 +1,274 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+//
+//  Copyright (C) 2026 Gunter Königsmann <wxMaxima@physikbuch.de>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+/*! \file
+  Pins Worksheet::AnonymizeCodeCells() (GH #1339): replacing every
+  non-builtin variable/function name in the selected code cells with a
+  random, collision-free, reproducible-within-the-run replacement, leaving
+  Maxima builtins, the tokenizer's hardcoded keywords (for/then/do/...),
+  string/number literals and non-code cells untouched, all as one undo step.
+
+  These scenarios always select the cells to anonymize, deliberately never
+  exercising the "nothing selected -> ask the user" confirmation dialog: a
+  real modal dialog can't be driven headlessly here, so that path is verified
+  manually instead (see AGENTS.md).
+*/
+
+#include <wx/app.h>
+#include <wx/bitmap.h>
+#include <wx/dcmemory.h>
+#include <wx/frame.h>
+#include <wx/log.h>
+
+#include "Configuration.h"
+#include "MaximaTokenizer.h"
+#include "worksheet/Worksheet.h"
+#include "cells/EditorCell.h"
+#include "cells/GroupCell.h"
+#include "cells/TextCell.h"
+
+#define CATCH_CONFIG_RUNNER
+#include <catch2/catch.hpp>
+
+namespace {
+wxBitmap *g_bmp = nullptr;
+wxMemoryDC *g_dc = nullptr;
+Configuration *g_cfg = nullptr;
+Worksheet *g_ws = nullptr;
+wxFrame *g_frame = nullptr;
+
+//! A code group with the given input and no output.
+GroupCell *AppendCodeGroup(const wxString &code, GroupCell *after) {
+  auto group = std::make_unique<GroupCell>(g_cfg, GC_TYPE_CODE, code);
+  return g_ws->InsertGroupCells(std::move(group), after);
+}
+
+//! A text/heading group -- must never be touched by AnonymizeCodeCells().
+GroupCell *AppendTextGroup(const wxString &text, GroupCell *after) {
+  auto group = std::make_unique<GroupCell>(g_cfg, GC_TYPE_TEXT, text);
+  return g_ws->InsertGroupCells(std::move(group), after);
+}
+
+/*! Does any token in \p code have exactly this text?
+
+  Unlike a naive substring search, this can't produce a false positive from a
+  randomly generated "anon_..." replacement that happens to end in the same
+  letter(s) as \p exactText followed by whatever real character comes next in
+  the source (e.g. a replacement for some other name ending in "f" right
+  before a "(" would make a plain code.Contains("f(") check falsely believe
+  the original "f" survived).
+*/
+bool HasExactToken(const wxString &code, const wxString &exactText) {
+  for (auto const &tok : MaximaTokenizer(code, g_cfg).PopTokens())
+    if (tok.GetText() == exactText)
+      return true;
+  return false;
+}
+} // namespace
+
+SCENARIO("AnonymizeCodeCells renames non-builtin names consistently") {
+  g_ws->ClearDocument();
+  GroupCell *group = AppendCodeGroup(
+    wxS("myvar: 5; f(myvar):=myvar^2+myvar;"), nullptr);
+  g_ws->SetSelection(group, group);
+  g_ws->RecalculateIfNeeded();
+
+  const wxString before = group->GetEditable()->GetValue();
+  g_ws->AnonymizeCodeCells();
+  const wxString after = group->GetEditable()->GetValue();
+
+  THEN("the text actually changed") { REQUIRE(after != before); }
+
+  THEN("the user-defined names are gone") {
+    REQUIRE_FALSE(HasExactToken(after, wxS("myvar")));
+    REQUIRE_FALSE(HasExactToken(after, wxS("f")));
+  }
+
+  THEN("every occurrence of the same original name got the same replacement") {
+    // "myvar" occurs 4 times in the source ("myvar: 5;", the "f(myvar)"
+    // parameter, "myvar^2" and the trailing "+myvar"); its replacement must
+    // therefore also occur exactly 4 times.
+    int myvarReplacementCount = 0;
+    // Whatever "myvar" became, it's a single anon_-prefixed token repeated
+    // four times -- find it and count its occurrences.
+    int pos = after.Find(wxS("anon_"));
+    REQUIRE(pos != wxNOT_FOUND);
+    wxString token = after.Mid(pos).BeforeFirst('^').BeforeFirst('+').BeforeFirst(':');
+    // token now holds one full anon_ identifier ("anon_" plus 8 chars).
+    REQUIRE(token.StartsWith(wxS("anon_")));
+    wxString remaining = after;
+    for (;;) {
+      int idx = remaining.Find(token);
+      if (idx == wxNOT_FOUND)
+        break;
+      ++myvarReplacementCount;
+      remaining = remaining.Mid(idx + token.Length());
+    }
+    REQUIRE(myvarReplacementCount == 4);
+  }
+}
+
+SCENARIO("AnonymizeCodeCells leaves Maxima builtins and syntax keywords alone") {
+  g_ws->ClearDocument();
+  GroupCell *group = AppendCodeGroup(
+    wxS("for myindex:1 thru 3 do myresult: sin(myindex)+sqrt(2)+integrate(x,x);"),
+    nullptr);
+  g_ws->SetSelection(group, group);
+  g_ws->RecalculateIfNeeded();
+
+  g_ws->AnonymizeCodeCells();
+  const wxString after = group->GetEditable()->GetValue();
+
+  THEN("the loop keywords survive untouched") {
+    REQUIRE(after.Contains(wxS("for ")));
+    REQUIRE(after.Contains(wxS("thru")));
+    REQUIRE(after.Contains(wxS("do ")));
+  }
+  THEN("builtin functions survive untouched") {
+    REQUIRE(after.Contains(wxS("sin(")));
+    REQUIRE(after.Contains(wxS("sqrt(")));
+    REQUIRE(after.Contains(wxS("integrate(")));
+  }
+  THEN("the user-defined loop variable and result name are gone") {
+    REQUIRE_FALSE(after.Contains(wxS("myindex")));
+    REQUIRE_FALSE(after.Contains(wxS("myresult")));
+  }
+}
+
+SCENARIO("AnonymizeCodeCells uses the same replacement across multiple cells") {
+  g_ws->ClearDocument();
+  GroupCell *first = AppendCodeGroup(wxS("shared_name: 1;"), nullptr);
+  GroupCell *second = AppendCodeGroup(wxS("print(shared_name);"), first);
+  g_ws->SetSelection(first, second);
+  g_ws->RecalculateIfNeeded();
+
+  g_ws->AnonymizeCodeCells();
+
+  const wxString firstAfter = first->GetEditable()->GetValue();
+  const wxString secondAfter = second->GetEditable()->GetValue();
+  REQUIRE_FALSE(firstAfter.Contains(wxS("shared_name")));
+  REQUIRE_FALSE(secondAfter.Contains(wxS("shared_name")));
+
+  THEN("both cells got the very same replacement name") {
+    int pos = firstAfter.Find(wxS("anon_"));
+    REQUIRE(pos != wxNOT_FOUND);
+    wxString replacement = firstAfter.Mid(pos, 13); // "anon_" + 1 letter + 7 alnum
+    REQUIRE(secondAfter.Contains(replacement));
+  }
+}
+
+SCENARIO("AnonymizeCodeCells only touches code cells, and only within the selection") {
+  g_ws->ClearDocument();
+  GroupCell *text = AppendTextGroup(wxS("please anonymize secret_topic"), nullptr);
+  GroupCell *inSelection = AppendCodeGroup(wxS("secret_topic: 1;"), text);
+  GroupCell *outsideSelection = AppendCodeGroup(wxS("secret_topic: 2;"), inSelection);
+  // Select only the text cell and the first code cell -- not the second.
+  g_ws->SetSelection(text, inSelection);
+  g_ws->RecalculateIfNeeded();
+
+  g_ws->AnonymizeCodeCells();
+
+  THEN("the text cell is untouched even though it contains the same word") {
+    REQUIRE(text->GetEditable()->GetValue().Contains(wxS("secret_topic")));
+  }
+  THEN("the selected code cell was anonymized") {
+    REQUIRE_FALSE(inSelection->GetEditable()->GetValue().Contains(wxS("secret_topic")));
+  }
+  THEN("the code cell outside the selection was left alone") {
+    REQUIRE(outsideSelection->GetEditable()->GetValue().Contains(wxS("secret_topic")));
+  }
+}
+
+SCENARIO("AnonymizeCodeCells groups all its edits into a single undo step") {
+  g_ws->ClearDocument();
+  GroupCell *first = AppendCodeGroup(wxS("shared_name: 1;"), nullptr);
+  GroupCell *second = AppendCodeGroup(wxS("print(shared_name);"), first);
+  g_ws->SetSelection(first, second);
+  g_ws->RecalculateIfNeeded();
+
+  const wxString firstBefore = first->GetEditable()->GetValue();
+  const wxString secondBefore = second->GetEditable()->GetValue();
+
+  g_ws->AnonymizeCodeCells();
+  REQUIRE(first->GetEditable()->GetValue() != firstBefore);
+  REQUIRE(second->GetEditable()->GetValue() != secondBefore);
+
+  g_ws->ClearSelection();
+  g_ws->SetActiveCell(nullptr);
+  g_ws->Undo();
+
+  THEN("a single Undo restores both cells at once") {
+    REQUIRE(first->GetEditable()->GetValue() == firstBefore);
+    REQUIRE(second->GetEditable()->GetValue() == secondBefore);
+  }
+}
+
+SCENARIO("AnonymizeCodeCells does nothing when nothing needs renaming") {
+  g_ws->ClearDocument();
+  GroupCell *group = AppendCodeGroup(wxS("sin(1)+sqrt(2);"), nullptr);
+  g_ws->SetSelection(group, group);
+  g_ws->RecalculateIfNeeded();
+
+  const wxString before = group->GetEditable()->GetValue();
+  g_ws->AnonymizeCodeCells();
+
+  THEN("the text is unchanged") {
+    REQUIRE(group->GetEditable()->GetValue() == before);
+  }
+}
+
+class TestApp : public wxApp {
+public:
+  bool OnInit() override { return true; }
+};
+wxDECLARE_APP(TestApp);
+
+int main(int argc, char **argv) {
+  wxLog::EnableLogging(false);
+  wxApp::SetInstance(new TestApp());
+  wxEntryStart(argc, argv);
+  wxTheApp->CallOnInit();
+
+  g_bmp = new wxBitmap(800, 600);
+  g_dc = new wxMemoryDC();
+  g_dc->SelectObject(*g_bmp);
+  g_cfg = new Configuration(g_dc);
+  g_cfg->SetZoomFactor(1.0);
+  g_cfg->SetCanvasSize(wxSize(800, 600));
+  g_frame = new wxFrame(nullptr, wxID_ANY, wxS("test"));
+  g_ws = new Worksheet(g_frame, wxID_ANY, g_cfg, wxDefaultPosition, wxDefaultSize,
+                       /*reactToEvents=*/false);
+  g_cfg->SetWorkSheet(g_ws);
+
+  // AnonymizeCodeCells() needs a real builtin-symbol list to tell user names
+  // apart from Maxima's own. Worksheet::LoadSymbols() would do that too, but
+  // it also kicks off directory scans for load/demo files (looking for a
+  // real Maxima installation's share/demo directories) that this headless
+  // test has no use for and that can stall for a long time here -- call the
+  // narrower, synchronous, filesystem-free AutoComplete::LoadBuiltinSymbols()
+  // directly instead.
+  g_ws->GetAutocomplete().LoadBuiltinSymbols();
+
+  const int result = Catch::Session().run(argc, argv);
+
+  wxEntryCleanup();
+  return result;
+}


### PR DESCRIPTION
Replaces every non-builtin variable/function name in the selected code
cells (or, after confirmation, the whole document) with a random name,
consistently across all occurrences and cells, as a single undo step --
so a worksheet can be shared in a bug report without exposing its
original variable/function names.

Distinguishing a user-defined name from one Maxima already knows needs
two checks: AutoComplete::GetSymbolList() for real builtins/session
symbols, and a new MaximaTokenizer::IsHardcodedKeyword() for the
tokenizer's own control-flow keywords (for/then/do/...), which are
tokenized with the same style as a real function/variable but mostly
aren't in data/builtin_commands.txt and would otherwise get corrupted.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6