### PR TITLE
Correct tutorial_10Minutes root-cause docs and add commandSequenceIntegrity regression test (GH #2196)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,44 +77,87 @@ working without extra checks.
   scratch; both are sandbox/pre-existing, not something a code change here
   broke.
 
-- **`tutorial_10Minutes` intermittent CI failure, root-caused (2026-08):**
-  failed with "Batch mode: Maxima asked a question with no scripted answer
+- **`tutorial_10Minutes` intermittent CI failure -- the workaround below is
+  verified, but the real underlying bug is CONFIRMED and still UNFIXED
+  (2026-08). Do not re-close this as "explained by Maxima-side
+  nondeterminism" -- that theory was directly disproven, see below.**
+  Failed with "Batch mode: Maxima asked a question with no scripted answer
   available" for `Is a positive or negative?`, at a genuinely low rate
   (reproduced locally at roughly 1-in-20 to 1-in-30 with a tight
   parallel-Xvfb repro loop -- not reproducible from a handful of manual
   runs, so don't conclude "can't reproduce" from fewer than ~50 attempts).
-  **This is not app-level nondeterminism** -- confirmed directly by
-  instrumenting the exact failure path (`MaximaResponseReader::ReadPrompt`'s
-  halt branch) to dump `GetDocumentCellPointers().GetWorkingGroup(false)`
-  vs. `Worksheet::GetWorkingGroup(true)`'s resolved cell: they were always
-  the *same*, correct `GroupCell`, with its `m_autoAnswer`/`m_knownAnswers`
-  exactly as authored in the `.wxm` file -- ruling out a stale/wrong
-  "current working group" pointer, the first (and wrong) theory. The
-  `assume(a > 0)$ integrate(1/(x^2+a),x); forget(a > 0)$` cell (the
-  tutorial's own demonstration that `assume()` normally makes the question
-  unnecessary) is genuinely the one asking -- and since it was never meant
-  to need an interactive answer, it had none recorded. `EvaluationQueue`
-  sends each cell's statements one at a time, gated on receiving Maxima's
-  own prompt for the previous one (`ProduceNextCommand()`/`RemoveFirst()`),
-  so the client-side ordering is not in question: Maxima had already fully
-  processed and returned from `assume(a > 0)$` before `integrate(...)` was
-  even sent. So the "sometimes still asks despite the assumption" behavior
-  is on **Maxima's own side** -- plausibly GCL's address-based hash-table
-  iteration order affecting which internal branch `integrate()`'s algorithm
-  explores (never proven by cracking open GCL internals here, but every
-  app-level explanation was directly ruled out first, not assumed away).
-  Adding a plain `wxLogMessage`-based diagnostic to the *hot* path
-  (`Worksheet::WillAutoAnswer()`, called on every question, not just
-  failures) measurably suppressed the race (0 failures in 70 runs, vs. ~10%
-  before) -- a classic instrumentation-perturbs-the-race signature. The fix
-  that actually worked: add the diagnostic dump *only inside the
-  already-failing branch* (zero cost on the hot/success path, since that
-  branch only runs when about to halt anyway) -- this reliably caught it
-  without perturbing timing. Fixed for real by recording an auto-answer
+  The asking cell is `assume(a > 0)$ integrate(1/(x^2+a),x); forget(a > 0)$`
+  (the tutorial's own demonstration that `assume()` normally makes the
+  question unnecessary) -- and since it was never meant to need an
+  interactive answer, it had none recorded, hence the halt.
+  **Two theories were tried and directly disproven, in order, before the
+  real one was confirmed -- both by hard evidence, not by reasoning about
+  the code:**
+  1. *Stale "current working group" pointer.* Instrumenting
+     `Worksheet::WillAutoAnswer()` to dump
+     `GetDocumentCellPointers().GetWorkingGroup(false)` vs.
+     `Worksheet::GetWorkingGroup(true)`'s resolved cell showed they were
+     always the *same*, correct `GroupCell` -- ruled out.
+  2. *Maxima/GCL-internal nondeterminism* (the theory originally written
+     here): that `integrate()`'s own algorithm occasionally doesn't consult
+     the assumption database, e.g. via GCL's address-based hash-table
+     iteration order. This looked plausible because `EvaluationQueue` sends
+     each cell's statements one at a time, gated on receiving Maxima's own
+     prompt for the previous one, so it *seemed* like `assume(a > 0)$` must
+     already have been fully processed before `integrate(...)` was sent.
+     **This was wrong, and directly disproven** by an actual `tcpdump`
+     capture (`tcp portrange 49000-49999` on `lo`, per the debugging
+     technique note under Communication with Maxima) of a live failing run,
+     followed with `tshark -z follow,tcp,ascii,<stream>`: the raw
+     wxMaxima->Maxima wire transcript shows `integrate( 1 / (x^2 + a), x);`
+     sent *immediately* after the previous cell's last command, with
+     **`assume(a > 0)$` never transmitted at all**. Not corrupted, not
+     reordered, not delayed -- entirely absent from the wire. (Credit:
+     this line of investigation started from the user's specific recollection
+     of a past incident where a Lisp runtime's flush-on-no-wait behavior hit
+     an MTU-triggered code path that shuffled packets while keeping their
+     content correct -- a good reason to check the wire directly instead of
+     trusting either "the client surely sent it" or "Maxima is nondeterministic".)
+  **The real bug: `assume(a > 0)$`, the FIRST statement of a multi-statement
+  cell, is being silently dropped somewhere in the client-side command
+  queuing before it ever reaches `Maxima::Write()`.** Confirmed narrowed
+  further: instrumenting `EvaluationQueue::RemoveFirst()` to log whenever
+  `m_commands.front()` contains `"assume("` -- gated on a plain, cheap
+  `wxString::Contains()` check so it fires on essentially none of the many
+  calls per run -- caught a live failure where *that log never fired at
+  all*, meaning `"assume(a > 0)$"` never even transiently became
+  `m_commands.front()`; the drop happens no later than the very first
+  `AddTokens()`/`ProduceNextCommand()` peel for that cell (or possibly
+  even earlier, in what `cell->GetEditable()->ToString(true)` itself
+  returns -- not yet distinguished). **This remains the open question.**
+  A follow-up attempt using a genuinely zero-I/O in-memory ring buffer
+  (plain array writes in `RemoveFirst()`/`AddTokens()`/
+  `ProduceNextCommand()`, dumped only from the one place that's already
+  proven zero-cost -- the halt branch) failed to reproduce across 3
+  consecutive 150-run batches (450 runs, 0 hits), a real deviation from the
+  established ~1-in-20-to-30 baseline -- this is an extraordinarily
+  narrow race, and printf/logging-based approaches (even genuinely cheap
+  ones) may be fundamentally unable to catch it without perturbing it away;
+  a live `gdb` session with conditional breakpoints (no per-hit I/O) is the
+  more promising next tool, following the pattern already used successfully
+  for the *different* `--exit-on-error` timing bugs elsewhere in this file.
+  **The workaround that IS verified and shipped:** recording an auto-answer
   ("p;") for this cell too, mirroring the defensive multi-variant recording
   the *other* "positive or negative?" cell earlier in the same file already
-  has. Verified with 180 back-to-back parallel runs (0 failures) after the
-  fix, vs. the ~1-in-20 to 1-in-30 rate before it.
+  has -- this makes the test resilient to the halt regardless of the
+  underlying cause, verified with 180 back-to-back parallel runs (0
+  failures) vs. the ~1-in-20-to-30 rate before it, but **it papers over the
+  symptom, not the underlying silent-statement-drop bug**, which is a real
+  correctness issue (a side-effecting command a user's worksheet depends on
+  can silently never execute) independent of this specific tutorial file.
+  See GH #2196 for the ongoing follow-up. Also worth flagging: this bug
+  class (a whole statement silently dropped, no error, no visible symptom)
+  would be invisible to nearly every other test in this suite -- it was
+  only caught here because this one specific cell happens to have an
+  observable side effect (whether Maxima needs to ask an interactive
+  question) that differs depending on whether the dropped statement ran.
+  A cell without such a canary would just silently produce a
+  different-but-plausible-looking answer.
 
 ## Architecture & GUI
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # Current development version
 
+- New regression test `commandSequenceIntegrity` (GH #2196): a confirmed
+  but not yet root-caused bug lets the first statement of a multi-statement
+  cell be silently dropped and never sent to Maxima at all during `--batch`
+  evaluation, with no error and no visible symptom unless something later
+  happens to depend on it. This test maximizes the number of independent
+  cell-to-cell transitions (the exact boundary where the drop was observed)
+  in a single run -- 150 small cells, each appending a unique sequential tag
+  to a shared list -- and asserts via a real Maxima `error()` that every
+  statement actually ran, turning a currently invisible class of bug into
+  a reproducible CI failure instead of a silently wrong answer.
 - Test fixtures: `test/automatic_test_files/10MinuteTutorial.wxm`'s
   `assume(a > 0)$ integrate(1/(x^2+a),x); forget(a > 0)$` cell now has a
   recorded auto-answer for the "Is a positive or negative?" question, fixing

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1062,6 +1062,16 @@ add_test(
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/automatic_test_files
     COMMAND wxmaxima --debug --logtostderr --pipe  --batch --exit-on-error 10MinuteTutorial.wxm)
 
+# GH #2196: the first statement of a multi-statement cell can be silently
+# dropped and never sent to Maxima at all. This file maximizes the number of
+# independent cell-to-cell transitions (the boundary where the drop was
+# observed) in a single run and asserts, via a real Maxima error(), that
+# every one of them actually ran -- see the file's own header comment.
+add_test(
+    NAME commandSequenceIntegrity
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/automatic_test_files
+    COMMAND wxmaxima --debug --logtostderr --pipe --batch --exit-on-error commandSequenceIntegrity.wxm)
+
 add_test(
     NAME comment_begin
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/automatic_test_files

--- a/test/automatic_test_files/commandSequenceIntegrity.wxm
+++ b/test/automatic_test_files/commandSequenceIntegrity.wxm
@@ -1,0 +1,784 @@
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 26.07.1-dev ] */
+
+/* [wxMaxima: comment start ]
+Regression test for GH #2196: the first statement of a multi-statement
+cell can be silently dropped during --batch evaluation and never reach
+Maxima at all (confirmed via a live tcpdump capture, not corrupted or
+reordered -- simply never sent). This file maximizes the number of
+independent cell-to-cell transitions (the exact boundary where the drop
+was observed) in a single run: each of the many small cells below has
+exactly two statements appending a unique, sequential tag to a shared
+list. The final cell asserts the list matches the full expected
+sequence -- if any statement (especially a cell's first, the specific
+case seen in GH #2196) is silently dropped, the assertion fails with a
+real Maxima error(), which --exit-on-error turns into a nonzero exit
+code instead of the drop passing by unnoticed.
+   [wxMaxima: comment end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: []$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(1, chk)$
+chk: cons(2, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(3, chk)$
+chk: cons(4, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(5, chk)$
+chk: cons(6, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(7, chk)$
+chk: cons(8, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(9, chk)$
+chk: cons(10, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(11, chk)$
+chk: cons(12, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(13, chk)$
+chk: cons(14, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(15, chk)$
+chk: cons(16, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(17, chk)$
+chk: cons(18, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(19, chk)$
+chk: cons(20, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(21, chk)$
+chk: cons(22, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(23, chk)$
+chk: cons(24, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(25, chk)$
+chk: cons(26, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(27, chk)$
+chk: cons(28, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(29, chk)$
+chk: cons(30, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(31, chk)$
+chk: cons(32, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(33, chk)$
+chk: cons(34, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(35, chk)$
+chk: cons(36, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(37, chk)$
+chk: cons(38, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(39, chk)$
+chk: cons(40, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(41, chk)$
+chk: cons(42, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(43, chk)$
+chk: cons(44, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(45, chk)$
+chk: cons(46, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(47, chk)$
+chk: cons(48, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(49, chk)$
+chk: cons(50, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(51, chk)$
+chk: cons(52, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(53, chk)$
+chk: cons(54, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(55, chk)$
+chk: cons(56, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(57, chk)$
+chk: cons(58, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(59, chk)$
+chk: cons(60, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(61, chk)$
+chk: cons(62, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(63, chk)$
+chk: cons(64, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(65, chk)$
+chk: cons(66, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(67, chk)$
+chk: cons(68, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(69, chk)$
+chk: cons(70, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(71, chk)$
+chk: cons(72, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(73, chk)$
+chk: cons(74, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(75, chk)$
+chk: cons(76, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(77, chk)$
+chk: cons(78, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(79, chk)$
+chk: cons(80, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(81, chk)$
+chk: cons(82, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(83, chk)$
+chk: cons(84, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(85, chk)$
+chk: cons(86, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(87, chk)$
+chk: cons(88, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(89, chk)$
+chk: cons(90, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(91, chk)$
+chk: cons(92, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(93, chk)$
+chk: cons(94, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(95, chk)$
+chk: cons(96, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(97, chk)$
+chk: cons(98, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(99, chk)$
+chk: cons(100, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(101, chk)$
+chk: cons(102, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(103, chk)$
+chk: cons(104, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(105, chk)$
+chk: cons(106, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(107, chk)$
+chk: cons(108, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(109, chk)$
+chk: cons(110, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(111, chk)$
+chk: cons(112, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(113, chk)$
+chk: cons(114, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(115, chk)$
+chk: cons(116, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(117, chk)$
+chk: cons(118, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(119, chk)$
+chk: cons(120, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(121, chk)$
+chk: cons(122, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(123, chk)$
+chk: cons(124, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(125, chk)$
+chk: cons(126, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(127, chk)$
+chk: cons(128, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(129, chk)$
+chk: cons(130, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(131, chk)$
+chk: cons(132, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(133, chk)$
+chk: cons(134, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(135, chk)$
+chk: cons(136, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(137, chk)$
+chk: cons(138, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(139, chk)$
+chk: cons(140, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(141, chk)$
+chk: cons(142, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(143, chk)$
+chk: cons(144, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(145, chk)$
+chk: cons(146, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(147, chk)$
+chk: cons(148, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(149, chk)$
+chk: cons(150, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(151, chk)$
+chk: cons(152, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(153, chk)$
+chk: cons(154, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(155, chk)$
+chk: cons(156, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(157, chk)$
+chk: cons(158, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(159, chk)$
+chk: cons(160, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(161, chk)$
+chk: cons(162, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(163, chk)$
+chk: cons(164, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(165, chk)$
+chk: cons(166, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(167, chk)$
+chk: cons(168, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(169, chk)$
+chk: cons(170, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(171, chk)$
+chk: cons(172, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(173, chk)$
+chk: cons(174, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(175, chk)$
+chk: cons(176, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(177, chk)$
+chk: cons(178, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(179, chk)$
+chk: cons(180, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(181, chk)$
+chk: cons(182, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(183, chk)$
+chk: cons(184, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(185, chk)$
+chk: cons(186, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(187, chk)$
+chk: cons(188, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(189, chk)$
+chk: cons(190, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(191, chk)$
+chk: cons(192, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(193, chk)$
+chk: cons(194, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(195, chk)$
+chk: cons(196, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(197, chk)$
+chk: cons(198, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(199, chk)$
+chk: cons(200, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(201, chk)$
+chk: cons(202, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(203, chk)$
+chk: cons(204, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(205, chk)$
+chk: cons(206, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(207, chk)$
+chk: cons(208, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(209, chk)$
+chk: cons(210, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(211, chk)$
+chk: cons(212, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(213, chk)$
+chk: cons(214, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(215, chk)$
+chk: cons(216, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(217, chk)$
+chk: cons(218, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(219, chk)$
+chk: cons(220, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(221, chk)$
+chk: cons(222, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(223, chk)$
+chk: cons(224, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(225, chk)$
+chk: cons(226, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(227, chk)$
+chk: cons(228, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(229, chk)$
+chk: cons(230, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(231, chk)$
+chk: cons(232, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(233, chk)$
+chk: cons(234, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(235, chk)$
+chk: cons(236, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(237, chk)$
+chk: cons(238, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(239, chk)$
+chk: cons(240, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(241, chk)$
+chk: cons(242, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(243, chk)$
+chk: cons(244, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(245, chk)$
+chk: cons(246, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(247, chk)$
+chk: cons(248, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(249, chk)$
+chk: cons(250, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(251, chk)$
+chk: cons(252, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(253, chk)$
+chk: cons(254, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(255, chk)$
+chk: cons(256, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(257, chk)$
+chk: cons(258, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(259, chk)$
+chk: cons(260, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(261, chk)$
+chk: cons(262, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(263, chk)$
+chk: cons(264, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(265, chk)$
+chk: cons(266, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(267, chk)$
+chk: cons(268, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(269, chk)$
+chk: cons(270, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(271, chk)$
+chk: cons(272, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(273, chk)$
+chk: cons(274, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(275, chk)$
+chk: cons(276, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(277, chk)$
+chk: cons(278, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(279, chk)$
+chk: cons(280, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(281, chk)$
+chk: cons(282, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(283, chk)$
+chk: cons(284, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(285, chk)$
+chk: cons(286, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(287, chk)$
+chk: cons(288, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(289, chk)$
+chk: cons(290, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(291, chk)$
+chk: cons(292, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(293, chk)$
+chk: cons(294, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(295, chk)$
+chk: cons(296, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(297, chk)$
+chk: cons(298, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+chk: cons(299, chk)$
+chk: cons(300, chk)$
+/* [wxMaxima: input   end   ] */
+
+/* [wxMaxima: input   start ] */
+expected: makelist(i, i, 1, 300)$
+actual: reverse(chk)$
+if actual # expected then
+  error("Command sequence integrity check failed (GH #2196): a statement ",
+        "was silently dropped. missing=",
+        setdifference(setify(expected), setify(actual)),
+        " unexpected=", setdifference(setify(actual), setify(expected)),
+        " got_length=", length(actual), " expected_length=", length(expected))
+else print("Command sequence integrity check passed: all", length(expected), "statements ran.")$
+/* [wxMaxima: input   end   ] */
+


### PR DESCRIPTION
Follow-up to #2195, which merged before these two commits were pushed (my mistake — they were pushed to the same branch after the PR had already been merged and closed, so they never made it into `main`). Rebased onto current `main` and re-verified; opening as a fresh PR since #2195 can't be reused.

**Commit 1 — corrects `AGENTS.md`:** the "plausibly GCL's address-based hash-table iteration order" explanation #2195 shipped for the `tutorial_10Minutes` flake is **wrong**, disproven directly with a `tcpdump`/`tshark` capture of a live failing run: `assume(a > 0)$` is never transmitted to Maxima at all in a failing run — not corrupted, not reordered, simply absent from the wire. That's a real, still-open client-side bug, tracked in #2196. The recorded auto-answer from #2195 still stands as a verified workaround for the test's own flakiness; it just isn't a fix for the actual underlying bug, and the docs now say so.

**Commit 2 — adds a regression test** (`commandSequenceIntegrity`) for the underlying bug itself, since it's a real correctness issue independent of this one test file: a side-effecting statement at the start of a multi-statement cell can silently never execute, with no visible symptom unless something downstream happens to behave differently as a result — which is exactly how the `tutorial_10Minutes` flake was found in the first place, by accident, via one specific cell's interactive question. The new test deliberately maximizes independent cell-to-cell transitions (the exact boundary where the drop was observed) in a single run: 150 small cells, each appending a unique sequential tag to a shared list, followed by a real Maxima `error()` asserting the full sequence ran. Verified end-to-end both ways: passes cleanly on an unmodified run (~42s), and correctly fails with a diagnostic (`missing=...`) when a statement is deliberately removed to simulate the drop.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_