### PR TITLE
Fix missing #include &lt;vector&gt; in CellIterators.h (compile_2204/Cygwin CI red on main)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Current development version
 
+- Fixed a build failure on GCC 11 (Ubuntu 22.04) and Cygwin:
+  `src/cells/CellIterators.h` used `std::vector` without including `<vector>`,
+  which happened to work only where some other header transitively pulled it
+  in first -- not the case for every toolchain/include order (introduced by
+  the `m_nextToDraw` removal below).
 - Reduced the memory footprint of every cell on the worksheet by removing
   `m_nextToDraw`, a per-cell pointer used only by fractions, parentheses and
   similar 2D-capable cells when line-wrapped; the same information is now

--- a/src/cells/CellIterators.h
+++ b/src/cells/CellIterators.h
@@ -31,6 +31,7 @@
 #include <memory>
 #include <type_traits>
 #include <iterator>
+#include <vector>
 
 template <typename Cell> class CellListIterator final {
   static_assert(std::is_class<Cell>::value, "The type argument must be a class");


### PR DESCRIPTION
`src/cells/CellIterators.h`'s `CellDrawListIterator` stores its resume stack
in `std::vector<Frame> m_stack`, but the header never includes `<vector>` --
it only compiled because some other header happened to pull `<vector>` in
first for a given translation unit/toolchain.

This is currently breaking `main`'s own CI on two jobs (confirmed live on
`main`'s current tip, not just on a branch): `compile_2204` (Ubuntu 22.04,
GCC 11) and `compile_cygwin`, both with the identical error:

```
CellIterators.h:114:8: error: 'vector' in namespace 'std' does not name a template type
  114 |   std::vector<Frame> m_stack;
```

It was introduced by the `m_nextToDraw` removal (#1445, merged as `a25740c`)
that added this file; other CI jobs (different GCC/Clang versions, different
translation-unit compile order) happened to pull `<vector>` in transitively
before this header, masking the missing include.

Fix: add the missing `#include <vector>`. Verified with a clean from-scratch
build (`cmake -S . -B build -G Ninja && ninja -C build`) that the previously
failing translation unit (`src/ArtProvider.cpp`, the first to include
`CellIterators.h` via `Cell.h`) now compiles, and that the full build
succeeds.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_