### PR TITLE
Render an integral's differential upright in LaTeX export (closes #972)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -460,6 +460,31 @@ tried without rebuilding.
 - **`Cell` Bitfields Use C++20 Default Member Initializers, Not `InitBitFields_ClassName()`:** Every per-class flag bit-field (`Cell`, `EditorCell`, `GroupCell`, `TextCell`, `MatrCell`, and the rest of `src/cells/`) declares its default inline, e.g. `bool m_foo : 1 = false;`. The older pattern -- an `InitBitFields_ClassName()` method called from the constructor body, with each field tagged `/* InitBitFields_ClassName */` -- predated C++20 support for bit-field default member initializers and has been fully removed (2026-08); don't reintroduce it for new flags. Classes with zero bit-fields of their own no longer carry an empty stub either. Before folding an existing full-size `bool m_foo;` into a class's bitfield, check (1) nothing takes its address (`&m_foo` doesn't work on a bit-field member) and (2) it's only touched from the GUI thread (no cross-thread `bool` atomicity/tearing expectations) -- worksheet cells are not thread-shared, but double-check call sites rather than assuming. **Declaration order matters more than usual here**: C++ initializes members in declaration order, not constructor-init-list order, so a bit-field read by a *later*-declared member's own initializer (e.g. `IntervalCell::m_leftBracketOpensLeft`/`m_rightBracketOpensRight`, read by the `m_openBracket`/`m_closeBracket` initializers) must stay declared *before* those members -- relocating it next to an unrelated bitfield group to save a byte is undefined behavior (reading the bit-field before it's initialized), not just a style choice, caught before it shipped by tracing the actual initialization order rather than trusting the mem-initializer-list order. When a field can't move, bit-fielding it in place still works: two adjacent `: 1` declarations pack into a shared byte regardless of position.
 - **Tab Characters in `EditorCell`:** A `'\t'` is a real, single character in `m_text` (see `EditorCell::NormalizeLineEndings()`, which replaced the old `TabExpand()` that irreversibly rewrote every tab to 1-4 spaces on input/paste/load). It is expanded to the next 4-column tab stop -- one column being the width of a space glyph in the current font -- only where text becomes pixels, via `EditorCell::NextTabStop(startX)`/`MeasureTextWidth(startX, text)`. Tab width is **position-dependent**, the one thing `GetTextExtent()`/`GetTextSize()` cannot compute on their own (unlike every other character), so it can never be cached the way `StyledText::SetWidth()` caches other tokens' widths. `MaximaTokenizer` guarantees a tab is always its own isolated, single-character token (never merged into a space run, mirroring how a newline is already its own token) -- this is *load-bearing*: every `m_styledText`-based site (`Draw()`, `Recalculate()`, `GetLineWidth()`, `SelectPointText()`'s code-cell branch, `StyleTextCode()`) only needs a `text == wxS("\t")` equality check as a result, never substring splitting. Prose/text cells don't go through `MaximaTokenizer` at all, so `EditorCell::StyleTextTexts()` uses its own splitter, `PushTextLine()`, to get the same isolation guarantee for a tab embedded in an otherwise plain line of text. Sites that measure a raw `m_text` substring instead of a single token (`MarkSelection()`, `MixedDirectionOffset()`, `StyleTextTexts()`'s wrap check) go through `MeasureTextWidth()` instead, which splits on `'\t'` internally since a substring can still have one embedded anywhere. Left/Right arrow and Delete need **no special-casing** for tabs -- they already move/delete exactly one `m_text` character, which is now correct automatically. The plain `WXK_BACK` case's old "gobble up to 4 trailing spaces" shim was a workaround for the old space-expanded-tab world and is gone; a real tab deletes in one plain single-character backspace like anything else.
 
+- **`TextCell::ToTeX()`'s `TS_SPECIAL_CONSTANT` branch is a hardcoded
+  allowlist with a silent fall-through, not a general style handler
+  (GH #972):** `<s>` in wxMathML.lisp is used for `%pi`/`%i`/`%e`/`inf`/
+  `minf` and, separately, for the "d" of an integral's "dx"/"d\theta"/...
+  (`wxxml-int`) -- all five constants get an explicit `if/else if`, but
+  "d" didn't, so it fell through to the branch's final `else return text;`
+  as a bare, unstyled character instead of ever reaching the later
+  `\ensuremath{\mathrm{...}}` wrapping code that runs for `TS_VARIABLE`/
+  `TS_GREEK_CONSTANT`/`TS_SPECIAL_CONSTANT` further down the function --
+  that later code is dead for every `TS_SPECIAL_CONSTANT` value, since the
+  early branch always returns first. Fixed by adding an explicit `d` case
+  returning `\mathrm{d}` (no `\ensuremath{}` needed: it's only ever emitted
+  already inside `IntCell::ToTeX()`'s math-mode string, which also already
+  supplies the separating `\, ` ahead of it, so don't duplicate that here).
+  Adding a new special case to this list resurfaced a second, easy-to-miss
+  coupling: `TextCell::ToTeX()`'s own multiplication-dot logic (for e.g. the
+  denominator of `d/dt` or a `dx*dy`-style differential product) identifies
+  "the previous cell was that same 'd'" by comparing
+  `GetPrevious()->ToTeX() == wxS("d")` -- once "d" stopped returning the
+  literal string `"d"`, this comparison went permanently false. Any
+  `TS_SPECIAL_CONSTANT` case whose `ToTeX()` output no longer equals its raw
+  text needs same-file call sites recompared with `ToString()` (returns the
+  untransformed `m_text`) instead of `ToTeX()`, not just the one place a new
+  case is added.
+
 ## Layout & Compatibility
 
 - **Mathematical Cell Padding:** Use `MC_TEXT_PADDING` (in `Configuration.h`) for text-based cells. **Exception:** `DigitCell` does not include padding to ensure visual consistency in broken-up numbers.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Current development version
 
+- Fixed the LaTeX export of an integral's differential ("dx", "d\theta", ...):
+  it now renders upright (`\mathrm{d}`) instead of in math mode's default
+  italic (#972).
 - Fixed a build failure on GCC 11 (Ubuntu 22.04) and Cygwin:
   `src/cells/CellIterators.h` used `std::vector` without including `<vector>`,
   which happened to work only where some other header transitively pulled it

--- a/src/cells/TextCell.cpp
+++ b/src/cells/TextCell.cpp
@@ -847,7 +847,7 @@ wxString TextCell::ToTeX() const {
       // look if there actually is a last element.
       if (GetPrevious()) {
         if (GetPrevious()->GetTextStyle() == TS_SPECIAL_CONSTANT &&
-            GetPrevious()->ToTeX() == wxS("d")) {
+            GetPrevious()->ToString() == wxS("d")) {
           text.Replace(wxS("*"), wxS("\\, "));
           text.Replace(wxS("\u00B7"), wxS("\\, "));
         } else {
@@ -972,6 +972,12 @@ wxString TextCell::ToTeX() const {
       return wxS("i");
     else if (text == wxS("\\% pi"))
       return wxS("\\ensuremath{\\pi} ");
+    else if (text == wxS("d"))
+      // The "d" of an integral's "dx"/"dtheta"/... (the only other user of
+      // this style, see wxxml-int in wxMathML.lisp): must render upright,
+      // not in math mode's default italic (GH #972). IntCell::ToTeX()
+      // already inserts the separating "\, " ahead of this cell.
+      return wxS("\\mathrm{d}");
     else
       return text;
   }

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -441,6 +441,17 @@ if(TARGET wxmTestApp)
     add_test(NAME LayoutInvariants
         COMMAND ${WXM_TEST_LAUNCHER} "$<TARGET_FILE:test_LayoutInvariants>")
 
+    # An integral's "d" (dx/dtheta/...) must render upright in LaTeX export,
+    # not in math mode's default italic (GH #972).
+    add_executable(test_IntegralToTeX
+        test_IntegralToTeX.cpp groupcell_test_stubs.cpp ${WXM_TEST_SETUP}
+        $<TARGET_OBJECTS:wxmTestApp>)
+    target_compile_features(test_IntegralToTeX PUBLIC cxx_std_20)
+    target_link_libraries(test_IntegralToTeX PRIVATE
+        ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${WXM_TESTAPP_EXTRA_LIBS})
+    add_test(NAME IntegralToTeX
+        COMMAND ${WXM_TEST_LAUNCHER} "$<TARGET_FILE:test_IntegralToTeX>")
+
     # Round-trip test for the mechanical scalar settings: guards that
     # ReadConfig() and the settings-write side share one key<->member table
     # (Configuration::ScalarConfigSettings) so a setting can never be written

--- a/test/unit_tests/test_IntegralToTeX.cpp
+++ b/test/unit_tests/test_IntegralToTeX.cpp
@@ -1,0 +1,132 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+//
+//  Copyright (C) 2026 Gunter Königsmann <wxMaxima@physikbuch.de>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+/*! \file
+  Pins the LaTeX export of an integral's "d" (GH #972): the "d" of "dx"/
+  "d\theta"/... must render upright (\mathrm{d}), not in math mode's default
+  italic. wxMathML.lisp's wxxml-int emits this "d" as its own <s> ("special
+  constant") tag -- the same style %e/%i/%pi/inf/minf use -- but unlike
+  those, "d" fell all the way through TextCell::ToTeX()'s early-returning
+  TS_SPECIAL_CONSTANT branch as a bare, unstyled character, since none of
+  that branch's specific cases matched it.
+
+  The math content is two hand-written <in> (IntCell) XML fragments, parsed
+  through the real MathParser exactly like wxMathML.lisp would emit them for
+  the definite and indefinite forms of integrate() -- no live Maxima needed.
+*/
+
+#include <wx/app.h>
+#include <wx/bitmap.h>
+#include <wx/dcmemory.h>
+#include <wx/log.h>
+
+#include "Configuration.h"
+#include "MathParser.h"
+#include "cells/Cell.h"
+
+#define CATCH_CONFIG_RUNNER
+#include <catch2/catch.hpp>
+
+namespace {
+wxBitmap *g_bmp = nullptr;
+wxMemoryDC *g_dc = nullptr;
+Configuration *g_cfg = nullptr;
+
+// integrate(x, x, 0, 1): the definite-integral (5-argument) form wxxml-int
+// emits as <in><mrow>low</mrow><mrow>hi</mrow><mrow>base</mrow>
+// <mrow><s>d</s>var</mrow></in>.
+const char *const definiteIntegralXml =
+  R"(<mth><in><mrow><n>0</n></mrow><mrow><n>1</n></mrow><mrow><mi>x</mi></mrow><mrow><s>d</s><mi>x</mi></mrow></in></mth>)";
+
+// integrate(sin(theta), theta): the indefinite-integral (3-argument) form,
+// <in def="false"><mrow>base</mrow><mrow><s>d</s>var</mrow></in>.
+const char *const indefiniteIntegralXml =
+  R"(<mth><in def="false"><mrow><fnm>sin</fnm><mi>theta</mi></mrow><mrow><s>d</s><mi>theta</mi></mrow></in></mth>)";
+
+// The GH #972 report's own example, byte-for-byte as captured from a live
+// Maxima 5.46.0 + wxMathML.lisp for
+//   'integrate('integrate(r^2*sin(theta)+8,r,0,theta),theta,0,%pi);
+// (quoted so it stays a symbolic nested integral instead of evaluating).
+const char *const reportedExampleXml =
+  R"(<math><in><mrow><mn>0</mn></mrow><mrow><s>%pi</s></mrow><mrow><in><mrow><mn>0</mn></mrow><mrow><g>theta</g></mrow><mrow><msup><mrow><mi lisp="*var-tag*">r</mi></mrow><mn>2</mn></msup><h>*</h><fn lisp="wxxml-function"><fnm lisp="wxxml-function">sin</fnm><mrow><p><mrow><g>theta</g></mrow></p></mrow></fn><mo>+</mo><mn>8</mn></mrow><mrow><s>d</s><mi lisp="*var-tag*">r</mi></mrow></in></mrow><mrow><s>d</s><g>theta</g></mrow></in></math>)";
+} // namespace
+
+SCENARIO("A definite integral's LaTeX export renders \"d\" upright") {
+  MathParser parser(g_cfg);
+  auto output = parser.ParseLine(wxString::FromUTF8(definiteIntegralXml));
+  REQUIRE(output != nullptr);
+  const wxString tex = output->ListToTeX();
+
+  THEN("the differential is \\mathrm{d}, not a bare, italic \"d\"") {
+    REQUIRE(tex.Contains(wxS("\\mathrm{d}")));
+  }
+  THEN("it directly precedes the integration variable") {
+    REQUIRE(tex.Contains(wxS("\\mathrm{d}x")));
+  }
+}
+
+SCENARIO("An indefinite integral's LaTeX export renders \"d\" upright") {
+  MathParser parser(g_cfg);
+  auto output = parser.ParseLine(wxString::FromUTF8(indefiniteIntegralXml));
+  REQUIRE(output != nullptr);
+  const wxString tex = output->ListToTeX();
+
+  THEN("the differential is \\mathrm{d}, not a bare, italic \"d\"") {
+    REQUIRE(tex.Contains(wxS("\\mathrm{d}")));
+  }
+}
+
+SCENARIO("GH #972's own nested double-integral example exports both differentials upright") {
+  MathParser parser(g_cfg);
+  auto output = parser.ParseLine(wxString::FromUTF8(reportedExampleXml));
+  REQUIRE(output != nullptr);
+  const wxString tex = output->ListToTeX();
+
+  THEN("both \"dr\" and \"dtheta\" render upright") {
+    REQUIRE(tex.Contains(wxS("\\mathrm{d}r")));
+    REQUIRE(tex.Contains(wxS("\\mathrm{d}theta")));
+  }
+}
+
+class TestApp : public wxApp {
+public:
+  bool OnInit() override { return true; }
+};
+wxDECLARE_APP(TestApp);
+
+int main(int argc, char **argv) {
+  wxLog::EnableLogging(false);
+  wxApp::SetInstance(new TestApp());
+  wxEntryStart(argc, argv);
+  wxTheApp->CallOnInit();
+
+  g_bmp = new wxBitmap(800, 600);
+  g_dc = new wxMemoryDC();
+  g_dc->SelectObject(*g_bmp);
+  g_cfg = new Configuration(g_dc);
+  g_cfg->SetZoomFactor(1.0);
+  g_cfg->SetCanvasSize(wxSize(800, 600));
+
+  const int result = Catch::Session().run(argc, argv);
+
+  wxEntryCleanup();
+  return result;
+}


### PR DESCRIPTION
wxMathML.lisp's wxxml-int emits the "d" of "dx"/"dtheta"/... with the
same <s> ("special constant") style as %pi/%i/%e/inf/minf, but
TextCell::ToTeX()'s TS_SPECIAL_CONSTANT branch only had explicit cases
for those five -- "d" fell through to a bare, unstyled return and
rendered in math mode's default italic instead of upright.

Also fixes a second, easy-to-miss coupling this change exposed:
TextCell::ToTeX()'s multiplication-dot suppression logic compared
GetPrevious()->ToTeX() against the literal string "d" to detect the
same differential; that comparison silently broke once "d" stopped
returning "d" verbatim. Switched it to ToString() (the untransformed
text), which is what it actually meant to check.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6