### PR TITLE
Recover UI translations wiped by Crowdin's initial project sync

### DIFF
--- a/locales/wxMaxima/ar.po
+++ b/locales/wxMaxima/ar.po
@@ -138,7 +138,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:689
 msgid "&Edit"
-msgstr ""
+msgstr "&تحرير"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "&Eliminate Variable..."
@@ -174,7 +174,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:626
 msgid "&File"
-msgstr ""
+msgstr "&ملف"
 
 #: ../../src/wxMaximaFrame.cpp:1019
 msgid "&Functions"
@@ -186,7 +186,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1968
 msgid "&Help"
-msgstr ""
+msgstr "&مساعدة"
 
 #: ../../src/wxMaximaFrame.cpp:1453
 msgid "&Integrate..."
@@ -206,7 +206,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1763
 msgid "&List"
-msgstr ""
+msgstr "&قائمة"
 
 #: ../../src/wxMaximaFrame.cpp:610
 msgid "&Load Package...\tCtrl+L"
@@ -230,11 +230,12 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1870
 msgid "&Numeric"
-msgstr ""
+msgstr "&عددي"
 
 #: ../../src/wxMaximaFrame.cpp:1785
+#, fuzzy
 msgid "&Numeric Output"
-msgstr ""
+msgstr "&عددي"
 
 #: ../../src/main.cpp:436
 msgid "&Open\tCtrl+O"
@@ -246,7 +247,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "&Plot"
-msgstr ""
+msgstr "&رسم"
 
 #: ../../src/wxMaximaFrame.cpp:622
 msgid "&Print...\tCtrl+P"
@@ -442,7 +443,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1963
 msgid "About"
-msgstr ""
+msgstr "حول"
 
 #: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
 msgid "About wxMaxima"
@@ -989,7 +990,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Cancel"
-msgstr ""
+msgstr "إلغاء"
 
 #: ../../src/wxMaxima.cpp:3292
 msgid "Cannot authenticate Maxima!"
@@ -1656,7 +1657,7 @@ msgstr ""
 #: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
 #: ../../src/Worksheet.cpp:1684
 msgid "Copy"
-msgstr ""
+msgstr "نسخ"
 
 #: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
 #: ../../src/Worksheet.cpp:1514
@@ -1717,8 +1718,9 @@ msgid "Copy as plain text"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7576
+#, fuzzy
 msgid "Copy file"
-msgstr ""
+msgstr "نسخ"
 
 #: ../../src/wxMaximaFrame.cpp:1214
 msgid "Copy file..."
@@ -1878,7 +1880,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
 msgid "Cut"
-msgstr ""
+msgstr "قص"
 
 #: ../../src/wxMaximaFrame.cpp:636
 msgid "Cut\tCtrl+X"
@@ -2441,7 +2443,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
 #: ../../src/wxMaxima.cpp:11166
 msgid "Error"
-msgstr ""
+msgstr "خطأ"
 
 #: ../../src/wxMaxima.cpp:2456
 msgid "Error writing to Maxima"
@@ -2450,8 +2452,9 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:6164 ../../src/wxMaxima.cpp:6176
 #: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
 #: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
+#, fuzzy
 msgid "Error!"
-msgstr ""
+msgstr "خطأ"
 
 #: ../../src/Image.cpp:696
 #, c-format
@@ -2609,7 +2612,7 @@ msgstr ""
 
 #: ../../src/main.cpp:438
 msgid "Exit"
-msgstr ""
+msgstr "خروج"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "Exit wxMaxima"
@@ -2915,11 +2918,12 @@ msgstr ""
 
 #: ../../src/main.cpp:439
 msgid "File"
-msgstr ""
+msgstr "ملف"
 
 #: ../../src/wxMaximaFrame.cpp:1333
+#, fuzzy
 msgid "File I/O"
-msgstr ""
+msgstr "ملف"
 
 #: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
 #: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
@@ -2959,7 +2963,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:222
 msgid "Find"
-msgstr ""
+msgstr "بحث"
 
 #: ../../src/wxMaximaFrame.cpp:670
 msgid "Find\tCtrl+F"
@@ -3423,7 +3427,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
 msgid "Help"
-msgstr ""
+msgstr "مساعدة"
 
 #: ../../src/ToolBar.cpp:635
 msgid "Help button"
@@ -3649,7 +3653,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:314
 msgid "Insert"
-msgstr ""
+msgstr "إدراج"
 
 #: ../../src/wxMaximaFrame.cpp:905
 msgid "Insert &Section Cell\tCtrl+3"
@@ -3672,8 +3676,9 @@ msgid "Insert Heading6 Cell"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:10854
+#, fuzzy
 msgid "Insert Image"
-msgstr ""
+msgstr "إدراج"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert Image..."
@@ -3756,8 +3761,9 @@ msgid "Insert a page break"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1164
+#, fuzzy
 msgid "Insert char..."
-msgstr ""
+msgstr "إدراج"
 
 #: ../../src/wxMaximaFrame.cpp:912
 msgid "Insert heading5 Cell\tCtrl+6"
@@ -3768,8 +3774,9 @@ msgid "Insert heading6 Cell\tCtrl+7"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:917
+#, fuzzy
 msgid "Insert image"
-msgstr ""
+msgstr "إدراج"
 
 #: ../../src/wxMaximaFrame.cpp:916
 msgid "Insert textbased cell"
@@ -4162,16 +4169,19 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
 #: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
 #: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
+#, fuzzy
 msgid "List"
-msgstr ""
+msgstr "&قائمة"
 
 #: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
+#, fuzzy
 msgid "List #1"
-msgstr ""
+msgstr "&قائمة"
 
 #: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
+#, fuzzy
 msgid "List #2"
-msgstr ""
+msgstr "&قائمة"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "List directory"
@@ -4199,8 +4209,9 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
+#, fuzzy
 msgid "List:"
-msgstr ""
+msgstr "&قائمة"
 
 #: ../../src/wxMaxima.cpp:6200
 msgid "Load Package"
@@ -4698,7 +4709,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:174
 msgid "New"
-msgstr ""
+msgstr "جديد"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "New\tCtrl+N"
@@ -4749,7 +4760,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "No"
-msgstr ""
+msgstr "لا"
 
 #: ../../src/Worksheet.cpp:1972
 msgid "No Array"
@@ -4850,8 +4861,9 @@ msgid "Number:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1786
+#, fuzzy
 msgid "Numeric output"
-msgstr ""
+msgstr "&عددي"
 
 #: ../../src/wxMaxima.cpp:8040
 msgid "Numerical QR decomposition of a matrix"
@@ -4879,7 +4891,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
 msgid "OK"
-msgstr ""
+msgstr "موافق"
 
 #: ../../src/wxMaximaFrame.cpp:122
 #, c-format
@@ -4950,7 +4962,7 @@ msgstr ""
 #: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593
 #: ../../src/wxMaxima.cpp:6074
 msgid "Open"
-msgstr ""
+msgstr "فتح"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "Open a document"
@@ -5024,7 +5036,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:199
 msgid "Options"
-msgstr ""
+msgstr "خيارات"
 
 #: ../../src/wxMaximaFrame.cpp:1225
 msgid "Output C"
@@ -5141,7 +5153,7 @@ msgstr ""
 #: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
 #: ../../src/Worksheet.cpp:1685
 msgid "Paste"
-msgstr ""
+msgstr "لصق"
 
 #: ../../src/wxMaximaFrame.cpp:667
 msgid "Paste\tCtrl+V"
@@ -5172,16 +5184,18 @@ msgid "Plot &Format..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
+#, fuzzy
 msgid "Plot 2D"
-msgstr ""
+msgstr "&رسم"
 
 #: ../../src/Worksheet.cpp:1593
 msgid "Plot 2D..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
+#, fuzzy
 msgid "Plot 3D"
-msgstr ""
+msgstr "&رسم"
 
 #: ../../src/Worksheet.cpp:1595
 msgid "Plot 3D..."
@@ -5275,20 +5289,23 @@ msgid "Precision"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1616
+#, fuzzy
 msgid "Prefer user labels"
-msgstr ""
+msgstr "تفضيلات"
 
 #: ../../src/main.cpp:437
 msgid "Preferences"
-msgstr ""
+msgstr "تفضيلات"
 
 #: ../../src/ToolBar.cpp:626
+#, fuzzy
 msgid "Preferences button"
-msgstr ""
+msgstr "تفضيلات"
 
 #: ../../src/wxMaximaFrame.cpp:685
+#, fuzzy
 msgid "Preferences...\tCtrl+,"
-msgstr ""
+msgstr "تفضيلات"
 
 #: ../../src/wxMaximaFrame.cpp:1733
 msgid "Prepend an element"
@@ -5300,7 +5317,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:184
 msgid "Print"
-msgstr ""
+msgstr "طباعة"
 
 #: ../../src/ToolBar.cpp:620
 msgid "Print button"
@@ -5523,7 +5540,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:192
 msgid "Redo"
-msgstr ""
+msgstr "إعادة"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo\tCtrl+Y"
@@ -5878,15 +5895,16 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
 msgid "Save"
-msgstr ""
+msgstr "حفظ"
 
 #: ../../src/Worksheet.cpp:1294
 msgid "Save Animation..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:5672
+#, fuzzy
 msgid "Save As"
-msgstr ""
+msgstr "حفظ"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save As...\tShift+Ctrl+S"
@@ -5996,33 +6014,38 @@ msgid "Seems like the package with the maxima share files isn't installed."
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
+#, fuzzy
 msgid "Select All"
-msgstr ""
+msgstr "تحديد الكل"
 
 #: ../../src/wxMaximaFrame.cpp:673
+#, fuzzy
 msgid "Select All\tCtrl+A"
-msgstr ""
+msgstr "تحديد الكل"
 
 #: ../../src/ToolBar.cpp:629
+#, fuzzy
 msgid "Select All button"
-msgstr ""
+msgstr "تحديد الكل"
 
 #: ../../src/wxMaxima.cpp:9631
+#, fuzzy
 msgid "Select Subsample"
-msgstr ""
+msgstr "تحديد الكل"
 
 #: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select all"
-msgstr ""
+msgstr "تحديد الكل"
 
 #: ../../src/wxMaxima.cpp:6971
 msgid "Select math display algorithm"
 msgstr ""
 
 #: ../../src/Configuration.cpp:98
+#, fuzzy
 msgid "Selection color"
-msgstr ""
+msgstr "تحديد الكل"
 
 #: ../../src/ToolBar.cpp:252
 msgid "Send all cells to maxima"
@@ -7411,7 +7434,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:191
 msgid "Undo"
-msgstr ""
+msgstr "تراجع"
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo\tCtrl+Z"
@@ -7665,7 +7688,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:836
 msgid "View"
-msgstr ""
+msgstr "عرض"
 
 #: ../../src/Autocomplete.cpp:235
 msgid "Waiting for m_addFiles_backgroundThread to finish"
@@ -7687,11 +7710,12 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
 #: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
 msgid "Warning"
-msgstr ""
+msgstr "تحذير"
 
 #: ../../src/wxMaximaFrame.cpp:1556
+#, fuzzy
 msgid "Warning:"
-msgstr ""
+msgstr "تحذير"
 
 #: ../../src/Dirstructure.cpp:72
 #, c-format
@@ -7932,8 +7956,9 @@ msgid "precision:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7255
+#, fuzzy
 msgid "printf"
-msgstr ""
+msgstr "طباعة"
 
 #: ../../src/wxMaximaFrame.cpp:1108
 msgid "printf..."

--- a/locales/wxMaxima/cs.po
+++ b/locales/wxMaxima/cs.po
@@ -58,9 +58,9 @@ msgid "\"..\" means \"one directory up\"."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:5053
-#, c-format
+#, fuzzy, c-format
 msgid "%i cells in evaluation queue"
-msgstr ""
+msgstr "%i cel·les en la coa d'avaluació"
 
 #: ../../src/Worksheet.cpp:330
 #, c-format
@@ -73,20 +73,21 @@ msgid "%s: Can't interpret line: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1655
+#, fuzzy
 msgid "&Algebraic Mode"
-msgstr ""
+msgstr "&Algebra"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "&Apropos..."
-msgstr ""
+msgstr "&Apropos..."
 
 #: ../../src/wxMaximaFrame.cpp:615
 msgid "&Batch File...\tCtrl+B"
-msgstr ""
+msgstr "Dávkový sou&bor...\tCtrl+B"
 
 #: ../../src/wxMaximaFrame.cpp:1278
 msgid "&Boundary Value Problem..."
-msgstr ""
+msgstr "Okrajová &úloha..."
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "&Bug Report"
@@ -94,207 +95,216 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1505
 msgid "&Calculus"
-msgstr ""
+msgstr "&Analýza"
 
 #: ../../src/wxMaximaFrame.cpp:1601
 msgid "&Canonical Form"
-msgstr ""
+msgstr "&Kanonická forma"
 
 #: ../../src/wxMaximaFrame.cpp:1358
 msgid "&Characteristic Polynomial..."
-msgstr ""
+msgstr "&Charakteristický polynom..."
 
 #: ../../src/wxMaximaFrame.cpp:990
 msgid "&Clear Memory"
-msgstr ""
+msgstr "&Vyčistit paměť"
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "&Combine Factorials"
-msgstr ""
+msgstr "&Sloučit faktoriály"
 
 #: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Complex Simplification"
-msgstr ""
+msgstr "&Komplexní zjednodušení"
 
 #: ../../src/wxMaximaFrame.cpp:1502
 msgid "&Continued Fraction"
-msgstr ""
+msgstr "&Celá část"
 
 #: ../../src/wxMaximaFrame.cpp:638
 msgid "&Copy\tCtrl+C"
-msgstr ""
+msgstr "&Kopírovat\tCtrl+C"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "&Demoivre"
-msgstr ""
+msgstr "&Trigonometrický tvar"
 
 #: ../../src/wxMaximaFrame.cpp:1362
 msgid "&Determinant"
-msgstr ""
+msgstr "&Determinant"
 
 #: ../../src/wxMaximaFrame.cpp:1466
 msgid "&Differentiate..."
-msgstr ""
+msgstr "&Derivovat..."
 
 #: ../../src/wxMaximaFrame.cpp:689
 msgid "&Edit"
-msgstr ""
+msgstr "&Editovat"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "&Eliminate Variable..."
-msgstr ""
+msgstr "&Eliminovat proměnnou..."
 
 #: ../../src/wxMaximaFrame.cpp:1318
 msgid "&Enter Matrix..."
-msgstr ""
+msgstr "Zadání matic&e..."
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "&Example..."
-msgstr ""
+msgstr "&Příklad..."
 
 #: ../../src/wxMaximaFrame.cpp:1524
 msgid "&Expand Expression"
-msgstr ""
+msgstr "&Rozložit výraz"
 
 #: ../../src/wxMaximaFrame.cpp:1597
 msgid "&Expand Trigonometric"
-msgstr ""
+msgstr "Rozložit trigonom&etrický výraz"
 
 #: ../../src/wxMaximaFrame.cpp:1626
 msgid "&Exponentialize"
-msgstr ""
+msgstr "Do &exponenciálního tvaru"
 
 #: ../../src/wxMaximaFrame.cpp:618
 msgid "&Export..."
-msgstr ""
+msgstr "&Export..."
 
 #: ../../src/wxMaximaFrame.cpp:1516
 msgid "&Factor Expression"
-msgstr ""
+msgstr "Na součin"
 
 #: ../../src/wxMaximaFrame.cpp:626
 msgid "&File"
-msgstr ""
+msgstr "&Soubor"
 
 #: ../../src/wxMaximaFrame.cpp:1019
+#, fuzzy
 msgid "&Functions"
-msgstr ""
+msgstr "Funkce:"
 
 #: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Greatest Common Divisor..."
-msgstr ""
+msgstr "&Největší společný dělitel..."
 
 #: ../../src/wxMaximaFrame.cpp:1968
 msgid "&Help"
-msgstr ""
+msgstr "&Nápověda"
 
 #: ../../src/wxMaximaFrame.cpp:1453
 msgid "&Integrate..."
-msgstr ""
+msgstr "&Integrovat..."
 
 #: ../../src/wxMaximaFrame.cpp:964
 msgid "&Interrupt\tCtrl+G"
-msgstr ""
+msgstr "Přeruš&it\tCtrl+G"
 
 #: ../../src/wxMaximaFrame.cpp:1355
 msgid "&Invert Matrix"
-msgstr ""
+msgstr "&Inverzní matice"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "&License"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1763
+#, fuzzy
 msgid "&List"
-msgstr ""
+msgstr "Seznam:"
 
 #: ../../src/wxMaximaFrame.cpp:610
 msgid "&Load Package...\tCtrl+L"
-msgstr ""
+msgstr "&Load Package\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "&Maxima"
-msgstr ""
+msgstr "&Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1882
+#, fuzzy
 msgid "&Maxima help"
-msgstr ""
+msgstr "Zobrazit nápovědu programu Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1660
 msgid "&Modulus Computation..."
-msgstr ""
+msgstr "Výpočet &modulo..."
 
 #: ../../src/main.cpp:435
+#, fuzzy
 msgid "&New\tCtrl+N"
-msgstr ""
+msgstr "&Nový\tCtrl+N"
 
 #: ../../src/wxMaximaFrame.cpp:1870
 msgid "&Numeric"
-msgstr ""
+msgstr "N&umerické výpočty"
 
 #: ../../src/wxMaximaFrame.cpp:1785
+#, fuzzy
 msgid "&Numeric Output"
-msgstr ""
+msgstr "Přepnout &numerický výstup"
 
 #: ../../src/main.cpp:436
+#, fuzzy
 msgid "&Open\tCtrl+O"
-msgstr ""
+msgstr "&Otevřít\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "&Open...\tCtrl+O"
-msgstr ""
+msgstr "&Otevřít\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "&Plot"
-msgstr ""
+msgstr "&Grafy"
 
 #: ../../src/wxMaximaFrame.cpp:622
 msgid "&Print...\tCtrl+P"
-msgstr ""
+msgstr "&Tisk...\tCtrl+P"
 
 #: ../../src/wxMaximaFrame.cpp:1594
 msgid "&Reduce Trigonometric"
-msgstr ""
+msgstr "Zjednodušit t&rigonometrický výraz"
 
 #: ../../src/wxMaximaFrame.cpp:974
+#, fuzzy
 msgid "&Restart Maxima\tCtrl+Alt+R"
-msgstr ""
+msgstr "&Restart programu Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:608
 msgid "&Save\tCtrl+S"
-msgstr ""
+msgstr "&Uložit\tCtrl+S"
 
 #: ../../src/wxMaximaFrame.cpp:1662
 msgid "&Simplify"
-msgstr ""
+msgstr "&Zjednodušit"
 
 #: ../../src/wxMaximaFrame.cpp:1581
 msgid "&Simplify Factorials"
-msgstr ""
+msgstr "Zjednodušit faktoriály"
 
 #: ../../src/wxMaximaFrame.cpp:1591
 msgid "&Simplify Trigonometric"
-msgstr ""
+msgstr "Trigonometrické zjednodušení"
 
 #: ../../src/wxMaximaFrame.cpp:1238
 msgid "&Solve..."
-msgstr ""
+msgstr "&Řešit..."
 
 #: ../../src/wxMaximaFrame.cpp:1035
+#, fuzzy
 msgid "&Time Display"
-msgstr ""
+msgstr "Přepnou&t zobrazení času"
 
 #: ../../src/wxMaximaFrame.cpp:1375
 msgid "&Transpose Matrix"
-msgstr ""
+msgstr "&Transponovat matici"
 
 #: ../../src/wxMaximaFrame.cpp:1605
 msgid "&Trigonometric Simplification"
-msgstr ""
+msgstr "&Trigonometrické zjednodušení"
 
 #: ../../src/wxMaximaFrame.cpp:1021
+#, fuzzy
 msgid "&Variables"
-msgstr ""
+msgstr "Proměnné"
 
 #: ../../src/wxMaxima.cpp:2443
 msgid "(Config tells to suppress the output of long cells)"
@@ -337,22 +347,27 @@ msgid "(f(x),x,y) with singularities+discontinuities"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:2065
+#, fuzzy
 msgid ""
 "... [suppressed additional lines as the output is longer than allowed in the"
 " wxMaxima configuration] "
 msgstr ""
+"...[suprimides línies addicionals degut a què la sortida és més llarga del "
+"què permet la configuració] "
 
 #: ../../src/Worksheet.cpp:6666
 msgid ".wxm clipboard data with unusual header"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8047
+#, fuzzy
 msgid "1×n Matrix b:"
-msgstr ""
+msgstr "Matice:"
 
 #: ../../src/wxMaximaFrame.cpp:1312
+#, fuzzy
 msgid "2D Array to Matrix..."
-msgstr ""
+msgstr "&Použít na matici..."
 
 #: ../../src/wxMaximaFrame.cpp:743
 msgid "2D equations using ASCII Art"
@@ -393,24 +408,27 @@ msgid "A function returning positive numbers"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1965
+#, fuzzy
 msgid "A irrational variable"
-msgstr ""
+msgstr "Substituce"
 
 #: ../../src/Worksheet.cpp:2016
 msgid "A left-associative function"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:2019
+#, fuzzy
 msgid "A linear function"
-msgstr ""
+msgstr "Zrušit funkci"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "A matrix in which each row is a set of variables"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1963
+#, fuzzy
 msgid "A rational variable"
-msgstr ""
+msgstr "Substituce"
 
 #: ../../src/Worksheet.cpp:2018
 msgid "A right-associative function"
@@ -429,12 +447,13 @@ msgid "A text control got the mouse focus"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1442
+#, fuzzy
 msgid "A&pply function to each Matrix element..."
-msgstr ""
+msgstr "Přidat funkci do seznamu"
 
 #: ../../src/wxMaximaFrame.cpp:1291
 msgid "A&t Value..."
-msgstr ""
+msgstr "Hodno&ta v bodě..."
 
 #: ../../src/Configuration.cpp:85
 msgid "ASCII maths"
@@ -442,11 +461,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1963
 msgid "About"
-msgstr ""
+msgstr "O programu"
 
 #: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
 msgid "About wxMaxima"
-msgstr ""
+msgstr "O programu wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7837
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
@@ -462,15 +481,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1371
 msgid "Ad&joint Matrix"
-msgstr ""
+msgstr "Ad&jungovaná matice"
 
 #: ../../src/wxMaximaFrame.cpp:1657
 msgid "Add Algebraic E&quality..."
-msgstr ""
+msgstr "Přidat alg&ebraickou rovnost..."
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add a directory to search path"
-msgstr ""
+msgstr "Přidat adresář k prohledávaným (path)"
 
 #: ../../src/wxMaximaFrame.cpp:1752
 msgid ""
@@ -478,24 +497,26 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8602
+#, fuzzy
 msgid "Add an element to the end of a list"
-msgstr ""
+msgstr "Otevřít dokument"
 
 #: ../../src/wxMaxima.cpp:8597
+#, fuzzy
 msgid "Add an element to the start of a list"
-msgstr ""
+msgstr "Otevřít dokument"
 
 #: ../../src/wxMaxima.cpp:7625
 msgid "Add dir to path:"
-msgstr ""
+msgstr "Přidat adresář do path:"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "Add equality to the rational simplifier"
-msgstr ""
+msgstr "Přidat rovnost k zjednodušovateli racionálních výrazů"
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add to &Path..."
-msgstr ""
+msgstr "Přidat do &path..."
 
 #: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
 #: ../../src/Worksheet.cpp:1704
@@ -531,18 +552,22 @@ msgid ""
 "After clicking on animations created with with_slider_draw() or similar this"
 " slider allows to change the current frame."
 msgstr ""
+"Després de fer clic en animacions generades amb with_slider_draw() o "
+"similars, aquest control lliscant permet canviar el quadre actual."
 
 #: ../../src/wxMaximaFrame.cpp:1028
 msgid "Aliases"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1714
+#, fuzzy
 msgid "All but the 1st n elements"
-msgstr ""
+msgstr "Přidat funkci do seznamu"
 
 #: ../../src/wxMaximaFrame.cpp:1716
+#, fuzzy
 msgid "All but the last n elements"
-msgstr ""
+msgstr "Přidat funkci do seznamu"
 
 #: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
 msgid ""
@@ -553,8 +578,9 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:733
+#, fuzzy
 msgid "All visible sidebars"
-msgstr ""
+msgstr "Původní proměnná:"
 
 #: ../../src/wxMaximaFrame.cpp:1650
 msgid "Allow to substitute operators"
@@ -596,8 +622,9 @@ msgid "Angles"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1775
+#, fuzzy
 msgid "Animation autoplay"
-msgstr ""
+msgstr "Uložit animaci do souboru"
 
 #: ../../src/wxMaximaFrame.cpp:1778
 msgid "Animation framerate..."
@@ -616,28 +643,34 @@ msgid "Append a list"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1736
+#, fuzzy
 msgid "Append a list to an existing list"
-msgstr ""
+msgstr "Najít limitu výrazu"
 
 #: ../../src/wxMaxima.cpp:8607
+#, fuzzy
 msgid "Append a list to another list"
-msgstr ""
+msgstr "Najít limitu výrazu"
 
 #: ../../src/wxMaximaFrame.cpp:1729
+#, fuzzy
 msgid "Append an element"
-msgstr ""
+msgstr "Otevřít dokument"
 
 #: ../../src/wxMaximaFrame.cpp:1734
+#, fuzzy
 msgid "Append an element to the beginning an existing list"
-msgstr ""
+msgstr "Najít limitu výrazu"
 
 #: ../../src/wxMaximaFrame.cpp:1730
+#, fuzzy
 msgid "Append an element to the end of an existing list"
-msgstr ""
+msgstr "Najít limitu výrazu"
 
 #: ../../src/wxMaxima.cpp:8552
+#, fuzzy
 msgid "Apply a function to each list element"
-msgstr ""
+msgstr "Přidat funkci do seznamu"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 #, c-format
@@ -662,15 +695,16 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9474
 msgid "Apropos"
-msgstr ""
+msgstr "Hledání výskytů řetězce"
 
 #: ../../src/wxMaxima.cpp:7317
 msgid "Are the chars equal, if case is ignored?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7312
+#, fuzzy
 msgid "Are the chars equal?"
-msgstr ""
+msgstr "Pole podkapitoly"
 
 #: ../../src/wxMaxima.cpp:7349
 msgid "Are these strings equal if case is ignored?"
@@ -685,12 +719,14 @@ msgid "Arguments:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8189
+#, fuzzy
 msgid "Array"
-msgstr ""
+msgstr "Pole:"
 
 #: ../../src/wxMaximaFrame.cpp:1023
+#, fuzzy
 msgid "Arrays"
-msgstr ""
+msgstr "Pole:"
 
 #: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
 msgid "Ascii code to char"
@@ -757,8 +793,9 @@ msgid "Autosubscript numbers and text following single letters"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:6529
+#, fuzzy
 msgid "Autosubscript this variable"
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #: ../../src/MaximaManual.cpp:536
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -770,7 +807,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6210
 msgid "Batch File"
-msgstr ""
+msgstr "Dávkový soubor"
 
 #: ../../src/wxMaxima.cpp:5318
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -781,8 +818,9 @@ msgid "Bottom end"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7817
+#, fuzzy
 msgid "Boundary value problem"
-msgstr ""
+msgstr "Okrajová &úloha..."
 
 #: ../../src/wxMathml.cpp:101
 msgid ""
@@ -876,23 +914,24 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1948
 msgid "Build &Info"
-msgstr ""
+msgstr "Build &Info"
 
 #: ../../src/wxMaxima.cpp:7275
 msgid "Byte:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1458
+#, fuzzy
 msgid "C&hange Variable in Integrate..."
-msgstr ""
+msgstr "Změnit proměnnou..."
 
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "C&onfigure"
-msgstr ""
+msgstr "Nastavení"
 
 #: ../../src/wxMaximaFrame.cpp:1482
 msgid "Calculate &Product..."
-msgstr ""
+msgstr "Vý&počet součinu..."
 
 #: ../../src/wxMaxima.cpp:8057
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
@@ -906,35 +945,38 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate Su&m..."
-msgstr ""
+msgstr "Výpočet su&my..."
 
 #: ../../src/wxMaximaFrame.cpp:1795
 msgid "Calculate bigfloat value of the last result"
-msgstr ""
+msgstr "Poslední výsledek s přesností bigfloat"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Calculate float value of the last result"
-msgstr ""
+msgstr "Poslední výsledek s přesností float"
 
 #: ../../src/wxMaxima.cpp:9550
+#, fuzzy
 msgid "Calculate mean value"
-msgstr ""
+msgstr "Výpočet modulo:"
 
 #: ../../src/wxMaxima.cpp:9554
+#, fuzzy
 msgid "Calculate median value"
-msgstr ""
+msgstr "Výpočet modulo:"
 
 #: ../../src/wxMaxima.cpp:8871
 msgid "Calculate modulus:"
-msgstr ""
+msgstr "Výpočet modulo:"
 
 #: ../../src/wxMaximaFrame.cpp:1798
+#, fuzzy
 msgid "Calculate numeric value of the last result"
-msgstr ""
+msgstr "Poslední výsledek s přesností float"
 
 #: ../../src/wxMaximaFrame.cpp:1483
 msgid "Calculate products"
-msgstr ""
+msgstr "Výpočet součinu"
 
 #: ../../src/wxMaxima.cpp:9562
 msgid "Calculate standard deviation"
@@ -942,23 +984,25 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate sums"
-msgstr ""
+msgstr "Výpočet sumy"
 
 #: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
 msgid "Calculate the eigenvalues and eigenvectors numerically"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
+#, fuzzy
 msgid "Calculate the eigenvalues of a matrix numerically"
-msgstr ""
+msgstr "Výpočet inverzní matice"
 
 #: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
 msgid "Calculate the root of the sum of squares of matrix entries"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9558
+#, fuzzy
 msgid "Calculate variation"
-msgstr ""
+msgstr "Výpočet součinu"
 
 #: ../../src/wxMaxima.cpp:8949
 msgid "Calculates the fourier coefficients for the expression from -p to p"
@@ -989,11 +1033,14 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Cancel"
-msgstr ""
+msgstr "Zrušit"
 
 #: ../../src/wxMaxima.cpp:3292
+#, fuzzy
 msgid "Cannot authenticate Maxima!"
 msgstr ""
+"\n"
+"Není připojeno k programu Maxima!\n"
 
 #: ../../src/wxMaxima.cpp:2677
 msgid ""
@@ -1026,8 +1073,9 @@ msgid "Cannot set the communication port to %i."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3656 ../../src/wxMaxima.cpp:6359
+#, fuzzy
 msgid "Cannot start gnuplot"
-msgstr ""
+msgstr "Graf zadaný parametricky"
 
 #: ../../src/StatusBar.cpp:216 ../../src/wxMaxima.cpp:2662
 msgid "Cannot start the maxima binary"
@@ -1059,51 +1107,58 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1038
 msgid "Change &2d Display"
-msgstr ""
+msgstr "Změnit &2D výstup"
 
 #: ../../src/wxMaxima.cpp:10146
+#, fuzzy
 msgid "Change Image"
-msgstr ""
+msgstr "Substituce"
 
 #: ../../src/Worksheet.cpp:1324
+#, fuzzy
 msgid "Change Image..."
-msgstr ""
+msgstr "Uložit obrázek..."
 
 #: ../../src/wxMaximaFrame.cpp:1954
+#, fuzzy
 msgid "Change Log"
-msgstr ""
+msgstr "Substituce"
 
 #: ../../src/wxMaxima.cpp:7555
 msgid "Change directory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1202
+#, fuzzy
 msgid "Change directory..."
-msgstr ""
+msgstr "Uložit obrázek..."
 
 #: ../../src/wxMaximaFrame.cpp:1039
 msgid "Change the 2d display algorithm used to display math output"
-msgstr ""
+msgstr "Změnit 2D výstup pro zobrazení výsledků výpočtů."
 
 #: ../../src/wxMaxima.cpp:8885
 msgid "Change variable"
-msgstr ""
+msgstr "Substituce"
 
 #: ../../src/wxMaxima.cpp:8905
+#, fuzzy
 msgid "Change variable and evaluate"
-msgstr ""
+msgstr "Substituce v integrálu nebo sumě"
 
 #: ../../src/wxMaximaFrame.cpp:1459
 msgid "Change variable in integral or sum"
-msgstr ""
+msgstr "Substituce v integrálu nebo sumě"
 
 #: ../../src/wxMaximaFrame.cpp:1463
+#, fuzzy
 msgid "Change variable in integral or sum and evaluate the result"
-msgstr ""
+msgstr "Substituce v integrálu nebo sumě"
 
 #: ../../src/wxMaximaFrame.cpp:1026
+#, fuzzy
 msgid "Changed option variables"
-msgstr ""
+msgstr "Substituce"
 
 #: ../../src/wxMaxima.cpp:10170
 #, c-format
@@ -1119,8 +1174,9 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
 #: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
+#, fuzzy
 msgid "Char #2:"
-msgstr ""
+msgstr "Matice:"
 
 #: ../../src/wxMaximaFrame.cpp:1140
 msgid "Char to Unicode code point..."
@@ -1143,8 +1199,9 @@ msgid "Character Tests"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8181
+#, fuzzy
 msgid "Characteristic polynom"
-msgstr ""
+msgstr "&Charakteristický polynom..."
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Chars are strings that are one character long"
@@ -1155,8 +1212,11 @@ msgid "Check for Updates"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1958
+#, fuzzy
 msgid "Check if a newer version of wxMaxima is available."
 msgstr ""
+"bylo uloženo v novější verzi programu wxMaxima. Prosím proveďte update "
+"programu."
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Choose the parenthesis type for Matrices"
@@ -1171,56 +1231,68 @@ msgid "Classic matrix operations"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:998
+#, fuzzy
 msgid "Clear all aliases"
-msgstr ""
+msgstr "&Vyčistit paměť"
 
 #: ../../src/wxMaximaFrame.cpp:995
+#, fuzzy
 msgid "Clear all arrays"
-msgstr ""
+msgstr "&Vyčistit paměť"
 
 #: ../../src/wxMaximaFrame.cpp:992
+#, fuzzy
 msgid "Clear all dependencies"
-msgstr ""
+msgstr "&Vyčistit paměť"
 
 #: ../../src/wxMaximaFrame.cpp:994
+#, fuzzy
 msgid "Clear all functions"
-msgstr ""
+msgstr "Zrušit funkci"
 
 #: ../../src/wxMaximaFrame.cpp:1001
+#, fuzzy
 msgid "Clear all gradefs"
-msgstr ""
+msgstr "&Vyčistit paměť"
 
 #: ../../src/wxMaximaFrame.cpp:1000
+#, fuzzy
 msgid "Clear all labels"
-msgstr ""
+msgstr "&Vyčistit paměť"
 
 #: ../../src/wxMaximaFrame.cpp:1004
 msgid "Clear all let rule packages"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1003
+#, fuzzy
 msgid "Clear all macros"
-msgstr ""
+msgstr "&Vyčistit paměť"
 
 #: ../../src/wxMaximaFrame.cpp:1002
+#, fuzzy
 msgid "Clear all props"
-msgstr ""
+msgstr "&Vyčistit paměť"
 
 #: ../../src/wxMaximaFrame.cpp:997
+#, fuzzy
 msgid "Clear all rules"
-msgstr ""
+msgstr "&Vyčistit paměť"
 
 #: ../../src/wxMaximaFrame.cpp:999
+#, fuzzy
 msgid "Clear all structures"
-msgstr ""
+msgstr "&Vyčistit paměť"
 
 #: ../../src/wxMaximaFrame.cpp:993
+#, fuzzy
 msgid "Clear all variables"
-msgstr ""
+msgstr "Zrušit proměnnou"
 
 #: ../../src/wxMaximaFrame.cpp:606
+#, fuzzy
 msgid "Close\tCtrl+W"
-msgstr ""
+msgstr "&Kopírovat\tCtrl+C"
 
 #: ../../src/wxMaxima.cpp:7235
 msgid "Close Stream"
@@ -1231,16 +1303,18 @@ msgid "Close window"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1105
+#, fuzzy
 msgid "Close..."
-msgstr ""
+msgstr "Řešit..."
 
 #: ../../src/WXMXformat.cpp:301
 msgid "Closed the zip archive"
 msgstr ""
 
 #: ../../src/Configuration.cpp:77
+#, fuzzy
 msgid "Code Default (Maxima input)"
-msgstr ""
+msgstr "Vstup programu Maxima"
 
 #: ../../src/Configuration.cpp:103
 msgid "Code highlighting: Comments"
@@ -1275,83 +1349,98 @@ msgid "Code highlighting: Variables"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
+#, fuzzy
 msgid "Code number:"
-msgstr ""
+msgstr "Sloupce:"
 
 #: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
+#, fuzzy
 msgid "Codepoint number:"
-msgstr ""
+msgstr "Sloupce:"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "Col. names:"
-msgstr ""
+msgstr "Jména sloupců:"
 
 #: ../../src/Configuration.cpp:100
 msgid "Color of Outdated cells"
 msgstr ""
 
 #: ../../src/Configuration.cpp:99
+#, fuzzy
 msgid "Color of text equal to selection"
-msgstr ""
+msgstr "Vystřihnout výběr"
 
 #: ../../src/wxMaxima.cpp:7962
+#, fuzzy
 msgid "Column number:"
-msgstr ""
+msgstr "Sloupce:"
 
 #: ../../src/wxMaxima.cpp:7978
+#, fuzzy
 msgid "Column numbers:"
-msgstr ""
+msgstr "Sloupce:"
 
 #: ../../src/wxMaxima.cpp:8202
+#, fuzzy
 msgid "Columns"
-msgstr ""
+msgstr "Sloupce:"
 
 #: ../../src/wxMaximaFrame.cpp:1584
 msgid "Combine factorials in an expression"
-msgstr ""
+msgstr "Sloučit faktoriály ve výrazu"
 
 #: ../../src/wxMaxima.cpp:10454
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7259
+#, fuzzy
 msgid "Comma-separated arguments"
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
+#, fuzzy
 msgid "Comma-separated commands"
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #: ../../src/wxMaxima.cpp:8458
+#, fuzzy
 msgid "Comma-separated elements"
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 #: ../../src/wxMaxima.cpp:10031
+#, fuzzy
 msgid "Comma-separated equations"
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
 #: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
 #: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
+#, fuzzy
 msgid "Comma-separated expressions"
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #: ../../src/wxMaxima.cpp:7215
+#, fuzzy
 msgid "Comma-separated expressions that shall be converted to a string"
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
+#, fuzzy
 msgid "Comma-separated expressions."
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
+#, fuzzy
 msgid "Comma-separated function names"
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #: ../../src/wxMaxima.cpp:7086
+#, fuzzy
 msgid "Comma-separated function names."
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
 #: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
@@ -1367,8 +1456,9 @@ msgid "Comma-separated names the parameters will be referenced by later."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
+#, fuzzy
 msgid "Comma-separated numbers from 0 to 255"
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #: ../../src/wxMaxima.cpp:8770
 msgid "Comma-separated numbers of the terms to substitute in"
@@ -1396,15 +1486,16 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1692
 msgid "Comment Selection"
-msgstr ""
+msgstr "Zakomentovat výběr"
 
 #: ../../src/wxMaximaFrame.cpp:681
 msgid "Comment out the currently selected text"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:680
+#, fuzzy
 msgid "Comment selection\tCtrl+/"
-msgstr ""
+msgstr "Zakomentovat výběr"
 
 #: ../../src/Worksheet.cpp:2004
 msgid "Commutative function"
@@ -1415,12 +1506,14 @@ msgid "Compile a QR decomposition using dgeqrf"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7162
+#, fuzzy
 msgid "Compile a function"
-msgstr ""
+msgstr "Zrušit funkci"
 
 #: ../../src/wxMaximaFrame.cpp:1188
+#, fuzzy
 msgid "Compile a regular expression"
-msgstr ""
+msgstr "Zrušit funkci"
 
 #: ../../src/wxMaximaFrame.cpp:1385
 msgid "Compile eigenvalues using dgeev"
@@ -1439,12 +1532,14 @@ msgid "Compile eigenvalues+eigenvectors using zgeev"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1076
+#, fuzzy
 msgid "Compile function..."
-msgstr ""
+msgstr "Zrušit &funkci..."
 
 #: ../../src/wxMaxima.cpp:7511
+#, fuzzy
 msgid "Compile regex"
-msgstr ""
+msgstr "Doplnit slovo"
 
 #: ../../src/wxMathml.cpp:53
 msgid "Compiler-Bug? wxMathml.lisp is shorter than expected!"
@@ -1463,12 +1558,13 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:892
+#, fuzzy
 msgid "Complete Word\tCtrl+Space"
-msgstr ""
+msgstr "Doplnit slovo\tCtrl+K"
 
 #: ../../src/wxMaximaFrame.cpp:893
 msgid "Complete word"
-msgstr ""
+msgstr "Doplnit slovo"
 
 #: ../../src/ToolBar.cpp:230
 msgid "Completely stop maxima and restart it"
@@ -1476,44 +1572,46 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1503
 msgid "Compute continued fraction of a value"
-msgstr ""
+msgstr "Výpočet celé části hodnoty"
 
 #: ../../src/wxMaximaFrame.cpp:1372
 msgid "Compute the adjoint matrix"
-msgstr ""
+msgstr "Výpočet adjungované matice"
 
 #: ../../src/wxMaximaFrame.cpp:1359
 msgid "Compute the characteristic polynomial of a matrix"
-msgstr ""
+msgstr "Výpočet charakteristického polynomu matice"
 
 #: ../../src/wxMaximaFrame.cpp:1363
 msgid "Compute the determinant of a matrix"
-msgstr ""
+msgstr "Výpočet determinantu matice"
 
 #: ../../src/wxMaximaFrame.cpp:1491
 msgid "Compute the greatest common divisor"
-msgstr ""
+msgstr "Výpočet největšího společného dělitele"
 
 #: ../../src/wxMaximaFrame.cpp:1356
 msgid "Compute the inverse of a matrix"
-msgstr ""
+msgstr "Výpočet inverzní matice"
 
 #: ../../src/wxMaximaFrame.cpp:1494
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
+"Výpočet nejmenšího společného násobku (před tím proveďte load(functs))"
 
 #: ../../src/wxMaximaFrame.cpp:1374
+#, fuzzy
 msgid "Compute the rank of a matrix"
-msgstr ""
+msgstr "Výpočet determinantu matice"
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Condition:"
-msgstr ""
+msgstr "Podmínka:"
 
 #: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "Configure wxMaxima"
-msgstr ""
+msgstr "Nastavení programu wxMaxima"
 
 #: ../../src/wxMaxima.cpp:2504
 msgid "Connection attempt, but connection failed."
@@ -1524,16 +1622,19 @@ msgid "Connection to Maxima lost."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7921
+#, fuzzy
 msgid "Construct a fraction"
-msgstr ""
+msgstr "&Celá část"
 
 #: ../../src/wxMaximaFrame.cpp:1305
+#, fuzzy
 msgid "Construct fraction..."
-msgstr ""
+msgstr "&Celá část"
 
 #: ../../src/wxMaxima.cpp:7158
+#, fuzzy
 msgid "Contents:"
-msgstr ""
+msgstr "Konstanty označené řeckými písmeny"
 
 #: ../../src/wxMaximaFrame.cpp:1877
 msgid "Context-sensitive &Help\tCtrl+?"
@@ -1545,27 +1646,32 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1542
 msgid "Contract Logarithms"
-msgstr ""
+msgstr "Sloučit logaritmy"
 
 #: ../../src/wxMaximaFrame.cpp:1161
+#, fuzzy
 msgid "Conversions"
-msgstr ""
+msgstr "Konverze na algeb&raický tvar"
 
 #: ../../src/wxMaximaFrame.cpp:1229
+#, fuzzy
 msgid "Convert"
-msgstr ""
+msgstr "Konverze na algeb&raický tvar"
 
 #: ../../src/wxMaximaFrame.cpp:1230
+#, fuzzy
 msgid "Convert + Write to file"
-msgstr ""
+msgstr "Konverze na faktoriály"
 
 #: ../../src/wxMaximaFrame.cpp:1434
+#, fuzzy
 msgid "Convert Column to list..."
-msgstr ""
+msgstr "Konverze na faktoriály"
 
 #: ../../src/wxMaximaFrame.cpp:1430
+#, fuzzy
 msgid "Convert Row to list..."
-msgstr ""
+msgstr "Konverze na faktoriály"
 
 #: ../../src/wxMaximaFrame.cpp:1044
 msgid "Convert a command to maxima code"
@@ -1577,60 +1683,66 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1574
 msgid "Convert binomials, beta and gamma function to factorials"
-msgstr ""
+msgstr "Převod binomických koeficientů, beta a gama funkcí na faktoriály"
 
 #: ../../src/wxMaximaFrame.cpp:1578
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
+"Převod binomických koeficientů, faktoriálů a beta funkcí na gama funkce"
 
 #: ../../src/wxMaximaFrame.cpp:1613
 msgid "Convert complex expression to polar form"
-msgstr ""
+msgstr "Převod komplexního výrazu na polární tvar"
 
 #: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert complex expression to rect form"
-msgstr ""
+msgstr "Převod komplexního výrazu na standardní tvar"
 
 #: ../../src/wxMaximaFrame.cpp:1622
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
+"Převod exponenciální funkce imaginárního argumentu na trigonometrický tvar"
 
 #: ../../src/wxMaxima.cpp:7411
+#, fuzzy
 msgid "Convert string to lowercase"
-msgstr ""
+msgstr "Konverze na faktoriály"
 
 #: ../../src/wxMaxima.cpp:7543
+#, fuzzy
 msgid "Convert string to matching regex"
-msgstr ""
+msgstr "Konverze na &Gamma funkce"
 
 #: ../../src/wxMaximaFrame.cpp:1543
 msgid "Convert sum of logarithms to logarithm of product"
-msgstr ""
+msgstr "Převod součtu logaritmů na logaritmus součinu"
 
 #: ../../src/wxMaximaFrame.cpp:1573
 msgid "Convert to &Factorials"
-msgstr ""
+msgstr "Konverze na faktoriály"
 
 #: ../../src/wxMaximaFrame.cpp:1577
 msgid "Convert to &Gamma"
-msgstr ""
+msgstr "Konverze na &Gamma funkce"
 
 #: ../../src/wxMaximaFrame.cpp:1612
 msgid "Convert to &Polarform"
-msgstr ""
+msgstr "Převod na &polární tvar"
 
 #: ../../src/wxMaximaFrame.cpp:1609
 msgid "Convert to &Rectform"
-msgstr ""
+msgstr "Konverze na algeb&raický tvar"
 
 #: ../../src/wxMaximaFrame.cpp:1166
+#, fuzzy
 msgid "Convert to downcase..."
-msgstr ""
+msgstr "Konverze na faktoriály"
 
 #: ../../src/wxMaxima.cpp:7016
+#, fuzzy
 msgid "Convert to programming language"
-msgstr ""
+msgstr "Konverze na &Gamma funkce"
 
 #: ../../src/wxMaxima.cpp:7022
 msgid "Convert to programming language file"
@@ -1638,11 +1750,12 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1602
 msgid "Convert trigonometric expression to canonical quasilinear form"
-msgstr ""
+msgstr "Převod trigonometrického výrazu na kanonický kvazilineární tvar"
 
 #: ../../src/wxMaximaFrame.cpp:1627
+#, fuzzy
 msgid "Convert trigonometric functions to exponential form"
-msgstr ""
+msgstr "Převod trigonometrických funkcí do exponenciálního tvaru"
 
 #: ../../src/wxMaximaFrame.cpp:1762
 msgid "Converts a matrix to a list of lists"
@@ -1656,24 +1769,27 @@ msgstr ""
 #: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
 #: ../../src/Worksheet.cpp:1684
 msgid "Copy"
-msgstr ""
+msgstr "Kopírovat"
 
 #: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
 #: ../../src/Worksheet.cpp:1514
+#, fuzzy
 msgid "Copy Animation"
-msgstr ""
+msgstr "Zastavit animaci"
 
 #: ../../src/wxMaximaFrame.cpp:887
 msgid "Copy Previous Input\tCtrl+I"
-msgstr ""
+msgstr "Kopírovat předchozí vstup\tCtrl+I"
 
 #: ../../src/wxMaximaFrame.cpp:890
+#, fuzzy
 msgid "Copy Previous Output\tCtrl+U"
-msgstr ""
+msgstr "Kopírovat předchozí vstup\tCtrl+I"
 
 #: ../../src/wxMaxima.cpp:7992
+#, fuzzy
 msgid "Copy a matrix"
-msgstr ""
+msgstr "Kopírovat jako obrázek"
 
 #: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
 #: ../../src/wxMaximaFrame.cpp:663
@@ -1683,16 +1799,17 @@ msgstr ""
 #: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Copy as Image"
-msgstr ""
+msgstr "Kopírovat jako obrázek"
 
 #: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
 #: ../../src/wxMaximaFrame.cpp:645
 msgid "Copy as LaTeX"
-msgstr ""
+msgstr "Kopírovat jako LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:648
+#, fuzzy
 msgid "Copy as MathML"
-msgstr ""
+msgstr "Kopírovat jako obrázek"
 
 #: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
 msgid "Copy as MathML (e.g. to word processor)"
@@ -1700,29 +1817,34 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
 #: ../../src/wxMaximaFrame.cpp:658
+#, fuzzy
 msgid "Copy as RTF"
-msgstr ""
+msgstr "Kopírovat jako LaTeX"
 
 #: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
 #: ../../src/wxMaximaFrame.cpp:655
+#, fuzzy
 msgid "Copy as SVG"
-msgstr ""
+msgstr "Kopírovat jako LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:640
 msgid "Copy as Text\tCtrl+Shift+C"
-msgstr ""
+msgstr "Kopírovat jako text\tCtrl+Shift+C"
 
 #: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
+#, fuzzy
 msgid "Copy as plain text"
-msgstr ""
+msgstr "Kopírovat jako obrázek"
 
 #: ../../src/wxMaxima.cpp:7576
+#, fuzzy
 msgid "Copy file"
-msgstr ""
+msgstr "Kopírovat"
 
 #: ../../src/wxMaximaFrame.cpp:1214
+#, fuzzy
 msgid "Copy file..."
-msgstr ""
+msgstr "Řešit..."
 
 #: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
 #: ../../src/wxMaximaFrame.cpp:643
@@ -1731,32 +1853,34 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
 msgid "Copy selection"
-msgstr ""
+msgstr "Kopírovat výběr"
 
 #: ../../src/wxMaximaFrame.cpp:664
 msgid "Copy selection from document as an Enhanced Metafile"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:656
+#, fuzzy
 msgid "Copy selection from document as an SVG image"
-msgstr ""
+msgstr "Kopírovat výběr z dokumentu jako obrázek"
 
 #: ../../src/wxMaximaFrame.cpp:653
 msgid "Copy selection from document as an image"
-msgstr ""
+msgstr "Kopírovat výběr z dokumentu jako obrázek"
 
 #: ../../src/wxMaximaFrame.cpp:659
+#, fuzzy
 msgid ""
 "Copy selection from document as rtf that a word processor might understand"
-msgstr ""
+msgstr "Kopírovat výběr z dokumentu jako obrázek"
 
 #: ../../src/wxMaximaFrame.cpp:641
 msgid "Copy selection from document as text"
-msgstr ""
+msgstr "Kopírovat výběr z dokumentu jako text"
 
 #: ../../src/wxMaximaFrame.cpp:646
 msgid "Copy selection from document in LaTeX format"
-msgstr ""
+msgstr "Kopírovat výběr z dokumentu jako kód LaTeXu"
 
 #: ../../src/wxMaximaFrame.cpp:644
 msgid "Copy selection from document in Matlab format"
@@ -1769,12 +1893,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7403
+#, fuzzy
 msgid "Copy string"
-msgstr ""
+msgstr "Kopírovat výběr"
 
 #: ../../src/wxMaximaFrame.cpp:1165
+#, fuzzy
 msgid "Copy string..."
-msgstr ""
+msgstr "Vložte matici..."
 
 #: ../../src/ToolBar.cpp:623
 msgid "Copy, Cut and Paste button"
@@ -1805,20 +1931,23 @@ msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1325
+#, fuzzy
 msgid "Create Matrix"
-msgstr ""
+msgstr "Vytvořit matici"
 
 #: ../../src/wxMaximaFrame.cpp:1688
+#, fuzzy
 msgid "Create a list"
-msgstr ""
+msgstr "Vytvořit seznam"
 
 #: ../../src/wxMaxima.cpp:8487
 msgid "Create a list as a storage for the values of variables"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8463 ../../src/wxMaxima.cpp:8476
+#, fuzzy
 msgid "Create a list from a rule"
-msgstr ""
+msgstr "Vytvořit seznam z výrazů"
 
 #: ../../src/wxMaximaFrame.cpp:1670
 msgid "Create a list from comma-separated elements"
@@ -1826,43 +1955,50 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:888
 msgid "Create a new cell with previous input"
-msgstr ""
+msgstr "Vytvořit vstupní pole s předchozím vstupem"
 
 #: ../../src/wxMaximaFrame.cpp:891
+#, fuzzy
 msgid "Create a new cell with previous output"
-msgstr ""
+msgstr "Vytvořit vstupní pole s předchozím vstupem"
 
 #: ../../src/wxMaximaFrame.cpp:1348
 msgid "Create copy, not clone..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7561
+#, fuzzy
 msgid "Create directory"
-msgstr ""
+msgstr "Vytvořit seznam"
 
 #: ../../src/wxMaximaFrame.cpp:1203
+#, fuzzy
 msgid "Create directory..."
-msgstr ""
+msgstr "Vytvořit seznam"
 
 #: ../../src/wxMaxima.cpp:7419
+#, fuzzy
 msgid "Create empty string"
-msgstr ""
+msgstr "Vytvořit matici"
 
 #: ../../src/wxMaximaFrame.cpp:1168
+#, fuzzy
 msgid "Create empty string..."
-msgstr ""
+msgstr "Vytvořit seznam"
 
 #: ../../src/wxMaximaFrame.cpp:1687
+#, fuzzy
 msgid "Create list"
-msgstr ""
+msgstr "Vytvořit seznam"
 
 #: ../../src/wxMaxima.cpp:8457
 msgid "Create list from comma-separated elements"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1082
+#, fuzzy
 msgid "Create struct..."
-msgstr ""
+msgstr "Vytvořit seznam"
 
 #: ../../src/WXMXformat.cpp:80
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
@@ -1873,28 +2009,29 @@ msgid "Creates an independent matrix with the same contents"
 msgstr ""
 
 #: ../../src/Configuration.cpp:97
+#, fuzzy
 msgid "Cursor color"
-msgstr ""
+msgstr "Kurzor"
 
 #: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
 msgid "Cut"
-msgstr ""
+msgstr "Vyjmout"
 
 #: ../../src/wxMaximaFrame.cpp:636
 msgid "Cut\tCtrl+X"
-msgstr ""
+msgstr "Vyjmout\tCtrl+X"
 
 #: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
 msgid "Cut selection"
-msgstr ""
+msgstr "Vystřihnout výběr"
 
 #: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
 msgid "Data Matrix:"
-msgstr ""
+msgstr "Matice dat:"
 
 #: ../../src/wxMaxima.cpp:9599
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
-msgstr ""
+msgstr "Datový soubor (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wxMaxima.cpp:9529 ../../src/wxMaxima.cpp:9534
 #: ../../src/wxMaxima.cpp:9539 ../../src/wxMaxima.cpp:9543
@@ -1903,7 +2040,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9563 ../../src/wxMaxima.cpp:9577
 #: ../../src/wxMaxima.cpp:9582 ../../src/wxMaxima.cpp:10030
 msgid "Data:"
-msgstr ""
+msgstr "Data:"
 
 #: ../../src/wxMaximaFrame.cpp:1057
 msgid "Debugger trigger"
@@ -1927,8 +2064,9 @@ msgid "Declare facts about %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8800
+#, fuzzy
 msgid "Declare main variable:"
-msgstr ""
+msgstr "Zrušit proměnnou"
 
 #: ../../src/wxMaxima.cpp:7171
 msgid "Declare the type of a function parameter"
@@ -1940,15 +2078,17 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1500 ../../src/wxMaximaFrame.cpp:1536
 msgid "Decompose rational function to partial fractions"
-msgstr ""
+msgstr "Rozložit racionální funkci na parciální zlomky"
 
 #: ../../src/Worksheet.cpp:2010
+#, fuzzy
 msgid "Decreasing function f(x)<x"
-msgstr ""
+msgstr "Zrušit funkci (funkce)"
 
 #: ../../src/wxMaxima.cpp:7134
+#, fuzzy
 msgid "Define a function"
-msgstr ""
+msgstr "Zrušit funkci"
 
 #: ../../src/wxMaxima.cpp:7147
 msgid "Define a macro"
@@ -1963,12 +2103,14 @@ msgid "Define a structure type"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7156
+#, fuzzy
 msgid "Define a variable"
-msgstr ""
+msgstr "Zrušit proměnnou"
 
 #: ../../src/wxMaximaFrame.cpp:1072
+#, fuzzy
 msgid "Define function..."
-msgstr ""
+msgstr "Zrušit &funkci..."
 
 #: ../../src/wxMaximaFrame.cpp:1079
 msgid "Define macro..."
@@ -1983,8 +2125,9 @@ msgid "Define struct..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1080
+#, fuzzy
 msgid "Define variable..."
-msgstr ""
+msgstr "Zrušit proměnnou"
 
 #: ../../src/wxMaximaFrame.cpp:1776
 msgid ""
@@ -1997,23 +2140,23 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:985
 msgid "Delete F&unction..."
-msgstr ""
+msgstr "Zrušit &funkci..."
 
 #: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
 msgid "Delete Selection"
-msgstr ""
+msgstr "Odstranit výběr"
 
 #: ../../src/wxMaximaFrame.cpp:987
 msgid "Delete V&ariable..."
-msgstr ""
+msgstr "Zrušit proměnnou..."
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Delete a function"
-msgstr ""
+msgstr "Zrušit funkci"
 
 #: ../../src/wxMaximaFrame.cpp:988
 msgid "Delete a variable"
-msgstr ""
+msgstr "Zrušit proměnnou"
 
 #: ../../src/wxMaximaFrame.cpp:982
 msgid "Delete all objects with a given name"
@@ -2021,35 +2164,42 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:991
 msgid "Delete all values from memory"
-msgstr ""
+msgstr "Zrušit všechny hodnoty z paměti"
 
 #: ../../src/wxMaxima.cpp:7588
+#, fuzzy
 msgid "Delete file"
-msgstr ""
+msgstr "Zrušit proměnnou"
 
 #: ../../src/wxMaximaFrame.cpp:1216
+#, fuzzy
 msgid "Delete file..."
-msgstr ""
+msgstr "Zrušit proměnnou..."
 
 #: ../../src/wxMaxima.cpp:7683
+#, fuzzy
 msgid "Delete function(s)"
-msgstr ""
+msgstr "Zrušit funkci (funkce)"
 
 #: ../../src/wxMaxima.cpp:7679
+#, fuzzy
 msgid "Delete named object(s)"
-msgstr ""
+msgstr "Zrušit funkci (funkce)"
 
 #: ../../src/wxMaximaFrame.cpp:981
+#, fuzzy
 msgid "Delete named object..."
-msgstr ""
+msgstr "Zrušit &funkci..."
 
 #: ../../src/wxMaxima.cpp:7674
+#, fuzzy
 msgid "Delete variable(s)"
-msgstr ""
+msgstr "Zrušit proměnnou (proměnné):"
 
 #: ../../src/wxMaxima.cpp:7430
+#, fuzzy
 msgid "Delimiter:"
-msgstr ""
+msgstr "Eliminovat"
 
 #: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
 #, c-format
@@ -2062,7 +2212,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8927
 msgid "Denom. deg:"
-msgstr ""
+msgstr "Stupeň jmenovatele:"
 
 #: ../../src/wxMaxima.cpp:7923
 msgid "Denominator:"
@@ -2078,7 +2228,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1497
 msgid "Di&vide Polynomials..."
-msgstr ""
+msgstr "Dělení polynomů..."
 
 #: ../../src/MaximaManual.cpp:517
 msgid "Didn't find the maxima HTML manual."
@@ -2092,35 +2242,38 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
 msgid "Differentiate"
-msgstr ""
+msgstr "Derivovat"
 
 #: ../../src/wxMaximaFrame.cpp:1467
 msgid "Differentiate expression"
-msgstr ""
+msgstr "Derivovat výraz"
 
 #: ../../src/Worksheet.cpp:1590
 msgid "Differentiate..."
-msgstr ""
+msgstr "Derivovat..."
 
 #: ../../src/wxMaxima.cpp:9010
+#, fuzzy
 msgid "Differentiates an expression n times"
-msgstr ""
+msgstr "Derivovat výraz"
 
 #: ../../src/wxMaxima.cpp:10055
+#, fuzzy
 msgid "Differentiates the expression n times"
-msgstr ""
+msgstr "Derivovat výraz"
 
 #: ../../src/wxMaximaFrame.cpp:1212
+#, fuzzy
 msgid "Directory operations"
-msgstr ""
+msgstr "Směr:"
 
 #: ../../src/wxMaximaFrame.cpp:1041
 msgid "Display Te&X Form"
-msgstr ""
+msgstr "Výstup ve formátu Te&X"
 
 #: ../../src/wxMaxima.cpp:6972
 msgid "Display algorithm"
-msgstr ""
+msgstr "Druh výstupu"
 
 #: ../../src/wxMaximaFrame.cpp:751
 msgid "Display an expression as maxima's internal lisp representation"
@@ -2131,8 +2284,9 @@ msgid "Display an expression as wxMaxima's internal XML representation"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:758
+#, fuzzy
 msgid "Display equations"
-msgstr ""
+msgstr "Řešit rovnici/rovnice"
 
 #: ../../src/wxMaxima.cpp:6508
 msgid "Display expression in maxima's internal representation"
@@ -2144,7 +2298,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1042
 msgid "Display last result in TeX form"
-msgstr ""
+msgstr "Poslední výsledek ve formátu TeX"
 
 #: ../../src/ToolBar.cpp:360
 #, c-format
@@ -2152,24 +2306,27 @@ msgid "Display resolution according to wxWidgets: %li x %li ppi"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:802
+#, fuzzy
 msgid "Display string quotation marks"
-msgstr ""
+msgstr "Řešit rovnici/rovnice"
 
 #: ../../src/wxMaximaFrame.cpp:1036
 msgid "Display time used for evaluation"
-msgstr ""
+msgstr "Zobrazit čas potřebný pro výpočet"
 
 #: ../../src/wxMaxima.cpp:9206
+#, fuzzy
 msgid "Displayed Precision"
-msgstr ""
+msgstr "Řešit rovnici/rovnice"
 
 #: ../../src/wxMaximaFrame.cpp:1913
 msgid "Displaying 3d curves"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1462
+#, fuzzy
 msgid "Dito, and evaluate the result..."
-msgstr ""
+msgstr "Vyhodnotit nevyhodnocené funkce"
 
 #: ../../src/wxMaximaFrame.cpp:1445
 msgid "Dito, but affect all clones of the Matrix..."
@@ -2185,15 +2342,16 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
 msgid "Divide Cell"
-msgstr ""
+msgstr "Rozdělit pole"
 
 #: ../../src/wxMaximaFrame.cpp:1498
 msgid "Divide numbers or polynomials"
-msgstr ""
+msgstr "Dělit čísla nebo polynomy"
 
 #: ../../src/wxMaxima.cpp:8578
+#, fuzzy
 msgid "Do for each list element"
-msgstr ""
+msgstr "Přidat funkci do seznamu"
 
 #: ../../src/wxMaxima.cpp:11197
 #, c-format
@@ -2206,35 +2364,44 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:94
 msgid "Document background"
-msgstr ""
+msgstr "Pozadí dokumentu"
 
 #: ../../src/wxMaxima.cpp:4611
+#, fuzzy
 msgid ""
 "Document was saved using a newer version of wxMaxima so it may not load "
 "correctly. Please update your wxMaxima."
 msgstr ""
+"bylo uloženo v novější verzi programu wxMaxima, takže nemůže být korektně "
+"načteno. Prosím proveďte update programu."
 
 #: ../../src/wxMaxima.cpp:4603
+#, fuzzy
 msgid ""
 "Document was saved using a newer version of wxMaxima. Please update your "
 "wxMaxima."
 msgstr ""
+"bylo uloženo v novější verzi programu wxMaxima. Prosím proveďte update "
+"programu."
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "Don't autosubscript after an underscore"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1086
+#, fuzzy
 msgid "Don't evaluate Expression..."
-msgstr ""
+msgstr "Integrovat výraz"
 
 #: ../../src/wxMaxima.cpp:7117
+#, fuzzy
 msgid "Don't evaluate one command"
-msgstr ""
+msgstr "Zobrazit příklad k příkazu:"
 
 #: ../../src/wxMaxima.cpp:7129
+#, fuzzy
 msgid "Don't evaluate one whole expression"
-msgstr ""
+msgstr "Určit reálnou část komplexního výrazu"
 
 #: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
 msgid "Don't mark cells that contain tooltips in yellow"
@@ -2261,36 +2428,40 @@ msgid "Don't use parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8525
+#, fuzzy
 msgid "Drop the first n list elements"
-msgstr ""
+msgstr "Přidat funkci do seznamu"
 
 #: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
+#, fuzzy
 msgid "Drop the last n list elements"
-msgstr ""
+msgstr "Přidat funkci do seznamu"
 
 #: ../../src/wxMaximaFrame.cpp:1306
 msgid "E&quations"
-msgstr ""
+msgstr "&Rovnice"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "E&xit\tCtrl+Q"
-msgstr ""
+msgstr "Ukončit\tCtrl+Q"
 
 #: ../../src/wxMaximaFrame.cpp:1368
 msgid "Eige&nvectors"
-msgstr ""
+msgstr "Vlastní &vektory"
 
 #: ../../src/wxMaximaFrame.cpp:1365
 msgid "Eigen&values"
-msgstr ""
+msgstr "Vlastní &hodnoty"
 
 #: ../../src/wxMaximaFrame.cpp:1387
+#, fuzzy
 msgid "Eigenvalues (complex)"
-msgstr ""
+msgstr "Vlastní &hodnoty"
 
 #: ../../src/wxMaximaFrame.cpp:1384
+#, fuzzy
 msgid "Eigenvalues (real)"
-msgstr ""
+msgstr "Vlastní &hodnoty"
 
 #: ../../src/wxMaximaFrame.cpp:1393
 msgid "Eigenvalues, left+right eigenvectors (complex)"
@@ -2337,20 +2508,22 @@ msgid "Elements:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7847
+#, fuzzy
 msgid "Eliminate a variable"
-msgstr ""
+msgstr "&Eliminovat proměnnou..."
 
 #: ../../src/wxMaximaFrame.cpp:1247
 msgid "Eliminate a variable from a system of equations"
-msgstr ""
+msgstr "Eliminovat proměnnou ze soustavy rovnic"
 
 #: ../../src/wxMaxima.cpp:10651
 msgid "Empty command => re-triggering evaluation"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9225
+#, fuzzy
 msgid "Enable:"
-msgstr ""
+msgstr "Proměnná:"
 
 #: ../../src/MathParser.cpp:99
 #, c-format
@@ -2375,35 +2548,37 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1319
 msgid "Enter a matrix"
-msgstr ""
+msgstr "Zadání matice"
 
 #: ../../src/wxMaxima.cpp:8866
 msgid "Enter an equation for rational simplification:"
-msgstr ""
+msgstr "Zadejte rovnici pro racionální zjednodušení"
 
 #: ../../src/wxMaxima.cpp:8169
 msgid "Enter matrix"
-msgstr ""
+msgstr "Zadejte matici"
 
 #: ../../src/wxMaxima.cpp:9095
 msgid "Enter new animation frame rate [Hz, integer]:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9201
+#, fuzzy
 msgid "Enter new precision for bigfloats:"
-msgstr ""
+msgstr "Zadejte novou přesnost:"
 
 #: ../../src/wxMaxima.cpp:7922
 msgid "Enumerator:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1220
+#, fuzzy
 msgid "Environment variables"
-msgstr ""
+msgstr "Doplňkové parametry:"
 
 #: ../../src/wxMaxima.cpp:9045
 msgid "Epsilon:"
-msgstr ""
+msgstr "Epsilon:"
 
 #: ../../src/wxMaximaFrame.cpp:1124 ../../src/wxMaximaFrame.cpp:1135
 msgid "Equal, ignoring case?..."
@@ -2414,22 +2589,24 @@ msgid "Equal?..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8561
+#, fuzzy
 msgid "Equation"
-msgstr ""
+msgstr "Rovnice:"
 
 #: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
+#, fuzzy
 msgid "Equation(s)"
-msgstr ""
+msgstr "Rovnice:"
 
 #: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
 msgid "Equation(s):"
-msgstr ""
+msgstr "Rovnice:"
 
 #: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
 #: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
 #: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
 msgid "Equation:"
-msgstr ""
+msgstr "Rovnice:"
 
 #: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
 #: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
@@ -2441,7 +2618,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
 #: ../../src/wxMaxima.cpp:11166
 msgid "Error"
-msgstr ""
+msgstr "Chyba"
 
 #: ../../src/wxMaxima.cpp:2456
 msgid "Error writing to Maxima"
@@ -2451,7 +2628,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
 #: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
 msgid "Error!"
-msgstr ""
+msgstr "Chyba!"
 
 #: ../../src/Image.cpp:696
 #, c-format
@@ -2483,37 +2660,44 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1652
+#, fuzzy
 msgid "Evaluate &Noun Forms..."
-msgstr ""
+msgstr "Vyhodnotit nevyhodnocené funkce"
 
 #: ../../src/wxMaximaFrame.cpp:856
+#, fuzzy
 msgid "Evaluate All Cells\tCtrl+Shift+R"
-msgstr ""
+msgstr "Vyhodnotit všechna vstupní pole\tCtrl+R"
 
 #: ../../src/wxMaximaFrame.cpp:851
+#, fuzzy
 msgid "Evaluate All Visible Cells\tCtrl+R"
-msgstr ""
+msgstr "Vyhodnotit všechna vstupní pole\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1395
+#, fuzzy
 msgid "Evaluate Cell"
-msgstr ""
+msgstr "Vyhodnotit vstupní pole"
 
 #: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
 msgid "Evaluate Cell(s)"
-msgstr ""
+msgstr "Vyhodnotit vstupní pole"
 
 #: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
+#, fuzzy
 msgid "Evaluate Cells Above"
-msgstr ""
+msgstr "Vyhodnotit vstupní pole"
 
 #: ../../src/wxMaximaFrame.cpp:866
+#, fuzzy
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
-msgstr ""
+msgstr "Vyhodnotit všechna vstupní pole\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
 #: ../../src/wxMaximaFrame.cpp:876
+#, fuzzy
 msgid "Evaluate Cells Below"
-msgstr ""
+msgstr "Vyhodnotit vstupní pole"
 
 #: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
 #: ../../src/Worksheet.cpp:1890
@@ -2526,8 +2710,9 @@ msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8626
+#, fuzzy
 msgid "Evaluate Nouns"
-msgstr ""
+msgstr "Vyhodnotit nevyhodnocené funkce"
 
 #: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
 msgid "Evaluate Part\tShift+Ctrl+Enter"
@@ -2549,7 +2734,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:845
 msgid "Evaluate active or selected cell(s)"
-msgstr ""
+msgstr "Vyhodnotit aktivní nebo vybraná vstupní pole"
 
 #: ../../src/ToolBar.cpp:251
 msgid "Evaluate all"
@@ -2557,43 +2742,49 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:857
 msgid "Evaluate all cells in the document"
-msgstr ""
+msgstr "Vyhodnotit všechna vstupní pole v dokumentu"
 
 #: ../../src/wxMaximaFrame.cpp:1653
 msgid "Evaluate all noun forms in expression"
-msgstr ""
+msgstr "Vyhodnotit všechny nevyhodnocené funkce ve výrazu"
 
 #: ../../src/wxMaximaFrame.cpp:852
+#, fuzzy
 msgid "Evaluate all visible cells in the document"
-msgstr ""
+msgstr "Vyhodnotit všechna vstupní pole v dokumentu"
 
 #: ../../src/ToolBar.cpp:248
 msgid "Evaluate current cell"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7395
+#, fuzzy
 msgid "Evaluate string"
-msgstr ""
+msgstr "Vyhodnotit nevyhodnocené funkce"
 
 #: ../../src/wxMaximaFrame.cpp:1151
+#, fuzzy
 msgid "Evaluate string..."
-msgstr ""
+msgstr "Vyhodnotit nevyhodnocené funkce"
 
 #: ../../src/ToolBar.cpp:256
 msgid "Evaluate the file from its beginning to the cell above the cursor"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:259
+#, fuzzy
 msgid "Evaluate the file from the cursor to its end"
-msgstr ""
+msgstr "Vyhodnotit všechna vstupní pole v dokumentu"
 
 #: ../../src/ToolBar.cpp:258
+#, fuzzy
 msgid "Evaluate the rest"
-msgstr ""
+msgstr "Vyhodnotit nevyhodnocené funkce"
 
 #: ../../src/ToolBar.cpp:255
+#, fuzzy
 msgid "Evaluate to point"
-msgstr ""
+msgstr "Vyhodnotit nevyhodnocené funkce"
 
 #: ../../src/wxMaxima.cpp:10518
 msgid "Evaluation ended, since evaluation queue is empty."
@@ -2617,31 +2808,34 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1583
 msgid "Expand Expression"
-msgstr ""
+msgstr "Rozložit výraz"
 
 #: ../../src/wxMaximaFrame.cpp:1525
 msgid "Expand an expression"
-msgstr ""
+msgstr "Rozložit výraz"
 
 #: ../../src/wxMaximaFrame.cpp:1531
+#, fuzzy
 msgid "Expand for given variables"
-msgstr ""
+msgstr "Substituce"
 
 #: ../../src/wxMaxima.cpp:8781
 msgid "Expand for variable(s) including denominator:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8716
+#, fuzzy
 msgid "Expand for variable(s):"
-msgstr ""
+msgstr "Nová proměnná:"
 
 #: ../../src/wxMaximaFrame.cpp:1545
+#, fuzzy
 msgid "Expand log in previous expression"
-msgstr ""
+msgstr "Rozložit výraz"
 
 #: ../../src/wxMaximaFrame.cpp:1598
 msgid "Expand trigonometric expression"
-msgstr ""
+msgstr "Rozložit trigonometrický výraz"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Expect numbers harder to be complex"
@@ -2653,27 +2847,32 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6121
 msgid "Export"
-msgstr ""
+msgstr "Export"
 
 #: ../../src/wxMaximaFrame.cpp:1705
+#, fuzzy
 msgid "Export List to csv file..."
-msgstr ""
+msgstr "Export do TeXu byl neúspěšný!"
 
 #: ../../src/wxMaximaFrame.cpp:1706
+#, fuzzy
 msgid "Export a list to a csv file"
-msgstr ""
+msgstr "Načíst Maxima balíček"
 
 #: ../../src/wxMaximaFrame.cpp:1332
+#, fuzzy
 msgid "Export a matrix to a csv file"
-msgstr ""
+msgstr "Načíst Maxima balíček"
 
 #: ../../src/wxMaximaFrame.cpp:619
+#, fuzzy
 msgid "Export document to a HTML or LaTeX file"
-msgstr ""
+msgstr "Export dokumentu do HTML nebo pdfLaTeXu"
 
 #: ../../src/wxMaximaFrame.cpp:579
+#, fuzzy
 msgid "Export failed."
-msgstr ""
+msgstr "Export do TeXu byl neúspěšný!"
 
 #: ../../src/wxMaximaFrame.cpp:567
 msgid "Export successful."
@@ -2681,34 +2880,38 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6187
 msgid "Exporting to HTML failed!"
-msgstr ""
+msgstr "Export do HTML byl neúspěšný!"
 
 #: ../../src/wxMaxima.cpp:6164
 msgid "Exporting to TeX failed!"
-msgstr ""
+msgstr "Export do TeXu byl neúspěšný!"
 
 #: ../../src/wxMaxima.cpp:6175
+#, fuzzy
 msgid "Exporting to maxima batch file failed!"
-msgstr ""
+msgstr "Export do TeXu byl neúspěšný!"
 
 #: ../../src/wxMaximaFrame.cpp:561
+#, fuzzy
 msgid "Exporting..."
-msgstr ""
+msgstr "&Export..."
 
 #: ../../src/wxMaxima.cpp:6510 ../../src/wxMaxima.cpp:6516
 #: ../../src/wxMaxima.cpp:8218 ../../src/wxMaxima.cpp:8633
 #: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
 #: ../../src/wxMaxima.cpp:10065
 msgid "Expression"
-msgstr ""
+msgstr "Výraz"
 
 #: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
+#, fuzzy
 msgid "Expression or a list of comma-separated expressions"
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #: ../../src/wxMaximaFrame.cpp:1088
+#, fuzzy
 msgid "Expression to string..."
-msgstr ""
+msgstr "Výraz"
 
 #: ../../src/wxMaxima.cpp:7113
 msgid "Expression whose output is to be used as maxima's input."
@@ -2716,7 +2919,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7214
 msgid "Expression(s):"
-msgstr ""
+msgstr "Výraz(y):"
 
 #: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
 #: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
@@ -2725,19 +2928,21 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
 #: ../../src/wxMaxima.cpp:10056
 msgid "Expression:"
-msgstr ""
+msgstr "Výraz:"
 
 #: ../../src/wxMaximaFrame.cpp:1423
+#, fuzzy
 msgid "Extract Column..."
-msgstr ""
+msgstr "Vytvořit seznam z výrazů"
 
 #: ../../src/wxMaximaFrame.cpp:1726
 msgid "Extract Elements"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1421
+#, fuzzy
 msgid "Extract Row..."
-msgstr ""
+msgstr "Vytvořit seznam z výrazů"
 
 #: ../../src/wxMaximaFrame.cpp:1424
 msgid "Extract a column from the matrix"
@@ -2748,32 +2953,38 @@ msgid "Extract a column from the matrix and convert it to a list"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7960
+#, fuzzy
 msgid "Extract a matrix column"
-msgstr ""
+msgstr "Zadání matice"
 
 #: ../../src/wxMaxima.cpp:7970
+#, fuzzy
 msgid "Extract a matrix column as a list"
-msgstr ""
+msgstr "Zadání matice"
 
 #: ../../src/wxMaximaFrame.cpp:1313
+#, fuzzy
 msgid "Extract a matrix from a 2-dimensional array"
-msgstr ""
+msgstr "Vytvořit matici z 2D pole"
 
 #: ../../src/wxMaxima.cpp:7955
+#, fuzzy
 msgid "Extract a matrix row"
-msgstr ""
+msgstr "Zadání matice"
 
 #: ../../src/wxMaxima.cpp:7965
+#, fuzzy
 msgid "Extract a matrix row as a list"
-msgstr ""
+msgstr "Zadání matice"
 
 #: ../../src/wxMaximaFrame.cpp:1422
 msgid "Extract a row from the matrix"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1431
+#, fuzzy
 msgid "Extract a row from the matrix and convert it to a list"
-msgstr ""
+msgstr "Vytvořit seznam z výrazů"
 
 #: ../../src/wxMaxima.cpp:8564
 msgid "Extract a variable's value from a list of variable values"
@@ -2784,60 +2995,72 @@ msgid "Extract an actual value for a variable"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1163
+#, fuzzy
 msgid "Extract char..."
-msgstr ""
+msgstr "Vytvořit seznam z výrazů"
 
 #: ../../src/wxMaximaFrame.cpp:1207
+#, fuzzy
 msgid "Extract dir from path..."
-msgstr ""
+msgstr "Vytvořit seznam z výrazů"
 
 #: ../../src/wxMaxima.cpp:7605
+#, fuzzy
 msgid "Extract directory part"
-msgstr ""
+msgstr "Názvy funkcí"
 
 #: ../../src/wxMaxima.cpp:7617
+#, fuzzy
 msgid "Extract file type extension"
-msgstr ""
+msgstr "Vytvořit seznam z výrazů"
 
 #: ../../src/wxMaximaFrame.cpp:1209
 msgid "Extract filename from path..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7611
+#, fuzzy
 msgid "Extract filename part"
-msgstr ""
+msgstr "Vytvořit seznam z výrazů"
 
 #: ../../src/wxMaximaFrame.cpp:1211
 msgid "Extract filetype from path..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8445
+#, fuzzy
 msgid "Extract function arguments"
-msgstr ""
+msgstr "Názvy funkcí"
 
 #: ../../src/wxMaximaFrame.cpp:1727
+#, fuzzy
 msgid "Extract list Elements"
-msgstr ""
+msgstr "Vytvořit seznam z výrazů"
 
 #: ../../src/wxMaxima.cpp:8187
+#, fuzzy
 msgid "Extract matrix from 2D array"
-msgstr ""
+msgstr "Zadání matice"
 
 #: ../../src/wxMaximaFrame.cpp:1686
+#, fuzzy
 msgid "Extract the argument list from a function call"
-msgstr ""
+msgstr "Vytvořit seznam z výrazů"
 
 #: ../../src/wxMaxima.cpp:8538
+#, fuzzy
 msgid "Extract the last n elements from a list"
-msgstr ""
+msgstr "Vytvořit seznam z výrazů"
 
 #: ../../src/wxMaxima.cpp:7376
+#, fuzzy
 msgid "Extract the nth char of a string"
-msgstr ""
+msgstr "Vytvořit seznam z výrazů"
 
 #: ../../src/wxMaxima.cpp:8544
+#, fuzzy
 msgid "Extract the nth list elements"
-msgstr ""
+msgstr "Vytvořit seznam z výrazů"
 
 #: ../../src/wxMaximaFrame.cpp:1724
 msgid "Extract the value for one variable assigned in a list"
@@ -2848,32 +3071,34 @@ msgid "Extract, append or delete rows or columns"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8188
+#, fuzzy
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
-msgstr ""
+msgstr "Vytvořit seznam z výrazů"
 
 #: ../../src/wxMaximaFrame.cpp:1521
 msgid "Factor Complex"
-msgstr ""
+msgstr "Faktorizovat komplexní výraz"
 
 #: ../../src/Worksheet.cpp:1581
 msgid "Factor Expression"
-msgstr ""
+msgstr "Faktorizovat výraz"
 
 #: ../../src/wxMaximaFrame.cpp:1519
+#, fuzzy
 msgid "Factor Expression including subexpressions"
-msgstr ""
+msgstr "Faktorizovat výraz v Gaussových číslech"
 
 #: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
 msgid "Factor an expression"
-msgstr ""
+msgstr "Faktorizovat výraz"
 
 #: ../../src/wxMaximaFrame.cpp:1522
 msgid "Factor an expression in Gaussian numbers"
-msgstr ""
+msgstr "Faktorizovat výraz v Gaussových číslech"
 
 #: ../../src/wxMaximaFrame.cpp:1587
 msgid "Factorials and &Gamma"
-msgstr ""
+msgstr "Faktoriály a &gamma funkce"
 
 #: ../../src/Image.cpp:137
 #, c-format
@@ -2886,8 +3111,9 @@ msgid "Failed to delete gnuplot file %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:2667
+#, fuzzy
 msgid "Failed to start Maxima"
-msgstr ""
+msgstr "Restart programu Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1418
 msgid "Fast fortran routines that perform numerical tasks"
@@ -2899,15 +3125,17 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:2553
 msgid "Fatal error"
-msgstr ""
+msgstr "Závažná chyba"
 
 #: ../../src/wxMaxima.cpp:7191
+#, fuzzy
 msgid "Field contents:"
-msgstr ""
+msgstr "Konstanty označené řeckými písmeny"
 
 #: ../../src/wxMaxima.cpp:7198
+#, fuzzy
 msgid "Field name:"
-msgstr ""
+msgstr "Původní proměnná:"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "Fields:"
@@ -2915,43 +3143,49 @@ msgstr ""
 
 #: ../../src/main.cpp:439
 msgid "File"
-msgstr ""
+msgstr "Soubor"
 
 #: ../../src/wxMaximaFrame.cpp:1333
+#, fuzzy
 msgid "File I/O"
-msgstr ""
+msgstr "Soubor"
 
 #: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
 #: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
 #: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
 #: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
+#, fuzzy
 msgid "File could not be opened"
-msgstr ""
+msgstr "Soubor nenalezen"
 
 #: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
 #: ../../src/wxMaxima.cpp:7251
+#, fuzzy
 msgid "File name:"
-msgstr ""
+msgstr "Původní proměnná:"
 
 #: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
 msgid "File not found"
-msgstr ""
+msgstr "Soubor nenalezen"
 
 #: ../../src/wxMaxima.cpp:5631
+#, fuzzy
 msgid "File opened"
-msgstr ""
+msgstr "Soubor nenalezen"
 
 #: ../../src/wxMaximaFrame.cpp:1217
+#, fuzzy
 msgid "File operations"
-msgstr ""
+msgstr "Soubor nenalezen"
 
 #: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
 msgid "File you tried to open does not exist."
-msgstr ""
+msgstr "Soubor, který se pokoušíte otevřít, neexistuje."
 
 #: ../../src/wxMaximaFrame.cpp:1221
+#, fuzzy
 msgid "File/directory functions"
-msgstr ""
+msgstr "Směr:"
 
 #: ../../src/wxMaxima.cpp:7027
 msgid "Filename or a list of comma-separated file names"
@@ -2959,27 +3193,27 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:222
 msgid "Find"
-msgstr ""
+msgstr "Najdi"
 
 #: ../../src/wxMaximaFrame.cpp:670
 msgid "Find\tCtrl+F"
-msgstr ""
+msgstr "Najdi\tCtrl+F"
 
 #: ../../src/wxMaximaFrame.cpp:1468
 msgid "Find &Limit..."
-msgstr ""
+msgstr "Najít &limitu..."
 
 #: ../../src/wxMaximaFrame.cpp:1470
 msgid "Find Minimum..."
-msgstr ""
+msgstr "Najít minimum..."
 
 #: ../../src/Worksheet.cpp:1576
 msgid "Find Root..."
-msgstr ""
+msgstr "Najít kořen..."
 
 #: ../../src/wxMaximaFrame.cpp:1471
 msgid "Find a (unconstrained) minimum of an expression"
-msgstr ""
+msgstr "Najít minimum výrazu"
 
 #: ../../src/wxMaximaFrame.cpp:1804
 msgid "Find a fraction that represents this float exactly"
@@ -2987,35 +3221,36 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1469
 msgid "Find a limit of an expression"
-msgstr ""
+msgstr "Najít limitu výrazu"
 
 #: ../../src/wxMaximaFrame.cpp:1807
 msgid "Find a nice fraction that is similar to this float"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1283
+#, fuzzy
 msgid "Find a numerical solution for a first degree ODE"
-msgstr ""
+msgstr "Řešit ODR 1. řádu s počáteční podmínkou"
 
 #: ../../src/wxMaximaFrame.cpp:1252
 msgid "Find a root of an equation on an interval"
-msgstr ""
+msgstr "Najít kořen rovnice z intervalu"
 
 #: ../../src/wxMaximaFrame.cpp:1259
 msgid "Find all roots of a polynomial"
-msgstr ""
+msgstr "Najít všechny kořeny polynomu"
 
 #: ../../src/wxMaximaFrame.cpp:1262
 msgid "Find all roots of a polynomial (bfloat)"
-msgstr ""
+msgstr "Najít všechny kořeny polynomu (bfloat)"
 
 #: ../../src/wxMaxima.cpp:6589
 msgid "Find and Replace"
-msgstr ""
+msgstr "Najdi a nahraď"
 
 #: ../../src/ToolBar.cpp:222 ../../src/wxMaximaFrame.cpp:670
 msgid "Find and replace"
-msgstr ""
+msgstr "Najdi a nahraď"
 
 #: ../../src/wxMaxima.cpp:7434
 msgid "Find char in string"
@@ -3031,11 +3266,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1366
 msgid "Find eigenvalues of a matrix"
-msgstr ""
+msgstr "Nаjít vlastní hodnoty matice"
 
 #: ../../src/wxMaximaFrame.cpp:1369
 msgid "Find eigenvectors of a matrix"
-msgstr ""
+msgstr "Nаjít vlastní vektory matice"
 
 #: ../../src/wxMaxima.cpp:7424
 msgid "Find first difference"
@@ -3046,12 +3281,13 @@ msgid "Find first difference..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1256
+#, fuzzy
 msgid "Find fractions that real roots of a polynomial and "
-msgstr ""
+msgstr "Nаjít reálné kořeny polynomu"
 
 #: ../../src/wxMaxima.cpp:9039
 msgid "Find minimum"
-msgstr ""
+msgstr "Najít minimum"
 
 #: ../../src/wxMaximaFrame.cpp:1251
 msgid "Find numerical solution..."
@@ -3062,8 +3298,9 @@ msgid "Find root (solve numerically)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
+#, fuzzy
 msgid "Find the maximum absolute value of a matrix entry"
-msgstr ""
+msgstr "Nаjít vlastní hodnoty matice"
 
 #: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
 msgid "Find the maximum sum of the absolute values of a matrix column"
@@ -3094,8 +3331,9 @@ msgid "Flush..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:922
+#, fuzzy
 msgid "Fold All\tCtrl+Alt+["
-msgstr ""
+msgstr "Vybrat vše\tCtrl+A"
 
 #: ../../src/wxMaximaFrame.cpp:923
 msgid "Fold all sections"
@@ -3182,59 +3420,64 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "From:"
-msgstr ""
+msgstr "Od:"
 
 #: ../../src/wxMaximaFrame.cpp:827
 msgid "Full Screen\tAlt+Enter"
-msgstr ""
+msgstr "Celá obrazovka\tAlt+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:824
 msgid "Full Screen\tF11"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7140
+#, fuzzy
 msgid "Function contents:"
-msgstr ""
+msgstr "Názvy funkcí"
 
 #: ../../src/wxMaxima.cpp:7908
+#, fuzzy
 msgid "Function f(x):"
-msgstr ""
+msgstr "Funkce:"
 
 #: ../../src/wxMaxima.cpp:8572
+#, fuzzy
 msgid "Function name"
-msgstr ""
+msgstr "Názvy funkcí"
 
 #: ../../src/wxMaxima.cpp:7167
+#, fuzzy
 msgid "Function name(s):"
-msgstr ""
+msgstr "Názvy funkcí"
 
 #: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
+#, fuzzy
 msgid "Function name:"
-msgstr ""
+msgstr "Názvy funkcí"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Function:"
-msgstr ""
+msgstr "Funkce:"
 
 #: ../../src/wxMaximaFrame.cpp:1630
 msgid "Functions for complex simplification"
-msgstr ""
+msgstr "Funkce pro zjednodušení komplexních čísel"
 
 #: ../../src/wxMaximaFrame.cpp:1588
 msgid "Functions for simplifying factorials and gamma function"
-msgstr ""
+msgstr "Funkce pro zjednodušení faktoriálů a gamma funkcí"
 
 #: ../../src/wxMaximaFrame.cpp:1606
 msgid "Functions for simplifying trigonometric expressions"
-msgstr ""
+msgstr "Funkce pro zjednodušení trigonometických výrazů"
 
 #: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
 msgid "GCD"
-msgstr ""
+msgstr "Největší společný dělitel"
 
 #: ../../src/wxMaxima.cpp:10186
 msgid "GIF image (*.gif)|*.gif"
-msgstr ""
+msgstr "GIF image (*.gif)|*.gif"
 
 #: ../../src/Worksheet.cpp:103
 msgid ""
@@ -3245,19 +3488,19 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:295
 msgid "General Math"
-msgstr ""
+msgstr "Matematické operace"
 
 #: ../../src/wxMaximaFrame.cpp:699
 msgid "General Math\tAlt+Shift+M"
-msgstr ""
+msgstr "Matematické operace\tAlt+Shift+M"
 
 #: ../../src/wxMaximaFrame.cpp:1316
 msgid "Generate Matrix from Expression..."
-msgstr ""
+msgstr "Generovat matici z výrazu..."
 
 #: ../../src/wxMaximaFrame.cpp:1317
 msgid "Generate a matrix from a lambda expression"
-msgstr ""
+msgstr "Vytvořit matici z lambda výrazu"
 
 #: ../../src/wxMaximaFrame.cpp:1675
 msgid "Generate a new list using a lists' elements"
@@ -3274,8 +3517,9 @@ msgid "Generate list elements using a rule"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8196
+#, fuzzy
 msgid "Generate matrix from a rule"
-msgstr ""
+msgstr "Vytvořit seznam z výrazů"
 
 #: ../../src/wxMaximaFrame.cpp:1094
 msgid "Generate unused symbol name"
@@ -3293,15 +3537,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1619
 msgid "Get &Imaginary Part"
-msgstr ""
+msgstr "Imaginární část"
 
 #: ../../src/wxMaximaFrame.cpp:1485
 msgid "Get Laplace transformation of an expression"
-msgstr ""
+msgstr "Použít Laplaceovu transformaci"
 
 #: ../../src/wxMaximaFrame.cpp:1615
 msgid "Get Real P&art"
-msgstr ""
+msgstr "Reálná část"
 
 #: ../../src/wxMaximaFrame.cpp:1201
 msgid "Get current directory"
@@ -3309,23 +3553,24 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1489
 msgid "Get inverse Laplace transformation of an expression"
-msgstr ""
+msgstr "Použít inverzní Laplaceovu transformaci"
 
 #: ../../src/wxMaxima.cpp:7223
 msgid "Get position in stream"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1102
+#, fuzzy
 msgid "Get position..."
-msgstr ""
+msgstr "Deviace"
 
 #: ../../src/wxMaximaFrame.cpp:1620
 msgid "Get the imaginary part of complex expression"
-msgstr ""
+msgstr "Určit imaginární část komplexního výrazu"
 
 #: ../../src/wxMaximaFrame.cpp:1616
 msgid "Get the real part of complex expression"
-msgstr ""
+msgstr "Určit reálnou část komplexního výrazu"
 
 #: ../../src/wxMaxima.cpp:3609
 #, c-format
@@ -3351,8 +3596,9 @@ msgid "Go to URL"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3989
+#, fuzzy
 msgid "Got a new input prompt!"
-msgstr ""
+msgstr "Vložit nové vstupní pole"
 
 #: ../../src/Worksheet.cpp:6354
 msgid ""
@@ -3365,46 +3611,52 @@ msgid "Gradefs"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1967
+#, fuzzy
 msgid "Greater or less than a value"
-msgstr ""
+msgstr "Pole podkapitoly"
 
 #: ../../src/wxMaximaFrame.cpp:1130
 msgid "Greater, ignoring case?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:260
+#, fuzzy
 msgid "Greek Letters"
-msgstr ""
+msgstr "Konstanty označené řeckými písmeny"
 
 #: ../../src/wxMaximaFrame.cpp:703
+#, fuzzy
 msgid "Greek Letters\tAlt+Shift+G"
-msgstr ""
+msgstr "Matematické operace\tAlt+Shift+M"
 
 #: ../../src/wxMaximaFrame.cpp:1815
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:6123
+#, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file "
 "(*.tex)|*.tex"
-msgstr ""
+msgstr "Soubory HTML (*.html)|*.html|soubory pdfLaTeX (*.tex)|*.tex|All|*"
 
 #: ../../src/wxMaximaFrame.cpp:1341
 msgid "Hadamard (element-by-element) product..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8004
+#, fuzzy
 msgid "Hadamard Product"
-msgstr ""
+msgstr "Součin"
 
 #: ../../src/wxMaxima.cpp:8011
 msgid "Hadamard exponent"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1345
+#, fuzzy
 msgid "Hadamard exponent..."
-msgstr ""
+msgstr "Název matice:"
 
 #: ../../src/MaximaManual.cpp:260
 #, c-format
@@ -3423,7 +3675,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
 msgid "Help"
-msgstr ""
+msgstr "Nápověda"
 
 #: ../../src/ToolBar.cpp:635
 msgid "Help button"
@@ -3435,16 +3687,19 @@ msgid "Help on \"%s\""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:729
+#, fuzzy
 msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr ""
+msgstr "Skrýt vše\tAlt+Shift+-"
 
 #: ../../src/ToolBar.cpp:264
+#, fuzzy
 msgid "Hide Code"
-msgstr ""
+msgstr "Rozdělit pole"
 
 #: ../../src/wxMaximaFrame.cpp:727
+#, fuzzy
 msgid "Hide Code Cells\tAlt+Ctrl+H"
-msgstr ""
+msgstr "Rozdělit pole"
 
 #: ../../src/Worksheet.cpp:1896
 msgid "Hide Heading 5"
@@ -3455,32 +3710,38 @@ msgid "Hide Heading 6"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1855
+#, fuzzy
 msgid "Hide Part"
-msgstr ""
+msgstr "Rozdělit pole"
 
 #: ../../src/Worksheet.cpp:1863
+#, fuzzy
 msgid "Hide Section"
-msgstr ""
+msgstr "Sekce"
 
 #: ../../src/Worksheet.cpp:1874
+#, fuzzy
 msgid "Hide Subsection"
-msgstr ""
+msgstr "Podkapitola"
 
 #: ../../src/Worksheet.cpp:1885
+#, fuzzy
 msgid "Hide Subsubsection"
-msgstr ""
+msgstr "Podkapitola"
 
 #: ../../src/wxMaximaFrame.cpp:730
 msgid "Hide all panes"
-msgstr ""
+msgstr "Skrýt panely nástrojů"
 
 #: ../../src/Worksheet.cpp:1491
+#, fuzzy
 msgid "Hide cell brackets"
-msgstr ""
+msgstr "Suport de cel·la activa"
 
 #: ../../src/Worksheet.cpp:1915
+#, fuzzy
 msgid "Hide contents"
-msgstr ""
+msgstr "Konstanty označené řeckými písmeny"
 
 #: ../../src/Worksheet.cpp:1552
 msgid "Hide multiplication dots"
@@ -3495,20 +3756,22 @@ msgid "Hide yellow tooltip marker for this message type"
 msgstr ""
 
 #: ../../src/Configuration.cpp:82
+#, fuzzy
 msgid "Highlight (box)"
-msgstr ""
+msgstr "Zvýraznění (dpart)"
 
 #: ../../src/wxMaxima.cpp:9528
 msgid "Histogram"
-msgstr ""
+msgstr "Histogram"
 
 #: ../../src/wxMaximaFrame.cpp:232
 msgid "History"
-msgstr ""
+msgstr "History"
 
 #: ../../src/wxMaximaFrame.cpp:709
+#, fuzzy
 msgid "History\tAlt+Shift+I"
-msgstr ""
+msgstr "History\tAlt+Shift+H"
 
 #: ../../src/wxMaximaFrame.cpp:1526
 msgid "Horner's rule"
@@ -3606,12 +3869,13 @@ msgid "Index Step:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
+#, fuzzy
 msgid "Index variable:"
-msgstr ""
+msgstr "Nová proměnná:"
 
 #: ../../src/wxMaximaFrame.cpp:1949
 msgid "Info about Maxima build"
-msgstr ""
+msgstr "Informace o programu Maxima"
 
 #: ../../src/Worksheet.cpp:2046
 msgid "Inform maxima about facts you know for this symbol"
@@ -3624,44 +3888,49 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
+#, fuzzy
 msgid "Initial Condition"
-msgstr ""
+msgstr "Podmínka:"
 
 #: ../../src/wxMaximaFrame.cpp:1270
 msgid "Initial Value Problem (&1)..."
-msgstr ""
+msgstr "Počáteční podmínka (&1) ..."
 
 #: ../../src/wxMaximaFrame.cpp:1274
 msgid "Initial Value Problem (&2)..."
-msgstr ""
+msgstr "Počáteční podmínka (&2) ..."
 
 #: ../../src/wxMaxima.cpp:9044
+#, fuzzy
 msgid "Initial estimates:"
-msgstr ""
+msgstr "Počáteční odhady:"
 
 #: ../../src/wxMaxima.cpp:7840
+#, fuzzy
 msgid "Initial x:"
-msgstr ""
+msgstr "Počáteční odhady:"
 
 #: ../../src/Configuration.cpp:78
 msgid "Input labels"
-msgstr ""
+msgstr "Značka pro vstup"
 
 #: ../../src/wxMaximaFrame.cpp:314
 msgid "Insert"
-msgstr ""
+msgstr "Vložit"
 
 #: ../../src/wxMaximaFrame.cpp:905
+#, fuzzy
 msgid "Insert &Section Cell\tCtrl+3"
-msgstr ""
+msgstr "Vložit pole s kapitolou\tF8"
 
 #: ../../src/wxMaximaFrame.cpp:901
+#, fuzzy
 msgid "Insert &Text Cell\tCtrl+1"
-msgstr ""
+msgstr "Vložit textové pole\tF6"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Insert Cell\tAlt+Shift+C"
-msgstr ""
+msgstr "Vložit pole\tAlt+Shift+C"
 
 #: ../../src/Worksheet.cpp:1669
 msgid "Insert Heading5 Cell"
@@ -3673,51 +3942,61 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10854
 msgid "Insert Image"
-msgstr ""
+msgstr "Vložit obrázek"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert Image..."
-msgstr ""
+msgstr "Vložit obrázek..."
 
 #: ../../src/wxMaximaFrame.cpp:899
+#, fuzzy
 msgid "Insert Input &Cell\tCtrl+0"
-msgstr ""
+msgstr "Vložit vstupní pole\tF5"
 
 #: ../../src/wxMaximaFrame.cpp:919
+#, fuzzy
 msgid "Insert Page Break"
-msgstr ""
+msgstr "Vložit zlom stránky\tF10"
 
 #: ../../src/wxMaximaFrame.cpp:907
+#, fuzzy
 msgid "Insert S&ubsection Cell\tCtrl+4"
-msgstr ""
+msgstr "Vložit pole s podkapitolou\tF8"
 
 #: ../../src/wxMaximaFrame.cpp:910
+#, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
-msgstr ""
+msgstr "Vložit pole s podkapitolou\tF8"
 
 #: ../../src/Worksheet.cpp:1662
+#, fuzzy
 msgid "Insert Section Cell"
-msgstr ""
+msgstr "Vložit pole s kapitolou\tF8"
 
 #: ../../src/Worksheet.cpp:1664
+#, fuzzy
 msgid "Insert Subsection Cell"
-msgstr ""
+msgstr "Vložit pole s podkapitolou\tF8"
 
 #: ../../src/Worksheet.cpp:1667
+#, fuzzy
 msgid "Insert Subsubsection Cell"
-msgstr ""
+msgstr "Vložit pole s podkapitolou\tF8"
 
 #: ../../src/wxMaximaFrame.cpp:903
+#, fuzzy
 msgid "Insert T&itle Cell\tCtrl+2"
-msgstr ""
+msgstr "Vložit pole s nadpisem\tF9"
 
 #: ../../src/Worksheet.cpp:1658
+#, fuzzy
 msgid "Insert Text Cell"
-msgstr ""
+msgstr "Vložit textové pole\tF6"
 
 #: ../../src/Worksheet.cpp:1660
+#, fuzzy
 msgid "Insert Title Cell"
-msgstr ""
+msgstr "Vložit pole s nadpisem\tF9"
 
 #: ../../src/wxMaximaFrame.cpp:913
 msgid "Insert a new heading5 cell"
@@ -3729,35 +4008,37 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:900
 msgid "Insert a new input cell"
-msgstr ""
+msgstr "Vložit nové vstupní pole"
 
 #: ../../src/wxMaximaFrame.cpp:906
 msgid "Insert a new section cell"
-msgstr ""
+msgstr "Vložit pole s novou kapitolou"
 
 #: ../../src/wxMaximaFrame.cpp:908
 msgid "Insert a new subsection cell"
-msgstr ""
+msgstr "Vložit pole s novou podkapitolou"
 
 #: ../../src/wxMaximaFrame.cpp:911
+#, fuzzy
 msgid "Insert a new subsubsection cell"
-msgstr ""
+msgstr "Vložit pole s novou podkapitolou"
 
 #: ../../src/wxMaximaFrame.cpp:902
 msgid "Insert a new text cell"
-msgstr ""
+msgstr "Vložit nové textové pole"
 
 #: ../../src/wxMaximaFrame.cpp:904
 msgid "Insert a new title cell"
-msgstr ""
+msgstr "Vložit pole s novým nadpisem"
 
 #: ../../src/wxMaximaFrame.cpp:920
 msgid "Insert a page break"
-msgstr ""
+msgstr "Vložit zlom stránky"
 
 #: ../../src/wxMaximaFrame.cpp:1164
+#, fuzzy
 msgid "Insert char..."
-msgstr ""
+msgstr "Vložit obrázek..."
 
 #: ../../src/wxMaximaFrame.cpp:912
 msgid "Insert heading5 Cell\tCtrl+6"
@@ -3772,8 +4053,9 @@ msgid "Insert image"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:916
+#, fuzzy
 msgid "Insert textbased cell"
-msgstr ""
+msgstr "Vložit textové pole\tF6"
 
 #: ../../src/wxMaxima.cpp:3566
 msgid "Instructed to prefer gnuplot over wgnuplot"
@@ -3785,43 +4067,47 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
 msgid "Integral/Sum:"
-msgstr ""
+msgstr "Integrál/suma:"
 
 #: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
 msgid "Integrate"
-msgstr ""
+msgstr "Integrovat"
 
 #: ../../src/wxMaxima.cpp:8980
 msgid "Integrate (risch)"
-msgstr ""
+msgstr "Integrovat (Rischův algoritmus)"
 
 #: ../../src/wxMaximaFrame.cpp:1454
 msgid "Integrate expression"
-msgstr ""
+msgstr "Integrovat výraz"
 
 #: ../../src/wxMaximaFrame.cpp:1456
 msgid "Integrate expression with Risch algorithm"
-msgstr ""
+msgstr "Integrovat výraz pomocí Rischova algoritmu"
 
 #: ../../src/wxMaximaFrame.cpp:1869
+#, fuzzy
 msgid "Integrate numerically"
-msgstr ""
+msgstr "Integrovat (Rischův algoritmus)"
 
 #: ../../src/Worksheet.cpp:1588
 msgid "Integrate..."
-msgstr ""
+msgstr "Integrovat..."
 
 #: ../../src/wxMaximaFrame.cpp:1737
+#, fuzzy
 msgid "Interleave"
-msgstr ""
+msgstr "Integrovat"
 
 #: ../../src/wxMaximaFrame.cpp:1738
+#, fuzzy
 msgid "Interleave the values of two lists"
-msgstr ""
+msgstr "Integrovat"
 
 #: ../../src/wxMaxima.cpp:8612
+#, fuzzy
 msgid "Interleave two lists"
-msgstr ""
+msgstr "Integrovat"
 
 #: ../../src/wxMaximaFrame.cpp:1087
 msgid "Interpret like input..."
@@ -3836,16 +4122,17 @@ msgid "Interpret string as maxima code"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1089
+#, fuzzy
 msgid "Interpret string..."
-msgstr ""
+msgstr "Vložte matici..."
 
 #: ../../src/ToolBar.cpp:231
 msgid "Interrupt"
-msgstr ""
+msgstr "Přerušit"
 
 #: ../../src/wxMaximaFrame.cpp:965
 msgid "Interrupt current computation"
-msgstr ""
+msgstr "Přerušit probíhající výpočet"
 
 #: ../../src/ToolBar.cpp:232
 msgid ""
@@ -3872,11 +4159,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9003
 msgid "Inverse Laplace"
-msgstr ""
+msgstr "Inverzní Laplaceova transformace"
 
 #: ../../src/wxMaximaFrame.cpp:1488
 msgid "Inverse Laplace T&ransform..."
-msgstr ""
+msgstr "Inverzní Laplaceova transformace..."
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Invert worksheet brightness"
@@ -3887,8 +4174,9 @@ msgid "Is Char 1 greater than Char2, if case is ignored?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7333
+#, fuzzy
 msgid "Is Char 1 greater than Char2?"
-msgstr ""
+msgstr "Pole podkapitoly"
 
 #: ../../src/wxMaxima.cpp:7327
 msgid "Is Char 1 less than Char2, if case is ignored?"
@@ -3907,12 +4195,14 @@ msgid "Is a char?..."
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1952
+#, fuzzy
 msgid "Is a complex variable"
-msgstr ""
+msgstr "Nová proměnná:"
 
 #: ../../src/wxMaxima.cpp:7292
+#, fuzzy
 msgid "Is a digit?"
-msgstr ""
+msgstr "Druh výstupu"
 
 #: ../../src/wxMaximaFrame.cpp:1118
 msgid "Is a digit?..."
@@ -3927,8 +4217,9 @@ msgid "Is a printable char?"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1949
+#, fuzzy
 msgid "Is a real variable"
-msgstr ""
+msgstr "Substituce"
 
 #: ../../src/wxMaxima.cpp:7300
 msgid "Is a uppercase char?"
@@ -3951,28 +4242,33 @@ msgid "Is an alphanumeric char?"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1991
+#, fuzzy
 msgid "Is an even function"
-msgstr ""
+msgstr "Zrušit funkci"
 
 #: ../../src/Worksheet.cpp:1955
+#, fuzzy
 msgid "Is an imaginary variable"
-msgstr ""
+msgstr "Substituce"
 
 #: ../../src/Worksheet.cpp:1960
+#, fuzzy
 msgid "Is an integer variable"
-msgstr ""
+msgstr "Substituce"
 
 #: ../../src/Worksheet.cpp:1993
+#, fuzzy
 msgid "Is an odd function"
-msgstr ""
+msgstr "Zrušit funkci"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Is equal?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1128
+#, fuzzy
 msgid "Is greater?..."
-msgstr ""
+msgstr "Vytvořit seznam"
 
 #: ../../src/wxMaximaFrame.cpp:1125
 msgid "Is lower?..."
@@ -3983,8 +4279,9 @@ msgid "Is lowercase?..."
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1962
+#, fuzzy
 msgid "Is no integer variable"
-msgstr ""
+msgstr "Substituce"
 
 #: ../../src/wxMaximaFrame.cpp:1119
 msgid "Is printable?..."
@@ -4007,8 +4304,9 @@ msgid "Item"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8581
+#, fuzzy
 msgid "Iterator name:"
-msgstr ""
+msgstr "Název matice:"
 
 #: ../../src/wxMaximaFrame.cpp:1048
 msgid "Jump to first error"
@@ -4020,7 +4318,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8960
 msgid "LCM"
-msgstr ""
+msgstr "Nejmenší společný násobek"
 
 #: ../../src/wxMaximaFrame.cpp:1407
 msgid "L[1] Norm (complex)"
@@ -4039,8 +4337,9 @@ msgid "L[inf] Norm (real)"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1025
+#, fuzzy
 msgid "Labels"
-msgstr ""
+msgstr "Značka pro vstup"
 
 #: ../../src/wxMaxima.cpp:7090
 msgid "Lambda"
@@ -4055,11 +4354,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8997
 msgid "Laplace"
-msgstr ""
+msgstr "Laplaceova transformace"
 
 #: ../../src/wxMaximaFrame.cpp:1484
 msgid "Laplace &Transform..."
-msgstr ""
+msgstr "Laplaceova transformace..."
 
 #: ../../src/wxMaximaFrame.cpp:1718
 msgid "Last"
@@ -4076,8 +4375,9 @@ msgid "Last message from maxima's stdout: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1720
+#, fuzzy
 msgid "Last n"
-msgstr ""
+msgstr "Seznam:"
 
 #: ../../src/wxMaxima.cpp:10400
 msgid "Last non-whitespace is a question mark"
@@ -4094,16 +4394,17 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1493
 msgid "Least Common Multiple..."
-msgstr ""
+msgstr "Nejmenší společný násobek..."
 
 #: ../../src/wxMaxima.cpp:9587
 msgid "Least Squares Fit"
-msgstr ""
+msgstr "Metoda nejmenších čtverců"
 
 #: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
 #: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
+#, fuzzy
 msgid "Left Matrix:"
-msgstr ""
+msgstr "Otevřít matici"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Left end"
@@ -4130,16 +4431,18 @@ msgid "Letrules"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1976
+#, fuzzy
 msgid "Likely to be the main variable"
-msgstr ""
+msgstr "Zrušit proměnnou"
 
 #: ../../src/wxMaxima.cpp:9028
 msgid "Limit"
-msgstr ""
+msgstr "Limita"
 
 #: ../../src/wxMaxima.cpp:7256
+#, fuzzy
 msgid "Lisp format string:"
-msgstr ""
+msgstr "Otázka programu Maxima"
 
 #: ../../src/wxMaxima.cpp:7258
 msgid "Lisp format strings are more powerful than c++ format strings"
@@ -4162,16 +4465,19 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
 #: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
 #: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
+#, fuzzy
 msgid "List"
-msgstr ""
+msgstr "Seznam:"
 
 #: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
+#, fuzzy
 msgid "List #1"
-msgstr ""
+msgstr "Seznam:"
 
 #: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
+#, fuzzy
 msgid "List #2"
-msgstr ""
+msgstr "Seznam:"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "List directory"
@@ -4186,12 +4492,14 @@ msgid "List of char to String"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1150
+#, fuzzy
 msgid "List of chars to string..."
-msgstr ""
+msgstr "Výraz"
 
 #: ../../src/wxMaxima.cpp:7386
+#, fuzzy
 msgid "List of chars:"
-msgstr ""
+msgstr "Značka pro vstup"
 
 #: ../../src/wxMaxima.cpp:8559
 msgid "List with values"
@@ -4200,43 +4508,49 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
 msgid "List:"
-msgstr ""
+msgstr "Seznam:"
 
 #: ../../src/wxMaxima.cpp:6200
 msgid "Load Package"
-msgstr ""
+msgstr "Načíst balíček\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:613
+#, fuzzy
 msgid "Load Recent Package"
-msgstr ""
+msgstr "Načíst balíček\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:616
 msgid "Load a Maxima file using the batch command"
-msgstr ""
+msgstr "Načíst soubor programu Maxima s použitím dávkového příkazu"
 
 #: ../../src/wxMaximaFrame.cpp:611
 msgid "Load a Maxima package file"
-msgstr ""
+msgstr "Načíst Maxima balíček"
 
 #: ../../src/wxMaximaFrame.cpp:1678
+#, fuzzy
 msgid "Load a list from a csv file"
-msgstr ""
+msgstr "Načíst Maxima balíček"
 
 #: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
+#, fuzzy
 msgid "Load a matrix from a csv file"
-msgstr ""
+msgstr "Načíst Maxima balíček"
 
 #: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
+#, fuzzy
 msgid "Load lapack"
-msgstr ""
+msgstr "Načíst balíček\tCtrl+L"
 
 #: ../../src/wxMaxima.cpp:7208
+#, fuzzy
 msgid "Load lisp code"
-msgstr ""
+msgstr "Načíst balíček\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1092
+#, fuzzy
 msgid "Load lisp..."
-msgstr ""
+msgstr "Načíst balíček\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1198
 msgid "Load the file/dir operations (operatingsystem)"
@@ -4251,36 +4565,41 @@ msgid "Load the translation generator (gentran)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8219
+#, fuzzy
 msgid "Loop variable"
-msgstr ""
+msgstr "Nová proměnná:"
 
 #: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
 msgid "Lower bound:"
-msgstr ""
+msgstr "Dolní mez:"
 
 #: ../../src/wxMaximaFrame.cpp:1127
 msgid "Lower, ignoring case?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1448
+#, fuzzy
 msgid "M&atrix"
-msgstr ""
+msgstr "Matice"
 
 #: ../../src/wxMaxima.cpp:7153
+#, fuzzy
 msgid "Macro contents:"
-msgstr ""
+msgstr "Konstanty označené řeckými písmeny"
 
 #: ../../src/wxMaxima.cpp:7148
+#, fuzzy
 msgid "Macro name:"
-msgstr ""
+msgstr "Název matice:"
 
 #: ../../src/wxMaximaFrame.cpp:1024
 msgid "Macros"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:697
+#, fuzzy
 msgid "Main Toolbar\tAlt+Shift+B"
-msgstr ""
+msgstr "Panel nástrojů\tAlt+Shift+T"
 
 #: ../../src/wxMaxima.cpp:7906
 msgid "Make a function value at a specific point known"
@@ -4291,28 +4610,32 @@ msgid "Make an eventual ev() evaluate this"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1070
+#, fuzzy
 msgid "Make function local..."
-msgstr ""
+msgstr "Použít funkci na prvky seznamu"
 
 #: ../../src/wxMaxima.cpp:8207
 msgid "Map"
-msgstr ""
+msgstr "Použít na prvky"
 
 #: ../../src/wxMaxima.cpp:8215
+#, fuzzy
 msgid "Map an expression"
-msgstr ""
+msgstr "Rozložit výraz"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "Map function to a matrix"
-msgstr ""
+msgstr "Použít funkci na prvky matice"
 
 #: ../../src/wxMaximaFrame.cpp:1446
+#, fuzzy
 msgid "Map function to a matrix, affecting all of its clones"
-msgstr ""
+msgstr "Použít funkci na prvky matice"
 
 #: ../../src/Configuration.cpp:109
+#, fuzzy
 msgid "Math Default"
-msgstr ""
+msgstr "Implicitní"
 
 #: ../../src/wxMaximaFrame.cpp:286
 msgid "Mathematical Symbols"
@@ -4332,39 +4655,45 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
 #: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
 msgid "Matrix"
-msgstr ""
+msgstr "Matice"
 
 #: ../../src/wxMaxima.cpp:7986
+#, fuzzy
 msgid "Matrix Exponent"
-msgstr ""
+msgstr "Název matice:"
 
 #: ../../src/wxMaximaFrame.cpp:1339
+#, fuzzy
 msgid "Matrix exponent..."
-msgstr ""
+msgstr "Název matice:"
 
 #: ../../src/wxMaximaFrame.cpp:1329
+#, fuzzy
 msgid "Matrix from csv file"
-msgstr ""
+msgstr "Načíst styl ze souboru"
 
 #: ../../src/wxMaximaFrame.cpp:1323
+#, fuzzy
 msgid "Matrix from csv file..."
-msgstr ""
+msgstr "Načíst styl ze souboru"
 
 #: ../../src/wxMaxima.cpp:8137
 msgid "Matrix map"
-msgstr ""
+msgstr "Použít na matici"
 
 #: ../../src/wxMaxima.cpp:9630
 msgid "Matrix name:"
-msgstr ""
+msgstr "Název matice:"
 
 #: ../../src/wxMaximaFrame.cpp:798
+#, fuzzy
 msgid "Matrix parenthesis"
-msgstr ""
+msgstr "Kontrola závorek v textovém vstupu"
 
 #: ../../src/wxMaximaFrame.cpp:1331
+#, fuzzy
 msgid "Matrix to csv file"
-msgstr ""
+msgstr "Načíst styl ze souboru"
 
 #: ../../src/wxMaximaFrame.cpp:1334
 msgid "Matrix to file or Matrix from file"
@@ -4379,7 +4708,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
 #: ../../src/wxMaxima.cpp:8136
 msgid "Matrix:"
-msgstr ""
+msgstr "Matice:"
 
 #: ../../src/wxMaxima.cpp:8627
 msgid ""
@@ -4395,12 +4724,14 @@ msgid "Maxima architecture: %s"
 msgstr ""
 
 #: ../../src/StatusBar.cpp:252
+#, fuzzy
 msgid "Maxima asks a question"
-msgstr ""
+msgstr "Otázka programu Maxima"
 
 #: ../../src/wxMaxima.cpp:4066
+#, fuzzy
 msgid "Maxima asks a question!"
-msgstr ""
+msgstr "Otázka programu Maxima"
 
 #: ../../src/wxMaxima.cpp:7118
 msgid ""
@@ -4417,16 +4748,19 @@ msgid "Maxima errors"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3289
+#, fuzzy
 msgid "Maxima has authenticated!"
-msgstr ""
+msgstr "Proces Maxima ukončen."
 
 #: ../../src/wxMaxima.cpp:10533
+#, fuzzy
 msgid "Maxima has finished calculating."
-msgstr ""
+msgstr "Maxima počítá"
 
 #: ../../src/wxMaxima.cpp:5832
+#, fuzzy
 msgid "Maxima has issued an error!"
-msgstr ""
+msgstr "Otázka programu Maxima"
 
 #: ../../src/wxMaxima.cpp:3696
 #, c-format
@@ -4438,20 +4772,22 @@ msgid "Maxima has sent a new variable value."
 msgstr ""
 
 #: ../../src/MaximaManual.cpp:552
+#, fuzzy
 msgid "Maxima help file not found!"
-msgstr ""
+msgstr "Soubor nenalezen"
 
 #: ../../src/wxMaximaFrame.cpp:1043
 msgid "Maxima input"
-msgstr ""
+msgstr "Vstup programu Maxima"
 
 #: ../../src/StatusBar.cpp:236
 msgid "Maxima is calculating"
-msgstr ""
+msgstr "Maxima počítá"
 
 #: ../../src/wxMaxima.cpp:5068
+#, fuzzy
 msgid "Maxima is ready for input."
-msgstr ""
+msgstr "Vstup programu Maxima"
 
 #: ../../src/Dirstructure.cpp:144
 #, c-format
@@ -4460,19 +4796,20 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6211
 msgid "Maxima package (*.mac)|*.mac"
-msgstr ""
+msgstr "Maxima balíček (*.mac)|*.mac"
 
 #: ../../src/wxMaxima.cpp:6202
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
-msgstr ""
+msgstr "Maxima balíček (*.mac)|*.mac|Lisp balíček (*.lisp)|*.lisp|Vše|*"
 
 #: ../../src/wxMaxima.cpp:3012
 msgid "Maxima process terminated unexpectedly."
 msgstr ""
 
 #: ../../src/Configuration.cpp:79
+#, fuzzy
 msgid "Maxima question labels"
-msgstr ""
+msgstr "Otázka programu Maxima"
 
 #: ../../src/wxMaxima.cpp:3380
 msgid "Maxima sends a new set of auto-completable symbols."
@@ -4491,28 +4828,33 @@ msgid "Maxima shows help in a sidebar"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1935
+#, fuzzy
 msgid "Maxima shows help in the console"
-msgstr ""
+msgstr "Soubor nenalezen"
 
 #: ../../src/StatusBar.cpp:232
+#, fuzzy
 msgid "Maxima started. Waiting for authentication..."
-msgstr ""
+msgstr "Maxima je spuštěna. Čekání na připojení..."
 
 #: ../../src/StatusBar.cpp:212
 msgid "Maxima started. Waiting for connection..."
-msgstr ""
+msgstr "Maxima je spuštěna. Čekání na připojení..."
 
 #: ../../src/StatusBar.cpp:228
+#, fuzzy
 msgid "Maxima started. Waiting for initial prompt..."
-msgstr ""
+msgstr "Maxima je spuštěna. Čekání na připojení..."
 
 #: ../../src/wxMaximaFrame.cpp:1231
+#, fuzzy
 msgid "Maxima to other language"
-msgstr ""
+msgstr "Otázka programu Maxima"
 
 #: ../../src/wxMaxima.cpp:7213
+#, fuzzy
 msgid "Maxima to string"
-msgstr ""
+msgstr "Otázka programu Maxima"
 
 #: ../../src/wxMaxima.cpp:3397
 #, c-format
@@ -4535,12 +4877,14 @@ msgid "Maxima version: %s, Anchors cache version"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1925
+#, fuzzy
 msgid "Maxima vs. Programming languages"
-msgstr ""
+msgstr "Konverze na &Gamma funkce"
 
 #: ../../src/Configuration.cpp:83
+#, fuzzy
 msgid "Maxima warnings"
-msgstr ""
+msgstr "Nastavení programu Maxima"
 
 #: ../../src/wxMaxima.cpp:3687
 #, c-format
@@ -4568,9 +4912,9 @@ msgid "Maxima's manual is located in directory %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3670
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's share files are located in directory %s"
-msgstr ""
+msgstr "Spustit animaci"
 
 #: ../../src/StatusBar.cpp:66
 msgid ""
@@ -4613,19 +4957,20 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9568
 msgid "Mean:"
-msgstr ""
+msgstr "Průměr:"
 
 #: ../../src/wxMaximaFrame.cpp:1924
 msgid "Memoizing"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1013
+#, fuzzy
 msgid "Memory"
-msgstr ""
+msgstr "&Vyčistit paměť"
 
 #: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
 msgid "Merge Cells"
-msgstr ""
+msgstr "Spojit pole"
 
 #: ../../src/wxMaxima.cpp:5780
 msgid "Message from the stdout of Maxima: "
@@ -4645,8 +4990,9 @@ msgid "Minimum absolute value printed without exponent:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:10449 ../../src/wxMaxima.cpp:10451
+#, fuzzy
 msgid "Mismatched parenthesis"
-msgstr ""
+msgstr "Kontrola závorek v textovém vstupu"
 
 #: ../../src/wxMaximaFrame.cpp:1352
 msgid "Multiplication, exponent and similar"
@@ -4665,16 +5011,19 @@ msgid "Multiply two matrices"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9581
+#, fuzzy
 msgid "Multivariate linear regression"
-msgstr ""
+msgstr "LIneární regrese"
 
 #: ../../src/wxMaxima.cpp:7842
+#, fuzzy
 msgid "Name of t:"
-msgstr ""
+msgstr "Jméno:"
 
 #: ../../src/wxMaxima.cpp:7838
+#, fuzzy
 msgid "Name of x:"
-msgstr ""
+msgstr "Jméno:"
 
 #: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
 msgid "Nested list to Matrix"
@@ -4685,8 +5034,9 @@ msgid "Never"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:6534
+#, fuzzy
 msgid "Never autosubscript this variable"
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #: ../../src/wxMaximaFrame.cpp:776
 msgid "Never display this variable with subscript"
@@ -4701,8 +5051,9 @@ msgid "New"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:597
+#, fuzzy
 msgid "New\tCtrl+N"
-msgstr ""
+msgstr "&Nový\tCtrl+N"
 
 #: ../../src/ToolBar.cpp:611
 msgid "New button"
@@ -4722,8 +5073,9 @@ msgid "New connection attempt, but no currently running maxima process."
 msgstr ""
 
 #: ../../src/ToolBar.cpp:174
+#, fuzzy
 msgid "New document"
-msgstr ""
+msgstr "Otevřít dokument"
 
 #: ../../src/wxMaxima.cpp:3899
 #, c-format
@@ -4731,13 +5083,14 @@ msgid "New maxima Operators detected: %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7390
+#, fuzzy
 msgid "New part:"
-msgstr ""
+msgstr "Nová proměnná:"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
 #: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
 msgid "New variable:"
-msgstr ""
+msgstr "Nová proměnná:"
 
 #: ../../src/wxMaximaFrame.cpp:929
 msgid "Next Command\tAlt+Down"
@@ -4752,8 +5105,9 @@ msgid "No"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1972
+#, fuzzy
 msgid "No Array"
-msgstr ""
+msgstr "Pole:"
 
 #: ../../src/Worksheet.cpp:1974
 msgid "No Scalar"
@@ -4799,11 +5153,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8163
 msgid "Not a valid matrix dimension!"
-msgstr ""
+msgstr "Nesprávná hodnota řádu matice!"
 
 #: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
 msgid "Not a valid number of equations!"
-msgstr ""
+msgstr "Nesprávný počet rovnic!"
 
 #: ../../src/StatusBar.cpp:256
 msgid "Not connected to Maxima"
@@ -4823,63 +5177,73 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8926
 msgid "Num. deg:"
-msgstr ""
+msgstr "Stupeň polynomu v čitateli:"
 
 #: ../../src/wxMaxima.cpp:8540
+#, fuzzy
 msgid "Number of elements"
-msgstr ""
+msgstr "Počet rovnic:"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
 msgid "Number of equations:"
-msgstr ""
+msgstr "Počet rovnic:"
 
 #: ../../src/wxMaxima.cpp:7481
+#, fuzzy
 msgid "Number to octets"
-msgstr ""
+msgstr "Počet rovnic:"
 
 #: ../../src/wxMaximaFrame.cpp:1154
+#, fuzzy
 msgid "Number to octets..."
-msgstr ""
+msgstr "Počet rovnic:"
 
 #: ../../src/wxMaximaFrame.cpp:1906
 msgid "Number types"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7482
+#, fuzzy
 msgid "Number:"
-msgstr ""
+msgstr "Počty"
 
 #: ../../src/wxMaximaFrame.cpp:1786
+#, fuzzy
 msgid "Numeric output"
-msgstr ""
+msgstr "Přepnout numerický výstup"
 
 #: ../../src/wxMaxima.cpp:8040
 msgid "Numerical QR decomposition of a matrix"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1417
+#, fuzzy
 msgid "Numerical operations (lapack)"
-msgstr ""
+msgstr "&Numerické integrování"
 
 #: ../../src/wxMaxima.cpp:7831
+#, fuzzy
 msgid "Numerical solution for 1st degree ODE"
-msgstr ""
+msgstr "Řešit ODR 1. řádu s počáteční podmínkou"
 
 #: ../../src/wxMaximaFrame.cpp:1282
+#, fuzzy
 msgid "Numerical solution..."
-msgstr ""
+msgstr "Přepnout numerický výstup"
 
 #: ../../src/wxMaximaFrame.cpp:1261
+#, fuzzy
 msgid "Numerical solutions of polynomial (bfloat)..."
-msgstr ""
+msgstr "Najít všechny kořeny polynomu"
 
 #: ../../src/wxMaximaFrame.cpp:1258
+#, fuzzy
 msgid "Numerical solutions of polynomial..."
-msgstr ""
+msgstr "Najít všechny kořeny polynomu"
 
 #: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: ../../src/wxMaximaFrame.cpp:122
 #, c-format
@@ -4887,16 +5251,19 @@ msgid "OS: %s Version %li.%li"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
+#, fuzzy
 msgid "Object composed of elements"
-msgstr ""
+msgstr "Počet rovnic:"
 
 #: ../../src/wxMaxima.cpp:7680
+#, fuzzy
 msgid "Object name:"
-msgstr ""
+msgstr "Seznam:"
 
 #: ../../src/wxMaxima.cpp:7281
+#, fuzzy
 msgid "Object:"
-msgstr ""
+msgstr "Seznam:"
 
 #: ../../src/wxMaxima.cpp:7486
 msgid "Octets to Number"
@@ -4911,8 +5278,9 @@ msgid "Octets to number..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1158
+#, fuzzy
 msgid "Octets to string..."
-msgstr ""
+msgstr "Výraz"
 
 #: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
 msgid "Octets:"
@@ -4925,23 +5293,25 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
 #: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
 msgid "Old variable:"
-msgstr ""
+msgstr "Původní proměnná:"
 
 #: ../../src/wxMaximaFrame.cpp:1055
+#, fuzzy
 msgid "On all errors"
-msgstr ""
+msgstr "Závažná chyba"
 
 #: ../../src/wxMaximaFrame.cpp:1054
 msgid "On lisp errors"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9566
+#, fuzzy
 msgid "One sample t-test"
-msgstr ""
+msgstr "Text příkladu"
 
 #: ../../src/wxMaximaFrame.cpp:1927
 msgid "Online tutorials"
-msgstr ""
+msgstr "Online tutoriály"
 
 #: ../../src/wxMaximaFrame.cpp:766
 msgid "Only Integers and single letters"
@@ -4950,15 +5320,15 @@ msgstr ""
 #: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593
 #: ../../src/wxMaxima.cpp:6074
 msgid "Open"
-msgstr ""
+msgstr "Otevřít"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "Open a document"
-msgstr ""
+msgstr "Otevřít dokument"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "Open a new window"
-msgstr ""
+msgstr "Otevřít nové okno"
 
 #: ../../src/ToolBar.cpp:617
 msgid "Open and save button"
@@ -4966,7 +5336,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:176
 msgid "Open document"
-msgstr ""
+msgstr "Otevřít dokument"
 
 #: ../../src/wxMaxima.cpp:7239
 msgid "Open for appending"
@@ -4981,24 +5351,28 @@ msgid "Open for reading"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1098
+#, fuzzy
 msgid "Open for reading..."
-msgstr ""
+msgstr "Výraz"
 
 #: ../../src/wxMaxima.cpp:7249
 msgid "Open for writing"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1100
+#, fuzzy
 msgid "Open for writing..."
-msgstr ""
+msgstr "&Export..."
 
 #: ../../src/wxMaxima.cpp:9598
+#, fuzzy
 msgid "Open matrix"
-msgstr ""
+msgstr "Otevřít matici"
 
 #: ../../src/wxMaximaFrame.cpp:600
+#, fuzzy
 msgid "Open recent"
-msgstr ""
+msgstr "Otevřít naposledy použité"
 
 #: ../../src/wxMaxima.cpp:4309
 msgid "Opening a wxmx file"
@@ -5007,7 +5381,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4153 ../../src/wxMaxima.cpp:4214
 #: ../../src/wxMaxima.cpp:4313 ../../src/wxMaxima.cpp:4622
 msgid "Opening file"
-msgstr ""
+msgstr "Chyba při otevírání souboru"
 
 #: ../../src/wxMaxima.cpp:5030
 #, c-format
@@ -5024,11 +5398,12 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:199
 msgid "Options"
-msgstr ""
+msgstr "Volby"
 
 #: ../../src/wxMaximaFrame.cpp:1225
+#, fuzzy
 msgid "Output C"
-msgstr ""
+msgstr "Značky výstupů"
 
 #: ../../src/wxMaximaFrame.cpp:1226
 msgid "Output Fortran"
@@ -5040,11 +5415,12 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:80
 msgid "Output labels"
-msgstr ""
+msgstr "Značky výstupů"
 
 #: ../../src/Configuration.cpp:73
+#, fuzzy
 msgid "Output: Function names"
-msgstr ""
+msgstr "Názvy funkcí"
 
 #: ../../src/Configuration.cpp:75
 msgid "Output: Latin names as greek symbols"
@@ -5055,21 +5431,24 @@ msgid "Output: Numbers and Digits"
 msgstr ""
 
 #: ../../src/Configuration.cpp:71
+#, fuzzy
 msgid "Output: Operators"
-msgstr ""
+msgstr "Značky výstupů"
 
 #: ../../src/Configuration.cpp:74
-#, c-format
+#, fuzzy, c-format
 msgid "Output: Special constants (%e,%i)"
-msgstr ""
+msgstr "Speciální konstanty"
 
 #: ../../src/Configuration.cpp:76
+#, fuzzy
 msgid "Output: Strings"
-msgstr ""
+msgstr "Řetězce"
 
 #: ../../src/Configuration.cpp:70
+#, fuzzy
 msgid "Output: Variable names"
-msgstr ""
+msgstr "Původní proměnná:"
 
 #: ../../src/wxMaxima.cpp:6442
 msgid ""
@@ -5088,39 +5467,43 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8924
 msgid "Pade approximation"
-msgstr ""
+msgstr "Padého aproximace"
 
 #: ../../src/wxMaximaFrame.cpp:1478
 msgid "Pade approximation of a Taylor series"
-msgstr ""
+msgstr "Padého aproximace Taylorovy řady"
 
 #: ../../src/wxMaximaFrame.cpp:1637
+#, fuzzy
 msgid "Parallel Substitute..."
-msgstr ""
+msgstr "Substituce..."
 
 #: ../../src/wxMaxima.cpp:8738
 msgid "Parallel substitution"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7179
+#, fuzzy
 msgid "Parameter name:"
-msgstr ""
+msgstr "Název matice:"
 
 #: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
+#, fuzzy
 msgid "Parameter(s):"
-msgstr ""
+msgstr "Proměnné:"
 
 #: ../../src/wxMaxima.cpp:7399
 msgid "Parse string"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1152
+#, fuzzy
 msgid "Parse string only..."
-msgstr ""
+msgstr "Vložte matici..."
 
 #: ../../src/StatusBar.cpp:240
 msgid "Parsing output"
-msgstr ""
+msgstr "Analýza výstupu"
 
 #: ../../src/wxMaxima.cpp:7464
 msgid "Part:"
@@ -5128,64 +5511,65 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1499 ../../src/wxMaximaFrame.cpp:1535
 msgid "Partial &Fractions..."
-msgstr ""
+msgstr "Parciální zlomky..."
 
 #: ../../src/wxMaxima.cpp:8975
+#, fuzzy
 msgid "Partial Fractions"
-msgstr ""
+msgstr "Parciální zlomky"
 
 #: ../../src/wxMaxima.cpp:4702
 msgid "Parts of the document will not be loaded correctly!"
-msgstr ""
+msgstr "Část dokumentu nebude otevřena korektně!"
 
 #: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
 #: ../../src/Worksheet.cpp:1685
 msgid "Paste"
-msgstr ""
+msgstr "Vložit"
 
 #: ../../src/wxMaximaFrame.cpp:667
 msgid "Paste\tCtrl+V"
-msgstr ""
+msgstr "Vložit\tCtrl+V"
 
 #: ../../src/ToolBar.cpp:211
 msgid "Paste from clipboard"
-msgstr ""
+msgstr "Vložit ze schránky"
 
 #: ../../src/wxMaximaFrame.cpp:668
 msgid "Paste text from clipboard"
-msgstr ""
+msgstr "Vložit text z clipboardu"
 
 #: ../../src/wxMaxima.cpp:4841
 msgid "Please configure wxMaxima with 'Edit->Configure'."
-msgstr ""
+msgstr "Konfigurujte program wxMaxima pomocí 'Edit->Configure'."
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot &2d..."
-msgstr ""
+msgstr "&2D graf..."
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot &3d..."
-msgstr ""
+msgstr "&3D graf..."
 
 #: ../../src/wxMaximaFrame.cpp:1772
 msgid "Plot &Format..."
-msgstr ""
+msgstr "&Formát grafu..."
 
 #: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
 msgid "Plot 2D"
-msgstr ""
+msgstr "2D graf"
 
 #: ../../src/Worksheet.cpp:1593
 msgid "Plot 2D..."
-msgstr ""
+msgstr "2D graf..."
 
 #: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
 msgid "Plot 3D"
-msgstr ""
+msgstr "3D graf"
 
 #: ../../src/Worksheet.cpp:1595
 msgid "Plot 3D..."
-msgstr ""
+msgstr "3D graf..."
 
 #: ../../src/wxMaxima.cpp:9538
 msgid "Plot as bars"
@@ -5201,15 +5585,15 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9112
 msgid "Plot format"
-msgstr ""
+msgstr "Formát grafu"
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot in 2 dimensions"
-msgstr ""
+msgstr "2D graf"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot in 3 dimensions"
-msgstr ""
+msgstr "3D graf"
 
 #: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
 msgid "Plot using Draw"
@@ -5229,22 +5613,23 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
 msgid "Point:"
-msgstr ""
+msgstr "Bod:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 1:"
-msgstr ""
+msgstr "Polynom 1:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 2:"
-msgstr ""
+msgstr "Polynom 2:"
 
 #: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
 #: ../../src/wxMaxima.cpp:7739
+#, fuzzy
 msgid "Polynomial:"
-msgstr ""
+msgstr "Polynom 1:"
 
 #: ../../src/wxMaximaFrame.cpp:1754
 msgid "Pop"
@@ -5259,20 +5644,23 @@ msgid "Position of a match"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
+#, fuzzy
 msgid "Position:"
-msgstr ""
+msgstr "Podmínka:"
 
 #: ../../src/wxMaxima.cpp:8939
+#, fuzzy
 msgid "Power series"
-msgstr ""
+msgstr "&Mocninná řada"
 
 #: ../../src/wxMaximaFrame.cpp:1475
+#, fuzzy
 msgid "Power series..."
-msgstr ""
+msgstr "&Mocninná řada"
 
 #: ../../src/wxMaxima.cpp:9202
 msgid "Precision"
-msgstr ""
+msgstr "Přesnost"
 
 #: ../../src/Worksheet.cpp:1616
 msgid "Prefer user labels"
@@ -5291,8 +5679,9 @@ msgid "Preferences...\tCtrl+,"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1733
+#, fuzzy
 msgid "Prepend an element"
-msgstr ""
+msgstr "Otevřít dokument"
 
 #: ../../src/wxMaximaFrame.cpp:927
 msgid "Previous Command\tAlt+Up"
@@ -5300,19 +5689,20 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:184
 msgid "Print"
-msgstr ""
+msgstr "Tisk"
 
 #: ../../src/ToolBar.cpp:620
 msgid "Print button"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1493
+#, fuzzy
 msgid "Print cell brackets"
-msgstr ""
+msgstr "Suport de cel·la activa"
 
 #: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
 msgid "Print document"
-msgstr ""
+msgstr "Tisk dokumentu"
 
 #: ../../src/wxMaximaFrame.cpp:1829
 msgid "Print floating-point numbers with exponents dividable by 3"
@@ -5326,15 +5716,17 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9061
 msgid "Product"
-msgstr ""
+msgstr "Součin"
 
 #: ../../src/wxMaximaFrame.cpp:1095
+#, fuzzy
 msgid "Program"
-msgstr ""
+msgstr "Histogram"
 
 #: ../../src/wxMaxima.cpp:7061
+#, fuzzy
 msgid "Program (no local variables)"
-msgstr ""
+msgstr "Substituce"
 
 #: ../../src/wxMaxima.cpp:7052
 msgid "Program block"
@@ -5353,8 +5745,9 @@ msgid "Push"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8508
+#, fuzzy
 msgid "Push an element to a list"
-msgstr ""
+msgstr "Vytvořit seznam z výrazů"
 
 #: ../../src/wxMaximaFrame.cpp:1395
 msgid "QR decomposition"
@@ -5386,20 +5779,23 @@ msgid "Re-Reading the config from the default location."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:867
+#, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
-msgstr ""
+msgstr "Vyhodnotit všechna vstupní pole v dokumentu"
 
 #: ../../src/wxMaximaFrame.cpp:877
+#, fuzzy
 msgid "Re-evaluate all cells below the one the cursor is in"
-msgstr ""
+msgstr "Vyhodnotit všechna vstupní pole v dokumentu"
 
 #: ../../src/main.cpp:366
 msgid "Re-opening STDERR failed."
 msgstr ""
 
 #: ../../src/main.cpp:367
+#, fuzzy
 msgid "Re-opening STDIN failed."
-msgstr ""
+msgstr "Chyba při otevírání souboru"
 
 #: ../../src/main.cpp:365
 msgid "Re-opening STDOUT failed."
@@ -5412,16 +5808,18 @@ msgid ""
 msgstr ""
 
 #: ../../src/Worksheet.cpp:6668
+#, fuzzy
 msgid "Read .wxm data from clipboard"
-msgstr ""
+msgstr "Vložit text z clipboardu"
 
 #: ../../src/wxMaxima.cpp:7599
 msgid "Read Directory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1677
+#, fuzzy
 msgid "Read List from csv file..."
-msgstr ""
+msgstr "Načíst styl ze souboru"
 
 #: ../../src/wxMaxima.cpp:7196
 msgid "Read a structure field"
@@ -5432,16 +5830,19 @@ msgid "Read byte"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7266
+#, fuzzy
 msgid "Read char"
-msgstr ""
+msgstr "Zadání matic&e..."
 
 #: ../../src/wxMaxima.cpp:7593
+#, fuzzy
 msgid "Read environment variable"
-msgstr ""
+msgstr "Doplňkové parametry:"
 
 #: ../../src/wxMaximaFrame.cpp:1219
+#, fuzzy
 msgid "Read environment variable..."
-msgstr ""
+msgstr "Zrušit proměnnou"
 
 #: ../../src/wxMaxima.cpp:7262
 msgid "Read line"
@@ -5454,7 +5855,7 @@ msgstr ""
 
 #: ../../src/StatusBar.cpp:245
 msgid "Reading Maxima output"
-msgstr ""
+msgstr "Čtení výstupu programu Maxima"
 
 #: ../../src/StatusBar.cpp:247
 #, c-format
@@ -5481,7 +5882,7 @@ msgstr ""
 
 #: ../../src/StatusBar.cpp:224
 msgid "Ready for user input"
-msgstr ""
+msgstr "Připraven na vstup"
 
 #: ../../src/Worksheet.cpp:960
 msgid "Recalculated the whole worksheet at once => Updating its size"
@@ -5510,12 +5911,14 @@ msgid "Received maxima's first prompt: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:603
+#, fuzzy
 msgid "Recover unsaved"
-msgstr ""
+msgstr "[ neuloženo ]"
 
 #: ../../src/wxMaximaFrame.cpp:1640
+#, fuzzy
 msgid "Recursive Substitute..."
-msgstr ""
+msgstr "Substituce..."
 
 #: ../../src/wxMaxima.cpp:8746
 msgid "Recursive substitution"
@@ -5526,16 +5929,18 @@ msgid "Redo"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:633
+#, fuzzy
 msgid "Redo\tCtrl+Y"
-msgstr ""
+msgstr "Zpět\tCtrl+Z"
 
 #: ../../src/wxMaximaFrame.cpp:633
+#, fuzzy
 msgid "Redo last change"
-msgstr ""
+msgstr "Zpět poslední změnu"
 
 #: ../../src/wxMaximaFrame.cpp:1595
 msgid "Reduce trigonometric expression"
-msgstr ""
+msgstr "Zjednodušení trigonometrických výrazů"
 
 #: ../../src/wxMaxima.cpp:2366 ../../src/wxMaxima.cpp:10630
 msgid "Refusing to send cell to maxima: "
@@ -5550,16 +5955,19 @@ msgid "Regex match position"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1195
+#, fuzzy
 msgid "Regular expression that matches a string"
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #: ../../src/wxMaximaFrame.cpp:1196
+#, fuzzy
 msgid "Regular expressions"
-msgstr ""
+msgstr "Integrovat výraz"
 
 #: ../../src/Worksheet.cpp:1314
+#, fuzzy
 msgid "Reload Image"
-msgstr ""
+msgstr "Kopírovat jako obrázek"
 
 #: ../../src/Worksheet.cpp:1320
 #, c-format
@@ -5567,13 +5975,13 @@ msgid "Reload Image \"%s\""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9809
-#, c-format
+#, fuzzy, c-format
 msgid "Reloading image file %s."
-msgstr ""
+msgstr "Proces Maxima ukončen."
 
 #: ../../src/wxMaximaFrame.cpp:883
 msgid "Remove All Output"
-msgstr ""
+msgstr "Vymazat všechny výsledky výpočtů"
 
 #: ../../src/wxMaximaFrame.cpp:1426
 msgid "Remove Rows or Columns..."
@@ -5594,8 +6002,9 @@ msgid "Remove all occurrences of part"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8592
+#, fuzzy
 msgid "Remove an element from a list"
-msgstr ""
+msgstr "Vytvořit seznam z výrazů"
 
 #: ../../src/wxMaxima.cpp:7566
 msgid "Remove directory"
@@ -5619,7 +6028,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:884
 msgid "Remove output from input cells"
-msgstr ""
+msgstr "Odstranit výsledky ze vstupních polí"
 
 #: ../../src/wxMaxima.cpp:7975
 msgid "Remove rows and/or columns"
@@ -5630,16 +6039,19 @@ msgid "Remove rows and/or columns from the matrix"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7582
+#, fuzzy
 msgid "Rename file"
-msgstr ""
+msgstr "Chyba při otevírání souboru"
 
 #: ../../src/wxMaximaFrame.cpp:1215
+#, fuzzy
 msgid "Rename file..."
-msgstr ""
+msgstr "Zrušit proměnnou"
 
 #: ../../src/wxMaximaFrame.cpp:1527
+#, fuzzy
 msgid "Reorganize an expression using horner's rule"
-msgstr ""
+msgstr "Faktorizovat výraz v Gaussových číslech"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "Repetitive element-by-element multiplication"
@@ -5654,37 +6066,42 @@ msgid "Replace first regex match"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7463
+#, fuzzy
 msgid "Replace the first occurrence of Part"
-msgstr ""
+msgstr "Nahrazeno %d výskytů"
 
 #: ../../src/wxMaximaFrame.cpp:1180
+#, fuzzy
 msgid "Replace..."
-msgstr ""
+msgstr "Vybrat vše"
 
 #: ../../src/wxMaxima.cpp:6719
-#, c-format
+#, fuzzy, c-format
 msgid "Replaced %li occurrences."
-msgstr ""
+msgstr "Nahrazeno %d výskytů"
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "Report bug"
-msgstr ""
+msgstr "Nahlásit chybu"
 
 #: ../../src/wxMaximaFrame.cpp:996
+#, fuzzy
 msgid "Reset option variables"
-msgstr ""
+msgstr "Substituce"
 
 #: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
 msgid "Restart Maxima"
-msgstr ""
+msgstr "Restart programu Maxima"
 
 #: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
+#, fuzzy
 msgid "Restrict Maximum size"
-msgstr ""
+msgstr "Restart programu Maxima"
 
 #: ../../src/wxMaxima.cpp:10031
+#, fuzzy
 msgid "Result variables:"
-msgstr ""
+msgstr "Zrušit proměnnou (proměnné):"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Resulting Matrix name (may be empty):"
@@ -5758,8 +6175,9 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
 #: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
+#, fuzzy
 msgid "Right Matrix:"
-msgstr ""
+msgstr "Zadejte matici"
 
 #: ../../src/wxMaxima.cpp:8190
 msgid "Right end"
@@ -5771,7 +6189,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1455
 msgid "Risch Integration..."
-msgstr ""
+msgstr "Integrovat (Rischův algoritmus)..."
 
 #: ../../src/wxMaximaFrame.cpp:785
 msgid "Rounded"
@@ -5787,12 +6205,14 @@ msgid "Row number:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7977
+#, fuzzy
 msgid "Row numbers:"
-msgstr ""
+msgstr "Počty"
 
 #: ../../src/wxMaxima.cpp:8203
+#, fuzzy
 msgid "Rows"
-msgstr ""
+msgstr "Řádky:"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Rule"
@@ -5807,8 +6227,9 @@ msgid "Rules"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1693
+#, fuzzy
 msgid "Run each element through an expression"
-msgstr ""
+msgstr "Najít limitu výrazu"
 
 #: ../../src/wxMaxima.cpp:6355
 #, c-format
@@ -5861,80 +6282,83 @@ msgid "Runs each element through a function"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1694
+#, fuzzy
 msgid "Runs each element through an expression"
-msgstr ""
+msgstr "Najít limitu výrazu"
 
 #: ../../src/wxMaxima.cpp:9572
 msgid "Sample 1:"
-msgstr ""
+msgstr "Příklad 1:"
 
 #: ../../src/wxMaxima.cpp:9573
 msgid "Sample 2:"
-msgstr ""
+msgstr "Příklad 2:"
 
 #: ../../src/wxMaxima.cpp:9567
 msgid "Sample:"
-msgstr ""
+msgstr "Příklad:"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
 msgid "Save"
-msgstr ""
+msgstr "Uložit"
 
 #: ../../src/Worksheet.cpp:1294
 msgid "Save Animation..."
-msgstr ""
+msgstr "Uložit animaci..."
 
 #: ../../src/wxMaxima.cpp:5672
 msgid "Save As"
-msgstr ""
+msgstr "Uložit jako"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save As...\tShift+Ctrl+S"
-msgstr ""
+msgstr "Uložit jako...\tShift+Ctrl+S"
 
 #: ../../src/Worksheet.cpp:1291
 msgid "Save Image..."
-msgstr ""
+msgstr "Uložit obrázek..."
 
 #: ../../src/wxMaxima.cpp:6440
 msgid "Save Selection to Image"
-msgstr ""
+msgstr "Uložit výběr jako obrázek"
 
 #: ../../src/wxMaximaFrame.cpp:675
 msgid "Save Selection to Image..."
-msgstr ""
+msgstr "Uložit výběr jako obrázek..."
 
 #: ../../src/wxMaxima.cpp:10184
 msgid "Save animation to file"
-msgstr ""
+msgstr "Uložit animaci do souboru"
 
 #: ../../src/wxMaxima.cpp:7203
 msgid "Save as lisp code"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1091
+#, fuzzy
 msgid "Save as lisp..."
-msgstr ""
+msgstr "Načíst balíček\tCtrl+L"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
 msgid "Save document"
-msgstr ""
+msgstr "Uložit dokument"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save document as"
-msgstr ""
+msgstr "Uložit dokument jako"
 
 #: ../../src/wxMaximaFrame.cpp:676
 msgid "Save selection from document to an image file"
-msgstr ""
+msgstr "Uložit výběr z dokumentu jako obrázkový soubor"
 
 #: ../../src/wxMaxima.cpp:10125
 msgid "Save selection to file"
-msgstr ""
+msgstr "Uložit označené do souboru"
 
 #: ../../src/wxMaximaFrame.cpp:573
+#, fuzzy
 msgid "Saving failed."
-msgstr ""
+msgstr "Start serveru selhal"
 
 #: ../../src/WXMXformat.cpp:310
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
@@ -5977,15 +6401,16 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:273
 msgid "Section"
-msgstr ""
+msgstr "Sekce"
 
 #: ../../src/Configuration.cpp:91
 msgid "Section cell (Heading 2)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7218
+#, fuzzy
 msgid "Seek to position"
-msgstr ""
+msgstr "Padého aproximace"
 
 #: ../../src/BTextCtrl.cpp:45
 msgid "Seems like something is broken with a font."
@@ -5997,32 +6422,34 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
 msgid "Select All"
-msgstr ""
+msgstr "Vybrat vše"
 
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select All\tCtrl+A"
-msgstr ""
+msgstr "Vybrat vše\tCtrl+A"
 
 #: ../../src/ToolBar.cpp:629
 msgid "Select All button"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9631
+#, fuzzy
 msgid "Select Subsample"
-msgstr ""
+msgstr "Vybrat vše"
 
 #: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select all"
-msgstr ""
+msgstr "Vybrat vše"
 
 #: ../../src/wxMaxima.cpp:6971
 msgid "Select math display algorithm"
-msgstr ""
+msgstr "Vybrat způsob zobrazení"
 
 #: ../../src/Configuration.cpp:98
+#, fuzzy
 msgid "Selection color"
-msgstr ""
+msgstr "Výběr"
 
 #: ../../src/ToolBar.cpp:252
 msgid "Send all cells to maxima"
@@ -6057,24 +6484,27 @@ msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1533
+#, fuzzy
 msgid "Sequential Comparative Simplification"
-msgstr ""
+msgstr "&Komplexní zjednodušení"
 
 #: ../../src/wxMaxima.cpp:9016
 msgid "Series"
-msgstr ""
+msgstr "Řady"
 
 #: ../../src/wxMaximaFrame.cpp:1479
+#, fuzzy
 msgid "Series approximation"
-msgstr ""
+msgstr "Padého aproximace"
 
 #: ../../src/wxMaxima.cpp:2561
 msgid "Server started"
-msgstr ""
+msgstr "Spouštění serveru"
 
 #: ../../src/wxMaximaFrame.cpp:1824
+#, fuzzy
 msgid "Set &displayed Precision..."
-msgstr ""
+msgstr "Nastavit &přesnost..."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Set Maxima option variable logexpand:all"
@@ -6090,39 +6520,44 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:822
 msgid "Set Zoom"
-msgstr ""
+msgstr "Nastavit zvětšení"
 
 #: ../../src/wxMaximaFrame.cpp:1819
+#, fuzzy
 msgid "Set bigfloat &Precision..."
-msgstr ""
+msgstr "Nastavit přesnost bigfloat"
 
 #: ../../src/Worksheet.cpp:1306 ../../src/Worksheet.cpp:1479
 msgid "Set image resolution"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1510
+#, fuzzy
 msgid "Set main variable..."
-msgstr ""
+msgstr "Zrušit proměnnou"
 
 #: ../../src/wxMaximaFrame.cpp:1773
 msgid "Set plot format"
-msgstr ""
+msgstr "Nastavit formát grafu"
 
 #: ../../src/wxMaximaFrame.cpp:1101
+#, fuzzy
 msgid "Set position..."
-msgstr ""
+msgstr "Uložit animaci..."
 
 #: ../../src/wxMaximaFrame.cpp:1656
+#, fuzzy
 msgid "Set the \"algebraic\" flag"
-msgstr ""
+msgstr "Přepnout příznak algebraic"
 
 #: ../../src/wxMaxima.cpp:8314
 msgid "Set the diagram title"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1779
+#, fuzzy
 msgid "Set the frame rate for animations."
-msgstr ""
+msgstr "Spustit animaci"
 
 #: ../../src/wxMaxima.cpp:8377
 msgid "Set the grid density."
@@ -6140,27 +6575,27 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:811
 msgid "Set zoom to 100%"
-msgstr ""
+msgstr "Nastavit zvětšení na 100%"
 
 #: ../../src/wxMaximaFrame.cpp:813
 msgid "Set zoom to 120%"
-msgstr ""
+msgstr "Nastavit zvětšení na 120%"
 
 #: ../../src/wxMaximaFrame.cpp:815
 msgid "Set zoom to 150%"
-msgstr ""
+msgstr "Nastavit zvětšení na 150%"
 
 #: ../../src/wxMaximaFrame.cpp:817
 msgid "Set zoom to 200%"
-msgstr ""
+msgstr "Nastavit zvětšení na 200%"
 
 #: ../../src/wxMaximaFrame.cpp:819
 msgid "Set zoom to 300%"
-msgstr ""
+msgstr "Nastavit zvětšení na 300%"
 
 #: ../../src/wxMaximaFrame.cpp:809
 msgid "Set zoom to 80%"
-msgstr ""
+msgstr "Nastavit zvětšení na 80%"
 
 #: ../../src/wxMaxima.cpp:4731
 #, c-format
@@ -6168,16 +6603,17 @@ msgid "Setting gnuplot_binary to %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:4804
+#, fuzzy
 msgid "Setting prompt and help format"
-msgstr ""
+msgstr "Nastavit formát grafu"
 
 #: ../../src/wxMaximaFrame.cpp:1292
 msgid "Setup atvalues for solving ODE with Laplace transformation"
-msgstr ""
+msgstr "Nastavit hodnoty pro řešení ODR pomocí Laplaceovy transformace"
 
 #: ../../src/wxMaximaFrame.cpp:1661
 msgid "Setup modulus computation"
-msgstr ""
+msgstr "Nastavit výpočet modulo"
 
 #: ../../src/wxMaxima.cpp:9220
 msgid "Setup the engineering format"
@@ -6192,28 +6628,31 @@ msgid "Shapiro-Wilk test for normality"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1543
+#, fuzzy
 msgid "Show \"%\" in special constants"
-msgstr ""
+msgstr "Speciální konstanty"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show &Tips..."
-msgstr ""
+msgstr "Ukázat &tipy"
 
 #: ../../src/Worksheet.cpp:1556
 msgid "Show * as multiplication dot"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:895
+#, fuzzy
 msgid "Show Template\tCtrl+Shift+Space"
-msgstr ""
+msgstr "Ukázat vzor\tCtrl+Shift+K"
 
 #: ../../src/wxMaximaFrame.cpp:753
+#, fuzzy
 msgid "Show XML representation"
-msgstr ""
+msgstr "Zobrazit dlouhé výrazy"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show a tip"
-msgstr ""
+msgstr "Zobrazit tip"
 
 #: ../../src/Worksheet.cpp:1607
 msgid "Show all + allow linebreaks in long numbers"
@@ -6221,51 +6660,54 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9475
 msgid "Show all commands similar to:"
-msgstr ""
+msgstr "Zobrazit všechny příkazy podobné na:"
 
 #: ../../src/wxMaxima.cpp:9468
 msgid "Show an example for the command:"
-msgstr ""
+msgstr "Zobrazit příklad k příkazu:"
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "Show an example of usage"
-msgstr ""
+msgstr "Ukázat příklad použití"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "Show commands similar to"
-msgstr ""
+msgstr "Zobrazit podobné příkazy"
 
 #: ../../src/wxMaximaFrame.cpp:1020
 msgid "Show defined functions"
-msgstr ""
+msgstr "Zobrazit definované funkce"
 
 #: ../../src/wxMaximaFrame.cpp:1022
 msgid "Show defined variables"
-msgstr ""
+msgstr "Zobrazit definované proměnné"
 
 #: ../../src/wxMaximaFrame.cpp:1074
 msgid "Show definition of a function"
-msgstr ""
+msgstr "Zobrazit definici funkcí"
 
 #: ../../src/wxMaximaFrame.cpp:740
 msgid "Show equations in their linear form"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1073
+#, fuzzy
 msgid "Show function &Definition..."
-msgstr ""
+msgstr "Zobrazit &definici..."
 
 #: ../../src/wxMaximaFrame.cpp:896
 msgid "Show function template"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1614
+#, fuzzy
 msgid "Show input labels"
-msgstr ""
+msgstr "Značka pro vstup"
 
 #: ../../src/wxMaximaFrame.cpp:750
+#, fuzzy
 msgid "Show lisp representation"
-msgstr ""
+msgstr "Zobrazit dlouhé výrazy"
 
 #: ../../src/Worksheet.cpp:1604
 msgid "Show max. 100 digits"
@@ -6304,8 +6746,9 @@ msgid "Show the Copy, Cut and the Paste button?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7033
+#, fuzzy
 msgid "Show the function's definition"
-msgstr ""
+msgstr "Zobrazit definici funkce:"
 
 #: ../../src/ToolBar.cpp:618
 msgid "Show the open and the save button?"
@@ -6320,21 +6763,24 @@ msgid "Show the print button?"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:615
+#, fuzzy
 msgid "Show the undo and redo button?"
-msgstr ""
+msgstr "Zobrazit definici funkce:"
 
 #: ../../src/wxMaximaFrame.cpp:1006 ../../src/wxMaximaFrame.cpp:1011
 msgid "Show used + to-be-freed memory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1033
+#, fuzzy
 msgid "Show user definitions"
-msgstr ""
+msgstr "Zobrazit definici funkce:"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
 #: ../../src/wxMaximaFrame.cpp:1879
+#, fuzzy
 msgid "Show wxMaxima help"
-msgstr ""
+msgstr "Zobrazit nápovědu programu Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1825
 msgid "Shows how many digits of a numbers are displayed"
@@ -6345,48 +6791,53 @@ msgid "Sidebars"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1513
+#, fuzzy
 msgid "Simplify &Radicals..."
-msgstr ""
+msgstr "Zjednodušit vý&raz s odmocninami"
 
 #: ../../src/Worksheet.cpp:1579
 msgid "Simplify Expression"
-msgstr ""
+msgstr "Zjednodušit výraz"
 
 #: ../../src/wxMaximaFrame.cpp:1568
+#, fuzzy
 msgid "Simplify Logarithms"
-msgstr ""
+msgstr "Zjednodušit sumu"
 
 #: ../../src/wxMaximaFrame.cpp:1582
 msgid "Simplify an expression containing factorials"
-msgstr ""
+msgstr "Zjednodušit výraz obsahující faktoriály"
 
 #: ../../src/wxMaximaFrame.cpp:1539
+#, fuzzy
 msgid "Simplify equations"
-msgstr ""
+msgstr "Řešit rovnici/rovnice"
 
 #: ../../src/wxMaximaFrame.cpp:1514
 msgid "Simplify expression containing radicals"
-msgstr ""
+msgstr "Zjednodušit výraz s odmocninami"
 
 #: ../../src/wxMaxima.cpp:8649
+#, fuzzy
 msgid "Simplify radicals"
-msgstr ""
+msgstr "Zjednodušit vý&raz s odmocninami"
 
 #: ../../src/wxMaximaFrame.cpp:1512
 msgid "Simplify rational expression"
-msgstr ""
+msgstr "Zjednodušit racionální výraz"
 
 #: ../../src/wxMaximaFrame.cpp:1538
 msgid "Simplify sum() commands..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8636
+#, fuzzy
 msgid "Simplify sums"
-msgstr ""
+msgstr "Zjednodušit"
 
 #: ../../src/wxMaximaFrame.cpp:1592
 msgid "Simplify trigonometric expression"
-msgstr ""
+msgstr "Zjednodušit trigonometrický výraz"
 
 #: ../../src/wxMaximaFrame.cpp:1399
 msgid "Singular Values"
@@ -6401,105 +6852,113 @@ msgid "Singular values, left + right vectors"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1635
+#, fuzzy
 msgid "Smart Substitute..."
-msgstr ""
+msgstr "Substituce..."
 
 #: ../../src/wxMaxima.cpp:8730
+#, fuzzy
 msgid "Smart substitution"
-msgstr ""
+msgstr "Provést substituci"
 
 #: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
 #: ../../src/wxMaxima.cpp:7823
+#, fuzzy
 msgid "Solution of the ODE:"
-msgstr ""
+msgstr "Řešení:"
 
 #: ../../src/wxMaxima.cpp:10017
 msgid "Solve"
-msgstr ""
+msgstr "Řešit"
 
 #: ../../src/wxMaximaFrame.cpp:1244
 msgid "Solve &Algebraic System..."
-msgstr ""
+msgstr "Řešit &algebraický systém..."
 
 #: ../../src/wxMaximaFrame.cpp:1242
 msgid "Solve &Linear System..."
-msgstr ""
+msgstr "Řešit &lineární systém..."
 
 #: ../../src/wxMaximaFrame.cpp:1266
 msgid "Solve &ODE..."
-msgstr ""
+msgstr "Řešit &ODR..."
 
 #: ../../src/wxMaximaFrame.cpp:1240
 msgid "Solve (to_poly)..."
-msgstr ""
+msgstr "Řešit (to_poly)..."
 
 #: ../../src/wxMaxima.cpp:8045
 msgid "Solve A*x=b numerically"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1397
+#, fuzzy
 msgid "Solve Ax=b"
-msgstr ""
+msgstr "Řešit"
 
 #: ../../src/wxMaxima.cpp:7783
 msgid "Solve ODE"
-msgstr ""
+msgstr "Řešit ODR"
 
 #: ../../src/wxMaximaFrame.cpp:1287
 msgid "Solve ODE with Lapla&ce..."
-msgstr ""
+msgstr "Řešit ODR pomocí LTR..."
 
 #: ../../src/wxMaximaFrame.cpp:1398
+#, fuzzy
 msgid "Solve a linear equation system using dgesv"
-msgstr ""
+msgstr "Řešit systém lineárních rovnic"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
 msgid "Solve algebraic system"
-msgstr ""
+msgstr "Řesit algebraický systém"
 
 #: ../../src/wxMaximaFrame.cpp:1245
 msgid "Solve algebraic system of equations"
-msgstr ""
+msgstr "Řesit systém algebraických rovnic"
 
 #: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve boundary value problem for second degree ODE"
-msgstr ""
+msgstr "Řešit okrajovou úlohu pro ODR druhého řádu"
 
 #: ../../src/wxMaxima.cpp:7895
+#, fuzzy
 msgid "Solve differential equations using laplace()"
-msgstr ""
+msgstr "Řešit ODR pomocí Laplaceovy transfromace"
 
 #: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
 msgid "Solve equation(s)"
-msgstr ""
+msgstr "Řešit rovnici/rovnice"
 
 #: ../../src/wxMaximaFrame.cpp:1241
 msgid "Solve equation(s) with to_poly_solve"
-msgstr ""
+msgstr "Řešit rovnici/rovnice pomocí to_poly_solve"
 
 #: ../../src/wxMaxima.cpp:7773
+#, fuzzy
 msgid "Solve equations numerically"
-msgstr ""
+msgstr "Řešit rovnici/rovnice"
 
 #: ../../src/wxMaxima.cpp:7757
+#, fuzzy
 msgid "Solve equations to polynom"
-msgstr ""
+msgstr "Řešit rovnici/rovnice pomocí to_poly_solve"
 
 #: ../../src/wxMaximaFrame.cpp:1271
 msgid "Solve initial value problem for first degree ODE"
-msgstr ""
+msgstr "Řešit ODR 1. řádu s počáteční podmínkou"
 
 #: ../../src/wxMaximaFrame.cpp:1275
 msgid "Solve initial value problem for second degree ODE"
-msgstr ""
+msgstr "Řešit ODR 2. řádu s počáteční podmínkou"
 
 #: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
 msgid "Solve linear system"
-msgstr ""
+msgstr "Řešit lineární systém"
 
 #: ../../src/wxMaximaFrame.cpp:1243
 msgid "Solve linear system of equations"
-msgstr ""
+msgstr "Řešit systém lineárních rovnic"
 
 #: ../../src/wxMaximaFrame.cpp:1263
 msgid "Solve numerical, 1 Variable"
@@ -6507,31 +6966,35 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1267
 msgid "Solve ordinary differential equation of maximum degree 2"
-msgstr ""
+msgstr "Řešit ODR nejvýše 2. řádu"
 
 #: ../../src/wxMaximaFrame.cpp:1288
 msgid "Solve ordinary differential equations with Laplace transformation"
-msgstr ""
+msgstr "Řešit ODR pomocí Laplaceovy transfromace"
 
 #: ../../src/wxMaxima.cpp:7708
+#, fuzzy
 msgid "Solve polynomials numerically"
-msgstr ""
+msgstr "Řešit rovnici/rovnice"
 
 #: ../../src/wxMaxima.cpp:7718
+#, fuzzy
 msgid "Solve polynomials numerically (bfloats)"
-msgstr ""
+msgstr "Řešit rovnici/rovnice"
 
 #: ../../src/wxMaxima.cpp:7729
+#, fuzzy
 msgid "Solve polynomials numerically (real roots)"
-msgstr ""
+msgstr "Řešit rovnici/rovnice"
 
 #: ../../src/wxMaximaFrame.cpp:1249
+#, fuzzy
 msgid "Solve symbolically"
-msgstr ""
+msgstr "Řešit rovnici/rovnice"
 
 #: ../../src/Worksheet.cpp:1574
 msgid "Solve..."
-msgstr ""
+msgstr "Řešit..."
 
 #: ../../src/wxMaximaFrame.cpp:1916
 msgid "Solving differential equations"
@@ -6553,20 +7016,23 @@ msgid "Sort"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8496
+#, fuzzy
 msgid "Sort a list"
-msgstr ""
+msgstr "Vytvořit seznam"
 
 #: ../../src/wxMaxima.cpp:7459
 msgid "Sort all characters in string"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1179
+#, fuzzy
 msgid "Sort the characters..."
-msgstr ""
+msgstr "Konstanty označené řeckými písmeny"
 
 #: ../../src/wxMaxima.cpp:8482
+#, fuzzy
 msgid "Source list:"
-msgstr ""
+msgstr "Vytvořit seznam"
 
 #: ../../src/wxMaxima.cpp:7429
 msgid "Split"
@@ -6585,28 +7051,32 @@ msgid "Split string into tokens"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1171
+#, fuzzy
 msgid "Split..."
-msgstr ""
+msgstr "Export"
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Square"
 msgstr ""
 
 #: ../../src/Configuration.cpp:86
+#, fuzzy
 msgid "Standard Text"
-msgstr ""
+msgstr "Volby"
 
 #: ../../src/Worksheet.cpp:1298
+#, fuzzy
 msgid "Start Animation"
-msgstr ""
+msgstr "Spustit animaci"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Start of t:"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:305
+#, fuzzy
 msgid "Start or Stop animation"
-msgstr ""
+msgstr "Spustit animaci"
 
 #: ../../src/ToolBar.cpp:306
 msgid ""
@@ -6616,11 +7086,12 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:386
 msgid "Starting Maxima process failed"
-msgstr ""
+msgstr "Start programu Maxima selhal"
 
 #: ../../src/main.cpp:667
+#, fuzzy
 msgid "Starting a new wxMaxima process for a new window"
-msgstr ""
+msgstr "Start programu Maxima selhal"
 
 #: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:5633
 msgid "Starting evaluation of the document"
@@ -6628,7 +7099,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:2544
 msgid "Starting server failed"
-msgstr ""
+msgstr "Start serveru selhal"
 
 #: ../../src/WXMXformat.cpp:64
 msgid "Starting to save the worksheet as .wxmx"
@@ -6636,15 +7107,16 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:252
 msgid "Statistics"
-msgstr ""
+msgstr "Statistika"
 
 #: ../../src/wxMaximaFrame.cpp:701
 msgid "Statistics\tAlt+Shift+S"
-msgstr ""
+msgstr "Statistika\tAlt+Shift+S"
 
 #: ../../src/wxMaxima.cpp:7844
+#, fuzzy
 msgid "Step width:"
-msgstr ""
+msgstr "Součin"
 
 #: ../../src/wxMaximaFrame.cpp:794
 msgid "Straight lines"
@@ -6669,26 +7141,31 @@ msgid "Stream:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1185
+#, fuzzy
 msgid "String"
-msgstr ""
+msgstr "Řetězce"
 
 #: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
 #: ../../src/wxMaxima.cpp:7425
+#, fuzzy
 msgid "String #1:"
-msgstr ""
+msgstr "Řetězce"
 
 #: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
 #: ../../src/wxMaxima.cpp:7426
+#, fuzzy
 msgid "String #2:"
-msgstr ""
+msgstr "Řetězce"
 
 #: ../../src/wxMaximaFrame.cpp:1136
+#, fuzzy
 msgid "String Tests"
-msgstr ""
+msgstr "Řetězce"
 
 #: ../../src/wxMaxima.cpp:7415
+#, fuzzy
 msgid "String length"
-msgstr ""
+msgstr "Řetězce"
 
 #: ../../src/wxMaxima.cpp:7381
 msgid "String to list of char"
@@ -6699,8 +7176,9 @@ msgid "String to list of chars..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7496
+#, fuzzy
 msgid "String to octets"
-msgstr ""
+msgstr "Řetězce"
 
 #: ../../src/wxMaximaFrame.cpp:1160
 msgid "String to octets..."
@@ -6717,8 +7195,9 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7465 ../../src/wxMaxima.cpp:7470
 #: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
 #: ../../src/wxMaxima.cpp:7497
+#, fuzzy
 msgid "String:"
-msgstr ""
+msgstr "Řetězce"
 
 #: ../../src/wxMaxima.cpp:7197
 msgid "Struct :"
@@ -6734,7 +7213,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:274
 msgid "Subsection"
-msgstr ""
+msgstr "Podkapitola"
 
 #: ../../src/Configuration.cpp:90
 msgid "Subsection cell (Heading 3)"
@@ -6751,19 +7230,21 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
 #: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
 msgid "Substitute"
-msgstr ""
+msgstr "Provést substituci"
 
 #: ../../src/wxMaximaFrame.cpp:1193
+#, fuzzy
 msgid "Substitute all matches"
-msgstr ""
+msgstr "Substituce..."
 
 #: ../../src/wxMaximaFrame.cpp:1192
 msgid "Substitute first match"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1646
+#, fuzzy
 msgid "Substitute only in parts..."
-msgstr ""
+msgstr "Substituce..."
 
 #: ../../src/wxMaxima.cpp:8763
 msgid "Substitute only in specific parts"
@@ -6775,7 +7256,7 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
 msgid "Substitute..."
-msgstr ""
+msgstr "Substituce..."
 
 #: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
 msgid "Substitutes until the equation no more changes"
@@ -6810,16 +7291,18 @@ msgid ""
 msgstr ""
 
 #: ../../src/ToolBar.cpp:275
+#, fuzzy
 msgid "Subsubsection"
-msgstr ""
+msgstr "Podkapitola"
 
 #: ../../src/Configuration.cpp:89
 msgid "Subsubsection cell (Heading 4)"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1831
+#, fuzzy
 msgid "Suggestion: "
-msgstr ""
+msgstr "Podkapitola"
 
 #: ../../src/Worksheet.cpp:2030
 msgid "Suitable as flag for ev()"
@@ -6827,7 +7310,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9049
 msgid "Sum"
-msgstr ""
+msgstr "Suma"
 
 #: ../../src/wxMaximaFrame.cpp:1551
 msgid ""
@@ -6844,12 +7327,14 @@ msgid "Switched to lisp mode after receiving a lisp prompt!"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1971
+#, fuzzy
 msgid "Symbolic Constant"
-msgstr ""
+msgstr "Vybrat konstantu"
 
 #: ../../src/wxMaximaFrame.cpp:705
+#, fuzzy
 msgid "Symbols\tAlt+Shift+Y"
-msgstr ""
+msgstr "Statistika\tAlt+Shift+S"
 
 #: ../../src/Worksheet.cpp:2006
 msgid "Symmetric function: f(x)=f(-x)"
@@ -6860,20 +7345,23 @@ msgid "Table of Contents"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:711
+#, fuzzy
 msgid "Table of Contents\tAlt+Shift+T"
-msgstr ""
+msgstr "Panel nástrojů\tAlt+Shift+T"
 
 #: ../../src/wxMaxima.cpp:8930
+#, fuzzy
 msgid "Taylor series"
-msgstr ""
+msgstr "Taylorova řada:"
 
 #: ../../src/wxMaximaFrame.cpp:1474
+#, fuzzy
 msgid "Taylor series..."
-msgstr ""
+msgstr "Taylorova řada:"
 
 #: ../../src/wxMaxima.cpp:8925
 msgid "Taylor series:"
-msgstr ""
+msgstr "Taylorova řada:"
 
 #: ../../src/wxMaxima.cpp:4132
 msgid "Telling maxima about the new working directory."
@@ -6900,11 +7388,11 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:271
 msgid "Text"
-msgstr ""
+msgstr "Text"
 
 #: ../../src/Configuration.cpp:93
 msgid "Text cell background"
-msgstr ""
+msgstr "Pozadí textového pole"
 
 #: ../../src/wxMaxima.cpp:6541
 msgid "Text snippet"
@@ -6945,8 +7433,9 @@ msgid "The comma-separated contents of the struct fields"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7186
+#, fuzzy
 msgid "The comma-separated names of the struct fields"
-msgstr ""
+msgstr "Zadejte seznam proměnných oddělených čárkami."
 
 #: ../../src/wxMaxima.cpp:7070
 msgid ""
@@ -7006,8 +7495,9 @@ msgid "The manual of Maxima"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1881
+#, fuzzy
 msgid "The manual of wxMaxima"
-msgstr ""
+msgstr "Vítejte v programu wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7125
 msgid "The name of a function we don't want to be evaluated here"
@@ -7096,10 +7586,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:2143
+#, fuzzy
 msgid ""
 "There was an error in the XML maxima has generated.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Chyba při vytváření XML!\n"
+"\n"
+"Nahlaste prosím tuto chybu."
 
 #: ../../src/wxMaxima.cpp:3911
 msgid ""
@@ -7120,10 +7614,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3257
+#, fuzzy
 msgid ""
 "There was an error in the XML that should describe the manual topics.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Chyba při vytváření XML!\n"
+"\n"
+"Nahlaste prosím tuto chybu."
 
 #: ../../src/wxMaxima.cpp:3202
 msgid ""
@@ -7164,11 +7662,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9013 ../../src/wxMaxima.cpp:10058
 msgid "Times:"
-msgstr ""
+msgstr "Násobit:"
 
 #: ../../src/ToolBar.cpp:272
 msgid "Title"
-msgstr ""
+msgstr "Název"
 
 #: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
@@ -7180,35 +7678,37 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1794
 msgid "To &Bigfloat"
-msgstr ""
+msgstr "Přesnost &bigfloat"
 
 #: ../../src/wxMaximaFrame.cpp:1791
 msgid "To &Float"
-msgstr ""
+msgstr "převést na &Float (plovoucí řádová čárka)"
 
 #: ../../src/Worksheet.cpp:1571
 msgid "To Float"
-msgstr ""
+msgstr "Float (plovoucí řádová čárka)"
 
 #: ../../src/wxMaximaFrame.cpp:1797
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1803
+#, fuzzy
 msgid "To exact fraction"
-msgstr ""
+msgstr "Parciální zlomky"
 
 #: ../../src/wxMaximaFrame.cpp:1814
+#, fuzzy
 msgid "To exact number"
-msgstr ""
+msgstr "Zobrazit &funkce"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "To:"
-msgstr ""
+msgstr "Do:"
 
 #: ../../src/wxMaximaFrame.cpp:825 ../../src/wxMaximaFrame.cpp:828
 msgid "Toggle full screen editing"
-msgstr ""
+msgstr "Zapnutí celoobrazovkového editačního režimu"
 
 #: ../../src/ToolBar.cpp:265
 msgid "Toggle the visibility of code cells"
@@ -7227,20 +7727,23 @@ msgid "Top end"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1078
+#, fuzzy
 msgid "Trace a function..."
-msgstr ""
+msgstr "Zrušit funkci"
 
 #: ../../src/wxMaxima.cpp:7084
+#, fuzzy
 msgid "Trace function(s)"
-msgstr ""
+msgstr "Zrušit funkci (funkce)"
 
 #: ../../src/wxMaximaFrame.cpp:1184
+#, fuzzy
 msgid "Transformations"
-msgstr ""
+msgstr "Transponovat matici"
 
 #: ../../src/wxMaximaFrame.cpp:1376
 msgid "Transpose a matrix"
-msgstr ""
+msgstr "Transponovat matici"
 
 #: ../../src/wxMaxima.cpp:7832
 msgid ""
@@ -7293,12 +7796,14 @@ msgid "Trim both ends..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1182
+#, fuzzy
 msgid "Trim left..."
-msgstr ""
+msgstr "Limita..."
 
 #: ../../src/wxMaximaFrame.cpp:1183
+#, fuzzy
 msgid "Trim right..."
-msgstr ""
+msgstr "Limita..."
 
 #: ../../src/wxMaxima.cpp:7473
 msgid "Trim string left"
@@ -7369,19 +7874,21 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1928
 msgid "Tutorials"
-msgstr ""
+msgstr "Tutoriál"
 
 #: ../../src/wxMaxima.cpp:9571
+#, fuzzy
 msgid "Two sample t-test"
-msgstr ""
+msgstr "Text příkladu"
 
 #: ../../src/Worksheet.cpp:8013
+#, fuzzy
 msgid "Type"
-msgstr ""
+msgstr "Typ:"
 
 #: ../../src/wxMaxima.cpp:7180
 msgid "Type:"
-msgstr ""
+msgstr "Typ:"
 
 #: ../../src/wxMaxima.cpp:9429
 msgid "URL"
@@ -7406,8 +7913,9 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1007
+#, fuzzy
 msgid "Undefine"
-msgstr ""
+msgstr "Podtržení"
 
 #: ../../src/ToolBar.cpp:191
 msgid "Undo"
@@ -7415,7 +7923,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo\tCtrl+Z"
-msgstr ""
+msgstr "Zpět\tCtrl+Z"
 
 #: ../../src/ToolBar.cpp:614
 msgid "Undo and redo button"
@@ -7423,11 +7931,12 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo last change"
-msgstr ""
+msgstr "Zpět poslední změnu"
 
 #: ../../src/wxMaximaFrame.cpp:924
+#, fuzzy
 msgid "Unfold All\tCtrl+Alt+]"
-msgstr ""
+msgstr "Vybrat vše\tCtrl+A"
 
 #: ../../src/wxMaximaFrame.cpp:925
 msgid "Unfold all folded sections"
@@ -7446,24 +7955,29 @@ msgid "Unhide Part"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1860
+#, fuzzy
 msgid "Unhide Section"
-msgstr ""
+msgstr "Sekce"
 
 #: ../../src/Worksheet.cpp:1871
+#, fuzzy
 msgid "Unhide Subsection"
-msgstr ""
+msgstr "Podkapitola"
 
 #: ../../src/Worksheet.cpp:1882
+#, fuzzy
 msgid "Unhide Subsubsection"
-msgstr ""
+msgstr "Podkapitola"
 
 #: ../../src/Worksheet.cpp:1912
+#, fuzzy
 msgid "Unhide contents"
-msgstr ""
+msgstr "Konstanty označené řeckými písmeny"
 
 #: ../../src/wxMaximaFrame.cpp:266
+#, fuzzy
 msgid "Unicode characters"
-msgstr ""
+msgstr "Konstanty označené řeckými písmeny"
 
 #: ../../src/wxMaximaFrame.cpp:707
 msgid "Unicode chars\tAlt+Shift+U"
@@ -7510,23 +8024,25 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
 msgid "Upper bound:"
-msgstr ""
+msgstr "Horní mez:"
 
 #: ../../src/wxMaximaFrame.cpp:792
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
+#, fuzzy
 msgid "Use a list"
-msgstr ""
+msgstr "Vytvořit seznam"
 
 #: ../../src/wxMaxima.cpp:8571
 msgid "Use a list as parameter list for a function"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1708
+#, fuzzy
 msgid "Use list"
-msgstr ""
+msgstr "Vytvořit seznam"
 
 #: ../../src/wxMaximaFrame.cpp:1701
 msgid "Use list as the arguments of a function"
@@ -7541,8 +8057,9 @@ msgid "Use square parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1083
+#, fuzzy
 msgid "Use struct field..."
-msgstr ""
+msgstr "&Celá část"
 
 #: ../../src/wxMaximaFrame.cpp:795
 msgid "Use vertical lines instead of parenthesis for matrices"
@@ -7566,8 +8083,9 @@ msgid "Using Maxima path from command line."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:4822
+#, fuzzy
 msgid "Using configured Maxima path."
-msgstr ""
+msgstr "Nastavení programu wxMaxima"
 
 #: ../../src/wxMaxima.cpp:2961
 msgid ""
@@ -7589,25 +8107,28 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8755
+#, fuzzy
 msgid "Value at a given point"
-msgstr ""
+msgstr "Vyhodnotit nevyhodnocené funkce"
 
 #: ../../src/Worksheet.cpp:1987
 msgid "Value at a specific point"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7801
+#, fuzzy
 msgid "Value at that point:"
-msgstr ""
+msgstr "Vyhodnotit nevyhodnocené funkce"
 
 #: ../../src/wxMaxima.cpp:7812 ../../src/wxMaxima.cpp:7825
 #: ../../src/wxMaxima.cpp:7827
+#, fuzzy
 msgid "Value y at that point:"
-msgstr ""
+msgstr "Vyhodnotit nevyhodnocené funkce"
 
 #: ../../src/wxMaxima.cpp:7910
 msgid "Value:"
-msgstr ""
+msgstr "Hodnota:"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Var #1"
@@ -7623,25 +8144,29 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
 #: ../../src/wxMaxima.cpp:8568
+#, fuzzy
 msgid "Variable name"
-msgstr ""
+msgstr "Původní proměnná:"
 
 #: ../../src/wxMaximaFrame.cpp:1085
+#, fuzzy
 msgid "Variable name, not contents..."
-msgstr ""
+msgstr "Původní proměnná:"
 
 #: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
+#, fuzzy
 msgid "Variable name:"
-msgstr ""
+msgstr "Původní proměnná:"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
+#, fuzzy
 msgid "Variable(s)"
-msgstr ""
+msgstr "Proměnné:"
 
 #: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
 #: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
 msgid "Variable(s):"
-msgstr ""
+msgstr "Proměnné:"
 
 #: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
 #: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
@@ -7649,15 +8174,15 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
 #: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
 msgid "Variable:"
-msgstr ""
+msgstr "Proměnná:"
 
 #: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
 msgid "Variables"
-msgstr ""
+msgstr "Proměnné"
 
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
 msgid "Variables:"
-msgstr ""
+msgstr "Proměnné:"
 
 #: ../../src/WXMXformat.cpp:337
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -7687,11 +8212,12 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
 #: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
 msgid "Warning"
-msgstr ""
+msgstr "Varování"
 
 #: ../../src/wxMaximaFrame.cpp:1556
+#, fuzzy
 msgid "Warning:"
-msgstr ""
+msgstr "Varování"
 
 #: ../../src/Dirstructure.cpp:72
 #, c-format
@@ -7707,7 +8233,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5063
 msgid "Welcome to wxMaxima"
-msgstr ""
+msgstr "Vítejte v programu wxMaxima"
 
 #: ../../src/wxMaxima.cpp:8583
 msgid "What to do:"
@@ -7776,28 +8302,30 @@ msgid "Your version of wxMaxima is up to date."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:805
+#, fuzzy
 msgid "Zoom &In\tCtrl++"
-msgstr ""
+msgstr "Zvětš&it\tAlt+I"
 
 #: ../../src/wxMaximaFrame.cpp:806
+#, fuzzy
 msgid "Zoom Ou&t\tCtrl+-"
-msgstr ""
+msgstr "Zmenšit\tAlt+O"
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom in 10%"
-msgstr ""
+msgstr "Zvětšit o 10%"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom out 10%"
-msgstr ""
+msgstr "Zmenšit o 10%"
 
 #: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
 msgid "[ unsaved ]"
-msgstr ""
+msgstr "[ neuloženo ]"
 
 #: ../../src/wxMaxima.cpp:10920
 msgid "[ unsaved* ]"
-msgstr ""
+msgstr "[ neuloženo* ]"
 
 #: ../../src/Worksheet.cpp:5278
 #, c-format
@@ -7810,8 +8338,9 @@ msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"la
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1690
+#, fuzzy
 msgid "apply function to each element"
-msgstr ""
+msgstr "Přidat funkci do seznamu"
 
 #: ../../src/wxMaximaFrame.cpp:739
 msgid "as 1D ASCII"
@@ -7846,44 +8375,50 @@ msgid "ev() shall evaluate this automatically"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7130
+#, fuzzy
 msgid "expression:"
-msgstr ""
+msgstr "Výraz:"
 
 #: ../../src/Worksheet.cpp:2025
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
+#, fuzzy
 msgid "filename:"
-msgstr ""
+msgstr "Původní proměnná:"
 
 #: ../../src/wxMaximaFrame.cpp:1674
+#, fuzzy
 msgid "from a list"
-msgstr ""
+msgstr "Vytvořit seznam"
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "from a rule"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1685
+#, fuzzy
 msgid "from function arguments"
-msgstr ""
+msgstr "Názvy funkcí"
 
 #: ../../src/wxMaximaFrame.cpp:1669
 msgid "from individual elements"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
+#, fuzzy
 msgid "function"
-msgstr ""
+msgstr "Funkce"
 
 #: ../../src/wxMaximaFrame.cpp:747
 msgid "in 2D"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8554
+#, fuzzy
 msgid "list"
-msgstr ""
+msgstr "Vytvořit seznam"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "max(abs(A(i,j))) (complex)"
@@ -7894,13 +8429,15 @@ msgid "max(abs(A(i,j))) (real)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8046
+#, fuzzy
 msgid "m×n Matrix A:"
-msgstr ""
+msgstr "Matice:"
 
 #: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533
+#, fuzzy
 msgid "n:"
-msgstr ""
+msgstr "Najdi"
 
 #: ../../src/Worksheet.cpp:2000
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -7911,8 +8448,9 @@ msgid "noun: Not evaluated by default"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1710
+#, fuzzy
 msgid "nth"
-msgstr ""
+msgstr "ne"
 
 #: ../../src/Worksheet.cpp:2021
 msgid "outative: f(2*x) = 2*f(x)"
@@ -7924,20 +8462,24 @@ msgid "part:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8942
+#, fuzzy
 msgid "point:"
-msgstr ""
+msgstr "Bod:"
 
 #: ../../src/wxMaxima.cpp:7740
+#, fuzzy
 msgid "precision:"
-msgstr ""
+msgstr "Přesnost"
 
 #: ../../src/wxMaxima.cpp:7255
+#, fuzzy
 msgid "printf"
-msgstr ""
+msgstr "Tisk"
 
 #: ../../src/wxMaximaFrame.cpp:1108
+#, fuzzy
 msgid "printf..."
-msgstr ""
+msgstr "Derivovat..."
 
 #: ../../src/wxMaxima.cpp:8650
 msgid ""
@@ -7953,16 +8495,19 @@ msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1111
+#, fuzzy
 msgid "readbyte..."
-msgstr ""
+msgstr "Integrovat..."
 
 #: ../../src/wxMaximaFrame.cpp:1110
+#, fuzzy
 msgid "readchar..."
-msgstr ""
+msgstr "Koláčový graf"
 
 #: ../../src/wxMaximaFrame.cpp:1109
+#, fuzzy
 msgid "readline..."
-msgstr ""
+msgstr "Rozptyl"
 
 #: ../../src/wxMaxima.cpp:10018
 msgid ""
@@ -7992,17 +8537,19 @@ msgid "unnamed function (lambda)..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:11190
+#, fuzzy
 msgid "unsaved"
-msgstr ""
+msgstr "[ neuloženo ]"
 
 #: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
 #: ../../src/wxMaximaFrame.cpp:189
 msgid "untitled"
-msgstr ""
+msgstr "untitled"
 
 #: ../../src/wxMaximaFrame.cpp:1700
+#, fuzzy
 msgid "use as function arguments"
-msgstr ""
+msgstr "Názvy funkcí"
 
 #: ../../src/wxMaximaFrame.cpp:1696
 msgid "use the actual values stored"
@@ -8017,16 +8564,16 @@ msgid "wxMaxima"
 msgstr ""
 
 #: ../../src/main.cpp:516
-#, c-format
+#, fuzzy, c-format
 msgid "wxMaxima %ld"
-msgstr ""
+msgstr "wxMaxima %s"
 
 #: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
 #: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
 #: ../../src/wxMaximaFrame.cpp:185
-#, c-format
+#, fuzzy, c-format
 msgid "wxMaxima %s (%s) "
-msgstr ""
+msgstr "wxMaxima %s"
 
 #: ../../src/wxMaxima.cpp:4490
 msgid "wxMaxima cannot read the xml contents of "
@@ -8042,12 +8589,12 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5285
 msgid "wxMaxima document"
-msgstr ""
+msgstr "wxMaxima dokument"
 
 #: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
 #: ../../src/wxMaxima.cpp:4230
 msgid "wxMaxima encountered an error loading "
-msgstr ""
+msgstr "Chyba při načítání programu wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "wxMaxima help"
@@ -8066,12 +8613,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1896
+#, fuzzy
 msgid "wxMaxima shows help in a browser"
-msgstr ""
+msgstr "Soubor nenalezen"
 
 #: ../../src/wxMaximaFrame.cpp:1894
+#, fuzzy
 msgid "wxMaxima shows help in the sidebar"
-msgstr ""
+msgstr "Soubor nenalezen"
 
 #: ../../src/wxMaximaFrame.cpp:111
 #, c-format
@@ -8079,8 +8628,9 @@ msgid "wxMaxima version %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1954
+#, fuzzy
 msgid "wxMaxima's ChangeLog"
-msgstr ""
+msgstr "Nastavení programu wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "wxMaxima's license"
@@ -8144,13 +8694,15 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:10
+#, fuzzy
 msgid "# Introduction to wxMaxima"
-msgstr ""
+msgstr "Vítejte v programu wxMaxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:12
+#, fuzzy
 msgid "## _Maxima_ and wxMaxima"
-msgstr ""
+msgstr "Ukončení programu wxMaxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:14
@@ -8184,8 +8736,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:18
+#, fuzzy
 msgid "### _Maxima_"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:20
@@ -8220,8 +8773,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:26
+#, fuzzy
 msgid "### WxMaxima"
-msgstr ""
+msgstr "wxMaxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:28
@@ -8344,8 +8898,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:54
+#, fuzzy
 msgid "### Cells"
-msgstr ""
+msgstr "Spojit pole"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:56
@@ -8366,8 +8921,9 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Image cells."
-msgstr ""
+msgstr "Spojit pole"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
@@ -8383,8 +8939,9 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Page breaks."
-msgstr ""
+msgstr "Zlom stránky"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:65
@@ -8507,8 +9064,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:94
+#, fuzzy
 msgid "### Command autocompletion"
-msgstr ""
+msgstr "Nastavení varovných hlášení"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:96
@@ -8538,8 +9096,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:102
+#, fuzzy
 msgid "#### Greek characters"
-msgstr ""
+msgstr "Konstanty označené řeckými písmeny"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:104
@@ -8830,8 +9389,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:234
+#, fuzzy
 msgid "### MathML output"
-msgstr ""
+msgstr "Matematický font:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:236
@@ -8954,8 +9514,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:282
+#, fuzzy
 msgid "## File Formats"
-msgstr ""
+msgstr "Soubor nenalezen"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:284
@@ -8966,8 +9527,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:286
+#, fuzzy
 msgid "### .mac"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:288
@@ -9010,8 +9572,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:299
+#, fuzzy
 msgid "### .wxm"
-msgstr ""
+msgstr "wxMaxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:302
@@ -9144,8 +9707,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:357
+#, fuzzy
 msgid "### .wxmx"
-msgstr ""
+msgstr "wxMaxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:359
@@ -9215,8 +9779,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:375
+#, fuzzy
 msgid "## Configuration options"
-msgstr ""
+msgstr "Nastavení varovných hlášení"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:377
@@ -9249,8 +9814,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:384
+#, fuzzy
 msgid "### Default animation framerate"
-msgstr ""
+msgstr "Uložit animaci..."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:386
@@ -9295,8 +9861,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:403
+#, fuzzy
 msgid "### Match parenthesis in text controls"
-msgstr ""
+msgstr "Kontrola závorek v textovém vstupu"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:405
@@ -9392,8 +9959,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:432
+#, fuzzy
 msgid "## Subscripted variables"
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:434
@@ -9568,8 +10136,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:498
+#, fuzzy
 msgid "## Plotting"
-msgstr ""
+msgstr "Hlášení o chy&bě"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:500
@@ -10005,8 +10574,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:694
+#, fuzzy
 msgid "#### 2D"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:696
@@ -10028,8 +10598,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:700
+#, fuzzy
 msgid "#### 3D"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:702
@@ -10041,8 +10612,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:704
+#, fuzzy
 msgid "#### Expression"
-msgstr ""
+msgstr "Výraz"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:706
@@ -10069,8 +10641,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:712
+#, fuzzy
 msgid "#### Parametric plot"
-msgstr ""
+msgstr "Graf zadaný parametricky"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:714
@@ -10083,8 +10656,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:716
+#, fuzzy
 msgid "#### Points"
-msgstr ""
+msgstr "Bod:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:718
@@ -10106,8 +10680,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:724
+#, fuzzy
 msgid "#### Axis"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:726
@@ -10131,8 +10706,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:732
+#, fuzzy
 msgid "#### Plot name"
-msgstr ""
+msgstr "Seznam:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:734
@@ -10168,8 +10744,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:744
+#, fuzzy
 msgid "#### Grid"
-msgstr ""
+msgstr "Mřížka:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:746
@@ -10178,8 +10755,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:748
+#, fuzzy
 msgid "#### Accuracy"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:750
@@ -10308,8 +10886,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:794
+#, fuzzy
 msgid "## Special variables wx..."
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:805
@@ -10481,8 +11060,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:837
+#, fuzzy
 msgid "Example:"
-msgstr ""
+msgstr "Příklad"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:842
@@ -10496,8 +11076,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:844
+#, fuzzy
 msgid "## Bug reporting"
-msgstr ""
+msgstr "Hlášení o chy&bě"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:846
@@ -10533,8 +11114,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:856
+#, fuzzy
 msgid "## Output rendering."
-msgstr ""
+msgstr "Řetězce"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:858
@@ -10612,8 +11194,11 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:885
+#, fuzzy
 msgid "## Cannot connect to _Maxima_"
 msgstr ""
+"\n"
+"Není připojeno."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:887
@@ -10960,8 +11545,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:988
+#, fuzzy
 msgid "E.g. start wxMaxima with:"
-msgstr ""
+msgstr "Restart programu Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:990
@@ -11321,8 +11907,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1140
+#, fuzzy
 msgid "# Command-line arguments"
-msgstr ""
+msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1142

--- a/locales/wxMaxima/da.po
+++ b/locales/wxMaxima/da.po
@@ -73,20 +73,21 @@ msgid "%s: Can't interpret line: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1655
+#, fuzzy
 msgid "&Algebraic Mode"
-msgstr ""
+msgstr "&Algebra"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "&Apropos..."
-msgstr ""
+msgstr "&Apropros..."
 
 #: ../../src/wxMaximaFrame.cpp:615
 msgid "&Batch File...\tCtrl+B"
-msgstr ""
+msgstr "&Batchfil...\tCtrl+B"
 
 #: ../../src/wxMaximaFrame.cpp:1278
 msgid "&Boundary Value Problem..."
-msgstr ""
+msgstr "Rand&værdiproblem..."
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "&Bug Report"
@@ -94,207 +95,216 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1505
 msgid "&Calculus"
-msgstr ""
+msgstr "&Infinitesimalregning"
 
 #: ../../src/wxMaximaFrame.cpp:1601
 msgid "&Canonical Form"
-msgstr ""
+msgstr "&Kanonisk form"
 
 #: ../../src/wxMaximaFrame.cpp:1358
 msgid "&Characteristic Polynomial..."
-msgstr ""
+msgstr "&Karakteristisk polynomium..."
 
 #: ../../src/wxMaximaFrame.cpp:990
 msgid "&Clear Memory"
-msgstr ""
+msgstr "&Ryd hukommelse"
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "&Combine Factorials"
-msgstr ""
+msgstr "&Kombiner fakulteter"
 
 #: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Complex Simplification"
-msgstr ""
+msgstr "&Kompleks omskrivning"
 
 #: ../../src/wxMaximaFrame.cpp:1502
 msgid "&Continued Fraction"
-msgstr ""
+msgstr "&Kædebrøk"
 
 #: ../../src/wxMaximaFrame.cpp:638
 msgid "&Copy\tCtrl+C"
-msgstr ""
+msgstr "K&opier\tCtrl+C"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "&Demoivre"
-msgstr ""
+msgstr "&Demoivre"
 
 #: ../../src/wxMaximaFrame.cpp:1362
 msgid "&Determinant"
-msgstr ""
+msgstr "&Determinant"
 
 #: ../../src/wxMaximaFrame.cpp:1466
 msgid "&Differentiate..."
-msgstr ""
+msgstr "&Differentier..."
 
 #: ../../src/wxMaximaFrame.cpp:689
 msgid "&Edit"
-msgstr ""
+msgstr "&Rediger"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "&Eliminate Variable..."
-msgstr ""
+msgstr "&Eliminer variabel..."
 
 #: ../../src/wxMaximaFrame.cpp:1318
 msgid "&Enter Matrix..."
-msgstr ""
+msgstr "I&ndtast matrix..."
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "&Example..."
-msgstr ""
+msgstr "&Eksempel..."
 
 #: ../../src/wxMaximaFrame.cpp:1524
 msgid "&Expand Expression"
-msgstr ""
+msgstr "&Udvid udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1597
 msgid "&Expand Trigonometric"
-msgstr ""
+msgstr "&Udvid trigonometrisk udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1626
 msgid "&Exponentialize"
-msgstr ""
+msgstr "&Eksponentiel form"
 
 #: ../../src/wxMaximaFrame.cpp:618
 msgid "&Export..."
-msgstr ""
+msgstr "&Eksporter..."
 
 #: ../../src/wxMaximaFrame.cpp:1516
 msgid "&Factor Expression"
-msgstr ""
+msgstr "&Faktoriser udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:626
 msgid "&File"
-msgstr ""
+msgstr "&Filer"
 
 #: ../../src/wxMaximaFrame.cpp:1019
+#, fuzzy
 msgid "&Functions"
-msgstr ""
+msgstr "Funktion:"
 
 #: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Greatest Common Divisor..."
-msgstr ""
+msgstr "Største &fælles divisor..."
 
 #: ../../src/wxMaximaFrame.cpp:1968
 msgid "&Help"
-msgstr ""
+msgstr "&Hjælp"
 
 #: ../../src/wxMaximaFrame.cpp:1453
 msgid "&Integrate..."
-msgstr ""
+msgstr "&Integrer..."
 
 #: ../../src/wxMaximaFrame.cpp:964
 msgid "&Interrupt\tCtrl+G"
-msgstr ""
+msgstr "&Afbryd\tCtrl+."
 
 #: ../../src/wxMaximaFrame.cpp:1355
 msgid "&Invert Matrix"
-msgstr ""
+msgstr "&Inverter matrix"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "&License"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1763
+#, fuzzy
 msgid "&List"
-msgstr ""
+msgstr "Liste:"
 
 #: ../../src/wxMaximaFrame.cpp:610
 msgid "&Load Package...\tCtrl+L"
-msgstr ""
+msgstr "Ind&læs pakke...\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "&Maxima"
-msgstr ""
+msgstr "&Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1882
+#, fuzzy
 msgid "&Maxima help"
-msgstr ""
+msgstr "Vis Maxima Hjælp"
 
 #: ../../src/wxMaximaFrame.cpp:1660
 msgid "&Modulus Computation..."
-msgstr ""
+msgstr "&Modulus-beregning..."
 
 #: ../../src/main.cpp:435
+#, fuzzy
 msgid "&New\tCtrl+N"
-msgstr ""
+msgstr "&Ny\tCtrl+N"
 
 #: ../../src/wxMaximaFrame.cpp:1870
 msgid "&Numeric"
-msgstr ""
+msgstr "&Talformat"
 
 #: ../../src/wxMaximaFrame.cpp:1785
+#, fuzzy
 msgid "&Numeric Output"
-msgstr ""
+msgstr "&Vis eksakt/decimaltal "
 
 #: ../../src/main.cpp:436
+#, fuzzy
 msgid "&Open\tCtrl+O"
-msgstr ""
+msgstr "&Åbn\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "&Open...\tCtrl+O"
-msgstr ""
+msgstr "Å&bn...\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "&Plot"
-msgstr ""
+msgstr "&Plot"
 
 #: ../../src/wxMaximaFrame.cpp:622
 msgid "&Print...\tCtrl+P"
-msgstr ""
+msgstr "&Udskriv...\tCtrl+P"
 
 #: ../../src/wxMaximaFrame.cpp:1594
 msgid "&Reduce Trigonometric"
-msgstr ""
+msgstr "&Sammentræk trigonometrisk udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:974
+#, fuzzy
 msgid "&Restart Maxima\tCtrl+Alt+R"
-msgstr ""
+msgstr "&Genstart Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:608
 msgid "&Save\tCtrl+S"
-msgstr ""
+msgstr "&Gem\tCtrl+S"
 
 #: ../../src/wxMaximaFrame.cpp:1662
 msgid "&Simplify"
-msgstr ""
+msgstr "&Omskriv"
 
 #: ../../src/wxMaximaFrame.cpp:1581
 msgid "&Simplify Factorials"
-msgstr ""
+msgstr "&Reducer fakulteter"
 
 #: ../../src/wxMaximaFrame.cpp:1591
 msgid "&Simplify Trigonometric"
-msgstr ""
+msgstr "&Reducer trigonometrisk udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1238
 msgid "&Solve..."
-msgstr ""
+msgstr "&Løs..."
 
 #: ../../src/wxMaximaFrame.cpp:1035
+#, fuzzy
 msgid "&Time Display"
-msgstr ""
+msgstr "Skjul/vis beregningstid "
 
 #: ../../src/wxMaximaFrame.cpp:1375
 msgid "&Transpose Matrix"
-msgstr ""
+msgstr "&Transponer matrix"
 
 #: ../../src/wxMaximaFrame.cpp:1605
 msgid "&Trigonometric Simplification"
-msgstr ""
+msgstr "&Trigonometrisk omskrivning"
 
 #: ../../src/wxMaximaFrame.cpp:1021
+#, fuzzy
 msgid "&Variables"
-msgstr ""
+msgstr "Variable"
 
 #: ../../src/wxMaxima.cpp:2443
 msgid "(Config tells to suppress the output of long cells)"
@@ -347,12 +357,14 @@ msgid ".wxm clipboard data with unusual header"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8047
+#, fuzzy
 msgid "1×n Matrix b:"
-msgstr ""
+msgstr "Matrix:"
 
 #: ../../src/wxMaximaFrame.cpp:1312
+#, fuzzy
 msgid "2D Array to Matrix..."
-msgstr ""
+msgstr "Afbild &matrix"
 
 #: ../../src/wxMaximaFrame.cpp:743
 msgid "2D equations using ASCII Art"
@@ -393,24 +405,27 @@ msgid "A function returning positive numbers"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1965
+#, fuzzy
 msgid "A irrational variable"
-msgstr ""
+msgstr "Udskift variabel"
 
 #: ../../src/Worksheet.cpp:2016
 msgid "A left-associative function"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:2019
+#, fuzzy
 msgid "A linear function"
-msgstr ""
+msgstr "Slet en funktion"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "A matrix in which each row is a set of variables"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1963
+#, fuzzy
 msgid "A rational variable"
-msgstr ""
+msgstr "Udskift variabel"
 
 #: ../../src/Worksheet.cpp:2018
 msgid "A right-associative function"
@@ -429,12 +444,13 @@ msgid "A text control got the mouse focus"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1442
+#, fuzzy
 msgid "A&pply function to each Matrix element..."
-msgstr ""
+msgstr "Anvend funktion på liste"
 
 #: ../../src/wxMaximaFrame.cpp:1291
 msgid "A&t Value..."
-msgstr ""
+msgstr "Ra&ndbetingelser..."
 
 #: ../../src/Configuration.cpp:85
 msgid "ASCII maths"
@@ -442,11 +458,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1963
 msgid "About"
-msgstr ""
+msgstr "&Om"
 
 #: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
 msgid "About wxMaxima"
-msgstr ""
+msgstr "Om wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7837
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
@@ -462,15 +478,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1371
 msgid "Ad&joint Matrix"
-msgstr ""
+msgstr "Ad&jungeret matrix"
 
 #: ../../src/wxMaximaFrame.cpp:1657
 msgid "Add Algebraic E&quality..."
-msgstr ""
+msgstr "Tilføj alge&braisk udtryk (tellrat)..."
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add a directory to search path"
-msgstr ""
+msgstr "Føj en mappe til søgestien"
 
 #: ../../src/wxMaximaFrame.cpp:1752
 msgid ""
@@ -478,24 +494,26 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8602
+#, fuzzy
 msgid "Add an element to the end of a list"
-msgstr ""
+msgstr "Åbn dokument"
 
 #: ../../src/wxMaxima.cpp:8597
+#, fuzzy
 msgid "Add an element to the start of a list"
-msgstr ""
+msgstr "Åbn dokument"
 
 #: ../../src/wxMaxima.cpp:7625
 msgid "Add dir to path:"
-msgstr ""
+msgstr "Føj mappe til sti:"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "Add equality to the rational simplifier"
-msgstr ""
+msgstr "Tilføj algebraisk udtryk med Maxima-kommandoen tellrat"
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add to &Path..."
-msgstr ""
+msgstr "Føj &til sti"
 
 #: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
 #: ../../src/Worksheet.cpp:1704
@@ -537,12 +555,14 @@ msgid "Aliases"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1714
+#, fuzzy
 msgid "All but the 1st n elements"
-msgstr ""
+msgstr "Anvend funktion på liste"
 
 #: ../../src/wxMaximaFrame.cpp:1716
+#, fuzzy
 msgid "All but the last n elements"
-msgstr ""
+msgstr "Anvend funktion på liste"
 
 #: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
 msgid ""
@@ -553,8 +573,9 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:733
+#, fuzzy
 msgid "All visible sidebars"
-msgstr ""
+msgstr "Tidligere variabel:"
 
 #: ../../src/wxMaximaFrame.cpp:1650
 msgid "Allow to substitute operators"
@@ -596,8 +617,9 @@ msgid "Angles"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1775
+#, fuzzy
 msgid "Animation autoplay"
-msgstr ""
+msgstr "Gem markering i fil"
 
 #: ../../src/wxMaximaFrame.cpp:1778
 msgid "Animation framerate..."
@@ -616,28 +638,34 @@ msgid "Append a list"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1736
+#, fuzzy
 msgid "Append a list to an existing list"
-msgstr ""
+msgstr "Bestem grænseværdi for et udtryk"
 
 #: ../../src/wxMaxima.cpp:8607
+#, fuzzy
 msgid "Append a list to another list"
-msgstr ""
+msgstr "Bestem grænseværdi for et udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1729
+#, fuzzy
 msgid "Append an element"
-msgstr ""
+msgstr "Åbn dokument"
 
 #: ../../src/wxMaximaFrame.cpp:1734
+#, fuzzy
 msgid "Append an element to the beginning an existing list"
-msgstr ""
+msgstr "Bestem grænseværdi for et udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1730
+#, fuzzy
 msgid "Append an element to the end of an existing list"
-msgstr ""
+msgstr "Bestem grænseværdi for et udtryk"
 
 #: ../../src/wxMaxima.cpp:8552
+#, fuzzy
 msgid "Apply a function to each list element"
-msgstr ""
+msgstr "Anvend funktion på liste"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 #, c-format
@@ -662,15 +690,16 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9474
 msgid "Apropos"
-msgstr ""
+msgstr "Apropros"
 
 #: ../../src/wxMaxima.cpp:7317
 msgid "Are the chars equal, if case is ignored?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7312
+#, fuzzy
 msgid "Are the chars equal?"
-msgstr ""
+msgstr "Afsnitscelle"
 
 #: ../../src/wxMaxima.cpp:7349
 msgid "Are these strings equal if case is ignored?"
@@ -685,12 +714,14 @@ msgid "Arguments:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8189
+#, fuzzy
 msgid "Array"
-msgstr ""
+msgstr "2D-array:"
 
 #: ../../src/wxMaximaFrame.cpp:1023
+#, fuzzy
 msgid "Arrays"
-msgstr ""
+msgstr "2D-array:"
 
 #: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
 msgid "Ascii code to char"
@@ -757,8 +788,9 @@ msgid "Autosubscript numbers and text following single letters"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:6529
+#, fuzzy
 msgid "Autosubscript this variable"
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #: ../../src/MaximaManual.cpp:536
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -770,7 +802,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6210
 msgid "Batch File"
-msgstr ""
+msgstr "Batchfil"
 
 #: ../../src/wxMaxima.cpp:5318
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -781,8 +813,9 @@ msgid "Bottom end"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7817
+#, fuzzy
 msgid "Boundary value problem"
-msgstr ""
+msgstr "Rand&værdiproblem..."
 
 #: ../../src/wxMathml.cpp:101
 msgid ""
@@ -876,23 +909,24 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1948
 msgid "Build &Info"
-msgstr ""
+msgstr "&Version"
 
 #: ../../src/wxMaxima.cpp:7275
 msgid "Byte:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1458
+#, fuzzy
 msgid "C&hange Variable in Integrate..."
-msgstr ""
+msgstr "&Udskift variabel..."
 
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "C&onfigure"
-msgstr ""
+msgstr "&Indstillinger..."
 
 #: ../../src/wxMaximaFrame.cpp:1482
 msgid "Calculate &Product..."
-msgstr ""
+msgstr "Beregn &produkt"
 
 #: ../../src/wxMaxima.cpp:8057
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
@@ -906,35 +940,38 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate Su&m..."
-msgstr ""
+msgstr "Beregn &sum"
 
 #: ../../src/wxMaximaFrame.cpp:1795
 msgid "Calculate bigfloat value of the last result"
-msgstr ""
+msgstr "Beregn seneste værdi som decimaltal 2"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Calculate float value of the last result"
-msgstr ""
+msgstr "Beregn seneste værdi som decimaltal 1"
 
 #: ../../src/wxMaxima.cpp:9550
+#, fuzzy
 msgid "Calculate mean value"
-msgstr ""
+msgstr "Beregn modulo:"
 
 #: ../../src/wxMaxima.cpp:9554
+#, fuzzy
 msgid "Calculate median value"
-msgstr ""
+msgstr "Beregn modulo:"
 
 #: ../../src/wxMaxima.cpp:8871
 msgid "Calculate modulus:"
-msgstr ""
+msgstr "Beregn modulo:"
 
 #: ../../src/wxMaximaFrame.cpp:1798
+#, fuzzy
 msgid "Calculate numeric value of the last result"
-msgstr ""
+msgstr "Beregn seneste værdi som decimaltal 1"
 
 #: ../../src/wxMaximaFrame.cpp:1483
 msgid "Calculate products"
-msgstr ""
+msgstr "Beregn produkter"
 
 #: ../../src/wxMaxima.cpp:9562
 msgid "Calculate standard deviation"
@@ -942,23 +979,25 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate sums"
-msgstr ""
+msgstr "Beregn summer"
 
 #: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
 msgid "Calculate the eigenvalues and eigenvectors numerically"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
+#, fuzzy
 msgid "Calculate the eigenvalues of a matrix numerically"
-msgstr ""
+msgstr "Beregn en matrixs inverse"
 
 #: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
 msgid "Calculate the root of the sum of squares of matrix entries"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9558
+#, fuzzy
 msgid "Calculate variation"
-msgstr ""
+msgstr "Beregn produkter"
 
 #: ../../src/wxMaxima.cpp:8949
 msgid "Calculates the fourier coefficients for the expression from -p to p"
@@ -989,7 +1028,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Cancel"
-msgstr ""
+msgstr "Annuller"
 
 #: ../../src/wxMaxima.cpp:3292
 msgid "Cannot authenticate Maxima!"
@@ -1026,8 +1065,9 @@ msgid "Cannot set the communication port to %i."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3656 ../../src/wxMaxima.cpp:6359
+#, fuzzy
 msgid "Cannot start gnuplot"
-msgstr ""
+msgstr "Parameterplot"
 
 #: ../../src/StatusBar.cpp:216 ../../src/wxMaxima.cpp:2662
 msgid "Cannot start the maxima binary"
@@ -1046,12 +1086,14 @@ msgid "Ce&ll"
 msgstr ""
 
 #: ../../src/Configuration.cpp:96
+#, fuzzy
 msgid "Cell bracket fill, Active"
-msgstr ""
+msgstr "Celleparentes"
 
 #: ../../src/Configuration.cpp:95
+#, fuzzy
 msgid "Cell bracket fill, Inactive"
-msgstr ""
+msgstr "Celleparentes"
 
 #: ../../src/wxMaxima.cpp:10395
 msgid "Cell ends in a backslash"
@@ -1059,51 +1101,58 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1038
 msgid "Change &2d Display"
-msgstr ""
+msgstr "2D-visning"
 
 #: ../../src/wxMaxima.cpp:10146
+#, fuzzy
 msgid "Change Image"
-msgstr ""
+msgstr "Udskift variabel"
 
 #: ../../src/Worksheet.cpp:1324
+#, fuzzy
 msgid "Change Image..."
-msgstr ""
+msgstr "Gem billede..."
 
 #: ../../src/wxMaximaFrame.cpp:1954
+#, fuzzy
 msgid "Change Log"
-msgstr ""
+msgstr "Udskift variabel"
 
 #: ../../src/wxMaxima.cpp:7555
 msgid "Change directory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1202
+#, fuzzy
 msgid "Change directory..."
-msgstr ""
+msgstr "Gem billede..."
 
 #: ../../src/wxMaximaFrame.cpp:1039
 msgid "Change the 2d display algorithm used to display math output"
-msgstr ""
+msgstr "Vælg algoritme til 2D-visning af matematisk output"
 
 #: ../../src/wxMaxima.cpp:8885
 msgid "Change variable"
-msgstr ""
+msgstr "Udskift variabel"
 
 #: ../../src/wxMaxima.cpp:8905
+#, fuzzy
 msgid "Change variable and evaluate"
-msgstr ""
+msgstr "Udskift variabel i integral eller sum"
 
 #: ../../src/wxMaximaFrame.cpp:1459
 msgid "Change variable in integral or sum"
-msgstr ""
+msgstr "Udskift variabel i integral eller sum"
 
 #: ../../src/wxMaximaFrame.cpp:1463
+#, fuzzy
 msgid "Change variable in integral or sum and evaluate the result"
-msgstr ""
+msgstr "Udskift variabel i integral eller sum"
 
 #: ../../src/wxMaximaFrame.cpp:1026
+#, fuzzy
 msgid "Changed option variables"
-msgstr ""
+msgstr "Udskift variabel"
 
 #: ../../src/wxMaxima.cpp:10170
 #, c-format
@@ -1119,8 +1168,9 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
 #: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
+#, fuzzy
 msgid "Char #2:"
-msgstr ""
+msgstr "Matrix:"
 
 #: ../../src/wxMaximaFrame.cpp:1140
 msgid "Char to Unicode code point..."
@@ -1143,8 +1193,9 @@ msgid "Character Tests"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8181
+#, fuzzy
 msgid "Characteristic polynom"
-msgstr ""
+msgstr "&Karakteristisk polynomium..."
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Chars are strings that are one character long"
@@ -1155,8 +1206,10 @@ msgid "Check for Updates"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1958
+#, fuzzy
 msgid "Check if a newer version of wxMaxima is available."
 msgstr ""
+" er gemt fra en nyere version af wxMaxima. Opdater venligst din wxMaxima."
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Choose the parenthesis type for Matrices"
@@ -1171,56 +1224,68 @@ msgid "Classic matrix operations"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:998
+#, fuzzy
 msgid "Clear all aliases"
-msgstr ""
+msgstr "&Ryd hukommelse"
 
 #: ../../src/wxMaximaFrame.cpp:995
+#, fuzzy
 msgid "Clear all arrays"
-msgstr ""
+msgstr "&Ryd hukommelse"
 
 #: ../../src/wxMaximaFrame.cpp:992
+#, fuzzy
 msgid "Clear all dependencies"
-msgstr ""
+msgstr "&Ryd hukommelse"
 
 #: ../../src/wxMaximaFrame.cpp:994
+#, fuzzy
 msgid "Clear all functions"
-msgstr ""
+msgstr "Slet en funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1001
+#, fuzzy
 msgid "Clear all gradefs"
-msgstr ""
+msgstr "&Ryd hukommelse"
 
 #: ../../src/wxMaximaFrame.cpp:1000
+#, fuzzy
 msgid "Clear all labels"
-msgstr ""
+msgstr "&Ryd hukommelse"
 
 #: ../../src/wxMaximaFrame.cpp:1004
 msgid "Clear all let rule packages"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1003
+#, fuzzy
 msgid "Clear all macros"
-msgstr ""
+msgstr "&Ryd hukommelse"
 
 #: ../../src/wxMaximaFrame.cpp:1002
+#, fuzzy
 msgid "Clear all props"
-msgstr ""
+msgstr "&Ryd hukommelse"
 
 #: ../../src/wxMaximaFrame.cpp:997
+#, fuzzy
 msgid "Clear all rules"
-msgstr ""
+msgstr "&Ryd hukommelse"
 
 #: ../../src/wxMaximaFrame.cpp:999
+#, fuzzy
 msgid "Clear all structures"
-msgstr ""
+msgstr "&Ryd hukommelse"
 
 #: ../../src/wxMaximaFrame.cpp:993
+#, fuzzy
 msgid "Clear all variables"
-msgstr ""
+msgstr "Slet en variabel"
 
 #: ../../src/wxMaximaFrame.cpp:606
+#, fuzzy
 msgid "Close\tCtrl+W"
-msgstr ""
+msgstr "K&opier\tCtrl+C"
 
 #: ../../src/wxMaxima.cpp:7235
 msgid "Close Stream"
@@ -1231,16 +1296,18 @@ msgid "Close window"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1105
+#, fuzzy
 msgid "Close..."
-msgstr ""
+msgstr "Løs..."
 
 #: ../../src/WXMXformat.cpp:301
 msgid "Closed the zip archive"
 msgstr ""
 
 #: ../../src/Configuration.cpp:77
+#, fuzzy
 msgid "Code Default (Maxima input)"
-msgstr ""
+msgstr "Maxima-input"
 
 #: ../../src/Configuration.cpp:103
 msgid "Code highlighting: Comments"
@@ -1275,83 +1342,100 @@ msgid "Code highlighting: Variables"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
+#, fuzzy
 msgid "Code number:"
-msgstr ""
+msgstr "Søjler:"
 
 #: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
+#, fuzzy
 msgid "Codepoint number:"
-msgstr ""
+msgstr "Søjler:"
 
 #: ../../src/wxMaxima.cpp:9590
+#, fuzzy
 msgid "Col. names:"
-msgstr ""
+msgstr "Søjler:"
 
 #: ../../src/Configuration.cpp:100
+#, fuzzy
 msgid "Color of Outdated cells"
-msgstr ""
+msgstr "Forældede celler"
 
 #: ../../src/Configuration.cpp:99
+#, fuzzy
 msgid "Color of text equal to selection"
-msgstr ""
+msgstr "Klip markering"
 
 #: ../../src/wxMaxima.cpp:7962
+#, fuzzy
 msgid "Column number:"
-msgstr ""
+msgstr "Søjler:"
 
 #: ../../src/wxMaxima.cpp:7978
+#, fuzzy
 msgid "Column numbers:"
-msgstr ""
+msgstr "Søjler:"
 
 #: ../../src/wxMaxima.cpp:8202
+#, fuzzy
 msgid "Columns"
-msgstr ""
+msgstr "Søjler:"
 
 #: ../../src/wxMaximaFrame.cpp:1584
 msgid "Combine factorials in an expression"
-msgstr ""
+msgstr "Kombiner fakulteter i et udtryk"
 
 #: ../../src/wxMaxima.cpp:10454
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7259
+#, fuzzy
 msgid "Comma-separated arguments"
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
+#, fuzzy
 msgid "Comma-separated commands"
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #: ../../src/wxMaxima.cpp:8458
+#, fuzzy
 msgid "Comma-separated elements"
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 #: ../../src/wxMaxima.cpp:10031
+#, fuzzy
 msgid "Comma-separated equations"
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
 #: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
 #: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
+#, fuzzy
 msgid "Comma-separated expressions"
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #: ../../src/wxMaxima.cpp:7215
+#, fuzzy
 msgid "Comma-separated expressions that shall be converted to a string"
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
+#, fuzzy
 msgid "Comma-separated expressions."
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
+#, fuzzy
 msgid "Comma-separated function names"
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #: ../../src/wxMaxima.cpp:7086
+#, fuzzy
 msgid "Comma-separated function names."
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
 #: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
@@ -1367,8 +1451,9 @@ msgid "Comma-separated names the parameters will be referenced by later."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
+#, fuzzy
 msgid "Comma-separated numbers from 0 to 255"
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #: ../../src/wxMaxima.cpp:8770
 msgid "Comma-separated numbers of the terms to substitute in"
@@ -1395,16 +1480,18 @@ msgid "Command:"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1692
+#, fuzzy
 msgid "Comment Selection"
-msgstr ""
+msgstr "Klip markering"
 
 #: ../../src/wxMaximaFrame.cpp:681
 msgid "Comment out the currently selected text"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:680
+#, fuzzy
 msgid "Comment selection\tCtrl+/"
-msgstr ""
+msgstr "Klip markering"
 
 #: ../../src/Worksheet.cpp:2004
 msgid "Commutative function"
@@ -1415,12 +1502,14 @@ msgid "Compile a QR decomposition using dgeqrf"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7162
+#, fuzzy
 msgid "Compile a function"
-msgstr ""
+msgstr "Slet en funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1188
+#, fuzzy
 msgid "Compile a regular expression"
-msgstr ""
+msgstr "Slet en funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1385
 msgid "Compile eigenvalues using dgeev"
@@ -1439,8 +1528,9 @@ msgid "Compile eigenvalues+eigenvectors using zgeev"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1076
+#, fuzzy
 msgid "Compile function..."
-msgstr ""
+msgstr "Slet f&unktion"
 
 #: ../../src/wxMaxima.cpp:7511
 msgid "Compile regex"
@@ -1476,44 +1566,48 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1503
 msgid "Compute continued fraction of a value"
-msgstr ""
+msgstr "Beregn en størrelses kædebrøk"
 
 #: ../../src/wxMaximaFrame.cpp:1372
+#, fuzzy
 msgid "Compute the adjoint matrix"
-msgstr ""
+msgstr "Beregn den adjungerede matrix"
 
 #: ../../src/wxMaximaFrame.cpp:1359
 msgid "Compute the characteristic polynomial of a matrix"
-msgstr ""
+msgstr "Beregn en matrixs karakteristiske polynomium"
 
 #: ../../src/wxMaximaFrame.cpp:1363
 msgid "Compute the determinant of a matrix"
-msgstr ""
+msgstr "Beregn en matrixs determinant"
 
 #: ../../src/wxMaximaFrame.cpp:1491
 msgid "Compute the greatest common divisor"
-msgstr ""
+msgstr "Beregn største fælles divisor"
 
 #: ../../src/wxMaximaFrame.cpp:1356
 msgid "Compute the inverse of a matrix"
-msgstr ""
+msgstr "Beregn en matrixs inverse"
 
 #: ../../src/wxMaximaFrame.cpp:1494
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
+"Beregn mindste fælles multiplum (anvend kommandoen load(functs) før brug)"
 
 #: ../../src/wxMaximaFrame.cpp:1374
+#, fuzzy
 msgid "Compute the rank of a matrix"
-msgstr ""
+msgstr "Beregn en matrixs determinant"
 
 #: ../../src/wxMaxima.cpp:9629
+#, fuzzy
 msgid "Condition:"
-msgstr ""
+msgstr "Animation"
 
 #: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "Configure wxMaxima"
-msgstr ""
+msgstr "wxMaxima indstillinger"
 
 #: ../../src/wxMaxima.cpp:2504
 msgid "Connection attempt, but connection failed."
@@ -1524,16 +1618,19 @@ msgid "Connection to Maxima lost."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7921
+#, fuzzy
 msgid "Construct a fraction"
-msgstr ""
+msgstr "&Kædebrøk"
 
 #: ../../src/wxMaximaFrame.cpp:1305
+#, fuzzy
 msgid "Construct fraction..."
-msgstr ""
+msgstr "&Kædebrøk"
 
 #: ../../src/wxMaxima.cpp:7158
+#, fuzzy
 msgid "Contents:"
-msgstr ""
+msgstr "Græske konstanter"
 
 #: ../../src/wxMaximaFrame.cpp:1877
 msgid "Context-sensitive &Help\tCtrl+?"
@@ -1545,27 +1642,32 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1542
 msgid "Contract Logarithms"
-msgstr ""
+msgstr "Sammentræk logaritmer"
 
 #: ../../src/wxMaximaFrame.cpp:1161
+#, fuzzy
 msgid "Conversions"
-msgstr ""
+msgstr "&Omregn til rektangulær form"
 
 #: ../../src/wxMaximaFrame.cpp:1229
+#, fuzzy
 msgid "Convert"
-msgstr ""
+msgstr "&Omregn til rektangulær form"
 
 #: ../../src/wxMaximaFrame.cpp:1230
+#, fuzzy
 msgid "Convert + Write to file"
-msgstr ""
+msgstr "Omregn til &fakultet"
 
 #: ../../src/wxMaximaFrame.cpp:1434
+#, fuzzy
 msgid "Convert Column to list..."
-msgstr ""
+msgstr "Omregn til &fakultet"
 
 #: ../../src/wxMaximaFrame.cpp:1430
+#, fuzzy
 msgid "Convert Row to list..."
-msgstr ""
+msgstr "Omregn til &fakultet"
 
 #: ../../src/wxMaximaFrame.cpp:1044
 msgid "Convert a command to maxima code"
@@ -1578,59 +1680,67 @@ msgstr ""
 #: ../../src/wxMaximaFrame.cpp:1574
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr ""
+"Omregn binomialkoefficienter, Beta- og Gamma-funktioner til fakulteter"
 
 #: ../../src/wxMaximaFrame.cpp:1578
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
+"Omregn binomialkoefficienter, fakulteter og Beta-funktioner til Gamma-"
+"funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1613
 msgid "Convert complex expression to polar form"
-msgstr ""
+msgstr "Omregn komplekst udtryk til polær form"
 
 #: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert complex expression to rect form"
-msgstr ""
+msgstr "Omregn komplekst udtryk til rektangulær form"
 
 #: ../../src/wxMaximaFrame.cpp:1622
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
+"Omregn eksponentiel funktion med imaginært argument til trigonometrisk form"
 
 #: ../../src/wxMaxima.cpp:7411
+#, fuzzy
 msgid "Convert string to lowercase"
-msgstr ""
+msgstr "Omregn til &fakultet"
 
 #: ../../src/wxMaxima.cpp:7543
+#, fuzzy
 msgid "Convert string to matching regex"
-msgstr ""
+msgstr "Omregn til &Gamma-funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1543
 msgid "Convert sum of logarithms to logarithm of product"
-msgstr ""
+msgstr "Omregn sum af logaritmer til logaritme af produkt"
 
 #: ../../src/wxMaximaFrame.cpp:1573
 msgid "Convert to &Factorials"
-msgstr ""
+msgstr "Omregn til &fakultet"
 
 #: ../../src/wxMaximaFrame.cpp:1577
 msgid "Convert to &Gamma"
-msgstr ""
+msgstr "Omregn til &Gamma-funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1612
 msgid "Convert to &Polarform"
-msgstr ""
+msgstr "Omregn til &polær form"
 
 #: ../../src/wxMaximaFrame.cpp:1609
 msgid "Convert to &Rectform"
-msgstr ""
+msgstr "&Omregn til rektangulær form"
 
 #: ../../src/wxMaximaFrame.cpp:1166
+#, fuzzy
 msgid "Convert to downcase..."
-msgstr ""
+msgstr "Omregn til &fakultet"
 
 #: ../../src/wxMaxima.cpp:7016
+#, fuzzy
 msgid "Convert to programming language"
-msgstr ""
+msgstr "Omregn til &Gamma-funktion"
 
 #: ../../src/wxMaxima.cpp:7022
 msgid "Convert to programming language file"
@@ -1638,11 +1748,12 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1602
 msgid "Convert trigonometric expression to canonical quasilinear form"
-msgstr ""
+msgstr "Omregn trigonometrisk udtryk til kanonisk kvasilineær form"
 
 #: ../../src/wxMaximaFrame.cpp:1627
+#, fuzzy
 msgid "Convert trigonometric functions to exponential form"
-msgstr ""
+msgstr "Omregn trigonometrisk funktion til eksponentiel form"
 
 #: ../../src/wxMaximaFrame.cpp:1762
 msgid "Converts a matrix to a list of lists"
@@ -1656,12 +1767,13 @@ msgstr ""
 #: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
 #: ../../src/Worksheet.cpp:1684
 msgid "Copy"
-msgstr ""
+msgstr "Kopier"
 
 #: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
 #: ../../src/Worksheet.cpp:1514
+#, fuzzy
 msgid "Copy Animation"
-msgstr ""
+msgstr "Stop animation"
 
 #: ../../src/wxMaximaFrame.cpp:887
 msgid "Copy Previous Input\tCtrl+I"
@@ -1672,8 +1784,9 @@ msgid "Copy Previous Output\tCtrl+U"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7992
+#, fuzzy
 msgid "Copy a matrix"
-msgstr ""
+msgstr "Kopier som billede"
 
 #: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
 #: ../../src/wxMaximaFrame.cpp:663
@@ -1683,16 +1796,18 @@ msgstr ""
 #: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Copy as Image"
-msgstr ""
+msgstr "Kopier som billede"
 
 #: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
 #: ../../src/wxMaximaFrame.cpp:645
+#, fuzzy
 msgid "Copy as LaTeX"
-msgstr ""
+msgstr "Kopier som LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:648
+#, fuzzy
 msgid "Copy as MathML"
-msgstr ""
+msgstr "Kopier som billede"
 
 #: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
 msgid "Copy as MathML (e.g. to word processor)"
@@ -1700,29 +1815,35 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
 #: ../../src/wxMaximaFrame.cpp:658
+#, fuzzy
 msgid "Copy as RTF"
-msgstr ""
+msgstr "Kopier som LaTeX"
 
 #: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
 #: ../../src/wxMaximaFrame.cpp:655
+#, fuzzy
 msgid "Copy as SVG"
-msgstr ""
+msgstr "Kopier som LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:640
+#, fuzzy
 msgid "Copy as Text\tCtrl+Shift+C"
-msgstr ""
+msgstr "Kopier celle(r)\tCtrl+Shift+C"
 
 #: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
+#, fuzzy
 msgid "Copy as plain text"
-msgstr ""
+msgstr "Kopier som billede"
 
 #: ../../src/wxMaxima.cpp:7576
+#, fuzzy
 msgid "Copy file"
-msgstr ""
+msgstr "Kopier"
 
 #: ../../src/wxMaximaFrame.cpp:1214
+#, fuzzy
 msgid "Copy file..."
-msgstr ""
+msgstr "Løs..."
 
 #: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
 #: ../../src/wxMaximaFrame.cpp:643
@@ -1731,32 +1852,35 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
 msgid "Copy selection"
-msgstr ""
+msgstr "Kopier markering"
 
 #: ../../src/wxMaximaFrame.cpp:664
 msgid "Copy selection from document as an Enhanced Metafile"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:656
+#, fuzzy
 msgid "Copy selection from document as an SVG image"
-msgstr ""
+msgstr "Kopier markering fra dokument som billede"
 
 #: ../../src/wxMaximaFrame.cpp:653
 msgid "Copy selection from document as an image"
-msgstr ""
+msgstr "Kopier markering fra dokument som billede"
 
 #: ../../src/wxMaximaFrame.cpp:659
+#, fuzzy
 msgid ""
 "Copy selection from document as rtf that a word processor might understand"
-msgstr ""
+msgstr "Kopier markering fra dokument som billede"
 
 #: ../../src/wxMaximaFrame.cpp:641
+#, fuzzy
 msgid "Copy selection from document as text"
-msgstr ""
+msgstr "Kopier markering fra dokument som billede"
 
 #: ../../src/wxMaximaFrame.cpp:646
 msgid "Copy selection from document in LaTeX format"
-msgstr ""
+msgstr "Kopier markering fra dokument som LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:644
 msgid "Copy selection from document in Matlab format"
@@ -1769,12 +1893,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7403
+#, fuzzy
 msgid "Copy string"
-msgstr ""
+msgstr "Kopier markering"
 
 #: ../../src/wxMaximaFrame.cpp:1165
+#, fuzzy
 msgid "Copy string..."
-msgstr ""
+msgstr "I&ndtast matrix..."
 
 #: ../../src/ToolBar.cpp:623
 msgid "Copy, Cut and Paste button"
@@ -1805,20 +1931,23 @@ msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1325
+#, fuzzy
 msgid "Create Matrix"
-msgstr ""
+msgstr "Opret matrix"
 
 #: ../../src/wxMaximaFrame.cpp:1688
+#, fuzzy
 msgid "Create a list"
-msgstr ""
+msgstr "Opret liste"
 
 #: ../../src/wxMaxima.cpp:8487
 msgid "Create a list as a storage for the values of variables"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8463 ../../src/wxMaxima.cpp:8476
+#, fuzzy
 msgid "Create a list from a rule"
-msgstr ""
+msgstr "Opret liste ud fra udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1670
 msgid "Create a list from comma-separated elements"
@@ -1837,32 +1966,38 @@ msgid "Create copy, not clone..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7561
+#, fuzzy
 msgid "Create directory"
-msgstr ""
+msgstr "Opret liste"
 
 #: ../../src/wxMaximaFrame.cpp:1203
+#, fuzzy
 msgid "Create directory..."
-msgstr ""
+msgstr "Opret liste"
 
 #: ../../src/wxMaxima.cpp:7419
+#, fuzzy
 msgid "Create empty string"
-msgstr ""
+msgstr "Opret matrix"
 
 #: ../../src/wxMaximaFrame.cpp:1168
+#, fuzzy
 msgid "Create empty string..."
-msgstr ""
+msgstr "Opret liste"
 
 #: ../../src/wxMaximaFrame.cpp:1687
+#, fuzzy
 msgid "Create list"
-msgstr ""
+msgstr "Opret liste"
 
 #: ../../src/wxMaxima.cpp:8457
 msgid "Create list from comma-separated elements"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1082
+#, fuzzy
 msgid "Create struct..."
-msgstr ""
+msgstr "Opret liste"
 
 #: ../../src/WXMXformat.cpp:80
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
@@ -1873,24 +2008,26 @@ msgid "Creates an independent matrix with the same contents"
 msgstr ""
 
 #: ../../src/Configuration.cpp:97
+#, fuzzy
 msgid "Cursor color"
-msgstr ""
+msgstr "Markør"
 
 #: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
 msgid "Cut"
-msgstr ""
+msgstr "Klip"
 
 #: ../../src/wxMaximaFrame.cpp:636
 msgid "Cut\tCtrl+X"
-msgstr ""
+msgstr "&Klip\tCtrl+X"
 
 #: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
 msgid "Cut selection"
-msgstr ""
+msgstr "Klip markering"
 
 #: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
+#, fuzzy
 msgid "Data Matrix:"
-msgstr ""
+msgstr "Matrix:"
 
 #: ../../src/wxMaxima.cpp:9599
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
@@ -1927,8 +2064,9 @@ msgid "Declare facts about %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8800
+#, fuzzy
 msgid "Declare main variable:"
-msgstr ""
+msgstr "Slet en variabel"
 
 #: ../../src/wxMaxima.cpp:7171
 msgid "Declare the type of a function parameter"
@@ -1940,15 +2078,17 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1500 ../../src/wxMaximaFrame.cpp:1536
 msgid "Decompose rational function to partial fractions"
-msgstr ""
+msgstr "Opløs rational funktion i partialbrøker"
 
 #: ../../src/Worksheet.cpp:2010
+#, fuzzy
 msgid "Decreasing function f(x)<x"
-msgstr ""
+msgstr "Slet funktion(er):"
 
 #: ../../src/wxMaxima.cpp:7134
+#, fuzzy
 msgid "Define a function"
-msgstr ""
+msgstr "Slet en funktion"
 
 #: ../../src/wxMaxima.cpp:7147
 msgid "Define a macro"
@@ -1963,12 +2103,14 @@ msgid "Define a structure type"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7156
+#, fuzzy
 msgid "Define a variable"
-msgstr ""
+msgstr "Slet en variabel"
 
 #: ../../src/wxMaximaFrame.cpp:1072
+#, fuzzy
 msgid "Define function..."
-msgstr ""
+msgstr "Slet f&unktion"
 
 #: ../../src/wxMaximaFrame.cpp:1079
 msgid "Define macro..."
@@ -1983,8 +2125,9 @@ msgid "Define struct..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1080
+#, fuzzy
 msgid "Define variable..."
-msgstr ""
+msgstr "Slet en variabel"
 
 #: ../../src/wxMaximaFrame.cpp:1776
 msgid ""
@@ -1997,23 +2140,23 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:985
 msgid "Delete F&unction..."
-msgstr ""
+msgstr "Slet f&unktion"
 
 #: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
 msgid "Delete Selection"
-msgstr ""
+msgstr "Slet markering"
 
 #: ../../src/wxMaximaFrame.cpp:987
 msgid "Delete V&ariable..."
-msgstr ""
+msgstr "&Slet variabel"
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Delete a function"
-msgstr ""
+msgstr "Slet en funktion"
 
 #: ../../src/wxMaximaFrame.cpp:988
 msgid "Delete a variable"
-msgstr ""
+msgstr "Slet en variabel"
 
 #: ../../src/wxMaximaFrame.cpp:982
 msgid "Delete all objects with a given name"
@@ -2021,35 +2164,42 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:991
 msgid "Delete all values from memory"
-msgstr ""
+msgstr "Slet alle værdier fra hukommelsen"
 
 #: ../../src/wxMaxima.cpp:7588
+#, fuzzy
 msgid "Delete file"
-msgstr ""
+msgstr "Slet en variabel"
 
 #: ../../src/wxMaximaFrame.cpp:1216
+#, fuzzy
 msgid "Delete file..."
-msgstr ""
+msgstr "&Slet variabel"
 
 #: ../../src/wxMaxima.cpp:7683
+#, fuzzy
 msgid "Delete function(s)"
-msgstr ""
+msgstr "Slet funktion(er):"
 
 #: ../../src/wxMaxima.cpp:7679
+#, fuzzy
 msgid "Delete named object(s)"
-msgstr ""
+msgstr "Slet funktion(er):"
 
 #: ../../src/wxMaximaFrame.cpp:981
+#, fuzzy
 msgid "Delete named object..."
-msgstr ""
+msgstr "Slet f&unktion"
 
 #: ../../src/wxMaxima.cpp:7674
+#, fuzzy
 msgid "Delete variable(s)"
-msgstr ""
+msgstr "Slet variable:"
 
 #: ../../src/wxMaxima.cpp:7430
+#, fuzzy
 msgid "Delimiter:"
-msgstr ""
+msgstr "Eliminer"
 
 #: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
 #, c-format
@@ -2062,7 +2212,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8927
 msgid "Denom. deg:"
-msgstr ""
+msgstr "Nævners grad:"
 
 #: ../../src/wxMaxima.cpp:7923
 msgid "Denominator:"
@@ -2078,7 +2228,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1497
 msgid "Di&vide Polynomials..."
-msgstr ""
+msgstr "P&olynomiers division..."
 
 #: ../../src/MaximaManual.cpp:517
 msgid "Didn't find the maxima HTML manual."
@@ -2092,35 +2242,38 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
 msgid "Differentiate"
-msgstr ""
+msgstr "Differentier"
 
 #: ../../src/wxMaximaFrame.cpp:1467
 msgid "Differentiate expression"
-msgstr ""
+msgstr "Differentier udtryk"
 
 #: ../../src/Worksheet.cpp:1590
 msgid "Differentiate..."
-msgstr ""
+msgstr "Differentier..."
 
 #: ../../src/wxMaxima.cpp:9010
+#, fuzzy
 msgid "Differentiates an expression n times"
-msgstr ""
+msgstr "Differentier udtryk"
 
 #: ../../src/wxMaxima.cpp:10055
+#, fuzzy
 msgid "Differentiates the expression n times"
-msgstr ""
+msgstr "Differentier udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1212
+#, fuzzy
 msgid "Directory operations"
-msgstr ""
+msgstr "Fra:"
 
 #: ../../src/wxMaximaFrame.cpp:1041
 msgid "Display Te&X Form"
-msgstr ""
+msgstr "Vis som Te&X"
 
 #: ../../src/wxMaxima.cpp:6972
 msgid "Display algorithm"
-msgstr ""
+msgstr "2D-visning"
 
 #: ../../src/wxMaximaFrame.cpp:751
 msgid "Display an expression as maxima's internal lisp representation"
@@ -2131,8 +2284,9 @@ msgid "Display an expression as wxMaxima's internal XML representation"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:758
+#, fuzzy
 msgid "Display equations"
-msgstr ""
+msgstr "Løs ligning(er)"
 
 #: ../../src/wxMaxima.cpp:6508
 msgid "Display expression in maxima's internal representation"
@@ -2144,7 +2298,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1042
 msgid "Display last result in TeX form"
-msgstr ""
+msgstr "Vis seneste resultat som TeX"
 
 #: ../../src/ToolBar.cpp:360
 #, c-format
@@ -2152,24 +2306,27 @@ msgid "Display resolution according to wxWidgets: %li x %li ppi"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:802
+#, fuzzy
 msgid "Display string quotation marks"
-msgstr ""
+msgstr "Løs ligning(er)"
 
 #: ../../src/wxMaximaFrame.cpp:1036
 msgid "Display time used for evaluation"
-msgstr ""
+msgstr "Vis beregningstid"
 
 #: ../../src/wxMaxima.cpp:9206
+#, fuzzy
 msgid "Displayed Precision"
-msgstr ""
+msgstr "Løs ligning(er)"
 
 #: ../../src/wxMaximaFrame.cpp:1913
 msgid "Displaying 3d curves"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1462
+#, fuzzy
 msgid "Dito, and evaluate the result..."
-msgstr ""
+msgstr "Evaluer &navneformer"
 
 #: ../../src/wxMaximaFrame.cpp:1445
 msgid "Dito, but affect all clones of the Matrix..."
@@ -2184,16 +2341,18 @@ msgid "Dito, including denominator"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
+#, fuzzy
 msgid "Divide Cell"
-msgstr ""
+msgstr "Division"
 
 #: ../../src/wxMaximaFrame.cpp:1498
 msgid "Divide numbers or polynomials"
-msgstr ""
+msgstr "Division med tal eller polynomier"
 
 #: ../../src/wxMaxima.cpp:8578
+#, fuzzy
 msgid "Do for each list element"
-msgstr ""
+msgstr "Anvend funktion på liste"
 
 #: ../../src/wxMaxima.cpp:11197
 #, c-format
@@ -2206,35 +2365,43 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:94
 msgid "Document background"
-msgstr ""
+msgstr "Dokument baggrund"
 
 #: ../../src/wxMaxima.cpp:4611
+#, fuzzy
 msgid ""
 "Document was saved using a newer version of wxMaxima so it may not load "
 "correctly. Please update your wxMaxima."
 msgstr ""
+" er gemt fra en nyere version af wxMaxima, så den indlæses måske ikke "
+"korrekt. Opdater venligst din wxMaxima."
 
 #: ../../src/wxMaxima.cpp:4603
+#, fuzzy
 msgid ""
 "Document was saved using a newer version of wxMaxima. Please update your "
 "wxMaxima."
 msgstr ""
+" er gemt fra en nyere version af wxMaxima. Opdater venligst din wxMaxima."
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "Don't autosubscript after an underscore"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1086
+#, fuzzy
 msgid "Don't evaluate Expression..."
-msgstr ""
+msgstr "Integrer udtryk"
 
 #: ../../src/wxMaxima.cpp:7117
+#, fuzzy
 msgid "Don't evaluate one command"
-msgstr ""
+msgstr "Vis eksempel med kommandoen:"
 
 #: ../../src/wxMaxima.cpp:7129
+#, fuzzy
 msgid "Don't evaluate one whole expression"
-msgstr ""
+msgstr "Bestem realdelen af komplekst udtryk"
 
 #: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
 msgid "Don't mark cells that contain tooltips in yellow"
@@ -2261,36 +2428,40 @@ msgid "Don't use parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8525
+#, fuzzy
 msgid "Drop the first n list elements"
-msgstr ""
+msgstr "Anvend funktion på liste"
 
 #: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
+#, fuzzy
 msgid "Drop the last n list elements"
-msgstr ""
+msgstr "Anvend funktion på liste"
 
 #: ../../src/wxMaximaFrame.cpp:1306
 msgid "E&quations"
-msgstr ""
+msgstr "&Ligninger"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "E&xit\tCtrl+Q"
-msgstr ""
+msgstr "&Afslut\tCtrl+Q"
 
 #: ../../src/wxMaximaFrame.cpp:1368
 msgid "Eige&nvectors"
-msgstr ""
+msgstr "Egenv&ektorer"
 
 #: ../../src/wxMaximaFrame.cpp:1365
 msgid "Eigen&values"
-msgstr ""
+msgstr "Egen&værdier"
 
 #: ../../src/wxMaximaFrame.cpp:1387
+#, fuzzy
 msgid "Eigenvalues (complex)"
-msgstr ""
+msgstr "Egen&værdier"
 
 #: ../../src/wxMaximaFrame.cpp:1384
+#, fuzzy
 msgid "Eigenvalues (real)"
-msgstr ""
+msgstr "Egen&værdier"
 
 #: ../../src/wxMaximaFrame.cpp:1393
 msgid "Eigenvalues, left+right eigenvectors (complex)"
@@ -2337,20 +2508,22 @@ msgid "Elements:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7847
+#, fuzzy
 msgid "Eliminate a variable"
-msgstr ""
+msgstr "&Eliminer variabel..."
 
 #: ../../src/wxMaximaFrame.cpp:1247
 msgid "Eliminate a variable from a system of equations"
-msgstr ""
+msgstr "Eliminer en variabel i et ligningssystem"
 
 #: ../../src/wxMaxima.cpp:10651
 msgid "Empty command => re-triggering evaluation"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9225
+#, fuzzy
 msgid "Enable:"
-msgstr ""
+msgstr "Variabel:"
 
 #: ../../src/MathParser.cpp:99
 #, c-format
@@ -2375,35 +2548,38 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1319
 msgid "Enter a matrix"
-msgstr ""
+msgstr "Opret matrix og indtast elementer"
 
 #: ../../src/wxMaxima.cpp:8866
 msgid "Enter an equation for rational simplification:"
-msgstr ""
+msgstr "Indtast udtryk:"
 
 #: ../../src/wxMaxima.cpp:8169
 msgid "Enter matrix"
-msgstr ""
+msgstr "Indtast matrixelementer"
 
 #: ../../src/wxMaxima.cpp:9095
 msgid "Enter new animation frame rate [Hz, integer]:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9201
+#, fuzzy
 msgid "Enter new precision for bigfloats:"
-msgstr ""
+msgstr "Angiv ny nøjagtighed:"
 
 #: ../../src/wxMaxima.cpp:7922
 msgid "Enumerator:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1220
+#, fuzzy
 msgid "Environment variables"
-msgstr ""
+msgstr "Yderligere parametre:"
 
 #: ../../src/wxMaxima.cpp:9045
+#, fuzzy
 msgid "Epsilon:"
-msgstr ""
+msgstr "Udtryk:"
 
 #: ../../src/wxMaximaFrame.cpp:1124 ../../src/wxMaximaFrame.cpp:1135
 msgid "Equal, ignoring case?..."
@@ -2414,22 +2590,24 @@ msgid "Equal?..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8561
+#, fuzzy
 msgid "Equation"
-msgstr ""
+msgstr "Ligning:"
 
 #: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
+#, fuzzy
 msgid "Equation(s)"
-msgstr ""
+msgstr "Ligning(er):"
 
 #: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
 msgid "Equation(s):"
-msgstr ""
+msgstr "Ligning(er):"
 
 #: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
 #: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
 #: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
 msgid "Equation:"
-msgstr ""
+msgstr "Ligning:"
 
 #: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
 #: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
@@ -2441,7 +2619,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
 #: ../../src/wxMaxima.cpp:11166
 msgid "Error"
-msgstr ""
+msgstr "Fejl"
 
 #: ../../src/wxMaxima.cpp:2456
 msgid "Error writing to Maxima"
@@ -2451,7 +2629,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
 #: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
 msgid "Error!"
-msgstr ""
+msgstr "Fejl!"
 
 #: ../../src/Image.cpp:696
 #, c-format
@@ -2483,37 +2661,44 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1652
+#, fuzzy
 msgid "Evaluate &Noun Forms..."
-msgstr ""
+msgstr "Evaluer &navneformer"
 
 #: ../../src/wxMaximaFrame.cpp:856
+#, fuzzy
 msgid "Evaluate All Cells\tCtrl+Shift+R"
-msgstr ""
+msgstr "Beregn alle celler\tCtrl+R"
 
 #: ../../src/wxMaximaFrame.cpp:851
+#, fuzzy
 msgid "Evaluate All Visible Cells\tCtrl+R"
-msgstr ""
+msgstr "Beregn alle celler\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1395
+#, fuzzy
 msgid "Evaluate Cell"
-msgstr ""
+msgstr "Beregn celle(r)"
 
 #: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
 msgid "Evaluate Cell(s)"
-msgstr ""
+msgstr "Beregn celle(r)"
 
 #: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
+#, fuzzy
 msgid "Evaluate Cells Above"
-msgstr ""
+msgstr "Beregn celle(r)"
 
 #: ../../src/wxMaximaFrame.cpp:866
+#, fuzzy
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
-msgstr ""
+msgstr "Beregn alle celler\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
 #: ../../src/wxMaximaFrame.cpp:876
+#, fuzzy
 msgid "Evaluate Cells Below"
-msgstr ""
+msgstr "Beregn celle(r)"
 
 #: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
 #: ../../src/Worksheet.cpp:1890
@@ -2526,8 +2711,9 @@ msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8626
+#, fuzzy
 msgid "Evaluate Nouns"
-msgstr ""
+msgstr "Evaluer &navneformer"
 
 #: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
 msgid "Evaluate Part\tShift+Ctrl+Enter"
@@ -2549,7 +2735,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:845
 msgid "Evaluate active or selected cell(s)"
-msgstr ""
+msgstr "Beregn aktiv(e) eller valgt(e) celle(r)"
 
 #: ../../src/ToolBar.cpp:251
 msgid "Evaluate all"
@@ -2557,43 +2743,49 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:857
 msgid "Evaluate all cells in the document"
-msgstr ""
+msgstr "Beregn alle celler i dokumentet"
 
 #: ../../src/wxMaximaFrame.cpp:1653
 msgid "Evaluate all noun forms in expression"
-msgstr ""
+msgstr "Evaluer alle navneformer i udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:852
+#, fuzzy
 msgid "Evaluate all visible cells in the document"
-msgstr ""
+msgstr "Beregn alle celler i dokumentet"
 
 #: ../../src/ToolBar.cpp:248
 msgid "Evaluate current cell"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7395
+#, fuzzy
 msgid "Evaluate string"
-msgstr ""
+msgstr "Evaluer &navneformer"
 
 #: ../../src/wxMaximaFrame.cpp:1151
+#, fuzzy
 msgid "Evaluate string..."
-msgstr ""
+msgstr "Evaluer &navneformer"
 
 #: ../../src/ToolBar.cpp:256
 msgid "Evaluate the file from its beginning to the cell above the cursor"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:259
+#, fuzzy
 msgid "Evaluate the file from the cursor to its end"
-msgstr ""
+msgstr "Beregn alle celler i dokumentet"
 
 #: ../../src/ToolBar.cpp:258
+#, fuzzy
 msgid "Evaluate the rest"
-msgstr ""
+msgstr "Evaluer &navneformer"
 
 #: ../../src/ToolBar.cpp:255
+#, fuzzy
 msgid "Evaluate to point"
-msgstr ""
+msgstr "Evaluer &navneformer"
 
 #: ../../src/wxMaxima.cpp:10518
 msgid "Evaluation ended, since evaluation queue is empty."
@@ -2617,31 +2809,34 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1583
 msgid "Expand Expression"
-msgstr ""
+msgstr "Udvid udtryk til ledform"
 
 #: ../../src/wxMaximaFrame.cpp:1525
 msgid "Expand an expression"
-msgstr ""
+msgstr "Udvid et udtryk til ledform"
 
 #: ../../src/wxMaximaFrame.cpp:1531
+#, fuzzy
 msgid "Expand for given variables"
-msgstr ""
+msgstr "Udskift variabel"
 
 #: ../../src/wxMaxima.cpp:8781
 msgid "Expand for variable(s) including denominator:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8716
+#, fuzzy
 msgid "Expand for variable(s):"
-msgstr ""
+msgstr "Ny variabel:"
 
 #: ../../src/wxMaximaFrame.cpp:1545
+#, fuzzy
 msgid "Expand log in previous expression"
-msgstr ""
+msgstr "Udvid et udtryk til ledform"
 
 #: ../../src/wxMaximaFrame.cpp:1598
 msgid "Expand trigonometric expression"
-msgstr ""
+msgstr "Udvid trigonometrisk udtryk til ledform"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Expect numbers harder to be complex"
@@ -2653,27 +2848,32 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6121
 msgid "Export"
-msgstr ""
+msgstr "Eksporter"
 
 #: ../../src/wxMaximaFrame.cpp:1705
+#, fuzzy
 msgid "Export List to csv file..."
-msgstr ""
+msgstr "TeX-eksport mislykkedes!"
 
 #: ../../src/wxMaximaFrame.cpp:1706
+#, fuzzy
 msgid "Export a list to a csv file"
-msgstr ""
+msgstr "Indlæs fil med Maxima-pakke"
 
 #: ../../src/wxMaximaFrame.cpp:1332
+#, fuzzy
 msgid "Export a matrix to a csv file"
-msgstr ""
+msgstr "Indlæs fil med Maxima-pakke"
 
 #: ../../src/wxMaximaFrame.cpp:619
+#, fuzzy
 msgid "Export document to a HTML or LaTeX file"
-msgstr ""
+msgstr "Eksporter dokument til HTML eller LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:579
+#, fuzzy
 msgid "Export failed."
-msgstr ""
+msgstr "TeX-eksport mislykkedes!"
 
 #: ../../src/wxMaximaFrame.cpp:567
 msgid "Export successful."
@@ -2681,34 +2881,38 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6187
 msgid "Exporting to HTML failed!"
-msgstr ""
+msgstr "HTML-eksport mislykkedes!"
 
 #: ../../src/wxMaxima.cpp:6164
 msgid "Exporting to TeX failed!"
-msgstr ""
+msgstr "TeX-eksport mislykkedes!"
 
 #: ../../src/wxMaxima.cpp:6175
+#, fuzzy
 msgid "Exporting to maxima batch file failed!"
-msgstr ""
+msgstr "TeX-eksport mislykkedes!"
 
 #: ../../src/wxMaximaFrame.cpp:561
+#, fuzzy
 msgid "Exporting..."
-msgstr ""
+msgstr "&Eksporter..."
 
 #: ../../src/wxMaxima.cpp:6510 ../../src/wxMaxima.cpp:6516
 #: ../../src/wxMaxima.cpp:8218 ../../src/wxMaxima.cpp:8633
 #: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
 #: ../../src/wxMaxima.cpp:10065
 msgid "Expression"
-msgstr ""
+msgstr "Udtryk"
 
 #: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
+#, fuzzy
 msgid "Expression or a list of comma-separated expressions"
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #: ../../src/wxMaximaFrame.cpp:1088
+#, fuzzy
 msgid "Expression to string..."
-msgstr ""
+msgstr "Udtryk"
 
 #: ../../src/wxMaxima.cpp:7113
 msgid "Expression whose output is to be used as maxima's input."
@@ -2716,7 +2920,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7214
 msgid "Expression(s):"
-msgstr ""
+msgstr "Udtryk:"
 
 #: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
 #: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
@@ -2725,19 +2929,21 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
 #: ../../src/wxMaxima.cpp:10056
 msgid "Expression:"
-msgstr ""
+msgstr "Udtryk:"
 
 #: ../../src/wxMaximaFrame.cpp:1423
+#, fuzzy
 msgid "Extract Column..."
-msgstr ""
+msgstr "Opret liste ud fra udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1726
 msgid "Extract Elements"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1421
+#, fuzzy
 msgid "Extract Row..."
-msgstr ""
+msgstr "Opret liste ud fra udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1424
 msgid "Extract a column from the matrix"
@@ -2748,32 +2954,38 @@ msgid "Extract a column from the matrix and convert it to a list"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7960
+#, fuzzy
 msgid "Extract a matrix column"
-msgstr ""
+msgstr "Opret matrix og indtast elementer"
 
 #: ../../src/wxMaxima.cpp:7970
+#, fuzzy
 msgid "Extract a matrix column as a list"
-msgstr ""
+msgstr "Opret matrix og indtast elementer"
 
 #: ../../src/wxMaximaFrame.cpp:1313
+#, fuzzy
 msgid "Extract a matrix from a 2-dimensional array"
-msgstr ""
+msgstr "Opret matrix ud fra et 2-dimensionalt array"
 
 #: ../../src/wxMaxima.cpp:7955
+#, fuzzy
 msgid "Extract a matrix row"
-msgstr ""
+msgstr "Opret matrix og indtast elementer"
 
 #: ../../src/wxMaxima.cpp:7965
+#, fuzzy
 msgid "Extract a matrix row as a list"
-msgstr ""
+msgstr "Opret matrix og indtast elementer"
 
 #: ../../src/wxMaximaFrame.cpp:1422
 msgid "Extract a row from the matrix"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1431
+#, fuzzy
 msgid "Extract a row from the matrix and convert it to a list"
-msgstr ""
+msgstr "Opret liste ud fra udtryk"
 
 #: ../../src/wxMaxima.cpp:8564
 msgid "Extract a variable's value from a list of variable values"
@@ -2784,60 +2996,72 @@ msgid "Extract an actual value for a variable"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1163
+#, fuzzy
 msgid "Extract char..."
-msgstr ""
+msgstr "Opret liste ud fra udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1207
+#, fuzzy
 msgid "Extract dir from path..."
-msgstr ""
+msgstr "Opret liste ud fra udtryk"
 
 #: ../../src/wxMaxima.cpp:7605
+#, fuzzy
 msgid "Extract directory part"
-msgstr ""
+msgstr "Navne på funktioner"
 
 #: ../../src/wxMaxima.cpp:7617
+#, fuzzy
 msgid "Extract file type extension"
-msgstr ""
+msgstr "Opret liste ud fra udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1209
 msgid "Extract filename from path..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7611
+#, fuzzy
 msgid "Extract filename part"
-msgstr ""
+msgstr "Opret liste ud fra udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1211
 msgid "Extract filetype from path..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8445
+#, fuzzy
 msgid "Extract function arguments"
-msgstr ""
+msgstr "Navne på funktioner"
 
 #: ../../src/wxMaximaFrame.cpp:1727
+#, fuzzy
 msgid "Extract list Elements"
-msgstr ""
+msgstr "Opret liste ud fra udtryk"
 
 #: ../../src/wxMaxima.cpp:8187
+#, fuzzy
 msgid "Extract matrix from 2D array"
-msgstr ""
+msgstr "Opret matrix og indtast elementer"
 
 #: ../../src/wxMaximaFrame.cpp:1686
+#, fuzzy
 msgid "Extract the argument list from a function call"
-msgstr ""
+msgstr "Opret liste ud fra udtryk"
 
 #: ../../src/wxMaxima.cpp:8538
+#, fuzzy
 msgid "Extract the last n elements from a list"
-msgstr ""
+msgstr "Opret liste ud fra udtryk"
 
 #: ../../src/wxMaxima.cpp:7376
+#, fuzzy
 msgid "Extract the nth char of a string"
-msgstr ""
+msgstr "Opret liste ud fra udtryk"
 
 #: ../../src/wxMaxima.cpp:8544
+#, fuzzy
 msgid "Extract the nth list elements"
-msgstr ""
+msgstr "Opret liste ud fra udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1724
 msgid "Extract the value for one variable assigned in a list"
@@ -2848,32 +3072,34 @@ msgid "Extract, append or delete rows or columns"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8188
+#, fuzzy
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
-msgstr ""
+msgstr "Opret liste ud fra udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1521
 msgid "Factor Complex"
-msgstr ""
+msgstr "Faktoriser komplekst udtryk"
 
 #: ../../src/Worksheet.cpp:1581
 msgid "Factor Expression"
-msgstr ""
+msgstr "Faktoriser udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1519
+#, fuzzy
 msgid "Factor Expression including subexpressions"
-msgstr ""
+msgstr "Faktoriser et udtryk i Gaussiske heltal"
 
 #: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
 msgid "Factor an expression"
-msgstr ""
+msgstr "Faktoriser et udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1522
 msgid "Factor an expression in Gaussian numbers"
-msgstr ""
+msgstr "Faktoriser et udtryk i Gaussiske heltal"
 
 #: ../../src/wxMaximaFrame.cpp:1587
 msgid "Factorials and &Gamma"
-msgstr ""
+msgstr "Fakultet og &Gamma-funktion"
 
 #: ../../src/Image.cpp:137
 #, c-format
@@ -2886,8 +3112,9 @@ msgid "Failed to delete gnuplot file %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:2667
+#, fuzzy
 msgid "Failed to start Maxima"
-msgstr ""
+msgstr "Genstart Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1418
 msgid "Fast fortran routines that perform numerical tasks"
@@ -2899,15 +3126,17 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:2553
 msgid "Fatal error"
-msgstr ""
+msgstr "Alvorlig fejl"
 
 #: ../../src/wxMaxima.cpp:7191
+#, fuzzy
 msgid "Field contents:"
-msgstr ""
+msgstr "Græske konstanter"
 
 #: ../../src/wxMaxima.cpp:7198
+#, fuzzy
 msgid "Field name:"
-msgstr ""
+msgstr "Tidligere variabel:"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "Fields:"
@@ -2915,71 +3144,81 @@ msgstr ""
 
 #: ../../src/main.cpp:439
 msgid "File"
-msgstr ""
+msgstr "Fil"
 
 #: ../../src/wxMaximaFrame.cpp:1333
+#, fuzzy
 msgid "File I/O"
-msgstr ""
+msgstr "Fil"
 
 #: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
 #: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
 #: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
 #: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
+#, fuzzy
 msgid "File could not be opened"
-msgstr ""
+msgstr "Filen blev ikke fundet"
 
 #: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
 #: ../../src/wxMaxima.cpp:7251
+#, fuzzy
 msgid "File name:"
-msgstr ""
+msgstr "Tidligere variabel:"
 
 #: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
 msgid "File not found"
-msgstr ""
+msgstr "Filen blev ikke fundet"
 
 #: ../../src/wxMaxima.cpp:5631
+#, fuzzy
 msgid "File opened"
-msgstr ""
+msgstr "Filen blev ikke fundet"
 
 #: ../../src/wxMaximaFrame.cpp:1217
+#, fuzzy
 msgid "File operations"
-msgstr ""
+msgstr "Filen blev ikke fundet"
 
 #: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
 msgid "File you tried to open does not exist."
-msgstr ""
+msgstr "Filen findes ikke."
 
 #: ../../src/wxMaximaFrame.cpp:1221
+#, fuzzy
 msgid "File/directory functions"
-msgstr ""
+msgstr "Fra:"
 
 #: ../../src/wxMaxima.cpp:7027
 msgid "Filename or a list of comma-separated file names"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:222
+#, fuzzy
 msgid "Find"
-msgstr ""
+msgstr "Bestem nulpunkt"
 
 #: ../../src/wxMaximaFrame.cpp:670
+#, fuzzy
 msgid "Find\tCtrl+F"
-msgstr ""
+msgstr "Fortryd\tCtrl+Z"
 
 #: ../../src/wxMaximaFrame.cpp:1468
 msgid "Find &Limit..."
-msgstr ""
+msgstr "Bestem &grænseværdi..."
 
 #: ../../src/wxMaximaFrame.cpp:1470
+#, fuzzy
 msgid "Find Minimum..."
-msgstr ""
+msgstr "Bestem &grænseværdi..."
 
 #: ../../src/Worksheet.cpp:1576
 msgid "Find Root..."
-msgstr ""
+msgstr "Bestem nulpunkt..."
 
 #: ../../src/wxMaximaFrame.cpp:1471
+#, fuzzy
 msgid "Find a (unconstrained) minimum of an expression"
-msgstr ""
+msgstr "Bestem grænseværdi for et udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1804
 msgid "Find a fraction that represents this float exactly"
@@ -2987,27 +3226,29 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1469
 msgid "Find a limit of an expression"
-msgstr ""
+msgstr "Bestem grænseværdi for et udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1807
 msgid "Find a nice fraction that is similar to this float"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1283
+#, fuzzy
 msgid "Find a numerical solution for a first degree ODE"
-msgstr ""
+msgstr "Løs begyndelsesværdiproblem for 1. ordens ODL"
 
 #: ../../src/wxMaximaFrame.cpp:1252
 msgid "Find a root of an equation on an interval"
-msgstr ""
+msgstr "Bestem et nulpunkt for et udtryk indenfor et interval"
 
 #: ../../src/wxMaximaFrame.cpp:1259
 msgid "Find all roots of a polynomial"
-msgstr ""
+msgstr "Bestem alle rødder i et polynomium"
 
 #: ../../src/wxMaximaFrame.cpp:1262
+#, fuzzy
 msgid "Find all roots of a polynomial (bfloat)"
-msgstr ""
+msgstr "Bestem alle rødder i et polynomium"
 
 #: ../../src/wxMaxima.cpp:6589
 msgid "Find and Replace"
@@ -3031,11 +3272,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1366
 msgid "Find eigenvalues of a matrix"
-msgstr ""
+msgstr "Bestem en matrixs egenværdier"
 
 #: ../../src/wxMaximaFrame.cpp:1369
 msgid "Find eigenvectors of a matrix"
-msgstr ""
+msgstr "Bestem en matrixs egenvektorer"
 
 #: ../../src/wxMaxima.cpp:7424
 msgid "Find first difference"
@@ -3046,8 +3287,9 @@ msgid "Find first difference..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1256
+#, fuzzy
 msgid "Find fractions that real roots of a polynomial and "
-msgstr ""
+msgstr "Bestem et polynomiums reelle rødder"
 
 #: ../../src/wxMaxima.cpp:9039
 msgid "Find minimum"
@@ -3062,8 +3304,9 @@ msgid "Find root (solve numerically)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
+#, fuzzy
 msgid "Find the maximum absolute value of a matrix entry"
-msgstr ""
+msgstr "Bestem en matrixs egenværdier"
 
 #: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
 msgid "Find the maximum sum of the absolute values of a matrix column"
@@ -3094,8 +3337,9 @@ msgid "Flush..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:922
+#, fuzzy
 msgid "Fold All\tCtrl+Alt+["
-msgstr ""
+msgstr "&Marker alt\tCtrl+A"
 
 #: ../../src/wxMaximaFrame.cpp:923
 msgid "Fold all sections"
@@ -3182,55 +3426,60 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "From:"
-msgstr ""
+msgstr "Fra:"
 
 #: ../../src/wxMaximaFrame.cpp:827
 msgid "Full Screen\tAlt+Enter"
-msgstr ""
+msgstr "Fuld skærm\tAlt+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:824
 msgid "Full Screen\tF11"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7140
+#, fuzzy
 msgid "Function contents:"
-msgstr ""
+msgstr "Navne på funktioner"
 
 #: ../../src/wxMaxima.cpp:7908
+#, fuzzy
 msgid "Function f(x):"
-msgstr ""
+msgstr "Funktion(er):"
 
 #: ../../src/wxMaxima.cpp:8572
+#, fuzzy
 msgid "Function name"
-msgstr ""
+msgstr "Navne på funktioner"
 
 #: ../../src/wxMaxima.cpp:7167
+#, fuzzy
 msgid "Function name(s):"
-msgstr ""
+msgstr "Navne på funktioner"
 
 #: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
+#, fuzzy
 msgid "Function name:"
-msgstr ""
+msgstr "Navne på funktioner"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Function:"
-msgstr ""
+msgstr "Funktion:"
 
 #: ../../src/wxMaximaFrame.cpp:1630
 msgid "Functions for complex simplification"
-msgstr ""
+msgstr "Faciliteter til reduktion af komplekse udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1588
 msgid "Functions for simplifying factorials and gamma function"
-msgstr ""
+msgstr "Faciliteter til reduktion af fakulteter og Gamma-funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1606
 msgid "Functions for simplifying trigonometric expressions"
-msgstr ""
+msgstr "Faciliteter til reduktion af trigonometriske funktioner"
 
 #: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
 msgid "GCD"
-msgstr ""
+msgstr "SFD"
 
 #: ../../src/wxMaxima.cpp:10186
 msgid "GIF image (*.gif)|*.gif"
@@ -3244,20 +3493,23 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:295
+#, fuzzy
 msgid "General Math"
-msgstr ""
+msgstr "Opret matrix"
 
 #: ../../src/wxMaximaFrame.cpp:699
 msgid "General Math\tAlt+Shift+M"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1316
+#, fuzzy
 msgid "Generate Matrix from Expression..."
-msgstr ""
+msgstr "&Opret matrix..."
 
 #: ../../src/wxMaximaFrame.cpp:1317
+#, fuzzy
 msgid "Generate a matrix from a lambda expression"
-msgstr ""
+msgstr "Opret matrix ud fra et 2-dimensionalt array"
 
 #: ../../src/wxMaximaFrame.cpp:1675
 msgid "Generate a new list using a lists' elements"
@@ -3274,8 +3526,9 @@ msgid "Generate list elements using a rule"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8196
+#, fuzzy
 msgid "Generate matrix from a rule"
-msgstr ""
+msgstr "Opret liste ud fra udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1094
 msgid "Generate unused symbol name"
@@ -3293,15 +3546,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1619
 msgid "Get &Imaginary Part"
-msgstr ""
+msgstr "&Imaginærdel"
 
 #: ../../src/wxMaximaFrame.cpp:1485
 msgid "Get Laplace transformation of an expression"
-msgstr ""
+msgstr "Bestem Laplace-transformation for et udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1615
 msgid "Get Real P&art"
-msgstr ""
+msgstr "&Realdel"
 
 #: ../../src/wxMaximaFrame.cpp:1201
 msgid "Get current directory"
@@ -3309,23 +3562,24 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1489
 msgid "Get inverse Laplace transformation of an expression"
-msgstr ""
+msgstr "Bestem invers Laplace-transformation for et udtryk"
 
 #: ../../src/wxMaxima.cpp:7223
 msgid "Get position in stream"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1102
+#, fuzzy
 msgid "Get position..."
-msgstr ""
+msgstr "Animation"
 
 #: ../../src/wxMaximaFrame.cpp:1620
 msgid "Get the imaginary part of complex expression"
-msgstr ""
+msgstr "Bestem imaginærdelen af komplekst udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1616
 msgid "Get the real part of complex expression"
-msgstr ""
+msgstr "Bestem realdelen af komplekst udtryk"
 
 #: ../../src/wxMaxima.cpp:3609
 #, c-format
@@ -3351,8 +3605,9 @@ msgid "Go to URL"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3989
+#, fuzzy
 msgid "Got a new input prompt!"
-msgstr ""
+msgstr "Indsæt en ny celle"
 
 #: ../../src/Worksheet.cpp:6354
 msgid ""
@@ -3365,46 +3620,52 @@ msgid "Gradefs"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1967
+#, fuzzy
 msgid "Greater or less than a value"
-msgstr ""
+msgstr "Afsnitscelle"
 
 #: ../../src/wxMaximaFrame.cpp:1130
 msgid "Greater, ignoring case?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:260
+#, fuzzy
 msgid "Greek Letters"
-msgstr ""
+msgstr "Græske konstanter"
 
 #: ../../src/wxMaximaFrame.cpp:703
+#, fuzzy
 msgid "Greek Letters\tAlt+Shift+G"
-msgstr ""
+msgstr "Græske konstanter"
 
 #: ../../src/wxMaximaFrame.cpp:1815
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:6123
+#, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file "
 "(*.tex)|*.tex"
-msgstr ""
+msgstr "HTML-fil (*.html)|*.html|pdfLaTeX-fil (*.tex)|*.tex|Alle|*"
 
 #: ../../src/wxMaximaFrame.cpp:1341
 msgid "Hadamard (element-by-element) product..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8004
+#, fuzzy
 msgid "Hadamard Product"
-msgstr ""
+msgstr "Produkt"
 
 #: ../../src/wxMaxima.cpp:8011
 msgid "Hadamard exponent"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1345
+#, fuzzy
 msgid "Hadamard exponent..."
-msgstr ""
+msgstr "Matrix:"
 
 #: ../../src/MaximaManual.cpp:260
 #, c-format
@@ -3423,7 +3684,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
 msgid "Help"
-msgstr ""
+msgstr "Hjælp"
 
 #: ../../src/ToolBar.cpp:635
 msgid "Help button"
@@ -3435,16 +3696,19 @@ msgid "Help on \"%s\""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:729
+#, fuzzy
 msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr ""
+msgstr "Indsæt celle(r)\tCtrl+Shift+V"
 
 #: ../../src/ToolBar.cpp:264
+#, fuzzy
 msgid "Hide Code"
-msgstr ""
+msgstr "Division"
 
 #: ../../src/wxMaximaFrame.cpp:727
+#, fuzzy
 msgid "Hide Code Cells\tAlt+Ctrl+H"
-msgstr ""
+msgstr "Indsæt celle(r)\tCtrl+Shift+V"
 
 #: ../../src/Worksheet.cpp:1896
 msgid "Hide Heading 5"
@@ -3455,32 +3719,38 @@ msgid "Hide Heading 6"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1855
+#, fuzzy
 msgid "Hide Part"
-msgstr ""
+msgstr "Division"
 
 #: ../../src/Worksheet.cpp:1863
+#, fuzzy
 msgid "Hide Section"
-msgstr ""
+msgstr "Markering"
 
 #: ../../src/Worksheet.cpp:1874
+#, fuzzy
 msgid "Hide Subsection"
-msgstr ""
+msgstr "Markering"
 
 #: ../../src/Worksheet.cpp:1885
+#, fuzzy
 msgid "Hide Subsubsection"
-msgstr ""
+msgstr "Markering"
 
 #: ../../src/wxMaximaFrame.cpp:730
 msgid "Hide all panes"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1491
+#, fuzzy
 msgid "Hide cell brackets"
-msgstr ""
+msgstr "Parentes for aktiv celle"
 
 #: ../../src/Worksheet.cpp:1915
+#, fuzzy
 msgid "Hide contents"
-msgstr ""
+msgstr "Græske konstanter"
 
 #: ../../src/Worksheet.cpp:1552
 msgid "Hide multiplication dots"
@@ -3495,8 +3765,9 @@ msgid "Hide yellow tooltip marker for this message type"
 msgstr ""
 
 #: ../../src/Configuration.cpp:82
+#, fuzzy
 msgid "Highlight (box)"
-msgstr ""
+msgstr "Fremhævning (dpart)"
 
 #: ../../src/wxMaxima.cpp:9528
 msgid "Histogram"
@@ -3507,8 +3778,9 @@ msgid "History"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:709
+#, fuzzy
 msgid "History\tAlt+Shift+I"
-msgstr ""
+msgstr "Indsæt celle(r)\tCtrl+Shift+V"
 
 #: ../../src/wxMaximaFrame.cpp:1526
 msgid "Horner's rule"
@@ -3606,12 +3878,13 @@ msgid "Index Step:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
+#, fuzzy
 msgid "Index variable:"
-msgstr ""
+msgstr "Ny variabel:"
 
 #: ../../src/wxMaximaFrame.cpp:1949
 msgid "Info about Maxima build"
-msgstr ""
+msgstr "Information om Maxima-version"
 
 #: ../../src/Worksheet.cpp:2046
 msgid "Inform maxima about facts you know for this symbol"
@@ -3624,16 +3897,17 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
+#, fuzzy
 msgid "Initial Condition"
-msgstr ""
+msgstr "Animation"
 
 #: ../../src/wxMaximaFrame.cpp:1270
 msgid "Initial Value Problem (&1)..."
-msgstr ""
+msgstr "Begyndelsesværdiproblem (&1)..."
 
 #: ../../src/wxMaximaFrame.cpp:1274
 msgid "Initial Value Problem (&2)..."
-msgstr ""
+msgstr "Begyndelsesværdiproblem (&2)..."
 
 #: ../../src/wxMaxima.cpp:9044
 msgid "Initial estimates:"
@@ -3645,23 +3919,27 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:78
 msgid "Input labels"
-msgstr ""
+msgstr "Input-etiketter"
 
 #: ../../src/wxMaximaFrame.cpp:314
+#, fuzzy
 msgid "Insert"
-msgstr ""
+msgstr "Indsæt tekstcelle"
 
 #: ../../src/wxMaximaFrame.cpp:905
+#, fuzzy
 msgid "Insert &Section Cell\tCtrl+3"
-msgstr ""
+msgstr "Indsæt &afsnitscelle\tCtrl+F6 "
 
 #: ../../src/wxMaximaFrame.cpp:901
+#, fuzzy
 msgid "Insert &Text Cell\tCtrl+1"
-msgstr ""
+msgstr "Indsæt &tekstcelle\tF6"
 
 #: ../../src/wxMaximaFrame.cpp:713
+#, fuzzy
 msgid "Insert Cell\tAlt+Shift+C"
-msgstr ""
+msgstr "Indsæt celle(r)\tCtrl+Shift+V"
 
 #: ../../src/Worksheet.cpp:1669
 msgid "Insert Heading5 Cell"
@@ -3673,51 +3951,61 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10854
 msgid "Insert Image"
-msgstr ""
+msgstr "Indsæt billede"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert Image..."
-msgstr ""
+msgstr "Indsæt billede..."
 
 #: ../../src/wxMaximaFrame.cpp:899
+#, fuzzy
 msgid "Insert Input &Cell\tCtrl+0"
-msgstr ""
+msgstr "Indsæt &input\tF7"
 
 #: ../../src/wxMaximaFrame.cpp:919
+#, fuzzy
 msgid "Insert Page Break"
-msgstr ""
+msgstr "Indsæt billede"
 
 #: ../../src/wxMaximaFrame.cpp:907
+#, fuzzy
 msgid "Insert S&ubsection Cell\tCtrl+4"
-msgstr ""
+msgstr "Indsæt &afsnitscelle\tCtrl+F6 "
 
 #: ../../src/wxMaximaFrame.cpp:910
+#, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
-msgstr ""
+msgstr "Indsæt &afsnitscelle\tCtrl+F6 "
 
 #: ../../src/Worksheet.cpp:1662
+#, fuzzy
 msgid "Insert Section Cell"
-msgstr ""
+msgstr "Indsæt &afsnitscelle\tCtrl+F6 "
 
 #: ../../src/Worksheet.cpp:1664
+#, fuzzy
 msgid "Insert Subsection Cell"
-msgstr ""
+msgstr "Indsæt &afsnitscelle\tCtrl+F6 "
 
 #: ../../src/Worksheet.cpp:1667
+#, fuzzy
 msgid "Insert Subsubsection Cell"
-msgstr ""
+msgstr "Indsæt &afsnitscelle\tCtrl+F6 "
 
 #: ../../src/wxMaximaFrame.cpp:903
+#, fuzzy
 msgid "Insert T&itle Cell\tCtrl+2"
-msgstr ""
+msgstr "Indsæt &tekstcelle\tF6"
 
 #: ../../src/Worksheet.cpp:1658
+#, fuzzy
 msgid "Insert Text Cell"
-msgstr ""
+msgstr "Indsæt &tekstcelle\tF6"
 
 #: ../../src/Worksheet.cpp:1660
+#, fuzzy
 msgid "Insert Title Cell"
-msgstr ""
+msgstr "Indsæt &tekstcelle\tF6"
 
 #: ../../src/wxMaximaFrame.cpp:913
 msgid "Insert a new heading5 cell"
@@ -3729,35 +4017,39 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:900
 msgid "Insert a new input cell"
-msgstr ""
+msgstr "Indsæt en ny celle"
 
 #: ../../src/wxMaximaFrame.cpp:906
 msgid "Insert a new section cell"
-msgstr ""
+msgstr "Indsæt en ny afsnitscelle"
 
 #: ../../src/wxMaximaFrame.cpp:908
+#, fuzzy
 msgid "Insert a new subsection cell"
-msgstr ""
+msgstr "Indsæt en ny afsnitscelle"
 
 #: ../../src/wxMaximaFrame.cpp:911
+#, fuzzy
 msgid "Insert a new subsubsection cell"
-msgstr ""
+msgstr "Indsæt en ny afsnitscelle"
 
 #: ../../src/wxMaximaFrame.cpp:902
 msgid "Insert a new text cell"
-msgstr ""
+msgstr "Indsæt ny tekstcelle"
 
 #: ../../src/wxMaximaFrame.cpp:904
 msgid "Insert a new title cell"
-msgstr ""
+msgstr "Indsæt en ny celle til overskrift"
 
 #: ../../src/wxMaximaFrame.cpp:920
+#, fuzzy
 msgid "Insert a page break"
-msgstr ""
+msgstr "Indsæt billede"
 
 #: ../../src/wxMaximaFrame.cpp:1164
+#, fuzzy
 msgid "Insert char..."
-msgstr ""
+msgstr "Indsæt billede..."
 
 #: ../../src/wxMaximaFrame.cpp:912
 msgid "Insert heading5 Cell\tCtrl+6"
@@ -3772,8 +4064,9 @@ msgid "Insert image"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:916
+#, fuzzy
 msgid "Insert textbased cell"
-msgstr ""
+msgstr "Indsæt &tekstcelle\tF6"
 
 #: ../../src/wxMaxima.cpp:3566
 msgid "Instructed to prefer gnuplot over wgnuplot"
@@ -3785,43 +4078,47 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
 msgid "Integral/Sum:"
-msgstr ""
+msgstr "Integral/Sum:"
 
 #: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
 msgid "Integrate"
-msgstr ""
+msgstr "Integrer"
 
 #: ../../src/wxMaxima.cpp:8980
 msgid "Integrate (risch)"
-msgstr ""
+msgstr "Integrer (Risch)"
 
 #: ../../src/wxMaximaFrame.cpp:1454
 msgid "Integrate expression"
-msgstr ""
+msgstr "Integrer udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1456
 msgid "Integrate expression with Risch algorithm"
-msgstr ""
+msgstr "Integrer udtryk ved hjælp af Risch-algoritme"
 
 #: ../../src/wxMaximaFrame.cpp:1869
+#, fuzzy
 msgid "Integrate numerically"
-msgstr ""
+msgstr "Integrer (Risch)"
 
 #: ../../src/Worksheet.cpp:1588
 msgid "Integrate..."
-msgstr ""
+msgstr "Integrer..."
 
 #: ../../src/wxMaximaFrame.cpp:1737
+#, fuzzy
 msgid "Interleave"
-msgstr ""
+msgstr "Integrer"
 
 #: ../../src/wxMaximaFrame.cpp:1738
+#, fuzzy
 msgid "Interleave the values of two lists"
-msgstr ""
+msgstr "Integrer"
 
 #: ../../src/wxMaxima.cpp:8612
+#, fuzzy
 msgid "Interleave two lists"
-msgstr ""
+msgstr "Integrer"
 
 #: ../../src/wxMaximaFrame.cpp:1087
 msgid "Interpret like input..."
@@ -3836,16 +4133,17 @@ msgid "Interpret string as maxima code"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1089
+#, fuzzy
 msgid "Interpret string..."
-msgstr ""
+msgstr "I&ndtast matrix..."
 
 #: ../../src/ToolBar.cpp:231
 msgid "Interrupt"
-msgstr ""
+msgstr "Afbryd"
 
 #: ../../src/wxMaximaFrame.cpp:965
 msgid "Interrupt current computation"
-msgstr ""
+msgstr "Afbryd igangværende beregning"
 
 #: ../../src/ToolBar.cpp:232
 msgid ""
@@ -3872,11 +4170,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9003
 msgid "Inverse Laplace"
-msgstr ""
+msgstr "Invers Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1488
 msgid "Inverse Laplace T&ransform..."
-msgstr ""
+msgstr "In&vers Laplace Transformation..."
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Invert worksheet brightness"
@@ -3887,8 +4185,9 @@ msgid "Is Char 1 greater than Char2, if case is ignored?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7333
+#, fuzzy
 msgid "Is Char 1 greater than Char2?"
-msgstr ""
+msgstr "Afsnitscelle"
 
 #: ../../src/wxMaxima.cpp:7327
 msgid "Is Char 1 less than Char2, if case is ignored?"
@@ -3907,12 +4206,14 @@ msgid "Is a char?..."
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1952
+#, fuzzy
 msgid "Is a complex variable"
-msgstr ""
+msgstr "Ny variabel:"
 
 #: ../../src/wxMaxima.cpp:7292
+#, fuzzy
 msgid "Is a digit?"
-msgstr ""
+msgstr "2D-visning"
 
 #: ../../src/wxMaximaFrame.cpp:1118
 msgid "Is a digit?..."
@@ -3927,8 +4228,9 @@ msgid "Is a printable char?"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1949
+#, fuzzy
 msgid "Is a real variable"
-msgstr ""
+msgstr "Udskift variabel"
 
 #: ../../src/wxMaxima.cpp:7300
 msgid "Is a uppercase char?"
@@ -3951,28 +4253,33 @@ msgid "Is an alphanumeric char?"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1991
+#, fuzzy
 msgid "Is an even function"
-msgstr ""
+msgstr "Slet en funktion"
 
 #: ../../src/Worksheet.cpp:1955
+#, fuzzy
 msgid "Is an imaginary variable"
-msgstr ""
+msgstr "Udskift variabel"
 
 #: ../../src/Worksheet.cpp:1960
+#, fuzzy
 msgid "Is an integer variable"
-msgstr ""
+msgstr "Udskift variabel"
 
 #: ../../src/Worksheet.cpp:1993
+#, fuzzy
 msgid "Is an odd function"
-msgstr ""
+msgstr "Slet en funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Is equal?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1128
+#, fuzzy
 msgid "Is greater?..."
-msgstr ""
+msgstr "Opret liste"
 
 #: ../../src/wxMaximaFrame.cpp:1125
 msgid "Is lower?..."
@@ -3983,8 +4290,9 @@ msgid "Is lowercase?..."
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1962
+#, fuzzy
 msgid "Is no integer variable"
-msgstr ""
+msgstr "Udskift variabel"
 
 #: ../../src/wxMaximaFrame.cpp:1119
 msgid "Is printable?..."
@@ -4007,8 +4315,9 @@ msgid "Item"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8581
+#, fuzzy
 msgid "Iterator name:"
-msgstr ""
+msgstr "Matrix:"
 
 #: ../../src/wxMaximaFrame.cpp:1048
 msgid "Jump to first error"
@@ -4020,7 +4329,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8960
 msgid "LCM"
-msgstr ""
+msgstr "MFM"
 
 #: ../../src/wxMaximaFrame.cpp:1407
 msgid "L[1] Norm (complex)"
@@ -4039,8 +4348,9 @@ msgid "L[inf] Norm (real)"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1025
+#, fuzzy
 msgid "Labels"
-msgstr ""
+msgstr "Input-etiketter"
 
 #: ../../src/wxMaxima.cpp:7090
 msgid "Lambda"
@@ -4055,11 +4365,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8997
 msgid "Laplace"
-msgstr ""
+msgstr "Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1484
 msgid "Laplace &Transform..."
-msgstr ""
+msgstr "Laplace &transformation..."
 
 #: ../../src/wxMaximaFrame.cpp:1718
 msgid "Last"
@@ -4076,8 +4386,9 @@ msgid "Last message from maxima's stdout: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1720
+#, fuzzy
 msgid "Last n"
-msgstr ""
+msgstr "Liste:"
 
 #: ../../src/wxMaxima.cpp:10400
 msgid "Last non-whitespace is a question mark"
@@ -4094,7 +4405,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1493
 msgid "Least Common Multiple..."
-msgstr ""
+msgstr "Mindste fælles multiplum..."
 
 #: ../../src/wxMaxima.cpp:9587
 msgid "Least Squares Fit"
@@ -4102,8 +4413,9 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
 #: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
+#, fuzzy
 msgid "Left Matrix:"
-msgstr ""
+msgstr "Indtast matrixelementer"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Left end"
@@ -4130,16 +4442,18 @@ msgid "Letrules"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1976
+#, fuzzy
 msgid "Likely to be the main variable"
-msgstr ""
+msgstr "Slet en variabel"
 
 #: ../../src/wxMaxima.cpp:9028
 msgid "Limit"
-msgstr ""
+msgstr "Grænseværdi"
 
 #: ../../src/wxMaxima.cpp:7256
+#, fuzzy
 msgid "Lisp format string:"
-msgstr ""
+msgstr "Maxima-spørgsmål"
 
 #: ../../src/wxMaxima.cpp:7258
 msgid "Lisp format strings are more powerful than c++ format strings"
@@ -4162,16 +4476,19 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
 #: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
 #: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
+#, fuzzy
 msgid "List"
-msgstr ""
+msgstr "Liste:"
 
 #: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
+#, fuzzy
 msgid "List #1"
-msgstr ""
+msgstr "Liste:"
 
 #: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
+#, fuzzy
 msgid "List #2"
-msgstr ""
+msgstr "Liste:"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "List directory"
@@ -4186,12 +4503,14 @@ msgid "List of char to String"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1150
+#, fuzzy
 msgid "List of chars to string..."
-msgstr ""
+msgstr "Udtryk"
 
 #: ../../src/wxMaxima.cpp:7386
+#, fuzzy
 msgid "List of chars:"
-msgstr ""
+msgstr "Input-etiketter"
 
 #: ../../src/wxMaxima.cpp:8559
 msgid "List with values"
@@ -4200,43 +4519,49 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
 msgid "List:"
-msgstr ""
+msgstr "Liste:"
 
 #: ../../src/wxMaxima.cpp:6200
 msgid "Load Package"
-msgstr ""
+msgstr "Indlæs pakke"
 
 #: ../../src/wxMaximaFrame.cpp:613
+#, fuzzy
 msgid "Load Recent Package"
-msgstr ""
+msgstr "Indlæs pakke"
 
 #: ../../src/wxMaximaFrame.cpp:616
 msgid "Load a Maxima file using the batch command"
-msgstr ""
+msgstr "Indlæs en Maxima-fil ved hjælp af batch-kommando"
 
 #: ../../src/wxMaximaFrame.cpp:611
 msgid "Load a Maxima package file"
-msgstr ""
+msgstr "Indlæs fil med Maxima-pakke"
 
 #: ../../src/wxMaximaFrame.cpp:1678
+#, fuzzy
 msgid "Load a list from a csv file"
-msgstr ""
+msgstr "Indlæs fil med Maxima-pakke"
 
 #: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
+#, fuzzy
 msgid "Load a matrix from a csv file"
-msgstr ""
+msgstr "Indlæs fil med Maxima-pakke"
 
 #: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
+#, fuzzy
 msgid "Load lapack"
-msgstr ""
+msgstr "Indlæs pakke"
 
 #: ../../src/wxMaxima.cpp:7208
+#, fuzzy
 msgid "Load lisp code"
-msgstr ""
+msgstr "Indlæs pakke"
 
 #: ../../src/wxMaximaFrame.cpp:1092
+#, fuzzy
 msgid "Load lisp..."
-msgstr ""
+msgstr "Indlæs pakke"
 
 #: ../../src/wxMaximaFrame.cpp:1198
 msgid "Load the file/dir operations (operatingsystem)"
@@ -4251,36 +4576,41 @@ msgid "Load the translation generator (gentran)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8219
+#, fuzzy
 msgid "Loop variable"
-msgstr ""
+msgstr "Ny variabel:"
 
 #: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
 msgid "Lower bound:"
-msgstr ""
+msgstr "Nedre grænse:"
 
 #: ../../src/wxMaximaFrame.cpp:1127
 msgid "Lower, ignoring case?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1448
+#, fuzzy
 msgid "M&atrix"
-msgstr ""
+msgstr "Matrix"
 
 #: ../../src/wxMaxima.cpp:7153
+#, fuzzy
 msgid "Macro contents:"
-msgstr ""
+msgstr "Græske konstanter"
 
 #: ../../src/wxMaxima.cpp:7148
+#, fuzzy
 msgid "Macro name:"
-msgstr ""
+msgstr "Matrix:"
 
 #: ../../src/wxMaximaFrame.cpp:1024
 msgid "Macros"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:697
+#, fuzzy
 msgid "Main Toolbar\tAlt+Shift+B"
-msgstr ""
+msgstr "Indsæt celle(r)\tCtrl+Shift+V"
 
 #: ../../src/wxMaxima.cpp:7906
 msgid "Make a function value at a specific point known"
@@ -4291,28 +4621,32 @@ msgid "Make an eventual ev() evaluate this"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1070
+#, fuzzy
 msgid "Make function local..."
-msgstr ""
+msgstr "Anvend funktion på listeelementer"
 
 #: ../../src/wxMaxima.cpp:8207
 msgid "Map"
-msgstr ""
+msgstr "Afbildning af liste"
 
 #: ../../src/wxMaxima.cpp:8215
+#, fuzzy
 msgid "Map an expression"
-msgstr ""
+msgstr "Udvid et udtryk til ledform"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "Map function to a matrix"
-msgstr ""
+msgstr "Anvend funktion på matrixelementer"
 
 #: ../../src/wxMaximaFrame.cpp:1446
+#, fuzzy
 msgid "Map function to a matrix, affecting all of its clones"
-msgstr ""
+msgstr "Anvend funktion på matrixelementer"
 
 #: ../../src/Configuration.cpp:109
+#, fuzzy
 msgid "Math Default"
-msgstr ""
+msgstr "Standard"
 
 #: ../../src/wxMaximaFrame.cpp:286
 msgid "Mathematical Symbols"
@@ -4332,39 +4666,46 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
 #: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
 msgid "Matrix"
-msgstr ""
+msgstr "Matrix"
 
 #: ../../src/wxMaxima.cpp:7986
+#, fuzzy
 msgid "Matrix Exponent"
-msgstr ""
+msgstr "Matrix:"
 
 #: ../../src/wxMaximaFrame.cpp:1339
+#, fuzzy
 msgid "Matrix exponent..."
-msgstr ""
+msgstr "Matrix:"
 
 #: ../../src/wxMaximaFrame.cpp:1329
+#, fuzzy
 msgid "Matrix from csv file"
-msgstr ""
+msgstr "Indlæs typografi fra fil"
 
 #: ../../src/wxMaximaFrame.cpp:1323
+#, fuzzy
 msgid "Matrix from csv file..."
-msgstr ""
+msgstr "Indlæs typografi fra fil"
 
 #: ../../src/wxMaxima.cpp:8137
 msgid "Matrix map"
-msgstr ""
+msgstr "Afbildning af matrix"
 
 #: ../../src/wxMaxima.cpp:9630
+#, fuzzy
 msgid "Matrix name:"
-msgstr ""
+msgstr "Matrix:"
 
 #: ../../src/wxMaximaFrame.cpp:798
+#, fuzzy
 msgid "Matrix parenthesis"
-msgstr ""
+msgstr "Automatisk parring af parenteser"
 
 #: ../../src/wxMaximaFrame.cpp:1331
+#, fuzzy
 msgid "Matrix to csv file"
-msgstr ""
+msgstr "Indlæs typografi fra fil"
 
 #: ../../src/wxMaximaFrame.cpp:1334
 msgid "Matrix to file or Matrix from file"
@@ -4379,7 +4720,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
 #: ../../src/wxMaxima.cpp:8136
 msgid "Matrix:"
-msgstr ""
+msgstr "Matrix:"
 
 #: ../../src/wxMaxima.cpp:8627
 msgid ""
@@ -4395,12 +4736,14 @@ msgid "Maxima architecture: %s"
 msgstr ""
 
 #: ../../src/StatusBar.cpp:252
+#, fuzzy
 msgid "Maxima asks a question"
-msgstr ""
+msgstr "Maxima-spørgsmål"
 
 #: ../../src/wxMaxima.cpp:4066
+#, fuzzy
 msgid "Maxima asks a question!"
-msgstr ""
+msgstr "Maxima-spørgsmål"
 
 #: ../../src/wxMaxima.cpp:7118
 msgid ""
@@ -4417,16 +4760,19 @@ msgid "Maxima errors"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3289
+#, fuzzy
 msgid "Maxima has authenticated!"
-msgstr ""
+msgstr "Maxima-proces er afsluttet."
 
 #: ../../src/wxMaxima.cpp:10533
+#, fuzzy
 msgid "Maxima has finished calculating."
-msgstr ""
+msgstr "Maxima beregner"
 
 #: ../../src/wxMaxima.cpp:5832
+#, fuzzy
 msgid "Maxima has issued an error!"
-msgstr ""
+msgstr "Maxima-spørgsmål"
 
 #: ../../src/wxMaxima.cpp:3696
 #, c-format
@@ -4438,20 +4784,22 @@ msgid "Maxima has sent a new variable value."
 msgstr ""
 
 #: ../../src/MaximaManual.cpp:552
+#, fuzzy
 msgid "Maxima help file not found!"
-msgstr ""
+msgstr "Filen blev ikke fundet"
 
 #: ../../src/wxMaximaFrame.cpp:1043
 msgid "Maxima input"
-msgstr ""
+msgstr "Maxima-input"
 
 #: ../../src/StatusBar.cpp:236
 msgid "Maxima is calculating"
-msgstr ""
+msgstr "Maxima beregner"
 
 #: ../../src/wxMaxima.cpp:5068
+#, fuzzy
 msgid "Maxima is ready for input."
-msgstr ""
+msgstr "Maxima-input"
 
 #: ../../src/Dirstructure.cpp:144
 #, c-format
@@ -4460,19 +4808,20 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6211
 msgid "Maxima package (*.mac)|*.mac"
-msgstr ""
+msgstr "Maxima-pakke (*.mac)|*.mac"
 
 #: ../../src/wxMaxima.cpp:6202
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
-msgstr ""
+msgstr "Maxima-pakke (*.mac)|*.mac|Lisp-pakke (*.lisp)|*.lisp|Alle|*"
 
 #: ../../src/wxMaxima.cpp:3012
 msgid "Maxima process terminated unexpectedly."
 msgstr ""
 
 #: ../../src/Configuration.cpp:79
+#, fuzzy
 msgid "Maxima question labels"
-msgstr ""
+msgstr "Maxima-spørgsmål"
 
 #: ../../src/wxMaxima.cpp:3380
 msgid "Maxima sends a new set of auto-completable symbols."
@@ -4491,28 +4840,33 @@ msgid "Maxima shows help in a sidebar"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1935
+#, fuzzy
 msgid "Maxima shows help in the console"
-msgstr ""
+msgstr "Filen blev ikke fundet"
 
 #: ../../src/StatusBar.cpp:232
+#, fuzzy
 msgid "Maxima started. Waiting for authentication..."
-msgstr ""
+msgstr "Maxima er i gang. Vent på forbindelse..."
 
 #: ../../src/StatusBar.cpp:212
 msgid "Maxima started. Waiting for connection..."
-msgstr ""
+msgstr "Maxima er i gang. Vent på forbindelse..."
 
 #: ../../src/StatusBar.cpp:228
+#, fuzzy
 msgid "Maxima started. Waiting for initial prompt..."
-msgstr ""
+msgstr "Maxima er i gang. Vent på forbindelse..."
 
 #: ../../src/wxMaximaFrame.cpp:1231
+#, fuzzy
 msgid "Maxima to other language"
-msgstr ""
+msgstr "Maxima-spørgsmål"
 
 #: ../../src/wxMaxima.cpp:7213
+#, fuzzy
 msgid "Maxima to string"
-msgstr ""
+msgstr "Maxima-spørgsmål"
 
 #: ../../src/wxMaxima.cpp:3397
 #, c-format
@@ -4535,12 +4889,14 @@ msgid "Maxima version: %s, Anchors cache version"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1925
+#, fuzzy
 msgid "Maxima vs. Programming languages"
-msgstr ""
+msgstr "Omregn til &Gamma-funktion"
 
 #: ../../src/Configuration.cpp:83
+#, fuzzy
 msgid "Maxima warnings"
-msgstr ""
+msgstr "Maxima-indstillinger"
 
 #: ../../src/wxMaxima.cpp:3687
 #, c-format
@@ -4568,9 +4924,9 @@ msgid "Maxima's manual is located in directory %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3670
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's share files are located in directory %s"
-msgstr ""
+msgstr "Afspil animation"
 
 #: ../../src/StatusBar.cpp:66
 msgid ""
@@ -4620,12 +4976,14 @@ msgid "Memoizing"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1013
+#, fuzzy
 msgid "Memory"
-msgstr ""
+msgstr "&Ryd hukommelse"
 
 #: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
+#, fuzzy
 msgid "Merge Cells"
-msgstr ""
+msgstr "&Slet celle(r)"
 
 #: ../../src/wxMaxima.cpp:5780
 msgid "Message from the stdout of Maxima: "
@@ -4645,8 +5003,9 @@ msgid "Minimum absolute value printed without exponent:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:10449 ../../src/wxMaxima.cpp:10451
+#, fuzzy
 msgid "Mismatched parenthesis"
-msgstr ""
+msgstr "Automatisk parring af parenteser"
 
 #: ../../src/wxMaximaFrame.cpp:1352
 msgid "Multiplication, exponent and similar"
@@ -4665,16 +5024,19 @@ msgid "Multiply two matrices"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9581
+#, fuzzy
 msgid "Multivariate linear regression"
-msgstr ""
+msgstr "Integrer udtryk"
 
 #: ../../src/wxMaxima.cpp:7842
+#, fuzzy
 msgid "Name of t:"
-msgstr ""
+msgstr "Navn:"
 
 #: ../../src/wxMaxima.cpp:7838
+#, fuzzy
 msgid "Name of x:"
-msgstr ""
+msgstr "Navn:"
 
 #: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
 msgid "Nested list to Matrix"
@@ -4685,8 +5047,9 @@ msgid "Never"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:6534
+#, fuzzy
 msgid "Never autosubscript this variable"
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #: ../../src/wxMaximaFrame.cpp:776
 msgid "Never display this variable with subscript"
@@ -4701,8 +5064,9 @@ msgid "New"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:597
+#, fuzzy
 msgid "New\tCtrl+N"
-msgstr ""
+msgstr "&Ny\tCtrl+N"
 
 #: ../../src/ToolBar.cpp:611
 msgid "New button"
@@ -4722,8 +5086,9 @@ msgid "New connection attempt, but no currently running maxima process."
 msgstr ""
 
 #: ../../src/ToolBar.cpp:174
+#, fuzzy
 msgid "New document"
-msgstr ""
+msgstr "Åbn dokument"
 
 #: ../../src/wxMaxima.cpp:3899
 #, c-format
@@ -4731,13 +5096,14 @@ msgid "New maxima Operators detected: %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7390
+#, fuzzy
 msgid "New part:"
-msgstr ""
+msgstr "Ny variabel:"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
 #: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
 msgid "New variable:"
-msgstr ""
+msgstr "Ny variabel:"
 
 #: ../../src/wxMaximaFrame.cpp:929
 msgid "Next Command\tAlt+Down"
@@ -4752,8 +5118,9 @@ msgid "No"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1972
+#, fuzzy
 msgid "No Array"
-msgstr ""
+msgstr "2D-array:"
 
 #: ../../src/Worksheet.cpp:1974
 msgid "No Scalar"
@@ -4799,11 +5166,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8163
 msgid "Not a valid matrix dimension!"
-msgstr ""
+msgstr "Ugyldig dimension for matrix!"
 
 #: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
 msgid "Not a valid number of equations!"
-msgstr ""
+msgstr "Ugyldigt antal ligninger!"
 
 #: ../../src/StatusBar.cpp:256
 msgid "Not connected to Maxima"
@@ -4823,63 +5190,73 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8926
 msgid "Num. deg:"
-msgstr ""
+msgstr "Tællers grad:"
 
 #: ../../src/wxMaxima.cpp:8540
+#, fuzzy
 msgid "Number of elements"
-msgstr ""
+msgstr "Antal ligninger:"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
 msgid "Number of equations:"
-msgstr ""
+msgstr "Antal ligninger:"
 
 #: ../../src/wxMaxima.cpp:7481
+#, fuzzy
 msgid "Number to octets"
-msgstr ""
+msgstr "Antal ligninger:"
 
 #: ../../src/wxMaximaFrame.cpp:1154
+#, fuzzy
 msgid "Number to octets..."
-msgstr ""
+msgstr "Antal ligninger:"
 
 #: ../../src/wxMaximaFrame.cpp:1906
 msgid "Number types"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7482
+#, fuzzy
 msgid "Number:"
-msgstr ""
+msgstr "Tal"
 
 #: ../../src/wxMaximaFrame.cpp:1786
+#, fuzzy
 msgid "Numeric output"
-msgstr ""
+msgstr "Slå numerisk beregning til eller fra"
 
 #: ../../src/wxMaxima.cpp:8040
 msgid "Numerical QR decomposition of a matrix"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1417
+#, fuzzy
 msgid "Numerical operations (lapack)"
-msgstr ""
+msgstr "&Numerisk integration"
 
 #: ../../src/wxMaxima.cpp:7831
+#, fuzzy
 msgid "Numerical solution for 1st degree ODE"
-msgstr ""
+msgstr "Løs begyndelsesværdiproblem for 1. ordens ODL"
 
 #: ../../src/wxMaximaFrame.cpp:1282
+#, fuzzy
 msgid "Numerical solution..."
-msgstr ""
+msgstr "Slå numerisk beregning til eller fra"
 
 #: ../../src/wxMaximaFrame.cpp:1261
+#, fuzzy
 msgid "Numerical solutions of polynomial (bfloat)..."
-msgstr ""
+msgstr "Bestem alle rødder i et polynomium"
 
 #: ../../src/wxMaximaFrame.cpp:1258
+#, fuzzy
 msgid "Numerical solutions of polynomial..."
-msgstr ""
+msgstr "Bestem alle rødder i et polynomium"
 
 #: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: ../../src/wxMaximaFrame.cpp:122
 #, c-format
@@ -4887,16 +5264,19 @@ msgid "OS: %s Version %li.%li"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
+#, fuzzy
 msgid "Object composed of elements"
-msgstr ""
+msgstr "Antal ligninger:"
 
 #: ../../src/wxMaxima.cpp:7680
+#, fuzzy
 msgid "Object name:"
-msgstr ""
+msgstr "Liste:"
 
 #: ../../src/wxMaxima.cpp:7281
+#, fuzzy
 msgid "Object:"
-msgstr ""
+msgstr "Liste:"
 
 #: ../../src/wxMaxima.cpp:7486
 msgid "Octets to Number"
@@ -4911,8 +5291,9 @@ msgid "Octets to number..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1158
+#, fuzzy
 msgid "Octets to string..."
-msgstr ""
+msgstr "Udtryk"
 
 #: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
 msgid "Octets:"
@@ -4925,23 +5306,26 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
 #: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
 msgid "Old variable:"
-msgstr ""
+msgstr "Tidligere variabel:"
 
 #: ../../src/wxMaximaFrame.cpp:1055
+#, fuzzy
 msgid "On all errors"
-msgstr ""
+msgstr "Alvorlig fejl"
 
 #: ../../src/wxMaximaFrame.cpp:1054
 msgid "On lisp errors"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9566
+#, fuzzy
 msgid "One sample t-test"
-msgstr ""
+msgstr "Teksteksempel"
 
 #: ../../src/wxMaximaFrame.cpp:1927
+#, fuzzy
 msgid "Online tutorials"
-msgstr ""
+msgstr "&Kombiner fakulteter"
 
 #: ../../src/wxMaximaFrame.cpp:766
 msgid "Only Integers and single letters"
@@ -4950,15 +5334,15 @@ msgstr ""
 #: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593
 #: ../../src/wxMaxima.cpp:6074
 msgid "Open"
-msgstr ""
+msgstr "Åbn"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "Open a document"
-msgstr ""
+msgstr "Åbn dokument"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "Open a new window"
-msgstr ""
+msgstr "Åbn nyt vindue"
 
 #: ../../src/ToolBar.cpp:617
 msgid "Open and save button"
@@ -4966,7 +5350,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:176
 msgid "Open document"
-msgstr ""
+msgstr "Åbn dokument"
 
 #: ../../src/wxMaxima.cpp:7239
 msgid "Open for appending"
@@ -4981,24 +5365,28 @@ msgid "Open for reading"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1098
+#, fuzzy
 msgid "Open for reading..."
-msgstr ""
+msgstr "Udtryk"
 
 #: ../../src/wxMaxima.cpp:7249
 msgid "Open for writing"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1100
+#, fuzzy
 msgid "Open for writing..."
-msgstr ""
+msgstr "&Eksporter..."
 
 #: ../../src/wxMaxima.cpp:9598
+#, fuzzy
 msgid "Open matrix"
-msgstr ""
+msgstr "Indtast matrixelementer"
 
 #: ../../src/wxMaximaFrame.cpp:600
+#, fuzzy
 msgid "Open recent"
-msgstr ""
+msgstr "Åbn seneste"
 
 #: ../../src/wxMaxima.cpp:4309
 msgid "Opening a wxmx file"
@@ -5007,7 +5395,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4153 ../../src/wxMaxima.cpp:4214
 #: ../../src/wxMaxima.cpp:4313 ../../src/wxMaxima.cpp:4622
 msgid "Opening file"
-msgstr ""
+msgstr "Åbner fil"
 
 #: ../../src/wxMaxima.cpp:5030
 #, c-format
@@ -5024,11 +5412,12 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:199
 msgid "Options"
-msgstr ""
+msgstr "Indstillinger"
 
 #: ../../src/wxMaximaFrame.cpp:1225
+#, fuzzy
 msgid "Output C"
-msgstr ""
+msgstr "Output-etiketter"
 
 #: ../../src/wxMaximaFrame.cpp:1226
 msgid "Output Fortran"
@@ -5040,11 +5429,12 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:80
 msgid "Output labels"
-msgstr ""
+msgstr "Output-etiketter"
 
 #: ../../src/Configuration.cpp:73
+#, fuzzy
 msgid "Output: Function names"
-msgstr ""
+msgstr "Navne på funktioner"
 
 #: ../../src/Configuration.cpp:75
 msgid "Output: Latin names as greek symbols"
@@ -5055,21 +5445,24 @@ msgid "Output: Numbers and Digits"
 msgstr ""
 
 #: ../../src/Configuration.cpp:71
+#, fuzzy
 msgid "Output: Operators"
-msgstr ""
+msgstr "Output-etiketter"
 
 #: ../../src/Configuration.cpp:74
-#, c-format
+#, fuzzy, c-format
 msgid "Output: Special constants (%e,%i)"
-msgstr ""
+msgstr "Særlige konstanter"
 
 #: ../../src/Configuration.cpp:76
+#, fuzzy
 msgid "Output: Strings"
-msgstr ""
+msgstr "Tekststrenge"
 
 #: ../../src/Configuration.cpp:70
+#, fuzzy
 msgid "Output: Variable names"
-msgstr ""
+msgstr "Tidligere variabel:"
 
 #: ../../src/wxMaxima.cpp:6442
 msgid ""
@@ -5088,39 +5481,43 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8924
 msgid "Pade approximation"
-msgstr ""
+msgstr "Padé-approksimation"
 
 #: ../../src/wxMaximaFrame.cpp:1478
 msgid "Pade approximation of a Taylor series"
-msgstr ""
+msgstr "Padé-approksimation for Taylorrække"
 
 #: ../../src/wxMaximaFrame.cpp:1637
+#, fuzzy
 msgid "Parallel Substitute..."
-msgstr ""
+msgstr "Substituer..."
 
 #: ../../src/wxMaxima.cpp:8738
 msgid "Parallel substitution"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7179
+#, fuzzy
 msgid "Parameter name:"
-msgstr ""
+msgstr "Matrix:"
 
 #: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
+#, fuzzy
 msgid "Parameter(s):"
-msgstr ""
+msgstr "Variable:"
 
 #: ../../src/wxMaxima.cpp:7399
 msgid "Parse string"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1152
+#, fuzzy
 msgid "Parse string only..."
-msgstr ""
+msgstr "I&ndtast matrix..."
 
 #: ../../src/StatusBar.cpp:240
 msgid "Parsing output"
-msgstr ""
+msgstr "Output fortolkes"
 
 #: ../../src/wxMaxima.cpp:7464
 msgid "Part:"
@@ -5128,11 +5525,12 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1499 ../../src/wxMaximaFrame.cpp:1535
 msgid "Partial &Fractions..."
-msgstr ""
+msgstr "Partial&brøker..."
 
 #: ../../src/wxMaxima.cpp:8975
+#, fuzzy
 msgid "Partial Fractions"
-msgstr ""
+msgstr "Partialbrøker"
 
 #: ../../src/wxMaxima.cpp:4702
 msgid "Parts of the document will not be loaded correctly!"
@@ -5141,51 +5539,52 @@ msgstr ""
 #: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
 #: ../../src/Worksheet.cpp:1685
 msgid "Paste"
-msgstr ""
+msgstr "Sæt ind"
 
 #: ../../src/wxMaximaFrame.cpp:667
 msgid "Paste\tCtrl+V"
-msgstr ""
+msgstr "&Sæt ind\tCtrl+V"
 
 #: ../../src/ToolBar.cpp:211
+#, fuzzy
 msgid "Paste from clipboard"
-msgstr ""
+msgstr "Indsæt tekst fra Udklipsholder"
 
 #: ../../src/wxMaximaFrame.cpp:668
 msgid "Paste text from clipboard"
-msgstr ""
+msgstr "Indsæt tekst fra Udklipsholder"
 
 #: ../../src/wxMaxima.cpp:4841
 msgid "Please configure wxMaxima with 'Edit->Configure'."
-msgstr ""
+msgstr "Ændrer indstillinger for wxMaxima i 'Rediger->Indstillinger'"
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot &2d..."
-msgstr ""
+msgstr "&2D-plot..."
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot &3d..."
-msgstr ""
+msgstr "&3D-plot..."
 
 #: ../../src/wxMaximaFrame.cpp:1772
 msgid "Plot &Format..."
-msgstr ""
+msgstr "Plot&format..."
 
 #: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
 msgid "Plot 2D"
-msgstr ""
+msgstr "2D-plot"
 
 #: ../../src/Worksheet.cpp:1593
 msgid "Plot 2D..."
-msgstr ""
+msgstr "2D-plot..."
 
 #: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
 msgid "Plot 3D"
-msgstr ""
+msgstr "3D-plot"
 
 #: ../../src/Worksheet.cpp:1595
 msgid "Plot 3D..."
-msgstr ""
+msgstr "3D-plot..."
 
 #: ../../src/wxMaxima.cpp:9538
 msgid "Plot as bars"
@@ -5201,15 +5600,15 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9112
 msgid "Plot format"
-msgstr ""
+msgstr "Plotformat"
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot in 2 dimensions"
-msgstr ""
+msgstr "Plot i 2 dimensioner"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot in 3 dimensions"
-msgstr ""
+msgstr "Plot i 3 dimensioner"
 
 #: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
 msgid "Plot using Draw"
@@ -5229,22 +5628,23 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
 msgid "Point:"
-msgstr ""
+msgstr "Punkt:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 1:"
-msgstr ""
+msgstr "Polynomium 1:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 2:"
-msgstr ""
+msgstr "Polynomium 2:"
 
 #: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
 #: ../../src/wxMaxima.cpp:7739
+#, fuzzy
 msgid "Polynomial:"
-msgstr ""
+msgstr "Polynomium 1:"
 
 #: ../../src/wxMaximaFrame.cpp:1754
 msgid "Pop"
@@ -5259,20 +5659,23 @@ msgid "Position of a match"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
+#, fuzzy
 msgid "Position:"
-msgstr ""
+msgstr "Animation"
 
 #: ../../src/wxMaxima.cpp:8939
+#, fuzzy
 msgid "Power series"
-msgstr ""
+msgstr "&Potensrækker"
 
 #: ../../src/wxMaximaFrame.cpp:1475
+#, fuzzy
 msgid "Power series..."
-msgstr ""
+msgstr "&Potensrækker"
 
 #: ../../src/wxMaxima.cpp:9202
 msgid "Precision"
-msgstr ""
+msgstr "Nøjagtighed"
 
 #: ../../src/Worksheet.cpp:1616
 msgid "Prefer user labels"
@@ -5291,8 +5694,9 @@ msgid "Preferences...\tCtrl+,"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1733
+#, fuzzy
 msgid "Prepend an element"
-msgstr ""
+msgstr "Åbn dokument"
 
 #: ../../src/wxMaximaFrame.cpp:927
 msgid "Previous Command\tAlt+Up"
@@ -5300,19 +5704,20 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:184
 msgid "Print"
-msgstr ""
+msgstr "Udskriv"
 
 #: ../../src/ToolBar.cpp:620
 msgid "Print button"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1493
+#, fuzzy
 msgid "Print cell brackets"
-msgstr ""
+msgstr "Parentes for aktiv celle"
 
 #: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
 msgid "Print document"
-msgstr ""
+msgstr "Udskriv dokument"
 
 #: ../../src/wxMaximaFrame.cpp:1829
 msgid "Print floating-point numbers with exponents dividable by 3"
@@ -5326,15 +5731,16 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9061
 msgid "Product"
-msgstr ""
+msgstr "Produkt"
 
 #: ../../src/wxMaximaFrame.cpp:1095
 msgid "Program"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7061
+#, fuzzy
 msgid "Program (no local variables)"
-msgstr ""
+msgstr "Udskift variabel"
 
 #: ../../src/wxMaxima.cpp:7052
 msgid "Program block"
@@ -5353,8 +5759,9 @@ msgid "Push"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8508
+#, fuzzy
 msgid "Push an element to a list"
-msgstr ""
+msgstr "Opret liste ud fra udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1395
 msgid "QR decomposition"
@@ -5386,20 +5793,23 @@ msgid "Re-Reading the config from the default location."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:867
+#, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
-msgstr ""
+msgstr "Beregn alle celler i dokumentet"
 
 #: ../../src/wxMaximaFrame.cpp:877
+#, fuzzy
 msgid "Re-evaluate all cells below the one the cursor is in"
-msgstr ""
+msgstr "Beregn alle celler i dokumentet"
 
 #: ../../src/main.cpp:366
 msgid "Re-opening STDERR failed."
 msgstr ""
 
 #: ../../src/main.cpp:367
+#, fuzzy
 msgid "Re-opening STDIN failed."
-msgstr ""
+msgstr "Åbner fil"
 
 #: ../../src/main.cpp:365
 msgid "Re-opening STDOUT failed."
@@ -5412,16 +5822,18 @@ msgid ""
 msgstr ""
 
 #: ../../src/Worksheet.cpp:6668
+#, fuzzy
 msgid "Read .wxm data from clipboard"
-msgstr ""
+msgstr "Indsæt tekst fra Udklipsholder"
 
 #: ../../src/wxMaxima.cpp:7599
 msgid "Read Directory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1677
+#, fuzzy
 msgid "Read List from csv file..."
-msgstr ""
+msgstr "Indlæs typografi fra fil"
 
 #: ../../src/wxMaxima.cpp:7196
 msgid "Read a structure field"
@@ -5432,16 +5844,19 @@ msgid "Read byte"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7266
+#, fuzzy
 msgid "Read char"
-msgstr ""
+msgstr "I&ndtast matrix..."
 
 #: ../../src/wxMaxima.cpp:7593
+#, fuzzy
 msgid "Read environment variable"
-msgstr ""
+msgstr "Yderligere parametre:"
 
 #: ../../src/wxMaximaFrame.cpp:1219
+#, fuzzy
 msgid "Read environment variable..."
-msgstr ""
+msgstr "Slet en variabel"
 
 #: ../../src/wxMaxima.cpp:7262
 msgid "Read line"
@@ -5454,7 +5869,7 @@ msgstr ""
 
 #: ../../src/StatusBar.cpp:245
 msgid "Reading Maxima output"
-msgstr ""
+msgstr "Maxima-output behandles"
 
 #: ../../src/StatusBar.cpp:247
 #, c-format
@@ -5481,7 +5896,7 @@ msgstr ""
 
 #: ../../src/StatusBar.cpp:224
 msgid "Ready for user input"
-msgstr ""
+msgstr "Klar til input fra bruger"
 
 #: ../../src/Worksheet.cpp:960
 msgid "Recalculated the whole worksheet at once => Updating its size"
@@ -5510,12 +5925,14 @@ msgid "Received maxima's first prompt: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:603
+#, fuzzy
 msgid "Recover unsaved"
-msgstr ""
+msgstr "[ ikke gemt ]"
 
 #: ../../src/wxMaximaFrame.cpp:1640
+#, fuzzy
 msgid "Recursive Substitute..."
-msgstr ""
+msgstr "Substituer..."
 
 #: ../../src/wxMaxima.cpp:8746
 msgid "Recursive substitution"
@@ -5526,16 +5943,18 @@ msgid "Redo"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:633
+#, fuzzy
 msgid "Redo\tCtrl+Y"
-msgstr ""
+msgstr "Fortryd\tCtrl+Z"
 
 #: ../../src/wxMaximaFrame.cpp:633
+#, fuzzy
 msgid "Redo last change"
-msgstr ""
+msgstr "Fortryd seneste ændring"
 
 #: ../../src/wxMaximaFrame.cpp:1595
 msgid "Reduce trigonometric expression"
-msgstr ""
+msgstr "Sammentræk trigonometrisk udtryk"
 
 #: ../../src/wxMaxima.cpp:2366 ../../src/wxMaxima.cpp:10630
 msgid "Refusing to send cell to maxima: "
@@ -5550,16 +5969,19 @@ msgid "Regex match position"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1195
+#, fuzzy
 msgid "Regular expression that matches a string"
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #: ../../src/wxMaximaFrame.cpp:1196
+#, fuzzy
 msgid "Regular expressions"
-msgstr ""
+msgstr "Integrer udtryk"
 
 #: ../../src/Worksheet.cpp:1314
+#, fuzzy
 msgid "Reload Image"
-msgstr ""
+msgstr "Kopier som billede"
 
 #: ../../src/Worksheet.cpp:1320
 #, c-format
@@ -5567,13 +5989,14 @@ msgid "Reload Image \"%s\""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9809
-#, c-format
+#, fuzzy, c-format
 msgid "Reloading image file %s."
-msgstr ""
+msgstr "Maxima-proces er afsluttet."
 
 #: ../../src/wxMaximaFrame.cpp:883
+#, fuzzy
 msgid "Remove All Output"
-msgstr ""
+msgstr "Fjern alle output"
 
 #: ../../src/wxMaximaFrame.cpp:1426
 msgid "Remove Rows or Columns..."
@@ -5594,8 +6017,9 @@ msgid "Remove all occurrences of part"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8592
+#, fuzzy
 msgid "Remove an element from a list"
-msgstr ""
+msgstr "Opret liste ud fra udtryk"
 
 #: ../../src/wxMaxima.cpp:7566
 msgid "Remove directory"
@@ -5619,7 +6043,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:884
 msgid "Remove output from input cells"
-msgstr ""
+msgstr "Fjern visning af hidtidige output"
 
 #: ../../src/wxMaxima.cpp:7975
 msgid "Remove rows and/or columns"
@@ -5630,16 +6054,19 @@ msgid "Remove rows and/or columns from the matrix"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7582
+#, fuzzy
 msgid "Rename file"
-msgstr ""
+msgstr "Åbner fil"
 
 #: ../../src/wxMaximaFrame.cpp:1215
+#, fuzzy
 msgid "Rename file..."
-msgstr ""
+msgstr "Slet en variabel"
 
 #: ../../src/wxMaximaFrame.cpp:1527
+#, fuzzy
 msgid "Reorganize an expression using horner's rule"
-msgstr ""
+msgstr "Faktoriser et udtryk i Gaussiske heltal"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "Repetitive element-by-element multiplication"
@@ -5658,8 +6085,9 @@ msgid "Replace the first occurrence of Part"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1180
+#, fuzzy
 msgid "Replace..."
-msgstr ""
+msgstr "Marker alt"
 
 #: ../../src/wxMaxima.cpp:6719
 #, c-format
@@ -5668,23 +6096,26 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "Report bug"
-msgstr ""
+msgstr "Information om fejlrapportering"
 
 #: ../../src/wxMaximaFrame.cpp:996
+#, fuzzy
 msgid "Reset option variables"
-msgstr ""
+msgstr "Udskift variabel"
 
 #: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
 msgid "Restart Maxima"
-msgstr ""
+msgstr "Genstart Maxima"
 
 #: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
+#, fuzzy
 msgid "Restrict Maximum size"
-msgstr ""
+msgstr "Genstart Maxima"
 
 #: ../../src/wxMaxima.cpp:10031
+#, fuzzy
 msgid "Result variables:"
-msgstr ""
+msgstr "Slet variable:"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Resulting Matrix name (may be empty):"
@@ -5758,8 +6189,9 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
 #: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
+#, fuzzy
 msgid "Right Matrix:"
-msgstr ""
+msgstr "Indtast matrixelementer"
 
 #: ../../src/wxMaxima.cpp:8190
 msgid "Right end"
@@ -5771,7 +6203,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1455
 msgid "Risch Integration..."
-msgstr ""
+msgstr "Risch-integration..."
 
 #: ../../src/wxMaximaFrame.cpp:785
 msgid "Rounded"
@@ -5787,12 +6219,14 @@ msgid "Row number:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7977
+#, fuzzy
 msgid "Row numbers:"
-msgstr ""
+msgstr "Tal"
 
 #: ../../src/wxMaxima.cpp:8203
+#, fuzzy
 msgid "Rows"
-msgstr ""
+msgstr "Rækker:"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Rule"
@@ -5807,8 +6241,9 @@ msgid "Rules"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1693
+#, fuzzy
 msgid "Run each element through an expression"
-msgstr ""
+msgstr "Bestem grænseværdi for et udtryk"
 
 #: ../../src/wxMaxima.cpp:6355
 #, c-format
@@ -5861,80 +6296,89 @@ msgid "Runs each element through a function"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1694
+#, fuzzy
 msgid "Runs each element through an expression"
-msgstr ""
+msgstr "Bestem grænseværdi for et udtryk"
 
 #: ../../src/wxMaxima.cpp:9572
+#, fuzzy
 msgid "Sample 1:"
-msgstr ""
+msgstr "Eksempel"
 
 #: ../../src/wxMaxima.cpp:9573
+#, fuzzy
 msgid "Sample 2:"
-msgstr ""
+msgstr "Eksempel"
 
 #: ../../src/wxMaxima.cpp:9567
+#, fuzzy
 msgid "Sample:"
-msgstr ""
+msgstr "Eksempel"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
 msgid "Save"
-msgstr ""
+msgstr "Gem"
 
 #: ../../src/Worksheet.cpp:1294
+#, fuzzy
 msgid "Save Animation..."
-msgstr ""
+msgstr "Padé-&approksimation"
 
 #: ../../src/wxMaxima.cpp:5672
 msgid "Save As"
-msgstr ""
+msgstr "Gem som"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save As...\tShift+Ctrl+S"
-msgstr ""
+msgstr "Ge&m som...\tShift+Ctrl+S"
 
 #: ../../src/Worksheet.cpp:1291
 msgid "Save Image..."
-msgstr ""
+msgstr "Gem billede..."
 
 #: ../../src/wxMaxima.cpp:6440
 msgid "Save Selection to Image"
-msgstr ""
+msgstr "Gem markering som billede"
 
 #: ../../src/wxMaximaFrame.cpp:675
 msgid "Save Selection to Image..."
-msgstr ""
+msgstr "Gem markering som billede..."
 
 #: ../../src/wxMaxima.cpp:10184
+#, fuzzy
 msgid "Save animation to file"
-msgstr ""
+msgstr "Gem markering i fil"
 
 #: ../../src/wxMaxima.cpp:7203
 msgid "Save as lisp code"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1091
+#, fuzzy
 msgid "Save as lisp..."
-msgstr ""
+msgstr "Indlæs pakke"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
 msgid "Save document"
-msgstr ""
+msgstr "Gem dokument"
 
 #: ../../src/wxMaximaFrame.cpp:609
+#, fuzzy
 msgid "Save document as"
-msgstr ""
+msgstr "Gem dokument"
 
 #: ../../src/wxMaximaFrame.cpp:676
 msgid "Save selection from document to an image file"
-msgstr ""
+msgstr "Gem det markerede område i dokumentet i en billedfil"
 
 #: ../../src/wxMaxima.cpp:10125
 msgid "Save selection to file"
-msgstr ""
+msgstr "Gem markering i fil"
 
 #: ../../src/wxMaximaFrame.cpp:573
+#, fuzzy
 msgid "Saving failed."
-msgstr ""
+msgstr "Server-opstart slog fejl"
 
 #: ../../src/WXMXformat.cpp:310
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
@@ -5976,16 +6420,18 @@ msgid "Search..."
 msgstr ""
 
 #: ../../src/ToolBar.cpp:273
+#, fuzzy
 msgid "Section"
-msgstr ""
+msgstr "Markering"
 
 #: ../../src/Configuration.cpp:91
 msgid "Section cell (Heading 2)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7218
+#, fuzzy
 msgid "Seek to position"
-msgstr ""
+msgstr "Padé-approksimation"
 
 #: ../../src/BTextCtrl.cpp:45
 msgid "Seems like something is broken with a font."
@@ -5996,33 +6442,36 @@ msgid "Seems like the package with the maxima share files isn't installed."
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
+#, fuzzy
 msgid "Select All"
-msgstr ""
+msgstr "Marker alt"
 
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select All\tCtrl+A"
-msgstr ""
+msgstr "&Marker alt\tCtrl+A"
 
 #: ../../src/ToolBar.cpp:629
 msgid "Select All button"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9631
+#, fuzzy
 msgid "Select Subsample"
-msgstr ""
+msgstr "Marker alt"
 
 #: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select all"
-msgstr ""
+msgstr "Marker alt"
 
 #: ../../src/wxMaxima.cpp:6971
 msgid "Select math display algorithm"
-msgstr ""
+msgstr "Vælg algoritme"
 
 #: ../../src/Configuration.cpp:98
+#, fuzzy
 msgid "Selection color"
-msgstr ""
+msgstr "Markering"
 
 #: ../../src/ToolBar.cpp:252
 msgid "Send all cells to maxima"
@@ -6057,24 +6506,27 @@ msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1533
+#, fuzzy
 msgid "Sequential Comparative Simplification"
-msgstr ""
+msgstr "&Kompleks omskrivning"
 
 #: ../../src/wxMaxima.cpp:9016
 msgid "Series"
-msgstr ""
+msgstr "Rækker"
 
 #: ../../src/wxMaximaFrame.cpp:1479
+#, fuzzy
 msgid "Series approximation"
-msgstr ""
+msgstr "Padé-approksimation"
 
 #: ../../src/wxMaxima.cpp:2561
 msgid "Server started"
-msgstr ""
+msgstr "Server er startet"
 
 #: ../../src/wxMaximaFrame.cpp:1824
+#, fuzzy
 msgid "Set &displayed Precision..."
-msgstr ""
+msgstr "Vælg &nøjagtighed"
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Set Maxima option variable logexpand:all"
@@ -6089,40 +6541,46 @@ msgid "Set Maxima option variable logexpand:true"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:822
+#, fuzzy
 msgid "Set Zoom"
-msgstr ""
+msgstr "Vælg plot format"
 
 #: ../../src/wxMaximaFrame.cpp:1819
+#, fuzzy
 msgid "Set bigfloat &Precision..."
-msgstr ""
+msgstr "Vælg nøjagtighed decimaltal 2"
 
 #: ../../src/Worksheet.cpp:1306 ../../src/Worksheet.cpp:1479
 msgid "Set image resolution"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1510
+#, fuzzy
 msgid "Set main variable..."
-msgstr ""
+msgstr "Slet en variabel"
 
 #: ../../src/wxMaximaFrame.cpp:1773
 msgid "Set plot format"
-msgstr ""
+msgstr "Vælg plot format"
 
 #: ../../src/wxMaximaFrame.cpp:1101
+#, fuzzy
 msgid "Set position..."
-msgstr ""
+msgstr "Padé-&approksimation"
 
 #: ../../src/wxMaximaFrame.cpp:1656
+#, fuzzy
 msgid "Set the \"algebraic\" flag"
-msgstr ""
+msgstr "Slå Maxima-indikatoren algebraic til eller fra"
 
 #: ../../src/wxMaxima.cpp:8314
 msgid "Set the diagram title"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1779
+#, fuzzy
 msgid "Set the frame rate for animations."
-msgstr ""
+msgstr "Afspil animation"
 
 #: ../../src/wxMaxima.cpp:8377
 msgid "Set the grid density."
@@ -6168,16 +6626,17 @@ msgid "Setting gnuplot_binary to %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:4804
+#, fuzzy
 msgid "Setting prompt and help format"
-msgstr ""
+msgstr "Vælg plot format"
 
 #: ../../src/wxMaximaFrame.cpp:1292
 msgid "Setup atvalues for solving ODE with Laplace transformation"
-msgstr ""
+msgstr "Opstil randbetingelser til løsning af ODL med Laplace-transformation"
 
 #: ../../src/wxMaximaFrame.cpp:1661
 msgid "Setup modulus computation"
-msgstr ""
+msgstr "Opsætning af modulus-beregning"
 
 #: ../../src/wxMaxima.cpp:9220
 msgid "Setup the engineering format"
@@ -6192,28 +6651,31 @@ msgid "Shapiro-Wilk test for normality"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1543
+#, fuzzy
 msgid "Show \"%\" in special constants"
-msgstr ""
+msgstr "Særlige konstanter"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show &Tips..."
-msgstr ""
+msgstr "Vis &tips..."
 
 #: ../../src/Worksheet.cpp:1556
 msgid "Show * as multiplication dot"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:895
+#, fuzzy
 msgid "Show Template\tCtrl+Shift+Space"
-msgstr ""
+msgstr "Kopier celle(r)\tCtrl+Shift+C"
 
 #: ../../src/wxMaximaFrame.cpp:753
+#, fuzzy
 msgid "Show XML representation"
-msgstr ""
+msgstr "Vis lange udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show a tip"
-msgstr ""
+msgstr "Vis et tip"
 
 #: ../../src/Worksheet.cpp:1607
 msgid "Show all + allow linebreaks in long numbers"
@@ -6221,51 +6683,55 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9475
 msgid "Show all commands similar to:"
-msgstr ""
+msgstr "Vis alle kommandoer i stil med:"
 
 #: ../../src/wxMaxima.cpp:9468
 msgid "Show an example for the command:"
-msgstr ""
+msgstr "Vis eksempel med kommandoen:"
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "Show an example of usage"
-msgstr ""
+msgstr "Vis et eksempel med anvendelse"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "Show commands similar to"
-msgstr ""
+msgstr "Vis alle kommandoer i stil med"
 
 #: ../../src/wxMaximaFrame.cpp:1020
 msgid "Show defined functions"
-msgstr ""
+msgstr "Vis erklærede funktioner"
 
 #: ../../src/wxMaximaFrame.cpp:1022
 msgid "Show defined variables"
-msgstr ""
+msgstr "Vis erklærede variable"
 
 #: ../../src/wxMaximaFrame.cpp:1074
 msgid "Show definition of a function"
-msgstr ""
+msgstr "Vis definition for en funktion"
 
 #: ../../src/wxMaximaFrame.cpp:740
 msgid "Show equations in their linear form"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1073
+#, fuzzy
 msgid "Show function &Definition..."
-msgstr ""
+msgstr "Vis &definitioner..."
 
 #: ../../src/wxMaximaFrame.cpp:896
+#, fuzzy
 msgid "Show function template"
-msgstr ""
+msgstr "Vis &funktioner"
 
 #: ../../src/Worksheet.cpp:1614
+#, fuzzy
 msgid "Show input labels"
-msgstr ""
+msgstr "Input-etiketter"
 
 #: ../../src/wxMaximaFrame.cpp:750
+#, fuzzy
 msgid "Show lisp representation"
-msgstr ""
+msgstr "Vis lange udtryk"
 
 #: ../../src/Worksheet.cpp:1604
 msgid "Show max. 100 digits"
@@ -6304,8 +6770,9 @@ msgid "Show the Copy, Cut and the Paste button?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7033
+#, fuzzy
 msgid "Show the function's definition"
-msgstr ""
+msgstr "Vis definition for funktionen:"
 
 #: ../../src/ToolBar.cpp:618
 msgid "Show the open and the save button?"
@@ -6320,21 +6787,24 @@ msgid "Show the print button?"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:615
+#, fuzzy
 msgid "Show the undo and redo button?"
-msgstr ""
+msgstr "Vis definition for funktionen:"
 
 #: ../../src/wxMaximaFrame.cpp:1006 ../../src/wxMaximaFrame.cpp:1011
 msgid "Show used + to-be-freed memory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1033
+#, fuzzy
 msgid "Show user definitions"
-msgstr ""
+msgstr "Vis definition for funktionen:"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
 #: ../../src/wxMaximaFrame.cpp:1879
+#, fuzzy
 msgid "Show wxMaxima help"
-msgstr ""
+msgstr "Vis Maxima Hjælp"
 
 #: ../../src/wxMaximaFrame.cpp:1825
 msgid "Shows how many digits of a numbers are displayed"
@@ -6345,48 +6815,53 @@ msgid "Sidebars"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1513
+#, fuzzy
 msgid "Simplify &Radicals..."
-msgstr ""
+msgstr "Reducer (&radcan)"
 
 #: ../../src/Worksheet.cpp:1579
 msgid "Simplify Expression"
-msgstr ""
+msgstr "Reducer udtryk (ratsimp)"
 
 #: ../../src/wxMaximaFrame.cpp:1568
+#, fuzzy
 msgid "Simplify Logarithms"
-msgstr ""
+msgstr "Reducer sum"
 
 #: ../../src/wxMaximaFrame.cpp:1582
 msgid "Simplify an expression containing factorials"
-msgstr ""
+msgstr "Reducer et udtryk indeholdende fakulteter"
 
 #: ../../src/wxMaximaFrame.cpp:1539
+#, fuzzy
 msgid "Simplify equations"
-msgstr ""
+msgstr "Løs ligning(er)"
 
 #: ../../src/wxMaximaFrame.cpp:1514
 msgid "Simplify expression containing radicals"
-msgstr ""
+msgstr "Reducer udtryk indeholdende radikaler/rødder"
 
 #: ../../src/wxMaxima.cpp:8649
+#, fuzzy
 msgid "Simplify radicals"
-msgstr ""
+msgstr "Reducer (&radcan)"
 
 #: ../../src/wxMaximaFrame.cpp:1512
 msgid "Simplify rational expression"
-msgstr ""
+msgstr "Reducer rationalt udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1538
 msgid "Simplify sum() commands..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8636
+#, fuzzy
 msgid "Simplify sums"
-msgstr ""
+msgstr "Reducer (ratsimp)"
 
 #: ../../src/wxMaximaFrame.cpp:1592
 msgid "Simplify trigonometric expression"
-msgstr ""
+msgstr "Reducer trigonometrisk udtryk"
 
 #: ../../src/wxMaximaFrame.cpp:1399
 msgid "Singular Values"
@@ -6401,105 +6876,116 @@ msgid "Singular values, left + right vectors"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1635
+#, fuzzy
 msgid "Smart Substitute..."
-msgstr ""
+msgstr "Substituer..."
 
 #: ../../src/wxMaxima.cpp:8730
+#, fuzzy
 msgid "Smart substitution"
-msgstr ""
+msgstr "Substituer"
 
 #: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
 #: ../../src/wxMaxima.cpp:7823
+#, fuzzy
 msgid "Solution of the ODE:"
-msgstr ""
+msgstr "Løsning:"
 
 #: ../../src/wxMaxima.cpp:10017
 msgid "Solve"
-msgstr ""
+msgstr "Løs"
 
 #: ../../src/wxMaximaFrame.cpp:1244
 msgid "Solve &Algebraic System..."
-msgstr ""
+msgstr "Løs &algebraisk ligningssystem..."
 
 #: ../../src/wxMaximaFrame.cpp:1242
 msgid "Solve &Linear System..."
-msgstr ""
+msgstr "Løs l&ineært ligningssystem"
 
 #: ../../src/wxMaximaFrame.cpp:1266
 msgid "Solve &ODE..."
-msgstr ""
+msgstr "Løs &ODL..."
 
 #: ../../src/wxMaximaFrame.cpp:1240
+#, fuzzy
 msgid "Solve (to_poly)..."
-msgstr ""
+msgstr "Løs..."
 
 #: ../../src/wxMaxima.cpp:8045
 msgid "Solve A*x=b numerically"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1397
+#, fuzzy
 msgid "Solve Ax=b"
-msgstr ""
+msgstr "Løs"
 
 #: ../../src/wxMaxima.cpp:7783
 msgid "Solve ODE"
-msgstr ""
+msgstr "Løs ODL"
 
 #: ../../src/wxMaximaFrame.cpp:1287
 msgid "Solve ODE with Lapla&ce..."
-msgstr ""
+msgstr "Løs O&DL med Laplace..."
 
 #: ../../src/wxMaximaFrame.cpp:1398
+#, fuzzy
 msgid "Solve a linear equation system using dgesv"
-msgstr ""
+msgstr "Løs lineært ligningssystem"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
 msgid "Solve algebraic system"
-msgstr ""
+msgstr "Løs algebraisk ligningssystem"
 
 #: ../../src/wxMaximaFrame.cpp:1245
 msgid "Solve algebraic system of equations"
-msgstr ""
+msgstr "Løs algebraisk ligningssystem"
 
 #: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve boundary value problem for second degree ODE"
-msgstr ""
+msgstr "Løs randværdiproblem for 2. ordens ODL"
 
 #: ../../src/wxMaxima.cpp:7895
+#, fuzzy
 msgid "Solve differential equations using laplace()"
 msgstr ""
+"Løs ordinære differentialligninger ved hjælp af Laplace-transformation"
 
 #: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
 msgid "Solve equation(s)"
-msgstr ""
+msgstr "Løs ligning(er)"
 
 #: ../../src/wxMaximaFrame.cpp:1241
+#, fuzzy
 msgid "Solve equation(s) with to_poly_solve"
-msgstr ""
+msgstr "Løs ligning(er)"
 
 #: ../../src/wxMaxima.cpp:7773
+#, fuzzy
 msgid "Solve equations numerically"
-msgstr ""
+msgstr "Løs ligning(er)"
 
 #: ../../src/wxMaxima.cpp:7757
+#, fuzzy
 msgid "Solve equations to polynom"
-msgstr ""
+msgstr "Løs ligning(er)"
 
 #: ../../src/wxMaximaFrame.cpp:1271
 msgid "Solve initial value problem for first degree ODE"
-msgstr ""
+msgstr "Løs begyndelsesværdiproblem for 1. ordens ODL"
 
 #: ../../src/wxMaximaFrame.cpp:1275
 msgid "Solve initial value problem for second degree ODE"
-msgstr ""
+msgstr "Løs begyndelsesværdiproblem for 2. ordens ODL"
 
 #: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
 msgid "Solve linear system"
-msgstr ""
+msgstr "Løs lineært ligningssystem..."
 
 #: ../../src/wxMaximaFrame.cpp:1243
 msgid "Solve linear system of equations"
-msgstr ""
+msgstr "Løs lineært ligningssystem"
 
 #: ../../src/wxMaximaFrame.cpp:1263
 msgid "Solve numerical, 1 Variable"
@@ -6507,31 +6993,36 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1267
 msgid "Solve ordinary differential equation of maximum degree 2"
-msgstr ""
+msgstr "Løs ordinær differentialligning af orden højst 2"
 
 #: ../../src/wxMaximaFrame.cpp:1288
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
+"Løs ordinære differentialligninger ved hjælp af Laplace-transformation"
 
 #: ../../src/wxMaxima.cpp:7708
+#, fuzzy
 msgid "Solve polynomials numerically"
-msgstr ""
+msgstr "Løs ligning(er)"
 
 #: ../../src/wxMaxima.cpp:7718
+#, fuzzy
 msgid "Solve polynomials numerically (bfloats)"
-msgstr ""
+msgstr "Løs ligning(er)"
 
 #: ../../src/wxMaxima.cpp:7729
+#, fuzzy
 msgid "Solve polynomials numerically (real roots)"
-msgstr ""
+msgstr "Løs ligning(er)"
 
 #: ../../src/wxMaximaFrame.cpp:1249
+#, fuzzy
 msgid "Solve symbolically"
-msgstr ""
+msgstr "Løs ligning(er)"
 
 #: ../../src/Worksheet.cpp:1574
 msgid "Solve..."
-msgstr ""
+msgstr "Løs..."
 
 #: ../../src/wxMaximaFrame.cpp:1916
 msgid "Solving differential equations"
@@ -6553,20 +7044,23 @@ msgid "Sort"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8496
+#, fuzzy
 msgid "Sort a list"
-msgstr ""
+msgstr "Opret liste"
 
 #: ../../src/wxMaxima.cpp:7459
 msgid "Sort all characters in string"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1179
+#, fuzzy
 msgid "Sort the characters..."
-msgstr ""
+msgstr "Unicode-tegn:"
 
 #: ../../src/wxMaxima.cpp:8482
+#, fuzzy
 msgid "Source list:"
-msgstr ""
+msgstr "Opret liste"
 
 #: ../../src/wxMaxima.cpp:7429
 msgid "Split"
@@ -6585,28 +7079,32 @@ msgid "Split string into tokens"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1171
+#, fuzzy
 msgid "Split..."
-msgstr ""
+msgstr "Eksporter"
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Square"
 msgstr ""
 
 #: ../../src/Configuration.cpp:86
+#, fuzzy
 msgid "Standard Text"
-msgstr ""
+msgstr "Indstillinger"
 
 #: ../../src/Worksheet.cpp:1298
+#, fuzzy
 msgid "Start Animation"
-msgstr ""
+msgstr "Afspil animation"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Start of t:"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:305
+#, fuzzy
 msgid "Start or Stop animation"
-msgstr ""
+msgstr "Afspil animation"
 
 #: ../../src/ToolBar.cpp:306
 msgid ""
@@ -6616,11 +7114,12 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:386
 msgid "Starting Maxima process failed"
-msgstr ""
+msgstr "Maxima-opstart slog fejl"
 
 #: ../../src/main.cpp:667
+#, fuzzy
 msgid "Starting a new wxMaxima process for a new window"
-msgstr ""
+msgstr "Maxima-opstart slog fejl"
 
 #: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:5633
 msgid "Starting evaluation of the document"
@@ -6628,23 +7127,25 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:2544
 msgid "Starting server failed"
-msgstr ""
+msgstr "Server-opstart slog fejl"
 
 #: ../../src/WXMXformat.cpp:64
 msgid "Starting to save the worksheet as .wxmx"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:252
+#, fuzzy
 msgid "Statistics"
-msgstr ""
+msgstr "antisymmetrisk"
 
 #: ../../src/wxMaximaFrame.cpp:701
 msgid "Statistics\tAlt+Shift+S"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7844
+#, fuzzy
 msgid "Step width:"
-msgstr ""
+msgstr "Produkt"
 
 #: ../../src/wxMaximaFrame.cpp:794
 msgid "Straight lines"
@@ -6669,26 +7170,31 @@ msgid "Stream:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1185
+#, fuzzy
 msgid "String"
-msgstr ""
+msgstr "Tekststrenge"
 
 #: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
 #: ../../src/wxMaxima.cpp:7425
+#, fuzzy
 msgid "String #1:"
-msgstr ""
+msgstr "Tekststrenge"
 
 #: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
 #: ../../src/wxMaxima.cpp:7426
+#, fuzzy
 msgid "String #2:"
-msgstr ""
+msgstr "Tekststrenge"
 
 #: ../../src/wxMaximaFrame.cpp:1136
+#, fuzzy
 msgid "String Tests"
-msgstr ""
+msgstr "Tekststrenge"
 
 #: ../../src/wxMaxima.cpp:7415
+#, fuzzy
 msgid "String length"
-msgstr ""
+msgstr "Tekststrenge"
 
 #: ../../src/wxMaxima.cpp:7381
 msgid "String to list of char"
@@ -6699,8 +7205,9 @@ msgid "String to list of chars..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7496
+#, fuzzy
 msgid "String to octets"
-msgstr ""
+msgstr "Tekststrenge"
 
 #: ../../src/wxMaximaFrame.cpp:1160
 msgid "String to octets..."
@@ -6717,8 +7224,9 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7465 ../../src/wxMaxima.cpp:7470
 #: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
 #: ../../src/wxMaxima.cpp:7497
+#, fuzzy
 msgid "String:"
-msgstr ""
+msgstr "Tekststrenge"
 
 #: ../../src/wxMaxima.cpp:7197
 msgid "Struct :"
@@ -6733,8 +7241,9 @@ msgid "Structs"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:274
+#, fuzzy
 msgid "Subsection"
-msgstr ""
+msgstr "Markering"
 
 #: ../../src/Configuration.cpp:90
 msgid "Subsection cell (Heading 3)"
@@ -6751,19 +7260,21 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
 #: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
 msgid "Substitute"
-msgstr ""
+msgstr "Substituer"
 
 #: ../../src/wxMaximaFrame.cpp:1193
+#, fuzzy
 msgid "Substitute all matches"
-msgstr ""
+msgstr "Substituer..."
 
 #: ../../src/wxMaximaFrame.cpp:1192
 msgid "Substitute first match"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1646
+#, fuzzy
 msgid "Substitute only in parts..."
-msgstr ""
+msgstr "Substituer..."
 
 #: ../../src/wxMaxima.cpp:8763
 msgid "Substitute only in specific parts"
@@ -6775,7 +7286,7 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
 msgid "Substitute..."
-msgstr ""
+msgstr "Substituer..."
 
 #: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
 msgid "Substitutes until the equation no more changes"
@@ -6810,16 +7321,18 @@ msgid ""
 msgstr ""
 
 #: ../../src/ToolBar.cpp:275
+#, fuzzy
 msgid "Subsubsection"
-msgstr ""
+msgstr "Markering"
 
 #: ../../src/Configuration.cpp:89
 msgid "Subsubsection cell (Heading 4)"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1831
+#, fuzzy
 msgid "Suggestion: "
-msgstr ""
+msgstr "Markering"
 
 #: ../../src/Worksheet.cpp:2030
 msgid "Suitable as flag for ev()"
@@ -6827,7 +7340,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9049
 msgid "Sum"
-msgstr ""
+msgstr "Sum"
 
 #: ../../src/wxMaximaFrame.cpp:1551
 msgid ""
@@ -6844,12 +7357,14 @@ msgid "Switched to lisp mode after receiving a lisp prompt!"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1971
+#, fuzzy
 msgid "Symbolic Constant"
-msgstr ""
+msgstr "Vælg en konstant"
 
 #: ../../src/wxMaximaFrame.cpp:705
+#, fuzzy
 msgid "Symbols\tAlt+Shift+Y"
-msgstr ""
+msgstr "Indsæt celle(r)\tCtrl+Shift+V"
 
 #: ../../src/Worksheet.cpp:2006
 msgid "Symmetric function: f(x)=f(-x)"
@@ -6860,20 +7375,23 @@ msgid "Table of Contents"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:711
+#, fuzzy
 msgid "Table of Contents\tAlt+Shift+T"
-msgstr ""
+msgstr "Indsæt celle(r)\tCtrl+Shift+V"
 
 #: ../../src/wxMaxima.cpp:8930
+#, fuzzy
 msgid "Taylor series"
-msgstr ""
+msgstr "Taylorrækker:"
 
 #: ../../src/wxMaximaFrame.cpp:1474
+#, fuzzy
 msgid "Taylor series..."
-msgstr ""
+msgstr "Taylorrækker:"
 
 #: ../../src/wxMaxima.cpp:8925
 msgid "Taylor series:"
-msgstr ""
+msgstr "Taylorrækker:"
 
 #: ../../src/wxMaxima.cpp:4132
 msgid "Telling maxima about the new working directory."
@@ -6899,12 +7417,13 @@ msgid "Tells maxima to show the help for ?, ?? and describe() on the console"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:271
+#, fuzzy
 msgid "Text"
-msgstr ""
+msgstr "Tekstcelle"
 
 #: ../../src/Configuration.cpp:93
 msgid "Text cell background"
-msgstr ""
+msgstr "Tekstcelle baggrund"
 
 #: ../../src/wxMaxima.cpp:6541
 msgid "Text snippet"
@@ -6945,8 +7464,9 @@ msgid "The comma-separated contents of the struct fields"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7186
+#, fuzzy
 msgid "The comma-separated names of the struct fields"
-msgstr ""
+msgstr "Indtast kommasepareret liste med variable."
 
 #: ../../src/wxMaxima.cpp:7070
 msgid ""
@@ -7006,8 +7526,9 @@ msgid "The manual of Maxima"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1881
+#, fuzzy
 msgid "The manual of wxMaxima"
-msgstr ""
+msgstr "Velkommen til wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7125
 msgid "The name of a function we don't want to be evaluated here"
@@ -7096,10 +7617,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:2143
+#, fuzzy
 msgid ""
 "There was an error in the XML maxima has generated.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Der var fejl i den dannede XML-fil!\n"
+"\n"
+"Rapporter venligdt dette som en programfejl."
 
 #: ../../src/wxMaxima.cpp:3911
 msgid ""
@@ -7120,10 +7645,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3257
+#, fuzzy
 msgid ""
 "There was an error in the XML that should describe the manual topics.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Der var fejl i den dannede XML-fil!\n"
+"\n"
+"Rapporter venligdt dette som en programfejl."
 
 #: ../../src/wxMaxima.cpp:3202
 msgid ""
@@ -7164,11 +7693,12 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9013 ../../src/wxMaxima.cpp:10058
 msgid "Times:"
-msgstr ""
+msgstr "Gange:"
 
 #: ../../src/ToolBar.cpp:272
+#, fuzzy
 msgid "Title"
-msgstr ""
+msgstr "Fil"
 
 #: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
@@ -7180,35 +7710,38 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1794
 msgid "To &Bigfloat"
-msgstr ""
+msgstr "Angiv som decimaltal &2\tCtrl+2"
 
 #: ../../src/wxMaximaFrame.cpp:1791
+#, fuzzy
 msgid "To &Float"
-msgstr ""
+msgstr "Angiv som decimaltal 1"
 
 #: ../../src/Worksheet.cpp:1571
 msgid "To Float"
-msgstr ""
+msgstr "Angiv som decimaltal 1"
 
 #: ../../src/wxMaximaFrame.cpp:1797
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1803
+#, fuzzy
 msgid "To exact fraction"
-msgstr ""
+msgstr "Partialbrøker"
 
 #: ../../src/wxMaximaFrame.cpp:1814
+#, fuzzy
 msgid "To exact number"
-msgstr ""
+msgstr "Vis &funktioner"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "To:"
-msgstr ""
+msgstr "Til:"
 
 #: ../../src/wxMaximaFrame.cpp:825 ../../src/wxMaximaFrame.cpp:828
 msgid "Toggle full screen editing"
-msgstr ""
+msgstr "Skift til fuldskærmsvisning"
 
 #: ../../src/ToolBar.cpp:265
 msgid "Toggle the visibility of code cells"
@@ -7227,20 +7760,23 @@ msgid "Top end"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1078
+#, fuzzy
 msgid "Trace a function..."
-msgstr ""
+msgstr "Slet en funktion"
 
 #: ../../src/wxMaxima.cpp:7084
+#, fuzzy
 msgid "Trace function(s)"
-msgstr ""
+msgstr "Slet funktion(er):"
 
 #: ../../src/wxMaximaFrame.cpp:1184
+#, fuzzy
 msgid "Transformations"
-msgstr ""
+msgstr "Transponer en matrix"
 
 #: ../../src/wxMaximaFrame.cpp:1376
 msgid "Transpose a matrix"
-msgstr ""
+msgstr "Transponer en matrix"
 
 #: ../../src/wxMaxima.cpp:7832
 msgid ""
@@ -7293,12 +7829,14 @@ msgid "Trim both ends..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1182
+#, fuzzy
 msgid "Trim left..."
-msgstr ""
+msgstr "Grænseværdi..."
 
 #: ../../src/wxMaximaFrame.cpp:1183
+#, fuzzy
 msgid "Trim right..."
-msgstr ""
+msgstr "Grænseværdi..."
 
 #: ../../src/wxMaxima.cpp:7473
 msgid "Trim string left"
@@ -7368,20 +7906,23 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1928
+#, fuzzy
 msgid "Tutorials"
-msgstr ""
+msgstr "&Kombiner fakulteter"
 
 #: ../../src/wxMaxima.cpp:9571
+#, fuzzy
 msgid "Two sample t-test"
-msgstr ""
+msgstr "Teksteksempel"
 
 #: ../../src/Worksheet.cpp:8013
+#, fuzzy
 msgid "Type"
-msgstr ""
+msgstr "Type:"
 
 #: ../../src/wxMaxima.cpp:7180
 msgid "Type:"
-msgstr ""
+msgstr "Type:"
 
 #: ../../src/wxMaxima.cpp:9429
 msgid "URL"
@@ -7406,8 +7947,9 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1007
+#, fuzzy
 msgid "Undefine"
-msgstr ""
+msgstr "Understreget"
 
 #: ../../src/ToolBar.cpp:191
 msgid "Undo"
@@ -7415,7 +7957,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo\tCtrl+Z"
-msgstr ""
+msgstr "Fortryd\tCtrl+Z"
 
 #: ../../src/ToolBar.cpp:614
 msgid "Undo and redo button"
@@ -7423,11 +7965,12 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo last change"
-msgstr ""
+msgstr "Fortryd seneste ændring"
 
 #: ../../src/wxMaximaFrame.cpp:924
+#, fuzzy
 msgid "Unfold All\tCtrl+Alt+]"
-msgstr ""
+msgstr "&Marker alt\tCtrl+A"
 
 #: ../../src/wxMaximaFrame.cpp:925
 msgid "Unfold all folded sections"
@@ -7446,24 +7989,29 @@ msgid "Unhide Part"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1860
+#, fuzzy
 msgid "Unhide Section"
-msgstr ""
+msgstr "Markering"
 
 #: ../../src/Worksheet.cpp:1871
+#, fuzzy
 msgid "Unhide Subsection"
-msgstr ""
+msgstr "Markering"
 
 #: ../../src/Worksheet.cpp:1882
+#, fuzzy
 msgid "Unhide Subsubsection"
-msgstr ""
+msgstr "Markering"
 
 #: ../../src/Worksheet.cpp:1912
+#, fuzzy
 msgid "Unhide contents"
-msgstr ""
+msgstr "Græske konstanter"
 
 #: ../../src/wxMaximaFrame.cpp:266
+#, fuzzy
 msgid "Unicode characters"
-msgstr ""
+msgstr "Unicode-tegn:"
 
 #: ../../src/wxMaximaFrame.cpp:707
 msgid "Unicode chars\tAlt+Shift+U"
@@ -7510,23 +8058,25 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
 msgid "Upper bound:"
-msgstr ""
+msgstr "Øvre grænse:"
 
 #: ../../src/wxMaximaFrame.cpp:792
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
+#, fuzzy
 msgid "Use a list"
-msgstr ""
+msgstr "Opret liste"
 
 #: ../../src/wxMaxima.cpp:8571
 msgid "Use a list as parameter list for a function"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1708
+#, fuzzy
 msgid "Use list"
-msgstr ""
+msgstr "Opret liste"
 
 #: ../../src/wxMaximaFrame.cpp:1701
 msgid "Use list as the arguments of a function"
@@ -7541,8 +8091,9 @@ msgid "Use square parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1083
+#, fuzzy
 msgid "Use struct field..."
-msgstr ""
+msgstr "&Kædebrøk"
 
 #: ../../src/wxMaximaFrame.cpp:795
 msgid "Use vertical lines instead of parenthesis for matrices"
@@ -7566,8 +8117,9 @@ msgid "Using Maxima path from command line."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:4822
+#, fuzzy
 msgid "Using configured Maxima path."
-msgstr ""
+msgstr "wxMaxima indstillinger"
 
 #: ../../src/wxMaxima.cpp:2961
 msgid ""
@@ -7589,25 +8141,28 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8755
+#, fuzzy
 msgid "Value at a given point"
-msgstr ""
+msgstr "Evaluer &navneformer"
 
 #: ../../src/Worksheet.cpp:1987
 msgid "Value at a specific point"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7801
+#, fuzzy
 msgid "Value at that point:"
-msgstr ""
+msgstr "Evaluer &navneformer"
 
 #: ../../src/wxMaxima.cpp:7812 ../../src/wxMaxima.cpp:7825
 #: ../../src/wxMaxima.cpp:7827
+#, fuzzy
 msgid "Value y at that point:"
-msgstr ""
+msgstr "Evaluer &navneformer"
 
 #: ../../src/wxMaxima.cpp:7910
 msgid "Value:"
-msgstr ""
+msgstr "Værdi:"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Var #1"
@@ -7623,25 +8178,29 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
 #: ../../src/wxMaxima.cpp:8568
+#, fuzzy
 msgid "Variable name"
-msgstr ""
+msgstr "Tidligere variabel:"
 
 #: ../../src/wxMaximaFrame.cpp:1085
+#, fuzzy
 msgid "Variable name, not contents..."
-msgstr ""
+msgstr "Tidligere variabel:"
 
 #: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
+#, fuzzy
 msgid "Variable name:"
-msgstr ""
+msgstr "Tidligere variabel:"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
+#, fuzzy
 msgid "Variable(s)"
-msgstr ""
+msgstr "Variable:"
 
 #: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
 #: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
 msgid "Variable(s):"
-msgstr ""
+msgstr "Variable:"
 
 #: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
 #: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
@@ -7649,15 +8208,15 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
 #: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
 msgid "Variable:"
-msgstr ""
+msgstr "Variabel:"
 
 #: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
 msgid "Variables"
-msgstr ""
+msgstr "Variable"
 
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
 msgid "Variables:"
-msgstr ""
+msgstr "Variable:"
 
 #: ../../src/WXMXformat.cpp:337
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -7687,11 +8246,12 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
 #: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
 msgid "Warning"
-msgstr ""
+msgstr "Advarsel"
 
 #: ../../src/wxMaximaFrame.cpp:1556
+#, fuzzy
 msgid "Warning:"
-msgstr ""
+msgstr "Advarsel"
 
 #: ../../src/Dirstructure.cpp:72
 #, c-format
@@ -7707,7 +8267,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5063
 msgid "Welcome to wxMaxima"
-msgstr ""
+msgstr "Velkommen til wxMaxima"
 
 #: ../../src/wxMaxima.cpp:8583
 msgid "What to do:"
@@ -7776,12 +8336,14 @@ msgid "Your version of wxMaxima is up to date."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:805
+#, fuzzy
 msgid "Zoom &In\tCtrl++"
-msgstr ""
+msgstr "Zoom i&nd\tAlt+I"
 
 #: ../../src/wxMaximaFrame.cpp:806
+#, fuzzy
 msgid "Zoom Ou&t\tCtrl+-"
-msgstr ""
+msgstr "Zoom &ud\tAlt+O"
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom in 10%"
@@ -7793,11 +8355,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
 msgid "[ unsaved ]"
-msgstr ""
+msgstr "[ ikke gemt ]"
 
 #: ../../src/wxMaxima.cpp:10920
 msgid "[ unsaved* ]"
-msgstr ""
+msgstr "[ ikke gemt* ]"
 
 #: ../../src/Worksheet.cpp:5278
 #, c-format
@@ -7810,8 +8372,9 @@ msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"la
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1690
+#, fuzzy
 msgid "apply function to each element"
-msgstr ""
+msgstr "Anvend funktion på liste"
 
 #: ../../src/wxMaximaFrame.cpp:739
 msgid "as 1D ASCII"
@@ -7846,44 +8409,50 @@ msgid "ev() shall evaluate this automatically"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7130
+#, fuzzy
 msgid "expression:"
-msgstr ""
+msgstr "Udtryk:"
 
 #: ../../src/Worksheet.cpp:2025
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
+#, fuzzy
 msgid "filename:"
-msgstr ""
+msgstr "Tidligere variabel:"
 
 #: ../../src/wxMaximaFrame.cpp:1674
+#, fuzzy
 msgid "from a list"
-msgstr ""
+msgstr "Opret liste"
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "from a rule"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1685
+#, fuzzy
 msgid "from function arguments"
-msgstr ""
+msgstr "Navne på funktioner"
 
 #: ../../src/wxMaximaFrame.cpp:1669
 msgid "from individual elements"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
+#, fuzzy
 msgid "function"
-msgstr ""
+msgstr "Funktion"
 
 #: ../../src/wxMaximaFrame.cpp:747
 msgid "in 2D"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8554
+#, fuzzy
 msgid "list"
-msgstr ""
+msgstr "Opret liste"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "max(abs(A(i,j))) (complex)"
@@ -7894,13 +8463,15 @@ msgid "max(abs(A(i,j))) (real)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8046
+#, fuzzy
 msgid "m×n Matrix A:"
-msgstr ""
+msgstr "Matrix:"
 
 #: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533
+#, fuzzy
 msgid "n:"
-msgstr ""
+msgstr "Bestem nulpunkt"
 
 #: ../../src/Worksheet.cpp:2000
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -7924,20 +8495,24 @@ msgid "part:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8942
+#, fuzzy
 msgid "point:"
-msgstr ""
+msgstr "Punkt:"
 
 #: ../../src/wxMaxima.cpp:7740
+#, fuzzy
 msgid "precision:"
-msgstr ""
+msgstr "Nøjagtighed"
 
 #: ../../src/wxMaxima.cpp:7255
+#, fuzzy
 msgid "printf"
-msgstr ""
+msgstr "Udskriv"
 
 #: ../../src/wxMaximaFrame.cpp:1108
+#, fuzzy
 msgid "printf..."
-msgstr ""
+msgstr "Differentier..."
 
 #: ../../src/wxMaxima.cpp:8650
 msgid ""
@@ -7953,16 +8528,18 @@ msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1111
+#, fuzzy
 msgid "readbyte..."
-msgstr ""
+msgstr "Integrer..."
 
 #: ../../src/wxMaximaFrame.cpp:1110
 msgid "readchar..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1109
+#, fuzzy
 msgid "readline..."
-msgstr ""
+msgstr "Variabel:"
 
 #: ../../src/wxMaxima.cpp:10018
 msgid ""
@@ -7992,17 +8569,19 @@ msgid "unnamed function (lambda)..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:11190
+#, fuzzy
 msgid "unsaved"
-msgstr ""
+msgstr "[ ikke gemt ]"
 
 #: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
 #: ../../src/wxMaximaFrame.cpp:189
 msgid "untitled"
-msgstr ""
+msgstr "unavngivet"
 
 #: ../../src/wxMaximaFrame.cpp:1700
+#, fuzzy
 msgid "use as function arguments"
-msgstr ""
+msgstr "Navne på funktioner"
 
 #: ../../src/wxMaximaFrame.cpp:1696
 msgid "use the actual values stored"
@@ -8017,16 +8596,16 @@ msgid "wxMaxima"
 msgstr ""
 
 #: ../../src/main.cpp:516
-#, c-format
+#, fuzzy, c-format
 msgid "wxMaxima %ld"
-msgstr ""
+msgstr "wxMaxima %s "
 
 #: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
 #: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
 #: ../../src/wxMaximaFrame.cpp:185
-#, c-format
+#, fuzzy, c-format
 msgid "wxMaxima %s (%s) "
-msgstr ""
+msgstr "wxMaxima %s "
 
 #: ../../src/wxMaxima.cpp:4490
 msgid "wxMaxima cannot read the xml contents of "
@@ -8042,12 +8621,12 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5285
 msgid "wxMaxima document"
-msgstr ""
+msgstr "wxMaxima-dokument"
 
 #: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
 #: ../../src/wxMaxima.cpp:4230
 msgid "wxMaxima encountered an error loading "
-msgstr ""
+msgstr "wxMaxima stødte på en fejl under indlæsning af "
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "wxMaxima help"
@@ -8066,12 +8645,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1896
+#, fuzzy
 msgid "wxMaxima shows help in a browser"
-msgstr ""
+msgstr "Filen blev ikke fundet"
 
 #: ../../src/wxMaximaFrame.cpp:1894
+#, fuzzy
 msgid "wxMaxima shows help in the sidebar"
-msgstr ""
+msgstr "Filen blev ikke fundet"
 
 #: ../../src/wxMaximaFrame.cpp:111
 #, c-format
@@ -8079,8 +8660,9 @@ msgid "wxMaxima version %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1954
+#, fuzzy
 msgid "wxMaxima's ChangeLog"
-msgstr ""
+msgstr "wxMaxima-indstillinger"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "wxMaxima's license"
@@ -8144,13 +8726,15 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:10
+#, fuzzy
 msgid "# Introduction to wxMaxima"
-msgstr ""
+msgstr "Velkommen til wxMaxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:12
+#, fuzzy
 msgid "## _Maxima_ and wxMaxima"
-msgstr ""
+msgstr "Afslut wxMaxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:14
@@ -8184,8 +8768,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:18
+#, fuzzy
 msgid "### _Maxima_"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:20
@@ -8220,8 +8805,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:26
+#, fuzzy
 msgid "### WxMaxima"
-msgstr ""
+msgstr "wxMaxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:28
@@ -8344,8 +8930,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:54
+#, fuzzy
 msgid "### Cells"
-msgstr ""
+msgstr "&Slet celle(r)"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:56
@@ -8366,8 +8953,9 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Image cells."
-msgstr ""
+msgstr "&Slet celle(r)"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
@@ -8383,8 +8971,9 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Page breaks."
-msgstr ""
+msgstr "Indsæt billede"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:65
@@ -8507,8 +9096,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:94
+#, fuzzy
 msgid "### Command autocompletion"
-msgstr ""
+msgstr "Konfigurationsadvarsel"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:96
@@ -8538,8 +9128,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:102
+#, fuzzy
 msgid "#### Greek characters"
-msgstr ""
+msgstr "Unicode-tegn:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:104
@@ -8830,8 +9421,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:234
+#, fuzzy
 msgid "### MathML output"
-msgstr ""
+msgstr "Standardskrifttype:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:236
@@ -8954,8 +9546,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:282
+#, fuzzy
 msgid "## File Formats"
-msgstr ""
+msgstr "Filen blev ikke fundet"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:284
@@ -8966,8 +9559,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:286
+#, fuzzy
 msgid "### .mac"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:288
@@ -9010,8 +9604,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:299
+#, fuzzy
 msgid "### .wxm"
-msgstr ""
+msgstr "wxMaxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:302
@@ -9144,8 +9739,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:357
+#, fuzzy
 msgid "### .wxmx"
-msgstr ""
+msgstr "wxMaxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:359
@@ -9215,8 +9811,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:375
+#, fuzzy
 msgid "## Configuration options"
-msgstr ""
+msgstr "Konfigurationsadvarsel"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:377
@@ -9249,8 +9846,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:384
+#, fuzzy
 msgid "### Default animation framerate"
-msgstr ""
+msgstr "Padé-&approksimation"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:386
@@ -9295,8 +9893,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:403
+#, fuzzy
 msgid "### Match parenthesis in text controls"
-msgstr ""
+msgstr "Automatisk parring af parenteser"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:405
@@ -9392,8 +9991,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:432
+#, fuzzy
 msgid "## Subscripted variables"
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:434
@@ -9568,8 +10168,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:498
+#, fuzzy
 msgid "## Plotting"
-msgstr ""
+msgstr "&Fejlrapportering"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:500
@@ -10005,8 +10606,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:694
+#, fuzzy
 msgid "#### 2D"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:696
@@ -10028,8 +10630,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:700
+#, fuzzy
 msgid "#### 3D"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:702
@@ -10041,8 +10644,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:704
+#, fuzzy
 msgid "#### Expression"
-msgstr ""
+msgstr "Udtryk"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:706
@@ -10069,8 +10673,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:712
+#, fuzzy
 msgid "#### Parametric plot"
-msgstr ""
+msgstr "Parameterplot"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:714
@@ -10083,8 +10688,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:716
+#, fuzzy
 msgid "#### Points"
-msgstr ""
+msgstr "Punkt:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:718
@@ -10106,8 +10712,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:724
+#, fuzzy
 msgid "#### Axis"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:726
@@ -10131,8 +10738,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:732
+#, fuzzy
 msgid "#### Plot name"
-msgstr ""
+msgstr "Liste:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:734
@@ -10168,8 +10776,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:744
+#, fuzzy
 msgid "#### Grid"
-msgstr ""
+msgstr "Gitter:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:746
@@ -10178,8 +10787,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:748
+#, fuzzy
 msgid "#### Accuracy"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:750
@@ -10308,8 +10918,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:794
+#, fuzzy
 msgid "## Special variables wx..."
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:805
@@ -10481,8 +11092,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:837
+#, fuzzy
 msgid "Example:"
-msgstr ""
+msgstr "Eksempel"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:842
@@ -10496,8 +11108,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:844
+#, fuzzy
 msgid "## Bug reporting"
-msgstr ""
+msgstr "&Fejlrapportering"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:846
@@ -10533,8 +11146,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:856
+#, fuzzy
 msgid "## Output rendering."
-msgstr ""
+msgstr "Tekststrenge"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:858
@@ -10960,8 +11574,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:988
+#, fuzzy
 msgid "E.g. start wxMaxima with:"
-msgstr ""
+msgstr "Genstart Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:990
@@ -11321,8 +11936,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1140
+#, fuzzy
 msgid "# Command-line arguments"
-msgstr ""
+msgstr "Kommaseparerede y-koordinater"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1142

--- a/locales/wxMaxima/de.po
+++ b/locales/wxMaxima/de.po
@@ -28,12 +28,17 @@ msgid ""
 "\n"
 "Maxima is currently using %3.3f%% of all available CPUs."
 msgstr ""
+"\n"
+"\n"
+"Maxima verwendet derzeit %3.3f%% der verfügbaren CPU-Last."
 
 #: ../../src/Image.cpp:690
 msgid ""
 "\n"
 "Image was loaded from a .wxmx file"
 msgstr ""
+"\n"
+"Bild wurde aus einer wxmx-Datei geladen"
 
 #: ../../src/wxMaxima.cpp:5153
 msgid ""
@@ -43,7 +48,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:4230
 msgid " (File format (WXM version 1, first line of the file) not recognized)"
-msgstr ""
+msgstr "(Dateiformat (WXM Version 1, erste Zeile der Datei) nicht erkannt)"
 
 #: ../../src/wxMaximaFrame.cpp:1559
 msgid " Wrong, if a is complex"
@@ -75,231 +80,231 @@ msgstr "%s-Bild, %li×%li, %li ppi"
 #: ../../src/Autocomplete.cpp:319
 #, c-format
 msgid "%s: Can't interpret line: %s"
-msgstr ""
+msgstr "%s: Nichtinterpretierbare Zeile: %s"
 
 #: ../../src/wxMaximaFrame.cpp:1655
 msgid "&Algebraic Mode"
-msgstr ""
+msgstr "&Algebraischer Modus"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "&Apropos..."
-msgstr ""
+msgstr "&Apropos ..."
 
 #: ../../src/wxMaximaFrame.cpp:615
 msgid "&Batch File...\tCtrl+B"
-msgstr ""
+msgstr "&Batch-Datei laden ...\tCtrl+B"
 
 #: ../../src/wxMaximaFrame.cpp:1278
 msgid "&Boundary Value Problem..."
-msgstr ""
+msgstr "&Randwertproblem ..."
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "&Bug Report"
-msgstr ""
+msgstr "&Bug melden"
 
 #: ../../src/wxMaximaFrame.cpp:1505
 msgid "&Calculus"
-msgstr ""
+msgstr "&Rechnen"
 
 #: ../../src/wxMaximaFrame.cpp:1601
 msgid "&Canonical Form"
-msgstr ""
+msgstr "&Kanonische Form"
 
 #: ../../src/wxMaximaFrame.cpp:1358
 msgid "&Characteristic Polynomial..."
-msgstr ""
+msgstr "&Charakteristisches Polynom ..."
 
 #: ../../src/wxMaximaFrame.cpp:990
 msgid "&Clear Memory"
-msgstr ""
+msgstr "&Speicher löschen"
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "&Combine Factorials"
-msgstr ""
+msgstr "Fakultäten &kombinieren"
 
 #: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Complex Simplification"
-msgstr ""
+msgstr "&Komplexe Ausdrücke"
 
 #: ../../src/wxMaximaFrame.cpp:1502
 msgid "&Continued Fraction"
-msgstr ""
+msgstr "&Kettenbruch"
 
 #: ../../src/wxMaximaFrame.cpp:638
 msgid "&Copy\tCtrl+C"
-msgstr ""
+msgstr "&Kopieren\tCtrl+C"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "&Demoivre"
-msgstr ""
+msgstr "Als &Winkelfunktionen"
 
 #: ../../src/wxMaximaFrame.cpp:1362
 msgid "&Determinant"
-msgstr ""
+msgstr "&Determinante"
 
 #: ../../src/wxMaximaFrame.cpp:1466
 msgid "&Differentiate..."
-msgstr ""
+msgstr "&Differenzieren ..."
 
 #: ../../src/wxMaximaFrame.cpp:689
 msgid "&Edit"
-msgstr ""
+msgstr "&Bearbeiten"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "&Eliminate Variable..."
-msgstr ""
+msgstr "Variable &eliminieren ..."
 
 #: ../../src/wxMaximaFrame.cpp:1318
 msgid "&Enter Matrix..."
-msgstr ""
+msgstr "Matrix &eingeben ..."
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "&Example..."
-msgstr ""
+msgstr "B&eispiel ..."
 
 #: ../../src/wxMaximaFrame.cpp:1524
 msgid "&Expand Expression"
-msgstr ""
+msgstr "Ausdruck &expandieren"
 
 #: ../../src/wxMaximaFrame.cpp:1597
 msgid "&Expand Trigonometric"
-msgstr ""
+msgstr "Winkelfunktionen &expandieren"
 
 #: ../../src/wxMaximaFrame.cpp:1626
 msgid "&Exponentialize"
-msgstr ""
+msgstr "Als &Expontialfunktionen"
 
 #: ../../src/wxMaximaFrame.cpp:618
 msgid "&Export..."
-msgstr ""
+msgstr "E&xportieren ..."
 
 #: ../../src/wxMaximaFrame.cpp:1516
 msgid "&Factor Expression"
-msgstr ""
+msgstr "Ausdruck &faktorisieren"
 
 #: ../../src/wxMaximaFrame.cpp:626
 msgid "&File"
-msgstr ""
+msgstr "&Datei"
 
 #: ../../src/wxMaximaFrame.cpp:1019
 msgid "&Functions"
-msgstr ""
+msgstr "&Funktionen"
 
 #: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Greatest Common Divisor..."
-msgstr ""
+msgstr "&Größter gemeinsamer Teiler..."
 
 #: ../../src/wxMaximaFrame.cpp:1968
 msgid "&Help"
-msgstr ""
+msgstr "&Hilfe"
 
 #: ../../src/wxMaximaFrame.cpp:1453
 msgid "&Integrate..."
-msgstr ""
+msgstr "&Integrieren ..."
 
 #: ../../src/wxMaximaFrame.cpp:964
 msgid "&Interrupt\tCtrl+G"
-msgstr ""
+msgstr "Unter&brechen\tCtrl+G"
 
 #: ../../src/wxMaximaFrame.cpp:1355
 msgid "&Invert Matrix"
-msgstr ""
+msgstr "Matrix &invertieren"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "&License"
-msgstr ""
+msgstr "&Lizenz"
 
 #: ../../src/wxMaximaFrame.cpp:1763
 msgid "&List"
-msgstr ""
+msgstr "&Liste"
 
 #: ../../src/wxMaximaFrame.cpp:610
 msgid "&Load Package...\tCtrl+L"
-msgstr ""
+msgstr "Paket &laden ...\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "&Maxima"
-msgstr ""
+msgstr "&Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "&Maxima help"
-msgstr ""
+msgstr "Zeige die Hilfe von Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1660
 msgid "&Modulus Computation..."
-msgstr ""
+msgstr "Setze &Modulo ..."
 
 #: ../../src/main.cpp:435
 msgid "&New\tCtrl+N"
-msgstr ""
+msgstr "Neu\tCtrl+N"
 
 #: ../../src/wxMaximaFrame.cpp:1870
 msgid "&Numeric"
-msgstr ""
+msgstr "&Numerisch"
 
 #: ../../src/wxMaximaFrame.cpp:1785
 msgid "&Numeric Output"
-msgstr ""
+msgstr "&Numerische Ausgabe"
 
 #: ../../src/main.cpp:436
 msgid "&Open\tCtrl+O"
-msgstr ""
+msgstr "&Öffnen\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "&Open...\tCtrl+O"
-msgstr ""
+msgstr "&Öffnen ...\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "&Plot"
-msgstr ""
+msgstr "&Plotten"
 
 #: ../../src/wxMaximaFrame.cpp:622
 msgid "&Print...\tCtrl+P"
-msgstr ""
+msgstr "Drucken ...\tCtrl+P"
 
 #: ../../src/wxMaximaFrame.cpp:1594
 msgid "&Reduce Trigonometric"
-msgstr ""
+msgstr "Winkelfunktionen &reduzieren"
 
 #: ../../src/wxMaximaFrame.cpp:974
 msgid "&Restart Maxima\tCtrl+Alt+R"
-msgstr ""
+msgstr "&Maxima neustarten\tCtrl+Alt+R"
 
 #: ../../src/wxMaximaFrame.cpp:608
 msgid "&Save\tCtrl+S"
-msgstr ""
+msgstr "Speichern\tCtrl+S"
 
 #: ../../src/wxMaximaFrame.cpp:1662
 msgid "&Simplify"
-msgstr ""
+msgstr "&Vereinfachen"
 
 #: ../../src/wxMaximaFrame.cpp:1581
 msgid "&Simplify Factorials"
-msgstr ""
+msgstr "Fakultäten &vereinfachen"
 
 #: ../../src/wxMaximaFrame.cpp:1591
 msgid "&Simplify Trigonometric"
-msgstr ""
+msgstr "Winkelfunktionen &vereinfachen"
 
 #: ../../src/wxMaximaFrame.cpp:1238
 msgid "&Solve..."
-msgstr ""
+msgstr "Gleichung lö&sen ..."
 
 #: ../../src/wxMaximaFrame.cpp:1035
 msgid "&Time Display"
-msgstr ""
+msgstr "&Zeitanzeige"
 
 #: ../../src/wxMaximaFrame.cpp:1375
 msgid "&Transpose Matrix"
-msgstr ""
+msgstr "Matrix &transponieren"
 
 #: ../../src/wxMaximaFrame.cpp:1605
 msgid "&Trigonometric Simplification"
-msgstr ""
+msgstr "&Winkelfunktionen vereinfachen"
 
 #: ../../src/wxMaximaFrame.cpp:1021
 msgid "&Variables"
-msgstr ""
+msgstr "&Variablen"
 
 #: ../../src/wxMaxima.cpp:2443
 msgid "(Config tells to suppress the output of long cells)"
@@ -307,11 +312,11 @@ msgstr ""
 
 #: ../../src/MathParser.cpp:1288
 msgid "(Invalid XML from maxima)"
-msgstr ""
+msgstr "(Ungültiges XML von Maxima)"
 
 #: ../../src/wxMaxima.cpp:4221
 msgid "(Maybe a permission problem?)"
-msgstr ""
+msgstr "(Vielleicht ein Rechte-Problem?)"
 
 #: ../../src/wxMaxima.cpp:9248
 msgid "(f(x),x,a,b)), Epsilon algorithm"
@@ -339,29 +344,31 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9361 ../../src/wxMaximaFrame.cpp:1867
 msgid "(f(x),x,y) with singularities+discontinuities"
-msgstr ""
+msgstr "(f(x),x,y) mit Singularitäten und Unstetigkeiten"
 
 #: ../../src/wxMaxima.cpp:2065
 msgid ""
 "... [suppressed additional lines as the output is longer than allowed in the"
 " wxMaxima configuration] "
 msgstr ""
+"... [unterdrücke die weiteren Zeilen der Ausgabe dieses Befehls, da bereits "
+"mehr als im Konfigurationsdialog erlaubt ausgegeben wurde]"
 
 #: ../../src/Worksheet.cpp:6666
 msgid ".wxm clipboard data with unusual header"
-msgstr ""
+msgstr ".wxm-Daten in Zwischenablage mit unüblichem Header"
 
 #: ../../src/wxMaxima.cpp:8047
 msgid "1×n Matrix b:"
-msgstr ""
+msgstr "1×n Matrix b:"
 
 #: ../../src/wxMaximaFrame.cpp:1312
 msgid "2D Array to Matrix..."
-msgstr ""
+msgstr "2D Array auf Matrix abbilden ..."
 
 #: ../../src/wxMaximaFrame.cpp:743
 msgid "2D equations using ASCII Art"
-msgstr ""
+msgstr "2D-Gleichungen aus Standard-Zeichen"
 
 #: ../../src/wxMaximaFrame.cpp:746
 msgid "2D equations using ASCII Art with unicode characters, if available"
@@ -370,11 +377,11 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:5057
 #, c-format
 msgid "; %i commands left in the current cell"
-msgstr ""
+msgstr "; %i ausstehende Befehle in aktueller Zelle"
 
 #: ../../src/wxMaxima.cpp:10617
 msgid "A \":lisp\" as the first command might fail to send a \"finished\" signal."
-msgstr ""
+msgstr "Ein \":lisp\" als erster Befehl meldet evtl. nicht, wenn er fertig ist."
 
 #: ../../src/wxMaxima.cpp:6585
 msgid "A Ctrl-F event"
@@ -391,23 +398,23 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:2012
 msgid "A function returning integers"
-msgstr ""
+msgstr "Eine Funktion, die ganze Zahlen retourniert"
 
 #: ../../src/Worksheet.cpp:2014
 msgid "A function returning positive numbers"
-msgstr ""
+msgstr "Eine Funktion, die positive ganze Zahlen retourniert"
 
 #: ../../src/Worksheet.cpp:1965
 msgid "A irrational variable"
-msgstr ""
+msgstr "Eine irrationale Variable"
 
 #: ../../src/Worksheet.cpp:2016
 msgid "A left-associative function"
-msgstr ""
+msgstr "Eine links-assoziative Funktion"
 
 #: ../../src/Worksheet.cpp:2019
 msgid "A linear function"
-msgstr ""
+msgstr "Eine lineare Funktion"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "A matrix in which each row is a set of variables"
@@ -415,15 +422,15 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1963
 msgid "A rational variable"
-msgstr ""
+msgstr "Eine rationale Variable"
 
 #: ../../src/Worksheet.cpp:2018
 msgid "A right-associative function"
-msgstr ""
+msgstr "Eine rechts-assoziative Funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1634
 msgid "A search-and-replace for equations"
-msgstr ""
+msgstr "Suchen und Ersetzen für Gleichungen"
 
 #: ../../src/wxMaximaFrame.cpp:1636
 msgid "A subst with basic maths knowledge"
@@ -434,94 +441,97 @@ msgid "A text control got the mouse focus"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1442
+#, fuzzy
 msgid "A&pply function to each Matrix element..."
-msgstr ""
+msgstr "Funktion auf jedes Matrixelement anwenden"
 
 #: ../../src/wxMaximaFrame.cpp:1291
 msgid "A&t Value..."
-msgstr ""
+msgstr "Rand&bedingung setzen ..."
 
 #: ../../src/Configuration.cpp:85
 msgid "ASCII maths"
-msgstr ""
+msgstr "ASCII-Art"
 
 #: ../../src/wxMaximaFrame.cpp:1963
 msgid "About"
-msgstr ""
+msgstr "Info"
 
 #: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
 msgid "About wxMaxima"
-msgstr ""
+msgstr "Information über wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7837
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
-msgstr ""
+msgstr "Akzeptiert einen Ausdruck oder eine Liste im Format [ode1,ode2,...]"
 
 #: ../../src/wxMaxima.cpp:7841
 msgid "Accepts one variable or a list in the format [1,4,...]"
-msgstr ""
+msgstr "Akzeptiert eine Variable oder eine Liste im Format [1,4,...]"
 
 #: ../../src/wxMaxima.cpp:7839
 msgid "Accepts one variable or a list in the format [var1,var2,...]"
-msgstr ""
+msgstr "Akzeptiert eine Variable oder eine Liste im Format [var1,var2,...]"
 
 #: ../../src/wxMaximaFrame.cpp:1371
 msgid "Ad&joint Matrix"
-msgstr ""
+msgstr "Ad&jungierte Matrix"
 
 #: ../../src/wxMaximaFrame.cpp:1657
 msgid "Add Algebraic E&quality..."
-msgstr ""
+msgstr "Algebraische Gleichheit &hinzufügen ..."
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add a directory to search path"
-msgstr ""
+msgstr "Ein Verzeichnis zum Suchpfad hinzufügen"
 
 #: ../../src/wxMaximaFrame.cpp:1752
 msgid ""
 "Add a new item to the beginning of the list. Useful for creating stacks."
 msgstr ""
+"Füge ein neues Element zum Anfang der Liste hinzu. Praktisch zur Generierung"
+" von Stapelspeichern."
 
 #: ../../src/wxMaxima.cpp:8602
 msgid "Add an element to the end of a list"
-msgstr ""
+msgstr "Füge ein Element am Ende der Liste hinzu"
 
 #: ../../src/wxMaxima.cpp:8597
 msgid "Add an element to the start of a list"
-msgstr ""
+msgstr "Füge ein Element am Anfang der Liste hinzu"
 
 #: ../../src/wxMaxima.cpp:7625
 msgid "Add dir to path:"
-msgstr ""
+msgstr "Verzeichnis zum Pfad hinzufügen"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "Add equality to the rational simplifier"
-msgstr ""
+msgstr "Gebe Vereinfacher für rationale Ausdrücke eine Gleichung"
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add to &Path..."
-msgstr ""
+msgstr "Zum &Pfad hinzufügen ..."
 
 #: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
 #: ../../src/Worksheet.cpp:1704
 msgid "Add to watchlist"
-msgstr ""
+msgstr "Zur Beobachtungsliste"
 
 #: ../../src/wxMaximaFrame.cpp:1562
 msgid "Additionally: log(a*b)=log(a)+log(b)"
-msgstr ""
+msgstr "Zusätzlich: log(a*b)=log(a)+log(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1566
 msgid "Additionally: log(a/b)=log(a)-log(b), a and b positive integers"
-msgstr ""
+msgstr "Zusätzlich: log(a/b)=log(a)-log(b), a und b positive ganze Zahlen"
 
 #: ../../src/Worksheet.cpp:1996
 msgid "Additive function: f(a+b)=f(a)+f(b)"
-msgstr ""
+msgstr "Additive Funktion: f(a+b)=f(a)+f(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1911
 msgid "Advanced 2d plotting"
-msgstr ""
+msgstr "Erweitertes 2D-Plotten"
 
 #: ../../src/wxMaximaFrame.cpp:1809
 msgid "Advanced guess (PSLQ algorithm)"
@@ -529,25 +539,28 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1920
 msgid "Advanced variable names"
-msgstr ""
+msgstr "Variablennamen für Fortgeschrittene"
 
 #: ../../src/ToolBar.cpp:321 ../../src/ToolBar.cpp:589
 msgid ""
 "After clicking on animations created with with_slider_draw() or similar this"
 " slider allows to change the current frame."
 msgstr ""
+"Wenn Animationen (diese können beispielsweise mit with_slider_draw() "
+"erstellt werden) angeklickt sind, erlaubt dieser Schieberegler es, das "
+"aktuell angezeigte Bild zu wählen."
 
 #: ../../src/wxMaximaFrame.cpp:1028
 msgid "Aliases"
-msgstr ""
+msgstr "Aliase"
 
 #: ../../src/wxMaximaFrame.cpp:1714
 msgid "All but the 1st n elements"
-msgstr ""
+msgstr "Alle Elemente bis auf die ersten n"
 
 #: ../../src/wxMaximaFrame.cpp:1716
 msgid "All but the last n elements"
-msgstr ""
+msgstr "Alle Elemente bis auf die letzten n"
 
 #: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
 msgid ""
@@ -556,93 +569,100 @@ msgid ""
 "*.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session "
 "(*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr ""
+"\"Alle unterstützten Dateien (*.wxm, *.wxmx, *.mac, *.out, *.xml)|*.wxm;*.wxmx;*.mac;*.\"\n"
+"\"out;*.xml|wxMaxima-Dokumente (*.wxm, *.wxmx)|*.wxm;*.wxmx|Maxima-Sitzungen (*.\"\n"
+"\"mac)|*.mac|Xmaxima-Sitzungen (*.out)|*.out|xml von beschädigtem .wxmx (*.xml)|*.xml\""
 
 #: ../../src/wxMaximaFrame.cpp:733
 msgid "All visible sidebars"
-msgstr ""
+msgstr "Alle sichtbaren Seitenleisten"
 
 #: ../../src/wxMaximaFrame.cpp:1650
 msgid "Allow to substitute operators"
-msgstr ""
+msgstr "Erlaube es, Operatoren zu ersetzen"
 
 #: ../../src/wxMaxima.cpp:9040
 msgid ""
 "Allows to vary the parameters of a function until it fits experimental data."
 msgstr ""
+"Erlaube es, Parameter einer Funktion zu variieren, bis sie zu den "
+"experimentellen Daten passt."
 
 #: ../../src/wxMaximaFrame.cpp:763
 msgid "Always after underscores"
-msgstr ""
+msgstr "Immer nach einem Unterstrich"
 
 #: ../../src/wxMaximaFrame.cpp:764
 msgid "Always autosubscript after an underscore"
-msgstr ""
+msgstr "Mache alles nach einem Unterstrich tiefgestellt"
 
 #: ../../src/wxMaximaFrame.cpp:774
 msgid "Always display this variable with subscript"
-msgstr ""
+msgstr "Stelle diese Variable immer mit Tiefstellung dar"
 
 #: ../../src/Worksheet.cpp:1605
 msgid "Always show all digits"
-msgstr ""
+msgstr "Zeige immer alle Ziffern"
 
 #: ../../src/wxMaxima.cpp:9241
 msgid ""
 "An integer between 1..6; Higher numbers work better for oscillating "
 "integrands"
 msgstr ""
+"Eine ganze Zahl zwischen 1..6; Höhere Zahlen sind für oszilierende "
+"Integranden besser geeignet"
 
 #: ../../src/MaximaManual.cpp:385
 msgid "Anchors file has no top node."
-msgstr ""
+msgstr "Die Datei mit den Handbuch-Ankern hat keinen obersten XML-Knoten"
 
 #: ../../src/wxMaximaFrame.cpp:791
 msgid "Angles"
-msgstr ""
+msgstr "Spitze Ecken"
 
 #: ../../src/wxMaximaFrame.cpp:1775
 msgid "Animation autoplay"
-msgstr ""
+msgstr "Automatisches Abspielen von Animationen"
 
 #: ../../src/wxMaximaFrame.cpp:1778
 msgid "Animation framerate..."
-msgstr ""
+msgstr "Bildwiederholrate für Animationen..."
 
 #: ../../src/Worksheet.cpp:2002
 msgid "Antisymmetric function: f(x)=-f(-x)"
-msgstr ""
+msgstr "Antisymmetrische Funktion: f(x)=-f(-x)"
 
 #: ../../src/wxMaximaFrame.cpp:1739
 msgid "Append"
-msgstr ""
+msgstr "Anfügen"
 
 #: ../../src/wxMaximaFrame.cpp:1735
 msgid "Append a list"
-msgstr ""
+msgstr "Aneinanderfügen von Listen"
 
 #: ../../src/wxMaximaFrame.cpp:1736
 msgid "Append a list to an existing list"
-msgstr ""
+msgstr "Hängt einer Liste an eine existierende Liste an"
 
 #: ../../src/wxMaxima.cpp:8607
 msgid "Append a list to another list"
-msgstr ""
+msgstr "Anhängen einer Liste an eine andere Liste"
 
 #: ../../src/wxMaximaFrame.cpp:1729
 msgid "Append an element"
-msgstr ""
+msgstr "Anhängen eines Elements"
 
 #: ../../src/wxMaximaFrame.cpp:1734
 msgid "Append an element to the beginning an existing list"
-msgstr ""
+msgstr "Füge ein Element am Beginn einer Liste hinzu"
 
 #: ../../src/wxMaximaFrame.cpp:1730
 msgid "Append an element to the end of an existing list"
-msgstr ""
+msgstr "Füge ein Element am Ende einer Liste hinzu"
 
 #: ../../src/wxMaxima.cpp:8552
 msgid "Apply a function to each list element"
-msgstr ""
+msgstr "Funktion auf jedes Listenelement anwenden"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 #, c-format
@@ -667,103 +687,108 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9474
 msgid "Apropos"
-msgstr ""
+msgstr "Apropos"
 
 #: ../../src/wxMaxima.cpp:7317
 msgid "Are the chars equal, if case is ignored?"
-msgstr ""
+msgstr "Sind diese Zeichen gleich, wenn man Groß/Kleinschreibung ignoriert?"
 
 #: ../../src/wxMaxima.cpp:7312
 msgid "Are the chars equal?"
-msgstr ""
+msgstr "Sind diese Zeichen gleich?"
 
 #: ../../src/wxMaxima.cpp:7349
 msgid "Are these strings equal if case is ignored?"
-msgstr ""
+msgstr "Sind diese Strings gleich, wenn Groß/Kleinschreibung ignoriert wird?"
 
 #: ../../src/wxMaxima.cpp:7344
 msgid "Are these strings equal?"
-msgstr ""
+msgstr "Sind diese Strings gleich?"
 
 #: ../../src/wxMaxima.cpp:7259
 msgid "Arguments:"
-msgstr ""
+msgstr "Argumente:"
 
 #: ../../src/wxMaxima.cpp:8189
 msgid "Array"
-msgstr ""
+msgstr "Array"
 
 #: ../../src/wxMaximaFrame.cpp:1023
 msgid "Arrays"
-msgstr ""
+msgstr "Arrays"
 
 #: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
 msgid "Ascii code to char"
-msgstr ""
+msgstr "Ascii-code in Zeichen konvertieren"
 
 #: ../../src/wxMaximaFrame.cpp:1138
 msgid "Ascii code to char..."
-msgstr ""
+msgstr "Ascii-code in Zeichen konvertieren..."
 
 #: ../../src/wxMaxima.cpp:10063
 msgid "Assignment(s):"
-msgstr ""
+msgstr "Zuweisung(en):"
 
 #: ../../src/wxMaxima.cpp:10064
 msgid "Assignments of the format a=10,b=20"
-msgstr ""
+msgstr "Zuweisungen der Form a=10,b=20"
 
 #: ../../src/wxMaxima.cpp:6851
 msgid "Assume a value range for a variable"
-msgstr ""
+msgstr "Nehme einen Wertebereich für eine Variable an"
 
 #: ../../src/wxMaxima.cpp:8545
 msgid ""
 "Attention: Extracting a random list element isn't efficient for long "
 "lists.Iterating over lists using makelist() or for loops is way faster."
 msgstr ""
+"Achtung: Ein zufälliges Listenelement extrahieren, ist nicht effizient für "
+"lange Listen.Iterieren mit makelist() oder for-Schleifen sind wesentlich "
+"schneller."
 
 #: ../../src/Worksheet.cpp:1618
 msgid "Automatic labels"
-msgstr ""
+msgstr "Automatische Marken"
 
 #: ../../src/wxMaximaFrame.cpp:952
 msgid "Automatically answer questions"
-msgstr ""
+msgstr "Automatisches Antworten auf Fragen"
 
 #: ../../src/wxMaximaFrame.cpp:953
 msgid "Automatically fill in answers known from the last run"
 msgstr ""
+"Automatisches Beantworten von Fragen, deren Antwort das letzte Mal gegeben "
+"wurde."
 
 #: ../../src/Worksheet.cpp:1464 ../../src/Worksheet.cpp:1838
 msgid "Automatically send known answers"
-msgstr ""
+msgstr "Automatisches Senden bekannter Antworten"
 
 #: ../../src/wxMaxima.cpp:6021
 #, c-format
 msgid "Autosaving as temp file %s"
-msgstr ""
+msgstr "Automatisches Speichern als temporäre Datei %s"
 
 #: ../../src/wxMaxima.cpp:6033
 #, c-format
 msgid "Autosaving the .wxmx file as %s"
-msgstr ""
+msgstr "Automatisches Speichern als %s"
 
 #: ../../src/wxMaximaFrame.cpp:781
 msgid "Autosubscript"
-msgstr ""
+msgstr "Automatisches Tiefstellen"
 
 #: ../../src/wxMaximaFrame.cpp:782
 msgid "Autosubscript chars after an underscore"
-msgstr ""
+msgstr "Automatisches Tiefstellen von Zeichen nach einem Unterstrich"
 
 #: ../../src/wxMaximaFrame.cpp:767
 msgid "Autosubscript numbers and text following single letters"
-msgstr ""
+msgstr "Stelle Zahlen und Text, der einzelnen Buchstaben folgt, tief"
 
 #: ../../src/wxMaxima.cpp:6529
 msgid "Autosubscript this variable"
-msgstr ""
+msgstr "Diese Variable automatisch mit Subscript ausstatten"
 
 #: ../../src/MaximaManual.cpp:536
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -771,40 +796,43 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1350
 msgid "Basic matrix operations"
-msgstr ""
+msgstr "Einfache Matrizenoperationen"
 
 #: ../../src/wxMaxima.cpp:6210
 msgid "Batch File"
-msgstr ""
+msgstr "Batch-Datei laden"
 
 #: ../../src/wxMaxima.cpp:5318
 msgid "Both horizontal and vertical cursor active at the same time"
-msgstr ""
+msgstr "Vertikaler und horizontaler Cursor sind gleichzeitig aktiv"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Bottom end"
-msgstr ""
+msgstr "Unteres Ende"
 
 #: ../../src/wxMaxima.cpp:7817
 msgid "Boundary value problem"
-msgstr ""
+msgstr "Randwertproblem"
 
 #: ../../src/wxMathml.cpp:101
 msgid ""
 "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
 msgstr ""
+"Fehler: Nach dem Entfernen von Leerzeichen und Zeilenwechseln ist "
+"wxMathml.lisp kürzer als erwartet!"
 
 #: ../../src/Autocomplete.cpp:509
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
+"Fehler: Textvervollständigung für eine unbekannte Kategorie aufgerufen."
 
 #: ../../src/Worksheet.cpp:2992
 msgid "Bug: Cell left but not entered."
-msgstr ""
+msgstr "Interner Fehler: Zelle wurde verlassen, aber zuvor nie besucht."
 
 #: ../../src/Worksheet.cpp:6203
 msgid "Bug: Cell with negative y position!"
-msgstr ""
+msgstr "Interner Fehler: Zelle mit negativer y-Position!"
 
 #: ../../src/Worksheet.cpp:7723
 msgid ""
@@ -818,36 +846,40 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:3112
 msgid "Bug: Got a question but no cell to answer it in"
-msgstr ""
+msgstr "Interner Fehler: Habe eine Frage, aber weiß nicht, in welcher Zelle"
 
 #: ../../src/Worksheet.cpp:6378
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of"
 " the worksheet."
 msgstr ""
+"Interner Fehler: Soll die Zelle vor dem Beginn des Arbeitsblattes ändern."
 
 #: ../../src/Worksheet.cpp:6346
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
+"Interner Fehler: Soll die Zelle vor dem Beginn des Arbeitsblattes löschen."
 
 #: ../../src/Worksheet.cpp:6415
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
-msgstr ""
+msgstr "Interner Fehler: soll den Inhalt einer Zelle ändern und sie löschen."
 
 #: ../../src/Worksheet.cpp:5578
 msgid "Bug: HTML output is no valid XML"
-msgstr ""
+msgstr "Interner Fehler: Die HTML-Ausgabe ist kein gültiges XML."
 
 #: ../../src/Configuration.h:615
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
 msgstr ""
+"Interner Fehler: Die Anzahl der Ziffern, die angezeigt werden soll, ist zu "
+"niedrig!"
 
 #: ../../src/MathParser.cpp:523
 msgid "Bug: Missing contents"
-msgstr ""
+msgstr "Interner Fehler: Fehlender Inhalt"
 
 #: ../../src/Worksheet.cpp:2597 ../../src/Worksheet.cpp:2711
 #: ../../src/Worksheet.cpp:2753 ../../src/Worksheet.cpp:2787
@@ -855,7 +887,7 @@ msgstr ""
 #: ../../src/Worksheet.cpp:4442 ../../src/Worksheet.cpp:6650
 #: ../../src/Worksheet.cpp:6863
 msgid "Bug: The clipboard is already opened"
-msgstr ""
+msgstr "Interner Fehler: Die Zwischenablage ist bereits geöffnet"
 
 #: ../../src/Worksheet.cpp:7763
 msgid "Bug: Trying to move a title out by one sectioning unit"
@@ -866,22 +898,30 @@ msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
+"Fehler: Versuche, den horizontal dargestellten Cursor in einer Zelle zu "
+"platzieren."
 
 #: ../../src/Worksheet.h:247 ../../src/Worksheet.h:252
 msgid "Bug: Trying to record a cell contents change for undo without a cell."
 msgstr ""
+"Interner Fehler: Versuche, die Änderung des Inhalts einer Zelle zu "
+"dokumentieren, ohne die Zelle zu kennen."
 
 #: ../../src/Worksheet.cpp:6417
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
+"Interner Fehler: Rückgängig will Zellen ändern und gleichzeitig Zellen "
+"hinzufügen."
 
 #: ../../src/Worksheet.cpp:6383
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
+"Interner Fehler: Rückgängigmachen setzt an Zellen außerhalb des "
+"Arbeitsblattes an."
 
 #: ../../src/wxMaximaFrame.cpp:1948
 msgid "Build &Info"
-msgstr ""
+msgstr "&Info über Maxima"
 
 #: ../../src/wxMaxima.cpp:7275
 msgid "Byte:"
@@ -889,19 +929,19 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1458
 msgid "C&hange Variable in Integrate..."
-msgstr ""
+msgstr "Integrationsvaria&ble ersetzen..."
 
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "C&onfigure"
-msgstr ""
+msgstr "&Einstellungen"
 
 #: ../../src/wxMaximaFrame.cpp:1482
 msgid "Calculate &Product..."
-msgstr ""
+msgstr "&Produkt berechnen..."
 
 #: ../../src/wxMaxima.cpp:8057
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
-msgstr ""
+msgstr "Berechne Singulärwertzerlegung einer Matrix numerisch"
 
 #: ../../src/wxMaxima.cpp:8050
 msgid ""
@@ -911,79 +951,80 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate Su&m..."
-msgstr ""
+msgstr "Su&mme berechnen ..."
 
 #: ../../src/wxMaximaFrame.cpp:1795
 msgid "Calculate bigfloat value of the last result"
-msgstr ""
+msgstr "Letztes Ergebnis als lange Gleitkommazahl"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Calculate float value of the last result"
-msgstr ""
+msgstr "Letztes Ergebnis als Gleitkommazahl"
 
 #: ../../src/wxMaxima.cpp:9550
 msgid "Calculate mean value"
-msgstr ""
+msgstr "Mittelwert berechnen"
 
 #: ../../src/wxMaxima.cpp:9554
 msgid "Calculate median value"
-msgstr ""
+msgstr "Medianwert berechnen"
 
 #: ../../src/wxMaxima.cpp:8871
 msgid "Calculate modulus:"
-msgstr ""
+msgstr "Rechne modulo:"
 
 #: ../../src/wxMaximaFrame.cpp:1798
 msgid "Calculate numeric value of the last result"
-msgstr ""
+msgstr "Letztes Ergebnis als Gleitkommazahl"
 
 #: ../../src/wxMaximaFrame.cpp:1483
 msgid "Calculate products"
-msgstr ""
+msgstr "Produkte berechnen"
 
 #: ../../src/wxMaxima.cpp:9562
 msgid "Calculate standard deviation"
-msgstr ""
+msgstr "Standardabweichung berechnen"
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate sums"
-msgstr ""
+msgstr "Summen berechnen"
 
 #: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
 msgid "Calculate the eigenvalues and eigenvectors numerically"
-msgstr ""
+msgstr "Eigenwerte und Eigenvektoren numerisch berechnen"
 
 #: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
 msgid "Calculate the eigenvalues of a matrix numerically"
-msgstr ""
+msgstr "Eigenwerte einer Matrix numerisch berechnen"
 
 #: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
 msgid "Calculate the root of the sum of squares of matrix entries"
-msgstr ""
+msgstr "Berechne die Wurzel der Summe der Quadrate von Matrixeinträgen"
 
 #: ../../src/wxMaxima.cpp:9558
 msgid "Calculate variation"
-msgstr ""
+msgstr "Variation berechnen"
 
 #: ../../src/wxMaxima.cpp:8949
 msgid "Calculates the fourier coefficients for the expression from -p to p"
-msgstr ""
+msgstr "Berechne die Fourier-Koeffizienten des Ausdrucks von -p bis p"
 
 #: ../../src/Worksheet.cpp:1968
 msgid "Calls assume() in order to tell maxima about the variable's range"
 msgstr ""
+"Rufe assume() auf, um Maxima den Wertebereich der Variablen mitzuteilen"
 
 #: ../../src/Worksheet.cpp:2031
 msgid "Can be specified as flag in ev(exp, flag)"
-msgstr ""
+msgstr "Kann als flag in ev(exp, flag) angegeben werden"
 
 #: ../../src/wxMaxima.cpp:11125
 msgid "Can not connect to the web server."
-msgstr ""
+msgstr "Keine Verbindung mit dem Webserver."
 
 #: ../../src/wxMaxima.cpp:11166
 msgid "Can not download version info."
-msgstr ""
+msgstr "Kann Information zur Version nicht laden."
 
 #: ../../src/wxMaxima.cpp:3016 ../../src/wxMaxima.cpp:4836
 msgid ""
@@ -991,10 +1032,14 @@ msgid ""
 " (it can be downloaded from https://maxima.sourceforge.io) or in wxMaxima's "
 "config dialogue the setting for Maxima's location is wrong."
 msgstr ""
+"Kann Maxima nicht starten. Meist heißt dies, dass Maxima (kann von "
+"https://maxima.sourceforge.io heruntergeladen werden) nicht installiert ist,"
+" oder im Konfigurationsdialog von wxMaxima ein falscher Ort angegeben ist, "
+"an dem Maxima zu suchen ist."
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Cancel"
-msgstr ""
+msgstr "Abbrechen"
 
 #: ../../src/wxMaxima.cpp:3292
 msgid "Cannot authenticate Maxima!"
@@ -1003,137 +1048,138 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:2677
 msgid ""
 "Cannot find a maxima binary and no binary chosen in the config dialogue."
-msgstr ""
+msgstr "Kann Maxima nicht dort finden, wo im Konfigurationsdialog angegeben."
 
 #: ../../src/Autocomplete.cpp:583
-#, c-format
+#, fuzzy, c-format
 msgid "Cannot interpret template %s"
-msgstr ""
+msgstr ": Nichtinterpretierbare Zeile: %s"
 
 #: ../../src/wxMaxima.cpp:3082
 #, c-format
 msgid "Cannot interpret the numeric value of pid %s"
-msgstr ""
+msgstr "Kann den numerischen Wert der Prozess-ID %s nicht interpretieren"
 
 #: ../../src/wxMaxima.cpp:11066 ../../src/wxMaxima.cpp:11073
 #: ../../src/wxMaxima.cpp:11080
 #, c-format
 msgid "Cannot interpret version number component %s"
-msgstr ""
+msgstr "Kann die Versionsnummer %s nicht interpretieren"
 
 #: ../../src/wxMaxima.cpp:2530
 msgid "Cannot set the communication address to localhost."
 msgstr ""
+"Der Kommunikationsendpunkt kann nicht auf \"Dieser Rechner\" gesetzt werden."
 
 #: ../../src/wxMaxima.cpp:2532
 #, c-format
 msgid "Cannot set the communication port to %i."
-msgstr ""
+msgstr "Kann den Kommunikationsport nicht auf %i setzen."
 
 #: ../../src/wxMaxima.cpp:3656 ../../src/wxMaxima.cpp:6359
 msgid "Cannot start gnuplot"
-msgstr ""
+msgstr "Konnte Gnuplot nicht starten"
 
 #: ../../src/StatusBar.cpp:216 ../../src/wxMaxima.cpp:2662
 msgid "Cannot start the maxima binary"
-msgstr ""
+msgstr "Kann Maxima nicht starten"
 
 #: ../../src/wxMaxima.cpp:9268
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
-msgstr ""
+msgstr "Cauchyscher Hauptwert von f(x)/(x-x), endliches Intervall"
 
 #: ../../src/wxMaximaFrame.cpp:1845
 msgid "Cauchy principal value, finite interval"
-msgstr ""
+msgstr "Cauchyscher Hauptwert, endliches Intervall"
 
 #: ../../src/wxMaximaFrame.cpp:955
 msgid "Ce&ll"
-msgstr ""
+msgstr "Ze&llen"
 
 #: ../../src/Configuration.cpp:96
 msgid "Cell bracket fill, Active"
-msgstr ""
+msgstr "Klammern Zelle (aktiv)"
 
 #: ../../src/Configuration.cpp:95
 msgid "Cell bracket fill, Inactive"
-msgstr ""
+msgstr "Klammern Zelle (nicht aktiv)"
 
 #: ../../src/wxMaxima.cpp:10395
 msgid "Cell ends in a backslash"
-msgstr ""
+msgstr "Zelle endet mit einem Backslash"
 
 #: ../../src/wxMaximaFrame.cpp:1038
 msgid "Change &2d Display"
-msgstr ""
+msgstr "Format &2D Anzeige"
 
 #: ../../src/wxMaxima.cpp:10146
 msgid "Change Image"
-msgstr ""
+msgstr "Bild ändern"
 
 #: ../../src/Worksheet.cpp:1324
 msgid "Change Image..."
-msgstr ""
+msgstr "Bild ändern..."
 
 #: ../../src/wxMaximaFrame.cpp:1954
 msgid "Change Log"
-msgstr ""
+msgstr "Neuerungen"
 
 #: ../../src/wxMaxima.cpp:7555
 msgid "Change directory"
-msgstr ""
+msgstr "Verzeichnis wechseln"
 
 #: ../../src/wxMaximaFrame.cpp:1202
 msgid "Change directory..."
-msgstr ""
+msgstr "Verzeichnis wechseln..."
 
 #: ../../src/wxMaximaFrame.cpp:1039
 msgid "Change the 2d display algorithm used to display math output"
-msgstr ""
+msgstr "Wähle ein Format für die 2D Anzeige"
 
 #: ../../src/wxMaxima.cpp:8885
 msgid "Change variable"
-msgstr ""
+msgstr "Variable ersetzen"
 
 #: ../../src/wxMaxima.cpp:8905
 msgid "Change variable and evaluate"
-msgstr ""
+msgstr "Variable ändern und auswerten"
 
 #: ../../src/wxMaximaFrame.cpp:1459
 msgid "Change variable in integral or sum"
-msgstr ""
+msgstr "Variable in Integral oder Summe ersetzen"
 
 #: ../../src/wxMaximaFrame.cpp:1463
 msgid "Change variable in integral or sum and evaluate the result"
-msgstr ""
+msgstr "Variable in Integral oder Summe ändern und Ergebnis auswerten"
 
 #: ../../src/wxMaximaFrame.cpp:1026
 msgid "Changed option variables"
-msgstr ""
+msgstr "Optionsvariable geändert"
 
 #: ../../src/wxMaxima.cpp:10170
 #, c-format
 msgid "Changing image originally loaded from file %s to %s."
-msgstr ""
+msgstr "Ändere das Bild, das von %s geladen wurde zu %s."
 
 #: ../../src/wxMaxima.cpp:7313 ../../src/wxMaxima.cpp:7318
 #: ../../src/wxMaxima.cpp:7323 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7334 ../../src/wxMaxima.cpp:7340
 msgid "Char #1:"
-msgstr ""
+msgstr "Zeichen #1:"
 
 #: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
 #: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
 msgid "Char #2:"
-msgstr ""
+msgstr "Zeichen #2:"
 
 #: ../../src/wxMaximaFrame.cpp:1140
 msgid "Char to Unicode code point..."
-msgstr ""
+msgstr "Zeichen in Unicode code point..."
 
 #: ../../src/wxMaxima.cpp:7358 ../../src/wxMaxima.cpp:7362
 msgid "Char to unicode code point"
-msgstr ""
+msgstr "Zeichen in Unicode code point..."
 
 #: ../../src/wxMaxima.cpp:7285 ../../src/wxMaxima.cpp:7289
 #: ../../src/wxMaxima.cpp:7293 ../../src/wxMaxima.cpp:7297
@@ -1141,91 +1187,93 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7359 ../../src/wxMaxima.cpp:7363
 #: ../../src/wxMaxima.cpp:7435
 msgid "Char:"
-msgstr ""
+msgstr "Zeichen:"
 
 #: ../../src/wxMaximaFrame.cpp:1131
 msgid "Character Tests"
-msgstr ""
+msgstr "Zeichen-Tests"
 
 #: ../../src/wxMaxima.cpp:8181
 msgid "Characteristic polynom"
-msgstr ""
+msgstr "&Charakteristisches Polynom"
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Chars are strings that are one character long"
-msgstr ""
+msgstr "Zeichen sind Strings, die ein Zeichen lang sind"
 
 #: ../../src/wxMaximaFrame.cpp:1957
 msgid "Check for Updates"
-msgstr ""
+msgstr "Prüfe auf Aktualisierungen"
 
 #: ../../src/wxMaximaFrame.cpp:1958
 msgid "Check if a newer version of wxMaxima is available."
-msgstr ""
+msgstr "Prüft, ob Sie eine aktuelle Version von wxMaxima erhältlich ist."
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Choose the parenthesis type for Matrices"
-msgstr ""
+msgstr "Darstellung der Klammern von Matrizen"
 
 #: ../../src/wxMaxima.cpp:9530 ../../src/wxMaxima.cpp:9535
 msgid "Classes:"
-msgstr ""
+msgstr "Klassen:"
 
 #: ../../src/wxMaximaFrame.cpp:1378
 msgid "Classic matrix operations"
-msgstr ""
+msgstr "Klassische Matrizen-Operationen"
 
 #: ../../src/wxMaximaFrame.cpp:998
 msgid "Clear all aliases"
-msgstr ""
+msgstr "Alle Aliases löschen"
 
 #: ../../src/wxMaximaFrame.cpp:995
 msgid "Clear all arrays"
-msgstr ""
+msgstr "Alle Arrays löschen"
 
 #: ../../src/wxMaximaFrame.cpp:992
 msgid "Clear all dependencies"
-msgstr ""
+msgstr "Alle Abhängigkeiten löschen"
 
 #: ../../src/wxMaximaFrame.cpp:994
 msgid "Clear all functions"
-msgstr ""
+msgstr "Alle Funktionen löschen"
 
 #: ../../src/wxMaximaFrame.cpp:1001
+#, fuzzy
 msgid "Clear all gradefs"
-msgstr ""
+msgstr "Funktionen mit partiellen Ableitungen (gradefs) löschen"
 
 #: ../../src/wxMaximaFrame.cpp:1000
 msgid "Clear all labels"
-msgstr ""
+msgstr "Alle Markierungen löschen"
 
 #: ../../src/wxMaximaFrame.cpp:1004
 msgid "Clear all let rule packages"
-msgstr ""
+msgstr "Alle let-Regeln löschen"
 
 #: ../../src/wxMaximaFrame.cpp:1003
 msgid "Clear all macros"
-msgstr ""
+msgstr "Alle Makros löschen"
 
 #: ../../src/wxMaximaFrame.cpp:1002
 msgid "Clear all props"
 msgstr ""
+"Eigenschaften (deklariert mit atvalue, matchdeclare, ...) (props) löschen"
 
 #: ../../src/wxMaximaFrame.cpp:997
 msgid "Clear all rules"
-msgstr ""
+msgstr "Alle Regeln löschen"
 
 #: ../../src/wxMaximaFrame.cpp:999
 msgid "Clear all structures"
-msgstr ""
+msgstr "Alle Strukturen löschen"
 
 #: ../../src/wxMaximaFrame.cpp:993
 msgid "Clear all variables"
-msgstr ""
+msgstr "Alle Variablen löschen"
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close\tCtrl+W"
-msgstr ""
+msgstr "Schließen\tCtrl+W"
 
 #: ../../src/wxMaxima.cpp:7235
 msgid "Close Stream"
@@ -1233,147 +1281,151 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close window"
-msgstr ""
+msgstr "Schließe Fenster"
 
 #: ../../src/wxMaximaFrame.cpp:1105
 msgid "Close..."
-msgstr ""
+msgstr "Schließen ..."
 
 #: ../../src/WXMXformat.cpp:301
 msgid "Closed the zip archive"
-msgstr ""
+msgstr "ZIP-Archiv schließen"
 
 #: ../../src/Configuration.cpp:77
+#, fuzzy
 msgid "Code Default (Maxima input)"
-msgstr ""
+msgstr "Maxima Eingabe"
 
 #: ../../src/Configuration.cpp:103
 msgid "Code highlighting: Comments"
-msgstr ""
+msgstr "Syntaxhervorhebung: Kommentare"
 
 #: ../../src/Configuration.cpp:108
 msgid "Code highlighting: End of line markers"
-msgstr ""
+msgstr "Syntaxhervorhebung: Zeilenende-Marker"
 
 #: ../../src/Configuration.cpp:102
 msgid "Code highlighting: Functions"
-msgstr ""
+msgstr "Syntaxhervorhebung: Funktionen"
 
 #: ../../src/Configuration.cpp:107
 msgid "Code highlighting: Lisp"
-msgstr ""
+msgstr "Syntaxhervorhebung: Lisp"
 
 #: ../../src/Configuration.cpp:104
 msgid "Code highlighting: Numbers"
-msgstr ""
+msgstr "Syntaxhervorhebung: Zahlen"
 
 #: ../../src/Configuration.cpp:106
 msgid "Code highlighting: Operators"
-msgstr ""
+msgstr "Syntaxhervorhebung: Operatoren"
 
 #: ../../src/Configuration.cpp:105
 msgid "Code highlighting: Strings"
-msgstr ""
+msgstr "Syntaxhervorhebung: Zeichenketten"
 
 #: ../../src/Configuration.cpp:101
 msgid "Code highlighting: Variables"
-msgstr ""
+msgstr "Syntaxhervorhebung: Variablen"
 
 #: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
+#, fuzzy
 msgid "Code number:"
-msgstr ""
+msgstr "Zeile Nummer:"
 
 #: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
+#, fuzzy
 msgid "Codepoint number:"
-msgstr ""
+msgstr "Zeile Nummer:"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "Col. names:"
-msgstr ""
+msgstr "Spaltennamen:"
 
 #: ../../src/Configuration.cpp:100
 msgid "Color of Outdated cells"
-msgstr ""
+msgstr "Farbe von veralteten Zellen"
 
 #: ../../src/Configuration.cpp:99
 msgid "Color of text equal to selection"
-msgstr ""
+msgstr "Textfarbe identisch mit der Auswahl"
 
 #: ../../src/wxMaxima.cpp:7962
 msgid "Column number:"
-msgstr ""
+msgstr "Spalten Nummer:"
 
 #: ../../src/wxMaxima.cpp:7978
 msgid "Column numbers:"
-msgstr ""
+msgstr "Spalten Nummern:"
 
 #: ../../src/wxMaxima.cpp:8202
 msgid "Columns"
-msgstr ""
+msgstr "Spalten"
 
 #: ../../src/wxMaximaFrame.cpp:1584
 msgid "Combine factorials in an expression"
-msgstr ""
+msgstr "Fakultäten in einem Ausdruck kombinieren"
 
 #: ../../src/wxMaxima.cpp:10454
 msgid "Comma directly followed by a closing parenthesis"
-msgstr ""
+msgstr "Komma wird von einer schließenden Klammer gefolgt"
 
 #: ../../src/wxMaxima.cpp:7259
 msgid "Comma-separated arguments"
-msgstr ""
+msgstr "Argumente (durch Kommata getrennt)"
 
 #: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
 msgid "Comma-separated commands"
-msgstr ""
+msgstr "Befehle (durch Kommata getrennt)"
 
 #: ../../src/wxMaxima.cpp:8458
 msgid "Comma-separated elements"
-msgstr ""
+msgstr "Elemente (durch Kommata getrennt)"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 #: ../../src/wxMaxima.cpp:10031
 msgid "Comma-separated equations"
-msgstr ""
+msgstr "Durch Kommata getrennte Gleichungen"
 
 #: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
 #: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
 #: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
 msgid "Comma-separated expressions"
-msgstr ""
+msgstr "Durch Kommata getrennte Ausdrücke"
 
 #: ../../src/wxMaxima.cpp:7215
 msgid "Comma-separated expressions that shall be converted to a string"
 msgstr ""
+"Durch Kommata getrennte Ausdrücke, die zu Strings konvertiert werden sollen"
 
 #: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
 msgid "Comma-separated expressions."
-msgstr ""
+msgstr "Durch Kommata getrennte Ausdrücke."
 
 #: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
 msgid "Comma-separated function names"
-msgstr ""
+msgstr "Durch Kommata getrennte Funktionsnamen"
 
 #: ../../src/wxMaxima.cpp:7086
 msgid "Comma-separated function names."
-msgstr ""
+msgstr "Durch Kommata getrennte Funktionsnamen."
 
 #: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
 #: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
 msgid "Comma-separated list entry in the format val1=1,val2=2"
-msgstr ""
+msgstr "Durch Komma getrennte Listen im Format wert1=1,wert2=2"
 
 #: ../../src/wxMaxima.cpp:7205
 msgid "Comma-separated names of the elements that shall be written"
-msgstr ""
+msgstr "Komma-getrennte Elementnamen, die geschrieben werden sollen"
 
 #: ../../src/wxMaxima.cpp:7099
 msgid "Comma-separated names the parameters will be referenced by later."
-msgstr ""
+msgstr "Komma-getrennte Parameternamen, die später gebraucht werden."
 
 #: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
 msgid "Comma-separated numbers from 0 to 255"
-msgstr ""
+msgstr "Komma-getrennte Zahlen von 0 bis 255"
 
 #: ../../src/wxMaxima.cpp:8770
 msgid "Comma-separated numbers of the terms to substitute in"
@@ -1388,32 +1440,34 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7054
 msgid "Comma-separated variable names, can be initialized by the \":\" operator."
 msgstr ""
+"Komma-getrennte Variablennamen, können mit dem \":\" operator initialisiert "
+"werden."
 
 #: ../../src/wxMaxima.cpp:7753 ../../src/wxMaxima.cpp:7767
 #: ../../src/wxMaxima.cpp:8719 ../../src/wxMaxima.cpp:8785
 #: ../../src/wxMaxima.cpp:10032
 msgid "Comma-separated variables"
-msgstr ""
+msgstr "Komma-getrennte Variablen"
 
 #: ../../src/wxMaxima.cpp:9469
 msgid "Command:"
-msgstr ""
+msgstr "Befehl:"
 
 #: ../../src/Worksheet.cpp:1692
 msgid "Comment Selection"
-msgstr ""
+msgstr "Auswahl auskommentieren"
 
 #: ../../src/wxMaximaFrame.cpp:681
 msgid "Comment out the currently selected text"
-msgstr ""
+msgstr "Kommentiert den aktuell ausgewählten Text aus."
 
 #: ../../src/wxMaximaFrame.cpp:680
 msgid "Comment selection\tCtrl+/"
-msgstr ""
+msgstr "Auswahl auskommentieren\tCtrl+/"
 
 #: ../../src/Worksheet.cpp:2004
 msgid "Commutative function"
-msgstr ""
+msgstr "Kommutative Funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1396
 msgid "Compile a QR decomposition using dgeqrf"
@@ -1421,44 +1475,44 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7162
 msgid "Compile a function"
-msgstr ""
+msgstr "Eine Funktion compilieren"
 
 #: ../../src/wxMaximaFrame.cpp:1188
 msgid "Compile a regular expression"
-msgstr ""
+msgstr "Einen regulären Ausdruck compilieren"
 
 #: ../../src/wxMaximaFrame.cpp:1385
 msgid "Compile eigenvalues using dgeev"
-msgstr ""
+msgstr "Eigenwerte mit dgeev berechnen"
 
 #: ../../src/wxMaximaFrame.cpp:1388
 msgid "Compile eigenvalues using zgeev"
-msgstr ""
+msgstr "Eigenwerte mit zgeev berechnen"
 
 #: ../../src/wxMaximaFrame.cpp:1391
 msgid "Compile eigenvalues+eigenvectors using dgeev"
-msgstr ""
+msgstr "Eigenwerte und Eigenvektoren mit dgeev berechnen"
 
 #: ../../src/wxMaximaFrame.cpp:1394
 msgid "Compile eigenvalues+eigenvectors using zgeev"
-msgstr ""
+msgstr "Eigenwerte und Eigenvektoren mit zgeev berechnen"
 
 #: ../../src/wxMaximaFrame.cpp:1076
 msgid "Compile function..."
-msgstr ""
+msgstr "Funktion compilieren..."
 
 #: ../../src/wxMaxima.cpp:7511
 msgid "Compile regex"
-msgstr ""
+msgstr "Regulären Ausdruck compilieren"
 
 #: ../../src/wxMathml.cpp:53
 msgid "Compiler-Bug? wxMathml.lisp is shorter than expected!"
-msgstr ""
+msgstr "Compiler-Fehler? wwxMathml.lisp ist kürzer als erwartet!"
 
 #: ../../src/wxMaxima.cpp:2234
 #, c-format
 msgid "Compiling %s"
-msgstr ""
+msgstr "Compiliere %s"
 
 #: ../../src/wxMaxima.cpp:7163
 msgid ""
@@ -1469,325 +1523,334 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:892
 msgid "Complete Word\tCtrl+Space"
-msgstr ""
+msgstr "Vervollständige Befehl\tCtrl+Space"
 
 #: ../../src/wxMaximaFrame.cpp:893
 msgid "Complete word"
-msgstr ""
+msgstr "Vervollständige Befehl"
 
 #: ../../src/ToolBar.cpp:230
 msgid "Completely stop maxima and restart it"
-msgstr ""
+msgstr "Vollständiges Beenden und Neustart von Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1503
 msgid "Compute continued fraction of a value"
-msgstr ""
+msgstr "Kettenbruch eines Werts berechnen"
 
 #: ../../src/wxMaximaFrame.cpp:1372
 msgid "Compute the adjoint matrix"
-msgstr ""
+msgstr "Adjungierte Matrix berechnen"
 
 #: ../../src/wxMaximaFrame.cpp:1359
 msgid "Compute the characteristic polynomial of a matrix"
-msgstr ""
+msgstr "Charakteristisches Polynom einer Matrix berechnen"
 
 #: ../../src/wxMaximaFrame.cpp:1363
 msgid "Compute the determinant of a matrix"
-msgstr ""
+msgstr "Determinante einer Matrix berechnen"
 
 #: ../../src/wxMaximaFrame.cpp:1491
 msgid "Compute the greatest common divisor"
-msgstr ""
+msgstr "Größten gemeinsamen Teiler berechnen"
 
 #: ../../src/wxMaximaFrame.cpp:1356
 msgid "Compute the inverse of a matrix"
-msgstr ""
+msgstr "Inverse einer Matrix berechnen"
 
 #: ../../src/wxMaximaFrame.cpp:1494
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
+"Kleinstes gemeinsames Vielfaches berechnen (vorher load(functs) ausführen)"
 
 #: ../../src/wxMaximaFrame.cpp:1374
 msgid "Compute the rank of a matrix"
-msgstr ""
+msgstr "Rang einer Matrix berechnen"
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Condition:"
-msgstr ""
+msgstr "Bedingung:"
 
 #: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "Configure wxMaxima"
-msgstr ""
+msgstr "wxMaxima konfigurieren"
 
 #: ../../src/wxMaxima.cpp:2504
 msgid "Connection attempt, but connection failed."
-msgstr ""
+msgstr "Verbindungsversuch, aber die Verbindung ist gescheitert."
 
 #: ../../src/wxMaxima.cpp:2459
 msgid "Connection to Maxima lost."
-msgstr ""
+msgstr "Verbindung mit Maxima verloren."
 
 #: ../../src/wxMaxima.cpp:7921
 msgid "Construct a fraction"
-msgstr ""
+msgstr "Bruch eingeben"
 
 #: ../../src/wxMaximaFrame.cpp:1305
 msgid "Construct fraction..."
-msgstr ""
+msgstr "Bruch eingeben..."
 
 #: ../../src/wxMaxima.cpp:7158
 msgid "Contents:"
-msgstr ""
+msgstr "Inhalt:"
 
 #: ../../src/wxMaximaFrame.cpp:1877
 msgid "Context-sensitive &Help\tCtrl+?"
-msgstr ""
+msgstr "Kontextsensitive Hilfe\tCtrl+?"
 
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Context-sensitive &Help\tF1"
-msgstr ""
+msgstr "Kontextsensitive &Hilfe\tF1"
 
 #: ../../src/wxMaximaFrame.cpp:1542
 msgid "Contract Logarithms"
-msgstr ""
+msgstr "L&ogarithmen zusammenfassen"
 
 #: ../../src/wxMaximaFrame.cpp:1161
 msgid "Conversions"
-msgstr ""
+msgstr "Konvertierungen"
 
 #: ../../src/wxMaximaFrame.cpp:1229
 msgid "Convert"
-msgstr ""
+msgstr "Konvertiere"
 
 #: ../../src/wxMaximaFrame.cpp:1230
 msgid "Convert + Write to file"
-msgstr ""
+msgstr "Konvertiere und schreibe als Datei"
 
 #: ../../src/wxMaximaFrame.cpp:1434
 msgid "Convert Column to list..."
-msgstr ""
+msgstr "Konvertiere Spalte in Liste..."
 
 #: ../../src/wxMaximaFrame.cpp:1430
 msgid "Convert Row to list..."
-msgstr ""
+msgstr "Konvertiere Zeile in Liste..."
 
 #: ../../src/wxMaximaFrame.cpp:1044
 msgid "Convert a command to maxima code"
-msgstr ""
+msgstr "Konvertiere einen Befehl als Maxima-code"
 
 #: ../../src/wxMaximaFrame.cpp:1321
 msgid "Convert a list of lists to a matrix"
-msgstr ""
+msgstr "Konvertiert eine Liste von Listen zu einer Matrix"
 
 #: ../../src/wxMaximaFrame.cpp:1574
 msgid "Convert binomials, beta and gamma function to factorials"
-msgstr ""
+msgstr "Ersetze Binomial-, Beta- und Gammafunktionen durch Fakultäten"
 
 #: ../../src/wxMaximaFrame.cpp:1578
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
+"Ersetze Binomialfunktionen, Fakultäten und Betafunktionen durch "
+"Gammafunktionen"
 
 #: ../../src/wxMaximaFrame.cpp:1613
 msgid "Convert complex expression to polar form"
-msgstr ""
+msgstr "Wandle komplexen Ausdruck in Polardarstellung"
 
 #: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert complex expression to rect form"
-msgstr ""
+msgstr "Wandle komplexen Ausdruck in Standarddarstellung"
 
 #: ../../src/wxMaximaFrame.cpp:1622
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
+"Exponentialfunktion mit imaginärem Argument in Winkelfunktion umwandeln"
 
 #: ../../src/wxMaxima.cpp:7411
 msgid "Convert string to lowercase"
-msgstr ""
+msgstr "String in Kleinbuchstaben umwandeln"
 
 #: ../../src/wxMaxima.cpp:7543
 msgid "Convert string to matching regex"
-msgstr ""
+msgstr "Konvertiere String in passenden regulären Ausdruck"
 
 #: ../../src/wxMaximaFrame.cpp:1543
 msgid "Convert sum of logarithms to logarithm of product"
-msgstr ""
+msgstr "Logarithmen von Summen in Produkt von Logarithmen umwandeln"
 
 #: ../../src/wxMaximaFrame.cpp:1573
 msgid "Convert to &Factorials"
-msgstr ""
+msgstr "In &Fakultäten umwandeln"
 
 #: ../../src/wxMaximaFrame.cpp:1577
 msgid "Convert to &Gamma"
-msgstr ""
+msgstr "In &Gammafunktionen umwandeln"
 
 #: ../../src/wxMaximaFrame.cpp:1612
 msgid "Convert to &Polarform"
-msgstr ""
+msgstr "&Polardarstellung"
 
 #: ../../src/wxMaximaFrame.cpp:1609
 msgid "Convert to &Rectform"
-msgstr ""
+msgstr "&Standarddarstellung"
 
 #: ../../src/wxMaximaFrame.cpp:1166
 msgid "Convert to downcase..."
-msgstr ""
+msgstr "Konvertiere in Kleinbuchstaben..."
 
 #: ../../src/wxMaxima.cpp:7016
 msgid "Convert to programming language"
-msgstr ""
+msgstr "Konvertiere in Programmiersprache"
 
 #: ../../src/wxMaxima.cpp:7022
 msgid "Convert to programming language file"
-msgstr ""
+msgstr "Konvertiere in Programmiersprachen-Datei"
 
 #: ../../src/wxMaximaFrame.cpp:1602
 msgid "Convert trigonometric expression to canonical quasilinear form"
-msgstr ""
+msgstr "Wandle trigonometrischen Ausdruck in eine kanonische Form"
 
 #: ../../src/wxMaximaFrame.cpp:1627
 msgid "Convert trigonometric functions to exponential form"
-msgstr ""
+msgstr "Ersetze Winkelfunktionen durch Exponentialfunktionen"
 
 #: ../../src/wxMaximaFrame.cpp:1762
 msgid "Converts a matrix to a list of lists"
-msgstr ""
+msgstr "Konvertiert eine Matrix zu einer Liste von Listen"
 
 #: ../../src/wxMaximaFrame.cpp:1760
 msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
-msgstr ""
+msgstr "Konvertiert verschachtelte Listen wie [[1,2],[3,4]] zu einer Matrix"
 
 #: ../../src/ToolBar.cpp:209 ../../src/Worksheet.cpp:1290
 #: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
 #: ../../src/Worksheet.cpp:1684
 msgid "Copy"
-msgstr ""
+msgstr "Kopieren"
 
 #: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
 #: ../../src/Worksheet.cpp:1514
 msgid "Copy Animation"
-msgstr ""
+msgstr "Kopiere Animation"
 
 #: ../../src/wxMaximaFrame.cpp:887
 msgid "Copy Previous Input\tCtrl+I"
-msgstr ""
+msgstr "Kopiere letzte Eingabe\tCtrl+I"
 
 #: ../../src/wxMaximaFrame.cpp:890
 msgid "Copy Previous Output\tCtrl+U"
-msgstr ""
+msgstr "Kopiere letzte Ausgabe\tCtrl+U"
 
 #: ../../src/wxMaxima.cpp:7992
 msgid "Copy a matrix"
-msgstr ""
+msgstr "Matrix kopieren"
 
 #: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
 #: ../../src/wxMaximaFrame.cpp:663
 msgid "Copy as EMF"
-msgstr ""
+msgstr "Als EMF kopieren"
 
 #: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Copy as Image"
-msgstr ""
+msgstr "Als Bild kopieren"
 
 #: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
 #: ../../src/wxMaximaFrame.cpp:645
 msgid "Copy as LaTeX"
-msgstr ""
+msgstr "Als LaTeX kopieren"
 
 #: ../../src/wxMaximaFrame.cpp:648
 msgid "Copy as MathML"
-msgstr ""
+msgstr "Als MathML kopieren"
 
 #: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
 msgid "Copy as MathML (e.g. to word processor)"
-msgstr ""
+msgstr "Kopiere als MathML (für Textverarbeitungen etc.)"
 
 #: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
 #: ../../src/wxMaximaFrame.cpp:658
 msgid "Copy as RTF"
-msgstr ""
+msgstr "Als RTF kopieren"
 
 #: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "Copy as SVG"
-msgstr ""
+msgstr "Als SVG kopieren"
 
 #: ../../src/wxMaximaFrame.cpp:640
 msgid "Copy as Text\tCtrl+Shift+C"
-msgstr ""
+msgstr "Als Text kopieren\tCtrl+Shift+C"
 
 #: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
 msgid "Copy as plain text"
-msgstr ""
+msgstr "Als Text kopieren"
 
 #: ../../src/wxMaxima.cpp:7576
 msgid "Copy file"
-msgstr ""
+msgstr "Datei Kopieren"
 
 #: ../../src/wxMaximaFrame.cpp:1214
 msgid "Copy file..."
-msgstr ""
+msgstr "Datei kopieren ..."
 
 #: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
 #: ../../src/wxMaximaFrame.cpp:643
 msgid "Copy for Octave/Matlab"
-msgstr ""
+msgstr "Kopiere für Octave/Matlab"
 
 #: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
 msgid "Copy selection"
-msgstr ""
+msgstr "Auswahl kopieren"
 
 #: ../../src/wxMaximaFrame.cpp:664
 msgid "Copy selection from document as an Enhanced Metafile"
-msgstr ""
+msgstr "Kopiere die Auswahl als Erweiterte Metadatei"
 
 #: ../../src/wxMaximaFrame.cpp:656
 msgid "Copy selection from document as an SVG image"
-msgstr ""
+msgstr "Auswahl als SVG-Bild kopieren"
 
 #: ../../src/wxMaximaFrame.cpp:653
 msgid "Copy selection from document as an image"
-msgstr ""
+msgstr "Auswahl als Bild kopieren"
 
 #: ../../src/wxMaximaFrame.cpp:659
 msgid ""
 "Copy selection from document as rtf that a word processor might understand"
 msgstr ""
+"Kopiert den markierten Text als RTF, ein Format, das von vielen "
+"Textverarbeitungen als 2D-Formel dargestellt wird."
 
 #: ../../src/wxMaximaFrame.cpp:641
 msgid "Copy selection from document as text"
-msgstr ""
+msgstr "Auswahl des Dokumentes als Text kopieren"
 
 #: ../../src/wxMaximaFrame.cpp:646
 msgid "Copy selection from document in LaTeX format"
-msgstr ""
+msgstr "Auswahl im LaTeX-Format kopieren"
 
 #: ../../src/wxMaximaFrame.cpp:644
 msgid "Copy selection from document in Matlab format"
-msgstr ""
+msgstr "Kopiere die Auswahl im Matlab/Octave-Format"
 
 #: ../../src/wxMaximaFrame.cpp:649
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
+"Kopiert den markierten Text in einem MathML-Format, das von vielen "
+"Textverarbeitungen als 2D-Formel dargestellt wird."
 
 #: ../../src/wxMaxima.cpp:7403
 msgid "Copy string"
-msgstr ""
+msgstr "String kopieren"
 
 #: ../../src/wxMaximaFrame.cpp:1165
 msgid "Copy string..."
-msgstr ""
+msgstr "String kopieren..."
 
 #: ../../src/ToolBar.cpp:623
 msgid "Copy, Cut and Paste button"
-msgstr ""
+msgstr "Knöpfe für Kopieren, Ausschneiden und Einfügen"
 
 #: ../../src/WXMXformat.cpp:295
 msgid "Could not create the backup file during saving => aborting."
 msgstr ""
+"Konnte keine Sicherungsdatei während der Speicherung anlegen => Abbruch."
 
 #: ../../src/wxMaxima.cpp:3294 ../../src/wxMaxima.cpp:3306
 msgid ""
@@ -1800,42 +1863,45 @@ msgid ""
 "Could not map view of the file needed in order to send an interrupt signal "
 "to maxima."
 msgstr ""
+"Konnte die virtuelle Datei, über die ich ein \"Unterbrechen\"-Signal senden "
+"will, nicht in den Speicher einblenden."
 
 #: ../../src/wxMaxima.cpp:2763 ../../src/wxMaxima.cpp:2805
 msgid "Could not send an interrupt signal to maxima."
-msgstr ""
+msgstr "Konnte kein \"Unterbrechen\"-Signal an Maxima senden."
 
 #: ../../src/WXMXformat.cpp:287
 msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
+"Konnte den Dateiinhalt während dem Speichern nicht schreiben => Abbruch."
 
 #: ../../src/wxMaximaFrame.cpp:1325
 msgid "Create Matrix"
-msgstr ""
+msgstr "Matrix erzeugen"
 
 #: ../../src/wxMaximaFrame.cpp:1688
 msgid "Create a list"
-msgstr ""
+msgstr "Eine Liste erzeugen"
 
 #: ../../src/wxMaxima.cpp:8487
 msgid "Create a list as a storage for the values of variables"
-msgstr ""
+msgstr "Erzeuge eine Liste als Speicher für die konkreten Werte von Variablen"
 
 #: ../../src/wxMaxima.cpp:8463 ../../src/wxMaxima.cpp:8476
 msgid "Create a list from a rule"
-msgstr ""
+msgstr "Liste aus einem Ausdruck erzeugen"
 
 #: ../../src/wxMaximaFrame.cpp:1670
 msgid "Create a list from comma-separated elements"
-msgstr ""
+msgstr "Erzeuge eine Liste von Komma-separierten Elementen"
 
 #: ../../src/wxMaximaFrame.cpp:888
 msgid "Create a new cell with previous input"
-msgstr ""
+msgstr "Neue Zelle mit letzter Eingabe erzeugen."
 
 #: ../../src/wxMaximaFrame.cpp:891
 msgid "Create a new cell with previous output"
-msgstr ""
+msgstr "Neue Zelle mit letzter Ausgabe erzeugen."
 
 #: ../../src/wxMaximaFrame.cpp:1348
 msgid "Create copy, not clone..."
@@ -1843,63 +1909,65 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7561
 msgid "Create directory"
-msgstr ""
+msgstr "Verzeichnis anlegen"
 
 #: ../../src/wxMaximaFrame.cpp:1203
 msgid "Create directory..."
-msgstr ""
+msgstr "Verzeichnis anlegen..."
 
 #: ../../src/wxMaxima.cpp:7419
 msgid "Create empty string"
-msgstr ""
+msgstr "Leeren String erzeugen"
 
 #: ../../src/wxMaximaFrame.cpp:1168
 msgid "Create empty string..."
-msgstr ""
+msgstr "Leeren String erzeugen..."
 
 #: ../../src/wxMaximaFrame.cpp:1687
 msgid "Create list"
-msgstr ""
+msgstr "Eine Liste erzeugen"
 
 #: ../../src/wxMaxima.cpp:8457
 msgid "Create list from comma-separated elements"
-msgstr ""
+msgstr "Erzeuge eine Liste aus komma-getrennten Elementen"
 
 #: ../../src/wxMaximaFrame.cpp:1082
+#, fuzzy
 msgid "Create struct..."
-msgstr ""
+msgstr "Eine Liste erzeugen"
 
 #: ../../src/WXMXformat.cpp:80
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
 msgstr ""
+"ZIP-Archiv erzeugt (eine .wxmx-Datei ist technisch gesehen eine .zip-Datei)"
 
 #: ../../src/wxMaximaFrame.cpp:1349
 msgid "Creates an independent matrix with the same contents"
-msgstr ""
+msgstr "Erzeugt eine unabhängige Matrix mit demselben Inhalt"
 
 #: ../../src/Configuration.cpp:97
 msgid "Cursor color"
-msgstr ""
+msgstr "Cursor Farbe"
 
 #: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
 msgid "Cut"
-msgstr ""
+msgstr "Ausschneiden"
 
 #: ../../src/wxMaximaFrame.cpp:636
 msgid "Cut\tCtrl+X"
-msgstr ""
+msgstr "Ausschneiden\tCtrl+X"
 
 #: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
 msgid "Cut selection"
-msgstr ""
+msgstr "Auswahl ausschneiden"
 
 #: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
 msgid "Data Matrix:"
-msgstr ""
+msgstr "Datenmatrix:"
 
 #: ../../src/wxMaxima.cpp:9599
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
-msgstr ""
+msgstr "Datendatei (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wxMaxima.cpp:9529 ../../src/wxMaxima.cpp:9534
 #: ../../src/wxMaxima.cpp:9539 ../../src/wxMaxima.cpp:9543
@@ -1908,7 +1976,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9563 ../../src/wxMaxima.cpp:9577
 #: ../../src/wxMaxima.cpp:9582 ../../src/wxMaxima.cpp:10030
 msgid "Data:"
-msgstr ""
+msgstr "Daten:"
 
 #: ../../src/wxMaximaFrame.cpp:1057
 msgid "Debugger trigger"
@@ -1916,7 +1984,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:779
 msgid "Declare Text to always be displayed as subscript"
-msgstr ""
+msgstr "Deklariere Text, der immer tiefgestellt angezeigt werden soll"
 
 #: ../../src/wxMaxima.cpp:7069
 msgid "Declare a function local to a Program"
@@ -1924,40 +1992,40 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6539
 msgid "Declare a text snippet to always be displayed as subscript"
-msgstr ""
+msgstr "Deklariere Text, der stets als Subscript darzustellen ist"
 
 #: ../../src/Worksheet.cpp:2044
 #, c-format
 msgid "Declare facts about %s"
-msgstr ""
+msgstr "Deklariere Fakten über %s"
 
 #: ../../src/wxMaxima.cpp:8800
 msgid "Declare main variable:"
-msgstr ""
+msgstr "Haupt-Variable deklarieren:"
 
 #: ../../src/wxMaxima.cpp:7171
 msgid "Declare the type of a function parameter"
-msgstr ""
+msgstr "Den Typ eines Funktionsparameters deklarieren"
 
 #: ../../src/Worksheet.cpp:2038
 msgid "Declare these chars as ordinary letters"
-msgstr ""
+msgstr "Deklariere diese Zeichen als normale Buchstaben"
 
 #: ../../src/wxMaximaFrame.cpp:1500 ../../src/wxMaximaFrame.cpp:1536
 msgid "Decompose rational function to partial fractions"
-msgstr ""
+msgstr "Partialbruchzerlegung"
 
 #: ../../src/Worksheet.cpp:2010
 msgid "Decreasing function f(x)<x"
-msgstr ""
+msgstr "Fallende Funktionen f(x)<x"
 
 #: ../../src/wxMaxima.cpp:7134
 msgid "Define a function"
-msgstr ""
+msgstr "Eine Funktion definieren"
 
 #: ../../src/wxMaxima.cpp:7147
 msgid "Define a macro"
-msgstr ""
+msgstr "Ein Makro definieren"
 
 #: ../../src/wxMaxima.cpp:7189
 msgid "Define a structure"
@@ -1969,15 +2037,15 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7156
 msgid "Define a variable"
-msgstr ""
+msgstr "Eine Variable definieren"
 
 #: ../../src/wxMaximaFrame.cpp:1072
 msgid "Define function..."
-msgstr ""
+msgstr "F&unktion definieren ..."
 
 #: ../../src/wxMaximaFrame.cpp:1079
 msgid "Define macro..."
-msgstr ""
+msgstr "Makro definieren..."
 
 #: ../../src/wxMaximaFrame.cpp:1077
 msgid "Define parameter type..."
@@ -1989,105 +2057,107 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1080
 msgid "Define variable..."
-msgstr ""
+msgstr "Variable definieren..."
 
 #: ../../src/wxMaximaFrame.cpp:1776
 msgid ""
 "Defines if an animation is automatically started or only by clicking on it."
 msgstr ""
+"Bestimmt, ob Animationen automatisch gestartet werden, oder erst beim "
+"Anklicken."
 
 #: ../../src/wxMaxima.cpp:8935
 msgid "Degree:"
-msgstr ""
+msgstr "Grad:"
 
 #: ../../src/wxMaximaFrame.cpp:985
 msgid "Delete F&unction..."
-msgstr ""
+msgstr "F&unktion löschen ..."
 
 #: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
 msgid "Delete Selection"
-msgstr ""
+msgstr "Auswahl löschen"
 
 #: ../../src/wxMaximaFrame.cpp:987
 msgid "Delete V&ariable..."
-msgstr ""
+msgstr "V&ariable löschen ..."
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Delete a function"
-msgstr ""
+msgstr "Eine Funktion löschen"
 
 #: ../../src/wxMaximaFrame.cpp:988
 msgid "Delete a variable"
-msgstr ""
+msgstr "Eine Variable löschen"
 
 #: ../../src/wxMaximaFrame.cpp:982
 msgid "Delete all objects with a given name"
-msgstr ""
+msgstr "Lösche alle Objekte mit einem vorgegebenen Namen"
 
 #: ../../src/wxMaximaFrame.cpp:991
 msgid "Delete all values from memory"
-msgstr ""
+msgstr "Alle Symbole aus dem Speicher löschen"
 
 #: ../../src/wxMaxima.cpp:7588
 msgid "Delete file"
-msgstr ""
+msgstr "Datei löschen"
 
 #: ../../src/wxMaximaFrame.cpp:1216
 msgid "Delete file..."
-msgstr ""
+msgstr "Datei löschen..."
 
 #: ../../src/wxMaxima.cpp:7683
 msgid "Delete function(s)"
-msgstr ""
+msgstr "Lösche die Funktion(en)"
 
 #: ../../src/wxMaxima.cpp:7679
 msgid "Delete named object(s)"
-msgstr ""
+msgstr "Lösche benannte Objekte"
 
 #: ../../src/wxMaximaFrame.cpp:981
 msgid "Delete named object..."
-msgstr ""
+msgstr "Benanntes Objekt löschen ..."
 
 #: ../../src/wxMaxima.cpp:7674
 msgid "Delete variable(s)"
-msgstr ""
+msgstr "Lösche die Variable(n)"
 
 #: ../../src/wxMaxima.cpp:7430
 msgid "Delimiter:"
-msgstr ""
+msgstr "Trennzeichen:"
 
 #: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
 #, c-format
 msgid "Demo for \"%s\""
-msgstr ""
+msgstr "Demo für \"%s\""
 
 #: ../../src/wxMaximaFrame.cpp:1930
 msgid "Demos"
-msgstr ""
+msgstr "Demos"
 
 #: ../../src/wxMaxima.cpp:8927
 msgid "Denom. deg:"
-msgstr ""
+msgstr "Grad Nenner:"
 
 #: ../../src/wxMaxima.cpp:7923
 msgid "Denominator:"
-msgstr ""
+msgstr "Nenner:"
 
 #: ../../src/wxMaximaFrame.cpp:1030
 msgid "Dependencies"
-msgstr ""
+msgstr "Abhängigkeiten"
 
 #: ../../src/wxMaxima.cpp:7813
 msgid "Derivate of y at that point:"
-msgstr ""
+msgstr "Ableitung von y an diesem Punkt:"
 
 #: ../../src/wxMaximaFrame.cpp:1497
 msgid "Di&vide Polynomials..."
-msgstr ""
+msgstr "Polynome di&vidieren ..."
 
 #: ../../src/MaximaManual.cpp:517
 msgid "Didn't find the maxima HTML manual."
-msgstr ""
+msgstr "Konnte das Maxima HTML Handbuch nicht finden."
 
 #: ../../src/wxMaxima.cpp:4907
 msgid ""
@@ -2097,213 +2167,219 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
 msgid "Differentiate"
-msgstr ""
+msgstr "Differenzieren"
 
 #: ../../src/wxMaximaFrame.cpp:1467
 msgid "Differentiate expression"
-msgstr ""
+msgstr "Ausdruck differenzieren"
 
 #: ../../src/Worksheet.cpp:1590
 msgid "Differentiate..."
-msgstr ""
+msgstr "Differenzieren ..."
 
 #: ../../src/wxMaxima.cpp:9010
 msgid "Differentiates an expression n times"
-msgstr ""
+msgstr "Einen Ausdruck n mal differenzieren"
 
 #: ../../src/wxMaxima.cpp:10055
 msgid "Differentiates the expression n times"
-msgstr ""
+msgstr "Den Ausdruck n mal differenzieren"
 
 #: ../../src/wxMaximaFrame.cpp:1212
 msgid "Directory operations"
-msgstr ""
+msgstr "Verzeichnisoperationen"
 
 #: ../../src/wxMaximaFrame.cpp:1041
 msgid "Display Te&X Form"
-msgstr ""
+msgstr "Zeige Te&X Format"
 
 #: ../../src/wxMaxima.cpp:6972
 msgid "Display algorithm"
-msgstr ""
+msgstr "Darstellungmethode"
 
 #: ../../src/wxMaximaFrame.cpp:751
 msgid "Display an expression as maxima's internal lisp representation"
-msgstr ""
+msgstr "Einen Ausdruck als Maxima's interne Lisp-Darstellung darstellen"
 
 #: ../../src/wxMaximaFrame.cpp:754
 msgid "Display an expression as wxMaxima's internal XML representation"
-msgstr ""
+msgstr "Einen Ausdruck als wxMaxima's interne XML-Darstellung darstellen"
 
 #: ../../src/wxMaximaFrame.cpp:758
 msgid "Display equations"
-msgstr ""
+msgstr "Anzeige von Gleichungen"
 
 #: ../../src/wxMaxima.cpp:6508
 msgid "Display expression in maxima's internal representation"
-msgstr ""
+msgstr "Einen Ausdruck in Maxima's interner Darstellung anzeigen"
 
 #: ../../src/wxMaxima.cpp:6514
 msgid "Display expression in wxMaxima's internal representation"
-msgstr ""
+msgstr "Einen Ausdruck in wxMaxima's interner Darstellung anzeigen"
 
 #: ../../src/wxMaximaFrame.cpp:1042
 msgid "Display last result in TeX form"
-msgstr ""
+msgstr "Zeige letztes Ergebnis in TeX Format"
 
 #: ../../src/ToolBar.cpp:360
 #, c-format
 msgid "Display resolution according to wxWidgets: %li x %li ppi"
-msgstr ""
+msgstr "Bildschirmauflösung laut wxWidgets: %li x %li Punkte pro Inch"
 
 #: ../../src/wxMaximaFrame.cpp:802
 msgid "Display string quotation marks"
-msgstr ""
+msgstr "Anzeige von Anführungsstrichen bei Strings"
 
 #: ../../src/wxMaximaFrame.cpp:1036
 msgid "Display time used for evaluation"
-msgstr ""
+msgstr "Zeige Zeit für die Auswertung an"
 
 #: ../../src/wxMaxima.cpp:9206
 msgid "Displayed Precision"
-msgstr ""
+msgstr "Zahl angezeigter Stellen"
 
 #: ../../src/wxMaximaFrame.cpp:1913
 msgid "Displaying 3d curves"
-msgstr ""
+msgstr "Anzeige dreidimensionaler Kurven"
 
 #: ../../src/wxMaximaFrame.cpp:1462
+#, fuzzy
 msgid "Dito, and evaluate the result..."
-msgstr ""
+msgstr "Ebenso, und das Ergebnis auswerten..."
 
 #: ../../src/wxMaximaFrame.cpp:1445
 msgid "Dito, but affect all clones of the Matrix..."
-msgstr ""
+msgstr "Ebenso, aber betrifft alle Klone der Matrix..."
 
 #: ../../src/wxMaximaFrame.cpp:1255
 msgid "Dito, but as fraction (real only)..."
-msgstr ""
+msgstr "Ebenso, aber als Bruch (nur Reele Werte)..."
 
 #: ../../src/wxMaximaFrame.cpp:1532
 msgid "Dito, including denominator"
-msgstr ""
+msgstr "Ebenso, inklusive Nenner"
 
 #: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
 msgid "Divide Cell"
-msgstr ""
+msgstr "Zelle teilen"
 
 #: ../../src/wxMaximaFrame.cpp:1498
 msgid "Divide numbers or polynomials"
-msgstr ""
+msgstr "Dividiere Zahlen oder Polynome"
 
 #: ../../src/wxMaxima.cpp:8578
 msgid "Do for each list element"
-msgstr ""
+msgstr "Tue dies für jedes Listenelement"
 
 #: ../../src/wxMaxima.cpp:11197
 #, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
-msgstr ""
+msgstr "Wollen Sie Änderungen im Dokument \"%s\" speichern?"
 
 #: ../../src/wxMaximaFrame.cpp:724
 msgid "Dock all Sidebars"
-msgstr ""
+msgstr "Andocken aller Seitenleisten"
 
 #: ../../src/Configuration.cpp:94
 msgid "Document background"
-msgstr ""
+msgstr "Hintergrundfarbe Dokument"
 
 #: ../../src/wxMaxima.cpp:4611
 msgid ""
 "Document was saved using a newer version of wxMaxima so it may not load "
 "correctly. Please update your wxMaxima."
 msgstr ""
+"Das Dokument wurde mit einer aktuelleren wxMaxima Version gespeichert. Die "
+"Datei wird möglicherweise nicht korrekt geladen. Bitte aktualisieren Sie "
+"wxMaxima."
 
 #: ../../src/wxMaxima.cpp:4603
 msgid ""
 "Document was saved using a newer version of wxMaxima. Please update your "
 "wxMaxima."
 msgstr ""
+"Das Dokument wurde mit einer aktuelleren wxMaxima Version gespeichert. Bitte"
+" aktualisieren Sie wxMaxima."
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "Don't autosubscript after an underscore"
-msgstr ""
+msgstr "Kein automatisches Tiefstellen."
 
 #: ../../src/wxMaximaFrame.cpp:1086
 msgid "Don't evaluate Expression..."
-msgstr ""
+msgstr "Ausdruck nicht auswerten..."
 
 #: ../../src/wxMaxima.cpp:7117
 msgid "Don't evaluate one command"
-msgstr ""
+msgstr "Einen Befehl nicht auswerten"
 
 #: ../../src/wxMaxima.cpp:7129
 msgid "Don't evaluate one whole expression"
-msgstr ""
+msgstr "Einen vollständigen Ausdruck nicht auswerten"
 
 #: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
 msgid "Don't mark cells that contain tooltips in yellow"
-msgstr ""
+msgstr "Entferne gelbe Markierung von Tooltips"
 
 #: ../../src/Worksheet.cpp:1938 ../../src/Worksheet.cpp:2070
 msgid "Don't mark this message text in yellow"
-msgstr ""
+msgstr "Markiere diese Nachricht nie in gelb"
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Don't save"
-msgstr ""
+msgstr "Nicht speichern"
 
 #: ../../src/Worksheet.cpp:1620
 msgid "Don't show labels"
-msgstr ""
+msgstr "Zeige keine Marken"
 
 #: ../../src/Worksheet.cpp:1979
 msgid "Don't use if unassigned"
-msgstr ""
+msgstr "Nicht verwenden, wenn nicht zugewiesen"
 
 #: ../../src/wxMaximaFrame.cpp:797
 msgid "Don't use parenthesis for matrices"
-msgstr ""
+msgstr "Keine Klammern für Matrizen"
 
 #: ../../src/wxMaxima.cpp:8525
 msgid "Drop the first n list elements"
-msgstr ""
+msgstr "Entferne die ersten n Listenelemente"
 
 #: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
 msgid "Drop the last n list elements"
-msgstr ""
+msgstr "Die letzten n Listenelemente entfernen"
 
 #: ../../src/wxMaximaFrame.cpp:1306
 msgid "E&quations"
-msgstr ""
+msgstr "&Gleichungen"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "E&xit\tCtrl+Q"
-msgstr ""
+msgstr "B&eenden\tCtrl+Q"
 
 #: ../../src/wxMaximaFrame.cpp:1368
 msgid "Eige&nvectors"
-msgstr ""
+msgstr "Eigen&vektoren"
 
 #: ../../src/wxMaximaFrame.cpp:1365
 msgid "Eigen&values"
-msgstr ""
+msgstr "Eigen&werte"
 
 #: ../../src/wxMaximaFrame.cpp:1387
 msgid "Eigenvalues (complex)"
-msgstr ""
+msgstr "Eigenwerte (komplex)"
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Eigenvalues (real)"
-msgstr ""
+msgstr "Eigenwerte (reell)"
 
 #: ../../src/wxMaximaFrame.cpp:1393
 msgid "Eigenvalues, left+right eigenvectors (complex)"
-msgstr ""
+msgstr "Eigenwerte, linke und rechte Eigenvektoren (komplex)"
 
 #: ../../src/wxMaximaFrame.cpp:1390
 msgid "Eigenvalues, left+right eigenvectors (real)"
-msgstr ""
+msgstr "Eigenwerte, linke und rechte Eigenvektoren (reell)"
 
 #: ../../src/wxMaxima.cpp:8584
 msgid ""
@@ -2311,43 +2387,48 @@ msgid ""
 "parenthesis. In the latter case the result of the last expression in the "
 "parenthesis is used."
 msgstr ""
+"Entweder ein einfacher Ausdruck oder eine Liste von Komma-getrennten "
+"Ausdrücken, die in runde Klammern verpackt wurde. Im letzten Fall wird das "
+"Ergebnis des letzten Ausdrucks aus der Klammer verwendet."
 
 #: ../../src/wxMaxima.cpp:8593
 msgid "Element"
-msgstr ""
+msgstr "Element"
 
 #: ../../src/wxMaxima.cpp:8549
 msgid "Element number"
-msgstr ""
+msgstr "Element Nummer"
 
 #: ../../src/wxMaxima.cpp:8005
 msgid ""
 "Element-by-element Product of matrices of the same size (Hadamard product)"
 msgstr ""
+"Multiplizieren der einzelnen Elemente von Matrizen derselben Größe "
+"(Hadamard-Produkt)"
 
 #: ../../src/wxMaxima.cpp:8012
 msgid "Element-by-element exponentiation of two matrices"
-msgstr ""
+msgstr "Element-für-Element Potenzierung von zwei Matrizen"
 
 #: ../../src/wxMaximaFrame.cpp:1342
 msgid "Element-by-element multiplication"
-msgstr ""
+msgstr "Element-für-Element-Multiplikation"
 
 #: ../../src/wxMaxima.cpp:8510
 msgid "Element:"
-msgstr ""
+msgstr "Element:"
 
 #: ../../src/wxMaxima.cpp:7204
 msgid "Elements:"
-msgstr ""
+msgstr "Elemente:"
 
 #: ../../src/wxMaxima.cpp:7847
 msgid "Eliminate a variable"
-msgstr ""
+msgstr "Variable &eliminieren ..."
 
 #: ../../src/wxMaximaFrame.cpp:1247
 msgid "Eliminate a variable from a system of equations"
-msgstr ""
+msgstr "Eliminiere eine Variable aus einem Gleichungssystem"
 
 #: ../../src/wxMaxima.cpp:10651
 msgid "Empty command => re-triggering evaluation"
@@ -2355,86 +2436,86 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9225
 msgid "Enable:"
-msgstr ""
+msgstr "Aktiviert:"
 
 #: ../../src/MathParser.cpp:99
 #, c-format
 msgid "Encountered an unknown XML tag: <%s>"
-msgstr ""
+msgstr "Unbekanntes XML-Element: <%s>"
 
 #: ../../src/wxMaxima.cpp:2476
 msgid "Encountered an unknown socket event."
-msgstr ""
+msgstr "Unbekanntes Netzwerk-Ereignis."
 
 #: ../../src/wxMaxima.cpp:7843
 msgid "End of t:"
-msgstr ""
+msgstr "Ende von t:"
 
 #: ../../src/wxMaxima.cpp:4097
 msgid "Ended lisp mode after receiving a maxima prompt!"
-msgstr ""
+msgstr "Lisp-Modus beendet, da Maxima nach Maxima-Befehlen fragt."
 
 #: ../../src/wxMaximaFrame.cpp:1828
 msgid "Engineering format (12.1e6 etc.)"
-msgstr ""
+msgstr "Zahlenformat für Ingenieure (12.1e6 etc.)"
 
 #: ../../src/wxMaximaFrame.cpp:1319
 msgid "Enter a matrix"
-msgstr ""
+msgstr "Eine Matrix eingeben"
 
 #: ../../src/wxMaxima.cpp:8866
 msgid "Enter an equation for rational simplification:"
-msgstr ""
+msgstr "Geben Sie eine Gleichung zum Vereinfachen rationaler Ausdrücke an:"
 
 #: ../../src/wxMaxima.cpp:8169
 msgid "Enter matrix"
-msgstr ""
+msgstr "Matrix eingeben"
 
 #: ../../src/wxMaxima.cpp:9095
 msgid "Enter new animation frame rate [Hz, integer]:"
-msgstr ""
+msgstr "Neue Bildwiederholrate für Animationen:"
 
 #: ../../src/wxMaxima.cpp:9201
 msgid "Enter new precision for bigfloats:"
-msgstr ""
+msgstr "Neue Genauigkeit für als Bigfloat deklarierte Zahlen eingeben:"
 
 #: ../../src/wxMaxima.cpp:7922
 msgid "Enumerator:"
-msgstr ""
+msgstr "Zähler:"
 
 #: ../../src/wxMaximaFrame.cpp:1220
 msgid "Environment variables"
-msgstr ""
+msgstr "Umgebungsvariablen"
 
 #: ../../src/wxMaxima.cpp:9045
 msgid "Epsilon:"
-msgstr ""
+msgstr "Epsilon:"
 
 #: ../../src/wxMaximaFrame.cpp:1124 ../../src/wxMaximaFrame.cpp:1135
 msgid "Equal, ignoring case?..."
-msgstr ""
+msgstr "Gleich, Groß/Kleinschreibung ignorieren?..."
 
 #: ../../src/wxMaximaFrame.cpp:1133
 msgid "Equal?..."
-msgstr ""
+msgstr "Gleich?..."
 
 #: ../../src/wxMaxima.cpp:8561
 msgid "Equation"
-msgstr ""
+msgstr "Gleichung"
 
 #: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
 msgid "Equation(s)"
-msgstr ""
+msgstr "Gleichung(en)"
 
 #: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
 msgid "Equation(s):"
-msgstr ""
+msgstr "Gleichung(en):"
 
 #: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
 #: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
 #: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
 msgid "Equation:"
-msgstr ""
+msgstr "Gleichung:"
 
 #: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
 #: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
@@ -2446,22 +2527,22 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
 #: ../../src/wxMaxima.cpp:11166
 msgid "Error"
-msgstr ""
+msgstr "Fehler"
 
 #: ../../src/wxMaxima.cpp:2456
 msgid "Error writing to Maxima"
-msgstr ""
+msgstr "Fehler beim Senden an Maxima"
 
 #: ../../src/wxMaxima.cpp:6164 ../../src/wxMaxima.cpp:6176
 #: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
 #: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
 msgid "Error!"
-msgstr ""
+msgstr "Fehler!"
 
 #: ../../src/Image.cpp:696
 #, c-format
 msgid "Error: Cannot render %s."
-msgstr ""
+msgstr "Fehler: Kann %s nicht rendern."
 
 #: ../../src/Image.cpp:699
 #, c-format
@@ -2469,10 +2550,12 @@ msgid ""
 "Error: Cannot render %s:\n"
 "%s"
 msgstr ""
+"Fehler: Kann %s nicht rendern.\n"
+"%s"
 
 #: ../../src/Image.cpp:704
 msgid "Error: Cannot render the image."
-msgstr ""
+msgstr "Fehler: Kann das Bild nicht rendern."
 
 #: ../../src/Image.cpp:706
 #, c-format
@@ -2480,6 +2563,8 @@ msgid ""
 "Error: Cannot render the image:\n"
 "%s"
 msgstr ""
+"Fehler: Kann das Bild nicht rendern.\n"
+"%s"
 
 #: ../../src/wxMaxima.cpp:7544
 msgid ""
@@ -2489,116 +2574,117 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1652
 msgid "Evaluate &Noun Forms..."
-msgstr ""
+msgstr "&Noun-Formen auswerten..."
 
 #: ../../src/wxMaximaFrame.cpp:856
 msgid "Evaluate All Cells\tCtrl+Shift+R"
-msgstr ""
+msgstr "Alle Zellen neu auswerten\tCtrl+Shift+R"
 
 #: ../../src/wxMaximaFrame.cpp:851
 msgid "Evaluate All Visible Cells\tCtrl+R"
-msgstr ""
+msgstr "Alle sichtbaren Zellen neu auswerten\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1395
 msgid "Evaluate Cell"
-msgstr ""
+msgstr "Zelle auswerten"
 
 #: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
 msgid "Evaluate Cell(s)"
-msgstr ""
+msgstr "Zelle(n) auswerten"
 
 #: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
 msgid "Evaluate Cells Above"
-msgstr ""
+msgstr "Zelle bis hier auswerten"
 
 #: ../../src/wxMaximaFrame.cpp:866
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
-msgstr ""
+msgstr "Zellen über dem Cursor neu auswerten\tCtrl+Shift+P"
 
 #: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
 #: ../../src/wxMaximaFrame.cpp:876
 msgid "Evaluate Cells Below"
-msgstr ""
+msgstr "Zellen ab hier auswerten"
 
 #: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
 #: ../../src/Worksheet.cpp:1890
 msgid "Evaluate Heading 5\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Werte den Paragraph aus\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1457 ../../src/Worksheet.cpp:1761
 #: ../../src/Worksheet.cpp:1901
 msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Werte den Unterparagraph aus\tShift+Ctrl+Enter"
 
 #: ../../src/wxMaxima.cpp:8626
 msgid "Evaluate Nouns"
-msgstr ""
+msgstr "&Noun-Formen auswerten"
 
 #: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
 msgid "Evaluate Part\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Evaluiere diesen Teil des Dokuments\tShift+Ctrl+Return"
 
 #: ../../src/Worksheet.cpp:1431 ../../src/Worksheet.cpp:1741
 msgid "Evaluate Section\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Evaluiere dieses Kapitel\tShift+Ctrl+Return"
 
 #: ../../src/Worksheet.cpp:1445 ../../src/Worksheet.cpp:1751
 #: ../../src/Worksheet.cpp:1879
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Evaluiere dieses Unterkapitel\tShift+Ctrl+Return"
 
 #: ../../src/Worksheet.cpp:1438 ../../src/Worksheet.cpp:1746
 #: ../../src/Worksheet.cpp:1868
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Evaluiere dieses Unter-Unterkapitel\tShift+Ctrl+Return"
 
 #: ../../src/wxMaximaFrame.cpp:845
 msgid "Evaluate active or selected cell(s)"
-msgstr ""
+msgstr "Aktive oder ausgewählte Zelle(n) auswerten"
 
 #: ../../src/ToolBar.cpp:251
 msgid "Evaluate all"
-msgstr ""
+msgstr "Alles Auswerten"
 
 #: ../../src/wxMaximaFrame.cpp:857
 msgid "Evaluate all cells in the document"
-msgstr ""
+msgstr "Alle Zellen im Dokument auswerten"
 
 #: ../../src/wxMaximaFrame.cpp:1653
 msgid "Evaluate all noun forms in expression"
-msgstr ""
+msgstr "Alle Noun-Formen im Ausdruck auswerten"
 
 #: ../../src/wxMaximaFrame.cpp:852
 msgid "Evaluate all visible cells in the document"
-msgstr ""
+msgstr "Alle sichtbaren Zellen im Dokument auswerten"
 
 #: ../../src/ToolBar.cpp:248
 msgid "Evaluate current cell"
-msgstr ""
+msgstr "Werte aktuelle Zelle aus"
 
 #: ../../src/wxMaxima.cpp:7395
 msgid "Evaluate string"
-msgstr ""
+msgstr "String auswerten"
 
 #: ../../src/wxMaximaFrame.cpp:1151
 msgid "Evaluate string..."
-msgstr ""
+msgstr "String auswerten..."
 
 #: ../../src/ToolBar.cpp:256
 msgid "Evaluate the file from its beginning to the cell above the cursor"
 msgstr ""
+"Evaluiert diese Datei von ihrem Beginn an bis zu der Zelle über dem Cursor"
 
 #: ../../src/ToolBar.cpp:259
 msgid "Evaluate the file from the cursor to its end"
-msgstr ""
+msgstr "Alle Zellen des Dokuments auswerten, die unter dem Cursor stehen"
 
 #: ../../src/ToolBar.cpp:258
 msgid "Evaluate the rest"
-msgstr ""
+msgstr "&Den Rest evaluieren"
 
 #: ../../src/ToolBar.cpp:255
 msgid "Evaluate to point"
-msgstr ""
+msgstr "&Zellen bis hier evaluieren"
 
 #: ../../src/wxMaxima.cpp:10518
 msgid "Evaluation ended, since evaluation queue is empty."
@@ -2606,122 +2692,125 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1957
 msgid "Even number"
-msgstr ""
+msgstr "Gerade Zahl"
 
 #: ../../src/wxMaximaFrame.cpp:1703
 msgid "Execute a command for each element of the list"
-msgstr ""
+msgstr "Führt einen Befehl für jedes Element der Liste aus."
 
 #: ../../src/main.cpp:438
 msgid "Exit"
-msgstr ""
+msgstr "Beenden"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "Exit wxMaxima"
-msgstr ""
+msgstr "Beende wxMaxima"
 
 #: ../../src/Worksheet.cpp:1583
 msgid "Expand Expression"
-msgstr ""
+msgstr "Ausdruck expandieren"
 
 #: ../../src/wxMaximaFrame.cpp:1525
 msgid "Expand an expression"
 msgstr ""
+"Einen Ausdruck expandieren (ausmultiplizieren und in Terme aufspalten)"
 
 #: ../../src/wxMaximaFrame.cpp:1531
+#, fuzzy
 msgid "Expand for given variables"
-msgstr ""
+msgstr "Variable ersetzen"
 
 #: ../../src/wxMaxima.cpp:8781
 msgid "Expand for variable(s) including denominator:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8716
+#, fuzzy
 msgid "Expand for variable(s):"
-msgstr ""
+msgstr "Laufvariable:"
 
 #: ../../src/wxMaximaFrame.cpp:1545
 msgid "Expand log in previous expression"
-msgstr ""
+msgstr "Logarithmen im vorhergehenden Ausdruck expandieren"
 
 #: ../../src/wxMaximaFrame.cpp:1598
 msgid "Expand trigonometric expression"
-msgstr ""
+msgstr "Trigonometrische Ausdrücke expandieren"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Expect numbers harder to be complex"
-msgstr ""
+msgstr "Erwarte an mehr Stellen komplexe Zahlen"
 
 #: ../../src/wxMaximaFrame.cpp:1789
 msgid "Expect variables to contain complex numbers"
-msgstr ""
+msgstr "Erwarte, dass Variablen komplexe Zahlen beinhalten"
 
 #: ../../src/wxMaxima.cpp:6121
 msgid "Export"
-msgstr ""
+msgstr "Exportieren"
 
 #: ../../src/wxMaximaFrame.cpp:1705
 msgid "Export List to csv file..."
-msgstr ""
+msgstr "Exportiere Liste in .csv-Datei..."
 
 #: ../../src/wxMaximaFrame.cpp:1706
 msgid "Export a list to a csv file"
-msgstr ""
+msgstr "Exportiere eine Liste als .csv-Datei"
 
 #: ../../src/wxMaximaFrame.cpp:1332
 msgid "Export a matrix to a csv file"
-msgstr ""
+msgstr "Matrix in csv-Datei exportieren"
 
 #: ../../src/wxMaximaFrame.cpp:619
 msgid "Export document to a HTML or LaTeX file"
-msgstr ""
+msgstr "Exportiere Dokument als HTML oder LaTeX-Datei"
 
 #: ../../src/wxMaximaFrame.cpp:579
 msgid "Export failed."
-msgstr ""
+msgstr "Exportieren der Datei ist fehlgeschlagen!"
 
 #: ../../src/wxMaximaFrame.cpp:567
 msgid "Export successful."
-msgstr ""
+msgstr "Das Exportieren war erfolgreich."
 
 #: ../../src/wxMaxima.cpp:6187
 msgid "Exporting to HTML failed!"
-msgstr ""
+msgstr "Export als HTML-Datei ist fehlgeschlagen!"
 
 #: ../../src/wxMaxima.cpp:6164
 msgid "Exporting to TeX failed!"
-msgstr ""
+msgstr "Export als TeX-Datei ist fehlgeschlagen!"
 
 #: ../../src/wxMaxima.cpp:6175
 msgid "Exporting to maxima batch file failed!"
-msgstr ""
+msgstr "Export als Maxima-Bibliothek ist fehlgeschlagen!"
 
 #: ../../src/wxMaximaFrame.cpp:561
 msgid "Exporting..."
-msgstr ""
+msgstr "Exportiere..."
 
 #: ../../src/wxMaxima.cpp:6510 ../../src/wxMaxima.cpp:6516
 #: ../../src/wxMaxima.cpp:8218 ../../src/wxMaxima.cpp:8633
 #: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
 #: ../../src/wxMaxima.cpp:10065
 msgid "Expression"
-msgstr ""
+msgstr "Ausdruck"
 
 #: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
 msgid "Expression or a list of comma-separated expressions"
-msgstr ""
+msgstr "Erzeuge eine Liste von Komma-separierten Ausdrücken"
 
 #: ../../src/wxMaximaFrame.cpp:1088
 msgid "Expression to string..."
-msgstr ""
+msgstr "Ausdruck als String..."
 
 #: ../../src/wxMaxima.cpp:7113
 msgid "Expression whose output is to be used as maxima's input."
-msgstr ""
+msgstr "Ausdruck, wessen Ausgabe als Eingabe von Maxima verwendet wird."
 
 #: ../../src/wxMaxima.cpp:7214
 msgid "Expression(s):"
-msgstr ""
+msgstr "Ausdruck/Ausdrücke:"
 
 #: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
 #: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
@@ -2730,385 +2819,389 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
 #: ../../src/wxMaxima.cpp:10056
 msgid "Expression:"
-msgstr ""
+msgstr "Ausdruck:"
 
 #: ../../src/wxMaximaFrame.cpp:1423
 msgid "Extract Column..."
-msgstr ""
+msgstr "Extrahiere eine Spalte..."
 
 #: ../../src/wxMaximaFrame.cpp:1726
 msgid "Extract Elements"
-msgstr ""
+msgstr "Extrahiere Elemente"
 
 #: ../../src/wxMaximaFrame.cpp:1421
 msgid "Extract Row..."
-msgstr ""
+msgstr "Extrahiere eine Zeile..."
 
 #: ../../src/wxMaximaFrame.cpp:1424
 msgid "Extract a column from the matrix"
-msgstr ""
+msgstr "Extrahiere eine Spalte der Matrix"
 
 #: ../../src/wxMaximaFrame.cpp:1435
 msgid "Extract a column from the matrix and convert it to a list"
-msgstr ""
+msgstr "Extrahiere eine Spalte der Matrix und konvertiere sie zu einer Liste"
 
 #: ../../src/wxMaxima.cpp:7960
 msgid "Extract a matrix column"
-msgstr ""
+msgstr "Extrahiere eine Matrixspalte"
 
 #: ../../src/wxMaxima.cpp:7970
 msgid "Extract a matrix column as a list"
-msgstr ""
+msgstr "Extrahiere eine Matrixspalte als Liste"
 
 #: ../../src/wxMaximaFrame.cpp:1313
 msgid "Extract a matrix from a 2-dimensional array"
-msgstr ""
+msgstr "Eine Matrix aus einem 2-dimensionalen Array erzeugen"
 
 #: ../../src/wxMaxima.cpp:7955
 msgid "Extract a matrix row"
-msgstr ""
+msgstr "Extrahiere eine Matrixzeile"
 
 #: ../../src/wxMaxima.cpp:7965
 msgid "Extract a matrix row as a list"
-msgstr ""
+msgstr "Extrahiere eine Matrixzeile als Liste"
 
 #: ../../src/wxMaximaFrame.cpp:1422
 msgid "Extract a row from the matrix"
-msgstr ""
+msgstr "Extrahiert eine Zeile einer Matrix"
 
 #: ../../src/wxMaximaFrame.cpp:1431
 msgid "Extract a row from the matrix and convert it to a list"
-msgstr ""
+msgstr "Extrahiert eine Zeile der Matrix und konvertiert sie zu einer Liste"
 
 #: ../../src/wxMaxima.cpp:8564
 msgid "Extract a variable's value from a list of variable values"
 msgstr ""
+"Extrahiert einen Variablenwert aus einer Liste mit Werten für Variablen"
 
 #: ../../src/wxMaximaFrame.cpp:1723
 msgid "Extract an actual value for a variable"
-msgstr ""
+msgstr "Extrahiere den Wert für eine Variable"
 
 #: ../../src/wxMaximaFrame.cpp:1163
 msgid "Extract char..."
-msgstr ""
+msgstr "Extrahiere ein Zeichen..."
 
 #: ../../src/wxMaximaFrame.cpp:1207
 msgid "Extract dir from path..."
-msgstr ""
+msgstr "Extrahiert ein Verzeichnis aus einem Pfad..."
 
 #: ../../src/wxMaxima.cpp:7605
 msgid "Extract directory part"
-msgstr ""
+msgstr "Extrahiere den Verzeichnis-Anteil"
 
 #: ../../src/wxMaxima.cpp:7617
 msgid "Extract file type extension"
-msgstr ""
+msgstr "Extrahiere die Datei-Extension"
 
 #: ../../src/wxMaximaFrame.cpp:1209
 msgid "Extract filename from path..."
-msgstr ""
+msgstr "Extrahiere Dateiname von Pfad..."
 
 #: ../../src/wxMaxima.cpp:7611
 msgid "Extract filename part"
-msgstr ""
+msgstr "Extrahiere den Dateinamen-Anteil"
 
 #: ../../src/wxMaximaFrame.cpp:1211
 msgid "Extract filetype from path..."
-msgstr ""
+msgstr "Extrahiere den Dateityp von Pfad..."
 
 #: ../../src/wxMaxima.cpp:8445
 msgid "Extract function arguments"
-msgstr ""
+msgstr "Extrahiere die Parameter einer Funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "Extract list Elements"
-msgstr ""
+msgstr "Extrahiere Elemente der Liste"
 
 #: ../../src/wxMaxima.cpp:8187
 msgid "Extract matrix from 2D array"
-msgstr ""
+msgstr "Extrahiere eine Matrix aus einem 2D-Array"
 
 #: ../../src/wxMaximaFrame.cpp:1686
 msgid "Extract the argument list from a function call"
-msgstr ""
+msgstr "Extrahiere die Liste der Parameter von einem Funktionsaufruf"
 
 #: ../../src/wxMaxima.cpp:8538
 msgid "Extract the last n elements from a list"
-msgstr ""
+msgstr "Extrahiere die letzten n Elemente einer Liste"
 
 #: ../../src/wxMaxima.cpp:7376
 msgid "Extract the nth char of a string"
-msgstr ""
+msgstr "Extrahiere das n. Zeichen eines Strings"
 
 #: ../../src/wxMaxima.cpp:8544
 msgid "Extract the nth list elements"
-msgstr ""
+msgstr "Extrahiere das n. Listenelement"
 
 #: ../../src/wxMaximaFrame.cpp:1724
 msgid "Extract the value for one variable assigned in a list"
 msgstr ""
+"Extrahiert den Wert, der einer Variable in einer Liste zugewiesen wird"
 
 #: ../../src/wxMaximaFrame.cpp:1439
 msgid "Extract, append or delete rows or columns"
-msgstr ""
+msgstr "Extrahieren, Anfügen oder Löschen von Zeilen oder Spalten"
 
 #: ../../src/wxMaxima.cpp:8188
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
 msgstr ""
+"Extrahiert ein Rechteck aus einem 2D-Array und konvertiert es in eine Matrix"
 
 #: ../../src/wxMaximaFrame.cpp:1521
 msgid "Factor Complex"
-msgstr ""
+msgstr "Ausdruck faktorisieren (Komplex)"
 
 #: ../../src/Worksheet.cpp:1581
 msgid "Factor Expression"
-msgstr ""
+msgstr "Ausdruck faktorisieren"
 
 #: ../../src/wxMaximaFrame.cpp:1519
 msgid "Factor Expression including subexpressions"
-msgstr ""
+msgstr "Faktorisiere einen Ausdruck inklusive Sub-Ausdrücke"
 
 #: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
 msgid "Factor an expression"
-msgstr ""
+msgstr "Einen Ausdruck in ein Produkt von Ausdrücken umwandeln"
 
 #: ../../src/wxMaximaFrame.cpp:1522
 msgid "Factor an expression in Gaussian numbers"
-msgstr ""
+msgstr "Faktorisiere einen Ausdruck in komplexe Zahlen"
 
 #: ../../src/wxMaximaFrame.cpp:1587
 msgid "Factorials and &Gamma"
-msgstr ""
+msgstr "Fakultät und &Gamma"
 
 #: ../../src/Image.cpp:137
 #, c-format
 msgid "Failed to delete gnuplot data file %s"
-msgstr ""
+msgstr "Konnte die Gnuplot Datendatei %s nicht löschen"
 
 #: ../../src/Image.cpp:121 ../../src/Image.cpp:128
 #, c-format
 msgid "Failed to delete gnuplot file %s"
-msgstr ""
+msgstr "Konnte die Gnuplotdatei %s nicht löschen"
 
 #: ../../src/wxMaxima.cpp:2667
 msgid "Failed to start Maxima"
-msgstr ""
+msgstr "Konnte Maxima nicht starten"
 
 #: ../../src/wxMaximaFrame.cpp:1418
 msgid "Fast fortran routines that perform numerical tasks"
-msgstr ""
+msgstr "Schnelle Fortran-Routinen die numerische Aufgaben erledigen"
 
 #: ../../src/wxMaximaFrame.cpp:1922
 msgid "Fast list access"
-msgstr ""
+msgstr "Schneller Zugriff auf Listen"
 
 #: ../../src/wxMaxima.cpp:2553
 msgid "Fatal error"
-msgstr ""
+msgstr "Fataler Fehler"
 
 #: ../../src/wxMaxima.cpp:7191
 msgid "Field contents:"
-msgstr ""
+msgstr "Feldinhalt:"
 
 #: ../../src/wxMaxima.cpp:7198
 msgid "Field name:"
-msgstr ""
+msgstr "Feldname:"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "Fields:"
-msgstr ""
+msgstr "Felder:"
 
 #: ../../src/main.cpp:439
 msgid "File"
-msgstr ""
+msgstr "Datei"
 
 #: ../../src/wxMaximaFrame.cpp:1333
 msgid "File I/O"
-msgstr ""
+msgstr "Datei Eingabe/Ausgabe"
 
 #: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
 #: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
 #: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
 #: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
 msgid "File could not be opened"
-msgstr ""
+msgstr "Datei kann nicht geöffnet werden"
 
 #: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
 #: ../../src/wxMaxima.cpp:7251
 msgid "File name:"
-msgstr ""
+msgstr "Dateiname:"
 
 #: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
 msgid "File not found"
-msgstr ""
+msgstr "Datei nicht gefunden"
 
 #: ../../src/wxMaxima.cpp:5631
 msgid "File opened"
-msgstr ""
+msgstr "Datei geöffnet"
 
 #: ../../src/wxMaximaFrame.cpp:1217
 msgid "File operations"
-msgstr ""
+msgstr "Dateioperationen"
 
 #: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
 msgid "File you tried to open does not exist."
-msgstr ""
+msgstr "Datei existiert nicht."
 
 #: ../../src/wxMaximaFrame.cpp:1221
 msgid "File/directory functions"
-msgstr ""
+msgstr "Datei/Verzeichnisoperationen"
 
 #: ../../src/wxMaxima.cpp:7027
 msgid "Filename or a list of comma-separated file names"
-msgstr ""
+msgstr "Dateiname oder Liste von Komma-separierten Dateinamen"
 
 #: ../../src/ToolBar.cpp:222
 msgid "Find"
-msgstr ""
+msgstr "Suchen"
 
 #: ../../src/wxMaximaFrame.cpp:670
 msgid "Find\tCtrl+F"
-msgstr ""
+msgstr "Suchen\tCtrl+F"
 
 #: ../../src/wxMaximaFrame.cpp:1468
 msgid "Find &Limit..."
-msgstr ""
+msgstr "Grenz&wert suchen ..."
 
 #: ../../src/wxMaximaFrame.cpp:1470
 msgid "Find Minimum..."
-msgstr ""
+msgstr "Minimum suchen ..."
 
 #: ../../src/Worksheet.cpp:1576
 msgid "Find Root..."
-msgstr ""
+msgstr "Nullstelle suchen ..."
 
 #: ../../src/wxMaximaFrame.cpp:1471
 msgid "Find a (unconstrained) minimum of an expression"
-msgstr ""
+msgstr "Finde das Minimum eines Ausdrucks"
 
 #: ../../src/wxMaximaFrame.cpp:1804
 msgid "Find a fraction that represents this float exactly"
-msgstr ""
+msgstr "Finde einen Bruch, der diese Gleitkommazahl exakt darstellt"
 
 #: ../../src/wxMaximaFrame.cpp:1469
 msgid "Find a limit of an expression"
-msgstr ""
+msgstr "Grenzwert eines Ausdrucks suchen"
 
 #: ../../src/wxMaximaFrame.cpp:1807
 msgid "Find a nice fraction that is similar to this float"
-msgstr ""
+msgstr "Finde einen schönen Bruch, der ähnlich wie diese Gleitkommazahl ist"
 
 #: ../../src/wxMaximaFrame.cpp:1283
 msgid "Find a numerical solution for a first degree ODE"
-msgstr ""
+msgstr "Eine numerische Lösung einer gewöhnlichen DGL ersten Grades finden"
 
 #: ../../src/wxMaximaFrame.cpp:1252
 msgid "Find a root of an equation on an interval"
-msgstr ""
+msgstr "Numerische Lösung einer Gleichung suchen"
 
 #: ../../src/wxMaximaFrame.cpp:1259
 msgid "Find all roots of a polynomial"
-msgstr ""
+msgstr "Alle Nullstellen eines Polynoms suchen"
 
 #: ../../src/wxMaximaFrame.cpp:1262
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr ""
+"Alle Nullstellen eines Polynoms mit langer Gleitkommagenauigkeit suchen"
 
 #: ../../src/wxMaxima.cpp:6589
 msgid "Find and Replace"
-msgstr ""
+msgstr "Suchen und Ersetzen"
 
 #: ../../src/ToolBar.cpp:222 ../../src/wxMaximaFrame.cpp:670
 msgid "Find and replace"
-msgstr ""
+msgstr "Suchen und Ersetzen"
 
 #: ../../src/wxMaxima.cpp:7434
 msgid "Find char in string"
-msgstr ""
+msgstr "Finde ein Zeichen in einem String"
 
 #: ../../src/wxMaximaFrame.cpp:1172
 msgid "Find char in string..."
-msgstr ""
+msgstr "Finde ein Zeichen in einem String..."
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Find common denominator"
-msgstr ""
+msgstr "Finde den gemeinsamen Nenner"
 
 #: ../../src/wxMaximaFrame.cpp:1366
 msgid "Find eigenvalues of a matrix"
-msgstr ""
+msgstr "Eigenwerte einer Matrix berechnen"
 
 #: ../../src/wxMaximaFrame.cpp:1369
 msgid "Find eigenvectors of a matrix"
-msgstr ""
+msgstr "Eigenvektoren einer Matrix berechnen"
 
 #: ../../src/wxMaxima.cpp:7424
 msgid "Find first difference"
-msgstr ""
+msgstr "Finde den ersten Unterschied"
 
 #: ../../src/wxMaximaFrame.cpp:1170
 msgid "Find first difference..."
-msgstr ""
+msgstr "Finde den ersten Unterschied..."
 
 #: ../../src/wxMaximaFrame.cpp:1256
 msgid "Find fractions that real roots of a polynomial and "
-msgstr ""
+msgstr "Finde die reellen Nullstellen eines Polynoms und "
 
 #: ../../src/wxMaxima.cpp:9039
 msgid "Find minimum"
-msgstr ""
+msgstr "Minimum suchen"
 
 #: ../../src/wxMaximaFrame.cpp:1251
 msgid "Find numerical solution..."
-msgstr ""
+msgstr "Finde numerische Lösung..."
 
 #: ../../src/wxMaxima.cpp:10035
 msgid "Find root (solve numerically)"
-msgstr ""
+msgstr "Finde eine Nullstelle (numerische Lösung)"
 
 #: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
 msgid "Find the maximum absolute value of a matrix entry"
-msgstr ""
+msgstr "Finde den maximalen absoluten Wert eines Matrix-Elements"
 
 #: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
 msgid "Find the maximum sum of the absolute values of a matrix column"
-msgstr ""
+msgstr "Berechne die maximale Summe der Absolutbeträge einer Matrixspalte"
 
 #: ../../src/wxMaxima.cpp:8073 ../../src/wxMaxima.cpp:8094
 msgid "Find the maximum sum of the absolute values of a matrix row"
-msgstr ""
+msgstr "Berechne die maximale Summe der Absolutbeträge einer Matrixzeile"
 
 #: ../../src/wxMaximaFrame.cpp:1832
 msgid "Fine-tune the display of engineering-format numbers"
-msgstr ""
+msgstr "Feineinstellung des Zahlenformats für Ingenieure"
 
 #: ../../src/wxMaximaFrame.cpp:1712
 msgid "First"
-msgstr ""
+msgstr "Erstes"
 
 #: ../../src/wxMaximaFrame.cpp:1918
 msgid "Fitting curves to measurement data"
-msgstr ""
+msgstr "Kurven an Messdaten anlegen"
 
 #: ../../src/wxMaxima.cpp:7227
 msgid "Flush stream"
-msgstr ""
+msgstr "Datenstrom entleeren"
 
 #: ../../src/wxMaximaFrame.cpp:1103
 msgid "Flush..."
-msgstr ""
+msgstr "Entleeren..."
 
 #: ../../src/wxMaximaFrame.cpp:922
 msgid "Fold All\tCtrl+Alt+["
-msgstr ""
+msgstr "Alles zuklappen\tCtrl+9"
 
 #: ../../src/wxMaximaFrame.cpp:923
 msgid "Fold all sections"
-msgstr ""
+msgstr "Alle Sektionen zuklappen"
 
 #: ../../src/ToolBar.cpp:240
 msgid "Follow"
-msgstr ""
+msgstr "Folge"
 
 #: ../../src/ToolBar.cpp:285
 msgid ""
@@ -3123,14 +3216,24 @@ msgid ""
 "   Ctrl+6: Heading5 cell\n"
 "   Ctrl+7: Heading6 cell\n"
 msgstr ""
+"Um die Erstellung von Zellen zu beschleunigen gibt es Tastenkürzel:\n"
+"\n"
+"   Ctrl+0: Mathematik\n"
+"   Ctrl+1: Text\n"
+"   Ctrl+2: Titel\n"
+"   Ctrl+3: Kapitel\n"
+"   Ctrl+4: Unterkapitel\n"
+"   Ctrl+5: Unter-Unterkapitel\n"
+"   Ctrl+6: Paragraph\n"
+"   Ctrl+7: Unterparagraph\n"
 
 #: ../../src/wxMaxima.cpp:7038
 msgid "For loop"
-msgstr ""
+msgstr "For Schleife"
 
 #: ../../src/wxMaximaFrame.cpp:1062
 msgid "For loop..."
-msgstr ""
+msgstr "For Schleife..."
 
 #: ../../src/Worksheet.cpp:237 ../../src/wxMaxima.cpp:11217
 msgid "Forwarding the keyboard focus to a text control"
@@ -3145,37 +3248,41 @@ msgstr ""
 msgid ""
 "Found %li anchors, URLs (individual files): %li, URLs (singlepage): %li"
 msgstr ""
+"%li Anker gefunden, URLs (individuelle Dateien): %li, URLs (Gesamtseite): "
+"%li"
 
 #: ../../src/MaximaManual.cpp:313
 #, c-format
 msgid "Found only %li keywords in maxima's manual. Not caching them to disc."
 msgstr ""
+"Nur %li Handbuchthemen gefunden. Speichere sie nicht auf der Festplatte "
+"zwischen."
 
 #: ../../src/MaximaManual.cpp:513
 #, c-format
 msgid "Found the maxima HTML manual in the folder %s."
-msgstr ""
+msgstr "Maxima's HTML-Handbuch im Verzeichnis %s gefunden."
 
 #: ../../src/wxMaxima.cpp:8948
 msgid "Fourier coefficients"
-msgstr ""
+msgstr "Fourier-Koeffizienten"
 
 #: ../../src/wxMaximaFrame.cpp:1476
 msgid "Fourier coefficients..."
-msgstr ""
+msgstr "Fourier-Koeffizienten..."
 
 #: ../../src/ToolBar.cpp:137
 #, c-format
 msgid "Frame %li of %li"
-msgstr ""
+msgstr "Bild %li von %li"
 
 #: ../../src/wxMaxima.cpp:9097
 msgid "Frame rate"
-msgstr ""
+msgstr "Bildwiederholrate"
 
 #: ../../src/wxMaximaFrame.cpp:1005 ../../src/wxMaximaFrame.cpp:1009
 msgid "Free all unused items now"
-msgstr ""
+msgstr "Alle unbenutzten Objekte jetzt freigeben"
 
 #: ../../src/wxMaximaFrame.cpp:1413
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
@@ -3187,59 +3294,59 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "From:"
-msgstr ""
+msgstr "Von:"
 
 #: ../../src/wxMaximaFrame.cpp:827
 msgid "Full Screen\tAlt+Enter"
-msgstr ""
+msgstr "Ganzer Bildschirm\tAlt+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:824
 msgid "Full Screen\tF11"
-msgstr ""
+msgstr "Vollbild\tF11"
 
 #: ../../src/wxMaxima.cpp:7140
 msgid "Function contents:"
-msgstr ""
+msgstr "Funktions-Inhalt:"
 
 #: ../../src/wxMaxima.cpp:7908
 msgid "Function f(x):"
-msgstr ""
+msgstr "Funktion f(x):"
 
 #: ../../src/wxMaxima.cpp:8572
 msgid "Function name"
-msgstr ""
+msgstr "Funktionsname"
 
 #: ../../src/wxMaxima.cpp:7167
 msgid "Function name(s):"
-msgstr ""
+msgstr "Funktionsname(n):"
 
 #: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
 msgid "Function name:"
-msgstr ""
+msgstr "Funktionsname:"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Function:"
-msgstr ""
+msgstr "Funktion:"
 
 #: ../../src/wxMaximaFrame.cpp:1630
 msgid "Functions for complex simplification"
-msgstr ""
+msgstr "Funktionen zum Vereinfachen komplexer Ausdrücke"
 
 #: ../../src/wxMaximaFrame.cpp:1588
 msgid "Functions for simplifying factorials and gamma function"
-msgstr ""
+msgstr "Funktionen zum Vereinfachen von Fakultäten und Gammafunktionen"
 
 #: ../../src/wxMaximaFrame.cpp:1606
 msgid "Functions for simplifying trigonometric expressions"
-msgstr ""
+msgstr "Funktionen zum Vereinfachen von trigonometrischen Ausdrücken"
 
 #: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
 msgid "GCD"
-msgstr ""
+msgstr "GGT"
 
 #: ../../src/wxMaxima.cpp:10186
 msgid "GIF image (*.gif)|*.gif"
-msgstr ""
+msgstr "GIF Bild (*.gif)|*.gif"
 
 #: ../../src/Worksheet.cpp:103
 msgid ""
@@ -3247,48 +3354,53 @@ msgid ""
 " hotkeys to be broken, see for example "
 "https://trac.wxwidgets.org/ticket/18462."
 msgstr ""
+"GTK_IM_MODULE ist auf \"xim\" gesetzt und GTK3 wird verwendet. Das Programm "
+"kann daher fürchterlich flackern, siehe "
+"https://trac.wxwidgets.org/ticket/18462."
 
 #: ../../src/wxMaximaFrame.cpp:295
 msgid "General Math"
-msgstr ""
+msgstr "Allgemeine Mathematik"
 
 #: ../../src/wxMaximaFrame.cpp:699
 msgid "General Math\tAlt+Shift+M"
-msgstr ""
+msgstr "Allg. Mathematik\tAlt+Shift+M"
 
 #: ../../src/wxMaximaFrame.cpp:1316
 msgid "Generate Matrix from Expression..."
-msgstr ""
+msgstr "Matrix aus Ausdruck erzeugen ..."
 
 #: ../../src/wxMaximaFrame.cpp:1317
 msgid "Generate a matrix from a lambda expression"
-msgstr ""
+msgstr "Matrix aus lambda-Ausdruck erzeugen"
 
 #: ../../src/wxMaximaFrame.cpp:1675
 msgid "Generate a new list using a lists' elements"
-msgstr ""
+msgstr "Erzeuge eine Liste aus den Elementen einer bereits bestehenden Liste."
 
 #: ../../src/wxMaximaFrame.cpp:1681
 msgid ""
 "Generate a storage for variable values that can be introduced into equations"
 " at any time"
 msgstr ""
+"Generiert einen Speicher für Variablenwerte, die dann später in Gleichungen "
+"eingesetzt werden können."
 
 #: ../../src/wxMaximaFrame.cpp:1672
 msgid "Generate list elements using a rule"
-msgstr ""
+msgstr "Erzeuge Listenelemente anhand einer Regel"
 
 #: ../../src/wxMaxima.cpp:8196
 msgid "Generate matrix from a rule"
-msgstr ""
+msgstr "Matrix aus einem Ausdruck erzeugen"
 
 #: ../../src/wxMaximaFrame.cpp:1094
 msgid "Generate unused symbol name"
-msgstr ""
+msgstr "Unbenutzten Symbolnamen erzeugen"
 
 #: ../../src/WXMXformat.cpp:231
 msgid "Generated the XML representation of the document"
-msgstr ""
+msgstr "XML Darstellung des Dokuments erzeugt"
 
 #: ../../src/wxMaxima.cpp:8197
 msgid ""
@@ -3298,23 +3410,23 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1619
 msgid "Get &Imaginary Part"
-msgstr ""
+msgstr "&Imaginärteil"
 
 #: ../../src/wxMaximaFrame.cpp:1485
 msgid "Get Laplace transformation of an expression"
-msgstr ""
+msgstr "Die Laplacetransformation eines Ausdrucks bestimmen"
 
 #: ../../src/wxMaximaFrame.cpp:1615
 msgid "Get Real P&art"
-msgstr ""
+msgstr "&Realteil"
 
 #: ../../src/wxMaximaFrame.cpp:1201
 msgid "Get current directory"
-msgstr ""
+msgstr "Aktuelles Verzeichnis"
 
 #: ../../src/wxMaximaFrame.cpp:1489
 msgid "Get inverse Laplace transformation of an expression"
-msgstr ""
+msgstr "Die inverse Laplacetransformation eines Ausdrucks bestimmen"
 
 #: ../../src/wxMaxima.cpp:7223
 msgid "Get position in stream"
@@ -3322,48 +3434,50 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1102
 msgid "Get position..."
-msgstr ""
+msgstr "Bestimme Position..."
 
 #: ../../src/wxMaximaFrame.cpp:1620
 msgid "Get the imaginary part of complex expression"
-msgstr ""
+msgstr "Imaginärteil eines komplexen Ausdrucks bestimmen"
 
 #: ../../src/wxMaximaFrame.cpp:1616
 msgid "Get the real part of complex expression"
-msgstr ""
+msgstr "Realteil eines komplexen Ausdrucks bestimmen"
 
 #: ../../src/wxMaxima.cpp:3609
 #, c-format
 msgid "Gnuplot (command line) found at: %s"
-msgstr ""
+msgstr "Gnuplot (Kommandozeilenversion) gefunden als: %s"
 
 #: ../../src/wxMaxima.cpp:3607
 #, c-format
 msgid "Gnuplot found at: %s"
-msgstr ""
+msgstr "Gnuplot gefunden als: %s"
 
 #: ../../src/wxMaxima.cpp:2974
 msgid "Gnuplot has closed."
-msgstr ""
+msgstr "Gnuplot wurde beendet."
 
 #: ../../src/wxMaxima.cpp:3598 ../../src/wxMaxima.cpp:3603
 #, c-format
 msgid "Gnuplot not found, using the default: %s"
-msgstr ""
+msgstr "Gnuplot nicht gefunden. Verwende: %s"
 
 #: ../../src/wxMaxima.cpp:9428 ../../src/wxMaximaFrame.cpp:1887
 msgid "Go to URL"
-msgstr ""
+msgstr "Gehe zu Webadresse"
 
 #: ../../src/wxMaxima.cpp:3989
 msgid "Got a new input prompt!"
-msgstr ""
+msgstr "Einen neuen Eingabe-Prompt erhalten!"
 
 #: ../../src/Worksheet.cpp:6354
 msgid ""
 "Got a request to undo an action that involves a delete which isn't possible "
 "at this moment."
 msgstr ""
+"Rückgängigmachen involviert das Löschen einer Zelle, die derzeit nicht "
+"gelöscht werden kann."
 
 #: ../../src/wxMaximaFrame.cpp:1031
 msgid "Gradefs"
@@ -3371,45 +3485,47 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1967
 msgid "Greater or less than a value"
-msgstr ""
+msgstr "Größer oder kleiner als ein Wert"
 
 #: ../../src/wxMaximaFrame.cpp:1130
 msgid "Greater, ignoring case?..."
-msgstr ""
+msgstr "Größer, Groß/Kleinschreibung ignorieren?..."
 
 #: ../../src/wxMaximaFrame.cpp:260
 msgid "Greek Letters"
-msgstr ""
+msgstr "Griechische Buchstaben"
 
 #: ../../src/wxMaximaFrame.cpp:703
 msgid "Greek Letters\tAlt+Shift+G"
-msgstr ""
+msgstr "Griechische Buchstaben\tAlt+Shift+G"
 
 #: ../../src/wxMaximaFrame.cpp:1815
 msgid "Guess an exact number that could be meant by this float"
-msgstr ""
+msgstr "Eine exakte Zahl schätzen, die diese Gleitkommazahl sein könnte"
 
 #: ../../src/wxMaxima.cpp:6123
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file "
 "(*.tex)|*.tex"
 msgstr ""
+"HTML-Datei (*.html)|*.html|Maxima-Bibliothek (*.mac)|*.mac|LaTeX-Datei "
+"(*.tex)|*.tex"
 
 #: ../../src/wxMaximaFrame.cpp:1341
 msgid "Hadamard (element-by-element) product..."
-msgstr ""
+msgstr "Hadamard-Produkt (Elementweises Produkt)..."
 
 #: ../../src/wxMaxima.cpp:8004
 msgid "Hadamard Product"
-msgstr ""
+msgstr "Hadamard Produkt"
 
 #: ../../src/wxMaxima.cpp:8011
 msgid "Hadamard exponent"
-msgstr ""
+msgstr "Hadamard Exponent"
 
 #: ../../src/wxMaximaFrame.cpp:1345
 msgid "Hadamard exponent..."
-msgstr ""
+msgstr "Hadamard Exponent..."
 
 #: ../../src/MaximaManual.cpp:260
 #, c-format
@@ -3420,116 +3536,116 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:88 ../../src/ToolBar.cpp:276
 msgid "Heading 5"
-msgstr ""
+msgstr "Paragraph"
 
 #: ../../src/Configuration.cpp:87 ../../src/ToolBar.cpp:277
 msgid "Heading 6"
-msgstr ""
+msgstr "Unterparagraph"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
 msgid "Help"
-msgstr ""
+msgstr "Hilfe"
 
 #: ../../src/ToolBar.cpp:635
 msgid "Help button"
-msgstr ""
+msgstr "Der \"Hilfe\"-Knopf"
 
 #: ../../src/Worksheet.cpp:1340 ../../src/Worksheet.cpp:1778
 #, c-format
 msgid "Help on \"%s\""
-msgstr ""
+msgstr "Hilfe für \"%s\""
 
 #: ../../src/wxMaximaFrame.cpp:729
 msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr ""
+msgstr "Alle Werkzeugleisten verbergen\tAlt+Shift+-"
 
 #: ../../src/ToolBar.cpp:264
 msgid "Hide Code"
-msgstr ""
+msgstr "Code verstecken"
 
 #: ../../src/wxMaximaFrame.cpp:727
 msgid "Hide Code Cells\tAlt+Ctrl+H"
-msgstr ""
+msgstr "Zellen mit Code verstecken\tAlt+Ctrl+H"
 
 #: ../../src/Worksheet.cpp:1896
 msgid "Hide Heading 5"
-msgstr ""
+msgstr "Verstecke Paragraph"
 
 #: ../../src/Worksheet.cpp:1907
 msgid "Hide Heading 6"
-msgstr ""
+msgstr "Verstecke Unterparagraph"
 
 #: ../../src/Worksheet.cpp:1855
 msgid "Hide Part"
-msgstr ""
+msgstr "Verstecke diesen Abschnitt"
 
 #: ../../src/Worksheet.cpp:1863
 msgid "Hide Section"
-msgstr ""
+msgstr "Verstecke dieses Kapitel"
 
 #: ../../src/Worksheet.cpp:1874
 msgid "Hide Subsection"
-msgstr ""
+msgstr "Verstecke dieses Unterkapitel"
 
 #: ../../src/Worksheet.cpp:1885
 msgid "Hide Subsubsection"
-msgstr ""
+msgstr "Verstecke dieses Unter-Unterkapitel"
 
 #: ../../src/wxMaximaFrame.cpp:730
 msgid "Hide all panes"
-msgstr ""
+msgstr "Alle Werkzeugleisten ausblenden"
 
 #: ../../src/Worksheet.cpp:1491
 msgid "Hide cell brackets"
-msgstr ""
+msgstr "Verstecke Zell-Klammern"
 
 #: ../../src/Worksheet.cpp:1915
 msgid "Hide contents"
-msgstr ""
+msgstr "Verstecke den Inhalt"
 
 #: ../../src/Worksheet.cpp:1552
 msgid "Hide multiplication dots"
-msgstr ""
+msgstr "Verstecke Multiplikationszeichen"
 
 #: ../../src/Worksheet.cpp:1930 ../../src/Worksheet.cpp:2063
 msgid "Hide yellow tooltip marker for this cell"
-msgstr ""
+msgstr "Verstecke den gelben Tooltip-Marker für diese Zelle"
 
 #: ../../src/Worksheet.cpp:1937 ../../src/Worksheet.cpp:2069
 msgid "Hide yellow tooltip marker for this message type"
-msgstr ""
+msgstr "Verstecke den gelben Tooltip-Marker für diese Art von Nachricht"
 
 #: ../../src/Configuration.cpp:82
 msgid "Highlight (box)"
-msgstr ""
+msgstr "Hervorgehoben (box)"
 
 #: ../../src/wxMaxima.cpp:9528
 msgid "Histogram"
-msgstr ""
+msgstr "Histogramm"
 
 #: ../../src/wxMaximaFrame.cpp:232
 msgid "History"
-msgstr ""
+msgstr "Historie der letzten Eingaben"
 
 #: ../../src/wxMaximaFrame.cpp:709
 msgid "History\tAlt+Shift+I"
-msgstr ""
+msgstr "Historie\tAlt+Shift+H"
 
 #: ../../src/wxMaximaFrame.cpp:1526
 msgid "Horner's rule"
-msgstr ""
+msgstr "Horner-Schema"
 
 #: ../../src/wxMaxima.cpp:9207
 msgid "How many digits to show:"
-msgstr ""
+msgstr "Zahl der angezeigten Stellen:"
 
 #: ../../src/wxMaximaFrame.cpp:759
 msgid "How to display new equations"
-msgstr ""
+msgstr "Wie sollen neue Gleichungen angezeigt werden?"
 
 #: ../../src/wxMaximaFrame.cpp:1113
 msgid "I/O"
-msgstr ""
+msgstr "Eingabe/Ausgabe"
 
 #: ../../src/wxMaxima.cpp:7062
 msgid ""
@@ -3551,32 +3667,37 @@ msgid ""
 "If this isn't a function returning a lambda() expression a multiplication "
 "sign (*) between closing and opening parenthesis is missing here."
 msgstr ""
+"Falls dies keine Funktion ist, die einen lambda()-Ausdruck zurückgibt, fehlt"
+" hier ein Malzeichen (*) zwischen der schließenden und der öffnenden "
+"Klammer."
 
 #: ../../src/MaximaManual.cpp:403
 msgid "Ignoring the cache version for the manual anchors."
-msgstr ""
+msgstr "Ignoriere den Zwischenspeicher für Handbucheinträge."
 
 #: ../../src/Image.cpp:79
 msgid "Image data had zero length!"
-msgstr ""
+msgstr "Bilddaten hatten eine Länge von null!"
 
 #: ../../src/wxMaxima.cpp:10147 ../../src/wxMaxima.cpp:10855
 msgid ""
 "Image files (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, "
 "*.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
 msgstr ""
+"Bilddateien (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, "
+"*.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
 
 #: ../../src/Worksheet.cpp:5509
 msgid "ImageCell without image."
-msgstr ""
+msgstr "Bild-Zelle ohne Bild."
 
 #: ../../src/MathParser.cpp:347
 msgid "Importing compressed gnuplot sources for an animation"
-msgstr ""
+msgstr "Importiere komprimierte Gnuplot Quellen für eine Animation"
 
 #: ../../src/MathParser.cpp:334
 msgid "Importing uncompressed gnuplot sources for an animation"
-msgstr ""
+msgstr "Importiere nicht komprimierte Gnuplot Quellen für eine Animation"
 
 #: ../../src/wxMaxima.cpp:7993
 msgid ""
@@ -3592,31 +3713,31 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Include columns:"
-msgstr ""
+msgstr "Spalten:"
 
 #: ../../src/Worksheet.cpp:2008
 msgid "Increasing function f(x)>x"
-msgstr ""
+msgstr "Steigende Funktion f(x)>x"
 
 #: ../../src/wxMaxima.cpp:8470
 msgid "Index End:"
-msgstr ""
+msgstr "Endindex:"
 
 #: ../../src/wxMaxima.cpp:8470
 msgid "Index Start:"
-msgstr ""
+msgstr "Startindex:"
 
 #: ../../src/wxMaxima.cpp:8471
 msgid "Index Step:"
-msgstr ""
+msgstr "Schrittweite:"
 
 #: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
 msgid "Index variable:"
-msgstr ""
+msgstr "Laufvariable:"
 
 #: ../../src/wxMaximaFrame.cpp:1949
 msgid "Info about Maxima build"
-msgstr ""
+msgstr "Information über Maxima Version"
 
 #: ../../src/Worksheet.cpp:2046
 msgid "Inform maxima about facts you know for this symbol"
@@ -3630,155 +3751,155 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
 msgid "Initial Condition"
-msgstr ""
+msgstr "Anfangsbedingung:"
 
 #: ../../src/wxMaximaFrame.cpp:1270
 msgid "Initial Value Problem (&1)..."
-msgstr ""
+msgstr "Anfangswertproblem (&1) ..."
 
 #: ../../src/wxMaximaFrame.cpp:1274
 msgid "Initial Value Problem (&2)..."
-msgstr ""
+msgstr "Anfangswertproblem (&2) ..."
 
 #: ../../src/wxMaxima.cpp:9044
 msgid "Initial estimates:"
-msgstr ""
+msgstr "Anfangswerte:"
 
 #: ../../src/wxMaxima.cpp:7840
 msgid "Initial x:"
-msgstr ""
+msgstr "Anfangswert x:"
 
 #: ../../src/Configuration.cpp:78
 msgid "Input labels"
-msgstr ""
+msgstr "Eingabemarken"
 
 #: ../../src/wxMaximaFrame.cpp:314
 msgid "Insert"
-msgstr ""
+msgstr "Zellen Einfügen"
 
 #: ../../src/wxMaximaFrame.cpp:905
 msgid "Insert &Section Cell\tCtrl+3"
-msgstr ""
+msgstr "Neue &Kapitelzelle\tCtrl+3"
 
 #: ../../src/wxMaximaFrame.cpp:901
 msgid "Insert &Text Cell\tCtrl+1"
-msgstr ""
+msgstr "Neue &Textzelle\tCtrl+1"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Insert Cell\tAlt+Shift+C"
-msgstr ""
+msgstr "Zellen einfügen\tAlt+Shift+C"
 
 #: ../../src/Worksheet.cpp:1669
 msgid "Insert Heading5 Cell"
-msgstr ""
+msgstr "Füge Paragraph ein"
 
 #: ../../src/Worksheet.cpp:1671
 msgid "Insert Heading6 Cell"
-msgstr ""
+msgstr "Füge Unterparagraph ein"
 
 #: ../../src/wxMaxima.cpp:10854
 msgid "Insert Image"
-msgstr ""
+msgstr "Bild einfügen"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert Image..."
-msgstr ""
+msgstr "Bild einfügen ..."
 
 #: ../../src/wxMaximaFrame.cpp:899
 msgid "Insert Input &Cell\tCtrl+0"
-msgstr ""
+msgstr "Neue &Eingabezelle\tCtrl+0"
 
 #: ../../src/wxMaximaFrame.cpp:919
 msgid "Insert Page Break"
-msgstr ""
+msgstr "Seitenumbruch einfügen"
 
 #: ../../src/wxMaximaFrame.cpp:907
 msgid "Insert S&ubsection Cell\tCtrl+4"
-msgstr ""
+msgstr "Neue &Unterkapitelzelle\tCtrl+4"
 
 #: ../../src/wxMaximaFrame.cpp:910
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
-msgstr ""
+msgstr "Neue &Unter-Unterkapitelzelle\tCtrl+5"
 
 #: ../../src/Worksheet.cpp:1662
 msgid "Insert Section Cell"
-msgstr ""
+msgstr "Neue &Kapitelzelle"
 
 #: ../../src/Worksheet.cpp:1664
 msgid "Insert Subsection Cell"
-msgstr ""
+msgstr "Neue &Unterkapitelzelle"
 
 #: ../../src/Worksheet.cpp:1667
 msgid "Insert Subsubsection Cell"
-msgstr ""
+msgstr "Neue &Unter-Unterkapitelzelle"
 
 #: ../../src/wxMaximaFrame.cpp:903
 msgid "Insert T&itle Cell\tCtrl+2"
-msgstr ""
+msgstr "Neue T&itelzelle\tCtrl+2"
 
 #: ../../src/Worksheet.cpp:1658
 msgid "Insert Text Cell"
-msgstr ""
+msgstr "Neue &Textzelle"
 
 #: ../../src/Worksheet.cpp:1660
 msgid "Insert Title Cell"
-msgstr ""
+msgstr "Neue T&itelzelle"
 
 #: ../../src/wxMaximaFrame.cpp:913
 msgid "Insert a new heading5 cell"
-msgstr ""
+msgstr "Füge Paragraph ein"
 
 #: ../../src/wxMaximaFrame.cpp:915
 msgid "Insert a new heading6 cell"
-msgstr ""
+msgstr "Einfügen einer neuen heading6-Zelle"
 
 #: ../../src/wxMaximaFrame.cpp:900
 msgid "Insert a new input cell"
-msgstr ""
+msgstr "Neue Zelle für Eingabe einfügen"
 
 #: ../../src/wxMaximaFrame.cpp:906
 msgid "Insert a new section cell"
-msgstr ""
+msgstr "Neue Zelle für Kapitel einfügen"
 
 #: ../../src/wxMaximaFrame.cpp:908
 msgid "Insert a new subsection cell"
-msgstr ""
+msgstr "Neue Zelle für Unterkapitel einfügen"
 
 #: ../../src/wxMaximaFrame.cpp:911
 msgid "Insert a new subsubsection cell"
-msgstr ""
+msgstr "Neue Zelle für Unter-Unterkapitel einfügen"
 
 #: ../../src/wxMaximaFrame.cpp:902
 msgid "Insert a new text cell"
-msgstr ""
+msgstr "Neue Zelle für Text einfügen"
 
 #: ../../src/wxMaximaFrame.cpp:904
 msgid "Insert a new title cell"
-msgstr ""
+msgstr "Neue Titelzelle einfügen"
 
 #: ../../src/wxMaximaFrame.cpp:920
 msgid "Insert a page break"
-msgstr ""
+msgstr "Seitenumbruch einfügen"
 
 #: ../../src/wxMaximaFrame.cpp:1164
 msgid "Insert char..."
-msgstr ""
+msgstr "Zeichen einfügen ..."
 
 #: ../../src/wxMaximaFrame.cpp:912
 msgid "Insert heading5 Cell\tCtrl+6"
-msgstr ""
+msgstr "Füge Paragraph ein\tCtrl+6"
 
 #: ../../src/wxMaximaFrame.cpp:914
 msgid "Insert heading6 Cell\tCtrl+7"
-msgstr ""
+msgstr "Füge Unterparagraph ein\tCtrl+7"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert image"
-msgstr ""
+msgstr "Bild einfügen"
 
 #: ../../src/wxMaximaFrame.cpp:916
 msgid "Insert textbased cell"
-msgstr ""
+msgstr "Neue &Textzelle"
 
 #: ../../src/wxMaxima.cpp:3566
 msgid "Instructed to prefer gnuplot over wgnuplot"
@@ -3790,43 +3911,43 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
 msgid "Integral/Sum:"
-msgstr ""
+msgstr "Integral/Summe:"
 
 #: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
 msgid "Integrate"
-msgstr ""
+msgstr "Integrieren"
 
 #: ../../src/wxMaxima.cpp:8980
 msgid "Integrate (risch)"
-msgstr ""
+msgstr "Integrieren nach Risch"
 
 #: ../../src/wxMaximaFrame.cpp:1454
 msgid "Integrate expression"
-msgstr ""
+msgstr "Ausdruck integrieren"
 
 #: ../../src/wxMaximaFrame.cpp:1456
 msgid "Integrate expression with Risch algorithm"
-msgstr ""
+msgstr "Ausdruck mit Risch-Algorithmus integrieren"
 
 #: ../../src/wxMaximaFrame.cpp:1869
 msgid "Integrate numerically"
-msgstr ""
+msgstr "Numerisch Integrieren"
 
 #: ../../src/Worksheet.cpp:1588
 msgid "Integrate..."
-msgstr ""
+msgstr "Integrieren ..."
 
 #: ../../src/wxMaximaFrame.cpp:1737
 msgid "Interleave"
-msgstr ""
+msgstr "Zusammenfügen nach dem Reissverschlussprinzip"
 
 #: ../../src/wxMaximaFrame.cpp:1738
 msgid "Interleave the values of two lists"
-msgstr ""
+msgstr "Nimm Elemente abwechselnd von zwei Listen"
 
 #: ../../src/wxMaxima.cpp:8612
 msgid "Interleave two lists"
-msgstr ""
+msgstr "Abwechselnd zusammenfügen"
 
 #: ../../src/wxMaximaFrame.cpp:1087
 msgid "Interpret like input..."
@@ -3834,42 +3955,46 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7104
 msgid "Interpret maxima's output as input"
-msgstr ""
+msgstr "Interpretiere Maxima's Ausgabe als Eingabe"
 
 #: ../../src/wxMaxima.cpp:7502
 msgid "Interpret string as maxima code"
-msgstr ""
+msgstr "Interpretiere String als Maxima Code"
 
 #: ../../src/wxMaximaFrame.cpp:1089
 msgid "Interpret string..."
-msgstr ""
+msgstr "String interpretieren..."
 
 #: ../../src/ToolBar.cpp:231
 msgid "Interrupt"
-msgstr ""
+msgstr "Unterbrechen"
 
 #: ../../src/wxMaximaFrame.cpp:965
 msgid "Interrupt current computation"
-msgstr ""
+msgstr "Auswertung abbrechen"
 
 #: ../../src/ToolBar.cpp:232
 msgid ""
 "Interrupt current computation. To completely restart maxima press the button"
 " left to this one."
 msgstr ""
+"Unterbreche den aktuellen Rechenschritt. Ein kompletter Neustart von Maxima "
+"kann durch einen Klick auf das Symbol links von diesem hier erreicht werden."
 
 #: ../../src/wxMaxima.cpp:2766
 #, c-format
 msgid "Interrupting maxima: %s"
-msgstr ""
+msgstr "Unterbrechen von Maxima: %s"
 
 #: ../../src/wxMaxima.cpp:8557
 msgid "Introduce a list of actual values into an equation"
-msgstr ""
+msgstr "Einsetzen konkreter Variablenwerte in eine Gleichung"
 
 #: ../../src/wxMaximaFrame.cpp:1697
 msgid "Introduce the actual values for variables stored in the list"
 msgstr ""
+"Einsetzen der konkreten Zahlenwerte für Variablen, die in einer Liste "
+"gespeichert sind, in eine Formel."
 
 #: ../../src/wxMaxima.cpp:10062
 msgid "Introduces one or more assignments into an expression"
@@ -3877,31 +4002,35 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9003
 msgid "Inverse Laplace"
-msgstr ""
+msgstr "Inverse Laplacetransformation"
 
 #: ../../src/wxMaximaFrame.cpp:1488
 msgid "Inverse Laplace T&ransform..."
-msgstr ""
+msgstr "Inverse Laplacet&ransformation ..."
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Invert worksheet brightness"
-msgstr ""
+msgstr "Invertiere die Helligkeit des Arbeitsblattes"
 
 #: ../../src/wxMaxima.cpp:7338
 msgid "Is Char 1 greater than Char2, if case is ignored?"
 msgstr ""
+"Ist Zeichen 1 größer als Zeichen 2, wenn Groß/Kleinschreibung ignoriert "
+"wird?"
 
 #: ../../src/wxMaxima.cpp:7333
 msgid "Is Char 1 greater than Char2?"
-msgstr ""
+msgstr "Ist Zeichen 1 größer als Zeichen 2?"
 
 #: ../../src/wxMaxima.cpp:7327
 msgid "Is Char 1 less than Char2, if case is ignored?"
 msgstr ""
+"Ist Zeichen 1 kleiner als Zeichen 2, wenn Groß/Kleinschreibung ignoriert "
+"wird?"
 
 #: ../../src/wxMaxima.cpp:7322
 msgid "Is Char 1 less than Char2?"
-msgstr ""
+msgstr "Ist Zeichen 1 kleiner als Zeichen 2?"
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Is a char?"
@@ -3913,31 +4042,31 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1952
 msgid "Is a complex variable"
-msgstr ""
+msgstr "Ist eine komplexe Variable"
 
 #: ../../src/wxMaxima.cpp:7292
 msgid "Is a digit?"
-msgstr ""
+msgstr "Ist es eine Ziffer?"
 
 #: ../../src/wxMaximaFrame.cpp:1118
 msgid "Is a digit?..."
-msgstr ""
+msgstr "Ist es eine Ziffer?"
 
 #: ../../src/wxMaxima.cpp:7304
 msgid "Is a lowercase char?"
-msgstr ""
+msgstr "Ist es ein Kleinbuchstabe?"
 
 #: ../../src/wxMaxima.cpp:7296
 msgid "Is a printable char?"
-msgstr ""
+msgstr "Ist es ein druckbares Zeichen?"
 
 #: ../../src/Worksheet.cpp:1949
 msgid "Is a real variable"
-msgstr ""
+msgstr "Ist es eine reelle Variable"
 
 #: ../../src/wxMaxima.cpp:7300
 msgid "Is a uppercase char?"
-msgstr ""
+msgstr "Ist es ein Großbuchstabe?"
 
 #: ../../src/wxMaximaFrame.cpp:1116
 msgid "Is alphabetic?..."
@@ -3945,7 +4074,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1117
 msgid "Is alphanumeric?..."
-msgstr ""
+msgstr "Ist es alphanumerisch?"
 
 #: ../../src/wxMaxima.cpp:7284
 msgid "Is an alphabetic char?"
@@ -3953,51 +4082,51 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7288
 msgid "Is an alphanumeric char?"
-msgstr ""
+msgstr "Ist es ein alphanumerisches Zeichen?"
 
 #: ../../src/Worksheet.cpp:1991
 msgid "Is an even function"
-msgstr ""
+msgstr "Ist es eine gerade Funktion"
 
 #: ../../src/Worksheet.cpp:1955
 msgid "Is an imaginary variable"
-msgstr ""
+msgstr "Ist es eine imaginäre Variable"
 
 #: ../../src/Worksheet.cpp:1960
 msgid "Is an integer variable"
-msgstr ""
+msgstr "Ist es eine ganzzahlige Variable"
 
 #: ../../src/Worksheet.cpp:1993
 msgid "Is an odd function"
-msgstr ""
+msgstr "Ist es eine ungerade Funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Is equal?..."
-msgstr ""
+msgstr "Ist es gleich?"
 
 #: ../../src/wxMaximaFrame.cpp:1128
 msgid "Is greater?..."
-msgstr ""
+msgstr "Ist es größer?"
 
 #: ../../src/wxMaximaFrame.cpp:1125
 msgid "Is lower?..."
-msgstr ""
+msgstr "Ist es kleiner?"
 
 #: ../../src/wxMaximaFrame.cpp:1121
 msgid "Is lowercase?..."
-msgstr ""
+msgstr "Ist es ein Kleinbuchstabe?..."
 
 #: ../../src/Worksheet.cpp:1962
 msgid "Is no integer variable"
-msgstr ""
+msgstr "Ist es keine ganzzahlige Variable"
 
 #: ../../src/wxMaximaFrame.cpp:1119
 msgid "Is printable?..."
-msgstr ""
+msgstr "Ist es druckbar?"
 
 #: ../../src/wxMaximaFrame.cpp:1120
 msgid "Is uppercase?..."
-msgstr ""
+msgstr "Ist es ein Großbuchstabe?..."
 
 #: ../../src/Worksheet.cpp:6256
 msgid "Issuing the active cell's undo function"
@@ -4009,23 +4138,23 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8598 ../../src/wxMaxima.cpp:8604
 msgid "Item"
-msgstr ""
+msgstr "Element"
 
 #: ../../src/wxMaxima.cpp:8581
 msgid "Iterator name:"
-msgstr ""
+msgstr "Laufvariable:"
 
 #: ../../src/wxMaximaFrame.cpp:1048
 msgid "Jump to first error"
-msgstr ""
+msgstr "Springe zum ersten Fehler"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Jump to the first cell Maxima has reported an error in."
-msgstr ""
+msgstr "Springe zur ersten Zelle, in der Maxima einen Fehler meldet."
 
 #: ../../src/wxMaxima.cpp:8960
 msgid "LCM"
-msgstr ""
+msgstr "KGV"
 
 #: ../../src/wxMaximaFrame.cpp:1407
 msgid "L[1] Norm (complex)"
@@ -4045,11 +4174,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1025
 msgid "Labels"
-msgstr ""
+msgstr "Markierungen"
 
 #: ../../src/wxMaxima.cpp:7090
 msgid "Lambda"
-msgstr ""
+msgstr "Lambda"
 
 #: ../../src/wxMaxima.cpp:7091
 msgid ""
@@ -4060,29 +4189,29 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8997
 msgid "Laplace"
-msgstr ""
+msgstr "Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1484
 msgid "Laplace &Transform..."
-msgstr ""
+msgstr "Laplace &Transformation ..."
 
 #: ../../src/wxMaximaFrame.cpp:1718
 msgid "Last"
-msgstr ""
+msgstr "Letztes"
 
 #: ../../src/wxMaxima.cpp:3006
 #, c-format
 msgid "Last message from maxima's stderr: %s"
-msgstr ""
+msgstr "Letzte Nachricht von Maxima's stderr: %s"
 
 #: ../../src/wxMaxima.cpp:2993
 #, c-format
 msgid "Last message from maxima's stdout: %s"
-msgstr ""
+msgstr "Letzte Nachricht von Maxima's stdout: %s"
 
 #: ../../src/wxMaximaFrame.cpp:1720
 msgid "Last n"
-msgstr ""
+msgstr "Letzte n"
 
 #: ../../src/wxMaxima.cpp:10400
 msgid "Last non-whitespace is a question mark"
@@ -4091,44 +4220,44 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4899
 #, c-format
 msgid "Launching the system's default help browser as %s."
-msgstr ""
+msgstr "Standard-Hilfe-Browser %s starten."
 
 #: ../../src/wxMaxima.cpp:4909
 msgid "Launching the system's default help browser failed."
-msgstr ""
+msgstr "Konnte den Hilfe-Browser des Systems nicht starten."
 
 #: ../../src/wxMaximaFrame.cpp:1493
 msgid "Least Common Multiple..."
-msgstr ""
+msgstr "KGV ..."
 
 #: ../../src/wxMaxima.cpp:9587
 msgid "Least Squares Fit"
-msgstr ""
+msgstr "Least-Squares-Fit"
 
 #: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
 #: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
 msgid "Left Matrix:"
-msgstr ""
+msgstr "Linke Matrix:"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Left end"
-msgstr ""
+msgstr "Linke Seite"
 
 #: ../../src/wxMaximaFrame.cpp:1297
 msgid "Left side to the \"=\""
-msgstr ""
+msgstr "Die Seite links vom \"=\""
 
 #: ../../src/wxMaximaFrame.cpp:1741
 msgid "Length"
-msgstr ""
+msgstr "Länge"
 
 #: ../../src/wxMaximaFrame.cpp:1104 ../../src/wxMaximaFrame.cpp:1167
 msgid "Length..."
-msgstr ""
+msgstr "Länge..."
 
 #: ../../src/wxMaxima.cpp:7421
 msgid "Length:"
-msgstr ""
+msgstr "Länge:"
 
 #: ../../src/wxMaximaFrame.cpp:1032
 msgid "Letrules"
@@ -4136,132 +4265,134 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1976
 msgid "Likely to be the main variable"
-msgstr ""
+msgstr "Wahrscheinlich die Haupt-Variable"
 
 #: ../../src/wxMaxima.cpp:9028
 msgid "Limit"
-msgstr ""
+msgstr "Grenzwert"
 
 #: ../../src/wxMaxima.cpp:7256
 msgid "Lisp format string:"
-msgstr ""
+msgstr "Lisp Formatstring:"
 
 #: ../../src/wxMaxima.cpp:7258
 msgid "Lisp format strings are more powerful than c++ format strings"
-msgstr ""
+msgstr "Lisp Formatstrngs sind mächtiger als C++ Formatstrings"
 
 #: ../../src/wxMaxima.cpp:5066
 msgid "Lisp mode."
-msgstr ""
+msgstr "Lisp-Modus."
 
 #: ../../src/wxMaximaFrame.cpp:1010 ../../src/wxMaximaFrame.cpp:1012
 msgid "Lisp normally frees memory only when it has time or runs out of space"
 msgstr ""
+"Lisp gibt Speicher normalerweise nur frei, wenn es Zeit hat oder der "
+"Speicher knapp wird"
 
 #: ../../src/wxMaxima.cpp:3691
 #, c-format
 msgid "Lisp version: %s"
-msgstr ""
+msgstr "Lisp-Version: %s"
 
 #: ../../src/wxMaxima.cpp:8435 ../../src/wxMaxima.cpp:8539
 #: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
 #: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
 #: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
 msgid "List"
-msgstr ""
+msgstr "Liste"
 
 #: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
 msgid "List #1"
-msgstr ""
+msgstr "Liste #1"
 
 #: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
 msgid "List #2"
-msgstr ""
+msgstr "Liste #2"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "List directory"
-msgstr ""
+msgstr "Verzeichnis anzeigen"
 
 #: ../../src/wxMaximaFrame.cpp:1205
 msgid "List directory..."
-msgstr ""
+msgstr "Verzeichnis anzeigen..."
 
 #: ../../src/wxMaxima.cpp:7385 ../../src/wxMaxima.cpp:7389
 msgid "List of char to String"
-msgstr ""
+msgstr "Liste von Zeichen in String"
 
 #: ../../src/wxMaximaFrame.cpp:1150
 msgid "List of chars to string..."
-msgstr ""
+msgstr "Liste von Zeichen in String..."
 
 #: ../../src/wxMaxima.cpp:7386
 msgid "List of chars:"
-msgstr ""
+msgstr "Liste der Zeichen:"
 
 #: ../../src/wxMaxima.cpp:8559
 msgid "List with values"
-msgstr ""
+msgstr "Liste mit Variablenwerten"
 
 #: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
 msgid "List:"
-msgstr ""
+msgstr "Liste:"
 
 #: ../../src/wxMaxima.cpp:6200
 msgid "Load Package"
-msgstr ""
+msgstr "Paket laden"
 
 #: ../../src/wxMaximaFrame.cpp:613
 msgid "Load Recent Package"
-msgstr ""
+msgstr "Vorheriges Paket laden"
 
 #: ../../src/wxMaximaFrame.cpp:616
 msgid "Load a Maxima file using the batch command"
-msgstr ""
+msgstr "Eine Maxima Batch-Datei laden"
 
 #: ../../src/wxMaximaFrame.cpp:611
 msgid "Load a Maxima package file"
-msgstr ""
+msgstr "Ein Maxima Paket laden"
 
 #: ../../src/wxMaximaFrame.cpp:1678
 msgid "Load a list from a csv file"
-msgstr ""
+msgstr "Liste aus csv-Datei"
 
 #: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
 msgid "Load a matrix from a csv file"
-msgstr ""
+msgstr "Matrix aus csv-Datei"
 
 #: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
 msgid "Load lapack"
-msgstr ""
+msgstr "Lapack-Paket laden"
 
 #: ../../src/wxMaxima.cpp:7208
 msgid "Load lisp code"
-msgstr ""
+msgstr "Lade Lisp Code"
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "Load lisp..."
-msgstr ""
+msgstr "Lade Lisp..."
 
 #: ../../src/wxMaximaFrame.cpp:1198
 msgid "Load the file/dir operations (operatingsystem)"
-msgstr ""
+msgstr "Lade Datei/Directory operationen (operatingsystem)"
 
 #: ../../src/wxMaximaFrame.cpp:1187
 msgid "Load the regular expression package (sregex)"
-msgstr ""
+msgstr "Lade das Reguläre-Ausdruck-Paket (sregex)"
 
 #: ../../src/wxMaximaFrame.cpp:1224
 msgid "Load the translation generator (gentran)"
-msgstr ""
+msgstr "Lade das Paket für andere Programmiersprachen (gentran)"
 
 #: ../../src/wxMaxima.cpp:8219
 msgid "Loop variable"
-msgstr ""
+msgstr "Schleifenvariable"
 
 #: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
 msgid "Lower bound:"
-msgstr ""
+msgstr "Untere Schranke:"
 
 #: ../../src/wxMaximaFrame.cpp:1127
 msgid "Lower, ignoring case?..."
@@ -4269,23 +4400,23 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1448
 msgid "M&atrix"
-msgstr ""
+msgstr "M&atrix"
 
 #: ../../src/wxMaxima.cpp:7153
 msgid "Macro contents:"
-msgstr ""
+msgstr "Makro-Inhalt:"
 
 #: ../../src/wxMaxima.cpp:7148
 msgid "Macro name:"
-msgstr ""
+msgstr "Makro Name:"
 
 #: ../../src/wxMaximaFrame.cpp:1024
 msgid "Macros"
-msgstr ""
+msgstr "Makros"
 
 #: ../../src/wxMaximaFrame.cpp:697
 msgid "Main Toolbar\tAlt+Shift+B"
-msgstr ""
+msgstr "Hauptsymbolleiste\tAlt+Shift+B"
 
 #: ../../src/wxMaxima.cpp:7906
 msgid "Make a function value at a specific point known"
@@ -4296,36 +4427,39 @@ msgid "Make an eventual ev() evaluate this"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1070
+#, fuzzy
 msgid "Make function local..."
-msgstr ""
+msgstr "Eine Funktion auf Elemente einer Liste anwenden"
 
 #: ../../src/wxMaxima.cpp:8207
 msgid "Map"
-msgstr ""
+msgstr "Auf Liste abbilden"
 
 #: ../../src/wxMaxima.cpp:8215
+#, fuzzy
 msgid "Map an expression"
 msgstr ""
+"Einen Ausdruck expandieren (ausmultiplizieren und in Terme aufspalten)"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "Map function to a matrix"
-msgstr ""
+msgstr "Eine Funktion auf Elemente einer Matrix anwenden"
 
 #: ../../src/wxMaximaFrame.cpp:1446
 msgid "Map function to a matrix, affecting all of its clones"
-msgstr ""
+msgstr "Eine Funktion auf Elemente einer Matrix (inklusive Klone) anwenden"
 
 #: ../../src/Configuration.cpp:109
 msgid "Math Default"
-msgstr ""
+msgstr "Standard für Mathematik"
 
 #: ../../src/wxMaximaFrame.cpp:286
 msgid "Mathematical Symbols"
-msgstr ""
+msgstr "Mathematische Symbole"
 
 #: ../../src/ToolBar.cpp:270
 msgid "Maths"
-msgstr ""
+msgstr "Mathematik"
 
 #: ../../src/wxMaxima.cpp:7945 ../../src/wxMaxima.cpp:8022
 #: ../../src/wxMaxima.cpp:8027 ../../src/wxMaxima.cpp:8032
@@ -4337,54 +4471,54 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
 #: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
 msgid "Matrix"
-msgstr ""
+msgstr "Matrix"
 
 #: ../../src/wxMaxima.cpp:7986
 msgid "Matrix Exponent"
-msgstr ""
+msgstr "Matrix-Exponent"
 
 #: ../../src/wxMaximaFrame.cpp:1339
 msgid "Matrix exponent..."
-msgstr ""
+msgstr "Matrix-Exponent..."
 
 #: ../../src/wxMaximaFrame.cpp:1329
 msgid "Matrix from csv file"
-msgstr ""
+msgstr "Matrix aus csv-Datei"
 
 #: ../../src/wxMaximaFrame.cpp:1323
 msgid "Matrix from csv file..."
-msgstr ""
+msgstr "Matrix aus csv-Datei..."
 
 #: ../../src/wxMaxima.cpp:8137
 msgid "Matrix map"
-msgstr ""
+msgstr "Auf Matrix abbilden"
 
 #: ../../src/wxMaxima.cpp:9630
 msgid "Matrix name:"
-msgstr ""
+msgstr "Matrix Name:"
 
 #: ../../src/wxMaximaFrame.cpp:798
 msgid "Matrix parenthesis"
-msgstr ""
+msgstr "Klammern um Matrizen"
 
 #: ../../src/wxMaximaFrame.cpp:1331
 msgid "Matrix to csv file"
-msgstr ""
+msgstr "Matrix als csv-Datei speichern"
 
 #: ../../src/wxMaximaFrame.cpp:1334
 msgid "Matrix to file or Matrix from file"
-msgstr ""
+msgstr "Matrix in Datei schreiben oder von Datei lesen"
 
 #: ../../src/wxMaximaFrame.cpp:1761
 msgid "Matrix to nested List"
-msgstr ""
+msgstr "Matrix zu verschachtelter Liste"
 
 #: ../../src/wxMaxima.cpp:7956 ../../src/wxMaxima.cpp:7961
 #: ../../src/wxMaxima.cpp:7966 ../../src/wxMaxima.cpp:7971
 #: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
 #: ../../src/wxMaxima.cpp:8136
 msgid "Matrix:"
-msgstr ""
+msgstr "Matrix:"
 
 #: ../../src/wxMaxima.cpp:8627
 msgid ""
@@ -4397,15 +4531,15 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:3473
 #, c-format
 msgid "Maxima architecture: %s"
-msgstr ""
+msgstr "Architektur von Maxima: %s"
 
 #: ../../src/StatusBar.cpp:252
 msgid "Maxima asks a question"
-msgstr ""
+msgstr "Maxima hat eine Frage."
 
 #: ../../src/wxMaxima.cpp:4066
 msgid "Maxima asks a question!"
-msgstr ""
+msgstr "Maxima hat eine Frage!"
 
 #: ../../src/wxMaxima.cpp:7118
 msgid ""
@@ -4414,168 +4548,172 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3304
+#, fuzzy
 msgid "Maxima didn't attempt to authenticate!"
-msgstr ""
+msgstr "Keine Verbindung mit Maxima in der festgelegten Zeit"
 
 #: ../../src/Configuration.cpp:84
 msgid "Maxima errors"
-msgstr ""
+msgstr "Fehlermeldungen von Maxima"
 
 #: ../../src/wxMaxima.cpp:3289
+#, fuzzy
 msgid "Maxima has authenticated!"
-msgstr ""
+msgstr "Maxima wurde beendet."
 
 #: ../../src/wxMaxima.cpp:10533
 msgid "Maxima has finished calculating."
-msgstr ""
+msgstr "Maxima ist mit dem Rechnen fertig."
 
 #: ../../src/wxMaxima.cpp:5832
 msgid "Maxima has issued an error!"
-msgstr ""
+msgstr "Maxima hat eine Fehlermeldung ausgegeben!"
 
 #: ../../src/wxMaxima.cpp:3696
 #, c-format
 msgid "Maxima has loaded the file %s."
-msgstr ""
+msgstr "Maxima hat die Datei %s geladen."
 
 #: ../../src/wxMaxima.cpp:3382
 msgid "Maxima has sent a new variable value."
-msgstr ""
+msgstr "Maxima hat einen neuen Variablenwert gesendet."
 
 #: ../../src/MaximaManual.cpp:552
 msgid "Maxima help file not found!"
-msgstr ""
+msgstr "Maxima-Hilfedatei nicht gefunden!"
 
 #: ../../src/wxMaximaFrame.cpp:1043
 msgid "Maxima input"
-msgstr ""
+msgstr "Maxima Eingabe"
 
 #: ../../src/StatusBar.cpp:236
 msgid "Maxima is calculating"
-msgstr ""
+msgstr "Maxima ist beim Rechnen"
 
 #: ../../src/wxMaxima.cpp:5068
 msgid "Maxima is ready for input."
-msgstr ""
+msgstr "Maxima ist bereit."
 
 #: ../../src/Dirstructure.cpp:144
 #, c-format
 msgid "Maxima not found as %s"
-msgstr ""
+msgstr "Maxima wurde nicht unter %s gefunden"
 
 #: ../../src/wxMaxima.cpp:6211
 msgid "Maxima package (*.mac)|*.mac"
-msgstr ""
+msgstr "Maxima Paket (*.mac)|*.mac"
 
 #: ../../src/wxMaxima.cpp:6202
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
-msgstr ""
+msgstr "Maxima Paket (*.mac)|*.mac|Lisp Paket (*.lisp)|*.lisp|Alle|*"
 
 #: ../../src/wxMaxima.cpp:3012
 msgid "Maxima process terminated unexpectedly."
-msgstr ""
+msgstr "Maxima wurde unerwartet beendet."
 
 #: ../../src/Configuration.cpp:79
 msgid "Maxima question labels"
-msgstr ""
+msgstr "Maxima Fragen-Markierungen"
 
 #: ../../src/wxMaxima.cpp:3380
 msgid "Maxima sends a new set of auto-completable symbols."
 msgstr ""
+"Maxima sendet einen neuen Satz von Symbolen für die Auto-Vervollständigung."
 
 #: ../../src/wxMaxima.cpp:3908
 msgid "Maxima sends us a new set of variables for the watch list."
-msgstr ""
+msgstr "Maxima sendet einen neuen Satz an Variablen für die Beobachtungsliste"
 
 #: ../../src/wxMaximaFrame.cpp:1944
 msgid "Maxima shows help in a browser"
-msgstr ""
+msgstr "Maxima zeigt die Hilfe im Browser"
 
 #: ../../src/wxMaximaFrame.cpp:1940
 msgid "Maxima shows help in a sidebar"
-msgstr ""
+msgstr "Maxima zeigt die Hilfe in der Seitenleiste"
 
 #: ../../src/wxMaximaFrame.cpp:1935
 msgid "Maxima shows help in the console"
-msgstr ""
+msgstr "Maxima zeigt die Hilfe in der Konsole"
 
 #: ../../src/StatusBar.cpp:232
+#, fuzzy
 msgid "Maxima started. Waiting for authentication..."
-msgstr ""
+msgstr "Maxima gestartet. Warte auf Verbindung ..."
 
 #: ../../src/StatusBar.cpp:212
 msgid "Maxima started. Waiting for connection..."
-msgstr ""
+msgstr "Maxima gestartet. Warte auf Verbindung ..."
 
 #: ../../src/StatusBar.cpp:228
 msgid "Maxima started. Waiting for initial prompt..."
-msgstr ""
+msgstr "Maxima gestartet. Warte auf den ersten Prompt..."
 
 #: ../../src/wxMaximaFrame.cpp:1231
 msgid "Maxima to other language"
-msgstr ""
+msgstr "Maxima in eine andere Programmiersprache konvertieren"
 
 #: ../../src/wxMaxima.cpp:7213
 msgid "Maxima to string"
-msgstr ""
+msgstr "Maxima als String"
 
 #: ../../src/wxMaxima.cpp:3397
 #, c-format
 msgid "Maxima user configuration is located in directory %s"
-msgstr ""
+msgstr "Die (Benutzer)Konfigurationsdateien von Maxima liegen unter %s"
 
 #: ../../src/wxMaxima.cpp:3443
 #, c-format
 msgid "Maxima uses temp directory %s"
-msgstr ""
+msgstr "Temporäre Dateien von Maxima liegen im Verzeichnis %s"
 
 #: ../../src/wxMaxima.cpp:3469
 #, c-format
 msgid "Maxima version: %s"
-msgstr ""
+msgstr "Maxima-Version: %s"
 
 #: ../../src/MaximaManual.cpp:390
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima version: %s, Anchors cache version"
-msgstr ""
+msgstr "Maxima-Version: %s"
 
 #: ../../src/wxMaximaFrame.cpp:1925
 msgid "Maxima vs. Programming languages"
-msgstr ""
+msgstr "Maxima vs. andere Programmiersprachen"
 
 #: ../../src/Configuration.cpp:83
 msgid "Maxima warnings"
-msgstr ""
+msgstr "Warnungen von Maxima"
 
 #: ../../src/wxMaxima.cpp:3687
 #, c-format
 msgid "Maxima was compiled using %s"
-msgstr ""
+msgstr "Maxima wurde mittels %s compiliert"
 
 #: ../../src/wxMaxima.cpp:3487
 #, c-format
 msgid "Maxima's HTML manuals are in directory %s"
-msgstr ""
+msgstr "Maxima's HTML-Handbuch liegt im Ordner %s"
 
 #: ../../src/wxMaxima.cpp:3099
 #, c-format
 msgid "Maxima's PID is %li"
-msgstr ""
+msgstr "Die Prozess-ID von Maxima ist %li"
 
 #: ../../src/wxMaxima.cpp:3681
 #, c-format
 msgid "Maxima's demo files are located in directory %s"
-msgstr ""
+msgstr "Die Demo-Dateien von Maxima liegen unter %s"
 
 #: ../../src/wxMaxima.cpp:3478
 #, c-format
 msgid "Maxima's manual is located in directory %s"
-msgstr ""
+msgstr "Maxima's Handbuch liegt im Ordner %s"
 
 #: ../../src/wxMaxima.cpp:3670
 #, c-format
 msgid "Maxima's share files are located in directory %s"
-msgstr ""
+msgstr "Die Zusatzdateien für Maxima liegen unter %s"
 
 #: ../../src/StatusBar.cpp:66
 msgid ""
@@ -4587,6 +4725,13 @@ msgid ""
 "not only intercepts connections from the outside, but also to intercept "
 "connections between two programs that run on the same computer."
 msgstr ""
+"Maxima, das das eigentliche Rechnen übernimmt und wxMaxima, das Programm, "
+"das das Arbeitsblatt anzeigt, werden als separate Prozesse gestartet. Falls "
+"Maxima abstürzt bleibt daher das Arbeitsblatt intakt. Die Kommunikation "
+"erfolgt dabei über ein lokales Netzwerk. Dieses Mal konnte kein "
+"Netzwerksocket erstellt werden, was heißen kann, dass die Firewall dieses "
+"Rechners so eingestellt ist, dass sie nicht nur Verbindungen von außerhalb "
+"des Rechners, sondern auch innerhalb des Rechners unterbindet."
 
 #: ../../src/StatusBar.cpp:75
 msgid ""
@@ -4601,194 +4746,208 @@ msgid ""
 "might be that maxima cannot be found (see wxMaxima's Configuration dialogue "
 "for a way to specify maxima's location) or isn't in a working order."
 msgstr ""
+"Maxima, das das eigentliche Rechnen übernimmt und wxMaxima, das Programm, "
+"das das Arbeitsblatt anzeigt, werden als separate Prozesse gestartet. Falls "
+"Maxima abstürzt bleibt daher das Arbeitsblatt intakt. Die Kommunikation "
+"erfolgt dabei über ein lokales Netzwerk. Diese Verbindung ist noch nicht "
+"erfolgt. Dies kann heißen, dass Maxima nicht gestartet werden konnte, noch "
+"am Hochfahren ist, oder, dass die Firewall dieses Rechners nicht nur "
+"Verbindungen von außerhalb, sondern auch zwischen zwei Programmen innerhalb "
+"dieses Computers unterbindet. Alternativ kann in der Konfiguration der "
+"falsche Ort angegeben sein, wo Maxima zu suchen ist oder Maxima ganz einfach"
+" nicht funktionieren."
 
 #: ../../src/StatusBar.cpp:61
 msgid ""
 "Maxima, the program that does the actual mathematics is started as a separate process. This has the advantage that an eventual crash of maxima cannot harm wxMaxima, which displays the worksheet.\n"
 "This icon indicates if data is transferred between maxima and wxMaxima."
 msgstr ""
+"Maxima, das das eigentliche Rechnen übernimmt und wxMaxima, das Programm, das das Arbeitsblatt anzeigt, werden als separate Prozesse auf demselben Rechner gestartet und kommunizieren über ein lokales Netzwerk.\n"
+"Dieses Icon zeigt an, wenn die Programme Daten miteinander austauschen."
 
 #: ../../src/wxMaxima.cpp:9228
 msgid "Maximum absolute value printed without exponent"
-msgstr ""
+msgstr "Betrag der höchsten Zahl, die ohne Exponent dargestellt werden soll"
 
 #: ../../src/wxMaxima.cpp:9230
 msgid "Maximum number of digits to be displayed:"
-msgstr ""
+msgstr "Maximale Anzahl an anzuzeigenden Ziffern:"
 
 #: ../../src/wxMaxima.cpp:9568
 msgid "Mean:"
-msgstr ""
+msgstr "Mittelwert:"
 
 #: ../../src/wxMaximaFrame.cpp:1924
 msgid "Memoizing"
-msgstr ""
+msgstr "Memoizing"
 
 #: ../../src/wxMaximaFrame.cpp:1013
 msgid "Memory"
-msgstr ""
+msgstr "Speicher"
 
 #: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
 msgid "Merge Cells"
-msgstr ""
+msgstr "Zellen verbinden"
 
 #: ../../src/wxMaxima.cpp:5780
 msgid "Message from the stdout of Maxima: "
-msgstr ""
+msgstr "Nachricht vom stdout von Maxima: "
 
 #: ../../src/wxMaximaFrame.cpp:1326
 msgid "Methods of generating a matrix"
-msgstr ""
+msgstr "Methoden, eine Matrix zu erzeugen"
 
 #: ../../src/Worksheet.cpp:6866
 #, c-format
 msgid "Middle-click clipboard data: %s"
 msgstr ""
+"Inhalt der Zwischenablage für Klicks mit dem mittleren Maus-Button: %s"
 
 #: ../../src/wxMaxima.cpp:9226
 msgid "Minimum absolute value printed without exponent:"
-msgstr ""
+msgstr "Betrag der kleinsten Zahl, die ohne Exponent dargestellt werden soll:"
 
 #: ../../src/wxMaxima.cpp:10449 ../../src/wxMaxima.cpp:10451
 msgid "Mismatched parenthesis"
-msgstr ""
+msgstr "Nicht-zusammengehörige Klammern"
 
 #: ../../src/wxMaximaFrame.cpp:1352
 msgid "Multiplication, exponent and similar"
-msgstr ""
+msgstr "Multiplikation, Exponent und ähnliches"
 
 #: ../../src/Worksheet.cpp:1998
 msgid "Multiplicative function: f(a*b)=f(a)*f(b)"
-msgstr ""
+msgstr "Multiplikative Funktion:  f(a*b)=f(a)*f(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1338
 msgid "Multiply matrices..."
-msgstr ""
+msgstr "Multipliziere Matrizen..."
 
 #: ../../src/wxMaxima.cpp:7981
 msgid "Multiply two matrices"
-msgstr ""
+msgstr "Multipliziere zwei Matrizen"
 
 #: ../../src/wxMaxima.cpp:9581
 msgid "Multivariate linear regression"
-msgstr ""
+msgstr "Multivariate Lineare Regression..."
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Name of t:"
-msgstr ""
+msgstr "Name von t:"
 
 #: ../../src/wxMaxima.cpp:7838
 msgid "Name of x:"
-msgstr ""
+msgstr "Name von x:"
 
 #: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
 msgid "Nested list to Matrix"
-msgstr ""
+msgstr "Verschachtelte Liste zu Matrix"
 
 #: ../../src/wxMaximaFrame.cpp:769 ../../src/wxMaximaFrame.cpp:1053
 msgid "Never"
-msgstr ""
+msgstr "Nie"
 
 #: ../../src/wxMaxima.cpp:6534
 msgid "Never autosubscript this variable"
-msgstr ""
+msgstr "Diese Variable niemals automatisch mit Subscript ausstatten"
 
 #: ../../src/wxMaximaFrame.cpp:776
 msgid "Never display this variable with subscript"
-msgstr ""
+msgstr "Stelle diese Variable nie mit Tiefstellung dar"
 
 #: ../../src/Worksheet.cpp:1469 ../../src/Worksheet.cpp:1843
 msgid "Never offer known answers"
-msgstr ""
+msgstr "Biete keine bekannten Antworten an"
 
 #: ../../src/ToolBar.cpp:174
 msgid "New"
-msgstr ""
+msgstr "Neu"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "New\tCtrl+N"
-msgstr ""
+msgstr "Neu\tCtrl+N"
 
 #: ../../src/ToolBar.cpp:611
 msgid "New button"
-msgstr ""
+msgstr "Der \"Neu\"-Knopf"
 
 #: ../../src/wxMaxima.cpp:2483
 msgid "New connection attempt whilst already connected."
-msgstr ""
+msgstr "Neue Verbindungsanfrage, während Maxima bereits verbunden ist."
 
 #: ../../src/wxMaxima.cpp:2491
+#, fuzzy
 msgid ""
 "New connection attempt, but no currently no socket maxima could connect to."
-msgstr ""
+msgstr "Neuer Verbindungsversuch, aber kein laufender Maxima-Prozess."
 
 #: ../../src/wxMaxima.cpp:2487
 msgid "New connection attempt, but no currently running maxima process."
-msgstr ""
+msgstr "Neuer Verbindungsversuch, aber kein laufender Maxima-Prozess."
 
 #: ../../src/ToolBar.cpp:174
 msgid "New document"
-msgstr ""
+msgstr "Neues Dokument"
 
 #: ../../src/wxMaxima.cpp:3899
 #, c-format
 msgid "New maxima Operators detected: %s"
-msgstr ""
+msgstr "Neue Maxima Operatoren erkannt: %s"
 
 #: ../../src/wxMaxima.cpp:7390
 msgid "New part:"
-msgstr ""
+msgstr "Neuer Abschnitt:"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
 #: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
 msgid "New variable:"
-msgstr ""
+msgstr "Neue Variable:"
 
 #: ../../src/wxMaximaFrame.cpp:929
 msgid "Next Command\tAlt+Down"
-msgstr ""
+msgstr "Nächster Befehl\tAlt+Down"
 
 #: ../../src/wxMaximaFrame.cpp:748
 msgid "Nice Graphical Equations"
-msgstr ""
+msgstr "Schöne graphische Darstellung der Gleichungen"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "No"
-msgstr ""
+msgstr "Nein"
 
 #: ../../src/Worksheet.cpp:1972
 msgid "No Array"
-msgstr ""
+msgstr "Kein Array"
 
 #: ../../src/Worksheet.cpp:1974
 msgid "No Scalar"
-msgstr ""
+msgstr "Kein Skalar"
 
 #: ../../src/wxMaxima.cpp:10482
 msgid "No dollar ($) or semicolon (;) at the end of command"
-msgstr ""
+msgstr "Kein Dollarzeichen ($) oder Semikolon (;) am Ende eines Befehls"
 
 #: ../../src/MaximaManual.cpp:406
 msgid "No entries in the caches for the subjects the manual contains."
-msgstr ""
+msgstr "Keine Einträge im Zwischenspeicher für Handbucheinträge."
 
 #: ../../src/MaximaManual.cpp:101
 msgid ""
 "No file with the subjects the manual contained in the last wxMaxima run."
-msgstr ""
+msgstr "Keine Datei für die Handbucheinträge gefunden."
 
 #: ../../src/Image.cpp:495
 msgid "No gnuplot data!"
-msgstr ""
+msgstr "Keine Gnuplot-Daten!"
 
 #: ../../src/Image.cpp:530
 msgid "No gnuplot source!"
-msgstr ""
+msgstr "Kein Gnuplot-Quellcode des Diagramms!"
 
 #: ../../src/wxMaxima.cpp:6662 ../../src/wxMaxima.cpp:6668
 #: ../../src/wxMaxima.cpp:6687 ../../src/wxMaxima.cpp:6697
 msgid "No matches found!"
-msgstr ""
+msgstr "Keine Übereinstimmung gefunden!"
 
 #: ../../src/wxMaxima.cpp:3240
 msgid "No topics found in topic flag"
@@ -4800,108 +4959,112 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:797
 msgid "None"
-msgstr ""
+msgstr "Keine"
 
 #: ../../src/wxMaxima.cpp:8163
 msgid "Not a valid matrix dimension!"
-msgstr ""
+msgstr "Keine gültige Dimension einer Matrix!"
 
 #: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
 msgid "Not a valid number of equations!"
-msgstr ""
+msgstr "Keine gültige Anzahl an Gleichungen!"
 
 #: ../../src/StatusBar.cpp:256
 msgid "Not connected to Maxima"
-msgstr ""
+msgstr "Nicht mit Maxima verbunden"
 
 #: ../../src/wxMaxima.cpp:10496
 msgid "Not triggering evaluation as maxima is still busy!"
-msgstr ""
+msgstr "Keine Evaluierung auslösen, Maxima ist beschäftigt!"
 
 #: ../../src/wxMaxima.cpp:10503
 msgid "Not triggering evaluation as maxima still asks a question!"
-msgstr ""
+msgstr "Keine Evaluierung auslösen, Maxima hat eine Frage!"
 
 #: ../../src/wxMaxima.cpp:10511
 msgid "Not triggering evaluation as there is no working maxima process"
-msgstr ""
+msgstr "Keine Evaluierung auslösen, es gibt keinen laufenden Maxima Prozess"
 
 #: ../../src/wxMaxima.cpp:8926
 msgid "Num. deg:"
-msgstr ""
+msgstr "Grad Zähler:"
 
 #: ../../src/wxMaxima.cpp:8540
 msgid "Number of elements"
-msgstr ""
+msgstr "Anzahl der Elemente"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
 msgid "Number of equations:"
-msgstr ""
+msgstr "Anzahl Gleichungen:"
 
 #: ../../src/wxMaxima.cpp:7481
+#, fuzzy
 msgid "Number to octets"
-msgstr ""
+msgstr "Zahlentypen"
 
 #: ../../src/wxMaximaFrame.cpp:1154
+#, fuzzy
 msgid "Number to octets..."
-msgstr ""
+msgstr "Anzahl der Elemente"
 
 #: ../../src/wxMaximaFrame.cpp:1906
 msgid "Number types"
-msgstr ""
+msgstr "Zahlentypen"
 
 #: ../../src/wxMaxima.cpp:7482
 msgid "Number:"
-msgstr ""
+msgstr "Zahl:"
 
 #: ../../src/wxMaximaFrame.cpp:1786
 msgid "Numeric output"
-msgstr ""
+msgstr "Numerische Ausgabe"
 
 #: ../../src/wxMaxima.cpp:8040
 msgid "Numerical QR decomposition of a matrix"
-msgstr ""
+msgstr "Numerische QR-Zerlegung einer Matrix"
 
 #: ../../src/wxMaximaFrame.cpp:1417
 msgid "Numerical operations (lapack)"
-msgstr ""
+msgstr "Numerische Operationen (Lapack)"
 
 #: ../../src/wxMaxima.cpp:7831
 msgid "Numerical solution for 1st degree ODE"
-msgstr ""
+msgstr "Numerische LÖsung einer gewöhnlichen DGL ersten Grades"
 
 #: ../../src/wxMaximaFrame.cpp:1282
 msgid "Numerical solution..."
-msgstr ""
+msgstr "Numerische Lösung..."
 
 #: ../../src/wxMaximaFrame.cpp:1261
 msgid "Numerical solutions of polynomial (bfloat)..."
-msgstr ""
+msgstr "Numerische Nullstellen eines Polynoms suchen (bfloat)..."
 
 #: ../../src/wxMaximaFrame.cpp:1258
 msgid "Numerical solutions of polynomial..."
-msgstr ""
+msgstr "Numerische Nullstellen eines Polynoms suchen..."
 
 #: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: ../../src/wxMaximaFrame.cpp:122
 #, c-format
 msgid "OS: %s Version %li.%li"
-msgstr ""
+msgstr "Betriebssystem: %s, Version %li.%li"
 
 #: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
+#, fuzzy
 msgid "Object composed of elements"
-msgstr ""
+msgstr "Anzahl der Elemente"
 
 #: ../../src/wxMaxima.cpp:7680
+#, fuzzy
 msgid "Object name:"
-msgstr ""
+msgstr "Name der Liste:"
 
 #: ../../src/wxMaxima.cpp:7281
 msgid "Object:"
-msgstr ""
+msgstr "Objekt:"
 
 #: ../../src/wxMaxima.cpp:7486
 msgid "Octets to Number"
@@ -4909,172 +5072,172 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7491
 msgid "Octets to String"
-msgstr ""
+msgstr "Oktett als String"
 
 #: ../../src/wxMaximaFrame.cpp:1156
 msgid "Octets to number..."
-msgstr ""
+msgstr "Oktett als Zahl..."
 
 #: ../../src/wxMaximaFrame.cpp:1158
 msgid "Octets to string..."
-msgstr ""
+msgstr "Oktett als String"
 
 #: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
 msgid "Octets:"
-msgstr ""
+msgstr "Oktette:"
 
 #: ../../src/Worksheet.cpp:1958
 msgid "Odd number"
-msgstr ""
+msgstr "Ungerade Zahl"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
 #: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
 msgid "Old variable:"
-msgstr ""
+msgstr "Alte Variable:"
 
 #: ../../src/wxMaximaFrame.cpp:1055
 msgid "On all errors"
-msgstr ""
+msgstr "Bei allen Fehlern"
 
 #: ../../src/wxMaximaFrame.cpp:1054
 msgid "On lisp errors"
-msgstr ""
+msgstr "Bei Lisp Fehlern"
 
 #: ../../src/wxMaxima.cpp:9566
 msgid "One sample t-test"
-msgstr ""
+msgstr "Einstichproben t-Test"
 
 #: ../../src/wxMaximaFrame.cpp:1927
 msgid "Online tutorials"
-msgstr ""
+msgstr "Online Tutorials"
 
 #: ../../src/wxMaximaFrame.cpp:766
 msgid "Only Integers and single letters"
-msgstr ""
+msgstr "Nur ganze Zahlen und einzelne Buchstaben"
 
 #: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593
 #: ../../src/wxMaxima.cpp:6074
 msgid "Open"
-msgstr ""
+msgstr "Öffnen"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "Open a document"
-msgstr ""
+msgstr "Dokument öffnen"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "Open a new window"
-msgstr ""
+msgstr "Neues Fenster öffnen"
 
 #: ../../src/ToolBar.cpp:617
 msgid "Open and save button"
-msgstr ""
+msgstr "Der \"Öffnen\"- und \"Speichern\"-Knopf"
 
 #: ../../src/ToolBar.cpp:176
 msgid "Open document"
-msgstr ""
+msgstr "Dokument öffnen"
 
 #: ../../src/wxMaxima.cpp:7239
 msgid "Open for appending"
-msgstr ""
+msgstr "Öffne zum Anfügen"
 
 #: ../../src/wxMaximaFrame.cpp:1099
 msgid "Open for appending..."
-msgstr ""
+msgstr "Öffnen zum Anfügen..."
 
 #: ../../src/wxMaxima.cpp:7244
 msgid "Open for reading"
-msgstr ""
+msgstr "Öffne zum Lesen"
 
 #: ../../src/wxMaximaFrame.cpp:1098
 msgid "Open for reading..."
-msgstr ""
+msgstr "Öffne zum Lesen..."
 
 #: ../../src/wxMaxima.cpp:7249
 msgid "Open for writing"
-msgstr ""
+msgstr "Öffne zum Schreiben"
 
 #: ../../src/wxMaximaFrame.cpp:1100
 msgid "Open for writing..."
-msgstr ""
+msgstr "Öffne zum Schreiben..."
 
 #: ../../src/wxMaxima.cpp:9598
 msgid "Open matrix"
-msgstr ""
+msgstr "Matrix laden"
 
 #: ../../src/wxMaximaFrame.cpp:600
 msgid "Open recent"
-msgstr ""
+msgstr "Zuletzt geöffnet"
 
 #: ../../src/wxMaxima.cpp:4309
 msgid "Opening a wxmx file"
-msgstr ""
+msgstr "Öffne eine .wxmx-Datei"
 
 #: ../../src/wxMaxima.cpp:4153 ../../src/wxMaxima.cpp:4214
 #: ../../src/wxMaxima.cpp:4313 ../../src/wxMaxima.cpp:4622
 msgid "Opening file"
-msgstr ""
+msgstr "Öffne Datei"
 
 #: ../../src/wxMaxima.cpp:5030
 #, c-format
 msgid "Opening help file %s"
-msgstr ""
+msgstr "Öffne die Hilfedatei %s"
 
 #: ../../src/wxMaximaFrame.cpp:1530
 msgid "Optimize for CPU time"
-msgstr ""
+msgstr "Optimiere die CPU-Zeit"
 
 #: ../../src/wxMaximaFrame.cpp:1529
 msgid "Optimize for memory"
-msgstr ""
+msgstr "Optimiere den Speicherbedarf"
 
 #: ../../src/ToolBar.cpp:199
 msgid "Options"
-msgstr ""
+msgstr "Optionen"
 
 #: ../../src/wxMaximaFrame.cpp:1225
 msgid "Output C"
-msgstr ""
+msgstr "C Code ausgeben"
 
 #: ../../src/wxMaximaFrame.cpp:1226
 msgid "Output Fortran"
-msgstr ""
+msgstr "Fortran Code ausgeben"
 
 #: ../../src/wxMaximaFrame.cpp:1228
 msgid "Output Rational Fortran"
-msgstr ""
+msgstr "Rational Fortran Code ausgeben"
 
 #: ../../src/Configuration.cpp:80
 msgid "Output labels"
-msgstr ""
+msgstr "Ausgabemarken"
 
 #: ../../src/Configuration.cpp:73
 msgid "Output: Function names"
-msgstr ""
+msgstr "Ausgabe: Funktionsnamen"
 
 #: ../../src/Configuration.cpp:75
 msgid "Output: Latin names as greek symbols"
-msgstr ""
+msgstr "Ausgabe: Namen als Griechische Symbole"
 
 #: ../../src/Configuration.cpp:72
 msgid "Output: Numbers and Digits"
-msgstr ""
+msgstr "Ausgabe: Zahlen und Ziffern"
 
 #: ../../src/Configuration.cpp:71
 msgid "Output: Operators"
-msgstr ""
+msgstr "Ausgabe: Operatoren"
 
 #: ../../src/Configuration.cpp:74
 #, c-format
 msgid "Output: Special constants (%e,%i)"
-msgstr ""
+msgstr "Ausgabe: Besondere Konstanten (%e,%i)"
 
 #: ../../src/Configuration.cpp:76
 msgid "Output: Strings"
-msgstr ""
+msgstr "Ausgabe: Strings"
 
 #: ../../src/Configuration.cpp:70
 msgid "Output: Variable names"
-msgstr ""
+msgstr "Ausgabe: Variablennamen"
 
 #: ../../src/wxMaxima.cpp:6442
 msgid ""
@@ -5083,6 +5246,10 @@ msgid ""
 "(*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format "
 "(*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"PNG-Bild (*.png)|*.png|JPEG-Bild (*.jpg)|*.jpg|GIF-Bild "
+"(*.gif)|*.gif|Scaleable vector graphics (*.svg)|*.svg|Windows bitmap "
+"(*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format "
+"(*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:10117
 msgid ""
@@ -5090,143 +5257,146 @@ msgid ""
 "(*.bmp)|*.bmp|GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged "
 "image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap "
+"(*.bmp)|*.bmp|GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged "
+"image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:8924
 msgid "Pade approximation"
-msgstr ""
+msgstr "Pade-Approximation"
 
 #: ../../src/wxMaximaFrame.cpp:1478
 msgid "Pade approximation of a Taylor series"
-msgstr ""
+msgstr "Pade-Approximation einer Taylorreihe"
 
 #: ../../src/wxMaximaFrame.cpp:1637
 msgid "Parallel Substitute..."
-msgstr ""
+msgstr "Parallel Substituieren..."
 
 #: ../../src/wxMaxima.cpp:8738
 msgid "Parallel substitution"
-msgstr ""
+msgstr "Parallel Substituieren"
 
 #: ../../src/wxMaxima.cpp:7179
 msgid "Parameter name:"
-msgstr ""
+msgstr "Parameter Name:"
 
 #: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
 msgid "Parameter(s):"
-msgstr ""
+msgstr "Parameter:"
 
 #: ../../src/wxMaxima.cpp:7399
 msgid "Parse string"
-msgstr ""
+msgstr "String auswerten"
 
 #: ../../src/wxMaximaFrame.cpp:1152
 msgid "Parse string only..."
-msgstr ""
+msgstr "Nur String auswerten..."
 
 #: ../../src/StatusBar.cpp:240
 msgid "Parsing output"
-msgstr ""
+msgstr "Werte die Ausgabe aus"
 
 #: ../../src/wxMaxima.cpp:7464
 msgid "Part:"
-msgstr ""
+msgstr "Teil:"
 
 #: ../../src/wxMaximaFrame.cpp:1499 ../../src/wxMaximaFrame.cpp:1535
 msgid "Partial &Fractions..."
-msgstr ""
+msgstr "Partialbruch&zerlegung ..."
 
 #: ../../src/wxMaxima.cpp:8975
 msgid "Partial Fractions"
-msgstr ""
+msgstr "Partialbrüche"
 
 #: ../../src/wxMaxima.cpp:4702
 msgid "Parts of the document will not be loaded correctly!"
-msgstr ""
+msgstr "Teile des Dokuments werden nicht korrekt geladen!"
 
 #: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
 #: ../../src/Worksheet.cpp:1685
 msgid "Paste"
-msgstr ""
+msgstr "Einfügen"
 
 #: ../../src/wxMaximaFrame.cpp:667
 msgid "Paste\tCtrl+V"
-msgstr ""
+msgstr "Einfügen\tCtrl+V"
 
 #: ../../src/ToolBar.cpp:211
 msgid "Paste from clipboard"
-msgstr ""
+msgstr "Aus Zwischenablage einfügen"
 
 #: ../../src/wxMaximaFrame.cpp:668
 msgid "Paste text from clipboard"
-msgstr ""
+msgstr "Text aus Zwischenablage einfügen"
 
 #: ../../src/wxMaxima.cpp:4841
 msgid "Please configure wxMaxima with 'Edit->Configure'."
-msgstr ""
+msgstr "Bitte konfigurieren Sie wxMaxima mit 'Bearbeiten->Einstellungen'."
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot &2d..."
-msgstr ""
+msgstr "Plot &2D ..."
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot &3d..."
-msgstr ""
+msgstr "Plot &3D ..."
 
 #: ../../src/wxMaximaFrame.cpp:1772
 msgid "Plot &Format..."
-msgstr ""
+msgstr "Plot &Format ..."
 
 #: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
 msgid "Plot 2D"
-msgstr ""
+msgstr "2D Plotten"
 
 #: ../../src/Worksheet.cpp:1593
 msgid "Plot 2D..."
-msgstr ""
+msgstr "2D Plotten ..."
 
 #: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
 msgid "Plot 3D"
-msgstr ""
+msgstr "3D Plotten"
 
 #: ../../src/Worksheet.cpp:1595
 msgid "Plot 3D..."
-msgstr ""
+msgstr "3D Plotten ..."
 
 #: ../../src/wxMaxima.cpp:9538
 msgid "Plot as bars"
-msgstr ""
+msgstr "Zeichne als Balkendiagramm"
 
 #: ../../src/wxMaxima.cpp:9542
 msgid "Plot as error bars"
-msgstr ""
+msgstr "Zeichne als Fehlerbalken"
 
 #: ../../src/wxMaxima.cpp:9546
 msgid "Plot as pie chart"
-msgstr ""
+msgstr "Zeichne als Tortendiagramm"
 
 #: ../../src/wxMaxima.cpp:9112
 msgid "Plot format"
-msgstr ""
+msgstr "Plot-Format"
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot in 2 dimensions"
-msgstr ""
+msgstr "In zwei Dimensionen plotten"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot in 3 dimensions"
-msgstr ""
+msgstr "In drei Dimensionen plotten"
 
 #: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
 msgid "Plot using Draw"
-msgstr ""
+msgstr "Plotte mittels Draw"
 
 #: ../../src/wxMaxima.cpp:7824
 msgid "Point #1 with known value:"
-msgstr ""
+msgstr "Punkt #1 mit bekanntem Wert:"
 
 #: ../../src/wxMaxima.cpp:7826
 msgid "Point #2 with known value:"
-msgstr ""
+msgstr "Punkt #2 mit bekanntem Wert:"
 
 #: ../../src/wxMaxima.cpp:7800 ../../src/wxMaxima.cpp:7811
 msgid "Point the value is known at:"
@@ -5234,140 +5404,143 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
 msgid "Point:"
-msgstr ""
+msgstr "Punkt:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 1:"
-msgstr ""
+msgstr "Polynom 1:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 2:"
-msgstr ""
+msgstr "Polynom 2:"
 
 #: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
 #: ../../src/wxMaxima.cpp:7739
 msgid "Polynomial:"
-msgstr ""
+msgstr "Polynom:"
 
 #: ../../src/wxMaximaFrame.cpp:1754
 msgid "Pop"
-msgstr ""
+msgstr "Pop"
 
 #: ../../src/Worksheet.cpp:1331 ../../src/Worksheet.cpp:1485
 msgid "Popout interactively"
-msgstr ""
+msgstr "In einem interaktiven Fenster öffnen."
 
 #: ../../src/wxMaximaFrame.cpp:1189
 msgid "Position of a match"
-msgstr ""
+msgstr "Position eines Treffers"
 
 #: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
 msgid "Position:"
-msgstr ""
+msgstr "Position:"
 
 #: ../../src/wxMaxima.cpp:8939
 msgid "Power series"
-msgstr ""
+msgstr "Potenzreihe"
 
 #: ../../src/wxMaximaFrame.cpp:1475
 msgid "Power series..."
-msgstr ""
+msgstr "Potenzreihe..."
 
 #: ../../src/wxMaxima.cpp:9202
 msgid "Precision"
-msgstr ""
+msgstr "Genauigkeit"
 
 #: ../../src/Worksheet.cpp:1616
 msgid "Prefer user labels"
-msgstr ""
+msgstr "Ziehe benutzerdefinierte Marken vor"
 
 #: ../../src/main.cpp:437
 msgid "Preferences"
-msgstr ""
+msgstr "\"Einstellungen\""
 
 #: ../../src/ToolBar.cpp:626
 msgid "Preferences button"
-msgstr ""
+msgstr "Der \"Einstellungen\"-Knopf"
 
 #: ../../src/wxMaximaFrame.cpp:685
 msgid "Preferences...\tCtrl+,"
-msgstr ""
+msgstr "Einstellungen...\tCtrl+,"
 
 #: ../../src/wxMaximaFrame.cpp:1733
 msgid "Prepend an element"
-msgstr ""
+msgstr "Voranstellen eines Elements"
 
 #: ../../src/wxMaximaFrame.cpp:927
 msgid "Previous Command\tAlt+Up"
-msgstr ""
+msgstr "Vorheriger Befehl\tAlt+Up"
 
 #: ../../src/ToolBar.cpp:184
 msgid "Print"
-msgstr ""
+msgstr "Drucken"
 
 #: ../../src/ToolBar.cpp:620
 msgid "Print button"
-msgstr ""
+msgstr "Der \"Drucken\"-Knopf"
 
 #: ../../src/Worksheet.cpp:1493
+#, fuzzy
 msgid "Print cell brackets"
-msgstr ""
+msgstr "Klammern aktive Zelle"
 
 #: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
 msgid "Print document"
-msgstr ""
+msgstr "Dokument drucken"
 
 #: ../../src/wxMaximaFrame.cpp:1829
 msgid "Print floating-point numbers with exponents dividable by 3"
-msgstr ""
+msgstr "Gebe Fließkommazahlen mit durch 3 teilbaren Exponenten aus"
 
 #: ../../src/WXMXformat.cpp:255
 msgid ""
 "Produced invalid XML. The erroneous XML data has therefore not been saved "
 "but has been put on the clipboard in order to allow to debug it."
 msgstr ""
+"Erzeugung von fehlerhaftem XML. Die XML-Daten wurden daher nicht "
+"gespeichert, sondern für die Analyse in die Zwischenablage gelegt."
 
 #: ../../src/wxMaxima.cpp:9061
 msgid "Product"
-msgstr ""
+msgstr "Produkt"
 
 #: ../../src/wxMaximaFrame.cpp:1095
 msgid "Program"
-msgstr ""
+msgstr "Programm"
 
 #: ../../src/wxMaxima.cpp:7061
 msgid "Program (no local variables)"
-msgstr ""
+msgstr "Programm (keine lokalen Variablen)"
 
 #: ../../src/wxMaxima.cpp:7052
 msgid "Program block"
-msgstr ""
+msgstr "Programmblock"
 
 #: ../../src/wxMaximaFrame.cpp:1066
 msgid "Program block with local variables..."
-msgstr ""
+msgstr "Programmblock mit lokalen Variablen..."
 
 #: ../../src/wxMaximaFrame.cpp:1068
 msgid "Program block, no local variables..."
-msgstr ""
+msgstr "Programmblock ohne lokale Variablen..."
 
 #: ../../src/wxMaximaFrame.cpp:1751
 msgid "Push"
-msgstr ""
+msgstr "Push"
 
 #: ../../src/wxMaxima.cpp:8508
 msgid "Push an element to a list"
-msgstr ""
+msgstr "Füge ein Listenelement an eine Liste an"
 
 #: ../../src/wxMaximaFrame.cpp:1395
 msgid "QR decomposition"
-msgstr ""
+msgstr "QR-Zerlegung"
 
 #: ../../src/wxMaxima.cpp:3621
 msgid "Querying gnuplot which graphics drivers it supports."
-msgstr ""
+msgstr "Frage Gnuplot, welche Graphiktreiber es unterstützt."
 
 #: ../../src/wxMaxima.cpp:8953
 msgid "Range radius:"
@@ -5375,58 +5548,60 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1374
 msgid "Rank"
-msgstr ""
+msgstr "Rang"
 
 #: ../../src/wxMaximaFrame.cpp:246 ../../src/wxMaximaFrame.cpp:722
 msgid "Raw XML monitor"
-msgstr ""
+msgstr "XML-Anzeige"
 
 #: ../../src/wxMaximaFrame.cpp:2117
 #, c-format
 msgid "Re-Reading the config from %s."
-msgstr ""
+msgstr "Lade die Konfiguration von %s neu."
 
 #: ../../src/wxMaximaFrame.cpp:2114
 msgid "Re-Reading the config from the default location."
-msgstr ""
+msgstr "Lade die Konfiguration vom Standardspeicherort neu."
 
 #: ../../src/wxMaximaFrame.cpp:867
 msgid "Re-evaluate all cells above the one the cursor is in"
-msgstr ""
+msgstr "Alle Zellen des Dokuments auswerten, die über dem Cursor stehen"
 
 #: ../../src/wxMaximaFrame.cpp:877
 msgid "Re-evaluate all cells below the one the cursor is in"
-msgstr ""
+msgstr "Alle Zellen des Dokuments auswerten, die unter dem Cursor stehen"
 
 #: ../../src/main.cpp:366
 msgid "Re-opening STDERR failed."
-msgstr ""
+msgstr "Standardfehlerausgabe neu öffnen hat nicht funktioniert."
 
 #: ../../src/main.cpp:367
 msgid "Re-opening STDIN failed."
-msgstr ""
+msgstr "Standardeingabe neu öffnen hat nicht funktioniert."
 
 #: ../../src/main.cpp:365
 msgid "Re-opening STDOUT failed."
-msgstr ""
+msgstr "Standardausgabe neu öffnen hat nicht funktioniert."
 
 #: ../../src/wxMaxima.cpp:7512
 msgid ""
 "Re-using a compiled regex is faster that using the same regex string "
 "multiple times."
 msgstr ""
+"Einen kompilierten Regulären Ausdruck wiederverwenden ist schneller als "
+"denselben Regulären Ausdruck mehrfach verwenden."
 
 #: ../../src/Worksheet.cpp:6668
 msgid "Read .wxm data from clipboard"
-msgstr ""
+msgstr "Lese .wxm-Daten von der Zwischenablage"
 
 #: ../../src/wxMaxima.cpp:7599
 msgid "Read Directory"
-msgstr ""
+msgstr "Verzeichnis einlesen"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Read List from csv file..."
-msgstr ""
+msgstr "Lade Liste aus einer csv-Datei..."
 
 #: ../../src/wxMaxima.cpp:7196
 msgid "Read a structure field"
@@ -5434,121 +5609,124 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7270 ../../src/wxMaxima.cpp:7274
 msgid "Read byte"
-msgstr ""
+msgstr "Lese ein Byte"
 
 #: ../../src/wxMaxima.cpp:7266
 msgid "Read char"
-msgstr ""
+msgstr "Lese ein Zeichen"
 
 #: ../../src/wxMaxima.cpp:7593
 msgid "Read environment variable"
-msgstr ""
+msgstr "Umgebungsvariable einlesen"
 
 #: ../../src/wxMaximaFrame.cpp:1219
 msgid "Read environment variable..."
-msgstr ""
+msgstr "Umgebungsvariable einlesen..."
 
 #: ../../src/wxMaxima.cpp:7262
 msgid "Read line"
-msgstr ""
+msgstr "Zeile einlesen"
 
 #: ../../src/MaximaManual.cpp:113
 #, c-format
 msgid "Read the entries the maxima manual offers from %s"
 msgstr ""
+"Stelle eine Liste der Stichwörter passend zu %s aus dem Handbuch zusammen"
 
 #: ../../src/StatusBar.cpp:245
 msgid "Reading Maxima output"
-msgstr ""
+msgstr "Die Ausgabe von Maxima wird gelesen"
 
 #: ../../src/StatusBar.cpp:247
 #, c-format
 msgid "Reading Maxima output: %li bytes"
-msgstr ""
+msgstr "Die Ausgabe von Maxima wird gelesen: %li Bytes"
 
 #: ../../src/wxMathml.cpp:55
 #, c-format
 msgid "Reading the Lisp part of wxMaxima from the file %s"
-msgstr ""
+msgstr "Lese den Lisp-Teil von wxMaxima aus folgender Datei: %s"
 
 #: ../../src/wxMathml.cpp:43
 msgid "Reading the Lisp part of wxMaxima from the included header file."
-msgstr ""
+msgstr "Lese den Lisp-Teil von wxMaxima aus der eingebauten Header-Datei."
 
 #: ../../src/wxMaximaFrame.cpp:148
 #, c-format
 msgid "Reading the config from %s."
-msgstr ""
+msgstr "Lade die Konfiguration von %s."
 
 #: ../../src/wxMaximaFrame.cpp:151
 msgid "Reading the config from the default location."
-msgstr ""
+msgstr "Lese die Konfiguration vom Standardspeicherort."
 
 #: ../../src/StatusBar.cpp:224
 msgid "Ready for user input"
-msgstr ""
+msgstr "Bereit für Benutzereingabe"
 
 #: ../../src/Worksheet.cpp:960
 msgid "Recalculated the whole worksheet at once => Updating its size"
-msgstr ""
+msgstr "Das komplette Arbeitsblatt neu berechnet => Aktualisiere die Größe"
 
 #: ../../src/Worksheet.cpp:946
 msgid "Recalculation hit the end of the worksheet => Updating its size"
 msgstr ""
+"Die Berechnung hat das Ende des Arbeitsblatts erreicht => Aktualisiere die "
+"Größe"
 
 #: ../../src/wxMaximaFrame.cpp:930
 msgid "Recall next command from history"
-msgstr ""
+msgstr "Wiederhole nächsten Befehl der Historie."
 
 #: ../../src/wxMaximaFrame.cpp:928
 msgid "Recall previous command from history"
-msgstr ""
+msgstr "Wiederhole vorherigen Befehl der Historie."
 
 #: ../../src/wxMaxima.cpp:3235
-#, c-format
+#, fuzzy, c-format
 msgid "Received manual topic request: %s"
-msgstr ""
+msgstr "Empfang der Startmeldung von Maxima: %s"
 
 #: ../../src/wxMaxima.cpp:3097
 #, c-format
 msgid "Received maxima's first prompt: %s"
-msgstr ""
+msgstr "Empfang der Startmeldung von Maxima: %s"
 
 #: ../../src/wxMaximaFrame.cpp:603
 msgid "Recover unsaved"
-msgstr ""
+msgstr "Nicht gespeicherte Dateien wiederherstellen"
 
 #: ../../src/wxMaximaFrame.cpp:1640
 msgid "Recursive Substitute..."
-msgstr ""
+msgstr "Rekursiv Substituieren ..."
 
 #: ../../src/wxMaxima.cpp:8746
 msgid "Recursive substitution"
-msgstr ""
+msgstr "Rekursive Ersetzung"
 
 #: ../../src/ToolBar.cpp:192
 msgid "Redo"
-msgstr ""
+msgstr "Wiederholen"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo\tCtrl+Y"
-msgstr ""
+msgstr "&Erneut\tCtrl+Y"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo last change"
-msgstr ""
+msgstr "Letzte Änderung erneut durchführen"
 
 #: ../../src/wxMaximaFrame.cpp:1595
 msgid "Reduce trigonometric expression"
-msgstr ""
+msgstr "Versucht den Grad von trigonometrischen Ausdrücken zu verringern"
 
 #: ../../src/wxMaxima.cpp:2366 ../../src/wxMaxima.cpp:10630
 msgid "Refusing to send cell to maxima: "
-msgstr ""
+msgstr "Weigere mich, die Zelle an Maxima zu senden: "
 
 #: ../../src/wxMaxima.cpp:7523
 msgid "Regex match"
-msgstr ""
+msgstr "Regulärer Ausdruck Entsprechung"
 
 #: ../../src/wxMaxima.cpp:7518
 msgid "Regex match position"
@@ -5556,144 +5734,146 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1195
 msgid "Regular expression that matches a string"
-msgstr ""
+msgstr "Regulärer Ausdruck, der einem String entspricht"
 
 #: ../../src/wxMaximaFrame.cpp:1196
 msgid "Regular expressions"
-msgstr ""
+msgstr "Regulärer Ausdruck"
 
 #: ../../src/Worksheet.cpp:1314
 msgid "Reload Image"
-msgstr ""
+msgstr "Bild neu laden"
 
 #: ../../src/Worksheet.cpp:1320
 #, c-format
 msgid "Reload Image \"%s\""
-msgstr ""
+msgstr "Bild \"%s\" neu laden"
 
 #: ../../src/wxMaxima.cpp:9809
 #, c-format
 msgid "Reloading image file %s."
-msgstr ""
+msgstr "Bilddatei %s neu laden."
 
 #: ../../src/wxMaximaFrame.cpp:883
 msgid "Remove All Output"
-msgstr ""
+msgstr "Lösche alle Ausgaben"
 
 #: ../../src/wxMaximaFrame.cpp:1426
 msgid "Remove Rows or Columns..."
-msgstr ""
+msgstr "Entferne Zeilen oder Spalten..."
 
 #: ../../src/wxMaximaFrame.cpp:1748
 msgid ""
 "Remove all list elements that appear twice in a row. Normally used in "
 "conjunction with sort."
 msgstr ""
+"Lösche alle Elemente, die zweimal direkt hintereinander in der Liste sind. "
+"Praktisch nach einem sort()."
 
 #: ../../src/wxMaximaFrame.cpp:1174
 msgid "Remove all occurrences of a word..."
-msgstr ""
+msgstr "Alle Vorkommnisse eines Wortes löschen..."
 
 #: ../../src/wxMaxima.cpp:7439
 msgid "Remove all occurrences of part"
-msgstr ""
+msgstr "Alle Vorkomnisse eines Teils löschen"
 
 #: ../../src/wxMaxima.cpp:8592
 msgid "Remove an element from a list"
-msgstr ""
+msgstr "Entferne ein Listenelement"
 
 #: ../../src/wxMaxima.cpp:7566
 msgid "Remove directory"
-msgstr ""
+msgstr "Verzeichnis löschen"
 
 #: ../../src/wxMaximaFrame.cpp:1204
 msgid "Remove directory..."
-msgstr ""
+msgstr "Verzeichnis löschen..."
 
 #: ../../src/wxMaximaFrame.cpp:1747
 msgid "Remove duplicates"
-msgstr ""
+msgstr "Entferne doppelte Elemente"
 
 #: ../../src/wxMaximaFrame.cpp:1176
 msgid "Remove first occurrence of a word..."
-msgstr ""
+msgstr "Erstes Vorkommnis eines Wortes löschen..."
 
 #: ../../src/wxMaxima.cpp:7444
 msgid "Remove first occurrence of part"
-msgstr ""
+msgstr "Erstes Vorkommnis eines Teils löschen"
 
 #: ../../src/wxMaximaFrame.cpp:884
 msgid "Remove output from input cells"
-msgstr ""
+msgstr "Lösche alle Ergebnisse der Eingabezellen"
 
 #: ../../src/wxMaxima.cpp:7975
 msgid "Remove rows and/or columns"
-msgstr ""
+msgstr "Entferne Zeilen und/oder Spalten"
 
 #: ../../src/wxMaximaFrame.cpp:1427
 msgid "Remove rows and/or columns from the matrix"
-msgstr ""
+msgstr "Entfernt Zeilen und/oder Spalten von der Matrix"
 
 #: ../../src/wxMaxima.cpp:7582
 msgid "Rename file"
-msgstr ""
+msgstr "Datei umbenennen"
 
 #: ../../src/wxMaximaFrame.cpp:1215
 msgid "Rename file..."
-msgstr ""
+msgstr "Datei umbenennen..."
 
 #: ../../src/wxMaximaFrame.cpp:1527
 msgid "Reorganize an expression using horner's rule"
-msgstr ""
+msgstr "Ausdruck neu umformen (Horner-Schema)"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "Repetitive element-by-element multiplication"
-msgstr ""
+msgstr "Wiederholte Element-für-Element-Multiplikation"
 
 #: ../../src/wxMaxima.cpp:7538
 msgid "Replace all regex matches"
-msgstr ""
+msgstr "Ersetze alle Regulären Ausdruck Treffer"
 
 #: ../../src/wxMaxima.cpp:7533
 msgid "Replace first regex match"
-msgstr ""
+msgstr "Ersetze den ersten Regulären Ausdruck Treffer"
 
 #: ../../src/wxMaxima.cpp:7463
 msgid "Replace the first occurrence of Part"
-msgstr ""
+msgstr "Ersetze das erste Auftreten des Teils"
 
 #: ../../src/wxMaximaFrame.cpp:1180
 msgid "Replace..."
-msgstr ""
+msgstr "Ersetzen..."
 
 #: ../../src/wxMaxima.cpp:6719
 #, c-format
 msgid "Replaced %li occurrences."
-msgstr ""
+msgstr "%li Ersetzungen ausgeführt."
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "Report bug"
-msgstr ""
+msgstr "Einen Fehler berichten"
 
 #: ../../src/wxMaximaFrame.cpp:996
 msgid "Reset option variables"
-msgstr ""
+msgstr "Optionsvariablen zurücksetzen"
 
 #: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
 msgid "Restart Maxima"
-msgstr ""
+msgstr "Maxima neu starten"
 
 #: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
 msgid "Restrict Maximum size"
-msgstr ""
+msgstr "Begrenze maximale Größe"
 
 #: ../../src/wxMaxima.cpp:10031
 msgid "Result variables:"
-msgstr ""
+msgstr "Ergebnisvariablen:"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Resulting Matrix name (may be empty):"
-msgstr ""
+msgstr "Name der Matrix (darf leer sein):"
 
 #: ../../src/wxMaximaFrame.cpp:1190
 msgid "Return a match"
@@ -5712,234 +5892,240 @@ msgid ""
 "Return the first item of the list and remove it from the list. Useful for "
 "creating stacks."
 msgstr ""
+"Liefert das erste Element einer Liste und entfernt dieses von der Liste. "
+"Praktisch für die Generierung von Stapelspeichern."
 
 #: ../../src/wxMaxima.cpp:8526
 msgid "Return the list without its first n elements"
-msgstr ""
+msgstr "Die Liste ohne ihre ersten n Elemente"
 
 #: ../../src/wxMaxima.cpp:8532
 msgid "Return the list without its last n elements"
-msgstr ""
+msgstr "Die Liste ohne ihre letzten n Elemente"
 
 #: ../../src/ToolBar.cpp:241
 msgid "Return to the cell that is currently being evaluated"
-msgstr ""
+msgstr "Zurückscrollen zu der Zelle, die derzeit evaluiert wird"
 
 #: ../../src/wxMaximaFrame.cpp:1711
 msgid "Returns an arbitrary list item"
-msgstr ""
+msgstr "Gibt ein beliebiges Listenelement zurück"
 
 #: ../../src/wxMaximaFrame.cpp:1713
 msgid "Returns the first item of the list"
-msgstr ""
+msgstr "Gibt das erste Element einer Liste zurück"
 
 #: ../../src/wxMaximaFrame.cpp:1719
 msgid "Returns the last item of the list"
-msgstr ""
+msgstr "Gibt das letzte Element einer Liste zurück"
 
 #: ../../src/wxMaximaFrame.cpp:1721
 msgid "Returns the last n items of the list"
-msgstr ""
+msgstr "Gibt die letzten n Elemente einer Liste zurück"
 
 #: ../../src/wxMaximaFrame.cpp:1742
 msgid "Returns the length of the list"
-msgstr ""
+msgstr "Ermittelt die Länge einer Liste"
 
 #: ../../src/wxMaximaFrame.cpp:1715
 msgid "Returns the list without its first n elements"
-msgstr ""
+msgstr "Gibt die Liste ohne ihre ersten n Elemente zurück"
 
 #: ../../src/wxMaximaFrame.cpp:1717
 msgid "Returns the list without its last n elements"
-msgstr ""
+msgstr "Gibt die Liste ohne ihre letzten n Elemente zurück"
 
 #: ../../src/wxMaximaFrame.cpp:1743
 msgid "Reverse"
-msgstr ""
+msgstr "Umkehren"
 
 #: ../../src/wxMaximaFrame.cpp:1744
 msgid "Reverse the order of the list items"
-msgstr ""
+msgstr "Kehre die Reihenfolge der Listenelemente um."
 
 #: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
 #: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
 msgid "Right Matrix:"
-msgstr ""
+msgstr "Rechte Matrix:"
 
 #: ../../src/wxMaxima.cpp:8190
 msgid "Right end"
-msgstr ""
+msgstr "Rechtes Ende"
 
 #: ../../src/wxMaximaFrame.cpp:1301
 msgid "Right side to the \"=\""
-msgstr ""
+msgstr "Die Seite rechts vom \"=\""
 
 #: ../../src/wxMaximaFrame.cpp:1455
 msgid "Risch Integration..."
-msgstr ""
+msgstr "Integrieren (Ri&sch) ..."
 
 #: ../../src/wxMaximaFrame.cpp:785
 msgid "Rounded"
-msgstr ""
+msgstr "Gerundet"
 
 #: ../../src/wxMaximaFrame.cpp:1437
 msgid "Row and column operations"
-msgstr ""
+msgstr "Zeilen- und Spaltenoperationen"
 
 #: ../../src/wxMaxima.cpp:7957 ../../src/wxMaxima.cpp:7967
 #: ../../src/wxMaxima.cpp:7972
 msgid "Row number:"
-msgstr ""
+msgstr "Zeile Nummer:"
 
 #: ../../src/wxMaxima.cpp:7977
 msgid "Row numbers:"
-msgstr ""
+msgstr "Zeilen Nummern:"
 
 #: ../../src/wxMaxima.cpp:8203
 msgid "Rows"
-msgstr ""
+msgstr "Zeilen"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Rule"
-msgstr ""
+msgstr "Regel"
 
 #: ../../src/wxMaxima.cpp:8464 ../../src/wxMaxima.cpp:8477
 msgid "Rule:"
-msgstr ""
+msgstr "Regel:"
 
 #: ../../src/wxMaximaFrame.cpp:1027
 msgid "Rules"
-msgstr ""
+msgstr "Regeln"
 
 #: ../../src/wxMaximaFrame.cpp:1693
+#, fuzzy
 msgid "Run each element through an expression"
-msgstr ""
+msgstr "Lässt jedes Element durch eine Funktion"
 
 #: ../../src/wxMaxima.cpp:6355
-#, c-format
+#, fuzzy, c-format
 msgid "Running %s on the file %s: "
-msgstr ""
+msgstr "Automatisches Speichern als temporäre Datei %s"
 
 #: ../../src/wxMaxima.cpp:2633
 #, c-format
 msgid "Running maxima as: %s"
-msgstr ""
+msgstr "Starte Maxima als: %s"
 
 #: ../../src/wxMaximaFrame.cpp:130
 msgid "Running on DirectFB"
-msgstr ""
+msgstr "Graphikausgabe über DirectFB"
 
 #: ../../src/wxMaximaFrame.cpp:114
 msgid "Running on MS Windows"
-msgstr ""
+msgstr "Graphikausgabe über MS Windows"
 
 #: ../../src/wxMaximaFrame.cpp:116
 msgid "Running on MS Windows using DirectDraw"
-msgstr ""
+msgstr "Verwende DirectDraw zur Anzeige des Arbeitsblatts"
 
 #: ../../src/wxMaximaFrame.cpp:136
 msgid "Running on Mac OS"
-msgstr ""
+msgstr "Graphikausgabe über Mac OS"
 
 #: ../../src/wxMaximaFrame.cpp:127
 msgid "Running on Motif"
-msgstr ""
+msgstr "Graphikausgabe über Motif"
 
 #: ../../src/wxMaximaFrame.cpp:133
 msgid "Running on the universal wxWidgets port"
-msgstr ""
+msgstr "Graphikausgabe über den universellen wxWidgets Port"
 
 #: ../../src/wxMaxima.cpp:8208
+#, fuzzy
 msgid ""
 "Runs each element of an object (list, matrix, equation,...) through a "
 "function individually"
-msgstr ""
+msgstr "Lässt jedes Element durch eine Funktion"
 
 #: ../../src/wxMaxima.cpp:8216
+#, fuzzy
 msgid ""
 "Runs each element of an object (list, matrix, equation,...) through an "
 "expression individually"
-msgstr ""
+msgstr "Lässt jedes Element durch eine Funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1691
 msgid "Runs each element through a function"
-msgstr ""
+msgstr "Lässt jedes Element durch eine Funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1694
+#, fuzzy
 msgid "Runs each element through an expression"
-msgstr ""
+msgstr "Lässt jedes Element durch eine Funktion"
 
 #: ../../src/wxMaxima.cpp:9572
 msgid "Sample 1:"
-msgstr ""
+msgstr "Probe 1:"
 
 #: ../../src/wxMaxima.cpp:9573
 msgid "Sample 2:"
-msgstr ""
+msgstr "Probe 2:"
 
 #: ../../src/wxMaxima.cpp:9567
 msgid "Sample:"
-msgstr ""
+msgstr "Probe:"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
 msgid "Save"
-msgstr ""
+msgstr "Speichern"
 
 #: ../../src/Worksheet.cpp:1294
 msgid "Save Animation..."
-msgstr ""
+msgstr "Speichere Animation ..."
 
 #: ../../src/wxMaxima.cpp:5672
 msgid "Save As"
-msgstr ""
+msgstr "Speichern als"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save As...\tShift+Ctrl+S"
-msgstr ""
+msgstr "Speichern als ...\tShift+Ctrl+S"
 
 #: ../../src/Worksheet.cpp:1291
 msgid "Save Image..."
-msgstr ""
+msgstr "Bild speichern ..."
 
 #: ../../src/wxMaxima.cpp:6440
 msgid "Save Selection to Image"
-msgstr ""
+msgstr "Auswahl als Bild speichern"
 
 #: ../../src/wxMaximaFrame.cpp:675
 msgid "Save Selection to Image..."
-msgstr ""
+msgstr "Auswahl als Bild speichern ..."
 
 #: ../../src/wxMaxima.cpp:10184
 msgid "Save animation to file"
-msgstr ""
+msgstr "Sichere Animation in Datei"
 
 #: ../../src/wxMaxima.cpp:7203
 msgid "Save as lisp code"
-msgstr ""
+msgstr "Speichere als Lisp-Code"
 
 #: ../../src/wxMaximaFrame.cpp:1091
 msgid "Save as lisp..."
-msgstr ""
+msgstr "Als Lisp-Datei speichern..."
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
 msgid "Save document"
-msgstr ""
+msgstr "Dokument speichern"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save document as"
-msgstr ""
+msgstr "Dokument speichern als"
 
 #: ../../src/wxMaximaFrame.cpp:676
 msgid "Save selection from document to an image file"
-msgstr ""
+msgstr "Auswahl des Dokumentes in Bild-Datei speichern"
 
 #: ../../src/wxMaxima.cpp:10125
 msgid "Save selection to file"
-msgstr ""
+msgstr "Auswahl in eine Datei speichern"
 
 #: ../../src/wxMaximaFrame.cpp:573
 msgid "Saving failed."
-msgstr ""
+msgstr "Das Speichern ist fehlgeschlagen."
 
 #: ../../src/WXMXformat.cpp:310
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
@@ -5952,245 +6138,261 @@ msgid ""
 "(*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|Portable anymap "
 "(*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"Skalierbare Vektorgraphik (*.svg)|*.svg|Komprimierte Skalierbare "
+"Vektorgraphik (*.svgz)|*.svgz|PNG Build (*.png)|*.png|JPEG Bild "
+"(*.jpg)|*.jpg|GIF Bild (*.gif)|*.gif|Windows Bitmap (*.bmp)|*.bmp|Portable "
+"Anymap (*.pnm)|*.pnm|Tagged Image File Format (*.tif)|*.tif|X PixMap "
+"(*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:9533
 msgid "Scatterplot"
-msgstr ""
+msgstr "Streudiagramm"
 
 #: ../../src/Autocomplete.cpp:125
 msgid ""
 "Scheduling a background task that compiles a new list of autocompletable "
 "maxima commands."
 msgstr ""
+"Starte einen Hintergrundtask, der eine neue Liste autovervollständigbarer "
+"Maxima-Befehle zusammenbaut."
 
 #: ../../src/Autocomplete.cpp:458
 msgid ""
 "Scheduling a background task that scans for autocompletable file names."
 msgstr ""
+"Starte einen Hintergrundtask, der Dateinamen für das automatische "
+"Vervollständigen sucht."
 
 #: ../../src/ToolBar.cpp:632
 msgid "Search button"
-msgstr ""
+msgstr "Der \"Finden\"-Knopf"
 
 #: ../../src/wxMaxima.cpp:7454
 msgid "Search first occurrence of part"
-msgstr ""
+msgstr "Erstes Vorkommnis eines Teils suchen"
 
 #: ../../src/wxMaximaFrame.cpp:1178
 msgid "Search..."
-msgstr ""
+msgstr "Suchen..."
 
 #: ../../src/ToolBar.cpp:273
 msgid "Section"
-msgstr ""
+msgstr "Kapitel"
 
 #: ../../src/Configuration.cpp:91
 msgid "Section cell (Heading 2)"
-msgstr ""
+msgstr "Sektion (2. Gliederungsebene)"
 
 #: ../../src/wxMaxima.cpp:7218
 msgid "Seek to position"
-msgstr ""
+msgstr "Position suchen"
 
 #: ../../src/BTextCtrl.cpp:45
 msgid "Seems like something is broken with a font."
-msgstr ""
+msgstr "Irgendwas stimmt mit dem Zeichensatz nicht."
 
 #: ../../src/Autocomplete.cpp:350
 msgid "Seems like the package with the maxima share files isn't installed."
 msgstr ""
+"Das Paket mit den Share-Dateien von Maxima scheint nicht installiert zu "
+"sein."
 
 #: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
 msgid "Select All"
-msgstr ""
+msgstr "Alles auswählen"
 
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select All\tCtrl+A"
-msgstr ""
+msgstr "Alles auswählen\tCtrl+A"
 
 #: ../../src/ToolBar.cpp:629
 msgid "Select All button"
-msgstr ""
+msgstr "Der \"alles auswählen\"-Knopf"
 
 #: ../../src/wxMaxima.cpp:9631
 msgid "Select Subsample"
-msgstr ""
+msgstr "Wähle Teilstichprobe"
 
 #: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select all"
-msgstr ""
+msgstr "Alles auswählen"
 
 #: ../../src/wxMaxima.cpp:6971
 msgid "Select math display algorithm"
-msgstr ""
+msgstr "Algorithmus zum Anzeigen von Formeln auswählen"
 
 #: ../../src/Configuration.cpp:98
 msgid "Selection color"
-msgstr ""
+msgstr "Farb-Auswahl"
 
 #: ../../src/ToolBar.cpp:252
 msgid "Send all cells to maxima"
-msgstr ""
+msgstr "Sende alle Zellen an Maxima"
 
 #: ../../src/ToolBar.cpp:249
 msgid "Send the current cell to maxima"
-msgstr ""
+msgstr "Sende die aktuelle Zelle an Maxima"
 
 #: ../../src/wxMaxima.cpp:2810
 msgid "Sending Maxima a SIGINT signal."
-msgstr ""
+msgstr "Sende Maxima ein SIGINT-Signal."
 
 #: ../../src/StatusBar.cpp:220
 msgid "Sending a command to Maxima"
-msgstr ""
+msgstr "Sende einen Befehl an Maxima"
 
 #: ../../src/wxMaxima.cpp:10598
 msgid "Sending a new command to Maxima."
-msgstr ""
+msgstr "Sende einen neuen Befehl an Maxima"
 
 #: ../../src/wxMaxima.cpp:2792
 msgid "Sending an interrupt signal to Maxima."
-msgstr ""
+msgstr "Sende ein \"Unterbrechen\"-Signal an Maxima."
 
 #: ../../src/wxMaxima.cpp:169
 msgid "Sending configuration data to maxima."
-msgstr ""
+msgstr "Sende die Konfigurationsdaten an Maxima."
 
 #: ../../src/wxMaxima.cpp:4718
 msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
+"Sende Maxima die Information, wie 2d-Mathematik als XML übertragen wird."
 
 #: ../../src/wxMaximaFrame.cpp:1533
+#, fuzzy
 msgid "Sequential Comparative Simplification"
-msgstr ""
+msgstr "&Komplexe Ausdrücke"
 
 #: ../../src/wxMaxima.cpp:9016
 msgid "Series"
-msgstr ""
+msgstr "Reihen"
 
 #: ../../src/wxMaximaFrame.cpp:1479
 msgid "Series approximation"
-msgstr ""
+msgstr "Reihen-Approximation"
 
 #: ../../src/wxMaxima.cpp:2561
 msgid "Server started"
-msgstr ""
+msgstr "Server gestartet"
 
 #: ../../src/wxMaximaFrame.cpp:1824
 msgid "Set &displayed Precision..."
-msgstr ""
+msgstr "Anzahl &der angezeigten Stellen..."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Set Maxima option variable logexpand:all"
-msgstr ""
+msgstr "Setze die Maxima Optionsvariable logexpand:all"
 
 #: ../../src/wxMaximaFrame.cpp:1567
 msgid "Set Maxima option variable logexpand:super"
-msgstr ""
+msgstr "Setze die Maxima Optionsvariable logexpand:super"
 
 #: ../../src/wxMaximaFrame.cpp:1560
 msgid "Set Maxima option variable logexpand:true"
-msgstr ""
+msgstr "Setze die Maxima Optionsvariable logexpand:true"
 
 #: ../../src/wxMaximaFrame.cpp:822
 msgid "Set Zoom"
-msgstr ""
+msgstr "Vergrößerung"
 
 #: ../../src/wxMaximaFrame.cpp:1819
 msgid "Set bigfloat &Precision..."
-msgstr ""
+msgstr "Genauigkeit für als bigfloat deklarierte Fließkommazahlen setzen ..."
 
 #: ../../src/Worksheet.cpp:1306 ../../src/Worksheet.cpp:1479
 msgid "Set image resolution"
-msgstr ""
+msgstr "Bildauflösung einstellen"
 
 #: ../../src/wxMaximaFrame.cpp:1510
 msgid "Set main variable..."
-msgstr ""
+msgstr "Hauptvariable definieren..."
 
 #: ../../src/wxMaximaFrame.cpp:1773
 msgid "Set plot format"
-msgstr ""
+msgstr "Das Plot-Format einstellen"
 
 #: ../../src/wxMaximaFrame.cpp:1101
 msgid "Set position..."
-msgstr ""
+msgstr "Die Position einstellen..."
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Set the \"algebraic\" flag"
-msgstr ""
+msgstr "Setze das \"Algebraisch\"-Flag"
 
 #: ../../src/wxMaxima.cpp:8314
 msgid "Set the diagram title"
-msgstr ""
+msgstr "Setze den Titel des Diagramms"
 
 #: ../../src/wxMaximaFrame.cpp:1779
 msgid "Set the frame rate for animations."
-msgstr ""
+msgstr "Wähle die Bildwiederholrate für Animationen."
 
 #: ../../src/wxMaxima.cpp:8377
 msgid "Set the grid density."
-msgstr ""
+msgstr "Setze die Linienfrequenz des Gitters."
 
 #: ../../src/wxMaxima.cpp:8327
 msgid "Set the next plot's title. Empty = no title."
-msgstr ""
+msgstr "Der Titel der nächsten Kurve. Leer = kein Titel."
 
 #: ../../src/wxMaximaFrame.cpp:1820
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can"
 " be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
+"Stellt die Anzahl der Stellen ein, auf die als bigfloat deklarierte Zahlen\n"
+"genau sind. Bigfloats können erstellt werden, indem Zahlen als 1.5b112 oder\n"
+"bfloat(1.234) eingegeben werden."
 
 #: ../../src/wxMaximaFrame.cpp:811
 msgid "Set zoom to 100%"
-msgstr ""
+msgstr "Setze Vergrößerung auf 100%"
 
 #: ../../src/wxMaximaFrame.cpp:813
 msgid "Set zoom to 120%"
-msgstr ""
+msgstr "Setze Vergrößerung auf 120%"
 
 #: ../../src/wxMaximaFrame.cpp:815
 msgid "Set zoom to 150%"
-msgstr ""
+msgstr "Setze Vergrößerung auf 150%"
 
 #: ../../src/wxMaximaFrame.cpp:817
 msgid "Set zoom to 200%"
-msgstr ""
+msgstr "Setze Vergrößerung auf 200%"
 
 #: ../../src/wxMaximaFrame.cpp:819
 msgid "Set zoom to 300%"
-msgstr ""
+msgstr "Setze Vergrößerung auf 300%"
 
 #: ../../src/wxMaximaFrame.cpp:809
 msgid "Set zoom to 80%"
-msgstr ""
+msgstr "Setze Vergrößerung auf 80%"
 
 #: ../../src/wxMaxima.cpp:4731
 #, c-format
 msgid "Setting gnuplot_binary to %s"
-msgstr ""
+msgstr "Setze die Adresse von Gnuplot auf %s"
 
 #: ../../src/wxMaxima.cpp:4804
 msgid "Setting prompt and help format"
-msgstr ""
+msgstr "Prompt- und Hilfe-Format einstellen"
 
 #: ../../src/wxMaximaFrame.cpp:1292
 msgid "Setup atvalues for solving ODE with Laplace transformation"
-msgstr ""
+msgstr "Bestimme Randwerte für das Lösen von GDG mit Laplacetransformation"
 
 #: ../../src/wxMaximaFrame.cpp:1661
 msgid "Setup modulus computation"
-msgstr ""
+msgstr "Die aktuelle Restklasse angeben"
 
 #: ../../src/wxMaxima.cpp:9220
 msgid "Setup the engineering format"
-msgstr ""
+msgstr "Einstellungen für das Ingenieursformat"
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "Setup the engineering format..."
-msgstr ""
+msgstr "Einstellungen für das Ingenieursformat..."
 
 #: ../../src/wxMaxima.cpp:9576
 msgid "Shapiro-Wilk test for normality"
@@ -6198,91 +6400,91 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1543
 msgid "Show \"%\" in special constants"
-msgstr ""
+msgstr "Zeige das \"%\" in mathematischen Konstanten"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show &Tips..."
-msgstr ""
+msgstr "Zeige &Tipp ..."
 
 #: ../../src/Worksheet.cpp:1556
 msgid "Show * as multiplication dot"
-msgstr ""
+msgstr "Zeige * als Mal-Zeichen an."
 
 #: ../../src/wxMaximaFrame.cpp:895
 msgid "Show Template\tCtrl+Shift+Space"
-msgstr ""
+msgstr "Zeige Muster\tCtrl+Shift+Space"
 
 #: ../../src/wxMaximaFrame.cpp:753
 msgid "Show XML representation"
-msgstr ""
+msgstr "Zeige die XML-Darstellung"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show a tip"
-msgstr ""
+msgstr "Zeige einen Tipp"
 
 #: ../../src/Worksheet.cpp:1607
 msgid "Show all + allow linebreaks in long numbers"
-msgstr ""
+msgstr "Alles anzeigen und Zeilenumbrüche bei langen Zahlen erlauben"
 
 #: ../../src/wxMaxima.cpp:9475
 msgid "Show all commands similar to:"
-msgstr ""
+msgstr "Zeige alle Befehle, die ähnlich sind zu:"
 
 #: ../../src/wxMaxima.cpp:9468
 msgid "Show an example for the command:"
-msgstr ""
+msgstr "Zeige ein Beispiel für den Befehl:"
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "Show an example of usage"
-msgstr ""
+msgstr "Zeige ein Anwendungsbeispiel"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "Show commands similar to"
-msgstr ""
+msgstr "Zeige ähnliche Befehle"
 
 #: ../../src/wxMaximaFrame.cpp:1020
 msgid "Show defined functions"
-msgstr ""
+msgstr "Zeige definierte Funktionen"
 
 #: ../../src/wxMaximaFrame.cpp:1022
 msgid "Show defined variables"
-msgstr ""
+msgstr "Zeige definierte Variablen"
 
 #: ../../src/wxMaximaFrame.cpp:1074
 msgid "Show definition of a function"
-msgstr ""
+msgstr "Zeige die Definition einer Funktion"
 
 #: ../../src/wxMaximaFrame.cpp:740
 msgid "Show equations in their linear form"
-msgstr ""
+msgstr "Zeigt Gleichungen in der linearen Form an"
 
 #: ../../src/wxMaximaFrame.cpp:1073
 msgid "Show function &Definition..."
-msgstr ""
+msgstr "Zeige Funktions-&Definition..."
 
 #: ../../src/wxMaximaFrame.cpp:896
 msgid "Show function template"
-msgstr ""
+msgstr "Zeige Muster der Funktion"
 
 #: ../../src/Worksheet.cpp:1614
 msgid "Show input labels"
-msgstr ""
+msgstr "Eingabemarken anzeigen"
 
 #: ../../src/wxMaximaFrame.cpp:750
 msgid "Show lisp representation"
-msgstr ""
+msgstr "Lisp Darstellung anzeigen"
 
 #: ../../src/Worksheet.cpp:1604
 msgid "Show max. 100 digits"
-msgstr ""
+msgstr "Zeige max. 100 Ziffern"
 
 #: ../../src/Worksheet.cpp:1602
 msgid "Show max. 20 digits"
-msgstr ""
+msgstr "Zeige max. 20 Ziffern"
 
 #: ../../src/Worksheet.cpp:1603
 msgid "Show max. 50 digits"
-msgstr ""
+msgstr "Zeige max. 50 Ziffern"
 
 #: ../../src/wxMaximaFrame.cpp:835
 msgid "Show or hide the wxMaxima logging window"
@@ -6290,108 +6492,108 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:612
 msgid "Show the \"New\" button?"
-msgstr ""
+msgstr "Zeige den \"Neue Datei\"-Knopf?"
 
 #: ../../src/ToolBar.cpp:636
 msgid "Show the \"help\" button?"
-msgstr ""
+msgstr "Zeige den \"Hilfe\"-Knopf?"
 
 #: ../../src/ToolBar.cpp:633
 msgid "Show the \"search\" button?"
-msgstr ""
+msgstr "Zeige den \"Finden\"-Knopf?"
 
 #: ../../src/ToolBar.cpp:630
 msgid "Show the \"select all\" button?"
-msgstr ""
+msgstr "Zeige den \"Alles auswählen\"-Knopf?"
 
 #: ../../src/ToolBar.cpp:624
 msgid "Show the Copy, Cut and the Paste button?"
-msgstr ""
+msgstr "Zeige die Knöpfe für \"Ausschneiden\", \"Kopieren\" und \"Einfügen\"?"
 
 #: ../../src/wxMaxima.cpp:7033
 msgid "Show the function's definition"
-msgstr ""
+msgstr "Zeige die Definition der Funktion"
 
 #: ../../src/ToolBar.cpp:618
 msgid "Show the open and the save button?"
-msgstr ""
+msgstr "Zeige die Knöpfe für öffnen und speichern?"
 
 #: ../../src/ToolBar.cpp:627
 msgid "Show the preferences button?"
-msgstr ""
+msgstr "Zeige den Knopf, der den \"Einstellungen\"-Dialog anzeigt."
 
 #: ../../src/ToolBar.cpp:621
 msgid "Show the print button?"
-msgstr ""
+msgstr "Zeige den \"Drucken\"-Knopf?"
 
 #: ../../src/ToolBar.cpp:615
 msgid "Show the undo and redo button?"
-msgstr ""
+msgstr "Zeige die Knöpfe für Rückgängigmachen und Wiederholen?"
 
 #: ../../src/wxMaximaFrame.cpp:1006 ../../src/wxMaximaFrame.cpp:1011
 msgid "Show used + to-be-freed memory"
-msgstr ""
+msgstr "Zeige benutzten und freizugebenden Speicher"
 
 #: ../../src/wxMaximaFrame.cpp:1033
 msgid "Show user definitions"
-msgstr ""
+msgstr "Zeige Benutzer-Definitionen"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Show wxMaxima help"
-msgstr ""
+msgstr "Zeige die Hilfe von wxMaxima an"
 
 #: ../../src/wxMaximaFrame.cpp:1825
 msgid "Shows how many digits of a numbers are displayed"
-msgstr ""
+msgstr "Zeigt, wie viele Stellen einer Zahl angezeigt werden"
 
 #: ../../src/wxMaximaFrame.cpp:732
 msgid "Sidebars"
-msgstr ""
+msgstr "Seitenleisten"
 
 #: ../../src/wxMaximaFrame.cpp:1513
 msgid "Simplify &Radicals..."
-msgstr ""
+msgstr "&Wurzeln vereinfachen..."
 
 #: ../../src/Worksheet.cpp:1579
 msgid "Simplify Expression"
-msgstr ""
+msgstr "Ausdruck vereinfachen"
 
 #: ../../src/wxMaximaFrame.cpp:1568
 msgid "Simplify Logarithms"
-msgstr ""
+msgstr "Vereinfache die Logarithmen"
 
 #: ../../src/wxMaximaFrame.cpp:1582
 msgid "Simplify an expression containing factorials"
-msgstr ""
+msgstr "Vereinfache einen Ausdruck mit Fakultäten"
 
 #: ../../src/wxMaximaFrame.cpp:1539
 msgid "Simplify equations"
-msgstr ""
+msgstr "Vereinfache Gleichungen"
 
 #: ../../src/wxMaximaFrame.cpp:1514
 msgid "Simplify expression containing radicals"
-msgstr ""
+msgstr "Einen Wurzelausdruck vereinfachen"
 
 #: ../../src/wxMaxima.cpp:8649
 msgid "Simplify radicals"
-msgstr ""
+msgstr "Wurzeln vereinfachen"
 
 #: ../../src/wxMaximaFrame.cpp:1512
 msgid "Simplify rational expression"
-msgstr ""
+msgstr "Vereinfache einen rationalen Ausdruck"
 
 #: ../../src/wxMaximaFrame.cpp:1538
 msgid "Simplify sum() commands..."
-msgstr ""
+msgstr "Vereinfache sum()-Befehle..."
 
 #: ../../src/wxMaxima.cpp:8636
 msgid "Simplify sums"
-msgstr ""
+msgstr "Vereinfache Summen"
 
 #: ../../src/wxMaximaFrame.cpp:1592
 msgid "Simplify trigonometric expression"
-msgstr ""
+msgstr "Ausdruck mit Winkelfunktionen vereinfachen"
 
 #: ../../src/wxMaximaFrame.cpp:1399
 msgid "Singular Values"
@@ -6407,144 +6609,145 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1635
 msgid "Smart Substitute..."
-msgstr ""
+msgstr "Intelligent substituieren..."
 
 #: ../../src/wxMaxima.cpp:8730
 msgid "Smart substitution"
-msgstr ""
+msgstr "Intelligent substituieren"
 
 #: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
 #: ../../src/wxMaxima.cpp:7823
 msgid "Solution of the ODE:"
-msgstr ""
+msgstr "Lösung der gewöhnlichen Differantialgleichung:"
 
 #: ../../src/wxMaxima.cpp:10017
 msgid "Solve"
-msgstr ""
+msgstr "Gleichung lösen"
 
 #: ../../src/wxMaximaFrame.cpp:1244
 msgid "Solve &Algebraic System..."
-msgstr ""
+msgstr "Löse &algebraisches System ..."
 
 #: ../../src/wxMaximaFrame.cpp:1242
 msgid "Solve &Linear System..."
-msgstr ""
+msgstr "Löse &lineares System ..."
 
 #: ../../src/wxMaximaFrame.cpp:1266
 msgid "Solve &ODE..."
-msgstr ""
+msgstr "Löse gewöhnliche Differentialgleichung ..."
 
 #: ../../src/wxMaximaFrame.cpp:1240
 msgid "Solve (to_poly)..."
-msgstr ""
+msgstr "Gleichung lösen (to_poly_solve) ..."
 
 #: ../../src/wxMaxima.cpp:8045
 msgid "Solve A*x=b numerically"
-msgstr ""
+msgstr "Gleichung A*x=b numerisch lösen"
 
 #: ../../src/wxMaximaFrame.cpp:1397
 msgid "Solve Ax=b"
-msgstr ""
+msgstr "Gleichung Ax=b lösen"
 
 #: ../../src/wxMaxima.cpp:7783
 msgid "Solve ODE"
-msgstr ""
+msgstr "Löse gewöhnliche Differentialgleichung"
 
 #: ../../src/wxMaximaFrame.cpp:1287
 msgid "Solve ODE with Lapla&ce..."
-msgstr ""
+msgstr "GDG mit Lapla&cetransformation lösen ..."
 
 #: ../../src/wxMaximaFrame.cpp:1398
 msgid "Solve a linear equation system using dgesv"
-msgstr ""
+msgstr "Lineares Gleichungssystem mit dgesv lösen"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
 msgid "Solve algebraic system"
-msgstr ""
+msgstr "Löse algebraisches System"
 
 #: ../../src/wxMaximaFrame.cpp:1245
 msgid "Solve algebraic system of equations"
-msgstr ""
+msgstr "Algebraisches Gleichungssystem lösen"
 
 #: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve boundary value problem for second degree ODE"
-msgstr ""
+msgstr "Randwertproblem für gewöhnliche DGL zweiten Grades lösen"
 
 #: ../../src/wxMaxima.cpp:7895
 msgid "Solve differential equations using laplace()"
-msgstr ""
+msgstr "Lösen von Differentialgleichungen mit laplace()"
 
 #: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
 msgid "Solve equation(s)"
-msgstr ""
+msgstr "Gleichung(en) lösen"
 
 #: ../../src/wxMaximaFrame.cpp:1241
 msgid "Solve equation(s) with to_poly_solve"
-msgstr ""
+msgstr "Gleichung(en) mit to_poly_solve lösen"
 
 #: ../../src/wxMaxima.cpp:7773
 msgid "Solve equations numerically"
-msgstr ""
+msgstr "Gleichungen numerisch lösen"
 
 #: ../../src/wxMaxima.cpp:7757
+#, fuzzy
 msgid "Solve equations to polynom"
-msgstr ""
+msgstr "Gleichung(en) mit to_poly_solve lösen"
 
 #: ../../src/wxMaximaFrame.cpp:1271
 msgid "Solve initial value problem for first degree ODE"
-msgstr ""
+msgstr "Anfangswertproblem einer gewöhnlichen DGL ersten Grades lösen"
 
 #: ../../src/wxMaximaFrame.cpp:1275
 msgid "Solve initial value problem for second degree ODE"
-msgstr ""
+msgstr "Anfangswertproblem einer gewöhnlichen DGL zweiten Grades lösen"
 
 #: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
 msgid "Solve linear system"
-msgstr ""
+msgstr "Lineares System lösen"
 
 #: ../../src/wxMaximaFrame.cpp:1243
 msgid "Solve linear system of equations"
-msgstr ""
+msgstr "Lineares Gleichungssystem lösen"
 
 #: ../../src/wxMaximaFrame.cpp:1263
 msgid "Solve numerical, 1 Variable"
-msgstr ""
+msgstr "Numerische Lösung, eine Variable"
 
 #: ../../src/wxMaximaFrame.cpp:1267
 msgid "Solve ordinary differential equation of maximum degree 2"
-msgstr ""
+msgstr "Eine gewöhnliche DGL von höchstens zweitem Grad lösen"
 
 #: ../../src/wxMaximaFrame.cpp:1288
 msgid "Solve ordinary differential equations with Laplace transformation"
-msgstr ""
+msgstr "Gewöhnliche DGL mit Laplacetransformation lösen"
 
 #: ../../src/wxMaxima.cpp:7708
 msgid "Solve polynomials numerically"
-msgstr ""
+msgstr "Polynome numerisch lösen"
 
 #: ../../src/wxMaxima.cpp:7718
 msgid "Solve polynomials numerically (bfloats)"
-msgstr ""
+msgstr "Polynome numerisch lösen (bfloats)"
 
 #: ../../src/wxMaxima.cpp:7729
 msgid "Solve polynomials numerically (real roots)"
-msgstr ""
+msgstr "Polynome numerisch löschen (real roots)"
 
 #: ../../src/wxMaximaFrame.cpp:1249
 msgid "Solve symbolically"
-msgstr ""
+msgstr "Symbolisch lösen"
 
 #: ../../src/Worksheet.cpp:1574
 msgid "Solve..."
-msgstr ""
+msgstr "Gleichung lösen ..."
 
 #: ../../src/wxMaximaFrame.cpp:1916
 msgid "Solving differential equations"
-msgstr ""
+msgstr "Lösen von Differentialgleichungen"
 
 #: ../../src/wxMaximaFrame.cpp:1904
 msgid "Solving equations with Maxima"
-msgstr ""
+msgstr "Lösen von Gleichungen mit Maxima"
 
 #: ../../src/wxMaxima.cpp:7105
 #, c-format
@@ -6555,11 +6758,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1746
 msgid "Sort"
-msgstr ""
+msgstr "Sortiere"
 
 #: ../../src/wxMaxima.cpp:8496
 msgid "Sort a list"
-msgstr ""
+msgstr "Eine Liste sortieren"
 
 #: ../../src/wxMaxima.cpp:7459
 msgid "Sort all characters in string"
@@ -6567,11 +6770,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1179
 msgid "Sort the characters..."
-msgstr ""
+msgstr "Sortiere die Zeichen..."
 
 #: ../../src/wxMaxima.cpp:8482
 msgid "Source list:"
-msgstr ""
+msgstr "Quellliste:"
 
 #: ../../src/wxMaxima.cpp:7429
 msgid "Split"
@@ -6590,70 +6793,73 @@ msgid "Split string into tokens"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1171
+#, fuzzy
 msgid "Split..."
-msgstr ""
+msgstr "Kastengraphik..."
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Square"
-msgstr ""
+msgstr "Rechteckig"
 
 #: ../../src/Configuration.cpp:86
 msgid "Standard Text"
-msgstr ""
+msgstr "Standard Text"
 
 #: ../../src/Worksheet.cpp:1298
 msgid "Start Animation"
-msgstr ""
+msgstr "Starte Animation"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Start of t:"
-msgstr ""
+msgstr "Beginn des t-Werts"
 
 #: ../../src/ToolBar.cpp:305
 msgid "Start or Stop animation"
-msgstr ""
+msgstr "Starte oder Stoppe Animation"
 
 #: ../../src/ToolBar.cpp:306
 msgid ""
 "Start or stop the currently selected animation that has been created with "
 "the with_slider class of commands"
 msgstr ""
+"Startet oder stoppt die aktuell ausgewählte Animation, die mit einem der "
+"with_slider-Kommandos erstellt wurde. "
 
 #: ../../src/wxMaxima.cpp:386
 msgid "Starting Maxima process failed"
-msgstr ""
+msgstr "Start von Maxima ist fehlgeschlagen"
 
 #: ../../src/main.cpp:667
 msgid "Starting a new wxMaxima process for a new window"
-msgstr ""
+msgstr "Starte einen neuen wxMaxima Prozess für ein neues Fenster"
 
 #: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:5633
 msgid "Starting evaluation of the document"
-msgstr ""
+msgstr "Starte das Auswerten des Dokuments."
 
 #: ../../src/wxMaxima.cpp:2544
 msgid "Starting server failed"
-msgstr ""
+msgstr "Das Starten des Servers ist fehlgeschlagen"
 
 #: ../../src/WXMXformat.cpp:64
 msgid "Starting to save the worksheet as .wxmx"
-msgstr ""
+msgstr "Beginne, das Arbeitsblatt als .wxmx-Datei zu speichern"
 
 #: ../../src/wxMaximaFrame.cpp:252
 msgid "Statistics"
-msgstr ""
+msgstr "Statistik"
 
 #: ../../src/wxMaximaFrame.cpp:701
 msgid "Statistics\tAlt+Shift+S"
-msgstr ""
+msgstr "Statistik\tAlt+Shift+S"
 
 #: ../../src/wxMaxima.cpp:7844
 msgid "Step width:"
-msgstr ""
+msgstr "Schrittweite:"
 
 #: ../../src/wxMaximaFrame.cpp:794
 msgid "Straight lines"
-msgstr ""
+msgstr "Gerade Linien"
 
 #: ../../src/wxMaximaFrame.cpp:1106
 msgid "Stream"
@@ -6675,25 +6881,25 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1185
 msgid "String"
-msgstr ""
+msgstr "Zeichenfolge"
 
 #: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
 #: ../../src/wxMaxima.cpp:7425
 msgid "String #1:"
-msgstr ""
+msgstr "Zeichenfolge #1:"
 
 #: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
 #: ../../src/wxMaxima.cpp:7426
 msgid "String #2:"
-msgstr ""
+msgstr "Zeichenfolge #2:"
 
 #: ../../src/wxMaximaFrame.cpp:1136
 msgid "String Tests"
-msgstr ""
+msgstr "Zeichenfolgen-Tests"
 
 #: ../../src/wxMaxima.cpp:7415
 msgid "String length"
-msgstr ""
+msgstr "Zeichenfolgen-Länge"
 
 #: ../../src/wxMaxima.cpp:7381
 msgid "String to list of char"
@@ -6704,8 +6910,9 @@ msgid "String to list of chars..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7496
+#, fuzzy
 msgid "String to octets"
-msgstr ""
+msgstr "Zeichenfolgen"
 
 #: ../../src/wxMaximaFrame.cpp:1160
 msgid "String to octets..."
@@ -6723,7 +6930,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
 #: ../../src/wxMaxima.cpp:7497
 msgid "String:"
-msgstr ""
+msgstr "Zeichenfolgen:"
 
 #: ../../src/wxMaxima.cpp:7197
 msgid "Struct :"
@@ -6739,11 +6946,11 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:274
 msgid "Subsection"
-msgstr ""
+msgstr "Unterkapitel"
 
 #: ../../src/Configuration.cpp:90
 msgid "Subsection cell (Heading 3)"
-msgstr ""
+msgstr "Untersektion (3. Gliederungsebene)"
 
 #: ../../src/wxMaximaFrame.cpp:1643
 msgid "Subst constant t into eq with diff(x,t)..."
@@ -6756,19 +6963,20 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
 #: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
 msgid "Substitute"
-msgstr ""
+msgstr "Substituieren"
 
 #: ../../src/wxMaximaFrame.cpp:1193
 msgid "Substitute all matches"
-msgstr ""
+msgstr "Ersetze alle Fundstellen"
 
 #: ../../src/wxMaximaFrame.cpp:1192
 msgid "Substitute first match"
-msgstr ""
+msgstr "Ersetze erste Fundstelle"
 
 #: ../../src/wxMaximaFrame.cpp:1646
+#, fuzzy
 msgid "Substitute only in parts..."
-msgstr ""
+msgstr "Substituieren ..."
 
 #: ../../src/wxMaxima.cpp:8763
 msgid "Substitute only in specific parts"
@@ -6780,7 +6988,7 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
 msgid "Substitute..."
-msgstr ""
+msgstr "Substituieren ..."
 
 #: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
 msgid "Substitutes until the equation no more changes"
@@ -6816,15 +7024,15 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:275
 msgid "Subsubsection"
-msgstr ""
+msgstr "Unter-Unterkapitel"
 
 #: ../../src/Configuration.cpp:89
 msgid "Subsubsection cell (Heading 4)"
-msgstr ""
+msgstr "Unter-Untersektion (4. Gliederungsebene)"
 
 #: ../../src/Worksheet.cpp:1831
 msgid "Suggestion: "
-msgstr ""
+msgstr "Empfehlung: "
 
 #: ../../src/Worksheet.cpp:2030
 msgid "Suitable as flag for ev()"
@@ -6832,114 +7040,131 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9049
 msgid "Sum"
-msgstr ""
+msgstr "Summieren"
 
 #: ../../src/wxMaximaFrame.cpp:1551
 msgid ""
 "Switch off simplifications of log(). Set Maxima option variable "
 "logexpand:false"
 msgstr ""
+"Vereinfachungen von log() deaktivieren. Setzt die Maxima Variable "
+"logexpand:false"
 
 #: ../../src/wxMaxima.cpp:4090
+#, fuzzy
 msgid "Switched to lisp mode after receiving a lisp debug prompt!"
-msgstr ""
+msgstr "Wechsle zum Lisp-Modus, da Maxima Lisp-Befehle anfordert!"
 
 #: ../../src/wxMaxima.cpp:4092
 msgid "Switched to lisp mode after receiving a lisp prompt!"
-msgstr ""
+msgstr "Wechsle zum Lisp-Modus, da Maxima Lisp-Befehle anfordert!"
 
 #: ../../src/Worksheet.cpp:1971
 msgid "Symbolic Constant"
-msgstr ""
+msgstr "Symbolische Konstante"
 
 #: ../../src/wxMaximaFrame.cpp:705
 msgid "Symbols\tAlt+Shift+Y"
-msgstr ""
+msgstr "Symbole\tAlt+Shift+Y"
 
 #: ../../src/Worksheet.cpp:2006
 msgid "Symmetric function: f(x)=f(-x)"
-msgstr ""
+msgstr "Achsensymmetrische Funktion: f(x)=f(-x)"
 
 #: ../../src/wxMaximaFrame.cpp:238
 msgid "Table of Contents"
-msgstr ""
+msgstr "Inhaltsverzeichnis"
 
 #: ../../src/wxMaximaFrame.cpp:711
 msgid "Table of Contents\tAlt+Shift+T"
-msgstr ""
+msgstr "Inhaltsverzeichnis\tAlt+Shift+T"
 
 #: ../../src/wxMaxima.cpp:8930
 msgid "Taylor series"
-msgstr ""
+msgstr "Taylorreihe"
 
 #: ../../src/wxMaximaFrame.cpp:1474
 msgid "Taylor series..."
-msgstr ""
+msgstr "Taylorreihe..."
 
 #: ../../src/wxMaxima.cpp:8925
 msgid "Taylor series:"
-msgstr ""
+msgstr "Taylorreihe:"
 
 #: ../../src/wxMaxima.cpp:4132
 msgid "Telling maxima about the new working directory."
-msgstr ""
+msgstr "Informiere Maxima über das neue Arbeitsverzeichnis."
 
 #: ../../src/wxMaxima.cpp:7907
 msgid "Tells maxima for an f(x), that f(x=t)=a"
-msgstr ""
+msgstr "Informiere Maxima für f(x), dass f(x=t)=a"
 
 #: ../../src/wxMaximaFrame.cpp:1945
 msgid ""
 "Tells maxima to show the help for ?, ?? and describe() in a separate browser"
 " window"
 msgstr ""
+"Sagt Maxima, dass die Hilfe für ?, ?? und describe() in einem separaten "
+"Browser angezeigt wird."
 
 #: ../../src/wxMaximaFrame.cpp:1941
 msgid ""
 "Tells maxima to show the help for ?, ?? and describe() in a wxMaxima sidebar"
 msgstr ""
+"Sagt Maxima, dass die Hilfe für ?, ?? und describe() in einem wxMaxima-"
+"Sidebar angezeigt wird."
 
 #: ../../src/wxMaximaFrame.cpp:1936
 msgid "Tells maxima to show the help for ?, ?? and describe() on the console"
 msgstr ""
+"Sagt Maxima, dass die Hilfe für ?, ?? und describe() in der Konsole "
+"angezeigt wird."
 
 #: ../../src/ToolBar.cpp:271
 msgid "Text"
-msgstr ""
+msgstr "Text"
 
 #: ../../src/Configuration.cpp:93
 msgid "Text cell background"
-msgstr ""
+msgstr "Hintergrundfarbe Textzelle"
 
 #: ../../src/wxMaxima.cpp:6541
 msgid "Text snippet"
-msgstr ""
+msgstr "Textschnipsel"
 
 #: ../../src/wxMaxima.cpp:4632
 msgid ""
 "The .xml file doesn't seem to be valid xml or isn't a content.xml extracted "
 "from a .wxmx zip archive"
 msgstr ""
+"Die .xml-Datei ist entweder kein gültiges xml, oder keine content.xml, die "
+"von einem .wxmx-Archiv extrahiert wurde."
 
 #: ../../src/wxMaxima.cpp:2734
 msgid ""
 "The Maxima process doesn't offer a shared memory segment we can send an "
 "interrupt signal to."
 msgstr ""
+"Maxima bietet keinen geteilten Speicher an, in dem ein "
+"\"Unterbrechen\"-Signal hinterlegt werden kann."
 
 #: ../../src/MaximaManual.cpp:107
 msgid "The cache for the subjects the manual contains cannot be read."
 msgstr ""
+"Der Zwischenspeicher für die Handbucheinträge kann nicht gelesen werden."
 
 #: ../../src/MaximaManual.cpp:378
 msgid "The cache for the subjects the manual contains has no head node."
 msgstr ""
+"Der Zwischenspeicher für die Handbucheinträge hat keinen obersten Knoten."
 
 #: ../../src/MaximaManual.cpp:396
 msgid ""
 "The cache for the subjects the manual contains is from a different Maxima "
 "version."
 msgstr ""
+"Der Zwischenspeicher für die Handbucheinträge ist von einer anderen Maxima-"
+"Version."
 
 #: ../../src/wxMaximaFrame.cpp:1379
 msgid "The classic operations one typically uses matrices for"
@@ -6950,8 +7175,9 @@ msgid "The comma-separated contents of the struct fields"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7186
+#, fuzzy
 msgid "The comma-separated names of the struct fields"
-msgstr ""
+msgstr "Geben Sie die Variablen durch Beistriche getrennt ein."
 
 #: ../../src/wxMaxima.cpp:7070
 msgid ""
@@ -6964,39 +7190,43 @@ msgid "The current Wizard"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9592
+#, fuzzy
 msgid "The equation to fit the data to"
-msgstr ""
+msgstr "Zeigt Gleichungen in der linearen Form an"
 
 #: ../../src/wxMaxima.cpp:8447
 msgid "The function call whose arguments to extract"
-msgstr ""
+msgstr "Die Funktion, deren Argumente extrahiert werden sollen"
 
 #: ../../src/wxMaximaFrame.cpp:1298
 msgid "The half of the equation that is to the left of the \"=\""
-msgstr ""
+msgstr "Die Hälfte der Gleichung, die links vom \"=\" steht."
 
 #: ../../src/wxMaximaFrame.cpp:1302
 msgid "The half of the equation that is to the right of the \"=\""
-msgstr ""
+msgstr "Die Seite der Gleichung, die rechts vom \"=\" steht."
 
 #: ../../src/MaximaManual.cpp:399
+#, fuzzy
 msgid "The help dir from the cache differs from the current one."
-msgstr ""
+msgstr "Einstellungen für die Axen für das aktuelle Diagramm."
 
 #: ../../src/Image.cpp:985
 msgid ""
 "The image could not be displayed. It may be broken, in a wrong format or be the result of gnuplot not being able to write the image or not being able to understand what maxima wanted to plot.\n"
 "One example of the latter would be: Gnuplot refuses to plot entirely empty images"
 msgstr ""
+"Das Bild konnte nicht angezeigt werden. Es könnte defekt sein, im falschen Format oder die Ursache könnte auch Gnuplot sein - entweder konnte es das Bild nicht speichern oder Gnuplot hat nicht verstanden, was Maxima plotten wollte.\n"
+"Alternative Erklärung: Gnuplot hat versucht, ein leeres Bild zu zeichnen."
 
 #: ../../src/wxMaxima.cpp:9799 ../../src/wxMaxima.cpp:10158
 #, c-format
 msgid "The image file \"%s\" cannot be found."
-msgstr ""
+msgstr "Die Bilddatei \"%s\" wurde nicht gefunden."
 
 #: ../../src/wxMaximaFrame.cpp:718
 msgid "The integrated help browser"
-msgstr ""
+msgstr "Wähle den integrierten Hilfebrowser"
 
 #: ../../src/wxMaxima.cpp:9591
 msgid "The list of variables contained in each matrix row"
@@ -7008,11 +7238,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "The manual of Maxima"
-msgstr ""
+msgstr "Das Handbuch von Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "The manual of wxMaxima"
-msgstr ""
+msgstr "Das Handbuch von wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7125
 msgid "The name of a function we don't want to be evaluated here"
@@ -7023,34 +7253,39 @@ msgid "The name of an expression that we don't want to be evaluated."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7199
+#, fuzzy
 msgid "The name of the field to read"
-msgstr ""
+msgstr "Die Farbe der nächsten Kurve"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "The name of the new struct type"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7198
+#, fuzzy
 msgid "The name of the struct"
-msgstr ""
+msgstr "Name des Parameters"
 
 #: ../../src/wxMaxima.cpp:7191
 msgid "The name of the struct type"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8220
+#, fuzzy
 msgid "The name of the variable that shall contain the current element"
-msgstr ""
+msgstr "Die Variable, die das aktuelle Element der Quellliste enthält."
 
 #: ../../src/wxMaxima.cpp:8468
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
-msgstr ""
+msgstr "Die Zahl des Elements wird von Startindex bis Endeindex durchgezählt."
 
 #: ../../src/wxMaxima.cpp:8465 ../../src/wxMaxima.cpp:8478
 msgid ""
 "The rule that explains how to generate the value of a list item.\n"
 "Might be something like \"i\", \"i^2\" or \"sin(i)\""
 msgstr ""
+"Die Regel, die beschreibt, welchen Wert ein Listenelement zu haben hat.\n"
+"Kann etwas wie \"i\" sein, \"i^2\" oder sin(i)."
 
 #: ../../src/wxMaxima.cpp:7785
 msgid ""
@@ -7080,7 +7315,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8481 ../../src/wxMaxima.cpp:8582
 msgid "The variable the value of the current source item is stored in."
-msgstr ""
+msgstr "Die Variable, die das aktuelle Element der Quellliste enthält."
 
 #: ../../src/wxMaxima.cpp:9594
 msgid "The variables to search the optimum solution for"
@@ -7088,23 +7323,27 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:193
 msgid "The worksheet"
-msgstr ""
+msgstr "Arbeitsblatt"
 
 #: ../../src/Worksheet.cpp:8122
 msgid "The worksheet containing maxima's input and output"
-msgstr ""
+msgstr "Das Arbeitsblatt mit Maxima's Ein- und Ausgabe"
 
 #: ../../src/MathParser.cpp:629
 msgid ""
 "The xml data from maxima or from the .wxmx file was missing data here.\n"
 "If you find a way how to reproduce this problem please file a bug report against wxMaxima."
 msgstr ""
+"Hier fehlte in der Ausgabe von Maxima oder in der .wxmx-Datei ein Element.\n"
+"Wenn dies reproduzierbar ist, bittet das wxMaxima-Team um einen Bug Report für wxMaxima."
 
 #: ../../src/wxMaxima.cpp:2143
 msgid ""
 "There was an error in the XML maxima has generated.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Das von Maxima erstellte XML ist fehlerhaft!\n"
+"Bitte berichten Sie dies als Fehler im wxMaxima Projekt!"
 
 #: ../../src/wxMaxima.cpp:3911
 msgid ""
@@ -7125,10 +7364,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3257
+#, fuzzy
 msgid ""
 "There was an error in the XML that should describe the manual topics.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Die erstellte XML-Datei ist fehlerhaft!\n"
+"\n"
+"Bitte berichten Sie dies als Programmfehler."
 
 #: ../../src/wxMaxima.cpp:3202
 msgid ""
@@ -7142,82 +7385,89 @@ msgid ""
 "It caches the list of subjects maxima's manual offers and is automatically\n"
 "overwritten if maxima's version changes or the file cannot be read"
 msgstr ""
+"Diese Datei wird von wxMaxima generiert.\n"
+"Sie speichert die Liste der Einträge in das Handbuch von Maxima zwischen und wird\n"
+"automatisch überschrieben, wenn eine andere Version von Maxima verwendet wird, oder\n"
+"die Datei nicht lesbar ist"
 
 #: ../../src/Worksheet.cpp:1992
 msgid "This function will return even integers"
-msgstr ""
+msgstr "Diese Funktion retourniert gerade Zahlen"
 
 #: ../../src/Worksheet.cpp:1994
 msgid "This function will return odd integers"
-msgstr ""
+msgstr "Diese Funktion retourniert ungerade Zahlen"
 
 #: ../../src/Worksheet.cpp:1950
 msgid "This symbol has no imaginary part"
-msgstr ""
+msgstr "Dieses Symbol hat keinen Imagnärteil"
 
 #: ../../src/Worksheet.cpp:1956
 msgid "This symbol has no real part"
-msgstr ""
+msgstr "Dieses Symbol hat keinen Realteil"
 
 #: ../../src/Worksheet.cpp:1953
 msgid "This symbol might have both real and imaginary part"
-msgstr ""
+msgstr "Dieses Symbol kann sowohl Real- als auch Imaginärteil enthalten"
 
 #: ../../src/Worksheet.cpp:1980
 msgid "Throw an error if this symbol is used before assigning it any contents"
 msgstr ""
+"Fehler ausgeben, falls das Symbol verwendet wird, bevor ein Wert zugewiesen "
+"wurde"
 
 #: ../../src/wxMaxima.cpp:9013 ../../src/wxMaxima.cpp:10058
 msgid "Times:"
-msgstr ""
+msgstr "Wie oft:"
 
 #: ../../src/ToolBar.cpp:272
 msgid "Title"
-msgstr ""
+msgstr "Titel"
 
 #: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
-msgstr ""
+msgstr "Titel (Hoch- und Tiefstellen als x_{10} oder x^{10})"
 
 #: ../../src/Configuration.cpp:92
 msgid "Title cell (Heading 1)"
-msgstr ""
+msgstr "Titel (1. Gliederungsebene)"
 
 #: ../../src/wxMaximaFrame.cpp:1794
 msgid "To &Bigfloat"
-msgstr ""
+msgstr "Als &lange Gleitkommazahl"
 
 #: ../../src/wxMaximaFrame.cpp:1791
 msgid "To &Float"
-msgstr ""
+msgstr "Letztes Ergebnis als Gleitkommazahl"
 
 #: ../../src/Worksheet.cpp:1571
 msgid "To Float"
-msgstr ""
+msgstr "Letztes Ergebnis als Gleitkommazahl"
 
 #: ../../src/wxMaximaFrame.cpp:1797
 msgid "To Numeri&c\tCtrl+Shift+N"
-msgstr ""
+msgstr "Als &Zahl\tCtrl+Shift+N"
 
 #: ../../src/wxMaximaFrame.cpp:1803
+#, fuzzy
 msgid "To exact fraction"
-msgstr ""
+msgstr "Partialbruchzerlegung"
 
 #: ../../src/wxMaximaFrame.cpp:1814
 msgid "To exact number"
-msgstr ""
+msgstr "Als exakte Zahl"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "To:"
-msgstr ""
+msgstr "bis:"
 
 #: ../../src/wxMaximaFrame.cpp:825 ../../src/wxMaximaFrame.cpp:828
 msgid "Toggle full screen editing"
-msgstr ""
+msgstr "Ganzer Bildschirm ein-/ausschalten"
 
 #: ../../src/ToolBar.cpp:265
 msgid "Toggle the visibility of code cells"
-msgstr ""
+msgstr "Macht die Codezellen sichtbar oder unsichtbar"
 
 #: ../../src/wxMaximaFrame.cpp:1177
 msgid "Tokenize..."
@@ -7225,27 +7475,27 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1909
 msgid "Tolerance calculations with Maxima"
-msgstr ""
+msgstr "Toleranzberechnungen mit Maxima"
 
 #: ../../src/wxMaxima.cpp:8192
 msgid "Top end"
-msgstr ""
+msgstr "Oberes Ende"
 
 #: ../../src/wxMaximaFrame.cpp:1078
 msgid "Trace a function..."
-msgstr ""
+msgstr "Eine Funktion verfolgen..."
 
 #: ../../src/wxMaxima.cpp:7084
 msgid "Trace function(s)"
-msgstr ""
+msgstr "Verfolge die Funktion(en)"
 
 #: ../../src/wxMaximaFrame.cpp:1184
 msgid "Transformations"
-msgstr ""
+msgstr "Transformationen"
 
 #: ../../src/wxMaximaFrame.cpp:1376
 msgid "Transpose a matrix"
-msgstr ""
+msgstr "Eine Matrix transponieren"
 
 #: ../../src/wxMaxima.cpp:7832
 msgid ""
@@ -7255,15 +7505,17 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:10036
+#, fuzzy
 msgid ""
 "Tries to find a solution of the equation that lies between the two bounds."
-msgstr ""
+msgstr "Die Hälfte der Gleichung, die links vom \"=\" steht."
 
 #: ../../src/wxMaxima.cpp:7774
+#, fuzzy
 msgid ""
 "Tries to find a value of the variable that solves the equation between the "
 "two bonds"
-msgstr ""
+msgstr "Die Hälfte der Gleichung, die links vom \"=\" steht."
 
 #: ../../src/wxMaxima.cpp:7719
 msgid ""
@@ -7298,12 +7550,14 @@ msgid "Trim both ends..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1182
+#, fuzzy
 msgid "Trim left..."
-msgstr ""
+msgstr "Grenzwert ..."
 
 #: ../../src/wxMaximaFrame.cpp:1183
+#, fuzzy
 msgid "Trim right..."
-msgstr ""
+msgstr "Grenzwert ..."
 
 #: ../../src/wxMaxima.cpp:7473
 msgid "Trim string left"
@@ -7330,40 +7584,42 @@ msgstr ""
 msgid ""
 "Trying to cache the list of subjects the manual contains in the file %s."
 msgstr ""
+"Versuche, die Liste der Themen, die das Handbuch in Datei %s enthält, zu "
+"cachen."
 
 #: ../../src/wxMaxima.cpp:4423
 msgid "Trying to discard all output."
-msgstr ""
+msgstr "Versuche, alle Ausgaben zu verwerfen."
 
 #: ../../src/wxMaxima.cpp:4380
 msgid "Trying to extract content.xml out of a broken .zip file."
-msgstr ""
+msgstr "Versuche, contents.xml aus einer defekten .zip-Datei zu extrahieren."
 
 #: ../../src/wxMaxima.cpp:5519
 msgid "Trying to open a file with an empty name!"
-msgstr ""
+msgstr "Interner Fehler: Versuch, eine Datei ohne Namen öffnen."
 
 #: ../../src/wxMaxima.cpp:5523
 #, c-format
 msgid "Trying to open the non-existing file %s"
-msgstr ""
+msgstr "Versuch, die nicht-existierende Datei %s zu öffnen."
 
 #: ../../src/wxMaxima.cpp:4457
 msgid "Trying to reconstruct the xml closing markers."
-msgstr ""
+msgstr "Versuche, schließende XML-Tags zu rekonstruieren."
 
 #: ../../src/wxMaxima.cpp:4376
 msgid "Trying to recover a broken .wxmx file."
-msgstr ""
+msgstr "Versuche, eine defekte .wxmx-Datei zu rekonstruieren."
 
 #: ../../src/wxMaxima.cpp:6026
 #, c-format
 msgid "Trying to remove the old temp file %s"
-msgstr ""
+msgstr "Versuche die alte temporäre Datei %s zu löschen."
 
 #: ../../src/wxMaxima.cpp:2507
 msgid "Trying to restart maxima."
-msgstr ""
+msgstr "Versuche, Maxima neuzustarten."
 
 #: ../../src/wxMaxima.cpp:2523
 #, c-format
@@ -7371,22 +7627,24 @@ msgid ""
 "Trying to start the socket a Maxima on the local machine can connect to on "
 "port %i"
 msgstr ""
+"Versuche, den Netzwerksocket des lokalen Rechners, zu dem sich Maxima "
+"verbinden kann an Port %i zu erstellen."
 
 #: ../../src/wxMaximaFrame.cpp:1928
 msgid "Tutorials"
-msgstr ""
+msgstr "Tutorials"
 
 #: ../../src/wxMaxima.cpp:9571
 msgid "Two sample t-test"
-msgstr ""
+msgstr "Zweistichproben t-Test"
 
 #: ../../src/Worksheet.cpp:8013
 msgid "Type"
-msgstr ""
+msgstr "Art"
 
 #: ../../src/wxMaxima.cpp:7180
 msgid "Type:"
-msgstr ""
+msgstr "Gestalt:"
 
 #: ../../src/wxMaxima.cpp:9429
 msgid "URL"
@@ -7398,81 +7656,85 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10479
 msgid "Un-closed parenthesis"
-msgstr ""
+msgstr "Nicht geschlossene Klammer"
 
 #: ../../src/wxMaxima.cpp:10467
 msgid "Un-closed parenthesis on encountering ; or $"
-msgstr ""
+msgstr "; oder $, bei dem nicht alle Klammern geschlossen waren"
 
 #: ../../src/wxMaxima.cpp:11160
 msgid ""
 "Unable to interpret the version info I got from http://wxMaxima-"
 "developers.github.io/wxmaxima/version.txt: "
 msgstr ""
+"Kann die Versions-Info von http://wxMaxima-"
+"developers.github.io/wxmaxima/version.txt nicht interpretieren: "
 
 #: ../../src/wxMaximaFrame.cpp:1007
+#, fuzzy
 msgid "Undefine"
-msgstr ""
+msgstr "Undefiniert"
 
 #: ../../src/ToolBar.cpp:191
 msgid "Undo"
-msgstr ""
+msgstr "Rückgängig machen"
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo\tCtrl+Z"
-msgstr ""
+msgstr "&Rückgängig\tCtrl+Z"
 
 #: ../../src/ToolBar.cpp:614
+#, fuzzy
 msgid "Undo and redo button"
-msgstr ""
+msgstr "Der \"Öffnen\"- und \"Speichern\"-Knopf"
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo last change"
-msgstr ""
+msgstr "Letzte Änderung rückgängig machen"
 
 #: ../../src/wxMaximaFrame.cpp:924
 msgid "Unfold All\tCtrl+Alt+]"
-msgstr ""
+msgstr "Alles aufklappen\tCtrl+8"
 
 #: ../../src/wxMaximaFrame.cpp:925
 msgid "Unfold all folded sections"
-msgstr ""
+msgstr "Alle zugeklappten Sektionen aufklappen"
 
 #: ../../src/Worksheet.cpp:1893
 msgid "Unhide Heading 5"
-msgstr ""
+msgstr "Zeige Paragraph"
 
 #: ../../src/Worksheet.cpp:1904
 msgid "Unhide Heading 6"
-msgstr ""
+msgstr "Zeige Unterparagraph"
 
 #: ../../src/Worksheet.cpp:1852
 msgid "Unhide Part"
-msgstr ""
+msgstr "Zeige diesen Abschnitt"
 
 #: ../../src/Worksheet.cpp:1860
 msgid "Unhide Section"
-msgstr ""
+msgstr "Zeige dieses Kapitel"
 
 #: ../../src/Worksheet.cpp:1871
 msgid "Unhide Subsection"
-msgstr ""
+msgstr "Zeige dieses Unterkapitel"
 
 #: ../../src/Worksheet.cpp:1882
 msgid "Unhide Subsubsection"
-msgstr ""
+msgstr "Zeige dieses Unter-Unterkapitel"
 
 #: ../../src/Worksheet.cpp:1912
 msgid "Unhide contents"
-msgstr ""
+msgstr "Zeige den Inhalt"
 
 #: ../../src/wxMaximaFrame.cpp:266
 msgid "Unicode characters"
-msgstr ""
+msgstr "Unicode Zeichen"
 
 #: ../../src/wxMaximaFrame.cpp:707
 msgid "Unicode chars\tAlt+Shift+U"
-msgstr ""
+msgstr "Unicode-Zeichen\tAlt+Shift+U"
 
 #: ../../src/wxMaximaFrame.cpp:1144
 msgid "Unicode code point to UTF8..."
@@ -7498,121 +7760,128 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10418
 msgid "Unterminated comment."
-msgstr ""
+msgstr "Fehlende Kommentarendemarkierung"
 
 #: ../../src/wxMaxima.cpp:10461
 msgid "Unterminated string."
-msgstr ""
+msgstr "Fehlendes schließendes Anführungszeichen"
 
 #: ../../src/wxMaxima.cpp:4786
 msgid "Updating maxima's configuration"
-msgstr ""
+msgstr "Aktualisiere Maxima's Konfiguration"
 
 #: ../../src/wxMaxima.cpp:11150 ../../src/wxMaxima.cpp:11157
 #: ../../src/wxMaxima.cpp:11163
 msgid "Upgrade"
-msgstr ""
+msgstr "Aktualisierung"
 
 #: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
 msgid "Upper bound:"
-msgstr ""
+msgstr "Obere Schranke:"
 
 #: ../../src/wxMaximaFrame.cpp:792
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
-msgstr ""
+msgstr "Verwende \"<\" und \">\" als Klammern für Matrizen"
 
 #: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
 msgid "Use a list"
-msgstr ""
+msgstr "Verwenden einer Liste"
 
 #: ../../src/wxMaxima.cpp:8571
 msgid "Use a list as parameter list for a function"
-msgstr ""
+msgstr "Verwende eine Liste als Parameterliste für eine Funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1708
 msgid "Use list"
-msgstr ""
+msgstr "Verwenden der Liste"
 
 #: ../../src/wxMaximaFrame.cpp:1701
 msgid "Use list as the arguments of a function"
-msgstr ""
+msgstr "Benutze die Listenelemente als Argumente einer Funktion"
 
 #: ../../src/wxMaximaFrame.cpp:786
 msgid "Use rounded parenthesis for matrices"
-msgstr ""
+msgstr "Runde Klammern für Matrizen"
 
 #: ../../src/wxMaximaFrame.cpp:789
 msgid "Use square parenthesis for matrices"
-msgstr ""
+msgstr "Eckige Klammern für Matrizen"
 
 #: ../../src/wxMaximaFrame.cpp:1083
+#, fuzzy
 msgid "Use struct field..."
-msgstr ""
+msgstr "&Kettenbruch"
 
 #: ../../src/wxMaximaFrame.cpp:795
 msgid "Use vertical lines instead of parenthesis for matrices"
-msgstr ""
+msgstr "Verwende vertikale Linien anstelle von Klammern für Matrizen"
 
 #: ../../src/Worksheet.cpp:1619
 msgid "User labels only"
-msgstr ""
+msgstr "Nur benutzerdefinierte Marken"
 
 #: ../../src/Configuration.cpp:81
 msgid "User-defined labels"
-msgstr ""
+msgstr "Benutzerdefinierte Marken"
 
 #: ../../src/MaximaManual.cpp:483
 msgid ""
 "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
 msgstr ""
+"Verwende die Maxima Hilfedatei aus der wxMaxima Konfiguration "
+"(helpFile=...)."
 
 #: ../../src/wxMaxima.cpp:4825
 msgid "Using Maxima path from command line."
-msgstr ""
+msgstr "Verwende den Pfad zu Maxima von der Kommandozeile."
 
 #: ../../src/wxMaxima.cpp:4822
 msgid "Using configured Maxima path."
-msgstr ""
+msgstr "Verwende den konfigurierten Pfad zu Maxima."
 
 #: ../../src/wxMaxima.cpp:2961
 msgid ""
 "Using gnuplot's antialiassing-less png driver for embedded plots as pngcairo"
 " could not be found"
 msgstr ""
+"Verwende Gnuplot's simplen png-Treiber, da Gnuplot ohne pngcairo compiliert "
+"wurde."
 
 #: ../../src/wxMaxima.cpp:2956
 msgid "Using gnuplot's pngcairo driver for embedded plots"
 msgstr ""
+"Verwende gnuplot's pngcairo-Treiber für ins Arbeitsblatt eingebettete "
+"Abbildungen."
 
 #: ../../src/MaximaManual.cpp:88
 msgid "Using the built-in list of manual anchors."
-msgstr ""
+msgstr "Verwende die eingebaute Liste an Handbuchthemen."
 
 #: ../../src/WXMXformat.cpp:266
 msgid ""
 "Validated that the XML representation of the document actually is valid XML"
-msgstr ""
+msgstr "Überprüft, daß die XML-Darstellung des Dokuments gültiges XML ist"
 
 #: ../../src/wxMaxima.cpp:8755
 msgid "Value at a given point"
-msgstr ""
+msgstr "Wert an einem vorgegebenen Punkt"
 
 #: ../../src/Worksheet.cpp:1987
 msgid "Value at a specific point"
-msgstr ""
+msgstr "Wert an einem bestimmten Punkt"
 
 #: ../../src/wxMaxima.cpp:7801
 msgid "Value at that point:"
-msgstr ""
+msgstr "Wert an diesem Punkt:"
 
 #: ../../src/wxMaxima.cpp:7812 ../../src/wxMaxima.cpp:7825
 #: ../../src/wxMaxima.cpp:7827
 msgid "Value y at that point:"
-msgstr ""
+msgstr "Wert von y an dieser Stelle:"
 
 #: ../../src/wxMaxima.cpp:7910
 msgid "Value:"
-msgstr ""
+msgstr "Wert:"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Var #1"
@@ -7624,29 +7893,29 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6852 ../../src/wxMaxima.cpp:8183
 msgid "Variable"
-msgstr ""
+msgstr "Variable"
 
 #: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
 #: ../../src/wxMaxima.cpp:8568
 msgid "Variable name"
-msgstr ""
+msgstr "Variablenname"
 
 #: ../../src/wxMaximaFrame.cpp:1085
 msgid "Variable name, not contents..."
-msgstr ""
+msgstr "Variablenname, nicht Inhalt..."
 
 #: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
 msgid "Variable name:"
-msgstr ""
+msgstr "Variablenname:"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 msgid "Variable(s)"
-msgstr ""
+msgstr "Variable(n)"
 
 #: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
 #: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
 msgid "Variable(s):"
-msgstr ""
+msgstr "Variable(n):"
 
 #: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
 #: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
@@ -7654,49 +7923,51 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
 #: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
 msgid "Variable:"
-msgstr ""
+msgstr "Variable:"
 
 #: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
 msgid "Variables"
-msgstr ""
+msgstr "Variablen"
 
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
 msgid "Variables:"
-msgstr ""
+msgstr "Variablen:"
 
 #: ../../src/WXMXformat.cpp:337
 msgid "Verified that we are able to read the whole .zip archive we produced."
 msgstr ""
+"Überprüft, dass wir das ZIP-Archiv, das wir produziert haben, lesen können."
 
 #: ../../src/wxMaximaFrame.cpp:836
 msgid "View"
-msgstr ""
+msgstr "Anzeige"
 
 #: ../../src/Autocomplete.cpp:235
 msgid "Waiting for m_addFiles_backgroundThread to finish"
-msgstr ""
+msgstr "Warte auf das Beenden von m_addFiles_backgroundThread"
 
 #: ../../src/Autocomplete.cpp:122 ../../src/Autocomplete.cpp:240
 msgid "Waiting for m_addSymbols_backgroundThread to finish"
-msgstr ""
+msgstr "Warte auf das Beenden von m_addSymbols_backgroundThread"
 
 #: ../../src/MaximaManual.cpp:533
 msgid "Waiting for the Manual anchors background task."
-msgstr ""
+msgstr "Warte auf den Hintergrundprozess für die Handbuch-Markierungen."
 
 #: ../../src/MaximaManual.cpp:562
+#, fuzzy
 msgid "Waiting for the thread that parses the maxima manual to finish"
-msgstr ""
+msgstr "Stelle eine Liste der Stichwörter im Handbuch zusammen"
 
 #: ../../src/MathParser.cpp:1229 ../../src/wxMaxima.cpp:3296
 #: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
 #: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
 msgid "Warning"
-msgstr ""
+msgstr "Warnung"
 
 #: ../../src/wxMaximaFrame.cpp:1556
 msgid "Warning:"
-msgstr ""
+msgstr "Warnung:"
 
 #: ../../src/Dirstructure.cpp:72
 #, c-format
@@ -7704,65 +7975,73 @@ msgid ""
 "Warning: Cannot create %s, the directory maxima keeps configuration, user packages and caches in.\n"
 "Make sure that your system's home directory is set up correctly"
 msgstr ""
+"%s, das Verzeichnis, in denen Maxima den Cache, Pakete des Benutzers und die"
+" Konfiguration ablegt, kann nicht gefunden werden. Oft heißt dies, dass das "
+"\"Eigene Dateien\"-Verzeichnis des Systems nicht korrekt aufgesetzt ist."
 
 #: ../../src/wxMaximaFrame.cpp:1546
 msgid ""
 "Warning: No test if the argument of the log is complex, positive or negative"
 msgstr ""
+"Warnung: Kein Test, ob das Argument von log komplex, positiv oder negativ "
+"ist"
 
 #: ../../src/wxMaxima.cpp:5063
 msgid "Welcome to wxMaxima"
-msgstr ""
+msgstr "Willkommen bei wxMaxima"
 
 #: ../../src/wxMaxima.cpp:8583
 msgid "What to do:"
-msgstr ""
+msgstr "Was ist zu tun:"
 
 #: ../../src/wxMaximaFrame.cpp:1058
 msgid "When to invoke the lisp compiler's debugger"
-msgstr ""
+msgstr "Wann soll der Lisp Debugger aufgerufen werden"
 
 #: ../../src/wxMaxima.cpp:7046
 msgid "While loop"
-msgstr ""
+msgstr "While Schleife"
 
 #: ../../src/wxMaximaFrame.cpp:1063
 msgid "While loop..."
-msgstr ""
+msgstr "While Schleife..."
 
 #: ../../src/wxMaxima.cpp:5673
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38)"
 " (*.wxm)|*.wxm|All Files (*.*)|*"
 msgstr ""
+"Gesamtes Dokument (*.wxmx)|*.wxmx|Die Eingabezellen, lesbar von load() in "
+"Maxima > 5.38 (*.wxm)|*.wxm|Alle Dateien (*.*)|*"
 
 #: ../../src/wxMaxima.cpp:210
 msgid "Will try to generate a stack backtrace, if the program ever crashes"
 msgstr ""
+"Versuche einen Stack-Backtrace zu generieren, falls das Programm abstürzt"
 
 #: ../../src/Worksheet.cpp:6920
 msgid "Worksheet got activated"
-msgstr ""
+msgstr "Arbeitsblatt wurde aktiviert"
 
 #: ../../src/Worksheet.cpp:6840
 msgid "Worksheet got the mouse focus"
-msgstr ""
+msgstr "Arbeitsblatt hat den Maus-Fokus bekommen"
 
 #: ../../src/Worksheet.cpp:7191 ../../src/Worksheet.cpp:7279
 msgid "Wrapped search"
-msgstr ""
+msgstr "Suche wurde über das Ende des Dokuments hinweg fortgesetzt"
 
 #: ../../src/WXMXformat.cpp:282
 msgid "Wrote all image and gnuplot files to the zip archive"
-msgstr ""
+msgstr "Alle Bild- und Gnuplot-Dateien in das ZIP-Archiv geschrieben"
 
 #: ../../src/WXMXformat.cpp:272
 msgid "Wrote the XML representation of the document to the zip archive"
-msgstr ""
+msgstr "XML Darstellung des Dokuments in das ZIP-Archiv geschrieben"
 
 #: ../../src/WXMXformat.cpp:116
 msgid "Wrote the mimetype info"
-msgstr ""
+msgstr "Mimetype Information geschrieben"
 
 #: ../../src/wxMaxima.cpp:11147
 #, c-format
@@ -7771,68 +8050,72 @@ msgid ""
 "\n"
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
+"Sie nutzen Version %s. Die aktuellste Sourcecode-Version ist %s.\n"
+"\n"
+"Wählen Sie OK, um die wxMaxima Homepage zu besuchen."
 
 #: ../../src/wxMaxima.cpp:11202
 msgid "Your changes will be lost if you don't save them."
-msgstr ""
+msgstr "Nicht gespeicherte Änderungen gehen verloren."
 
 #: ../../src/wxMaxima.cpp:11156
 msgid "Your version of wxMaxima is up to date."
-msgstr ""
+msgstr "Ihre wxMaxima Version ist aktuell."
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom &In\tCtrl++"
-msgstr ""
+msgstr "Ver&größern\tCtrl++"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom Ou&t\tCtrl+-"
-msgstr ""
+msgstr "Verk&leinern\tCtrl+-"
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom in 10%"
-msgstr ""
+msgstr "Hineinzoomen in Schritten von 10 %"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom out 10%"
-msgstr ""
+msgstr "Herauszoomen in Schritten von 10 %"
 
 #: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
 msgid "[ unsaved ]"
-msgstr ""
+msgstr "[ nicht gespeichert ]"
 
 #: ../../src/wxMaxima.cpp:10920
 msgid "[ unsaved* ]"
-msgstr ""
+msgstr "[ nicht gespeichert* ]"
 
 #: ../../src/Worksheet.cpp:5278
-#, c-format
+#, fuzzy, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" loading=\"lazy\" style=\"max-width:90%%;\">\n"
-msgstr ""
+msgstr "_%d.gif\"  alt=\"Animation\" loading=\"lazy\" style=\"max-width:90%%;\" />\n"
 
 #: ../../src/Worksheet.cpp:5484
-#, c-format
+#, fuzzy, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"lazy\">"
-msgstr ""
+msgstr "_%d.gif\" alt=\"Animation\" style=\"max-width:90%%;\" loading=\"lazy\" />"
 
 #: ../../src/wxMaximaFrame.cpp:1690
 msgid "apply function to each element"
-msgstr ""
+msgstr "Funktion auf jedes Element der Liste anwenden"
 
 #: ../../src/wxMaximaFrame.cpp:739
 msgid "as 1D ASCII"
-msgstr ""
+msgstr "Als 1D-Text"
 
 #: ../../src/wxMaximaFrame.cpp:742
 msgid "as ASCII Art"
-msgstr ""
+msgstr "Als Text"
 
 #: ../../src/wxMaximaFrame.cpp:745
+#, fuzzy
 msgid "as ASCII+Unicode Art"
-msgstr ""
+msgstr "Als Text"
 
 #: ../../src/wxMaximaFrame.cpp:1680
 msgid "as storage for actual values for variables"
-msgstr ""
+msgstr "als Speicher für die konkreten Inhalte von Variablen"
 
 #: ../../src/wxMaximaFrame.cpp:1139
 msgid "char to Ascii code..."
@@ -7844,15 +8127,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1064 ../../src/wxMaximaFrame.cpp:1702
 msgid "do for each element"
-msgstr ""
+msgstr "Tue das folgende für jedes Element:"
 
 #: ../../src/Worksheet.cpp:2027
 msgid "ev() shall evaluate this automatically"
-msgstr ""
+msgstr "ev() soll das automatisch evaluieren"
 
 #: ../../src/wxMaxima.cpp:7130
 msgid "expression:"
-msgstr ""
+msgstr "Ausdruck:"
 
 #: ../../src/Worksheet.cpp:2025
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
@@ -7860,35 +8143,36 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
 msgid "filename:"
-msgstr ""
+msgstr "Dateiname:"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "from a list"
-msgstr ""
+msgstr "von einer Liste"
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "from a rule"
-msgstr ""
+msgstr "anhand einer Regel"
 
 #: ../../src/wxMaximaFrame.cpp:1685
 msgid "from function arguments"
-msgstr ""
+msgstr "von den Argumenten einer Funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1669
 msgid "from individual elements"
-msgstr ""
+msgstr "Von einzelnen Elementen"
 
 #: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
 msgid "function"
-msgstr ""
+msgstr "Funktion"
 
 #: ../../src/wxMaximaFrame.cpp:747
 msgid "in 2D"
-msgstr ""
+msgstr "in 2D"
 
 #: ../../src/wxMaxima.cpp:8554
+#, fuzzy
 msgid "list"
-msgstr ""
+msgstr "Verwenden der Liste"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "max(abs(A(i,j))) (complex)"
@@ -7900,12 +8184,12 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8046
 msgid "m×n Matrix A:"
-msgstr ""
+msgstr "m×n Matrix A:"
 
 #: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533
 msgid "n:"
-msgstr ""
+msgstr "n:"
 
 #: ../../src/Worksheet.cpp:2000
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -7917,7 +8201,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1710
 msgid "nth"
-msgstr ""
+msgstr "n-tes Element"
 
 #: ../../src/Worksheet.cpp:2021
 msgid "outative: f(2*x) = 2*f(x)"
@@ -7926,23 +8210,25 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7440 ../../src/wxMaxima.cpp:7445
 #: ../../src/wxMaxima.cpp:7455
 msgid "part:"
-msgstr ""
+msgstr "Teil:"
 
 #: ../../src/wxMaxima.cpp:8942
 msgid "point:"
-msgstr ""
+msgstr "Punkt:"
 
 #: ../../src/wxMaxima.cpp:7740
 msgid "precision:"
-msgstr ""
+msgstr "Genauigkeit:"
 
 #: ../../src/wxMaxima.cpp:7255
+#, fuzzy
 msgid "printf"
-msgstr ""
+msgstr "Drucken"
 
 #: ../../src/wxMaximaFrame.cpp:1108
+#, fuzzy
 msgid "printf..."
-msgstr ""
+msgstr "Differenzieren ..."
 
 #: ../../src/wxMaxima.cpp:8650
 msgid ""
@@ -7956,41 +8242,50 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8731
 msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
+"ratsubst arbeitet wie subst, aber kennt einfache mathematische Regeln, falls"
+" erforderlich."
 
 #: ../../src/wxMaximaFrame.cpp:1111
 msgid "readbyte..."
-msgstr ""
+msgstr "Byte lesen..."
 
 #: ../../src/wxMaximaFrame.cpp:1110
 msgid "readchar..."
-msgstr ""
+msgstr "Zeichen lesen..."
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "readline..."
-msgstr ""
+msgstr "Zeile lesen..."
 
 #: ../../src/wxMaxima.cpp:10018
+#, fuzzy
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables can be used to to tell solve() which variables to eliminate from the solution\n"
 "solve() searches for a global solution. If a problem has different solutions depending on the range its variables are in one way to successfully use solve() is to use solve() to eliminate variables one by one and to manually choose which of the solutions solve() found matches the current problem."
 msgstr ""
+"solve() findet für eine Liste aus n voneinander unabhängigen Gleichungen nur Lösungen, wenn es auch n Variablen gibt, nach denen die Gleichungen aufzulösen sind.\n"
+"Falls nur eine Variable interessiert, können solve() als die anderen benötigten Variablen jene, die im Ergebnis eliminiert werden sollen, übergeben werden."
 
 #: ../../src/wxMaxima.cpp:7745
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables solve needs to do its work can be used to tell solve() which variables to eliminate in the solution for the interesting variable."
 msgstr ""
+"solve() findet für eine Liste aus n voneinander unabhängigen Gleichungen nur Lösungen, wenn es auch n Variablen gibt, nach denen die Gleichungen aufzulösen sind.\n"
+"Falls nur eine Variable interessiert, können solve() als die anderen benötigten Variablen jene, die im Ergebnis eliminiert werden sollen, übergeben werden."
 
 #: ../../src/wxMaxima.cpp:7784
 msgid ""
 "solves an equation of the form\n"
 "    'diff(y,t) = -y;"
 msgstr ""
+"Löst eine Gleichung der Form\n"
+"    'diff(y,t) = -y;"
 
 #: ../../src/wxMaxima.cpp:7789
 msgid "t:"
-msgstr ""
+msgstr "t:"
 
 #: ../../src/wxMaximaFrame.cpp:1075
 msgid "unnamed function (lambda)..."
@@ -7998,44 +8293,44 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11190
 msgid "unsaved"
-msgstr ""
+msgstr "nicht gespeichert"
 
 #: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
 #: ../../src/wxMaximaFrame.cpp:189
 msgid "untitled"
-msgstr ""
+msgstr "unbenannt"
 
 #: ../../src/wxMaximaFrame.cpp:1700
 msgid "use as function arguments"
-msgstr ""
+msgstr "Nutze als Parameterliste einer Funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1696
 msgid "use the actual values stored"
-msgstr ""
+msgstr "Verwende die konkreten in der Liste gespeicherten Variablenwerte"
 
 #: ../../src/wxMaximaFrame.cpp:1112
 msgid "writebyte..."
-msgstr ""
+msgstr "Byte schreiben..."
 
 #: ../../src/main.cpp:509
 msgid "wxMaxima"
-msgstr ""
+msgstr "wxMaxima"
 
 #: ../../src/main.cpp:516
 #, c-format
 msgid "wxMaxima %ld"
-msgstr ""
+msgstr "wxMaxima %ld"
 
 #: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
 #: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
 #: ../../src/wxMaximaFrame.cpp:185
 #, c-format
 msgid "wxMaxima %s (%s) "
-msgstr ""
+msgstr "wxMaxima %s (%s) "
 
 #: ../../src/wxMaxima.cpp:4490
 msgid "wxMaxima cannot read the xml contents of "
-msgstr ""
+msgstr "wxMaxima kann den XML-Inhalt nicht öffnen in "
 
 #: ../../src/wxMaxima.cpp:2546
 msgid ""
@@ -8047,77 +8342,82 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5285
 msgid "wxMaxima document"
-msgstr ""
+msgstr "wxMaxima-Dokument"
 
 #: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
 #: ../../src/wxMaxima.cpp:4230
 msgid "wxMaxima encountered an error loading "
-msgstr ""
+msgstr "wxMaxima hat einen Fehler beim Laden festgestellt"
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "wxMaxima help"
-msgstr ""
+msgstr "Die Hilfe für wxMaxima"
 
 #: ../../src/Worksheet.cpp:1465 ../../src/Worksheet.cpp:1839
 msgid ""
 "wxMaxima remembers answers from the last run and is able to automatically "
 "send them to maxima, if requested"
 msgstr ""
+"wxMaxima erinnert sich an die Antworten des letzten Durchlaufs und ist "
+"fähig, sie, wenn verlangt, automatisch an Maxima zu senden"
 
 #: ../../src/Worksheet.cpp:1470 ../../src/Worksheet.cpp:1844
 msgid ""
 "wxMaxima remembers answers from the last run and is able to offer them as "
 "the default answer"
 msgstr ""
+"wxMaxima erinnert sich an Antworten vom letzten Durchlauf und ist fähig, sie"
+" als Standardantwort anzubieten"
 
 #: ../../src/wxMaximaFrame.cpp:1896
 msgid "wxMaxima shows help in a browser"
-msgstr ""
+msgstr "wxMaxima zeigt die Hilfe im Browser"
 
 #: ../../src/wxMaximaFrame.cpp:1894
 msgid "wxMaxima shows help in the sidebar"
-msgstr ""
+msgstr "wxMaxima zeigt die Hilfe in der Seitenleiste"
 
 #: ../../src/wxMaximaFrame.cpp:111
 #, c-format
 msgid "wxMaxima version %s"
-msgstr ""
+msgstr "wxMaxima Version %s"
 
 #: ../../src/wxMaximaFrame.cpp:1954
 msgid "wxMaxima's ChangeLog"
-msgstr ""
+msgstr "Die Änderungen von wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "wxMaxima's license"
-msgstr ""
+msgstr "Die Lizenz von wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:144
 msgid "wxWidgets is using GTK 2"
-msgstr ""
+msgstr "wxWidgets verwendet GTK 2"
 
 #: ../../src/wxMaximaFrame.cpp:142
 msgid "wxWidgets is using GTK 3"
-msgstr ""
+msgstr "wxWidgets verwendet GTK 3"
 
 #: ../../src/WXMXformat.cpp:367
 msgid "wxmx file saved"
-msgstr ""
+msgstr ".wxmx-Datei gespeichert"
 
 #: ../../src/wxMaxima.cpp:8375
 msgid "x direction [in multiples of the tick frequency]"
-msgstr ""
+msgstr "In x-Richtung [Vielfache der Anzahl der Zahlen]"
 
 #: ../../src/wxMaxima.cpp:4500 ../../src/wxMaxima.cpp:4643
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
+"In der Datei enthaltenes xml behauptet, kein wxMaxima-Arbeitsblatt zu sein. "
 
 #: ../../src/wxMaxima.cpp:8376
 msgid "y direction [in multiples of the tick frequency]"
-msgstr ""
+msgstr "in y-Richtung [in vielfachen der Anzahl der Zahlen]"
 
 #: ../../src/wxMaxima.cpp:7789
 msgid "y:"
-msgstr ""
+msgstr "y:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:2
@@ -8799,8 +9099,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:134
+#, fuzzy
 msgid "##### Attention: Lookalike characters"
-msgstr ""
+msgstr "Warnung: Schwer unterscheidbare Zeichen: "
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:138
@@ -11336,8 +11637,9 @@ msgstr "Der `box()`-Befehl stellt sein Argument in _wxMaxima_ rot dar."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:856
+#, fuzzy
 msgid "## Output rendering."
-msgstr ""
+msgstr "Ausgabe: Strings"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:858

--- a/locales/wxMaxima/el.po
+++ b/locales/wxMaxima/el.po
@@ -73,20 +73,21 @@ msgid "%s: Can't interpret line: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1655
+#, fuzzy
 msgid "&Algebraic Mode"
-msgstr ""
+msgstr "Άλγεβρα"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "&Apropos..."
-msgstr ""
+msgstr "Σχετικά..."
 
 #: ../../src/wxMaximaFrame.cpp:615
 msgid "&Batch File...\tCtrl+B"
-msgstr ""
+msgstr "Αρχείο Batch...\tCtrl+B"
 
 #: ../../src/wxMaximaFrame.cpp:1278
 msgid "&Boundary Value Problem..."
-msgstr ""
+msgstr "Πρόβλημα οριακών τιμών..."
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "&Bug Report"
@@ -94,207 +95,216 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1505
 msgid "&Calculus"
-msgstr ""
+msgstr "Μαθηματική Ανάλυση"
 
 #: ../../src/wxMaximaFrame.cpp:1601
 msgid "&Canonical Form"
-msgstr ""
+msgstr "Κανονική μορφή"
 
 #: ../../src/wxMaximaFrame.cpp:1358
 msgid "&Characteristic Polynomial..."
-msgstr ""
+msgstr "Χαρακτηριστικό πολυώνυμο..."
 
 #: ../../src/wxMaximaFrame.cpp:990
 msgid "&Clear Memory"
-msgstr ""
+msgstr "Εκκαθάριση μνήμης"
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "&Combine Factorials"
-msgstr ""
+msgstr "Συνδυασμός παραγοντικών"
 
 #: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Complex Simplification"
-msgstr ""
+msgstr "Μιγαδική απλοποίηση"
 
 #: ../../src/wxMaximaFrame.cpp:1502
 msgid "&Continued Fraction"
-msgstr ""
+msgstr "Συνεχή κλάσματα"
 
 #: ../../src/wxMaximaFrame.cpp:638
 msgid "&Copy\tCtrl+C"
-msgstr ""
+msgstr "Αντιγραφή\tCtrl+C"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "&Demoivre"
-msgstr ""
+msgstr "Μετατροπή σε τριγωνομετρικές συναρτήσεις (Demoivre)"
 
 #: ../../src/wxMaximaFrame.cpp:1362
 msgid "&Determinant"
-msgstr ""
+msgstr "Ορίζουσα"
 
 #: ../../src/wxMaximaFrame.cpp:1466
 msgid "&Differentiate..."
-msgstr ""
+msgstr "Παραγώγιση..."
 
 #: ../../src/wxMaximaFrame.cpp:689
 msgid "&Edit"
-msgstr ""
+msgstr "Επεξεργασία"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "&Eliminate Variable..."
-msgstr ""
+msgstr "Απαλοιφή μεταβλητής..."
 
 #: ../../src/wxMaximaFrame.cpp:1318
 msgid "&Enter Matrix..."
-msgstr ""
+msgstr "Εισαγωγή πίνακα..."
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "&Example..."
-msgstr ""
+msgstr "Παράδειγμα..."
 
 #: ../../src/wxMaximaFrame.cpp:1524
 msgid "&Expand Expression"
-msgstr ""
+msgstr "Ανάπτυξη έκφρασης"
 
 #: ../../src/wxMaximaFrame.cpp:1597
 msgid "&Expand Trigonometric"
-msgstr ""
+msgstr "Ανάπτυξη τριγωνομετρικών παραστάσεων"
 
 #: ../../src/wxMaximaFrame.cpp:1626
 msgid "&Exponentialize"
-msgstr ""
+msgstr "Μετατροπή σε εκθετικές συναρτήσεις"
 
 #: ../../src/wxMaximaFrame.cpp:618
 msgid "&Export..."
-msgstr ""
+msgstr "Εξαγωγή..."
 
 #: ../../src/wxMaximaFrame.cpp:1516
 msgid "&Factor Expression"
-msgstr ""
+msgstr "Παραγοντοποίηση παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:626
 msgid "&File"
-msgstr ""
+msgstr "Αρχείο"
 
 #: ../../src/wxMaximaFrame.cpp:1019
+#, fuzzy
 msgid "&Functions"
-msgstr ""
+msgstr "Συνάρτηση:"
 
 #: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Greatest Common Divisor..."
-msgstr ""
+msgstr "Μέγιστος Κοινός Διαιρέτης..."
 
 #: ../../src/wxMaximaFrame.cpp:1968
 msgid "&Help"
-msgstr ""
+msgstr "Βοήθεια"
 
 #: ../../src/wxMaximaFrame.cpp:1453
 msgid "&Integrate..."
-msgstr ""
+msgstr "Ολοκλήρωση..."
 
 #: ../../src/wxMaximaFrame.cpp:964
 msgid "&Interrupt\tCtrl+G"
-msgstr ""
+msgstr "Διακοπή\tCtrl+G"
 
 #: ../../src/wxMaximaFrame.cpp:1355
 msgid "&Invert Matrix"
-msgstr ""
+msgstr "Αντιστροφος πίνακας"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "&License"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1763
+#, fuzzy
 msgid "&List"
-msgstr ""
+msgstr "Λίστα:"
 
 #: ../../src/wxMaximaFrame.cpp:610
 msgid "&Load Package...\tCtrl+L"
-msgstr ""
+msgstr "Φόρτωση πακέτου...\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "&Maxima"
-msgstr ""
+msgstr "Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1882
+#, fuzzy
 msgid "&Maxima help"
-msgstr ""
+msgstr "Εμφάνιση βοήθειας για το Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1660
 msgid "&Modulus Computation..."
-msgstr ""
+msgstr "Ορισμός του modulo (για rat, κτλ)..."
 
 #: ../../src/main.cpp:435
+#, fuzzy
 msgid "&New\tCtrl+N"
-msgstr ""
+msgstr "Νέο\tCtrl+N"
 
 #: ../../src/wxMaximaFrame.cpp:1870
 msgid "&Numeric"
-msgstr ""
+msgstr "Αριθμητικοί Υπολογισμοί"
 
 #: ../../src/wxMaximaFrame.cpp:1785
+#, fuzzy
 msgid "&Numeric Output"
-msgstr ""
+msgstr "Εναλλαγή μορφής αποτελεσμάτων"
 
 #: ../../src/main.cpp:436
+#, fuzzy
 msgid "&Open\tCtrl+O"
-msgstr ""
+msgstr "Άνοιγμα\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "&Open...\tCtrl+O"
-msgstr ""
+msgstr "Άνοιγμα...\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "&Plot"
-msgstr ""
+msgstr "Γράφημα"
 
 #: ../../src/wxMaximaFrame.cpp:622
 msgid "&Print...\tCtrl+P"
-msgstr ""
+msgstr "Εκτύπωση...\tCtrl+P"
 
 #: ../../src/wxMaximaFrame.cpp:1594
 msgid "&Reduce Trigonometric"
-msgstr ""
+msgstr "Αναγωγή τριγωνομετρικών παραστάσεων"
 
 #: ../../src/wxMaximaFrame.cpp:974
+#, fuzzy
 msgid "&Restart Maxima\tCtrl+Alt+R"
-msgstr ""
+msgstr "Επανεκκίνηση  Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:608
 msgid "&Save\tCtrl+S"
-msgstr ""
+msgstr "Αποθήκευση\tCtrl+S"
 
 #: ../../src/wxMaximaFrame.cpp:1662
 msgid "&Simplify"
-msgstr ""
+msgstr "Απλοποίηση"
 
 #: ../../src/wxMaximaFrame.cpp:1581
 msgid "&Simplify Factorials"
-msgstr ""
+msgstr "Απλοποίηση παραγοντικών"
 
 #: ../../src/wxMaximaFrame.cpp:1591
 msgid "&Simplify Trigonometric"
-msgstr ""
+msgstr "Απλοποίηση τριγωνομετρικών παραστάσεων"
 
 #: ../../src/wxMaximaFrame.cpp:1238
 msgid "&Solve..."
-msgstr ""
+msgstr "Επίλυση..."
 
 #: ../../src/wxMaximaFrame.cpp:1035
+#, fuzzy
 msgid "&Time Display"
-msgstr ""
+msgstr "Εναλλαγή εμφάνισης της ώρας"
 
 #: ../../src/wxMaximaFrame.cpp:1375
 msgid "&Transpose Matrix"
-msgstr ""
+msgstr "Ανάστροφος πίνακας"
 
 #: ../../src/wxMaximaFrame.cpp:1605
 msgid "&Trigonometric Simplification"
-msgstr ""
+msgstr "Τριγωνομετρική απλοποίηση"
 
 #: ../../src/wxMaximaFrame.cpp:1021
+#, fuzzy
 msgid "&Variables"
-msgstr ""
+msgstr "Μεταβλητές"
 
 #: ../../src/wxMaxima.cpp:2443
 msgid "(Config tells to suppress the output of long cells)"
@@ -347,12 +357,14 @@ msgid ".wxm clipboard data with unusual header"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8047
+#, fuzzy
 msgid "1×n Matrix b:"
-msgstr ""
+msgstr "Πίνακας:"
 
 #: ../../src/wxMaximaFrame.cpp:1312
+#, fuzzy
 msgid "2D Array to Matrix..."
-msgstr ""
+msgstr "Εφαρμογή στα μέλη πίνακα..."
 
 #: ../../src/wxMaximaFrame.cpp:743
 msgid "2D equations using ASCII Art"
@@ -393,24 +405,27 @@ msgid "A function returning positive numbers"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1965
+#, fuzzy
 msgid "A irrational variable"
-msgstr ""
+msgstr "Αλλαγή μεταβλητής"
 
 #: ../../src/Worksheet.cpp:2016
 msgid "A left-associative function"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:2019
+#, fuzzy
 msgid "A linear function"
-msgstr ""
+msgstr "Διαγραφή μίας συνάρτησης"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "A matrix in which each row is a set of variables"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1963
+#, fuzzy
 msgid "A rational variable"
-msgstr ""
+msgstr "Αλλαγή μεταβλητής"
 
 #: ../../src/Worksheet.cpp:2018
 msgid "A right-associative function"
@@ -429,12 +444,13 @@ msgid "A text control got the mouse focus"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1442
+#, fuzzy
 msgid "A&pply function to each Matrix element..."
-msgstr ""
+msgstr "Εφαρμογή συνάρτησης σε μία λίστα"
 
 #: ../../src/wxMaximaFrame.cpp:1291
 msgid "A&t Value..."
-msgstr ""
+msgstr "Ορισμός οριακών τιμών..."
 
 #: ../../src/Configuration.cpp:85
 msgid "ASCII maths"
@@ -442,11 +458,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1963
 msgid "About"
-msgstr ""
+msgstr "Πληροφορίες για το wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
 msgid "About wxMaxima"
-msgstr ""
+msgstr "Πληροφορίες για το wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7837
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
@@ -462,15 +478,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1371
 msgid "Ad&joint Matrix"
-msgstr ""
+msgstr "Προσαρτημένος πίνακας"
 
 #: ../../src/wxMaximaFrame.cpp:1657
 msgid "Add Algebraic E&quality..."
-msgstr ""
+msgstr "Εισαγωγή αλγεβρικής ισότητας..."
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add a directory to search path"
-msgstr ""
+msgstr "Προσθήκη καταλόγου στην διαδρομή αναζήτησης"
 
 #: ../../src/wxMaximaFrame.cpp:1752
 msgid ""
@@ -478,24 +494,26 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8602
+#, fuzzy
 msgid "Add an element to the end of a list"
-msgstr ""
+msgstr "Άνοιγμα ενός εγγράφου"
 
 #: ../../src/wxMaxima.cpp:8597
+#, fuzzy
 msgid "Add an element to the start of a list"
-msgstr ""
+msgstr "Άνοιγμα ενός εγγράφου"
 
 #: ../../src/wxMaxima.cpp:7625
 msgid "Add dir to path:"
-msgstr ""
+msgstr "Προσθήκη καταλόγου στο μονοπάτι:"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "Add equality to the rational simplifier"
-msgstr ""
+msgstr "Προσθήκη ισότητας στον απλοποιητή ρητών (παραστάσεων)"
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add to &Path..."
-msgstr ""
+msgstr "Προσθήκη στο μονοπάτι..."
 
 #: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
 #: ../../src/Worksheet.cpp:1704
@@ -537,12 +555,14 @@ msgid "Aliases"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1714
+#, fuzzy
 msgid "All but the 1st n elements"
-msgstr ""
+msgstr "Εφαρμογή συνάρτησης σε μία λίστα"
 
 #: ../../src/wxMaximaFrame.cpp:1716
+#, fuzzy
 msgid "All but the last n elements"
-msgstr ""
+msgstr "Εφαρμογή συνάρτησης σε μία λίστα"
 
 #: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
 msgid ""
@@ -553,8 +573,9 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:733
+#, fuzzy
 msgid "All visible sidebars"
-msgstr ""
+msgstr "Παλιά μεταβλητή:"
 
 #: ../../src/wxMaximaFrame.cpp:1650
 msgid "Allow to substitute operators"
@@ -596,8 +617,9 @@ msgid "Angles"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1775
+#, fuzzy
 msgid "Animation autoplay"
-msgstr ""
+msgstr "Αποθήκευση εφε κίνησης σε αρχείο"
 
 #: ../../src/wxMaximaFrame.cpp:1778
 msgid "Animation framerate..."
@@ -616,28 +638,34 @@ msgid "Append a list"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1736
+#, fuzzy
 msgid "Append a list to an existing list"
-msgstr ""
+msgstr "Εύρεση ορίου μιας παράστασης"
 
 #: ../../src/wxMaxima.cpp:8607
+#, fuzzy
 msgid "Append a list to another list"
-msgstr ""
+msgstr "Εύρεση ορίου μιας παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1729
+#, fuzzy
 msgid "Append an element"
-msgstr ""
+msgstr "Άνοιγμα ενός εγγράφου"
 
 #: ../../src/wxMaximaFrame.cpp:1734
+#, fuzzy
 msgid "Append an element to the beginning an existing list"
-msgstr ""
+msgstr "Εύρεση ορίου μιας παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1730
+#, fuzzy
 msgid "Append an element to the end of an existing list"
-msgstr ""
+msgstr "Εύρεση ορίου μιας παράστασης"
 
 #: ../../src/wxMaxima.cpp:8552
+#, fuzzy
 msgid "Apply a function to each list element"
-msgstr ""
+msgstr "Εφαρμογή συνάρτησης σε μία λίστα"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 #, c-format
@@ -662,15 +690,16 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9474
 msgid "Apropos"
-msgstr ""
+msgstr "Σχετικά"
 
 #: ../../src/wxMaxima.cpp:7317
 msgid "Are the chars equal, if case is ignored?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7312
+#, fuzzy
 msgid "Are the chars equal?"
-msgstr ""
+msgstr "Κελί υποενότητας"
 
 #: ../../src/wxMaxima.cpp:7349
 msgid "Are these strings equal if case is ignored?"
@@ -685,12 +714,14 @@ msgid "Arguments:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8189
+#, fuzzy
 msgid "Array"
-msgstr ""
+msgstr "Πίνακας:"
 
 #: ../../src/wxMaximaFrame.cpp:1023
+#, fuzzy
 msgid "Arrays"
-msgstr ""
+msgstr "Πίνακας:"
 
 #: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
 msgid "Ascii code to char"
@@ -770,7 +801,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6210
 msgid "Batch File"
-msgstr ""
+msgstr "Αρχείο Batch"
 
 #: ../../src/wxMaxima.cpp:5318
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -781,8 +812,9 @@ msgid "Bottom end"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7817
+#, fuzzy
 msgid "Boundary value problem"
-msgstr ""
+msgstr "Πρόβλημα οριακών τιμών..."
 
 #: ../../src/wxMathml.cpp:101
 msgid ""
@@ -876,23 +908,24 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1948
 msgid "Build &Info"
-msgstr ""
+msgstr "Πληροφορίες για το Maxima"
 
 #: ../../src/wxMaxima.cpp:7275
 msgid "Byte:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1458
+#, fuzzy
 msgid "C&hange Variable in Integrate..."
-msgstr ""
+msgstr "Αλλαγή μεταβλητής..."
 
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "C&onfigure"
-msgstr ""
+msgstr "Ρυθμίσεις"
 
 #: ../../src/wxMaximaFrame.cpp:1482
 msgid "Calculate &Product..."
-msgstr ""
+msgstr "Υπολογισμός γινομένου..."
 
 #: ../../src/wxMaxima.cpp:8057
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
@@ -906,35 +939,38 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate Su&m..."
-msgstr ""
+msgstr "Υπολογισμός αθροίσματος..."
 
 #: ../../src/wxMaximaFrame.cpp:1795
 msgid "Calculate bigfloat value of the last result"
-msgstr ""
+msgstr "Υπολογισμός της τιμής του τελευταίου αποτελέσματος με bigfloat"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Calculate float value of the last result"
-msgstr ""
+msgstr "Υπολογισμός της τιμής του τελευταίου αποτέλεσματος προσεγγιστικά"
 
 #: ../../src/wxMaxima.cpp:9550
+#, fuzzy
 msgid "Calculate mean value"
-msgstr ""
+msgstr "Υπολογισμοί  modulo ακέραιο:"
 
 #: ../../src/wxMaxima.cpp:9554
+#, fuzzy
 msgid "Calculate median value"
-msgstr ""
+msgstr "Υπολογισμοί  modulo ακέραιο:"
 
 #: ../../src/wxMaxima.cpp:8871
 msgid "Calculate modulus:"
-msgstr ""
+msgstr "Υπολογισμοί  modulo ακέραιο:"
 
 #: ../../src/wxMaximaFrame.cpp:1798
+#, fuzzy
 msgid "Calculate numeric value of the last result"
-msgstr ""
+msgstr "Υπολογισμός της τιμής του τελευταίου αποτέλεσματος προσεγγιστικά"
 
 #: ../../src/wxMaximaFrame.cpp:1483
 msgid "Calculate products"
-msgstr ""
+msgstr "Υπολογισμός γινομένων"
 
 #: ../../src/wxMaxima.cpp:9562
 msgid "Calculate standard deviation"
@@ -942,23 +978,25 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate sums"
-msgstr ""
+msgstr "Υπολογισμος αθροισμάτων"
 
 #: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
 msgid "Calculate the eigenvalues and eigenvectors numerically"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
+#, fuzzy
 msgid "Calculate the eigenvalues of a matrix numerically"
-msgstr ""
+msgstr "Υπολογισμός αντιστρόφου πίνακα"
 
 #: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
 msgid "Calculate the root of the sum of squares of matrix entries"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9558
+#, fuzzy
 msgid "Calculate variation"
-msgstr ""
+msgstr "Υπολογισμός γινομένων"
 
 #: ../../src/wxMaxima.cpp:8949
 msgid "Calculates the fourier coefficients for the expression from -p to p"
@@ -974,7 +1012,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11125
 msgid "Can not connect to the web server."
-msgstr ""
+msgstr "Η σύνδεση με τον web server δεν ήταν εφικτή."
 
 #: ../../src/wxMaxima.cpp:11166
 msgid "Can not download version info."
@@ -989,7 +1027,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Cancel"
-msgstr ""
+msgstr "Ακύρωση"
 
 #: ../../src/wxMaxima.cpp:3292
 msgid "Cannot authenticate Maxima!"
@@ -1026,8 +1064,9 @@ msgid "Cannot set the communication port to %i."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3656 ../../src/wxMaxima.cpp:6359
+#, fuzzy
 msgid "Cannot start gnuplot"
-msgstr ""
+msgstr "Παραμετρικό γράφημα"
 
 #: ../../src/StatusBar.cpp:216 ../../src/wxMaxima.cpp:2662
 msgid "Cannot start the maxima binary"
@@ -1046,12 +1085,14 @@ msgid "Ce&ll"
 msgstr ""
 
 #: ../../src/Configuration.cpp:96
+#, fuzzy
 msgid "Cell bracket fill, Active"
-msgstr ""
+msgstr "Άγκιστρο κελιού"
 
 #: ../../src/Configuration.cpp:95
+#, fuzzy
 msgid "Cell bracket fill, Inactive"
-msgstr ""
+msgstr "Άγκιστρο κελιού"
 
 #: ../../src/wxMaxima.cpp:10395
 msgid "Cell ends in a backslash"
@@ -1059,51 +1100,60 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1038
 msgid "Change &2d Display"
-msgstr ""
+msgstr "Αλλαγή 2-Δ προβολής μαθηματικών"
 
 #: ../../src/wxMaxima.cpp:10146
+#, fuzzy
 msgid "Change Image"
-msgstr ""
+msgstr "Αλλαγή μεταβλητής"
 
 #: ../../src/Worksheet.cpp:1324
+#, fuzzy
 msgid "Change Image..."
-msgstr ""
+msgstr "Αποθήκευση εικόνας..."
 
 #: ../../src/wxMaximaFrame.cpp:1954
+#, fuzzy
 msgid "Change Log"
-msgstr ""
+msgstr "Αλλαγή μεταβλητής"
 
 #: ../../src/wxMaxima.cpp:7555
 msgid "Change directory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1202
+#, fuzzy
 msgid "Change directory..."
-msgstr ""
+msgstr "Αποθήκευση εικόνας..."
 
 #: ../../src/wxMaximaFrame.cpp:1039
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
+"Αλλαγή του 2-Δ αλγορίθμου προβολής που χρησιμοποιείται για την απεικόνιση "
+"μαθηματικών αποτελεσμάτων"
 
 #: ../../src/wxMaxima.cpp:8885
 msgid "Change variable"
-msgstr ""
+msgstr "Αλλαγή μεταβλητής"
 
 #: ../../src/wxMaxima.cpp:8905
+#, fuzzy
 msgid "Change variable and evaluate"
-msgstr ""
+msgstr "Αλλαγή μεταβλητής στο ολοκλήρωμα ή στο άθροισμα "
 
 #: ../../src/wxMaximaFrame.cpp:1459
 msgid "Change variable in integral or sum"
-msgstr ""
+msgstr "Αλλαγή μεταβλητής στο ολοκλήρωμα ή στο άθροισμα "
 
 #: ../../src/wxMaximaFrame.cpp:1463
+#, fuzzy
 msgid "Change variable in integral or sum and evaluate the result"
-msgstr ""
+msgstr "Αλλαγή μεταβλητής στο ολοκλήρωμα ή στο άθροισμα "
 
 #: ../../src/wxMaximaFrame.cpp:1026
+#, fuzzy
 msgid "Changed option variables"
-msgstr ""
+msgstr "Αλλαγή μεταβλητής"
 
 #: ../../src/wxMaxima.cpp:10170
 #, c-format
@@ -1119,8 +1169,9 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
 #: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
+#, fuzzy
 msgid "Char #2:"
-msgstr ""
+msgstr "Πίνακας:"
 
 #: ../../src/wxMaximaFrame.cpp:1140
 msgid "Char to Unicode code point..."
@@ -1143,8 +1194,9 @@ msgid "Character Tests"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8181
+#, fuzzy
 msgid "Characteristic polynom"
-msgstr ""
+msgstr "Χαρακτηριστικό πολυώνυμο..."
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Chars are strings that are one character long"
@@ -1152,11 +1204,12 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1957
 msgid "Check for Updates"
-msgstr ""
+msgstr "Έλεγχος για ενημερώσεις"
 
 #: ../../src/wxMaximaFrame.cpp:1958
+#, fuzzy
 msgid "Check if a newer version of wxMaxima is available."
-msgstr ""
+msgstr "Έλεγχος ύπαρξης νεότερης έκδοσης του  wxMaxima/Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Choose the parenthesis type for Matrices"
@@ -1164,63 +1217,75 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9530 ../../src/wxMaxima.cpp:9535
 msgid "Classes:"
-msgstr ""
+msgstr "Τάξεις:"
 
 #: ../../src/wxMaximaFrame.cpp:1378
 msgid "Classic matrix operations"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:998
+#, fuzzy
 msgid "Clear all aliases"
-msgstr ""
+msgstr "Εκκαθάριση μνήμης"
 
 #: ../../src/wxMaximaFrame.cpp:995
+#, fuzzy
 msgid "Clear all arrays"
-msgstr ""
+msgstr "Εκκαθάριση μνήμης"
 
 #: ../../src/wxMaximaFrame.cpp:992
+#, fuzzy
 msgid "Clear all dependencies"
-msgstr ""
+msgstr "Εκκαθάριση μνήμης"
 
 #: ../../src/wxMaximaFrame.cpp:994
+#, fuzzy
 msgid "Clear all functions"
-msgstr ""
+msgstr "Διαγραφή μίας συνάρτησης"
 
 #: ../../src/wxMaximaFrame.cpp:1001
+#, fuzzy
 msgid "Clear all gradefs"
-msgstr ""
+msgstr "Εκκαθάριση μνήμης"
 
 #: ../../src/wxMaximaFrame.cpp:1000
+#, fuzzy
 msgid "Clear all labels"
-msgstr ""
+msgstr "Εκκαθάριση μνήμης"
 
 #: ../../src/wxMaximaFrame.cpp:1004
 msgid "Clear all let rule packages"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1003
+#, fuzzy
 msgid "Clear all macros"
-msgstr ""
+msgstr "Εκκαθάριση μνήμης"
 
 #: ../../src/wxMaximaFrame.cpp:1002
+#, fuzzy
 msgid "Clear all props"
-msgstr ""
+msgstr "Εκκαθάριση μνήμης"
 
 #: ../../src/wxMaximaFrame.cpp:997
+#, fuzzy
 msgid "Clear all rules"
-msgstr ""
+msgstr "Εκκαθάριση μνήμης"
 
 #: ../../src/wxMaximaFrame.cpp:999
+#, fuzzy
 msgid "Clear all structures"
-msgstr ""
+msgstr "Εκκαθάριση μνήμης"
 
 #: ../../src/wxMaximaFrame.cpp:993
+#, fuzzy
 msgid "Clear all variables"
-msgstr ""
+msgstr "Διαγραφή μίας μεταβλητής"
 
 #: ../../src/wxMaximaFrame.cpp:606
+#, fuzzy
 msgid "Close\tCtrl+W"
-msgstr ""
+msgstr "Αντιγραφή\tCtrl+C"
 
 #: ../../src/wxMaxima.cpp:7235
 msgid "Close Stream"
@@ -1231,16 +1296,18 @@ msgid "Close window"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1105
+#, fuzzy
 msgid "Close..."
-msgstr ""
+msgstr "Επίλυση..."
 
 #: ../../src/WXMXformat.cpp:301
 msgid "Closed the zip archive"
 msgstr ""
 
 #: ../../src/Configuration.cpp:77
+#, fuzzy
 msgid "Code Default (Maxima input)"
-msgstr ""
+msgstr "Είσοδος Maxima"
 
 #: ../../src/Configuration.cpp:103
 msgid "Code highlighting: Comments"
@@ -1275,83 +1342,99 @@ msgid "Code highlighting: Variables"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
+#, fuzzy
 msgid "Code number:"
-msgstr ""
+msgstr "Στήλες:"
 
 #: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
+#, fuzzy
 msgid "Codepoint number:"
-msgstr ""
+msgstr "Στήλες:"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "Col. names:"
-msgstr ""
+msgstr "Oνόματα στηλών:"
 
 #: ../../src/Configuration.cpp:100
+#, fuzzy
 msgid "Color of Outdated cells"
-msgstr ""
+msgstr "Μη ενημερωμένα κελιά"
 
 #: ../../src/Configuration.cpp:99
+#, fuzzy
 msgid "Color of text equal to selection"
-msgstr ""
+msgstr "Αποκοπή επιλογής"
 
 #: ../../src/wxMaxima.cpp:7962
+#, fuzzy
 msgid "Column number:"
-msgstr ""
+msgstr "Στήλες:"
 
 #: ../../src/wxMaxima.cpp:7978
+#, fuzzy
 msgid "Column numbers:"
-msgstr ""
+msgstr "Στήλες:"
 
 #: ../../src/wxMaxima.cpp:8202
+#, fuzzy
 msgid "Columns"
-msgstr ""
+msgstr "Στήλες:"
 
 #: ../../src/wxMaximaFrame.cpp:1584
 msgid "Combine factorials in an expression"
-msgstr ""
+msgstr "Συνδυασμός παραγοντικών σε μια παράσταση"
 
 #: ../../src/wxMaxima.cpp:10454
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7259
+#, fuzzy
 msgid "Comma-separated arguments"
-msgstr ""
+msgstr "Συντεταγμένες του x χωρισμένες με κόμμα"
 
 #: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
+#, fuzzy
 msgid "Comma-separated commands"
-msgstr ""
+msgstr "Συντεταγμένες του x χωρισμένες με κόμμα"
 
 #: ../../src/wxMaxima.cpp:8458
+#, fuzzy
 msgid "Comma-separated elements"
-msgstr ""
+msgstr "Συντεταγμένες του x χωρισμένες με κόμμα"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 #: ../../src/wxMaxima.cpp:10031
+#, fuzzy
 msgid "Comma-separated equations"
-msgstr ""
+msgstr "Συντεταγμένες του x χωρισμένες με κόμμα"
 
 #: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
 #: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
 #: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
+#, fuzzy
 msgid "Comma-separated expressions"
-msgstr ""
+msgstr "Συντεταγμένες του x χωρισμένες με κόμμα"
 
 #: ../../src/wxMaxima.cpp:7215
+#, fuzzy
 msgid "Comma-separated expressions that shall be converted to a string"
-msgstr ""
+msgstr "Συντεταγμένες του x χωρισμένες με κόμμα"
 
 #: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
+#, fuzzy
 msgid "Comma-separated expressions."
-msgstr ""
+msgstr "Συντεταγμένες του x χωρισμένες με κόμμα"
 
 #: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
+#, fuzzy
 msgid "Comma-separated function names"
-msgstr ""
+msgstr "Συντεταγμένες του x χωρισμένες με κόμμα"
 
 #: ../../src/wxMaxima.cpp:7086
+#, fuzzy
 msgid "Comma-separated function names."
-msgstr ""
+msgstr "Συντεταγμένες του x χωρισμένες με κόμμα"
 
 #: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
 #: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
@@ -1367,8 +1450,9 @@ msgid "Comma-separated names the parameters will be referenced by later."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
+#, fuzzy
 msgid "Comma-separated numbers from 0 to 255"
-msgstr ""
+msgstr "Συντεταγμένες του x χωρισμένες με κόμμα"
 
 #: ../../src/wxMaxima.cpp:8770
 msgid "Comma-separated numbers of the terms to substitute in"
@@ -1396,15 +1480,16 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1692
 msgid "Comment Selection"
-msgstr ""
+msgstr "Επιλογή Σχολίων"
 
 #: ../../src/wxMaximaFrame.cpp:681
 msgid "Comment out the currently selected text"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:680
+#, fuzzy
 msgid "Comment selection\tCtrl+/"
-msgstr ""
+msgstr "Επιλογή Σχολίων"
 
 #: ../../src/Worksheet.cpp:2004
 msgid "Commutative function"
@@ -1415,12 +1500,14 @@ msgid "Compile a QR decomposition using dgeqrf"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7162
+#, fuzzy
 msgid "Compile a function"
-msgstr ""
+msgstr "Διαγραφή μίας συνάρτησης"
 
 #: ../../src/wxMaximaFrame.cpp:1188
+#, fuzzy
 msgid "Compile a regular expression"
-msgstr ""
+msgstr "Διαγραφή μίας συνάρτησης"
 
 #: ../../src/wxMaximaFrame.cpp:1385
 msgid "Compile eigenvalues using dgeev"
@@ -1439,12 +1526,14 @@ msgid "Compile eigenvalues+eigenvectors using zgeev"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1076
+#, fuzzy
 msgid "Compile function..."
-msgstr ""
+msgstr "Διαγραφή συνάρτησης..."
 
 #: ../../src/wxMaxima.cpp:7511
+#, fuzzy
 msgid "Compile regex"
-msgstr ""
+msgstr "Συμπλήρωση λέξης"
 
 #: ../../src/wxMathml.cpp:53
 msgid "Compiler-Bug? wxMathml.lisp is shorter than expected!"
@@ -1463,12 +1552,13 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:892
+#, fuzzy
 msgid "Complete Word\tCtrl+Space"
-msgstr ""
+msgstr "Συμπλήρωση Λέξης\tCtrl+K"
 
 #: ../../src/wxMaximaFrame.cpp:893
 msgid "Complete word"
-msgstr ""
+msgstr "Συμπλήρωση λέξης"
 
 #: ../../src/ToolBar.cpp:230
 msgid "Completely stop maxima and restart it"
@@ -1476,44 +1566,47 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1503
 msgid "Compute continued fraction of a value"
-msgstr ""
+msgstr "Υπολογισμός συνεχούς κλάσματος μιας τιμής"
 
 #: ../../src/wxMaximaFrame.cpp:1372
 msgid "Compute the adjoint matrix"
-msgstr ""
+msgstr "Υπολογισμός του προσαρτημένου πίνακα"
 
 #: ../../src/wxMaximaFrame.cpp:1359
 msgid "Compute the characteristic polynomial of a matrix"
-msgstr ""
+msgstr "Υπολογισμός του χαρακτηριστικού πολυωνύμου ενός πίνακα"
 
 #: ../../src/wxMaximaFrame.cpp:1363
 msgid "Compute the determinant of a matrix"
-msgstr ""
+msgstr "Υπολογισμός ορίζουσας πίνακα"
 
 #: ../../src/wxMaximaFrame.cpp:1491
 msgid "Compute the greatest common divisor"
-msgstr ""
+msgstr "Υπολογισμός μέγιστου κοινού διαιρέτη"
 
 #: ../../src/wxMaximaFrame.cpp:1356
 msgid "Compute the inverse of a matrix"
-msgstr ""
+msgstr "Υπολογισμός αντιστρόφου πίνακα"
 
 #: ../../src/wxMaximaFrame.cpp:1494
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
+"Υπολογισμός του ελαχίστου κοινού πολλαπλασίου (εκτελέστε load(functs) πριν "
+"τη χρήση)"
 
 #: ../../src/wxMaximaFrame.cpp:1374
+#, fuzzy
 msgid "Compute the rank of a matrix"
-msgstr ""
+msgstr "Υπολογισμός ορίζουσας πίνακα"
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Condition:"
-msgstr ""
+msgstr "Συνθήκη:"
 
 #: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "Configure wxMaxima"
-msgstr ""
+msgstr "Ρυθμίσεις του wxMaxima"
 
 #: ../../src/wxMaxima.cpp:2504
 msgid "Connection attempt, but connection failed."
@@ -1524,16 +1617,19 @@ msgid "Connection to Maxima lost."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7921
+#, fuzzy
 msgid "Construct a fraction"
-msgstr ""
+msgstr "Συνεχή κλάσματα"
 
 #: ../../src/wxMaximaFrame.cpp:1305
+#, fuzzy
 msgid "Construct fraction..."
-msgstr ""
+msgstr "Συνεχή κλάσματα"
 
 #: ../../src/wxMaxima.cpp:7158
+#, fuzzy
 msgid "Contents:"
-msgstr ""
+msgstr "Ελληνικές σταθερές"
 
 #: ../../src/wxMaximaFrame.cpp:1877
 msgid "Context-sensitive &Help\tCtrl+?"
@@ -1545,27 +1641,32 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1542
 msgid "Contract Logarithms"
-msgstr ""
+msgstr "Συστολή λογαρίθμων"
 
 #: ../../src/wxMaximaFrame.cpp:1161
+#, fuzzy
 msgid "Conversions"
-msgstr ""
+msgstr "Μετατροπή σε ορθογώνιες συντεταγμένες"
 
 #: ../../src/wxMaximaFrame.cpp:1229
+#, fuzzy
 msgid "Convert"
-msgstr ""
+msgstr "Μετατροπή σε ορθογώνιες συντεταγμένες"
 
 #: ../../src/wxMaximaFrame.cpp:1230
+#, fuzzy
 msgid "Convert + Write to file"
-msgstr ""
+msgstr "Μετατροπή σε παραγοντικά"
 
 #: ../../src/wxMaximaFrame.cpp:1434
+#, fuzzy
 msgid "Convert Column to list..."
-msgstr ""
+msgstr "Μετατροπή σε παραγοντικά"
 
 #: ../../src/wxMaximaFrame.cpp:1430
+#, fuzzy
 msgid "Convert Row to list..."
-msgstr ""
+msgstr "Μετατροπή σε παραγοντικά"
 
 #: ../../src/wxMaximaFrame.cpp:1044
 msgid "Convert a command to maxima code"
@@ -1577,60 +1678,67 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1574
 msgid "Convert binomials, beta and gamma function to factorials"
-msgstr ""
+msgstr "Μετατροπή διωνυμικών,συναρτήσεων Βήτα και Γάμμα σε παραγοντικά"
 
 #: ../../src/wxMaximaFrame.cpp:1578
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
+"Μετατροπή διωνύμων, παραγοντικών και Βήτα συναρτήσεων σε Γάμμα συνάρτηση"
 
 #: ../../src/wxMaximaFrame.cpp:1613
 msgid "Convert complex expression to polar form"
-msgstr ""
+msgstr "Μετατροπή μιγαδικής παράστασης σε πολική μορφή"
 
 #: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert complex expression to rect form"
-msgstr ""
+msgstr "Μετατροπή μιγαδικών παραστάσεων σε ορθογώνιες συντεταγμένες"
 
 #: ../../src/wxMaximaFrame.cpp:1622
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
+"Μετατροπή της εκθετικής συνάρτησης φανταστικής μεταβλητής σε τριγωνομετρική "
+"μορφή"
 
 #: ../../src/wxMaxima.cpp:7411
+#, fuzzy
 msgid "Convert string to lowercase"
-msgstr ""
+msgstr "Μετατροπή σε παραγοντικά"
 
 #: ../../src/wxMaxima.cpp:7543
+#, fuzzy
 msgid "Convert string to matching regex"
-msgstr ""
+msgstr "Μετατροπή σε Γάμμα"
 
 #: ../../src/wxMaximaFrame.cpp:1543
 msgid "Convert sum of logarithms to logarithm of product"
-msgstr ""
+msgstr "Μετατροπή αθροίσματος λογαρίθμων σε λογάριθμο γινομένου"
 
 #: ../../src/wxMaximaFrame.cpp:1573
 msgid "Convert to &Factorials"
-msgstr ""
+msgstr "Μετατροπή σε παραγοντικά"
 
 #: ../../src/wxMaximaFrame.cpp:1577
 msgid "Convert to &Gamma"
-msgstr ""
+msgstr "Μετατροπή σε Γάμμα"
 
 #: ../../src/wxMaximaFrame.cpp:1612
 msgid "Convert to &Polarform"
-msgstr ""
+msgstr "Μετατροπή σε πολική μορφή"
 
 #: ../../src/wxMaximaFrame.cpp:1609
 msgid "Convert to &Rectform"
-msgstr ""
+msgstr "Μετατροπή σε ορθογώνιες συντεταγμένες"
 
 #: ../../src/wxMaximaFrame.cpp:1166
+#, fuzzy
 msgid "Convert to downcase..."
-msgstr ""
+msgstr "Μετατροπή σε παραγοντικά"
 
 #: ../../src/wxMaxima.cpp:7016
+#, fuzzy
 msgid "Convert to programming language"
-msgstr ""
+msgstr "Μετατροπή σε Γάμμα"
 
 #: ../../src/wxMaxima.cpp:7022
 msgid "Convert to programming language file"
@@ -1638,11 +1746,12 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1602
 msgid "Convert trigonometric expression to canonical quasilinear form"
-msgstr ""
+msgstr "Μετατροπή τριγωνομετρικής παράστασης σε κανονική ημιγραμμική μορφή"
 
 #: ../../src/wxMaximaFrame.cpp:1627
+#, fuzzy
 msgid "Convert trigonometric functions to exponential form"
-msgstr ""
+msgstr "Μετατροπή τριγωνομετρικών συναρτήσεων σε εκθετική μορφή"
 
 #: ../../src/wxMaximaFrame.cpp:1762
 msgid "Converts a matrix to a list of lists"
@@ -1656,24 +1765,27 @@ msgstr ""
 #: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
 #: ../../src/Worksheet.cpp:1684
 msgid "Copy"
-msgstr ""
+msgstr "Αντιγραφή"
 
 #: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
 #: ../../src/Worksheet.cpp:1514
+#, fuzzy
 msgid "Copy Animation"
-msgstr ""
+msgstr "Διακοπή του εφέ κίνησης"
 
 #: ../../src/wxMaximaFrame.cpp:887
 msgid "Copy Previous Input\tCtrl+I"
-msgstr ""
+msgstr "Αντιγραφή προηγούμενης εισαγωγής\tCtrl+I"
 
 #: ../../src/wxMaximaFrame.cpp:890
+#, fuzzy
 msgid "Copy Previous Output\tCtrl+U"
-msgstr ""
+msgstr "Αντιγραφή προηγούμενης εισαγωγής\tCtrl+I"
 
 #: ../../src/wxMaxima.cpp:7992
+#, fuzzy
 msgid "Copy a matrix"
-msgstr ""
+msgstr "Αντιγραφή ως εικόνα"
 
 #: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
 #: ../../src/wxMaximaFrame.cpp:663
@@ -1683,16 +1795,17 @@ msgstr ""
 #: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Copy as Image"
-msgstr ""
+msgstr "Αντιγραφή ως εικόνα"
 
 #: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
 #: ../../src/wxMaximaFrame.cpp:645
 msgid "Copy as LaTeX"
-msgstr ""
+msgstr "Αντιγραφή ως LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:648
+#, fuzzy
 msgid "Copy as MathML"
-msgstr ""
+msgstr "Αντιγραφή ως εικόνα"
 
 #: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
 msgid "Copy as MathML (e.g. to word processor)"
@@ -1700,29 +1813,34 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
 #: ../../src/wxMaximaFrame.cpp:658
+#, fuzzy
 msgid "Copy as RTF"
-msgstr ""
+msgstr "Αντιγραφή ως LaTeX"
 
 #: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
 #: ../../src/wxMaximaFrame.cpp:655
+#, fuzzy
 msgid "Copy as SVG"
-msgstr ""
+msgstr "Αντιγραφή ως LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:640
 msgid "Copy as Text\tCtrl+Shift+C"
-msgstr ""
+msgstr "Αντιγραφή ως κείμενο\tCtrl+Shift+C"
 
 #: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
+#, fuzzy
 msgid "Copy as plain text"
-msgstr ""
+msgstr "Αντιγραφή ως εικόνα"
 
 #: ../../src/wxMaxima.cpp:7576
+#, fuzzy
 msgid "Copy file"
-msgstr ""
+msgstr "Αντιγραφή"
 
 #: ../../src/wxMaximaFrame.cpp:1214
+#, fuzzy
 msgid "Copy file..."
-msgstr ""
+msgstr "Επίλυση..."
 
 #: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
 #: ../../src/wxMaximaFrame.cpp:643
@@ -1731,32 +1849,34 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
 msgid "Copy selection"
-msgstr ""
+msgstr "Αντιγραφή επιλογής"
 
 #: ../../src/wxMaximaFrame.cpp:664
 msgid "Copy selection from document as an Enhanced Metafile"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:656
+#, fuzzy
 msgid "Copy selection from document as an SVG image"
-msgstr ""
+msgstr "Αντιγραφή επιλογής από  έγγραφο ως εικόνα"
 
 #: ../../src/wxMaximaFrame.cpp:653
 msgid "Copy selection from document as an image"
-msgstr ""
+msgstr "Αντιγραφή επιλογής από  έγγραφο ως εικόνα"
 
 #: ../../src/wxMaximaFrame.cpp:659
+#, fuzzy
 msgid ""
 "Copy selection from document as rtf that a word processor might understand"
-msgstr ""
+msgstr "Αντιγραφή επιλογής από  έγγραφο ως εικόνα"
 
 #: ../../src/wxMaximaFrame.cpp:641
 msgid "Copy selection from document as text"
-msgstr ""
+msgstr "Αντιγραφή επιλογής από  έγγραφο ως κείμενο"
 
 #: ../../src/wxMaximaFrame.cpp:646
 msgid "Copy selection from document in LaTeX format"
-msgstr ""
+msgstr "Αντιγραφή επιλογής από έγγραφο σε μορφή LaTeX "
 
 #: ../../src/wxMaximaFrame.cpp:644
 msgid "Copy selection from document in Matlab format"
@@ -1769,12 +1889,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7403
+#, fuzzy
 msgid "Copy string"
-msgstr ""
+msgstr "Αντιγραφή επιλογής"
 
 #: ../../src/wxMaximaFrame.cpp:1165
+#, fuzzy
 msgid "Copy string..."
-msgstr ""
+msgstr "Εισαγωγή πίνακα..."
 
 #: ../../src/ToolBar.cpp:623
 msgid "Copy, Cut and Paste button"
@@ -1805,20 +1927,23 @@ msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1325
+#, fuzzy
 msgid "Create Matrix"
-msgstr ""
+msgstr "Δημιουργία πίνακα"
 
 #: ../../src/wxMaximaFrame.cpp:1688
+#, fuzzy
 msgid "Create a list"
-msgstr ""
+msgstr "Δημιουργία λίστας"
 
 #: ../../src/wxMaxima.cpp:8487
 msgid "Create a list as a storage for the values of variables"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8463 ../../src/wxMaxima.cpp:8476
+#, fuzzy
 msgid "Create a list from a rule"
-msgstr ""
+msgstr "Δημιουργία λίστας από παράσταση"
 
 #: ../../src/wxMaximaFrame.cpp:1670
 msgid "Create a list from comma-separated elements"
@@ -1826,43 +1951,50 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:888
 msgid "Create a new cell with previous input"
-msgstr ""
+msgstr "Δημιουργία κελιού με την τελευταία εισαγωγή"
 
 #: ../../src/wxMaximaFrame.cpp:891
+#, fuzzy
 msgid "Create a new cell with previous output"
-msgstr ""
+msgstr "Δημιουργία κελιού με την τελευταία εισαγωγή"
 
 #: ../../src/wxMaximaFrame.cpp:1348
 msgid "Create copy, not clone..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7561
+#, fuzzy
 msgid "Create directory"
-msgstr ""
+msgstr "Δημιουργία λίστας"
 
 #: ../../src/wxMaximaFrame.cpp:1203
+#, fuzzy
 msgid "Create directory..."
-msgstr ""
+msgstr "Δημιουργία λίστας"
 
 #: ../../src/wxMaxima.cpp:7419
+#, fuzzy
 msgid "Create empty string"
-msgstr ""
+msgstr "Δημιουργία πίνακα"
 
 #: ../../src/wxMaximaFrame.cpp:1168
+#, fuzzy
 msgid "Create empty string..."
-msgstr ""
+msgstr "Δημιουργία λίστας"
 
 #: ../../src/wxMaximaFrame.cpp:1687
+#, fuzzy
 msgid "Create list"
-msgstr ""
+msgstr "Δημιουργία λίστας"
 
 #: ../../src/wxMaxima.cpp:8457
 msgid "Create list from comma-separated elements"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1082
+#, fuzzy
 msgid "Create struct..."
-msgstr ""
+msgstr "Δημιουργία λίστας"
 
 #: ../../src/WXMXformat.cpp:80
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
@@ -1873,28 +2005,29 @@ msgid "Creates an independent matrix with the same contents"
 msgstr ""
 
 #: ../../src/Configuration.cpp:97
+#, fuzzy
 msgid "Cursor color"
-msgstr ""
+msgstr "Κέρσορας"
 
 #: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
 msgid "Cut"
-msgstr ""
+msgstr "Αποκοπή"
 
 #: ../../src/wxMaximaFrame.cpp:636
 msgid "Cut\tCtrl+X"
-msgstr ""
+msgstr "Αποκοπή\tCtrl+X"
 
 #: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
 msgid "Cut selection"
-msgstr ""
+msgstr "Αποκοπή επιλογής"
 
 #: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
 msgid "Data Matrix:"
-msgstr ""
+msgstr "Πίνακας Δεδομένων:"
 
 #: ../../src/wxMaxima.cpp:9599
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
-msgstr ""
+msgstr "Αρχείο δεδομένων (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wxMaxima.cpp:9529 ../../src/wxMaxima.cpp:9534
 #: ../../src/wxMaxima.cpp:9539 ../../src/wxMaxima.cpp:9543
@@ -1903,7 +2036,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9563 ../../src/wxMaxima.cpp:9577
 #: ../../src/wxMaxima.cpp:9582 ../../src/wxMaxima.cpp:10030
 msgid "Data:"
-msgstr ""
+msgstr "Δεδομένα:"
 
 #: ../../src/wxMaximaFrame.cpp:1057
 msgid "Debugger trigger"
@@ -1927,8 +2060,9 @@ msgid "Declare facts about %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8800
+#, fuzzy
 msgid "Declare main variable:"
-msgstr ""
+msgstr "Διαγραφή μίας μεταβλητής"
 
 #: ../../src/wxMaxima.cpp:7171
 msgid "Declare the type of a function parameter"
@@ -1940,15 +2074,17 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1500 ../../src/wxMaximaFrame.cpp:1536
 msgid "Decompose rational function to partial fractions"
-msgstr ""
+msgstr "Ανάλυση ρητής συνάρτησης σε μερικά κλάσματα"
 
 #: ../../src/Worksheet.cpp:2010
+#, fuzzy
 msgid "Decreasing function f(x)<x"
-msgstr ""
+msgstr "Διαγραφή συνάρτησης(-σεων)"
 
 #: ../../src/wxMaxima.cpp:7134
+#, fuzzy
 msgid "Define a function"
-msgstr ""
+msgstr "Διαγραφή μίας συνάρτησης"
 
 #: ../../src/wxMaxima.cpp:7147
 msgid "Define a macro"
@@ -1963,12 +2099,14 @@ msgid "Define a structure type"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7156
+#, fuzzy
 msgid "Define a variable"
-msgstr ""
+msgstr "Διαγραφή μίας μεταβλητής"
 
 #: ../../src/wxMaximaFrame.cpp:1072
+#, fuzzy
 msgid "Define function..."
-msgstr ""
+msgstr "Διαγραφή συνάρτησης..."
 
 #: ../../src/wxMaximaFrame.cpp:1079
 msgid "Define macro..."
@@ -1983,8 +2121,9 @@ msgid "Define struct..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1080
+#, fuzzy
 msgid "Define variable..."
-msgstr ""
+msgstr "Διαγραφή μίας μεταβλητής"
 
 #: ../../src/wxMaximaFrame.cpp:1776
 msgid ""
@@ -1997,23 +2136,23 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:985
 msgid "Delete F&unction..."
-msgstr ""
+msgstr "Διαγραφή συνάρτησης..."
 
 #: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
 msgid "Delete Selection"
-msgstr ""
+msgstr "Διαγραφή επιλογής"
 
 #: ../../src/wxMaximaFrame.cpp:987
 msgid "Delete V&ariable..."
-msgstr ""
+msgstr "Διαγραφή μεταβλητής..."
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Delete a function"
-msgstr ""
+msgstr "Διαγραφή μίας συνάρτησης"
 
 #: ../../src/wxMaximaFrame.cpp:988
 msgid "Delete a variable"
-msgstr ""
+msgstr "Διαγραφή μίας μεταβλητής"
 
 #: ../../src/wxMaximaFrame.cpp:982
 msgid "Delete all objects with a given name"
@@ -2021,35 +2160,42 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:991
 msgid "Delete all values from memory"
-msgstr ""
+msgstr "Διαγραφή όλων των τιμών από τη μνήμη"
 
 #: ../../src/wxMaxima.cpp:7588
+#, fuzzy
 msgid "Delete file"
-msgstr ""
+msgstr "Διαγραφή μίας μεταβλητής"
 
 #: ../../src/wxMaximaFrame.cpp:1216
+#, fuzzy
 msgid "Delete file..."
-msgstr ""
+msgstr "Διαγραφή μεταβλητής..."
 
 #: ../../src/wxMaxima.cpp:7683
+#, fuzzy
 msgid "Delete function(s)"
-msgstr ""
+msgstr "Διαγραφή συνάρτησης(-σεων)"
 
 #: ../../src/wxMaxima.cpp:7679
+#, fuzzy
 msgid "Delete named object(s)"
-msgstr ""
+msgstr "Διαγραφή συνάρτησης(-σεων)"
 
 #: ../../src/wxMaximaFrame.cpp:981
+#, fuzzy
 msgid "Delete named object..."
-msgstr ""
+msgstr "Διαγραφή συνάρτησης..."
 
 #: ../../src/wxMaxima.cpp:7674
+#, fuzzy
 msgid "Delete variable(s)"
-msgstr ""
+msgstr "Διαγραφή μεταβλητής(-ών):"
 
 #: ../../src/wxMaxima.cpp:7430
+#, fuzzy
 msgid "Delimiter:"
-msgstr ""
+msgstr "Απαλειφή"
 
 #: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
 #, c-format
@@ -2062,7 +2208,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8927
 msgid "Denom. deg:"
-msgstr ""
+msgstr "Βαθμός Παρανομαστή:"
 
 #: ../../src/wxMaxima.cpp:7923
 msgid "Denominator:"
@@ -2078,7 +2224,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1497
 msgid "Di&vide Polynomials..."
-msgstr ""
+msgstr "Διαίρεση πολυωνύμων..."
 
 #: ../../src/MaximaManual.cpp:517
 msgid "Didn't find the maxima HTML manual."
@@ -2092,35 +2238,38 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
 msgid "Differentiate"
-msgstr ""
+msgstr "Παραγώγιση"
 
 #: ../../src/wxMaximaFrame.cpp:1467
 msgid "Differentiate expression"
-msgstr ""
+msgstr "Παραγώγιση παράστασης"
 
 #: ../../src/Worksheet.cpp:1590
 msgid "Differentiate..."
-msgstr ""
+msgstr "Παραγώγιση..."
 
 #: ../../src/wxMaxima.cpp:9010
+#, fuzzy
 msgid "Differentiates an expression n times"
-msgstr ""
+msgstr "Παραγώγιση παράστασης"
 
 #: ../../src/wxMaxima.cpp:10055
+#, fuzzy
 msgid "Differentiates the expression n times"
-msgstr ""
+msgstr "Παραγώγιση παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1212
+#, fuzzy
 msgid "Directory operations"
-msgstr ""
+msgstr "Κατεύθυνση:"
 
 #: ../../src/wxMaximaFrame.cpp:1041
 msgid "Display Te&X Form"
-msgstr ""
+msgstr "Εμφάνιση σε μορφή TeX"
 
 #: ../../src/wxMaxima.cpp:6972
 msgid "Display algorithm"
-msgstr ""
+msgstr "Αλγόριθμος προβολής μαθηματικών"
 
 #: ../../src/wxMaximaFrame.cpp:751
 msgid "Display an expression as maxima's internal lisp representation"
@@ -2131,8 +2280,9 @@ msgid "Display an expression as wxMaxima's internal XML representation"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:758
+#, fuzzy
 msgid "Display equations"
-msgstr ""
+msgstr "Επίλυση εξίσωσης(-εων)"
 
 #: ../../src/wxMaxima.cpp:6508
 msgid "Display expression in maxima's internal representation"
@@ -2144,7 +2294,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1042
 msgid "Display last result in TeX form"
-msgstr ""
+msgstr "Εμφάνιση τελευταίου αποτελέσματος σε μορφή TeX"
 
 #: ../../src/ToolBar.cpp:360
 #, c-format
@@ -2152,24 +2302,27 @@ msgid "Display resolution according to wxWidgets: %li x %li ppi"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:802
+#, fuzzy
 msgid "Display string quotation marks"
-msgstr ""
+msgstr "Επίλυση εξίσωσης(-εων)"
 
 #: ../../src/wxMaximaFrame.cpp:1036
 msgid "Display time used for evaluation"
-msgstr ""
+msgstr "Εμφάνιση του χρόνου που απαιτήθηκε για τον υπολογισμό"
 
 #: ../../src/wxMaxima.cpp:9206
+#, fuzzy
 msgid "Displayed Precision"
-msgstr ""
+msgstr "Επίλυση εξίσωσης(-εων)"
 
 #: ../../src/wxMaximaFrame.cpp:1913
 msgid "Displaying 3d curves"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1462
+#, fuzzy
 msgid "Dito, and evaluate the result..."
-msgstr ""
+msgstr "Υπολογισμός ονοματικών μορφών"
 
 #: ../../src/wxMaximaFrame.cpp:1445
 msgid "Dito, but affect all clones of the Matrix..."
@@ -2185,15 +2338,16 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
 msgid "Divide Cell"
-msgstr ""
+msgstr "Διαίρεση κελιού"
 
 #: ../../src/wxMaximaFrame.cpp:1498
 msgid "Divide numbers or polynomials"
-msgstr ""
+msgstr "Διαίρεση αριθμών ή πολυωνύμων"
 
 #: ../../src/wxMaxima.cpp:8578
+#, fuzzy
 msgid "Do for each list element"
-msgstr ""
+msgstr "Εφαρμογή συνάρτησης σε μία λίστα"
 
 #: ../../src/wxMaxima.cpp:11197
 #, c-format
@@ -2206,35 +2360,44 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:94
 msgid "Document background"
-msgstr ""
+msgstr "Φόντο εγγράφου"
 
 #: ../../src/wxMaxima.cpp:4611
+#, fuzzy
 msgid ""
 "Document was saved using a newer version of wxMaxima so it may not load "
 "correctly. Please update your wxMaxima."
 msgstr ""
+"είχε αποθηκευθεί χρησιμοποιώντας μια νεότερη έκδοση του wxMaxima. Έτσι "
+"μπορεί να μην φορτωθεί σωστά.Παρακαλώ ενημερώστε το wxMaxima σας."
 
 #: ../../src/wxMaxima.cpp:4603
+#, fuzzy
 msgid ""
 "Document was saved using a newer version of wxMaxima. Please update your "
 "wxMaxima."
 msgstr ""
+"είχε αποθηκευθεί χρησιμοποιώντας μια νεότερη έκδοση του wxMaxima. Παρακαλώ "
+"ενημερώστε το wxMaxima σας."
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "Don't autosubscript after an underscore"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1086
+#, fuzzy
 msgid "Don't evaluate Expression..."
-msgstr ""
+msgstr "Ολοκλήρωση παράστασης"
 
 #: ../../src/wxMaxima.cpp:7117
+#, fuzzy
 msgid "Don't evaluate one command"
-msgstr ""
+msgstr "Εμφάνιση ενός παραδείγματος για την εντολή:"
 
 #: ../../src/wxMaxima.cpp:7129
+#, fuzzy
 msgid "Don't evaluate one whole expression"
-msgstr ""
+msgstr "Υπολογισμός πραγματικού μέρους μιας μιγαδικής παράστασης"
 
 #: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
 msgid "Don't mark cells that contain tooltips in yellow"
@@ -2261,36 +2424,40 @@ msgid "Don't use parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8525
+#, fuzzy
 msgid "Drop the first n list elements"
-msgstr ""
+msgstr "Εφαρμογή συνάρτησης σε μία λίστα"
 
 #: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
+#, fuzzy
 msgid "Drop the last n list elements"
-msgstr ""
+msgstr "Εφαρμογή συνάρτησης σε μία λίστα"
 
 #: ../../src/wxMaximaFrame.cpp:1306
 msgid "E&quations"
-msgstr ""
+msgstr "Εξισώσεις"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "E&xit\tCtrl+Q"
-msgstr ""
+msgstr "Έξοδος\tCtrl+Q"
 
 #: ../../src/wxMaximaFrame.cpp:1368
 msgid "Eige&nvectors"
-msgstr ""
+msgstr "Ιδιοδιανύσματα"
 
 #: ../../src/wxMaximaFrame.cpp:1365
 msgid "Eigen&values"
-msgstr ""
+msgstr "Ιδιοτιμές"
 
 #: ../../src/wxMaximaFrame.cpp:1387
+#, fuzzy
 msgid "Eigenvalues (complex)"
-msgstr ""
+msgstr "Ιδιοτιμές"
 
 #: ../../src/wxMaximaFrame.cpp:1384
+#, fuzzy
 msgid "Eigenvalues (real)"
-msgstr ""
+msgstr "Ιδιοτιμές"
 
 #: ../../src/wxMaximaFrame.cpp:1393
 msgid "Eigenvalues, left+right eigenvectors (complex)"
@@ -2337,20 +2504,22 @@ msgid "Elements:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7847
+#, fuzzy
 msgid "Eliminate a variable"
-msgstr ""
+msgstr "Απαλοιφή μεταβλητής..."
 
 #: ../../src/wxMaximaFrame.cpp:1247
 msgid "Eliminate a variable from a system of equations"
-msgstr ""
+msgstr "Απαλειφή μεταβλητής από σύστημα εξισώσεων"
 
 #: ../../src/wxMaxima.cpp:10651
 msgid "Empty command => re-triggering evaluation"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9225
+#, fuzzy
 msgid "Enable:"
-msgstr ""
+msgstr "Μεταβλητή:"
 
 #: ../../src/MathParser.cpp:99
 #, c-format
@@ -2375,35 +2544,37 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1319
 msgid "Enter a matrix"
-msgstr ""
+msgstr "Εισαγωγή πίνακα"
 
 #: ../../src/wxMaxima.cpp:8866
 msgid "Enter an equation for rational simplification:"
-msgstr ""
+msgstr "Εισαγωγή εξίσωσης για ρητή απλοποίηση:"
 
 #: ../../src/wxMaxima.cpp:8169
 msgid "Enter matrix"
-msgstr ""
+msgstr "Εισαγωγή πίνακα"
 
 #: ../../src/wxMaxima.cpp:9095
 msgid "Enter new animation frame rate [Hz, integer]:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9201
+#, fuzzy
 msgid "Enter new precision for bigfloats:"
-msgstr ""
+msgstr "Εισαγωγή νέας τιμής ακρίβειας:"
 
 #: ../../src/wxMaxima.cpp:7922
 msgid "Enumerator:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1220
+#, fuzzy
 msgid "Environment variables"
-msgstr ""
+msgstr "Επιπρόσθετοι παράμετροι:"
 
 #: ../../src/wxMaxima.cpp:9045
 msgid "Epsilon:"
-msgstr ""
+msgstr "Έψιλον:"
 
 #: ../../src/wxMaximaFrame.cpp:1124 ../../src/wxMaximaFrame.cpp:1135
 msgid "Equal, ignoring case?..."
@@ -2414,22 +2585,24 @@ msgid "Equal?..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8561
+#, fuzzy
 msgid "Equation"
-msgstr ""
+msgstr "Εξίσωση:"
 
 #: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
+#, fuzzy
 msgid "Equation(s)"
-msgstr ""
+msgstr "Εξίσωση(-εις):"
 
 #: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
 msgid "Equation(s):"
-msgstr ""
+msgstr "Εξίσωση(-εις):"
 
 #: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
 #: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
 #: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
 msgid "Equation:"
-msgstr ""
+msgstr "Εξίσωση:"
 
 #: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
 #: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
@@ -2441,7 +2614,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
 #: ../../src/wxMaxima.cpp:11166
 msgid "Error"
-msgstr ""
+msgstr "Σφάλμα"
 
 #: ../../src/wxMaxima.cpp:2456
 msgid "Error writing to Maxima"
@@ -2451,7 +2624,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
 #: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
 msgid "Error!"
-msgstr ""
+msgstr "Σφάλμα!"
 
 #: ../../src/Image.cpp:696
 #, c-format
@@ -2483,37 +2656,44 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1652
+#, fuzzy
 msgid "Evaluate &Noun Forms..."
-msgstr ""
+msgstr "Υπολογισμός ονοματικών μορφών"
 
 #: ../../src/wxMaximaFrame.cpp:856
+#, fuzzy
 msgid "Evaluate All Cells\tCtrl+Shift+R"
-msgstr ""
+msgstr "Υπολογισμός όλων των κελιών\tCtrl+R"
 
 #: ../../src/wxMaximaFrame.cpp:851
+#, fuzzy
 msgid "Evaluate All Visible Cells\tCtrl+R"
-msgstr ""
+msgstr "Υπολογισμός όλων των κελιών\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1395
+#, fuzzy
 msgid "Evaluate Cell"
-msgstr ""
+msgstr "Υπολογισμός κελιού(-ιών)"
 
 #: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
 msgid "Evaluate Cell(s)"
-msgstr ""
+msgstr "Υπολογισμός κελιού(-ιών)"
 
 #: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
+#, fuzzy
 msgid "Evaluate Cells Above"
-msgstr ""
+msgstr "Υπολογισμός κελιού(-ιών)"
 
 #: ../../src/wxMaximaFrame.cpp:866
+#, fuzzy
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
-msgstr ""
+msgstr "Υπολογισμός όλων των κελιών\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
 #: ../../src/wxMaximaFrame.cpp:876
+#, fuzzy
 msgid "Evaluate Cells Below"
-msgstr ""
+msgstr "Υπολογισμός κελιού(-ιών)"
 
 #: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
 #: ../../src/Worksheet.cpp:1890
@@ -2526,8 +2706,9 @@ msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8626
+#, fuzzy
 msgid "Evaluate Nouns"
-msgstr ""
+msgstr "Υπολογισμός ονοματικών μορφών"
 
 #: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
 msgid "Evaluate Part\tShift+Ctrl+Enter"
@@ -2549,7 +2730,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:845
 msgid "Evaluate active or selected cell(s)"
-msgstr ""
+msgstr "Υπολογισμός ενεργού(-ών) ή επιλεγμένου(-ων) κελιού(-ών)"
 
 #: ../../src/ToolBar.cpp:251
 msgid "Evaluate all"
@@ -2557,43 +2738,49 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:857
 msgid "Evaluate all cells in the document"
-msgstr ""
+msgstr "Υπολογισμός όλων των κελιών στο έγγραφο"
 
 #: ../../src/wxMaximaFrame.cpp:1653
 msgid "Evaluate all noun forms in expression"
-msgstr ""
+msgstr "Υπολογισμός όλων των ονοματικών μορφών στην παράσταση"
 
 #: ../../src/wxMaximaFrame.cpp:852
+#, fuzzy
 msgid "Evaluate all visible cells in the document"
-msgstr ""
+msgstr "Υπολογισμός όλων των κελιών στο έγγραφο"
 
 #: ../../src/ToolBar.cpp:248
 msgid "Evaluate current cell"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7395
+#, fuzzy
 msgid "Evaluate string"
-msgstr ""
+msgstr "Υπολογισμός ονοματικών μορφών"
 
 #: ../../src/wxMaximaFrame.cpp:1151
+#, fuzzy
 msgid "Evaluate string..."
-msgstr ""
+msgstr "Υπολογισμός ονοματικών μορφών"
 
 #: ../../src/ToolBar.cpp:256
 msgid "Evaluate the file from its beginning to the cell above the cursor"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:259
+#, fuzzy
 msgid "Evaluate the file from the cursor to its end"
-msgstr ""
+msgstr "Υπολογισμός όλων των κελιών στο έγγραφο"
 
 #: ../../src/ToolBar.cpp:258
+#, fuzzy
 msgid "Evaluate the rest"
-msgstr ""
+msgstr "Υπολογισμός ονοματικών μορφών"
 
 #: ../../src/ToolBar.cpp:255
+#, fuzzy
 msgid "Evaluate to point"
-msgstr ""
+msgstr "Υπολογισμός ονοματικών μορφών"
 
 #: ../../src/wxMaxima.cpp:10518
 msgid "Evaluation ended, since evaluation queue is empty."
@@ -2617,31 +2804,34 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1583
 msgid "Expand Expression"
-msgstr ""
+msgstr "Ανάπτυξη παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1525
 msgid "Expand an expression"
-msgstr ""
+msgstr "Ανάπτυξη μία παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1531
+#, fuzzy
 msgid "Expand for given variables"
-msgstr ""
+msgstr "Αλλαγή μεταβλητής"
 
 #: ../../src/wxMaxima.cpp:8781
 msgid "Expand for variable(s) including denominator:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8716
+#, fuzzy
 msgid "Expand for variable(s):"
-msgstr ""
+msgstr "Νέα μεταβλητή:"
 
 #: ../../src/wxMaximaFrame.cpp:1545
+#, fuzzy
 msgid "Expand log in previous expression"
-msgstr ""
+msgstr "Ανάπτυξη μία παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1598
 msgid "Expand trigonometric expression"
-msgstr ""
+msgstr "Ανάπτυξη τριγωνομετρικής παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Expect numbers harder to be complex"
@@ -2653,27 +2843,32 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6121
 msgid "Export"
-msgstr ""
+msgstr "Εξαγωγή"
 
 #: ../../src/wxMaximaFrame.cpp:1705
+#, fuzzy
 msgid "Export List to csv file..."
-msgstr ""
+msgstr "Η εξαγωγή σε TeX απέτυχε"
 
 #: ../../src/wxMaximaFrame.cpp:1706
+#, fuzzy
 msgid "Export a list to a csv file"
-msgstr ""
+msgstr "Φόρτωση αρχείου πακέτου Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1332
+#, fuzzy
 msgid "Export a matrix to a csv file"
-msgstr ""
+msgstr "Φόρτωση αρχείου πακέτου Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:619
+#, fuzzy
 msgid "Export document to a HTML or LaTeX file"
-msgstr ""
+msgstr "Εξαγωγή εγγράφου σε HTML ή pdfLaTeX αρχείο"
 
 #: ../../src/wxMaximaFrame.cpp:579
+#, fuzzy
 msgid "Export failed."
-msgstr ""
+msgstr "Η εξαγωγή σε TeX απέτυχε"
 
 #: ../../src/wxMaximaFrame.cpp:567
 msgid "Export successful."
@@ -2681,34 +2876,38 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6187
 msgid "Exporting to HTML failed!"
-msgstr ""
+msgstr "Η εξαγωγή σε HTML απέτυχε!"
 
 #: ../../src/wxMaxima.cpp:6164
 msgid "Exporting to TeX failed!"
-msgstr ""
+msgstr "Η εξαγωγή σε TeX απέτυχε"
 
 #: ../../src/wxMaxima.cpp:6175
+#, fuzzy
 msgid "Exporting to maxima batch file failed!"
-msgstr ""
+msgstr "Η εξαγωγή σε TeX απέτυχε"
 
 #: ../../src/wxMaximaFrame.cpp:561
+#, fuzzy
 msgid "Exporting..."
-msgstr ""
+msgstr "Εξαγωγή..."
 
 #: ../../src/wxMaxima.cpp:6510 ../../src/wxMaxima.cpp:6516
 #: ../../src/wxMaxima.cpp:8218 ../../src/wxMaxima.cpp:8633
 #: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
 #: ../../src/wxMaxima.cpp:10065
 msgid "Expression"
-msgstr ""
+msgstr "Παράσταση:"
 
 #: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
+#, fuzzy
 msgid "Expression or a list of comma-separated expressions"
-msgstr ""
+msgstr "Συντεταγμένες του x χωρισμένες με κόμμα"
 
 #: ../../src/wxMaximaFrame.cpp:1088
+#, fuzzy
 msgid "Expression to string..."
-msgstr ""
+msgstr "Παράσταση:"
 
 #: ../../src/wxMaxima.cpp:7113
 msgid "Expression whose output is to be used as maxima's input."
@@ -2716,7 +2915,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7214
 msgid "Expression(s):"
-msgstr ""
+msgstr "Παράσταση(-εις):"
 
 #: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
 #: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
@@ -2725,19 +2924,21 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
 #: ../../src/wxMaxima.cpp:10056
 msgid "Expression:"
-msgstr ""
+msgstr "Παράσταση:"
 
 #: ../../src/wxMaximaFrame.cpp:1423
+#, fuzzy
 msgid "Extract Column..."
-msgstr ""
+msgstr "Δημιουργία λίστας από παράσταση"
 
 #: ../../src/wxMaximaFrame.cpp:1726
 msgid "Extract Elements"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1421
+#, fuzzy
 msgid "Extract Row..."
-msgstr ""
+msgstr "Δημιουργία λίστας από παράσταση"
 
 #: ../../src/wxMaximaFrame.cpp:1424
 msgid "Extract a column from the matrix"
@@ -2748,32 +2949,38 @@ msgid "Extract a column from the matrix and convert it to a list"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7960
+#, fuzzy
 msgid "Extract a matrix column"
-msgstr ""
+msgstr "Εισαγωγή πίνακα"
 
 #: ../../src/wxMaxima.cpp:7970
+#, fuzzy
 msgid "Extract a matrix column as a list"
-msgstr ""
+msgstr "Εισαγωγή πίνακα"
 
 #: ../../src/wxMaximaFrame.cpp:1313
+#, fuzzy
 msgid "Extract a matrix from a 2-dimensional array"
-msgstr ""
+msgstr "Δημιουργία πίνακα από 2-Δ πίνακα"
 
 #: ../../src/wxMaxima.cpp:7955
+#, fuzzy
 msgid "Extract a matrix row"
-msgstr ""
+msgstr "Εισαγωγή πίνακα"
 
 #: ../../src/wxMaxima.cpp:7965
+#, fuzzy
 msgid "Extract a matrix row as a list"
-msgstr ""
+msgstr "Εισαγωγή πίνακα"
 
 #: ../../src/wxMaximaFrame.cpp:1422
 msgid "Extract a row from the matrix"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1431
+#, fuzzy
 msgid "Extract a row from the matrix and convert it to a list"
-msgstr ""
+msgstr "Δημιουργία λίστας από παράσταση"
 
 #: ../../src/wxMaxima.cpp:8564
 msgid "Extract a variable's value from a list of variable values"
@@ -2784,60 +2991,72 @@ msgid "Extract an actual value for a variable"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1163
+#, fuzzy
 msgid "Extract char..."
-msgstr ""
+msgstr "Δημιουργία λίστας από παράσταση"
 
 #: ../../src/wxMaximaFrame.cpp:1207
+#, fuzzy
 msgid "Extract dir from path..."
-msgstr ""
+msgstr "Δημιουργία λίστας από παράσταση"
 
 #: ../../src/wxMaxima.cpp:7605
+#, fuzzy
 msgid "Extract directory part"
-msgstr ""
+msgstr "Ονόματα συναρτήσεων"
 
 #: ../../src/wxMaxima.cpp:7617
+#, fuzzy
 msgid "Extract file type extension"
-msgstr ""
+msgstr "Δημιουργία λίστας από παράσταση"
 
 #: ../../src/wxMaximaFrame.cpp:1209
 msgid "Extract filename from path..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7611
+#, fuzzy
 msgid "Extract filename part"
-msgstr ""
+msgstr "Δημιουργία λίστας από παράσταση"
 
 #: ../../src/wxMaximaFrame.cpp:1211
 msgid "Extract filetype from path..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8445
+#, fuzzy
 msgid "Extract function arguments"
-msgstr ""
+msgstr "Ονόματα συναρτήσεων"
 
 #: ../../src/wxMaximaFrame.cpp:1727
+#, fuzzy
 msgid "Extract list Elements"
-msgstr ""
+msgstr "Δημιουργία λίστας από παράσταση"
 
 #: ../../src/wxMaxima.cpp:8187
+#, fuzzy
 msgid "Extract matrix from 2D array"
-msgstr ""
+msgstr "Εισαγωγή πίνακα"
 
 #: ../../src/wxMaximaFrame.cpp:1686
+#, fuzzy
 msgid "Extract the argument list from a function call"
-msgstr ""
+msgstr "Δημιουργία λίστας από παράσταση"
 
 #: ../../src/wxMaxima.cpp:8538
+#, fuzzy
 msgid "Extract the last n elements from a list"
-msgstr ""
+msgstr "Δημιουργία λίστας από παράσταση"
 
 #: ../../src/wxMaxima.cpp:7376
+#, fuzzy
 msgid "Extract the nth char of a string"
-msgstr ""
+msgstr "Δημιουργία λίστας από παράσταση"
 
 #: ../../src/wxMaxima.cpp:8544
+#, fuzzy
 msgid "Extract the nth list elements"
-msgstr ""
+msgstr "Δημιουργία λίστας από παράσταση"
 
 #: ../../src/wxMaximaFrame.cpp:1724
 msgid "Extract the value for one variable assigned in a list"
@@ -2848,32 +3067,34 @@ msgid "Extract, append or delete rows or columns"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8188
+#, fuzzy
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
-msgstr ""
+msgstr "Δημιουργία λίστας από παράσταση"
 
 #: ../../src/wxMaximaFrame.cpp:1521
 msgid "Factor Complex"
-msgstr ""
+msgstr "Παραγοντοποίηση παράστασης (Μιγαδική)"
 
 #: ../../src/Worksheet.cpp:1581
 msgid "Factor Expression"
-msgstr ""
+msgstr "Παραγοντοποίηση παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1519
+#, fuzzy
 msgid "Factor Expression including subexpressions"
-msgstr ""
+msgstr "Παραγοντοποίηση παράστασης σε Γκαουσιανούς αριθμούς"
 
 #: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
 msgid "Factor an expression"
-msgstr ""
+msgstr "Παραγοντοποίηση μιας παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1522
 msgid "Factor an expression in Gaussian numbers"
-msgstr ""
+msgstr "Παραγοντοποίηση παράστασης σε Γκαουσιανούς αριθμούς"
 
 #: ../../src/wxMaximaFrame.cpp:1587
 msgid "Factorials and &Gamma"
-msgstr ""
+msgstr "Παραγοντικά και Γάμμα"
 
 #: ../../src/Image.cpp:137
 #, c-format
@@ -2886,8 +3107,9 @@ msgid "Failed to delete gnuplot file %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:2667
+#, fuzzy
 msgid "Failed to start Maxima"
-msgstr ""
+msgstr "Επανεκίνηση του Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1418
 msgid "Fast fortran routines that perform numerical tasks"
@@ -2899,15 +3121,17 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:2553
 msgid "Fatal error"
-msgstr ""
+msgstr "Ολέθριο σφάλμα"
 
 #: ../../src/wxMaxima.cpp:7191
+#, fuzzy
 msgid "Field contents:"
-msgstr ""
+msgstr "Ελληνικές σταθερές"
 
 #: ../../src/wxMaxima.cpp:7198
+#, fuzzy
 msgid "Field name:"
-msgstr ""
+msgstr "Παλιά μεταβλητή:"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "Fields:"
@@ -2915,43 +3139,49 @@ msgstr ""
 
 #: ../../src/main.cpp:439
 msgid "File"
-msgstr ""
+msgstr "Αρχείο"
 
 #: ../../src/wxMaximaFrame.cpp:1333
+#, fuzzy
 msgid "File I/O"
-msgstr ""
+msgstr "Αρχείο"
 
 #: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
 #: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
 #: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
 #: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
+#, fuzzy
 msgid "File could not be opened"
-msgstr ""
+msgstr "Το αρχείο δεν βρέθηκε"
 
 #: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
 #: ../../src/wxMaxima.cpp:7251
+#, fuzzy
 msgid "File name:"
-msgstr ""
+msgstr "Παλιά μεταβλητή:"
 
 #: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
 msgid "File not found"
-msgstr ""
+msgstr "Το αρχείο δεν βρέθηκε"
 
 #: ../../src/wxMaxima.cpp:5631
+#, fuzzy
 msgid "File opened"
-msgstr ""
+msgstr "Το αρχείο δεν βρέθηκε"
 
 #: ../../src/wxMaximaFrame.cpp:1217
+#, fuzzy
 msgid "File operations"
-msgstr ""
+msgstr "Το αρχείο δεν βρέθηκε"
 
 #: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
 msgid "File you tried to open does not exist."
-msgstr ""
+msgstr "Το αρχείο που προσπαθήσατε να ανοίξετε δεν υπάρχει"
 
 #: ../../src/wxMaximaFrame.cpp:1221
+#, fuzzy
 msgid "File/directory functions"
-msgstr ""
+msgstr "Κατεύθυνση:"
 
 #: ../../src/wxMaxima.cpp:7027
 msgid "Filename or a list of comma-separated file names"
@@ -2959,27 +3189,27 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:222
 msgid "Find"
-msgstr ""
+msgstr "Εύρεση "
 
 #: ../../src/wxMaximaFrame.cpp:670
 msgid "Find\tCtrl+F"
-msgstr ""
+msgstr "Εύρεση \tCtrl+F"
 
 #: ../../src/wxMaximaFrame.cpp:1468
 msgid "Find &Limit..."
-msgstr ""
+msgstr "Εύρεση ορίου..."
 
 #: ../../src/wxMaximaFrame.cpp:1470
 msgid "Find Minimum..."
-msgstr ""
+msgstr "Εύρεση ελαχίστου..."
 
 #: ../../src/Worksheet.cpp:1576
 msgid "Find Root..."
-msgstr ""
+msgstr "Εύρεση ρίζας..."
 
 #: ../../src/wxMaximaFrame.cpp:1471
 msgid "Find a (unconstrained) minimum of an expression"
-msgstr ""
+msgstr "Εύρεση ενός (μη δεσμευμένου) ελαχίστου μιας παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1804
 msgid "Find a fraction that represents this float exactly"
@@ -2987,35 +3217,36 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1469
 msgid "Find a limit of an expression"
-msgstr ""
+msgstr "Εύρεση ορίου μιας παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1807
 msgid "Find a nice fraction that is similar to this float"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1283
+#, fuzzy
 msgid "Find a numerical solution for a first degree ODE"
-msgstr ""
+msgstr "Επίλυση προβλήματος αρχικών τιμών για πρωτοβάθμια ΣΔΕ"
 
 #: ../../src/wxMaximaFrame.cpp:1252
 msgid "Find a root of an equation on an interval"
-msgstr ""
+msgstr "Εύρεση ρίζας μιας εξίσωσης σε ένα διάστημα"
 
 #: ../../src/wxMaximaFrame.cpp:1259
 msgid "Find all roots of a polynomial"
-msgstr ""
+msgstr "Εύρεση όλων των ριζών ενός πολυωνύμου"
 
 #: ../../src/wxMaximaFrame.cpp:1262
 msgid "Find all roots of a polynomial (bfloat)"
-msgstr ""
+msgstr "Εύρεση όλων των ριζών ενός πολυωνύμου(bfloat)"
 
 #: ../../src/wxMaxima.cpp:6589
 msgid "Find and Replace"
-msgstr ""
+msgstr "Εύρεση και Αντικατάσταση"
 
 #: ../../src/ToolBar.cpp:222 ../../src/wxMaximaFrame.cpp:670
 msgid "Find and replace"
-msgstr ""
+msgstr "Εύρεση και αντικατάσταση"
 
 #: ../../src/wxMaxima.cpp:7434
 msgid "Find char in string"
@@ -3031,11 +3262,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1366
 msgid "Find eigenvalues of a matrix"
-msgstr ""
+msgstr "Εύρεση ιδιοτιμών πίνακα"
 
 #: ../../src/wxMaximaFrame.cpp:1369
 msgid "Find eigenvectors of a matrix"
-msgstr ""
+msgstr "Εύρεση ιδιοδιανυσμάτων πίνακα"
 
 #: ../../src/wxMaxima.cpp:7424
 msgid "Find first difference"
@@ -3046,12 +3277,13 @@ msgid "Find first difference..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1256
+#, fuzzy
 msgid "Find fractions that real roots of a polynomial and "
-msgstr ""
+msgstr "Εύρεση πραγματικών ριζών πολυωνύμου"
 
 #: ../../src/wxMaxima.cpp:9039
 msgid "Find minimum"
-msgstr ""
+msgstr "Εύρεση ελαχίστου"
 
 #: ../../src/wxMaximaFrame.cpp:1251
 msgid "Find numerical solution..."
@@ -3062,8 +3294,9 @@ msgid "Find root (solve numerically)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
+#, fuzzy
 msgid "Find the maximum absolute value of a matrix entry"
-msgstr ""
+msgstr "Εύρεση ιδιοτιμών πίνακα"
 
 #: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
 msgid "Find the maximum sum of the absolute values of a matrix column"
@@ -3094,8 +3327,9 @@ msgid "Flush..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:922
+#, fuzzy
 msgid "Fold All\tCtrl+Alt+["
-msgstr ""
+msgstr "Επιλογή Όλων\tCtrl+A"
 
 #: ../../src/wxMaximaFrame.cpp:923
 msgid "Fold all sections"
@@ -3182,59 +3416,64 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "From:"
-msgstr ""
+msgstr "Από:"
 
 #: ../../src/wxMaximaFrame.cpp:827
 msgid "Full Screen\tAlt+Enter"
-msgstr ""
+msgstr "Πλήρης οθόνη\tAlt+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:824
 msgid "Full Screen\tF11"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7140
+#, fuzzy
 msgid "Function contents:"
-msgstr ""
+msgstr "Ονόματα συναρτήσεων"
 
 #: ../../src/wxMaxima.cpp:7908
+#, fuzzy
 msgid "Function f(x):"
-msgstr ""
+msgstr "Συνάρτηση(-εις):"
 
 #: ../../src/wxMaxima.cpp:8572
+#, fuzzy
 msgid "Function name"
-msgstr ""
+msgstr "Ονόματα συναρτήσεων"
 
 #: ../../src/wxMaxima.cpp:7167
+#, fuzzy
 msgid "Function name(s):"
-msgstr ""
+msgstr "Ονόματα συναρτήσεων"
 
 #: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
+#, fuzzy
 msgid "Function name:"
-msgstr ""
+msgstr "Ονόματα συναρτήσεων"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Function:"
-msgstr ""
+msgstr "Συνάρτηση:"
 
 #: ../../src/wxMaximaFrame.cpp:1630
 msgid "Functions for complex simplification"
-msgstr ""
+msgstr "Συναρτήσεις για μιγαδική απλοποίηση"
 
 #: ../../src/wxMaximaFrame.cpp:1588
 msgid "Functions for simplifying factorials and gamma function"
-msgstr ""
+msgstr "Συναρτήσεις για απλοποίηση παραγοντικών και Γάμμα συναρτήσεων"
 
 #: ../../src/wxMaximaFrame.cpp:1606
 msgid "Functions for simplifying trigonometric expressions"
-msgstr ""
+msgstr "Συναρτήσεις για απλοποίηση τριγωνομετρικών παραστάσεων"
 
 #: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
 msgid "GCD"
-msgstr ""
+msgstr "ΜΚΔ"
 
 #: ../../src/wxMaxima.cpp:10186
 msgid "GIF image (*.gif)|*.gif"
-msgstr ""
+msgstr "Εικόνα GIF (*.gif)|*.gif"
 
 #: ../../src/Worksheet.cpp:103
 msgid ""
@@ -3245,19 +3484,19 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:295
 msgid "General Math"
-msgstr ""
+msgstr "Γενικά Μαθηματικά"
 
 #: ../../src/wxMaximaFrame.cpp:699
 msgid "General Math\tAlt+Shift+M"
-msgstr ""
+msgstr "Γενικά Μαθηματικά\tAlt+Shift+M"
 
 #: ../../src/wxMaximaFrame.cpp:1316
 msgid "Generate Matrix from Expression..."
-msgstr ""
+msgstr "Δημιουργία πίνακα απο παράσταση..."
 
 #: ../../src/wxMaximaFrame.cpp:1317
 msgid "Generate a matrix from a lambda expression"
-msgstr ""
+msgstr "Δημιουργία πίνακα από παράσταση lambda"
 
 #: ../../src/wxMaximaFrame.cpp:1675
 msgid "Generate a new list using a lists' elements"
@@ -3274,8 +3513,9 @@ msgid "Generate list elements using a rule"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8196
+#, fuzzy
 msgid "Generate matrix from a rule"
-msgstr ""
+msgstr "Δημιουργία λίστας από παράσταση"
 
 #: ../../src/wxMaximaFrame.cpp:1094
 msgid "Generate unused symbol name"
@@ -3293,15 +3533,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1619
 msgid "Get &Imaginary Part"
-msgstr ""
+msgstr "Εξαγωγή φανταστικού μέρους"
 
 #: ../../src/wxMaximaFrame.cpp:1485
 msgid "Get Laplace transformation of an expression"
-msgstr ""
+msgstr "Υπολογισμός μετασχηματισμού Laplace μιας παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1615
 msgid "Get Real P&art"
-msgstr ""
+msgstr "Εξαγωγή πραγματικού μέρους"
 
 #: ../../src/wxMaximaFrame.cpp:1201
 msgid "Get current directory"
@@ -3309,23 +3549,24 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1489
 msgid "Get inverse Laplace transformation of an expression"
-msgstr ""
+msgstr "Υπολογισμός του αντίστροφου μετασχηματισμού Laplace μιας παράστασης\""
 
 #: ../../src/wxMaxima.cpp:7223
 msgid "Get position in stream"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1102
+#, fuzzy
 msgid "Get position..."
-msgstr ""
+msgstr "Απόκλιση"
 
 #: ../../src/wxMaximaFrame.cpp:1620
 msgid "Get the imaginary part of complex expression"
-msgstr ""
+msgstr "Υπολογισμός φανταστικού μέρους μιας μιγαδικής παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1616
 msgid "Get the real part of complex expression"
-msgstr ""
+msgstr "Υπολογισμός πραγματικού μέρους μιας μιγαδικής παράστασης"
 
 #: ../../src/wxMaxima.cpp:3609
 #, c-format
@@ -3351,8 +3592,9 @@ msgid "Go to URL"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3989
+#, fuzzy
 msgid "Got a new input prompt!"
-msgstr ""
+msgstr "Προσθήκη νέου κελιού εντολών"
 
 #: ../../src/Worksheet.cpp:6354
 msgid ""
@@ -3365,46 +3607,52 @@ msgid "Gradefs"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1967
+#, fuzzy
 msgid "Greater or less than a value"
-msgstr ""
+msgstr "Κελί υποενότητας"
 
 #: ../../src/wxMaximaFrame.cpp:1130
 msgid "Greater, ignoring case?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:260
+#, fuzzy
 msgid "Greek Letters"
-msgstr ""
+msgstr "Ελληνικές σταθερές"
 
 #: ../../src/wxMaximaFrame.cpp:703
+#, fuzzy
 msgid "Greek Letters\tAlt+Shift+G"
-msgstr ""
+msgstr "Γενικά Μαθηματικά\tAlt+Shift+M"
 
 #: ../../src/wxMaximaFrame.cpp:1815
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:6123
+#, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file "
 "(*.tex)|*.tex"
-msgstr ""
+msgstr "Αρχείο HTML (*.html)|*.html|pdfLaTeX file (*.tex)|*.tex|All|*"
 
 #: ../../src/wxMaximaFrame.cpp:1341
 msgid "Hadamard (element-by-element) product..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8004
+#, fuzzy
 msgid "Hadamard Product"
-msgstr ""
+msgstr "Γινόμενο"
 
 #: ../../src/wxMaxima.cpp:8011
 msgid "Hadamard exponent"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1345
+#, fuzzy
 msgid "Hadamard exponent..."
-msgstr ""
+msgstr "Όνομα πίνακα:"
 
 #: ../../src/MaximaManual.cpp:260
 #, c-format
@@ -3423,7 +3671,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
 msgid "Help"
-msgstr ""
+msgstr "Βοήθεια"
 
 #: ../../src/ToolBar.cpp:635
 msgid "Help button"
@@ -3435,16 +3683,19 @@ msgid "Help on \"%s\""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:729
+#, fuzzy
 msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr ""
+msgstr "Απόκρυψη Όλων\tAlt+Shift+-"
 
 #: ../../src/ToolBar.cpp:264
+#, fuzzy
 msgid "Hide Code"
-msgstr ""
+msgstr "Διαίρεση κελιού"
 
 #: ../../src/wxMaximaFrame.cpp:727
+#, fuzzy
 msgid "Hide Code Cells\tAlt+Ctrl+H"
-msgstr ""
+msgstr "Προσθήκη κελιού\tAlt+Shift+C"
 
 #: ../../src/Worksheet.cpp:1896
 msgid "Hide Heading 5"
@@ -3455,32 +3706,38 @@ msgid "Hide Heading 6"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1855
+#, fuzzy
 msgid "Hide Part"
-msgstr ""
+msgstr "Διαίρεση κελιού"
 
 #: ../../src/Worksheet.cpp:1863
+#, fuzzy
 msgid "Hide Section"
-msgstr ""
+msgstr "Ενότητα"
 
 #: ../../src/Worksheet.cpp:1874
+#, fuzzy
 msgid "Hide Subsection"
-msgstr ""
+msgstr "Υποενότητα"
 
 #: ../../src/Worksheet.cpp:1885
+#, fuzzy
 msgid "Hide Subsubsection"
-msgstr ""
+msgstr "Υποενότητα"
 
 #: ../../src/wxMaximaFrame.cpp:730
 msgid "Hide all panes"
-msgstr ""
+msgstr "Απόκρυψη όλων των παλετών"
 
 #: ../../src/Worksheet.cpp:1491
+#, fuzzy
 msgid "Hide cell brackets"
-msgstr ""
+msgstr "Άγκιστρο ενεργού κελιού"
 
 #: ../../src/Worksheet.cpp:1915
+#, fuzzy
 msgid "Hide contents"
-msgstr ""
+msgstr "Ελληνικές σταθερές"
 
 #: ../../src/Worksheet.cpp:1552
 msgid "Hide multiplication dots"
@@ -3495,20 +3752,22 @@ msgid "Hide yellow tooltip marker for this message type"
 msgstr ""
 
 #: ../../src/Configuration.cpp:82
+#, fuzzy
 msgid "Highlight (box)"
-msgstr ""
+msgstr "Επισήμανση (dpart)"
 
 #: ../../src/wxMaxima.cpp:9528
 msgid "Histogram"
-msgstr ""
+msgstr "Ιστόγραμμα"
 
 #: ../../src/wxMaximaFrame.cpp:232
 msgid "History"
-msgstr ""
+msgstr "Ιστορικό"
 
 #: ../../src/wxMaximaFrame.cpp:709
+#, fuzzy
 msgid "History\tAlt+Shift+I"
-msgstr ""
+msgstr "Ιστορικό\tAlt+Shift+H"
 
 #: ../../src/wxMaximaFrame.cpp:1526
 msgid "Horner's rule"
@@ -3587,7 +3846,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Include columns:"
-msgstr ""
+msgstr "Συμπεριέλαβε τις στήλες:"
 
 #: ../../src/Worksheet.cpp:2008
 msgid "Increasing function f(x)>x"
@@ -3606,12 +3865,13 @@ msgid "Index Step:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
+#, fuzzy
 msgid "Index variable:"
-msgstr ""
+msgstr "Νέα μεταβλητή:"
 
 #: ../../src/wxMaximaFrame.cpp:1949
 msgid "Info about Maxima build"
-msgstr ""
+msgstr "Πληροφορίες για το Maxima build"
 
 #: ../../src/Worksheet.cpp:2046
 msgid "Inform maxima about facts you know for this symbol"
@@ -3624,44 +3884,49 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
+#, fuzzy
 msgid "Initial Condition"
-msgstr ""
+msgstr "Συνθήκη:"
 
 #: ../../src/wxMaximaFrame.cpp:1270
 msgid "Initial Value Problem (&1)..."
-msgstr ""
+msgstr "Πρόβλημα αρχικών τιμών (&1)..."
 
 #: ../../src/wxMaximaFrame.cpp:1274
 msgid "Initial Value Problem (&2)..."
-msgstr ""
+msgstr "Πρόβλημα αρχικών τιμών (&2)..."
 
 #: ../../src/wxMaxima.cpp:9044
+#, fuzzy
 msgid "Initial estimates:"
-msgstr ""
+msgstr "Αρχικές Εκτιμήσεις:"
 
 #: ../../src/wxMaxima.cpp:7840
+#, fuzzy
 msgid "Initial x:"
-msgstr ""
+msgstr "Αρχικές Εκτιμήσεις:"
 
 #: ../../src/Configuration.cpp:78
 msgid "Input labels"
-msgstr ""
+msgstr "Ετικέτες εισαγωγής"
 
 #: ../../src/wxMaximaFrame.cpp:314
 msgid "Insert"
-msgstr ""
+msgstr "Προσθήκη"
 
 #: ../../src/wxMaximaFrame.cpp:905
+#, fuzzy
 msgid "Insert &Section Cell\tCtrl+3"
-msgstr ""
+msgstr "Προσθήκη κελιού &ενότητας\tF8"
 
 #: ../../src/wxMaximaFrame.cpp:901
+#, fuzzy
 msgid "Insert &Text Cell\tCtrl+1"
-msgstr ""
+msgstr "Προσθήκη κελιού &κειμένου\tF6"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Insert Cell\tAlt+Shift+C"
-msgstr ""
+msgstr "Προσθήκη κελιού\tAlt+Shift+C"
 
 #: ../../src/Worksheet.cpp:1669
 msgid "Insert Heading5 Cell"
@@ -3673,51 +3938,61 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10854
 msgid "Insert Image"
-msgstr ""
+msgstr "Προσθήκη εικόνας"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert Image..."
-msgstr ""
+msgstr "Προσθήκη εικόνας..."
 
 #: ../../src/wxMaximaFrame.cpp:899
+#, fuzzy
 msgid "Insert Input &Cell\tCtrl+0"
-msgstr ""
+msgstr "Προσθήκη κελιού εντολών"
 
 #: ../../src/wxMaximaFrame.cpp:919
+#, fuzzy
 msgid "Insert Page Break"
-msgstr ""
+msgstr "Προσθήκη Page Break\tF10"
 
 #: ../../src/wxMaximaFrame.cpp:907
+#, fuzzy
 msgid "Insert S&ubsection Cell\tCtrl+4"
-msgstr ""
+msgstr "Προσθήκη κελιού υποενότητας"
 
 #: ../../src/wxMaximaFrame.cpp:910
+#, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
-msgstr ""
+msgstr "Προσθήκη κελιού υποενότητας"
 
 #: ../../src/Worksheet.cpp:1662
+#, fuzzy
 msgid "Insert Section Cell"
-msgstr ""
+msgstr "Προσθήκη κελιού &ενότητας\tF8"
 
 #: ../../src/Worksheet.cpp:1664
+#, fuzzy
 msgid "Insert Subsection Cell"
-msgstr ""
+msgstr "Προσθήκη κελιού υποενότητας"
 
 #: ../../src/Worksheet.cpp:1667
+#, fuzzy
 msgid "Insert Subsubsection Cell"
-msgstr ""
+msgstr "Προσθήκη κελιού υποενότητας"
 
 #: ../../src/wxMaximaFrame.cpp:903
+#, fuzzy
 msgid "Insert T&itle Cell\tCtrl+2"
-msgstr ""
+msgstr "Προσθήκη κελιού τίτλου"
 
 #: ../../src/Worksheet.cpp:1658
+#, fuzzy
 msgid "Insert Text Cell"
-msgstr ""
+msgstr "Προσθήκη κελιού &κειμένου\tF6"
 
 #: ../../src/Worksheet.cpp:1660
+#, fuzzy
 msgid "Insert Title Cell"
-msgstr ""
+msgstr "Προσθήκη κελιού τίτλου"
 
 #: ../../src/wxMaximaFrame.cpp:913
 msgid "Insert a new heading5 cell"
@@ -3729,35 +4004,37 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:900
 msgid "Insert a new input cell"
-msgstr ""
+msgstr "Προσθήκη νέου κελιού εντολών"
 
 #: ../../src/wxMaximaFrame.cpp:906
 msgid "Insert a new section cell"
-msgstr ""
+msgstr "Προσθήκη νέου κελιού ενότητας"
 
 #: ../../src/wxMaximaFrame.cpp:908
 msgid "Insert a new subsection cell"
-msgstr ""
+msgstr "Προσθήκη νέου κελιού υποενότητας"
 
 #: ../../src/wxMaximaFrame.cpp:911
+#, fuzzy
 msgid "Insert a new subsubsection cell"
-msgstr ""
+msgstr "Προσθήκη νέου κελιού υποενότητας"
 
 #: ../../src/wxMaximaFrame.cpp:902
 msgid "Insert a new text cell"
-msgstr ""
+msgstr "Προσθήκη νέου κελιού κειμένου"
 
 #: ../../src/wxMaximaFrame.cpp:904
 msgid "Insert a new title cell"
-msgstr ""
+msgstr "Προσθήκη νέου κελιού τίτλου"
 
 #: ../../src/wxMaximaFrame.cpp:920
 msgid "Insert a page break"
-msgstr ""
+msgstr "Προσθήκη αλλαγής σελίδας"
 
 #: ../../src/wxMaximaFrame.cpp:1164
+#, fuzzy
 msgid "Insert char..."
-msgstr ""
+msgstr "Προσθήκη εικόνας..."
 
 #: ../../src/wxMaximaFrame.cpp:912
 msgid "Insert heading5 Cell\tCtrl+6"
@@ -3772,8 +4049,9 @@ msgid "Insert image"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:916
+#, fuzzy
 msgid "Insert textbased cell"
-msgstr ""
+msgstr "Προσθήκη κελιού &κειμένου\tF6"
 
 #: ../../src/wxMaxima.cpp:3566
 msgid "Instructed to prefer gnuplot over wgnuplot"
@@ -3785,43 +4063,47 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
 msgid "Integral/Sum:"
-msgstr ""
+msgstr "Ολοκλήρωμα/Άθροισμα:"
 
 #: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
 msgid "Integrate"
-msgstr ""
+msgstr "Ολοκλήρωση"
 
 #: ../../src/wxMaxima.cpp:8980
 msgid "Integrate (risch)"
-msgstr ""
+msgstr "Ολοκλήρωση (risch)"
 
 #: ../../src/wxMaximaFrame.cpp:1454
 msgid "Integrate expression"
-msgstr ""
+msgstr "Ολοκλήρωση παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1456
 msgid "Integrate expression with Risch algorithm"
-msgstr ""
+msgstr "Ολοκλήρωση παράστασης με τον αλγόριθμο Risch "
 
 #: ../../src/wxMaximaFrame.cpp:1869
+#, fuzzy
 msgid "Integrate numerically"
-msgstr ""
+msgstr "Ολοκλήρωση (risch)"
 
 #: ../../src/Worksheet.cpp:1588
 msgid "Integrate..."
-msgstr ""
+msgstr "Ολοκλήρωση..."
 
 #: ../../src/wxMaximaFrame.cpp:1737
+#, fuzzy
 msgid "Interleave"
-msgstr ""
+msgstr "Ολοκλήρωση"
 
 #: ../../src/wxMaximaFrame.cpp:1738
+#, fuzzy
 msgid "Interleave the values of two lists"
-msgstr ""
+msgstr "Ολοκλήρωση"
 
 #: ../../src/wxMaxima.cpp:8612
+#, fuzzy
 msgid "Interleave two lists"
-msgstr ""
+msgstr "Ολοκλήρωση"
 
 #: ../../src/wxMaximaFrame.cpp:1087
 msgid "Interpret like input..."
@@ -3836,16 +4118,17 @@ msgid "Interpret string as maxima code"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1089
+#, fuzzy
 msgid "Interpret string..."
-msgstr ""
+msgstr "Εισαγωγή πίνακα..."
 
 #: ../../src/ToolBar.cpp:231
 msgid "Interrupt"
-msgstr ""
+msgstr "Διακοπή"
 
 #: ../../src/wxMaximaFrame.cpp:965
 msgid "Interrupt current computation"
-msgstr ""
+msgstr "Διακοπή τρέχοντος υπολογισμού"
 
 #: ../../src/ToolBar.cpp:232
 msgid ""
@@ -3872,11 +4155,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9003
 msgid "Inverse Laplace"
-msgstr ""
+msgstr "Αντίστροφος Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1488
 msgid "Inverse Laplace T&ransform..."
-msgstr ""
+msgstr "Αντίστροφος μετασχηματισμός Laplace..."
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Invert worksheet brightness"
@@ -3887,8 +4170,9 @@ msgid "Is Char 1 greater than Char2, if case is ignored?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7333
+#, fuzzy
 msgid "Is Char 1 greater than Char2?"
-msgstr ""
+msgstr "Κελί υποενότητας"
 
 #: ../../src/wxMaxima.cpp:7327
 msgid "Is Char 1 less than Char2, if case is ignored?"
@@ -3907,12 +4191,14 @@ msgid "Is a char?..."
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1952
+#, fuzzy
 msgid "Is a complex variable"
-msgstr ""
+msgstr "Νέα μεταβλητή:"
 
 #: ../../src/wxMaxima.cpp:7292
+#, fuzzy
 msgid "Is a digit?"
-msgstr ""
+msgstr "Αλγόριθμος προβολής μαθηματικών"
 
 #: ../../src/wxMaximaFrame.cpp:1118
 msgid "Is a digit?..."
@@ -3927,8 +4213,9 @@ msgid "Is a printable char?"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1949
+#, fuzzy
 msgid "Is a real variable"
-msgstr ""
+msgstr "Αλλαγή μεταβλητής"
 
 #: ../../src/wxMaxima.cpp:7300
 msgid "Is a uppercase char?"
@@ -3951,28 +4238,33 @@ msgid "Is an alphanumeric char?"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1991
+#, fuzzy
 msgid "Is an even function"
-msgstr ""
+msgstr "Διαγραφή μίας συνάρτησης"
 
 #: ../../src/Worksheet.cpp:1955
+#, fuzzy
 msgid "Is an imaginary variable"
-msgstr ""
+msgstr "Αλλαγή μεταβλητής"
 
 #: ../../src/Worksheet.cpp:1960
+#, fuzzy
 msgid "Is an integer variable"
-msgstr ""
+msgstr "Αλλαγή μεταβλητής"
 
 #: ../../src/Worksheet.cpp:1993
+#, fuzzy
 msgid "Is an odd function"
-msgstr ""
+msgstr "Διαγραφή μίας συνάρτησης"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Is equal?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1128
+#, fuzzy
 msgid "Is greater?..."
-msgstr ""
+msgstr "Δημιουργία λίστας"
 
 #: ../../src/wxMaximaFrame.cpp:1125
 msgid "Is lower?..."
@@ -3983,8 +4275,9 @@ msgid "Is lowercase?..."
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1962
+#, fuzzy
 msgid "Is no integer variable"
-msgstr ""
+msgstr "Αλλαγή μεταβλητής"
 
 #: ../../src/wxMaximaFrame.cpp:1119
 msgid "Is printable?..."
@@ -4007,8 +4300,9 @@ msgid "Item"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8581
+#, fuzzy
 msgid "Iterator name:"
-msgstr ""
+msgstr "Όνομα πίνακα:"
 
 #: ../../src/wxMaximaFrame.cpp:1048
 msgid "Jump to first error"
@@ -4020,7 +4314,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8960
 msgid "LCM"
-msgstr ""
+msgstr "ΕΚΠ"
 
 #: ../../src/wxMaximaFrame.cpp:1407
 msgid "L[1] Norm (complex)"
@@ -4039,8 +4333,9 @@ msgid "L[inf] Norm (real)"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1025
+#, fuzzy
 msgid "Labels"
-msgstr ""
+msgstr "Ετικέτες εισαγωγής"
 
 #: ../../src/wxMaxima.cpp:7090
 msgid "Lambda"
@@ -4055,11 +4350,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8997
 msgid "Laplace"
-msgstr ""
+msgstr "Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1484
 msgid "Laplace &Transform..."
-msgstr ""
+msgstr "Μετασχηματισμός Laplace..."
 
 #: ../../src/wxMaximaFrame.cpp:1718
 msgid "Last"
@@ -4076,8 +4371,9 @@ msgid "Last message from maxima's stdout: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1720
+#, fuzzy
 msgid "Last n"
-msgstr ""
+msgstr "Λίστα:"
 
 #: ../../src/wxMaxima.cpp:10400
 msgid "Last non-whitespace is a question mark"
@@ -4094,16 +4390,17 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1493
 msgid "Least Common Multiple..."
-msgstr ""
+msgstr "Ελάχιστο Κοινό Πολλαπλάσιο..."
 
 #: ../../src/wxMaxima.cpp:9587
 msgid "Least Squares Fit"
-msgstr ""
+msgstr "Παρεμβολή ελαχίστων τετραγώνων"
 
 #: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
 #: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
+#, fuzzy
 msgid "Left Matrix:"
-msgstr ""
+msgstr "Άνοιγμα πίνακα"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Left end"
@@ -4130,16 +4427,18 @@ msgid "Letrules"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1976
+#, fuzzy
 msgid "Likely to be the main variable"
-msgstr ""
+msgstr "Διαγραφή μίας μεταβλητής"
 
 #: ../../src/wxMaxima.cpp:9028
 msgid "Limit"
-msgstr ""
+msgstr "Όριο"
 
 #: ../../src/wxMaxima.cpp:7256
+#, fuzzy
 msgid "Lisp format string:"
-msgstr ""
+msgstr "Ερωτήσεις για το Maxima"
 
 #: ../../src/wxMaxima.cpp:7258
 msgid "Lisp format strings are more powerful than c++ format strings"
@@ -4162,16 +4461,19 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
 #: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
 #: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
+#, fuzzy
 msgid "List"
-msgstr ""
+msgstr "Λίστα:"
 
 #: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
+#, fuzzy
 msgid "List #1"
-msgstr ""
+msgstr "Λίστα:"
 
 #: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
+#, fuzzy
 msgid "List #2"
-msgstr ""
+msgstr "Λίστα:"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "List directory"
@@ -4186,12 +4488,14 @@ msgid "List of char to String"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1150
+#, fuzzy
 msgid "List of chars to string..."
-msgstr ""
+msgstr "Παράσταση:"
 
 #: ../../src/wxMaxima.cpp:7386
+#, fuzzy
 msgid "List of chars:"
-msgstr ""
+msgstr "Ετικέτες εισαγωγής"
 
 #: ../../src/wxMaxima.cpp:8559
 msgid "List with values"
@@ -4200,43 +4504,49 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
 msgid "List:"
-msgstr ""
+msgstr "Λίστα:"
 
 #: ../../src/wxMaxima.cpp:6200
 msgid "Load Package"
-msgstr ""
+msgstr "Φόρτωση πακέτου"
 
 #: ../../src/wxMaximaFrame.cpp:613
+#, fuzzy
 msgid "Load Recent Package"
-msgstr ""
+msgstr "Φόρτωση πακέτου"
 
 #: ../../src/wxMaximaFrame.cpp:616
 msgid "Load a Maxima file using the batch command"
-msgstr ""
+msgstr "Φόρτωση ένος αρχείου Maxima με την εντολή batch."
 
 #: ../../src/wxMaximaFrame.cpp:611
 msgid "Load a Maxima package file"
-msgstr ""
+msgstr "Φόρτωση αρχείου πακέτου Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1678
+#, fuzzy
 msgid "Load a list from a csv file"
-msgstr ""
+msgstr "Φόρτωση αρχείου πακέτου Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
+#, fuzzy
 msgid "Load a matrix from a csv file"
-msgstr ""
+msgstr "Φόρτωση αρχείου πακέτου Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
+#, fuzzy
 msgid "Load lapack"
-msgstr ""
+msgstr "Φόρτωση πακέτου"
 
 #: ../../src/wxMaxima.cpp:7208
+#, fuzzy
 msgid "Load lisp code"
-msgstr ""
+msgstr "Φόρτωση πακέτου"
 
 #: ../../src/wxMaximaFrame.cpp:1092
+#, fuzzy
 msgid "Load lisp..."
-msgstr ""
+msgstr "Φόρτωση πακέτου"
 
 #: ../../src/wxMaximaFrame.cpp:1198
 msgid "Load the file/dir operations (operatingsystem)"
@@ -4251,36 +4561,41 @@ msgid "Load the translation generator (gentran)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8219
+#, fuzzy
 msgid "Loop variable"
-msgstr ""
+msgstr "Νέα μεταβλητή:"
 
 #: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
 msgid "Lower bound:"
-msgstr ""
+msgstr "Κάτω φράγμα:"
 
 #: ../../src/wxMaximaFrame.cpp:1127
 msgid "Lower, ignoring case?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1448
+#, fuzzy
 msgid "M&atrix"
-msgstr ""
+msgstr "Πίνακας"
 
 #: ../../src/wxMaxima.cpp:7153
+#, fuzzy
 msgid "Macro contents:"
-msgstr ""
+msgstr "Ελληνικές σταθερές"
 
 #: ../../src/wxMaxima.cpp:7148
+#, fuzzy
 msgid "Macro name:"
-msgstr ""
+msgstr "Όνομα πίνακα:"
 
 #: ../../src/wxMaximaFrame.cpp:1024
 msgid "Macros"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:697
+#, fuzzy
 msgid "Main Toolbar\tAlt+Shift+B"
-msgstr ""
+msgstr "Γραμμή εργαλείων\tAlt+Shift+T"
 
 #: ../../src/wxMaxima.cpp:7906
 msgid "Make a function value at a specific point known"
@@ -4291,28 +4606,32 @@ msgid "Make an eventual ev() evaluate this"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1070
+#, fuzzy
 msgid "Make function local..."
-msgstr ""
+msgstr "Εφαρμογή συνάρτησης στα μέλη λίστας"
 
 #: ../../src/wxMaxima.cpp:8207
 msgid "Map"
-msgstr ""
+msgstr "Απεικόνιση"
 
 #: ../../src/wxMaxima.cpp:8215
+#, fuzzy
 msgid "Map an expression"
-msgstr ""
+msgstr "Ανάπτυξη μία παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "Map function to a matrix"
-msgstr ""
+msgstr "Εφαρμογή συνάρτησης στα μέλη πίνακα"
 
 #: ../../src/wxMaximaFrame.cpp:1446
+#, fuzzy
 msgid "Map function to a matrix, affecting all of its clones"
-msgstr ""
+msgstr "Εφαρμογή συνάρτησης στα μέλη πίνακα"
 
 #: ../../src/Configuration.cpp:109
+#, fuzzy
 msgid "Math Default"
-msgstr ""
+msgstr "Προεπιλεγμένος"
 
 #: ../../src/wxMaximaFrame.cpp:286
 msgid "Mathematical Symbols"
@@ -4332,39 +4651,45 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
 #: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
 msgid "Matrix"
-msgstr ""
+msgstr "Πίνακας"
 
 #: ../../src/wxMaxima.cpp:7986
+#, fuzzy
 msgid "Matrix Exponent"
-msgstr ""
+msgstr "Όνομα πίνακα:"
 
 #: ../../src/wxMaximaFrame.cpp:1339
+#, fuzzy
 msgid "Matrix exponent..."
-msgstr ""
+msgstr "Όνομα πίνακα:"
 
 #: ../../src/wxMaximaFrame.cpp:1329
+#, fuzzy
 msgid "Matrix from csv file"
-msgstr ""
+msgstr "Φόρτωση στυλ από αρχείο"
 
 #: ../../src/wxMaximaFrame.cpp:1323
+#, fuzzy
 msgid "Matrix from csv file..."
-msgstr ""
+msgstr "Φόρτωση στυλ από αρχείο"
 
 #: ../../src/wxMaxima.cpp:8137
 msgid "Matrix map"
-msgstr ""
+msgstr "Απεικόνιση πίνακα"
 
 #: ../../src/wxMaxima.cpp:9630
 msgid "Matrix name:"
-msgstr ""
+msgstr "Όνομα πίνακα:"
 
 #: ../../src/wxMaximaFrame.cpp:798
+#, fuzzy
 msgid "Matrix parenthesis"
-msgstr ""
+msgstr "Αντιστοίχιση παρενθέσεων σε έλεγχο κειμένου"
 
 #: ../../src/wxMaximaFrame.cpp:1331
+#, fuzzy
 msgid "Matrix to csv file"
-msgstr ""
+msgstr "Φόρτωση στυλ από αρχείο"
 
 #: ../../src/wxMaximaFrame.cpp:1334
 msgid "Matrix to file or Matrix from file"
@@ -4379,7 +4704,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
 #: ../../src/wxMaxima.cpp:8136
 msgid "Matrix:"
-msgstr ""
+msgstr "Πίνακας:"
 
 #: ../../src/wxMaxima.cpp:8627
 msgid ""
@@ -4395,12 +4720,14 @@ msgid "Maxima architecture: %s"
 msgstr ""
 
 #: ../../src/StatusBar.cpp:252
+#, fuzzy
 msgid "Maxima asks a question"
-msgstr ""
+msgstr "Ερωτήσεις για το Maxima"
 
 #: ../../src/wxMaxima.cpp:4066
+#, fuzzy
 msgid "Maxima asks a question!"
-msgstr ""
+msgstr "Ερωτήσεις για το Maxima"
 
 #: ../../src/wxMaxima.cpp:7118
 msgid ""
@@ -4417,16 +4744,19 @@ msgid "Maxima errors"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3289
+#, fuzzy
 msgid "Maxima has authenticated!"
-msgstr ""
+msgstr "Η διαδικασία Maxima τερμάτισε."
 
 #: ../../src/wxMaxima.cpp:10533
+#, fuzzy
 msgid "Maxima has finished calculating."
-msgstr ""
+msgstr "Το Maxima κάνει υπολογισμούς"
 
 #: ../../src/wxMaxima.cpp:5832
+#, fuzzy
 msgid "Maxima has issued an error!"
-msgstr ""
+msgstr "Ερωτήσεις για το Maxima"
 
 #: ../../src/wxMaxima.cpp:3696
 #, c-format
@@ -4438,20 +4768,22 @@ msgid "Maxima has sent a new variable value."
 msgstr ""
 
 #: ../../src/MaximaManual.cpp:552
+#, fuzzy
 msgid "Maxima help file not found!"
-msgstr ""
+msgstr "Το αρχείο δεν βρέθηκε"
 
 #: ../../src/wxMaximaFrame.cpp:1043
 msgid "Maxima input"
-msgstr ""
+msgstr "Είσοδος Maxima"
 
 #: ../../src/StatusBar.cpp:236
 msgid "Maxima is calculating"
-msgstr ""
+msgstr "Το Maxima κάνει υπολογισμούς"
 
 #: ../../src/wxMaxima.cpp:5068
+#, fuzzy
 msgid "Maxima is ready for input."
-msgstr ""
+msgstr "Είσοδος Maxima"
 
 #: ../../src/Dirstructure.cpp:144
 #, c-format
@@ -4460,19 +4792,20 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6211
 msgid "Maxima package (*.mac)|*.mac"
-msgstr ""
+msgstr "Πακέτο Maxima (*.mac)|*.mac"
 
 #: ../../src/wxMaxima.cpp:6202
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
-msgstr ""
+msgstr "Πακέτο Maxima(*.mac)|*.mac|πακέτο Lisp (*.lisp)|*.lisp|All|*"
 
 #: ../../src/wxMaxima.cpp:3012
 msgid "Maxima process terminated unexpectedly."
 msgstr ""
 
 #: ../../src/Configuration.cpp:79
+#, fuzzy
 msgid "Maxima question labels"
-msgstr ""
+msgstr "Ερωτήσεις για το Maxima"
 
 #: ../../src/wxMaxima.cpp:3380
 msgid "Maxima sends a new set of auto-completable symbols."
@@ -4491,28 +4824,33 @@ msgid "Maxima shows help in a sidebar"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1935
+#, fuzzy
 msgid "Maxima shows help in the console"
-msgstr ""
+msgstr "Το αρχείο δεν βρέθηκε"
 
 #: ../../src/StatusBar.cpp:232
+#, fuzzy
 msgid "Maxima started. Waiting for authentication..."
-msgstr ""
+msgstr "Το Maxima ξεκίνησε. Περιμένει για σύνδεση..."
 
 #: ../../src/StatusBar.cpp:212
 msgid "Maxima started. Waiting for connection..."
-msgstr ""
+msgstr "Το Maxima ξεκίνησε. Περιμένει για σύνδεση..."
 
 #: ../../src/StatusBar.cpp:228
+#, fuzzy
 msgid "Maxima started. Waiting for initial prompt..."
-msgstr ""
+msgstr "Το Maxima ξεκίνησε. Περιμένει για σύνδεση..."
 
 #: ../../src/wxMaximaFrame.cpp:1231
+#, fuzzy
 msgid "Maxima to other language"
-msgstr ""
+msgstr "Ερωτήσεις για το Maxima"
 
 #: ../../src/wxMaxima.cpp:7213
+#, fuzzy
 msgid "Maxima to string"
-msgstr ""
+msgstr "Ερωτήσεις για το Maxima"
 
 #: ../../src/wxMaxima.cpp:3397
 #, c-format
@@ -4535,12 +4873,14 @@ msgid "Maxima version: %s, Anchors cache version"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1925
+#, fuzzy
 msgid "Maxima vs. Programming languages"
-msgstr ""
+msgstr "Μετατροπή σε Γάμμα"
 
 #: ../../src/Configuration.cpp:83
+#, fuzzy
 msgid "Maxima warnings"
-msgstr ""
+msgstr "Επιλογές του Maxima"
 
 #: ../../src/wxMaxima.cpp:3687
 #, c-format
@@ -4568,9 +4908,9 @@ msgid "Maxima's manual is located in directory %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3670
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's share files are located in directory %s"
-msgstr ""
+msgstr "Εκκίνηση εφέ κίνησης"
 
 #: ../../src/StatusBar.cpp:66
 msgid ""
@@ -4613,19 +4953,20 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9568
 msgid "Mean:"
-msgstr ""
+msgstr "Μέση τιμή:"
 
 #: ../../src/wxMaximaFrame.cpp:1924
 msgid "Memoizing"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1013
+#, fuzzy
 msgid "Memory"
-msgstr ""
+msgstr "Εκκαθάριση μνήμης"
 
 #: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
 msgid "Merge Cells"
-msgstr ""
+msgstr "Συγχώνευση κελιών"
 
 #: ../../src/wxMaxima.cpp:5780
 msgid "Message from the stdout of Maxima: "
@@ -4645,8 +4986,9 @@ msgid "Minimum absolute value printed without exponent:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:10449 ../../src/wxMaxima.cpp:10451
+#, fuzzy
 msgid "Mismatched parenthesis"
-msgstr ""
+msgstr "Αντιστοίχιση παρενθέσεων σε έλεγχο κειμένου"
 
 #: ../../src/wxMaximaFrame.cpp:1352
 msgid "Multiplication, exponent and similar"
@@ -4665,16 +5007,19 @@ msgid "Multiply two matrices"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9581
+#, fuzzy
 msgid "Multivariate linear regression"
-msgstr ""
+msgstr "Γραμμική παλινδρόμηση"
 
 #: ../../src/wxMaxima.cpp:7842
+#, fuzzy
 msgid "Name of t:"
-msgstr ""
+msgstr "Όνομα:"
 
 #: ../../src/wxMaxima.cpp:7838
+#, fuzzy
 msgid "Name of x:"
-msgstr ""
+msgstr "Όνομα:"
 
 #: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
 msgid "Nested list to Matrix"
@@ -4701,8 +5046,9 @@ msgid "New"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:597
+#, fuzzy
 msgid "New\tCtrl+N"
-msgstr ""
+msgstr "Νέο\tCtrl+N"
 
 #: ../../src/ToolBar.cpp:611
 msgid "New button"
@@ -4722,8 +5068,9 @@ msgid "New connection attempt, but no currently running maxima process."
 msgstr ""
 
 #: ../../src/ToolBar.cpp:174
+#, fuzzy
 msgid "New document"
-msgstr ""
+msgstr "Άνοιγμα εγγράφου"
 
 #: ../../src/wxMaxima.cpp:3899
 #, c-format
@@ -4731,17 +5078,19 @@ msgid "New maxima Operators detected: %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7390
+#, fuzzy
 msgid "New part:"
-msgstr ""
+msgstr "Νέα μεταβλητή:"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
 #: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
 msgid "New variable:"
-msgstr ""
+msgstr "Νέα μεταβλητή:"
 
 #: ../../src/wxMaximaFrame.cpp:929
+#, fuzzy
 msgid "Next Command\tAlt+Down"
-msgstr ""
+msgstr "Επόμενη εντολή\tAlt+Down"
 
 #: ../../src/wxMaximaFrame.cpp:748
 msgid "Nice Graphical Equations"
@@ -4752,8 +5101,9 @@ msgid "No"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1972
+#, fuzzy
 msgid "No Array"
-msgstr ""
+msgstr "Πίνακας:"
 
 #: ../../src/Worksheet.cpp:1974
 msgid "No Scalar"
@@ -4783,7 +5133,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:6662 ../../src/wxMaxima.cpp:6668
 #: ../../src/wxMaxima.cpp:6687 ../../src/wxMaxima.cpp:6697
 msgid "No matches found!"
-msgstr ""
+msgstr "Καμμία αντιστοίχιση δεν βρέθηκε"
 
 #: ../../src/wxMaxima.cpp:3240
 msgid "No topics found in topic flag"
@@ -4799,11 +5149,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8163
 msgid "Not a valid matrix dimension!"
-msgstr ""
+msgstr "Μη έγκυρη διάσταση πίνακα!"
 
 #: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
 msgid "Not a valid number of equations!"
-msgstr ""
+msgstr "Μη έγκυρος αριθμός εξισώσεων!"
 
 #: ../../src/StatusBar.cpp:256
 msgid "Not connected to Maxima"
@@ -4823,63 +5173,73 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8926
 msgid "Num. deg:"
-msgstr ""
+msgstr "Βαθμός Αριθμητή:"
 
 #: ../../src/wxMaxima.cpp:8540
+#, fuzzy
 msgid "Number of elements"
-msgstr ""
+msgstr "Αριθμός εξισώσεων:"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
 msgid "Number of equations:"
-msgstr ""
+msgstr "Αριθμός εξισώσεων:"
 
 #: ../../src/wxMaxima.cpp:7481
+#, fuzzy
 msgid "Number to octets"
-msgstr ""
+msgstr "Αριθμός εξισώσεων:"
 
 #: ../../src/wxMaximaFrame.cpp:1154
+#, fuzzy
 msgid "Number to octets..."
-msgstr ""
+msgstr "Αριθμός εξισώσεων:"
 
 #: ../../src/wxMaximaFrame.cpp:1906
 msgid "Number types"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7482
+#, fuzzy
 msgid "Number:"
-msgstr ""
+msgstr "Αριθμοί"
 
 #: ../../src/wxMaximaFrame.cpp:1786
+#, fuzzy
 msgid "Numeric output"
-msgstr ""
+msgstr "Εναλλαγή αριθμητικού αποτελέσματος"
 
 #: ../../src/wxMaxima.cpp:8040
 msgid "Numerical QR decomposition of a matrix"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1417
+#, fuzzy
 msgid "Numerical operations (lapack)"
-msgstr ""
+msgstr "Αριθμητική Ολοκλήρωση"
 
 #: ../../src/wxMaxima.cpp:7831
+#, fuzzy
 msgid "Numerical solution for 1st degree ODE"
-msgstr ""
+msgstr "Επίλυση προβλήματος αρχικών τιμών για πρωτοβάθμια ΣΔΕ"
 
 #: ../../src/wxMaximaFrame.cpp:1282
+#, fuzzy
 msgid "Numerical solution..."
-msgstr ""
+msgstr "Εναλλαγή αριθμητικού αποτελέσματος"
 
 #: ../../src/wxMaximaFrame.cpp:1261
+#, fuzzy
 msgid "Numerical solutions of polynomial (bfloat)..."
-msgstr ""
+msgstr "Εύρεση όλων των ριζών ενός πολυωνύμου"
 
 #: ../../src/wxMaximaFrame.cpp:1258
+#, fuzzy
 msgid "Numerical solutions of polynomial..."
-msgstr ""
+msgstr "Εύρεση όλων των ριζών ενός πολυωνύμου"
 
 #: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
 msgid "OK"
-msgstr ""
+msgstr "Εντάξει"
 
 #: ../../src/wxMaximaFrame.cpp:122
 #, c-format
@@ -4887,16 +5247,19 @@ msgid "OS: %s Version %li.%li"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
+#, fuzzy
 msgid "Object composed of elements"
-msgstr ""
+msgstr "Αριθμός εξισώσεων:"
 
 #: ../../src/wxMaxima.cpp:7680
+#, fuzzy
 msgid "Object name:"
-msgstr ""
+msgstr "Λίστα:"
 
 #: ../../src/wxMaxima.cpp:7281
+#, fuzzy
 msgid "Object:"
-msgstr ""
+msgstr "Λίστα:"
 
 #: ../../src/wxMaxima.cpp:7486
 msgid "Octets to Number"
@@ -4911,8 +5274,9 @@ msgid "Octets to number..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1158
+#, fuzzy
 msgid "Octets to string..."
-msgstr ""
+msgstr "Παράσταση:"
 
 #: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
 msgid "Octets:"
@@ -4925,11 +5289,12 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
 #: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
 msgid "Old variable:"
-msgstr ""
+msgstr "Παλιά μεταβλητή:"
 
 #: ../../src/wxMaximaFrame.cpp:1055
+#, fuzzy
 msgid "On all errors"
-msgstr ""
+msgstr "Ολέθριο σφάλμα"
 
 #: ../../src/wxMaximaFrame.cpp:1054
 msgid "On lisp errors"
@@ -4937,11 +5302,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9566
 msgid "One sample t-test"
-msgstr ""
+msgstr "t-τεστ ενός δείγματος"
 
 #: ../../src/wxMaximaFrame.cpp:1927
 msgid "Online tutorials"
-msgstr ""
+msgstr "Online διδακτικές παρουσιάσεις"
 
 #: ../../src/wxMaximaFrame.cpp:766
 msgid "Only Integers and single letters"
@@ -4950,15 +5315,15 @@ msgstr ""
 #: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593
 #: ../../src/wxMaxima.cpp:6074
 msgid "Open"
-msgstr ""
+msgstr "Άνοιγμα"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "Open a document"
-msgstr ""
+msgstr "Άνοιγμα ενός εγγράφου"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "Open a new window"
-msgstr ""
+msgstr "Άνοιγμα νέου παραθύρου"
 
 #: ../../src/ToolBar.cpp:617
 msgid "Open and save button"
@@ -4966,7 +5331,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:176
 msgid "Open document"
-msgstr ""
+msgstr "Άνοιγμα εγγράφου"
 
 #: ../../src/wxMaxima.cpp:7239
 msgid "Open for appending"
@@ -4981,24 +5346,27 @@ msgid "Open for reading"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1098
+#, fuzzy
 msgid "Open for reading..."
-msgstr ""
+msgstr "Παράσταση:"
 
 #: ../../src/wxMaxima.cpp:7249
 msgid "Open for writing"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1100
+#, fuzzy
 msgid "Open for writing..."
-msgstr ""
+msgstr "Εξαγωγή..."
 
 #: ../../src/wxMaxima.cpp:9598
 msgid "Open matrix"
-msgstr ""
+msgstr "Άνοιγμα πίνακα"
 
 #: ../../src/wxMaximaFrame.cpp:600
+#, fuzzy
 msgid "Open recent"
-msgstr ""
+msgstr "Άνοιγμα πρόσφατου"
 
 #: ../../src/wxMaxima.cpp:4309
 msgid "Opening a wxmx file"
@@ -5007,7 +5375,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4153 ../../src/wxMaxima.cpp:4214
 #: ../../src/wxMaxima.cpp:4313 ../../src/wxMaxima.cpp:4622
 msgid "Opening file"
-msgstr ""
+msgstr "Άνοιγμα αρχείου"
 
 #: ../../src/wxMaxima.cpp:5030
 #, c-format
@@ -5024,11 +5392,12 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:199
 msgid "Options"
-msgstr ""
+msgstr "Επιλογές"
 
 #: ../../src/wxMaximaFrame.cpp:1225
+#, fuzzy
 msgid "Output C"
-msgstr ""
+msgstr "Ετικέτες εξόδου"
 
 #: ../../src/wxMaximaFrame.cpp:1226
 msgid "Output Fortran"
@@ -5040,11 +5409,12 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:80
 msgid "Output labels"
-msgstr ""
+msgstr "Ετικέτες εξόδου"
 
 #: ../../src/Configuration.cpp:73
+#, fuzzy
 msgid "Output: Function names"
-msgstr ""
+msgstr "Ονόματα συναρτήσεων"
 
 #: ../../src/Configuration.cpp:75
 msgid "Output: Latin names as greek symbols"
@@ -5055,21 +5425,24 @@ msgid "Output: Numbers and Digits"
 msgstr ""
 
 #: ../../src/Configuration.cpp:71
+#, fuzzy
 msgid "Output: Operators"
-msgstr ""
+msgstr "Ετικέτες εξόδου"
 
 #: ../../src/Configuration.cpp:74
-#, c-format
+#, fuzzy, c-format
 msgid "Output: Special constants (%e,%i)"
-msgstr ""
+msgstr "Ειδικές μεταβλητές"
 
 #: ../../src/Configuration.cpp:76
+#, fuzzy
 msgid "Output: Strings"
-msgstr ""
+msgstr "Συμβολοσειρές"
 
 #: ../../src/Configuration.cpp:70
+#, fuzzy
 msgid "Output: Variable names"
-msgstr ""
+msgstr "Παλιά μεταβλητή:"
 
 #: ../../src/wxMaxima.cpp:6442
 msgid ""
@@ -5088,39 +5461,43 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8924
 msgid "Pade approximation"
-msgstr ""
+msgstr "Προσέγγιση Pade..."
 
 #: ../../src/wxMaximaFrame.cpp:1478
 msgid "Pade approximation of a Taylor series"
-msgstr ""
+msgstr "Προσέγγιση Pade σειράς Taylor"
 
 #: ../../src/wxMaximaFrame.cpp:1637
+#, fuzzy
 msgid "Parallel Substitute..."
-msgstr ""
+msgstr "Αντικατάσταση..."
 
 #: ../../src/wxMaxima.cpp:8738
 msgid "Parallel substitution"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7179
+#, fuzzy
 msgid "Parameter name:"
-msgstr ""
+msgstr "Όνομα πίνακα:"
 
 #: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
+#, fuzzy
 msgid "Parameter(s):"
-msgstr ""
+msgstr "Μεταβλητή(-ές):"
 
 #: ../../src/wxMaxima.cpp:7399
 msgid "Parse string"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1152
+#, fuzzy
 msgid "Parse string only..."
-msgstr ""
+msgstr "Εισαγωγή πίνακα..."
 
 #: ../../src/StatusBar.cpp:240
 msgid "Parsing output"
-msgstr ""
+msgstr "Συντακτική ανάλυση αποτελέσματος"
 
 #: ../../src/wxMaxima.cpp:7464
 msgid "Part:"
@@ -5128,64 +5505,66 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1499 ../../src/wxMaximaFrame.cpp:1535
 msgid "Partial &Fractions..."
-msgstr ""
+msgstr "Μερικά κλάσματα..."
 
 #: ../../src/wxMaxima.cpp:8975
+#, fuzzy
 msgid "Partial Fractions"
-msgstr ""
+msgstr "Μερικά κλάσματα"
 
 #: ../../src/wxMaxima.cpp:4702
 msgid "Parts of the document will not be loaded correctly!"
-msgstr ""
+msgstr "Μέρη του εγγράφου δεν θα φορτωθούν σωστά"
 
 #: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
 #: ../../src/Worksheet.cpp:1685
 msgid "Paste"
-msgstr ""
+msgstr "Επικόλληση"
 
 #: ../../src/wxMaximaFrame.cpp:667
 msgid "Paste\tCtrl+V"
-msgstr ""
+msgstr "Επικόλληση\tCtrl+V"
 
 #: ../../src/ToolBar.cpp:211
 msgid "Paste from clipboard"
-msgstr ""
+msgstr "Επικόλληση κειμένου από το πρόχειρο"
 
 #: ../../src/wxMaximaFrame.cpp:668
 msgid "Paste text from clipboard"
-msgstr ""
+msgstr "Επικόλληση κειμένου από το πρόχειρο"
 
 #: ../../src/wxMaxima.cpp:4841
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr ""
+"Παρακαλώ ρυθμίστε το wxMaxima μεσα απο το μενου 'Επεξεργασία->Ρυθμίσεις'."
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot &2d..."
-msgstr ""
+msgstr "2-Δ γράφημα..."
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot &3d..."
-msgstr ""
+msgstr "3-Δ γράφημα..."
 
 #: ../../src/wxMaximaFrame.cpp:1772
 msgid "Plot &Format..."
-msgstr ""
+msgstr "Μορφή γραφήματος..."
 
 #: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
 msgid "Plot 2D"
-msgstr ""
+msgstr "2-Δ γράφημα"
 
 #: ../../src/Worksheet.cpp:1593
 msgid "Plot 2D..."
-msgstr ""
+msgstr "2-Δ γράφημα..."
 
 #: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
 msgid "Plot 3D"
-msgstr ""
+msgstr "3-Δ γράφημα"
 
 #: ../../src/Worksheet.cpp:1595
 msgid "Plot 3D..."
-msgstr ""
+msgstr "3-Δ γράφημα..."
 
 #: ../../src/wxMaxima.cpp:9538
 msgid "Plot as bars"
@@ -5201,15 +5580,15 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9112
 msgid "Plot format"
-msgstr ""
+msgstr "Μορφή γραφήματος"
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot in 2 dimensions"
-msgstr ""
+msgstr "Γράφημα σε 2 διαστάσεις"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot in 3 dimensions"
-msgstr ""
+msgstr "Γράφημα σε 3 διαστάσεις"
 
 #: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
 msgid "Plot using Draw"
@@ -5229,22 +5608,23 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
 msgid "Point:"
-msgstr ""
+msgstr "Σημείο:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 1:"
-msgstr ""
+msgstr "Πολυώνυμο 1:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 2:"
-msgstr ""
+msgstr "Πολυώνυμο 2:"
 
 #: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
 #: ../../src/wxMaxima.cpp:7739
+#, fuzzy
 msgid "Polynomial:"
-msgstr ""
+msgstr "Πολυώνυμο 1:"
 
 #: ../../src/wxMaximaFrame.cpp:1754
 msgid "Pop"
@@ -5259,20 +5639,23 @@ msgid "Position of a match"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
+#, fuzzy
 msgid "Position:"
-msgstr ""
+msgstr "Συνθήκη:"
 
 #: ../../src/wxMaxima.cpp:8939
+#, fuzzy
 msgid "Power series"
-msgstr ""
+msgstr "Δυναμοσειρές"
 
 #: ../../src/wxMaximaFrame.cpp:1475
+#, fuzzy
 msgid "Power series..."
-msgstr ""
+msgstr "Δυναμοσειρές"
 
 #: ../../src/wxMaxima.cpp:9202
 msgid "Precision"
-msgstr ""
+msgstr "Ακρίβεια"
 
 #: ../../src/Worksheet.cpp:1616
 msgid "Prefer user labels"
@@ -5291,28 +5674,31 @@ msgid "Preferences...\tCtrl+,"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1733
+#, fuzzy
 msgid "Prepend an element"
-msgstr ""
+msgstr "Άνοιγμα ενός εγγράφου"
 
 #: ../../src/wxMaximaFrame.cpp:927
+#, fuzzy
 msgid "Previous Command\tAlt+Up"
-msgstr ""
+msgstr "Προηγούμενη εντολή\tAlt+Up"
 
 #: ../../src/ToolBar.cpp:184
 msgid "Print"
-msgstr ""
+msgstr "Εκτύπωση"
 
 #: ../../src/ToolBar.cpp:620
 msgid "Print button"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1493
+#, fuzzy
 msgid "Print cell brackets"
-msgstr ""
+msgstr "Άγκιστρο ενεργού κελιού"
 
 #: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
 msgid "Print document"
-msgstr ""
+msgstr "Εκτύπωση εγγράφου"
 
 #: ../../src/wxMaximaFrame.cpp:1829
 msgid "Print floating-point numbers with exponents dividable by 3"
@@ -5326,15 +5712,17 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9061
 msgid "Product"
-msgstr ""
+msgstr "Γινόμενο"
 
 #: ../../src/wxMaximaFrame.cpp:1095
+#, fuzzy
 msgid "Program"
-msgstr ""
+msgstr "Ιστόγραμμα"
 
 #: ../../src/wxMaxima.cpp:7061
+#, fuzzy
 msgid "Program (no local variables)"
-msgstr ""
+msgstr "Αλλαγή μεταβλητής"
 
 #: ../../src/wxMaxima.cpp:7052
 msgid "Program block"
@@ -5353,8 +5741,9 @@ msgid "Push"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8508
+#, fuzzy
 msgid "Push an element to a list"
-msgstr ""
+msgstr "Δημιουργία λίστας από παράσταση"
 
 #: ../../src/wxMaximaFrame.cpp:1395
 msgid "QR decomposition"
@@ -5386,20 +5775,23 @@ msgid "Re-Reading the config from the default location."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:867
+#, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
-msgstr ""
+msgstr "Υπολογισμός όλων των κελιών στο έγγραφο"
 
 #: ../../src/wxMaximaFrame.cpp:877
+#, fuzzy
 msgid "Re-evaluate all cells below the one the cursor is in"
-msgstr ""
+msgstr "Υπολογισμός όλων των κελιών στο έγγραφο"
 
 #: ../../src/main.cpp:366
 msgid "Re-opening STDERR failed."
 msgstr ""
 
 #: ../../src/main.cpp:367
+#, fuzzy
 msgid "Re-opening STDIN failed."
-msgstr ""
+msgstr "Άνοιγμα αρχείου"
 
 #: ../../src/main.cpp:365
 msgid "Re-opening STDOUT failed."
@@ -5412,16 +5804,18 @@ msgid ""
 msgstr ""
 
 #: ../../src/Worksheet.cpp:6668
+#, fuzzy
 msgid "Read .wxm data from clipboard"
-msgstr ""
+msgstr "Επικόλληση κειμένου από το πρόχειρο"
 
 #: ../../src/wxMaxima.cpp:7599
 msgid "Read Directory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1677
+#, fuzzy
 msgid "Read List from csv file..."
-msgstr ""
+msgstr "Φόρτωση στυλ από αρχείο"
 
 #: ../../src/wxMaxima.cpp:7196
 msgid "Read a structure field"
@@ -5432,16 +5826,19 @@ msgid "Read byte"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7266
+#, fuzzy
 msgid "Read char"
-msgstr ""
+msgstr "Aνάγνωση πίνακα..."
 
 #: ../../src/wxMaxima.cpp:7593
+#, fuzzy
 msgid "Read environment variable"
-msgstr ""
+msgstr "Επιπρόσθετοι παράμετροι:"
 
 #: ../../src/wxMaximaFrame.cpp:1219
+#, fuzzy
 msgid "Read environment variable..."
-msgstr ""
+msgstr "Διαγραφή μίας μεταβλητής"
 
 #: ../../src/wxMaxima.cpp:7262
 msgid "Read line"
@@ -5454,7 +5851,7 @@ msgstr ""
 
 #: ../../src/StatusBar.cpp:245
 msgid "Reading Maxima output"
-msgstr ""
+msgstr "Διάβασμα αποτελέσματος Maxima"
 
 #: ../../src/StatusBar.cpp:247
 #, c-format
@@ -5481,7 +5878,7 @@ msgstr ""
 
 #: ../../src/StatusBar.cpp:224
 msgid "Ready for user input"
-msgstr ""
+msgstr "Έτοιμο για είσοδο από το χρήστη"
 
 #: ../../src/Worksheet.cpp:960
 msgid "Recalculated the whole worksheet at once => Updating its size"
@@ -5493,11 +5890,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:930
 msgid "Recall next command from history"
-msgstr ""
+msgstr "Επανάκληση επόμενης εντολής από το ιστορικό "
 
 #: ../../src/wxMaximaFrame.cpp:928
 msgid "Recall previous command from history"
-msgstr ""
+msgstr "Επανάκληση προηγούμενης εντολής από το ιστορικό "
 
 #: ../../src/wxMaxima.cpp:3235
 #, c-format
@@ -5510,12 +5907,14 @@ msgid "Received maxima's first prompt: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:603
+#, fuzzy
 msgid "Recover unsaved"
-msgstr ""
+msgstr "[ δεν έχει αποθηκευθεί ]"
 
 #: ../../src/wxMaximaFrame.cpp:1640
+#, fuzzy
 msgid "Recursive Substitute..."
-msgstr ""
+msgstr "Αντικατάσταση..."
 
 #: ../../src/wxMaxima.cpp:8746
 msgid "Recursive substitution"
@@ -5526,16 +5925,18 @@ msgid "Redo"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:633
+#, fuzzy
 msgid "Redo\tCtrl+Y"
-msgstr ""
+msgstr "Αναίρεση\tCtrl+Z"
 
 #: ../../src/wxMaximaFrame.cpp:633
+#, fuzzy
 msgid "Redo last change"
-msgstr ""
+msgstr "Αναίρεση τελευταίας αλλαγής"
 
 #: ../../src/wxMaximaFrame.cpp:1595
 msgid "Reduce trigonometric expression"
-msgstr ""
+msgstr "Αναγωγή τριγωνομετρικής παράστασης"
 
 #: ../../src/wxMaxima.cpp:2366 ../../src/wxMaxima.cpp:10630
 msgid "Refusing to send cell to maxima: "
@@ -5550,16 +5951,19 @@ msgid "Regex match position"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1195
+#, fuzzy
 msgid "Regular expression that matches a string"
-msgstr ""
+msgstr "Συντεταγμένες του x χωρισμένες με κόμμα"
 
 #: ../../src/wxMaximaFrame.cpp:1196
+#, fuzzy
 msgid "Regular expressions"
-msgstr ""
+msgstr "Ολοκλήρωση παράστασης"
 
 #: ../../src/Worksheet.cpp:1314
+#, fuzzy
 msgid "Reload Image"
-msgstr ""
+msgstr "Αντιγραφή ως εικόνα"
 
 #: ../../src/Worksheet.cpp:1320
 #, c-format
@@ -5573,7 +5977,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:883
 msgid "Remove All Output"
-msgstr ""
+msgstr "Αφαίρεση όλων των αποτελεσμάτων"
 
 #: ../../src/wxMaximaFrame.cpp:1426
 msgid "Remove Rows or Columns..."
@@ -5594,8 +5998,9 @@ msgid "Remove all occurrences of part"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8592
+#, fuzzy
 msgid "Remove an element from a list"
-msgstr ""
+msgstr "Δημιουργία λίστας από παράσταση"
 
 #: ../../src/wxMaxima.cpp:7566
 msgid "Remove directory"
@@ -5619,7 +6024,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:884
 msgid "Remove output from input cells"
-msgstr ""
+msgstr "Αφαίρεση αποτελεσμάτων από τα κελιά εντολών"
 
 #: ../../src/wxMaxima.cpp:7975
 msgid "Remove rows and/or columns"
@@ -5630,16 +6035,19 @@ msgid "Remove rows and/or columns from the matrix"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7582
+#, fuzzy
 msgid "Rename file"
-msgstr ""
+msgstr "Άνοιγμα αρχείου"
 
 #: ../../src/wxMaximaFrame.cpp:1215
+#, fuzzy
 msgid "Rename file..."
-msgstr ""
+msgstr "Διαγραφή μίας μεταβλητής"
 
 #: ../../src/wxMaximaFrame.cpp:1527
+#, fuzzy
 msgid "Reorganize an expression using horner's rule"
-msgstr ""
+msgstr "Παραγοντοποίηση παράστασης σε Γκαουσιανούς αριθμούς"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "Repetitive element-by-element multiplication"
@@ -5654,37 +6062,42 @@ msgid "Replace first regex match"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7463
+#, fuzzy
 msgid "Replace the first occurrence of Part"
-msgstr ""
+msgstr "Αντικατεστημένες %d εμφανίσεις"
 
 #: ../../src/wxMaximaFrame.cpp:1180
+#, fuzzy
 msgid "Replace..."
-msgstr ""
+msgstr "Επιλογή όλων"
 
 #: ../../src/wxMaxima.cpp:6719
-#, c-format
+#, fuzzy, c-format
 msgid "Replaced %li occurrences."
-msgstr ""
+msgstr "Αντικατεστημένες %d εμφανίσεις"
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "Report bug"
-msgstr ""
+msgstr "Αναφορά σφάλματος"
 
 #: ../../src/wxMaximaFrame.cpp:996
+#, fuzzy
 msgid "Reset option variables"
-msgstr ""
+msgstr "Αλλαγή μεταβλητής"
 
 #: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
 msgid "Restart Maxima"
-msgstr ""
+msgstr "Επανεκίνηση του Maxima"
 
 #: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
+#, fuzzy
 msgid "Restrict Maximum size"
-msgstr ""
+msgstr "Επανεκίνηση του Maxima"
 
 #: ../../src/wxMaxima.cpp:10031
+#, fuzzy
 msgid "Result variables:"
-msgstr ""
+msgstr "Διαγραφή μεταβλητής(-ών):"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Resulting Matrix name (may be empty):"
@@ -5758,8 +6171,9 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
 #: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
+#, fuzzy
 msgid "Right Matrix:"
-msgstr ""
+msgstr "Εισαγωγή πίνακα"
 
 #: ../../src/wxMaxima.cpp:8190
 msgid "Right end"
@@ -5771,7 +6185,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1455
 msgid "Risch Integration..."
-msgstr ""
+msgstr "Ολοκλήρωση Risch..."
 
 #: ../../src/wxMaximaFrame.cpp:785
 msgid "Rounded"
@@ -5787,12 +6201,14 @@ msgid "Row number:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7977
+#, fuzzy
 msgid "Row numbers:"
-msgstr ""
+msgstr "Αριθμοί"
 
 #: ../../src/wxMaxima.cpp:8203
+#, fuzzy
 msgid "Rows"
-msgstr ""
+msgstr "Γραμμές:"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Rule"
@@ -5807,8 +6223,9 @@ msgid "Rules"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1693
+#, fuzzy
 msgid "Run each element through an expression"
-msgstr ""
+msgstr "Εύρεση ορίου μιας παράστασης"
 
 #: ../../src/wxMaxima.cpp:6355
 #, c-format
@@ -5861,80 +6278,83 @@ msgid "Runs each element through a function"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1694
+#, fuzzy
 msgid "Runs each element through an expression"
-msgstr ""
+msgstr "Εύρεση ορίου μιας παράστασης"
 
 #: ../../src/wxMaxima.cpp:9572
 msgid "Sample 1:"
-msgstr ""
+msgstr "Δείγμα 1:"
 
 #: ../../src/wxMaxima.cpp:9573
 msgid "Sample 2:"
-msgstr ""
+msgstr "Δείγμα 2:"
 
 #: ../../src/wxMaxima.cpp:9567
 msgid "Sample:"
-msgstr ""
+msgstr "Δείγμα:"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
 msgid "Save"
-msgstr ""
+msgstr "Αποθήκευση"
 
 #: ../../src/Worksheet.cpp:1294
 msgid "Save Animation..."
-msgstr ""
+msgstr "Αποθήκευση εφε κίνησης ..."
 
 #: ../../src/wxMaxima.cpp:5672
 msgid "Save As"
-msgstr ""
+msgstr "Αποθήκευση ως"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save As...\tShift+Ctrl+S"
-msgstr ""
+msgstr "Αποθήκευση ως...\tShift+Ctrl+S"
 
 #: ../../src/Worksheet.cpp:1291
 msgid "Save Image..."
-msgstr ""
+msgstr "Αποθήκευση εικόνας..."
 
 #: ../../src/wxMaxima.cpp:6440
 msgid "Save Selection to Image"
-msgstr ""
+msgstr "Αποθήκευση επιλογής σε εικόνα"
 
 #: ../../src/wxMaximaFrame.cpp:675
 msgid "Save Selection to Image..."
-msgstr ""
+msgstr "Αποθήκευση επιλογής σε εικόνα..."
 
 #: ../../src/wxMaxima.cpp:10184
 msgid "Save animation to file"
-msgstr ""
+msgstr "Αποθήκευση εφε κίνησης σε αρχείο"
 
 #: ../../src/wxMaxima.cpp:7203
 msgid "Save as lisp code"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1091
+#, fuzzy
 msgid "Save as lisp..."
-msgstr ""
+msgstr "Φόρτωση πακέτου"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
 msgid "Save document"
-msgstr ""
+msgstr "Αποθήκευση εγγράφου"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save document as"
-msgstr ""
+msgstr "Αποθήκευση εγγράφου ως"
 
 #: ../../src/wxMaximaFrame.cpp:676
 msgid "Save selection from document to an image file"
-msgstr ""
+msgstr "Αποθήκευση επιλογής από το έγγραφο σε ένα αρχείο εικόνας"
 
 #: ../../src/wxMaxima.cpp:10125
 msgid "Save selection to file"
-msgstr ""
+msgstr "Αποθήκευση επιλογής σε αρχείο"
 
 #: ../../src/wxMaximaFrame.cpp:573
+#, fuzzy
 msgid "Saving failed."
-msgstr ""
+msgstr "Η εκκίνηση του εξυπηρετητή απέτυχε"
 
 #: ../../src/WXMXformat.cpp:310
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
@@ -5950,7 +6370,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9533
 msgid "Scatterplot"
-msgstr ""
+msgstr "Διάγραμμα διασποράς"
 
 #: ../../src/Autocomplete.cpp:125
 msgid ""
@@ -5977,15 +6397,16 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:273
 msgid "Section"
-msgstr ""
+msgstr "Ενότητα"
 
 #: ../../src/Configuration.cpp:91
 msgid "Section cell (Heading 2)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7218
+#, fuzzy
 msgid "Seek to position"
-msgstr ""
+msgstr "Προσέγγιση Pade..."
 
 #: ../../src/BTextCtrl.cpp:45
 msgid "Seems like something is broken with a font."
@@ -5997,11 +6418,11 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
 msgid "Select All"
-msgstr ""
+msgstr "Επιλογή όλων"
 
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select All\tCtrl+A"
-msgstr ""
+msgstr "Επιλογή Όλων\tCtrl+A"
 
 #: ../../src/ToolBar.cpp:629
 msgid "Select All button"
@@ -6009,20 +6430,21 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9631
 msgid "Select Subsample"
-msgstr ""
+msgstr "Επιλογή υποδείγματος"
 
 #: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select all"
-msgstr ""
+msgstr "Επιλογή όλων"
 
 #: ../../src/wxMaxima.cpp:6971
 msgid "Select math display algorithm"
-msgstr ""
+msgstr "Επιλογή αλγορίθμου προβολής μαθηματικών"
 
 #: ../../src/Configuration.cpp:98
+#, fuzzy
 msgid "Selection color"
-msgstr ""
+msgstr "Επιλογή"
 
 #: ../../src/ToolBar.cpp:252
 msgid "Send all cells to maxima"
@@ -6057,24 +6479,27 @@ msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1533
+#, fuzzy
 msgid "Sequential Comparative Simplification"
-msgstr ""
+msgstr "Μιγαδική απλοποίηση"
 
 #: ../../src/wxMaxima.cpp:9016
 msgid "Series"
-msgstr ""
+msgstr "Σειρές"
 
 #: ../../src/wxMaximaFrame.cpp:1479
+#, fuzzy
 msgid "Series approximation"
-msgstr ""
+msgstr "Προσέγγιση Pade..."
 
 #: ../../src/wxMaxima.cpp:2561
 msgid "Server started"
-msgstr ""
+msgstr "Ο εξυπηρετητής ξεκίνησε"
 
 #: ../../src/wxMaximaFrame.cpp:1824
+#, fuzzy
 msgid "Set &displayed Precision..."
-msgstr ""
+msgstr "Ορισμός ακρίβειας..."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Set Maxima option variable logexpand:all"
@@ -6090,39 +6515,44 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:822
 msgid "Set Zoom"
-msgstr ""
+msgstr "Ορισμός Μεγέθυνσης"
 
 #: ../../src/wxMaximaFrame.cpp:1819
+#, fuzzy
 msgid "Set bigfloat &Precision..."
-msgstr ""
+msgstr "Ορισμός ακρίβειας bigfloat"
 
 #: ../../src/Worksheet.cpp:1306 ../../src/Worksheet.cpp:1479
 msgid "Set image resolution"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1510
+#, fuzzy
 msgid "Set main variable..."
-msgstr ""
+msgstr "Διαγραφή μίας μεταβλητής"
 
 #: ../../src/wxMaximaFrame.cpp:1773
 msgid "Set plot format"
-msgstr ""
+msgstr "Ορισμός μορφής γραφήματος"
 
 #: ../../src/wxMaximaFrame.cpp:1101
+#, fuzzy
 msgid "Set position..."
-msgstr ""
+msgstr "Αποθήκευση εφε κίνησης ..."
 
 #: ../../src/wxMaximaFrame.cpp:1656
+#, fuzzy
 msgid "Set the \"algebraic\" flag"
-msgstr ""
+msgstr "Εναλλαγή αλγεβρικής σημαίας"
 
 #: ../../src/wxMaxima.cpp:8314
 msgid "Set the diagram title"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1779
+#, fuzzy
 msgid "Set the frame rate for animations."
-msgstr ""
+msgstr "Εκκίνηση εφέ κίνησης"
 
 #: ../../src/wxMaxima.cpp:8377
 msgid "Set the grid density."
@@ -6140,27 +6570,27 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:811
 msgid "Set zoom to 100%"
-msgstr ""
+msgstr "Ορισμός ζουμ στο 100%"
 
 #: ../../src/wxMaximaFrame.cpp:813
 msgid "Set zoom to 120%"
-msgstr ""
+msgstr "Ορισμός ζουμ στο 120%"
 
 #: ../../src/wxMaximaFrame.cpp:815
 msgid "Set zoom to 150%"
-msgstr ""
+msgstr "Ορισμός ζουμ στο 150%"
 
 #: ../../src/wxMaximaFrame.cpp:817
 msgid "Set zoom to 200%"
-msgstr ""
+msgstr "Ορισμός ζουμ στο 200%"
 
 #: ../../src/wxMaximaFrame.cpp:819
 msgid "Set zoom to 300%"
-msgstr ""
+msgstr "Ορισμός ζουμ στο 300%"
 
 #: ../../src/wxMaximaFrame.cpp:809
 msgid "Set zoom to 80%"
-msgstr ""
+msgstr "Ορισμός ζουμ στο 80%"
 
 #: ../../src/wxMaxima.cpp:4731
 #, c-format
@@ -6168,16 +6598,19 @@ msgid "Setting gnuplot_binary to %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:4804
+#, fuzzy
 msgid "Setting prompt and help format"
-msgstr ""
+msgstr "Ορισμός μορφής γραφήματος"
 
 #: ../../src/wxMaximaFrame.cpp:1292
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
+"Ορισμός τιμών με την atvalues για την επίλυση ΣΔΕ με το μετασχηματισμό "
+"Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1661
 msgid "Setup modulus computation"
-msgstr ""
+msgstr "Εγκατάσταση υπολογισμών modulo"
 
 #: ../../src/wxMaxima.cpp:9220
 msgid "Setup the engineering format"
@@ -6192,28 +6625,31 @@ msgid "Shapiro-Wilk test for normality"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1543
+#, fuzzy
 msgid "Show \"%\" in special constants"
-msgstr ""
+msgstr "Ειδικές μεταβλητές"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show &Tips..."
-msgstr ""
+msgstr "Εμφάνιση συμβουλών..."
 
 #: ../../src/Worksheet.cpp:1556
 msgid "Show * as multiplication dot"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:895
+#, fuzzy
 msgid "Show Template\tCtrl+Shift+Space"
-msgstr ""
+msgstr "Εμφάνιση προτύπου\tCtrl+Shift+K"
 
 #: ../../src/wxMaximaFrame.cpp:753
+#, fuzzy
 msgid "Show XML representation"
-msgstr ""
+msgstr "Εμφάνιση μεγάλων παραστάσεων"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show a tip"
-msgstr ""
+msgstr "Εμφάνιση μιας συμβουλής"
 
 #: ../../src/Worksheet.cpp:1607
 msgid "Show all + allow linebreaks in long numbers"
@@ -6221,51 +6657,54 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9475
 msgid "Show all commands similar to:"
-msgstr ""
+msgstr "Εμφάνιση ολων των εντολών που είναι παρόμοιες με:"
 
 #: ../../src/wxMaxima.cpp:9468
 msgid "Show an example for the command:"
-msgstr ""
+msgstr "Εμφάνιση ενός παραδείγματος για την εντολή:"
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "Show an example of usage"
-msgstr ""
+msgstr "Εμφάνιση ενός παραδείγματος χρήσης"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "Show commands similar to"
-msgstr ""
+msgstr "Εμφάνιση εντολών παρόμοιες με"
 
 #: ../../src/wxMaximaFrame.cpp:1020
 msgid "Show defined functions"
-msgstr ""
+msgstr "Εμφάνιση των συναρτήσεων που έχουν οριστεί"
 
 #: ../../src/wxMaximaFrame.cpp:1022
 msgid "Show defined variables"
-msgstr ""
+msgstr "Εμφάνιση των μεταβλητών που έχουν οριστεί"
 
 #: ../../src/wxMaximaFrame.cpp:1074
 msgid "Show definition of a function"
-msgstr ""
+msgstr "Εμφάνιση του ορισμού μίας συνάρτησης"
 
 #: ../../src/wxMaximaFrame.cpp:740
 msgid "Show equations in their linear form"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1073
+#, fuzzy
 msgid "Show function &Definition..."
-msgstr ""
+msgstr "Εμφάνιση ορισμού..."
 
 #: ../../src/wxMaximaFrame.cpp:896
 msgid "Show function template"
-msgstr ""
+msgstr "Εμφάνιση συναρτήσεων"
 
 #: ../../src/Worksheet.cpp:1614
+#, fuzzy
 msgid "Show input labels"
-msgstr ""
+msgstr "Ετικέτες εισαγωγής"
 
 #: ../../src/wxMaximaFrame.cpp:750
+#, fuzzy
 msgid "Show lisp representation"
-msgstr ""
+msgstr "Εμφάνιση μεγάλων παραστάσεων"
 
 #: ../../src/Worksheet.cpp:1604
 msgid "Show max. 100 digits"
@@ -6304,8 +6743,9 @@ msgid "Show the Copy, Cut and the Paste button?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7033
+#, fuzzy
 msgid "Show the function's definition"
-msgstr ""
+msgstr "Εμφάνιση ορισμού συνάρτησης:"
 
 #: ../../src/ToolBar.cpp:618
 msgid "Show the open and the save button?"
@@ -6320,21 +6760,24 @@ msgid "Show the print button?"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:615
+#, fuzzy
 msgid "Show the undo and redo button?"
-msgstr ""
+msgstr "Εμφάνιση ορισμού συνάρτησης:"
 
 #: ../../src/wxMaximaFrame.cpp:1006 ../../src/wxMaximaFrame.cpp:1011
 msgid "Show used + to-be-freed memory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1033
+#, fuzzy
 msgid "Show user definitions"
-msgstr ""
+msgstr "Εμφάνιση ορισμού συνάρτησης:"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
 #: ../../src/wxMaximaFrame.cpp:1879
+#, fuzzy
 msgid "Show wxMaxima help"
-msgstr ""
+msgstr "Εμφάνιση βοήθειας για το Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1825
 msgid "Shows how many digits of a numbers are displayed"
@@ -6345,48 +6788,53 @@ msgid "Sidebars"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1513
+#, fuzzy
 msgid "Simplify &Radicals..."
-msgstr ""
+msgstr "Απλοποίηση ριζικών"
 
 #: ../../src/Worksheet.cpp:1579
 msgid "Simplify Expression"
-msgstr ""
+msgstr "Απλοποίηση παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1568
+#, fuzzy
 msgid "Simplify Logarithms"
-msgstr ""
+msgstr "Απλοποίηση αθροίσματος"
 
 #: ../../src/wxMaximaFrame.cpp:1582
 msgid "Simplify an expression containing factorials"
-msgstr ""
+msgstr "Απλοποίηση παράστασης που περιέχει παραγοντικά"
 
 #: ../../src/wxMaximaFrame.cpp:1539
+#, fuzzy
 msgid "Simplify equations"
-msgstr ""
+msgstr "Επίλυση εξίσωσης(-εων)"
 
 #: ../../src/wxMaximaFrame.cpp:1514
 msgid "Simplify expression containing radicals"
-msgstr ""
+msgstr "Απλοποίηση παράστασης που περιέχει ριζικά"
 
 #: ../../src/wxMaxima.cpp:8649
+#, fuzzy
 msgid "Simplify radicals"
-msgstr ""
+msgstr "Απλοποίηση ριζικών"
 
 #: ../../src/wxMaximaFrame.cpp:1512
 msgid "Simplify rational expression"
-msgstr ""
+msgstr "Απλοποίηση ρητής παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1538
 msgid "Simplify sum() commands..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8636
+#, fuzzy
 msgid "Simplify sums"
-msgstr ""
+msgstr "Απλοποίηση"
 
 #: ../../src/wxMaximaFrame.cpp:1592
 msgid "Simplify trigonometric expression"
-msgstr ""
+msgstr "Απλοποίηση τριγωνομετρικής παράστασης"
 
 #: ../../src/wxMaximaFrame.cpp:1399
 msgid "Singular Values"
@@ -6401,105 +6849,113 @@ msgid "Singular values, left + right vectors"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1635
+#, fuzzy
 msgid "Smart Substitute..."
-msgstr ""
+msgstr "Αντικατάσταση..."
 
 #: ../../src/wxMaxima.cpp:8730
+#, fuzzy
 msgid "Smart substitution"
-msgstr ""
+msgstr "Αντικατάσταση"
 
 #: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
 #: ../../src/wxMaxima.cpp:7823
+#, fuzzy
 msgid "Solution of the ODE:"
-msgstr ""
+msgstr "Λύση:"
 
 #: ../../src/wxMaxima.cpp:10017
 msgid "Solve"
-msgstr ""
+msgstr "Επίλυση"
 
 #: ../../src/wxMaximaFrame.cpp:1244
 msgid "Solve &Algebraic System..."
-msgstr ""
+msgstr "Επίλυση αλγεβρικού συστήματος..."
 
 #: ../../src/wxMaximaFrame.cpp:1242
 msgid "Solve &Linear System..."
-msgstr ""
+msgstr "Επίλυση γραμμικού συστήματος..."
 
 #: ../../src/wxMaximaFrame.cpp:1266
 msgid "Solve &ODE..."
-msgstr ""
+msgstr "Επίλυση ΣΔΕ..."
 
 #: ../../src/wxMaximaFrame.cpp:1240
 msgid "Solve (to_poly)..."
-msgstr ""
+msgstr "Επίλυση (to_poly)..."
 
 #: ../../src/wxMaxima.cpp:8045
 msgid "Solve A*x=b numerically"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1397
+#, fuzzy
 msgid "Solve Ax=b"
-msgstr ""
+msgstr "Επίλυση"
 
 #: ../../src/wxMaxima.cpp:7783
 msgid "Solve ODE"
-msgstr ""
+msgstr "Επίλυση ΣΔΕ"
 
 #: ../../src/wxMaximaFrame.cpp:1287
 msgid "Solve ODE with Lapla&ce..."
-msgstr ""
+msgstr "Επίλυση ΣΔΕ με Laplace..."
 
 #: ../../src/wxMaximaFrame.cpp:1398
+#, fuzzy
 msgid "Solve a linear equation system using dgesv"
-msgstr ""
+msgstr "Επίλυση γραμμικού συστήματος εξισώσεων"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
 msgid "Solve algebraic system"
-msgstr ""
+msgstr "Επίλυση αλγεβρικού συστήματος"
 
 #: ../../src/wxMaximaFrame.cpp:1245
 msgid "Solve algebraic system of equations"
-msgstr ""
+msgstr "Επίλυση αλγεβρικού συστήματος εξισώσεων"
 
 #: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve boundary value problem for second degree ODE"
-msgstr ""
+msgstr "Επίλυση προβλήματος οριακών τιμών για δευτεροβάθμια ΣΔΕ"
 
 #: ../../src/wxMaxima.cpp:7895
+#, fuzzy
 msgid "Solve differential equations using laplace()"
-msgstr ""
+msgstr "Επίλυση συνήθους διαφορικής εξίσωσης με μετασχηματισμό Laplace"
 
 #: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
 msgid "Solve equation(s)"
-msgstr ""
+msgstr "Επίλυση εξίσωσης(-εων)"
 
 #: ../../src/wxMaximaFrame.cpp:1241
 msgid "Solve equation(s) with to_poly_solve"
-msgstr ""
+msgstr "Επίλυση εξίσωσης(-εων) με to_poly_solve"
 
 #: ../../src/wxMaxima.cpp:7773
+#, fuzzy
 msgid "Solve equations numerically"
-msgstr ""
+msgstr "Επίλυση εξίσωσης(-εων)"
 
 #: ../../src/wxMaxima.cpp:7757
+#, fuzzy
 msgid "Solve equations to polynom"
-msgstr ""
+msgstr "Επίλυση εξίσωσης(-εων) με to_poly_solve"
 
 #: ../../src/wxMaximaFrame.cpp:1271
 msgid "Solve initial value problem for first degree ODE"
-msgstr ""
+msgstr "Επίλυση προβλήματος αρχικών τιμών για πρωτοβάθμια ΣΔΕ"
 
 #: ../../src/wxMaximaFrame.cpp:1275
 msgid "Solve initial value problem for second degree ODE"
-msgstr ""
+msgstr "Επίλυση προβλήματος αρχικών τιμών για δευτεροβάθμια ΣΔΕ"
 
 #: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
 msgid "Solve linear system"
-msgstr ""
+msgstr "Επίλυση γραμμικού συστήματος"
 
 #: ../../src/wxMaximaFrame.cpp:1243
 msgid "Solve linear system of equations"
-msgstr ""
+msgstr "Επίλυση γραμμικού συστήματος εξισώσεων"
 
 #: ../../src/wxMaximaFrame.cpp:1263
 msgid "Solve numerical, 1 Variable"
@@ -6507,31 +6963,35 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1267
 msgid "Solve ordinary differential equation of maximum degree 2"
-msgstr ""
+msgstr "Επίλυση συνήθους διαφορικής εξίσωσης μέγιστου βαθμού 2"
 
 #: ../../src/wxMaximaFrame.cpp:1288
 msgid "Solve ordinary differential equations with Laplace transformation"
-msgstr ""
+msgstr "Επίλυση συνήθους διαφορικής εξίσωσης με μετασχηματισμό Laplace"
 
 #: ../../src/wxMaxima.cpp:7708
+#, fuzzy
 msgid "Solve polynomials numerically"
-msgstr ""
+msgstr "Επίλυση εξίσωσης(-εων)"
 
 #: ../../src/wxMaxima.cpp:7718
+#, fuzzy
 msgid "Solve polynomials numerically (bfloats)"
-msgstr ""
+msgstr "Επίλυση εξίσωσης(-εων)"
 
 #: ../../src/wxMaxima.cpp:7729
+#, fuzzy
 msgid "Solve polynomials numerically (real roots)"
-msgstr ""
+msgstr "Επίλυση εξίσωσης(-εων)"
 
 #: ../../src/wxMaximaFrame.cpp:1249
+#, fuzzy
 msgid "Solve symbolically"
-msgstr ""
+msgstr "Επίλυση εξίσωσης(-εων)"
 
 #: ../../src/Worksheet.cpp:1574
 msgid "Solve..."
-msgstr ""
+msgstr "Επίλυση..."
 
 #: ../../src/wxMaximaFrame.cpp:1916
 msgid "Solving differential equations"
@@ -6553,20 +7013,23 @@ msgid "Sort"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8496
+#, fuzzy
 msgid "Sort a list"
-msgstr ""
+msgstr "Δημιουργία λίστας"
 
 #: ../../src/wxMaxima.cpp:7459
 msgid "Sort all characters in string"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1179
+#, fuzzy
 msgid "Sort the characters..."
-msgstr ""
+msgstr "Ελληνικές σταθερές"
 
 #: ../../src/wxMaxima.cpp:8482
+#, fuzzy
 msgid "Source list:"
-msgstr ""
+msgstr "Δημιουργία λίστας"
 
 #: ../../src/wxMaxima.cpp:7429
 msgid "Split"
@@ -6585,28 +7048,31 @@ msgid "Split string into tokens"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1171
+#, fuzzy
 msgid "Split..."
-msgstr ""
+msgstr "Θηκόγραμμα"
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Square"
 msgstr ""
 
 #: ../../src/Configuration.cpp:86
+#, fuzzy
 msgid "Standard Text"
-msgstr ""
+msgstr "Επιλογές"
 
 #: ../../src/Worksheet.cpp:1298
 msgid "Start Animation"
-msgstr ""
+msgstr "Εκκίνηση εφέ κίνησης"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Start of t:"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:305
+#, fuzzy
 msgid "Start or Stop animation"
-msgstr ""
+msgstr "Εκκίνηση εφέ κίνησης"
 
 #: ../../src/ToolBar.cpp:306
 msgid ""
@@ -6616,11 +7082,12 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:386
 msgid "Starting Maxima process failed"
-msgstr ""
+msgstr "Η εκκίνηση της διεργασίας Maxima απέτυχε"
 
 #: ../../src/main.cpp:667
+#, fuzzy
 msgid "Starting a new wxMaxima process for a new window"
-msgstr ""
+msgstr "Η εκκίνηση της διεργασίας Maxima απέτυχε"
 
 #: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:5633
 msgid "Starting evaluation of the document"
@@ -6628,7 +7095,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:2544
 msgid "Starting server failed"
-msgstr ""
+msgstr "Η εκκίνηση του εξυπηρετητή απέτυχε"
 
 #: ../../src/WXMXformat.cpp:64
 msgid "Starting to save the worksheet as .wxmx"
@@ -6636,15 +7103,16 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:252
 msgid "Statistics"
-msgstr ""
+msgstr "Στατιστική"
 
 #: ../../src/wxMaximaFrame.cpp:701
 msgid "Statistics\tAlt+Shift+S"
-msgstr ""
+msgstr "Στατιστική\tAlt+Shift+S"
 
 #: ../../src/wxMaxima.cpp:7844
+#, fuzzy
 msgid "Step width:"
-msgstr ""
+msgstr "Γινόμενο"
 
 #: ../../src/wxMaximaFrame.cpp:794
 msgid "Straight lines"
@@ -6669,26 +7137,31 @@ msgid "Stream:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1185
+#, fuzzy
 msgid "String"
-msgstr ""
+msgstr "Συμβολοσειρές"
 
 #: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
 #: ../../src/wxMaxima.cpp:7425
+#, fuzzy
 msgid "String #1:"
-msgstr ""
+msgstr "Συμβολοσειρές"
 
 #: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
 #: ../../src/wxMaxima.cpp:7426
+#, fuzzy
 msgid "String #2:"
-msgstr ""
+msgstr "Συμβολοσειρές"
 
 #: ../../src/wxMaximaFrame.cpp:1136
+#, fuzzy
 msgid "String Tests"
-msgstr ""
+msgstr "Συμβολοσειρές"
 
 #: ../../src/wxMaxima.cpp:7415
+#, fuzzy
 msgid "String length"
-msgstr ""
+msgstr "Συμβολοσειρές"
 
 #: ../../src/wxMaxima.cpp:7381
 msgid "String to list of char"
@@ -6699,8 +7172,9 @@ msgid "String to list of chars..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7496
+#, fuzzy
 msgid "String to octets"
-msgstr ""
+msgstr "Συμβολοσειρές"
 
 #: ../../src/wxMaximaFrame.cpp:1160
 msgid "String to octets..."
@@ -6717,8 +7191,9 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7465 ../../src/wxMaxima.cpp:7470
 #: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
 #: ../../src/wxMaxima.cpp:7497
+#, fuzzy
 msgid "String:"
-msgstr ""
+msgstr "Συμβολοσειρές"
 
 #: ../../src/wxMaxima.cpp:7197
 msgid "Struct :"
@@ -6734,7 +7209,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:274
 msgid "Subsection"
-msgstr ""
+msgstr "Υποενότητα"
 
 #: ../../src/Configuration.cpp:90
 msgid "Subsection cell (Heading 3)"
@@ -6751,19 +7226,21 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
 #: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
 msgid "Substitute"
-msgstr ""
+msgstr "Αντικατάσταση"
 
 #: ../../src/wxMaximaFrame.cpp:1193
+#, fuzzy
 msgid "Substitute all matches"
-msgstr ""
+msgstr "Αντικατάσταση..."
 
 #: ../../src/wxMaximaFrame.cpp:1192
 msgid "Substitute first match"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1646
+#, fuzzy
 msgid "Substitute only in parts..."
-msgstr ""
+msgstr "Αντικατάσταση..."
 
 #: ../../src/wxMaxima.cpp:8763
 msgid "Substitute only in specific parts"
@@ -6775,7 +7252,7 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
 msgid "Substitute..."
-msgstr ""
+msgstr "Αντικατάσταση..."
 
 #: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
 msgid "Substitutes until the equation no more changes"
@@ -6810,16 +7287,18 @@ msgid ""
 msgstr ""
 
 #: ../../src/ToolBar.cpp:275
+#, fuzzy
 msgid "Subsubsection"
-msgstr ""
+msgstr "Υποενότητα"
 
 #: ../../src/Configuration.cpp:89
 msgid "Subsubsection cell (Heading 4)"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1831
+#, fuzzy
 msgid "Suggestion: "
-msgstr ""
+msgstr "Υποενότητα"
 
 #: ../../src/Worksheet.cpp:2030
 msgid "Suitable as flag for ev()"
@@ -6827,7 +7306,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9049
 msgid "Sum"
-msgstr ""
+msgstr "Άθροισμα"
 
 #: ../../src/wxMaximaFrame.cpp:1551
 msgid ""
@@ -6844,12 +7323,14 @@ msgid "Switched to lisp mode after receiving a lisp prompt!"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1971
+#, fuzzy
 msgid "Symbolic Constant"
-msgstr ""
+msgstr "Επιλογή μιας μεταβλητής"
 
 #: ../../src/wxMaximaFrame.cpp:705
+#, fuzzy
 msgid "Symbols\tAlt+Shift+Y"
-msgstr ""
+msgstr "Στατιστική\tAlt+Shift+S"
 
 #: ../../src/Worksheet.cpp:2006
 msgid "Symmetric function: f(x)=f(-x)"
@@ -6860,20 +7341,23 @@ msgid "Table of Contents"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:711
+#, fuzzy
 msgid "Table of Contents\tAlt+Shift+T"
-msgstr ""
+msgstr "Γραμμή εργαλείων\tAlt+Shift+T"
 
 #: ../../src/wxMaxima.cpp:8930
+#, fuzzy
 msgid "Taylor series"
-msgstr ""
+msgstr "Σειρές Taylor:"
 
 #: ../../src/wxMaximaFrame.cpp:1474
+#, fuzzy
 msgid "Taylor series..."
-msgstr ""
+msgstr "Σειρές Taylor:"
 
 #: ../../src/wxMaxima.cpp:8925
 msgid "Taylor series:"
-msgstr ""
+msgstr "Σειρές Taylor:"
 
 #: ../../src/wxMaxima.cpp:4132
 msgid "Telling maxima about the new working directory."
@@ -6900,11 +7384,11 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:271
 msgid "Text"
-msgstr ""
+msgstr "Κείμενο"
 
 #: ../../src/Configuration.cpp:93
 msgid "Text cell background"
-msgstr ""
+msgstr "Φόντο κελιού κειμένου"
 
 #: ../../src/wxMaxima.cpp:6541
 msgid "Text snippet"
@@ -6945,8 +7429,9 @@ msgid "The comma-separated contents of the struct fields"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7186
+#, fuzzy
 msgid "The comma-separated names of the struct fields"
-msgstr ""
+msgstr "Εισαγωγή λίστας μεταβλητών χωρισμένες με κόμμα"
 
 #: ../../src/wxMaxima.cpp:7070
 msgid ""
@@ -7006,8 +7491,9 @@ msgid "The manual of Maxima"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1881
+#, fuzzy
 msgid "The manual of wxMaxima"
-msgstr ""
+msgstr "Καλωσορίσατε στο wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7125
 msgid "The name of a function we don't want to be evaluated here"
@@ -7096,10 +7582,12 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:2143
+#, fuzzy
 msgid ""
 "There was an error in the XML maxima has generated.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Υπήρξε σφάλμα στο δημιουργημένο XML! Παρακαλώ αναφέρετε αυτό το σφάλμα."
 
 #: ../../src/wxMaxima.cpp:3911
 msgid ""
@@ -7120,10 +7608,12 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3257
+#, fuzzy
 msgid ""
 "There was an error in the XML that should describe the manual topics.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Υπήρξε σφάλμα στο δημιουργημένο XML! Παρακαλώ αναφέρετε αυτό το σφάλμα."
 
 #: ../../src/wxMaxima.cpp:3202
 msgid ""
@@ -7164,11 +7654,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9013 ../../src/wxMaxima.cpp:10058
 msgid "Times:"
-msgstr ""
+msgstr "Φορές:"
 
 #: ../../src/ToolBar.cpp:272
 msgid "Title"
-msgstr ""
+msgstr "Τίτλος"
 
 #: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
@@ -7180,35 +7670,37 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1794
 msgid "To &Bigfloat"
-msgstr ""
+msgstr "Σε μεγάλο αριθμό κινητής υποδιαστολής (bigfloat)"
 
 #: ../../src/wxMaximaFrame.cpp:1791
 msgid "To &Float"
-msgstr ""
+msgstr "Σε αριθμό κινητής υποδιαστολής"
 
 #: ../../src/Worksheet.cpp:1571
 msgid "To Float"
-msgstr ""
+msgstr "Σε αριθμό κινητής υποδιαστολής"
 
 #: ../../src/wxMaximaFrame.cpp:1797
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1803
+#, fuzzy
 msgid "To exact fraction"
-msgstr ""
+msgstr "Μερικά κλάσματα"
 
 #: ../../src/wxMaximaFrame.cpp:1814
+#, fuzzy
 msgid "To exact number"
-msgstr ""
+msgstr "Εμφάνιση συναρτήσεων"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "To:"
-msgstr ""
+msgstr "Μέχρι:"
 
 #: ../../src/wxMaximaFrame.cpp:825 ../../src/wxMaximaFrame.cpp:828
 msgid "Toggle full screen editing"
-msgstr ""
+msgstr "Εναλλαγή επεξεργασίας πλήρης οθόνης"
 
 #: ../../src/ToolBar.cpp:265
 msgid "Toggle the visibility of code cells"
@@ -7227,20 +7719,23 @@ msgid "Top end"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1078
+#, fuzzy
 msgid "Trace a function..."
-msgstr ""
+msgstr "Διαγραφή μίας συνάρτησης"
 
 #: ../../src/wxMaxima.cpp:7084
+#, fuzzy
 msgid "Trace function(s)"
-msgstr ""
+msgstr "Διαγραφή συνάρτησης(-σεων)"
 
 #: ../../src/wxMaximaFrame.cpp:1184
+#, fuzzy
 msgid "Transformations"
-msgstr ""
+msgstr "Αναστροφή πίνακα"
 
 #: ../../src/wxMaximaFrame.cpp:1376
 msgid "Transpose a matrix"
-msgstr ""
+msgstr "Αναστροφή πίνακα"
 
 #: ../../src/wxMaxima.cpp:7832
 msgid ""
@@ -7293,12 +7788,14 @@ msgid "Trim both ends..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1182
+#, fuzzy
 msgid "Trim left..."
-msgstr ""
+msgstr "Όριο..."
 
 #: ../../src/wxMaximaFrame.cpp:1183
+#, fuzzy
 msgid "Trim right..."
-msgstr ""
+msgstr "Όριο..."
 
 #: ../../src/wxMaxima.cpp:7473
 msgid "Trim string left"
@@ -7369,19 +7866,20 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1928
 msgid "Tutorials"
-msgstr ""
+msgstr "Διδακτικές παρουσιάσεις"
 
 #: ../../src/wxMaxima.cpp:9571
 msgid "Two sample t-test"
-msgstr ""
+msgstr "t-τεστ δυο δειγμάτων"
 
 #: ../../src/Worksheet.cpp:8013
+#, fuzzy
 msgid "Type"
-msgstr ""
+msgstr "Τύπος:"
 
 #: ../../src/wxMaxima.cpp:7180
 msgid "Type:"
-msgstr ""
+msgstr "Τύπος:"
 
 #: ../../src/wxMaxima.cpp:9429
 msgid "URL"
@@ -7406,8 +7904,9 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1007
+#, fuzzy
 msgid "Undefine"
-msgstr ""
+msgstr "Υπογραμμισμένος"
 
 #: ../../src/ToolBar.cpp:191
 msgid "Undo"
@@ -7415,7 +7914,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo\tCtrl+Z"
-msgstr ""
+msgstr "Αναίρεση\tCtrl+Z"
 
 #: ../../src/ToolBar.cpp:614
 msgid "Undo and redo button"
@@ -7423,11 +7922,12 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo last change"
-msgstr ""
+msgstr "Αναίρεση τελευταίας αλλαγής"
 
 #: ../../src/wxMaximaFrame.cpp:924
+#, fuzzy
 msgid "Unfold All\tCtrl+Alt+]"
-msgstr ""
+msgstr "Επιλογή Όλων\tCtrl+A"
 
 #: ../../src/wxMaximaFrame.cpp:925
 msgid "Unfold all folded sections"
@@ -7446,24 +7946,29 @@ msgid "Unhide Part"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1860
+#, fuzzy
 msgid "Unhide Section"
-msgstr ""
+msgstr "Ενότητα"
 
 #: ../../src/Worksheet.cpp:1871
+#, fuzzy
 msgid "Unhide Subsection"
-msgstr ""
+msgstr "Υποενότητα"
 
 #: ../../src/Worksheet.cpp:1882
+#, fuzzy
 msgid "Unhide Subsubsection"
-msgstr ""
+msgstr "Υποενότητα"
 
 #: ../../src/Worksheet.cpp:1912
+#, fuzzy
 msgid "Unhide contents"
-msgstr ""
+msgstr "Ελληνικές σταθερές"
 
 #: ../../src/wxMaximaFrame.cpp:266
+#, fuzzy
 msgid "Unicode characters"
-msgstr ""
+msgstr "Ελληνικές σταθερές"
 
 #: ../../src/wxMaximaFrame.cpp:707
 msgid "Unicode chars\tAlt+Shift+U"
@@ -7506,27 +8011,29 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:11150 ../../src/wxMaxima.cpp:11157
 #: ../../src/wxMaxima.cpp:11163
 msgid "Upgrade"
-msgstr ""
+msgstr "Αναβάθμιση"
 
 #: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
 msgid "Upper bound:"
-msgstr ""
+msgstr "Άνω φράγμα:"
 
 #: ../../src/wxMaximaFrame.cpp:792
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
+#, fuzzy
 msgid "Use a list"
-msgstr ""
+msgstr "Δημιουργία λίστας"
 
 #: ../../src/wxMaxima.cpp:8571
 msgid "Use a list as parameter list for a function"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1708
+#, fuzzy
 msgid "Use list"
-msgstr ""
+msgstr "Δημιουργία λίστας"
 
 #: ../../src/wxMaximaFrame.cpp:1701
 msgid "Use list as the arguments of a function"
@@ -7541,8 +8048,9 @@ msgid "Use square parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1083
+#, fuzzy
 msgid "Use struct field..."
-msgstr ""
+msgstr "Συνεχή κλάσματα"
 
 #: ../../src/wxMaximaFrame.cpp:795
 msgid "Use vertical lines instead of parenthesis for matrices"
@@ -7566,8 +8074,9 @@ msgid "Using Maxima path from command line."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:4822
+#, fuzzy
 msgid "Using configured Maxima path."
-msgstr ""
+msgstr "Ρυθμίσεις του wxMaxima"
 
 #: ../../src/wxMaxima.cpp:2961
 msgid ""
@@ -7589,25 +8098,28 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8755
+#, fuzzy
 msgid "Value at a given point"
-msgstr ""
+msgstr "Υπολογισμός ονοματικών μορφών"
 
 #: ../../src/Worksheet.cpp:1987
 msgid "Value at a specific point"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7801
+#, fuzzy
 msgid "Value at that point:"
-msgstr ""
+msgstr "Υπολογισμός ονοματικών μορφών"
 
 #: ../../src/wxMaxima.cpp:7812 ../../src/wxMaxima.cpp:7825
 #: ../../src/wxMaxima.cpp:7827
+#, fuzzy
 msgid "Value y at that point:"
-msgstr ""
+msgstr "Υπολογισμός ονοματικών μορφών"
 
 #: ../../src/wxMaxima.cpp:7910
 msgid "Value:"
-msgstr ""
+msgstr "Τιμή:"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Var #1"
@@ -7623,25 +8135,29 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
 #: ../../src/wxMaxima.cpp:8568
+#, fuzzy
 msgid "Variable name"
-msgstr ""
+msgstr "Παλιά μεταβλητή:"
 
 #: ../../src/wxMaximaFrame.cpp:1085
+#, fuzzy
 msgid "Variable name, not contents..."
-msgstr ""
+msgstr "Παλιά μεταβλητή:"
 
 #: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
+#, fuzzy
 msgid "Variable name:"
-msgstr ""
+msgstr "Παλιά μεταβλητή:"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
+#, fuzzy
 msgid "Variable(s)"
-msgstr ""
+msgstr "Μεταβλητή(-ές):"
 
 #: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
 #: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
 msgid "Variable(s):"
-msgstr ""
+msgstr "Μεταβλητή(-ές):"
 
 #: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
 #: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
@@ -7649,15 +8165,15 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
 #: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
 msgid "Variable:"
-msgstr ""
+msgstr "Μεταβλητή:"
 
 #: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
 msgid "Variables"
-msgstr ""
+msgstr "Μεταβλητές"
 
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
 msgid "Variables:"
-msgstr ""
+msgstr "Μεταβλητές:"
 
 #: ../../src/WXMXformat.cpp:337
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -7687,11 +8203,12 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
 #: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
 msgid "Warning"
-msgstr ""
+msgstr "Προειδοποίηση"
 
 #: ../../src/wxMaximaFrame.cpp:1556
+#, fuzzy
 msgid "Warning:"
-msgstr ""
+msgstr "Προειδοποίηση"
 
 #: ../../src/Dirstructure.cpp:72
 #, c-format
@@ -7707,7 +8224,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5063
 msgid "Welcome to wxMaxima"
-msgstr ""
+msgstr "Καλωσορίσατε στο wxMaxima"
 
 #: ../../src/wxMaxima.cpp:8583
 msgid "What to do:"
@@ -7760,12 +8277,15 @@ msgid "Wrote the mimetype info"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:11147
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have version %s. The newest version source code is available for is %s.\n"
 "\n"
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
+"Έχετε την έκδοση %s. Η νεότερη έκδοση είναι η %s . \n"
+"\n"
+"Επιλέξτε ΟΚ ώστε να μεταβείτε στην ιστοσελίδα του wxMaxima."
 
 #: ../../src/wxMaxima.cpp:11202
 msgid "Your changes will be lost if you don't save them."
@@ -7773,31 +8293,33 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11156
 msgid "Your version of wxMaxima is up to date."
-msgstr ""
+msgstr "Η έκδοση του wxMaxima που διαθέτετε ειναι η πιο πρόσφατη."
 
 #: ../../src/wxMaximaFrame.cpp:805
+#, fuzzy
 msgid "Zoom &In\tCtrl++"
-msgstr ""
+msgstr "Μεγένθυση"
 
 #: ../../src/wxMaximaFrame.cpp:806
+#, fuzzy
 msgid "Zoom Ou&t\tCtrl+-"
-msgstr ""
+msgstr "Σμίκρυνση"
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom in 10%"
-msgstr ""
+msgstr "Μεγέθυνση κατά 10%"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom out 10%"
-msgstr ""
+msgstr "Σμίκρυνση κατά 10%"
 
 #: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
 msgid "[ unsaved ]"
-msgstr ""
+msgstr "[ δεν έχει αποθηκευθεί ]"
 
 #: ../../src/wxMaxima.cpp:10920
 msgid "[ unsaved* ]"
-msgstr ""
+msgstr "[ δεν έχει αποθηκευθεί* ]"
 
 #: ../../src/Worksheet.cpp:5278
 #, c-format
@@ -7810,8 +8332,9 @@ msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"la
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1690
+#, fuzzy
 msgid "apply function to each element"
-msgstr ""
+msgstr "Εφαρμογή συνάρτησης σε μία λίστα"
 
 #: ../../src/wxMaximaFrame.cpp:739
 msgid "as 1D ASCII"
@@ -7846,44 +8369,50 @@ msgid "ev() shall evaluate this automatically"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7130
+#, fuzzy
 msgid "expression:"
-msgstr ""
+msgstr "Παράσταση:"
 
 #: ../../src/Worksheet.cpp:2025
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
+#, fuzzy
 msgid "filename:"
-msgstr ""
+msgstr "Παλιά μεταβλητή:"
 
 #: ../../src/wxMaximaFrame.cpp:1674
+#, fuzzy
 msgid "from a list"
-msgstr ""
+msgstr "Δημιουργία λίστας"
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "from a rule"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1685
+#, fuzzy
 msgid "from function arguments"
-msgstr ""
+msgstr "Ονόματα συναρτήσεων"
 
 #: ../../src/wxMaximaFrame.cpp:1669
 msgid "from individual elements"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
+#, fuzzy
 msgid "function"
-msgstr ""
+msgstr "Συνάρτηση"
 
 #: ../../src/wxMaximaFrame.cpp:747
 msgid "in 2D"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8554
+#, fuzzy
 msgid "list"
-msgstr ""
+msgstr "Δημιουργία λίστας"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "max(abs(A(i,j))) (complex)"
@@ -7894,13 +8423,15 @@ msgid "max(abs(A(i,j))) (real)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8046
+#, fuzzy
 msgid "m×n Matrix A:"
-msgstr ""
+msgstr "Πίνακας:"
 
 #: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533
+#, fuzzy
 msgid "n:"
-msgstr ""
+msgstr "Εύρεση "
 
 #: ../../src/Worksheet.cpp:2000
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -7911,8 +8442,9 @@ msgid "noun: Not evaluated by default"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1710
+#, fuzzy
 msgid "nth"
-msgstr ""
+msgstr "όχι"
 
 #: ../../src/Worksheet.cpp:2021
 msgid "outative: f(2*x) = 2*f(x)"
@@ -7924,20 +8456,24 @@ msgid "part:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8942
+#, fuzzy
 msgid "point:"
-msgstr ""
+msgstr "Σημείο:"
 
 #: ../../src/wxMaxima.cpp:7740
+#, fuzzy
 msgid "precision:"
-msgstr ""
+msgstr "Ακρίβεια"
 
 #: ../../src/wxMaxima.cpp:7255
+#, fuzzy
 msgid "printf"
-msgstr ""
+msgstr "Εκτύπωση"
 
 #: ../../src/wxMaximaFrame.cpp:1108
+#, fuzzy
 msgid "printf..."
-msgstr ""
+msgstr "Παραγώγιση..."
 
 #: ../../src/wxMaxima.cpp:8650
 msgid ""
@@ -7953,16 +8489,19 @@ msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1111
+#, fuzzy
 msgid "readbyte..."
-msgstr ""
+msgstr "Ολοκλήρωση..."
 
 #: ../../src/wxMaximaFrame.cpp:1110
+#, fuzzy
 msgid "readchar..."
-msgstr ""
+msgstr "Κυκλικό διάγραμμα (πίτας)"
 
 #: ../../src/wxMaximaFrame.cpp:1109
+#, fuzzy
 msgid "readline..."
-msgstr ""
+msgstr "Διακύμανση"
 
 #: ../../src/wxMaxima.cpp:10018
 msgid ""
@@ -7992,17 +8531,19 @@ msgid "unnamed function (lambda)..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:11190
+#, fuzzy
 msgid "unsaved"
-msgstr ""
+msgstr "[ δεν έχει αποθηκευθεί ]"
 
 #: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
 #: ../../src/wxMaximaFrame.cpp:189
 msgid "untitled"
-msgstr ""
+msgstr "ανώνυμο"
 
 #: ../../src/wxMaximaFrame.cpp:1700
+#, fuzzy
 msgid "use as function arguments"
-msgstr ""
+msgstr "Ονόματα συναρτήσεων"
 
 #: ../../src/wxMaximaFrame.cpp:1696
 msgid "use the actual values stored"
@@ -8017,16 +8558,16 @@ msgid "wxMaxima"
 msgstr ""
 
 #: ../../src/main.cpp:516
-#, c-format
+#, fuzzy, c-format
 msgid "wxMaxima %ld"
-msgstr ""
+msgstr "wxMaxima %s"
 
 #: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
 #: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
 #: ../../src/wxMaximaFrame.cpp:185
-#, c-format
+#, fuzzy, c-format
 msgid "wxMaxima %s (%s) "
-msgstr ""
+msgstr "wxMaxima %s"
 
 #: ../../src/wxMaxima.cpp:4490
 msgid "wxMaxima cannot read the xml contents of "
@@ -8042,12 +8583,12 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5285
 msgid "wxMaxima document"
-msgstr ""
+msgstr "έγγραφο wxMaxima"
 
 #: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
 #: ../../src/wxMaxima.cpp:4230
 msgid "wxMaxima encountered an error loading "
-msgstr ""
+msgstr "Το wxMaxima αντιμετώπισε ένα πρόβλημα κατά την φόρτωση"
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "wxMaxima help"
@@ -8066,12 +8607,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1896
+#, fuzzy
 msgid "wxMaxima shows help in a browser"
-msgstr ""
+msgstr "Το αρχείο δεν βρέθηκε"
 
 #: ../../src/wxMaximaFrame.cpp:1894
+#, fuzzy
 msgid "wxMaxima shows help in the sidebar"
-msgstr ""
+msgstr "Το αρχείο δεν βρέθηκε"
 
 #: ../../src/wxMaximaFrame.cpp:111
 #, c-format
@@ -8079,8 +8622,9 @@ msgid "wxMaxima version %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1954
+#, fuzzy
 msgid "wxMaxima's ChangeLog"
-msgstr ""
+msgstr "Εικοίδιο wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "wxMaxima's license"
@@ -8144,8 +8688,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:10
+#, fuzzy
 msgid "# Introduction to wxMaxima"
-msgstr ""
+msgstr "Καλωσορίσατε στο wxMaxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:12
@@ -8184,8 +8729,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:18
+#, fuzzy
 msgid "### _Maxima_"
-msgstr ""
+msgstr "Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:20
@@ -8220,8 +8766,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:26
+#, fuzzy
 msgid "### WxMaxima"
-msgstr ""
+msgstr "Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:28
@@ -8344,8 +8891,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:54
+#, fuzzy
 msgid "### Cells"
-msgstr ""
+msgstr "Συγχώνευση κελιών"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:56
@@ -8366,8 +8914,9 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Image cells."
-msgstr ""
+msgstr "Συγχώνευση κελιών"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
@@ -8383,8 +8932,9 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Page breaks."
-msgstr ""
+msgstr "Αλλαγή σελίδας"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:65
@@ -8538,8 +9088,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:102
+#, fuzzy
 msgid "#### Greek characters"
-msgstr ""
+msgstr "Ελληνικές σταθερές"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:104
@@ -8954,8 +9505,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:282
+#, fuzzy
 msgid "## File Formats"
-msgstr ""
+msgstr "Το αρχείο δεν βρέθηκε"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:284
@@ -9295,8 +9847,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:403
+#, fuzzy
 msgid "### Match parenthesis in text controls"
-msgstr ""
+msgstr "Ορισμός σταθερού μεγέθους γραμματοσειράς στους ελέγχους κειμένου."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:405
@@ -9392,8 +9945,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:432
+#, fuzzy
 msgid "## Subscripted variables"
-msgstr ""
+msgstr "Εμφάνιση των μεταβλητών που έχουν οριστεί"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:434
@@ -10041,8 +10595,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:704
+#, fuzzy
 msgid "#### Expression"
-msgstr ""
+msgstr "Παράσταση:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:706
@@ -10069,8 +10624,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:712
+#, fuzzy
 msgid "#### Parametric plot"
-msgstr ""
+msgstr "Παραμετρικό γράφημα"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:714
@@ -10083,8 +10639,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:716
+#, fuzzy
 msgid "#### Points"
-msgstr ""
+msgstr "Σημείο:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:718
@@ -10131,8 +10688,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:732
+#, fuzzy
 msgid "#### Plot name"
-msgstr ""
+msgstr "Λίστα:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:734
@@ -10168,8 +10726,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:744
+#, fuzzy
 msgid "#### Grid"
-msgstr ""
+msgstr "Πλέγμα:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:746
@@ -10308,8 +10867,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:794
+#, fuzzy
 msgid "## Special variables wx..."
-msgstr ""
+msgstr "Διαγραφή μίας μεταβλητής"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:805
@@ -10481,8 +11041,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:837
+#, fuzzy
 msgid "Example:"
-msgstr ""
+msgstr "Παράδειγμα"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:842
@@ -10533,8 +11094,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:856
+#, fuzzy
 msgid "## Output rendering."
-msgstr ""
+msgstr "Συμβολοσειρές"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:858
@@ -10612,8 +11174,11 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:885
+#, fuzzy
 msgid "## Cannot connect to _Maxima_"
 msgstr ""
+"\n"
+"Δεν υπάρχει σύνδεση."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:887
@@ -10960,8 +11525,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:988
+#, fuzzy
 msgid "E.g. start wxMaxima with:"
-msgstr ""
+msgstr "Επανεκίνηση του Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:990
@@ -11321,8 +11887,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1140
+#, fuzzy
 msgid "# Command-line arguments"
-msgstr ""
+msgstr "Συντεταγμένες του x χωρισμένες με κόμμα"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1142

--- a/locales/wxMaxima/es.po
+++ b/locales/wxMaxima/es.po
@@ -28,12 +28,17 @@ msgid ""
 "\n"
 "Maxima is currently using %3.3f%% of all available CPUs."
 msgstr ""
+"\n"
+"\n"
+"Actualmente ‘Maxima’ está usando %3.3f%% de todas las CPU disponibles."
 
 #: ../../src/Image.cpp:690
 msgid ""
 "\n"
 "Image was loaded from a .wxmx file"
 msgstr ""
+"\n"
+"La imagen fue cargada desde un fichero .wxmx"
 
 #: ../../src/wxMaxima.cpp:5153
 msgid ""
@@ -44,478 +49,489 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4230
 msgid " (File format (WXM version 1, first line of the file) not recognized)"
 msgstr ""
+" (Formato de archivo (WXM versión 1, primera línea del archivo) no "
+"reconocido)"
 
 #: ../../src/wxMaximaFrame.cpp:1559
 msgid " Wrong, if a is complex"
-msgstr ""
+msgstr " Error, si uno es complejo"
 
 #: ../../src/wxMaxima.cpp:7601
 msgid ""
 "\".\" = \"The current directory\"\n"
 "\"..\" = \"One directory up\""
 msgstr ""
+"\".\" = \"El directorio actual\"\n"
+"\"..\" = \"Un directorio por encima\""
 
 #: ../../src/wxMaxima.cpp:7557 ../../src/wxMaxima.cpp:7563
 #: ../../src/wxMaxima.cpp:7568
 msgid "\"..\" means \"one directory up\"."
-msgstr ""
+msgstr "\"..\" significa \"un directorio arriba\"."
 
 #: ../../src/wxMaxima.cpp:5053
 #, c-format
 msgid "%i cells in evaluation queue"
-msgstr ""
+msgstr "%i celdas en la cola de evaluación"
 
 #: ../../src/Worksheet.cpp:330
 #, c-format
 msgid "%s image, %li×%li, %li ppi"
-msgstr ""
+msgstr "%s imagen, %li×%li, %li ppp"
 
 #: ../../src/Autocomplete.cpp:319
 #, c-format
 msgid "%s: Can't interpret line: %s"
-msgstr ""
+msgstr "%s: no puede interpretar línea: %s"
 
 #: ../../src/wxMaximaFrame.cpp:1655
 msgid "&Algebraic Mode"
-msgstr ""
+msgstr "Modo &algebraico"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "&Apropos..."
-msgstr ""
+msgstr "&Propósito para…"
 
 #: ../../src/wxMaximaFrame.cpp:615
 msgid "&Batch File...\tCtrl+B"
-msgstr ""
+msgstr "Fichero por &lotes…\tCtrl+B"
 
 #: ../../src/wxMaximaFrame.cpp:1278
 msgid "&Boundary Value Problem..."
-msgstr ""
+msgstr "Pro&blema de valor frontera…"
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "&Bug Report"
-msgstr ""
+msgstr "&Gazapo a comunicar"
 
 #: ../../src/wxMaximaFrame.cpp:1505
 msgid "&Calculus"
-msgstr ""
+msgstr "A&nálisis"
 
 #: ../../src/wxMaximaFrame.cpp:1601
 msgid "&Canonical Form"
-msgstr ""
+msgstr "Formulario &canónico"
 
 #: ../../src/wxMaximaFrame.cpp:1358
 msgid "&Characteristic Polynomial..."
-msgstr ""
+msgstr "Polinomio &característico…"
 
 #: ../../src/wxMaximaFrame.cpp:990
 msgid "&Clear Memory"
-msgstr ""
+msgstr "&Purgar memoria"
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "&Combine Factorials"
-msgstr ""
+msgstr "&Combinar factoriales"
 
 #: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Complex Simplification"
-msgstr ""
+msgstr "Simplificación &compleja"
 
 #: ../../src/wxMaximaFrame.cpp:1502
 msgid "&Continued Fraction"
-msgstr ""
+msgstr "Fracción &continua"
 
 #: ../../src/wxMaximaFrame.cpp:638
 msgid "&Copy\tCtrl+C"
-msgstr ""
+msgstr "&Copiar\tCtrl+C"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "&Demoivre"
-msgstr ""
+msgstr "&Demoivre"
 
 #: ../../src/wxMaximaFrame.cpp:1362
 msgid "&Determinant"
-msgstr ""
+msgstr "&Determinante"
 
 #: ../../src/wxMaximaFrame.cpp:1466
 msgid "&Differentiate..."
-msgstr ""
+msgstr "&Diferencial…"
 
 #: ../../src/wxMaximaFrame.cpp:689
 msgid "&Edit"
-msgstr ""
+msgstr "&Editar"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "&Eliminate Variable..."
-msgstr ""
+msgstr "&Eliminar variable…"
 
 #: ../../src/wxMaximaFrame.cpp:1318
 msgid "&Enter Matrix..."
-msgstr ""
+msgstr "&Introducir matriz…"
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "&Example..."
-msgstr ""
+msgstr "&Ejemplo…"
 
 #: ../../src/wxMaximaFrame.cpp:1524
 msgid "&Expand Expression"
-msgstr ""
+msgstr "&Expandir expresión"
 
 #: ../../src/wxMaximaFrame.cpp:1597
 msgid "&Expand Trigonometric"
-msgstr ""
+msgstr "&Expandir trigonometría"
 
 #: ../../src/wxMaximaFrame.cpp:1626
 msgid "&Exponentialize"
-msgstr ""
+msgstr "&Exponencializar"
 
 #: ../../src/wxMaximaFrame.cpp:618
 msgid "&Export..."
-msgstr ""
+msgstr "&Exportar…"
 
 #: ../../src/wxMaximaFrame.cpp:1516
 msgid "&Factor Expression"
-msgstr ""
+msgstr "&Factorizar expresión"
 
 #: ../../src/wxMaximaFrame.cpp:626
 msgid "&File"
-msgstr ""
+msgstr "&Archivo"
 
 #: ../../src/wxMaximaFrame.cpp:1019
 msgid "&Functions"
-msgstr ""
+msgstr "&Funciones"
 
 #: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Greatest Common Divisor..."
-msgstr ""
+msgstr "Má&ximo común divisor…"
 
 #: ../../src/wxMaximaFrame.cpp:1968
 msgid "&Help"
-msgstr ""
+msgstr "Ay&uda"
 
 #: ../../src/wxMaximaFrame.cpp:1453
 msgid "&Integrate..."
-msgstr ""
+msgstr "&Integrar…"
 
 #: ../../src/wxMaximaFrame.cpp:964
 msgid "&Interrupt\tCtrl+G"
-msgstr ""
+msgstr "&Interrumpir\tCtrl+G"
 
 #: ../../src/wxMaximaFrame.cpp:1355
 msgid "&Invert Matrix"
-msgstr ""
+msgstr "&Invertir matriz"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "&License"
-msgstr ""
+msgstr "&Licencia"
 
 #: ../../src/wxMaximaFrame.cpp:1763
 msgid "&List"
-msgstr ""
+msgstr "&Listado"
 
 #: ../../src/wxMaximaFrame.cpp:610
 msgid "&Load Package...\tCtrl+L"
-msgstr ""
+msgstr "&Cargar paquete…\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "&Maxima"
-msgstr ""
+msgstr "‘&Maxima’"
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "&Maxima help"
-msgstr ""
+msgstr "Ayuda de ‘&Maxima’"
 
 #: ../../src/wxMaximaFrame.cpp:1660
 msgid "&Modulus Computation..."
-msgstr ""
+msgstr "&Módulos computables…"
 
 #: ../../src/main.cpp:435
 msgid "&New\tCtrl+N"
-msgstr ""
+msgstr "&Crear\tCtrl+N"
 
 #: ../../src/wxMaximaFrame.cpp:1870
 msgid "&Numeric"
-msgstr ""
+msgstr "&Numérico"
 
 #: ../../src/wxMaximaFrame.cpp:1785
 msgid "&Numeric Output"
-msgstr ""
+msgstr "Salida &numérica"
 
 #: ../../src/main.cpp:436
 msgid "&Open\tCtrl+O"
-msgstr ""
+msgstr "&Abrir\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "&Open...\tCtrl+O"
-msgstr ""
+msgstr "&Abrir…\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "&Plot"
-msgstr ""
+msgstr "&Tramado"
 
 #: ../../src/wxMaximaFrame.cpp:622
 msgid "&Print...\tCtrl+P"
-msgstr ""
+msgstr "&Imprimir…\tCtrl+P"
 
 #: ../../src/wxMaximaFrame.cpp:1594
 msgid "&Reduce Trigonometric"
-msgstr ""
+msgstr "&Reducir trigonometría"
 
 #: ../../src/wxMaximaFrame.cpp:974
 msgid "&Restart Maxima\tCtrl+Alt+R"
-msgstr ""
+msgstr "&Rearrancar Maxima\tCtrl+Alt+R"
 
 #: ../../src/wxMaximaFrame.cpp:608
 msgid "&Save\tCtrl+S"
-msgstr ""
+msgstr "&Guardar\tCtrl+S"
 
 #: ../../src/wxMaximaFrame.cpp:1662
 msgid "&Simplify"
-msgstr ""
+msgstr "&Simplificar"
 
 #: ../../src/wxMaximaFrame.cpp:1581
 msgid "&Simplify Factorials"
-msgstr ""
+msgstr "&Simplificar factoriales"
 
 #: ../../src/wxMaximaFrame.cpp:1591
 msgid "&Simplify Trigonometric"
-msgstr ""
+msgstr "&Simplificar trigonometría"
 
 #: ../../src/wxMaximaFrame.cpp:1238
 msgid "&Solve..."
-msgstr ""
+msgstr "&Resolver…"
 
 #: ../../src/wxMaximaFrame.cpp:1035
 msgid "&Time Display"
-msgstr ""
+msgstr "Desplegar &tiempo"
 
 #: ../../src/wxMaximaFrame.cpp:1375
 msgid "&Transpose Matrix"
-msgstr ""
+msgstr "&Transponer matriz"
 
 #: ../../src/wxMaximaFrame.cpp:1605
 msgid "&Trigonometric Simplification"
-msgstr ""
+msgstr "Simplificación &trigonométrica"
 
 #: ../../src/wxMaximaFrame.cpp:1021
 msgid "&Variables"
-msgstr ""
+msgstr "&Variables"
 
 #: ../../src/wxMaxima.cpp:2443
 msgid "(Config tells to suppress the output of long cells)"
-msgstr ""
+msgstr "(Configurar dice suprimir la salida de celdas largas)"
 
 #: ../../src/MathParser.cpp:1288
 msgid "(Invalid XML from maxima)"
-msgstr ""
+msgstr "(XML no válido desde ‘maxima‘)"
 
 #: ../../src/wxMaxima.cpp:4221
 msgid "(Maybe a permission problem?)"
-msgstr ""
+msgstr "(¿Tal vez un problema de permisos?)"
 
 #: ../../src/wxMaxima.cpp:9248
 msgid "(f(x),x,a,b)), Epsilon algorithm"
-msgstr ""
+msgstr "(f(x),x,a,b)), Algoritmo epsilón"
 
 #: ../../src/wxMaxima.cpp:9235
 msgid "(f(x),x,a,b)), Strategy of Aind"
-msgstr ""
+msgstr "(f(x),x,a,b)), Estrategia de Aind"
 
 #: ../../src/wxMaxima.cpp:9258
 msgid "(f(x),x,a,b), (semi-) infinite interval"
-msgstr ""
+msgstr "(f(x),x,a,b), (semi-) intervalo infinito"
 
 #: ../../src/wxMaximaFrame.cpp:1841
 msgid "(f(x),x,a,b), Epsilon algorithm"
-msgstr ""
+msgstr "(f(x),x,a,b), algoritmo Épsilon"
 
 #: ../../src/wxMaximaFrame.cpp:1843
 msgid "(f(x),x,a,b), infinite interval"
-msgstr ""
+msgstr "(f(x),x,a,b), intervalo infinito"
 
 #: ../../src/wxMaximaFrame.cpp:1839
 msgid "(f(x),x,a,b), strategy of Aind"
-msgstr ""
+msgstr "(f(x),x,a,b), estrategia de Aind"
 
 #: ../../src/wxMaxima.cpp:9361 ../../src/wxMaximaFrame.cpp:1867
 msgid "(f(x),x,y) with singularities+discontinuities"
-msgstr ""
+msgstr "(f(x),x,y) con singularidades+descontinuidades"
 
 #: ../../src/wxMaxima.cpp:2065
 msgid ""
 "... [suppressed additional lines as the output is longer than allowed in the"
 " wxMaxima configuration] "
 msgstr ""
+"… [líneas adicionales suprimidas como el resultado es más largo que lo "
+"permitido en la configuración de wxMaxima] "
 
 #: ../../src/Worksheet.cpp:6666
 msgid ".wxm clipboard data with unusual header"
-msgstr ""
+msgstr ".wxm del portapapeles de datos con cabecera inusual"
 
 #: ../../src/wxMaxima.cpp:8047
 msgid "1×n Matrix b:"
-msgstr ""
+msgstr "1×n Matriz b:"
 
 #: ../../src/wxMaximaFrame.cpp:1312
 msgid "2D Array to Matrix..."
-msgstr ""
+msgstr "Repertorio 2D a matriz…"
 
 #: ../../src/wxMaximaFrame.cpp:743
 msgid "2D equations using ASCII Art"
-msgstr ""
+msgstr "Ecuaciones 2D empleando Arte ASCII"
 
 #: ../../src/wxMaximaFrame.cpp:746
 msgid "2D equations using ASCII Art with unicode characters, if available"
 msgstr ""
+"Ecuaciones de 2D utilizando ASCII Art con caracteres Unicode, si está "
+"disponible"
 
 #: ../../src/wxMaxima.cpp:5057
-#, c-format
+#, fuzzy, c-format
 msgid "; %i commands left in the current cell"
-msgstr ""
+msgstr "; %li instrucciones dejadas en la celda actual"
 
 #: ../../src/wxMaxima.cpp:10617
 msgid "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
+"Un \":lisp\" como la primera instrucción puede fallar para enviar una señal "
+"\"finished\"."
 
 #: ../../src/wxMaxima.cpp:6585
 msgid "A Ctrl-F event"
-msgstr ""
+msgstr "Un evento Ctrl+F"
 
 #: ../../src/Worksheet.cpp:1973
 msgid "A Scalar"
-msgstr ""
+msgstr "Un Escalar"
 
 #: ../../src/wxMaxima.cpp:6653
 #, c-format
 msgid "A find event, %s"
-msgstr ""
+msgstr "Un evento encontrado, %s"
 
 #: ../../src/Worksheet.cpp:2012
 msgid "A function returning integers"
-msgstr ""
+msgstr "Una función devolviendo enteros"
 
 #: ../../src/Worksheet.cpp:2014
 msgid "A function returning positive numbers"
-msgstr ""
+msgstr "Una función devolviendo números positivos"
 
 #: ../../src/Worksheet.cpp:1965
 msgid "A irrational variable"
-msgstr ""
+msgstr "Una variable irracional"
 
 #: ../../src/Worksheet.cpp:2016
 msgid "A left-associative function"
-msgstr ""
+msgstr "Una función asociativa por la izquierda"
 
 #: ../../src/Worksheet.cpp:2019
 msgid "A linear function"
-msgstr ""
+msgstr "Una función lineal"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "A matrix in which each row is a set of variables"
-msgstr ""
+msgstr "Una matriz dentro de la cual cada fila es un conjunto de variables"
 
 #: ../../src/Worksheet.cpp:1963
 msgid "A rational variable"
-msgstr ""
+msgstr "Una variable racional"
 
 #: ../../src/Worksheet.cpp:2018
 msgid "A right-associative function"
-msgstr ""
+msgstr "Una función asociativa por la derecha"
 
 #: ../../src/wxMaximaFrame.cpp:1634
 msgid "A search-and-replace for equations"
-msgstr ""
+msgstr "Un buscar-y-sustituir para ecuaciones"
 
 #: ../../src/wxMaximaFrame.cpp:1636
 msgid "A subst with basic maths knowledge"
-msgstr ""
+msgstr "Una subcadena con conocimiento matemático básico"
 
 #: ../../src/BTextCtrl.cpp:64
 msgid "A text control got the mouse focus"
-msgstr ""
+msgstr "Un control de texto obtuvo el foco del ratón"
 
 #: ../../src/wxMaximaFrame.cpp:1442
 msgid "A&pply function to each Matrix element..."
-msgstr ""
+msgstr "A&plica función a cada elemento Matriz…"
 
 #: ../../src/wxMaximaFrame.cpp:1291
 msgid "A&t Value..."
-msgstr ""
+msgstr "&Valorado…"
 
 #: ../../src/Configuration.cpp:85
 msgid "ASCII maths"
-msgstr ""
+msgstr "Mates ASCII"
 
 #: ../../src/wxMaximaFrame.cpp:1963
 msgid "About"
-msgstr ""
+msgstr "Acerca de…"
 
 #: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
 msgid "About wxMaxima"
-msgstr ""
+msgstr "Acerca de wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7837
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
-msgstr ""
+msgstr "Acepta una expresión o un listado dentro del formato [edo1, edo,2,…]"
 
 #: ../../src/wxMaxima.cpp:7841
 msgid "Accepts one variable or a list in the format [1,4,...]"
-msgstr ""
+msgstr "Acepta una variable o un listado en el formato [1,4,…]"
 
 #: ../../src/wxMaxima.cpp:7839
 msgid "Accepts one variable or a list in the format [var1,var2,...]"
-msgstr ""
+msgstr "Acepta una variable o un listado en el formato [var1,var2,…]"
 
 #: ../../src/wxMaximaFrame.cpp:1371
 msgid "Ad&joint Matrix"
-msgstr ""
+msgstr "Ad&juntar matriz"
 
 #: ../../src/wxMaximaFrame.cpp:1657
 msgid "Add Algebraic E&quality..."
-msgstr ""
+msgstr "Agregar &igualdad algebraica…"
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add a directory to search path"
-msgstr ""
+msgstr "Agrega una carpeta a la ruta de búsqueda"
 
 #: ../../src/wxMaximaFrame.cpp:1752
 msgid ""
 "Add a new item to the beginning of the list. Useful for creating stacks."
 msgstr ""
+"Agrega un elemento nuevo al inicio del listado. útil para crear pilas."
 
 #: ../../src/wxMaxima.cpp:8602
 msgid "Add an element to the end of a list"
-msgstr ""
+msgstr "Agrega un elemento al final de un listado"
 
 #: ../../src/wxMaxima.cpp:8597
 msgid "Add an element to the start of a list"
-msgstr ""
+msgstr "Agrega un elemento al inicio de un listado"
 
 #: ../../src/wxMaxima.cpp:7625
 msgid "Add dir to path:"
-msgstr ""
+msgstr "Agregar carpeta a ruta:"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "Add equality to the rational simplifier"
-msgstr ""
+msgstr "Agregar igualdad al simplificador racional"
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add to &Path..."
-msgstr ""
+msgstr "Agregar por &ruta…"
 
 #: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
 #: ../../src/Worksheet.cpp:1704
 msgid "Add to watchlist"
-msgstr ""
+msgstr "Agregar al listado de vigía"
 
 #: ../../src/wxMaximaFrame.cpp:1562
 msgid "Additionally: log(a*b)=log(a)+log(b)"
-msgstr ""
+msgstr "Adicionalmente: log(a*b)=log(a)+log(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1566
 msgid "Additionally: log(a/b)=log(a)-log(b), a and b positive integers"
-msgstr ""
+msgstr "Adicionalmente: log(a/b)=log(a)-log(b), a y b enteros positivos"
 
 #: ../../src/Worksheet.cpp:1996
 msgid "Additive function: f(a+b)=f(a)+f(b)"
-msgstr ""
+msgstr "Función aditiva: f(a+b)=f(a)+f(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1911
 msgid "Advanced 2d plotting"
@@ -523,29 +539,31 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1809
 msgid "Advanced guess (PSLQ algorithm)"
-msgstr ""
+msgstr "Adivinación avanzada (algoritmo PSLQ)"
 
 #: ../../src/wxMaximaFrame.cpp:1920
 msgid "Advanced variable names"
-msgstr ""
+msgstr "Nombres de variable avanzadas"
 
 #: ../../src/ToolBar.cpp:321 ../../src/ToolBar.cpp:589
 msgid ""
 "After clicking on animations created with with_slider_draw() or similar this"
 " slider allows to change the current frame."
 msgstr ""
+"Tras pulsar sobre la animación creada con with_slider_draw() o similar, esta"
+" ranura deslizante permite cambiar de un marco actual."
 
 #: ../../src/wxMaximaFrame.cpp:1028
 msgid "Aliases"
-msgstr ""
+msgstr "Aliases"
 
 #: ../../src/wxMaximaFrame.cpp:1714
 msgid "All but the 1st n elements"
-msgstr ""
+msgstr "Todo excepto el primer n elemento"
 
 #: ../../src/wxMaximaFrame.cpp:1716
 msgid "All but the last n elements"
-msgstr ""
+msgstr "Todo excepto el último n elementos"
 
 #: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
 msgid ""
@@ -554,93 +572,101 @@ msgid ""
 "*.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session "
 "(*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr ""
+"Todos los tipos operables (*.wxm, *.wxmx, *.mac, *.out, "
+"*.xml)|*.wxm;*.wxmx;*.mac;*.out;*.xml|Documentos wxMaxima (*.wxm, "
+"*.wxmx)|*.wxm;*.wxmx|Sesión ‘Maxima’ (*.mac)|*.mac|Sesión Xmaxima "
+"(*.out)|*.out|xml desde .wxmx defectuoso (*.xml)|*.xml"
 
 #: ../../src/wxMaximaFrame.cpp:733
 msgid "All visible sidebars"
-msgstr ""
+msgstr "Todas las barras laterales visibles"
 
 #: ../../src/wxMaximaFrame.cpp:1650
 msgid "Allow to substitute operators"
-msgstr ""
+msgstr "Permite para operadores de sustitución"
 
 #: ../../src/wxMaxima.cpp:9040
 msgid ""
 "Allows to vary the parameters of a function until it fits experimental data."
 msgstr ""
+"Permite variar los parámetros de una función hasta que quepan los datos "
+"experimentales."
 
 #: ../../src/wxMaximaFrame.cpp:763
 msgid "Always after underscores"
-msgstr ""
+msgstr "Siempre tras puntuación inferior"
 
 #: ../../src/wxMaximaFrame.cpp:764
 msgid "Always autosubscript after an underscore"
-msgstr ""
+msgstr "Siempre autosuscribir tras una puntuación inferior"
 
 #: ../../src/wxMaximaFrame.cpp:774
 msgid "Always display this variable with subscript"
-msgstr ""
+msgstr "Despliega siempre esta variable con subscript"
 
 #: ../../src/Worksheet.cpp:1605
 msgid "Always show all digits"
-msgstr ""
+msgstr "Siempre muestra todos los dígitos"
 
 #: ../../src/wxMaxima.cpp:9241
 msgid ""
 "An integer between 1..6; Higher numbers work better for oscillating "
 "integrands"
 msgstr ""
+"Un entero entre 1..6; números más altos funciona mejor para integrantes "
+"oscilantes"
 
 #: ../../src/MaximaManual.cpp:385
 msgid "Anchors file has no top node."
-msgstr ""
+msgstr "Fichero anclaje no tiene nodo techo."
 
 #: ../../src/wxMaximaFrame.cpp:791
 msgid "Angles"
-msgstr ""
+msgstr "Ángulos"
 
 #: ../../src/wxMaximaFrame.cpp:1775
 msgid "Animation autoplay"
-msgstr ""
+msgstr "Autoreproducir animación"
 
 #: ../../src/wxMaximaFrame.cpp:1778
 msgid "Animation framerate..."
-msgstr ""
+msgstr "Frecuencia de animación…"
 
 #: ../../src/Worksheet.cpp:2002
 msgid "Antisymmetric function: f(x)=-f(-x)"
-msgstr ""
+msgstr "Función antisimétrica: f(x)=-f(-x)"
 
 #: ../../src/wxMaximaFrame.cpp:1739
 msgid "Append"
-msgstr ""
+msgstr "Encolar"
 
 #: ../../src/wxMaximaFrame.cpp:1735
 msgid "Append a list"
-msgstr ""
+msgstr "Encola un listado"
 
 #: ../../src/wxMaximaFrame.cpp:1736
 msgid "Append a list to an existing list"
-msgstr ""
+msgstr "Encola un listado a un listado existente"
 
 #: ../../src/wxMaxima.cpp:8607
 msgid "Append a list to another list"
-msgstr ""
+msgstr "Adjunta un listado a otro listado"
 
 #: ../../src/wxMaximaFrame.cpp:1729
 msgid "Append an element"
-msgstr ""
+msgstr "Encola un elemento"
 
 #: ../../src/wxMaximaFrame.cpp:1734
 msgid "Append an element to the beginning an existing list"
-msgstr ""
+msgstr "Encola un elemento al inicio de un listado existente"
 
 #: ../../src/wxMaximaFrame.cpp:1730
 msgid "Append an element to the end of an existing list"
-msgstr ""
+msgstr "Encola un elemento al final de un listado existente"
 
 #: ../../src/wxMaxima.cpp:8552
 msgid "Apply a function to each list element"
-msgstr ""
+msgstr "Aplica una función a cada elemento de lista"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 #, c-format
@@ -648,204 +674,228 @@ msgid ""
 "Approximate by a fraction using log(), sqrt() and %pi, when needed. Only "
 "available in maxima > 5.46.0"
 msgstr ""
+"Aproximar por una fracción utilizando log(), sqrt() y %pi, cuando se "
+"necesite. Solamente disponible en maxima > 5.46.0"
 
 #: ../../src/wxMaximaFrame.cpp:1806
 msgid "Approximate by nice fraction"
-msgstr ""
+msgstr "Aproximar por fracción buena"
 
 #: ../../src/wxMaxima.cpp:8931
 msgid ""
 "Approximates a expression around a point as a polynom\n"
 "The trailing \"...\" can be removed by using ratdisrep()"
 msgstr ""
+"Aproxima una expresión alrededor de un punto como un polinomio\n"
+"La cola \"…\" puede ser eliminada utilizando ratdisrep()"
 
 #: ../../src/wxMaxima.cpp:8939
 msgid "Approximates a expression as a polynom"
-msgstr ""
+msgstr "Aproxima una expresión como un polinomio"
 
 #: ../../src/wxMaxima.cpp:9474
 msgid "Apropos"
-msgstr ""
+msgstr "Propósito"
 
 #: ../../src/wxMaxima.cpp:7317
 msgid "Are the chars equal, if case is ignored?"
-msgstr ""
+msgstr "¿Son los caracteres iguales, sin distinguir MAYÚS/minús?"
 
 #: ../../src/wxMaxima.cpp:7312
 msgid "Are the chars equal?"
-msgstr ""
+msgstr "¿Son los caracteres iguales?"
 
 #: ../../src/wxMaxima.cpp:7349
 msgid "Are these strings equal if case is ignored?"
-msgstr ""
+msgstr "¿Son estas cadenas iguales sin distinguir MAYÚS/minús?"
 
 #: ../../src/wxMaxima.cpp:7344
 msgid "Are these strings equal?"
-msgstr ""
+msgstr "¿Son estas cadenas iguales?"
 
 #: ../../src/wxMaxima.cpp:7259
 msgid "Arguments:"
-msgstr ""
+msgstr "Argumentos:"
 
 #: ../../src/wxMaxima.cpp:8189
 msgid "Array"
-msgstr ""
+msgstr "Repertorio"
 
 #: ../../src/wxMaximaFrame.cpp:1023
 msgid "Arrays"
-msgstr ""
+msgstr "Repertorios"
 
 #: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
 msgid "Ascii code to char"
-msgstr ""
+msgstr "Código ASCII a carácter"
 
 #: ../../src/wxMaximaFrame.cpp:1138
 msgid "Ascii code to char..."
-msgstr ""
+msgstr "Código ASCII a carácter…"
 
 #: ../../src/wxMaxima.cpp:10063
 msgid "Assignment(s):"
-msgstr ""
+msgstr "Asignación(es):"
 
 #: ../../src/wxMaxima.cpp:10064
 msgid "Assignments of the format a=10,b=20"
-msgstr ""
+msgstr "Asignaciones de formato a=10,b=20"
 
 #: ../../src/wxMaxima.cpp:6851
 msgid "Assume a value range for a variable"
-msgstr ""
+msgstr "Asume un valor de intervalo para una variable"
 
 #: ../../src/wxMaxima.cpp:8545
 msgid ""
 "Attention: Extracting a random list element isn't efficient for long "
 "lists.Iterating over lists using makelist() or for loops is way faster."
 msgstr ""
+"Atención: extrayendo un elemento de listado aleatorio no es eficiente para "
+"«long lists.Iterating» sobre listados utilizando makelist() o para bucles es"
+" la manera más rápida."
 
 #: ../../src/Worksheet.cpp:1618
 msgid "Automatic labels"
-msgstr ""
+msgstr "Etiquetas automáticas"
 
 #: ../../src/wxMaximaFrame.cpp:952
 msgid "Automatically answer questions"
-msgstr ""
+msgstr "Responder automáticamente preguntas"
 
 #: ../../src/wxMaximaFrame.cpp:953
 msgid "Automatically fill in answers known from the last run"
 msgstr ""
+"Automáticamente rellena dentro d respuestas conocidas desde la última "
+"ejecución"
 
 #: ../../src/Worksheet.cpp:1464 ../../src/Worksheet.cpp:1838
 msgid "Automatically send known answers"
-msgstr ""
+msgstr "Automáticamente envía respuestas conocidas"
 
 #: ../../src/wxMaxima.cpp:6021
 #, c-format
 msgid "Autosaving as temp file %s"
-msgstr ""
+msgstr "Autoguardado como fichero temporal %s"
 
 #: ../../src/wxMaxima.cpp:6033
 #, c-format
 msgid "Autosaving the .wxmx file as %s"
-msgstr ""
+msgstr "Autoguardado del fichero .wxmx como %s"
 
 #: ../../src/wxMaximaFrame.cpp:781
 msgid "Autosubscript"
-msgstr ""
+msgstr "Autosuscribir"
 
 #: ../../src/wxMaximaFrame.cpp:782
 msgid "Autosubscript chars after an underscore"
-msgstr ""
+msgstr "Autosuscribir caracteres tras un guión bajo"
 
 #: ../../src/wxMaximaFrame.cpp:767
 msgid "Autosubscript numbers and text following single letters"
-msgstr ""
+msgstr "Números autosuscritos y texto seguido de letras simples"
 
 #: ../../src/wxMaxima.cpp:6529
 msgid "Autosubscript this variable"
-msgstr ""
+msgstr "Auto-suscribir esta variable"
 
 #: ../../src/MaximaManual.cpp:536
 msgid "Background task that compiles the Manual anchors scheduled."
 msgstr ""
+"Tarea en segundo plano que compila los anclajes del Manual planificado."
 
 #: ../../src/wxMaximaFrame.cpp:1350
 msgid "Basic matrix operations"
-msgstr ""
+msgstr "Operaciones matriciales básicas"
 
 #: ../../src/wxMaxima.cpp:6210
 msgid "Batch File"
-msgstr ""
+msgstr "Fichero Por Lotes"
 
 #: ../../src/wxMaxima.cpp:5318
 msgid "Both horizontal and vertical cursor active at the same time"
-msgstr ""
+msgstr "Ambos cursores horizontal y vertical se activa al mismo tiempo"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Bottom end"
-msgstr ""
+msgstr "Suelo final"
 
 #: ../../src/wxMaxima.cpp:7817
 msgid "Boundary value problem"
-msgstr ""
+msgstr "Problema de valor perimetral"
 
 #: ../../src/wxMathml.cpp:101
 msgid ""
 "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
 msgstr ""
+"Gazapo: ¡tras quitar el espacio en blanco wxMathml.lisp es más corto que los"
+" esperado!"
 
 #: ../../src/Autocomplete.cpp:509
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
+"Gazapo: autocompletado solicitado para un tipo de elemento desconocido."
 
 #: ../../src/Worksheet.cpp:2992
 msgid "Bug: Cell left but not entered."
-msgstr ""
+msgstr "Gazapo: celda abandonada sin haber entrado."
 
 #: ../../src/Worksheet.cpp:6203
 msgid "Bug: Cell with negative y position!"
-msgstr ""
+msgstr "Gazapo: ¡celda con negativo y positivo!"
 
 #: ../../src/Worksheet.cpp:7723
 msgid ""
 "Bug: Encountered a heading I don't know how to move in one sectioning unit"
 msgstr ""
+"Gazapo: encontrada una cabecera que no conozco como introducirla a una "
+"unidad de sección"
 
 #: ../../src/Worksheet.cpp:7766
 msgid ""
 "Bug: Encountered a heading I don't know how to move out one sectioning unit"
 msgstr ""
+"Gazapo: encontrada una cabecera que no conozco como extraerla de una unidad "
+"de selección"
 
 #: ../../src/Worksheet.cpp:3112
 msgid "Bug: Got a question but no cell to answer it in"
-msgstr ""
+msgstr "Gazapo: se ha obtenido una pregunta pero sin celda asociada"
 
 #: ../../src/Worksheet.cpp:6378
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of"
 " the worksheet."
 msgstr ""
+"Gazapo: se ha solicitado cambiar el contenido de una celda por encima del "
+"comienzo de la hoja del cuaderno."
 
 #: ../../src/Worksheet.cpp:6346
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
+"Gazapo: se ha solicitado borrar el contenido de una celda por encima del "
+"comienzo de la hoja de cuaderno."
 
 #: ../../src/Worksheet.cpp:6415
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
 msgstr ""
+"Gazapo: obtenga una solicitud para primera modificación de los contenidos de"
+" una celda y luego no borrarla."
 
 #: ../../src/Worksheet.cpp:5578
 msgid "Bug: HTML output is no valid XML"
-msgstr ""
+msgstr "Gazapo: salida HTML no es XML válido"
 
 #: ../../src/Configuration.h:615
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
 msgstr ""
+"Gazapo: ¡número máximo de dígitos que no está enseñado es demasiado bajo!"
 
 #: ../../src/MathParser.cpp:523
 msgid "Bug: Missing contents"
-msgstr ""
+msgstr "Gazapo: faltan contenidos"
 
 #: ../../src/Worksheet.cpp:2597 ../../src/Worksheet.cpp:2711
 #: ../../src/Worksheet.cpp:2753 ../../src/Worksheet.cpp:2787
@@ -853,135 +903,146 @@ msgstr ""
 #: ../../src/Worksheet.cpp:4442 ../../src/Worksheet.cpp:6650
 #: ../../src/Worksheet.cpp:6863
 msgid "Bug: The clipboard is already opened"
-msgstr ""
+msgstr "Gazapo: el portapapeles ya está abierto"
 
 #: ../../src/Worksheet.cpp:7763
 msgid "Bug: Trying to move a title out by one sectioning unit"
-msgstr ""
+msgstr "Gazapo: intentando extraer un título por una unidad de sección"
 
 #: ../../src/Worksheet.cpp:6934
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
+"Gazapo: intentando arrastrar el cursor horizontalmente a un lugar interno a "
+"un grupo de celdas."
 
 #: ../../src/Worksheet.h:247 ../../src/Worksheet.h:252
 msgid "Bug: Trying to record a cell contents change for undo without a cell."
 msgstr ""
+"Gazapo: intentando registrar un cambio del contenido de celda sin una celda."
 
 #: ../../src/Worksheet.cpp:6417
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
+"Gazapo: acción de deshacer con ambos contenidos de celda cambian y suman las"
+" celdas."
 
 #: ../../src/Worksheet.cpp:6383
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
+"Gazapo: solicitud de deshacer para una celda fuera da la hoja del cuaderno."
 
 #: ../../src/wxMaximaFrame.cpp:1948
 msgid "Build &Info"
-msgstr ""
+msgstr "Crear &informe"
 
 #: ../../src/wxMaxima.cpp:7275
 msgid "Byte:"
-msgstr ""
+msgstr "Byte:"
 
 #: ../../src/wxMaximaFrame.cpp:1458
 msgid "C&hange Variable in Integrate..."
-msgstr ""
+msgstr "Cambiar &variable en integración…"
 
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "C&onfigure"
-msgstr ""
+msgstr "C&onfigurar"
 
 #: ../../src/wxMaximaFrame.cpp:1482
 msgid "Calculate &Product..."
-msgstr ""
+msgstr "Calcular &producto…"
 
 #: ../../src/wxMaxima.cpp:8057
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
-msgstr ""
+msgstr "Calcula Descomposición de Valor Singular de una matriz numéricamente"
 
 #: ../../src/wxMaxima.cpp:8050
 msgid ""
 "Calculate Singular Value Decomposition, left and right singular vectors "
 "numerically"
 msgstr ""
+"Calcula Descomposición de Valor Singular, numéricamente vectores singulares "
+"izquierda y derecha"
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate Su&m..."
-msgstr ""
+msgstr "Calcular su&ma…"
 
 #: ../../src/wxMaximaFrame.cpp:1795
 msgid "Calculate bigfloat value of the last result"
-msgstr ""
+msgstr "Formato real grande de la última expresión"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Calculate float value of the last result"
-msgstr ""
+msgstr "Formato real de la última expresión"
 
 #: ../../src/wxMaxima.cpp:9550
 msgid "Calculate mean value"
-msgstr ""
+msgstr "Calcula valor medio"
 
 #: ../../src/wxMaxima.cpp:9554
 msgid "Calculate median value"
-msgstr ""
+msgstr "Calcula valor mediano"
 
 #: ../../src/wxMaxima.cpp:8871
 msgid "Calculate modulus:"
-msgstr ""
+msgstr "Calcular módulo:"
 
 #: ../../src/wxMaximaFrame.cpp:1798
 msgid "Calculate numeric value of the last result"
-msgstr ""
+msgstr "Calcula el valor numérico del último resultado"
 
 #: ../../src/wxMaximaFrame.cpp:1483
 msgid "Calculate products"
-msgstr ""
+msgstr "Calcular productos"
 
 #: ../../src/wxMaxima.cpp:9562
 msgid "Calculate standard deviation"
-msgstr ""
+msgstr "Calcula desviación estándar"
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate sums"
-msgstr ""
+msgstr "Calcular sumas"
 
 #: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
 msgid "Calculate the eigenvalues and eigenvectors numerically"
-msgstr ""
+msgstr "Calcula los enésimos valores y enésimos vectores numéricamente"
 
 #: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
 msgid "Calculate the eigenvalues of a matrix numerically"
-msgstr ""
+msgstr "Calcula los enésimos valores de una matriz numéricamente"
 
 #: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
 msgid "Calculate the root of the sum of squares of matrix entries"
-msgstr ""
+msgstr "Calcula la raíz del sumatorio de cuadrados de apuntes matriciales"
 
 #: ../../src/wxMaxima.cpp:9558
 msgid "Calculate variation"
-msgstr ""
+msgstr "Calcula variación"
 
 #: ../../src/wxMaxima.cpp:8949
 msgid "Calculates the fourier coefficients for the expression from -p to p"
 msgstr ""
+"Calcula los coeficientes de Fourier para la expresión desde -p hasta p"
 
 #: ../../src/Worksheet.cpp:1968
 msgid "Calls assume() in order to tell maxima about the variable's range"
 msgstr ""
+"Invoca assume() con el fin de decir a maxima acerca de intervalo de "
+"variables"
 
 #: ../../src/Worksheet.cpp:2031
 msgid "Can be specified as flag in ev(exp, flag)"
-msgstr ""
+msgstr "Puede estar especificado como indicador en ev(exp, indicador)"
 
 #: ../../src/wxMaxima.cpp:11125
 msgid "Can not connect to the web server."
-msgstr ""
+msgstr "No se puede acceder al servidor web."
 
 #: ../../src/wxMaxima.cpp:11166
 msgid "Can not download version info."
-msgstr ""
+msgstr "No se puede descargar la versión."
 
 #: ../../src/wxMaxima.cpp:3016 ../../src/wxMaxima.cpp:4836
 msgid ""
@@ -989,149 +1050,158 @@ msgid ""
 " (it can be downloaded from https://maxima.sourceforge.io) or in wxMaxima's "
 "config dialogue the setting for Maxima's location is wrong."
 msgstr ""
+"No se puede iniciar ‘Maxima‘. Lo más probable causa es que ‘Maxima‘ no está "
+"instalado (puede ser descargado desde https://maxima.sourceforge.io) o en el"
+" diálogo de configuración de ‘wxMaxima‘ el parámetro de la localización de "
+"‘Maxima‘ es erróneo."
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 #: ../../src/wxMaxima.cpp:3292
 msgid "Cannot authenticate Maxima!"
-msgstr ""
+msgstr "¡No se puede autenticar Maxima!"
 
 #: ../../src/wxMaxima.cpp:2677
 msgid ""
 "Cannot find a maxima binary and no binary chosen in the config dialogue."
 msgstr ""
+"No se puede encontrar un binario maxima y no binario elegido dentro del "
+"diálogo de configuración."
 
 #: ../../src/Autocomplete.cpp:583
 #, c-format
 msgid "Cannot interpret template %s"
-msgstr ""
+msgstr "No puede interpretar plantilla %s"
 
 #: ../../src/wxMaxima.cpp:3082
 #, c-format
 msgid "Cannot interpret the numeric value of pid %s"
-msgstr ""
+msgstr "No se puede interpretar el valor numérico de pid %s"
 
 #: ../../src/wxMaxima.cpp:11066 ../../src/wxMaxima.cpp:11073
 #: ../../src/wxMaxima.cpp:11080
 #, c-format
 msgid "Cannot interpret version number component %s"
-msgstr ""
+msgstr "No se puede interpretar el número de la versión del componente %s"
 
 #: ../../src/wxMaxima.cpp:2530
 msgid "Cannot set the communication address to localhost."
 msgstr ""
+"No se puede establecer la dirección de comunicación al hospedaje local."
 
 #: ../../src/wxMaxima.cpp:2532
-#, c-format
+#, fuzzy, c-format
 msgid "Cannot set the communication port to %i."
-msgstr ""
+msgstr "No se puede fijar el puerto de comunicación para %li."
 
 #: ../../src/wxMaxima.cpp:3656 ../../src/wxMaxima.cpp:6359
 msgid "Cannot start gnuplot"
-msgstr ""
+msgstr "No se puede iniciar gnuplot"
 
 #: ../../src/StatusBar.cpp:216 ../../src/wxMaxima.cpp:2662
 msgid "Cannot start the maxima binary"
-msgstr ""
+msgstr "No se puede iniciar el binario máximo"
 
 #: ../../src/wxMaxima.cpp:9268
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
-msgstr ""
+msgstr "Valor principal de Cauchy de f(x)/(x-c), intervalo finito"
 
 #: ../../src/wxMaximaFrame.cpp:1845
 msgid "Cauchy principal value, finite interval"
-msgstr ""
+msgstr "Valor principal de Cauchy, intervalo finito"
 
 #: ../../src/wxMaximaFrame.cpp:955
 msgid "Ce&ll"
-msgstr ""
+msgstr "Ce&lda"
 
 #: ../../src/Configuration.cpp:96
 msgid "Cell bracket fill, Active"
-msgstr ""
+msgstr "Corchete de celda completa, activa"
 
 #: ../../src/Configuration.cpp:95
 msgid "Cell bracket fill, Inactive"
-msgstr ""
+msgstr "Corchete de celda completa, inactiva"
 
 #: ../../src/wxMaxima.cpp:10395
 msgid "Cell ends in a backslash"
-msgstr ""
+msgstr "Celda termina en barra invertida"
 
 #: ../../src/wxMaximaFrame.cpp:1038
 msgid "Change &2d Display"
-msgstr ""
+msgstr "Modificar pantalla &2d"
 
 #: ../../src/wxMaxima.cpp:10146
 msgid "Change Image"
-msgstr ""
+msgstr "Cambiar Imagen"
 
 #: ../../src/Worksheet.cpp:1324
 msgid "Change Image..."
-msgstr ""
+msgstr "Modificar imagen…"
 
 #: ../../src/wxMaximaFrame.cpp:1954
 msgid "Change Log"
-msgstr ""
+msgstr "Cambiar Historial"
 
 #: ../../src/wxMaxima.cpp:7555
 msgid "Change directory"
-msgstr ""
+msgstr "Cambiar directorio"
 
 #: ../../src/wxMaximaFrame.cpp:1202
 msgid "Change directory..."
-msgstr ""
+msgstr "Cambiar directorio…"
 
 #: ../../src/wxMaximaFrame.cpp:1039
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
+"Modificar el algoritmo de pantalla 2d empleado para enseñar la salida "
+"matemática"
 
 #: ../../src/wxMaxima.cpp:8885
 msgid "Change variable"
-msgstr ""
+msgstr "Modificar variable"
 
 #: ../../src/wxMaxima.cpp:8905
 msgid "Change variable and evaluate"
-msgstr ""
+msgstr "Cambia variable y evaluar"
 
 #: ../../src/wxMaximaFrame.cpp:1459
 msgid "Change variable in integral or sum"
-msgstr ""
+msgstr "Modificar variable en integral o sumatorio"
 
 #: ../../src/wxMaximaFrame.cpp:1463
 msgid "Change variable in integral or sum and evaluate the result"
-msgstr ""
+msgstr "Cambia variable en integral o sumatorio y evaluar el resultado"
 
 #: ../../src/wxMaximaFrame.cpp:1026
 msgid "Changed option variables"
-msgstr ""
+msgstr "Variables de opción cambiadas"
 
 #: ../../src/wxMaxima.cpp:10170
 #, c-format
 msgid "Changing image originally loaded from file %s to %s."
-msgstr ""
+msgstr "Cambiando imagen originalmente cargada desde archivo %s al %s."
 
 #: ../../src/wxMaxima.cpp:7313 ../../src/wxMaxima.cpp:7318
 #: ../../src/wxMaxima.cpp:7323 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7334 ../../src/wxMaxima.cpp:7340
 msgid "Char #1:"
-msgstr ""
+msgstr "Car nº1:"
 
 #: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
 #: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
 msgid "Char #2:"
-msgstr ""
+msgstr "Car nº2:"
 
 #: ../../src/wxMaximaFrame.cpp:1140
 msgid "Char to Unicode code point..."
-msgstr ""
+msgstr "Carácter a punto de código Unicode…"
 
 #: ../../src/wxMaxima.cpp:7358 ../../src/wxMaxima.cpp:7362
 msgid "Char to unicode code point"
-msgstr ""
+msgstr "Carácter a punto de código Unicode"
 
 #: ../../src/wxMaxima.cpp:7285 ../../src/wxMaxima.cpp:7289
 #: ../../src/wxMaxima.cpp:7293 ../../src/wxMaxima.cpp:7297
@@ -1139,324 +1209,332 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7359 ../../src/wxMaxima.cpp:7363
 #: ../../src/wxMaxima.cpp:7435
 msgid "Char:"
-msgstr ""
+msgstr "Carácter:"
 
 #: ../../src/wxMaximaFrame.cpp:1131
 msgid "Character Tests"
-msgstr ""
+msgstr "Pruebas de Carácter"
 
 #: ../../src/wxMaxima.cpp:8181
 msgid "Characteristic polynom"
-msgstr ""
+msgstr "Polinomio característico"
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Chars are strings that are one character long"
-msgstr ""
+msgstr "Caracteres son cadenas que son un solo carácter largo"
 
 #: ../../src/wxMaximaFrame.cpp:1957
 msgid "Check for Updates"
-msgstr ""
+msgstr "Marcar Actualizaciones"
 
 #: ../../src/wxMaximaFrame.cpp:1958
 msgid "Check if a newer version of wxMaxima is available."
-msgstr ""
+msgstr "Comprueba si la versión más moderna de wxMaxima está disponible."
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Choose the parenthesis type for Matrices"
-msgstr ""
+msgstr "Elija el tipo de paréntesis para Matrices"
 
 #: ../../src/wxMaxima.cpp:9530 ../../src/wxMaxima.cpp:9535
 msgid "Classes:"
-msgstr ""
+msgstr "Clases:"
 
 #: ../../src/wxMaximaFrame.cpp:1378
 msgid "Classic matrix operations"
-msgstr ""
+msgstr "Operaciones matriciales clásicas"
 
 #: ../../src/wxMaximaFrame.cpp:998
 msgid "Clear all aliases"
-msgstr ""
+msgstr "Purga todos los aliases"
 
 #: ../../src/wxMaximaFrame.cpp:995
 msgid "Clear all arrays"
-msgstr ""
+msgstr "Purga todos los repertorios"
 
 #: ../../src/wxMaximaFrame.cpp:992
 msgid "Clear all dependencies"
-msgstr ""
+msgstr "Purga todas las dependencias"
 
 #: ../../src/wxMaximaFrame.cpp:994
 msgid "Clear all functions"
-msgstr ""
+msgstr "Vacía todas las funciones"
 
 #: ../../src/wxMaximaFrame.cpp:1001
 msgid "Clear all gradefs"
-msgstr ""
+msgstr "Purga todos los grados-fs"
 
 #: ../../src/wxMaximaFrame.cpp:1000
 msgid "Clear all labels"
-msgstr ""
+msgstr "Purga todas las etiquetas"
 
 #: ../../src/wxMaximaFrame.cpp:1004
 msgid "Clear all let rule packages"
-msgstr ""
+msgstr "Purga todos los paquetes de reglas definidas"
 
 #: ../../src/wxMaximaFrame.cpp:1003
 msgid "Clear all macros"
-msgstr ""
+msgstr "Purga todas las macros"
 
 #: ../../src/wxMaximaFrame.cpp:1002
 msgid "Clear all props"
-msgstr ""
+msgstr "Purga todos los propósitos"
 
 #: ../../src/wxMaximaFrame.cpp:997
 msgid "Clear all rules"
-msgstr ""
+msgstr "Purga todas las reglas"
 
 #: ../../src/wxMaximaFrame.cpp:999
 msgid "Clear all structures"
-msgstr ""
+msgstr "Purga todas las estructuras"
 
 #: ../../src/wxMaximaFrame.cpp:993
 msgid "Clear all variables"
-msgstr ""
+msgstr "Vacía todas las variables"
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close\tCtrl+W"
-msgstr ""
+msgstr "Cerrar\tCtrl+W"
 
 #: ../../src/wxMaxima.cpp:7235
 msgid "Close Stream"
-msgstr ""
+msgstr "Cerrar Flujo"
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close window"
-msgstr ""
+msgstr "Cerrar ventana"
 
 #: ../../src/wxMaximaFrame.cpp:1105
 msgid "Close..."
-msgstr ""
+msgstr "Cerrar…"
 
 #: ../../src/WXMXformat.cpp:301
 msgid "Closed the zip archive"
-msgstr ""
+msgstr "Ha cerrado el archivador zip"
 
 #: ../../src/Configuration.cpp:77
 msgid "Code Default (Maxima input)"
-msgstr ""
+msgstr "Código Predet. (Entrada de Maxima)"
 
 #: ../../src/Configuration.cpp:103
 msgid "Code highlighting: Comments"
-msgstr ""
+msgstr "Comentarios"
 
 #: ../../src/Configuration.cpp:108
 msgid "Code highlighting: End of line markers"
-msgstr ""
+msgstr "Resaltar código: marcadores de final de línea"
 
 #: ../../src/Configuration.cpp:102
 msgid "Code highlighting: Functions"
-msgstr ""
+msgstr "Funciones"
 
 #: ../../src/Configuration.cpp:107
 msgid "Code highlighting: Lisp"
-msgstr ""
+msgstr "Resalte de código: Liso"
 
 #: ../../src/Configuration.cpp:104
 msgid "Code highlighting: Numbers"
-msgstr ""
+msgstr "Números"
 
 #: ../../src/Configuration.cpp:106
 msgid "Code highlighting: Operators"
-msgstr ""
+msgstr "Operadores"
 
 #: ../../src/Configuration.cpp:105
 msgid "Code highlighting: Strings"
-msgstr ""
+msgstr "Cadenas textuales"
 
 #: ../../src/Configuration.cpp:101
 msgid "Code highlighting: Variables"
-msgstr ""
+msgstr "Variables"
 
 #: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
 msgid "Code number:"
-msgstr ""
+msgstr "Número de código:"
 
 #: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
 msgid "Codepoint number:"
-msgstr ""
+msgstr "Número de coma del código:"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "Col. names:"
-msgstr ""
+msgstr "Nombres col:"
 
 #: ../../src/Configuration.cpp:100
 msgid "Color of Outdated cells"
-msgstr ""
+msgstr "Color de celdas caducadas"
 
 #: ../../src/Configuration.cpp:99
 msgid "Color of text equal to selection"
-msgstr ""
+msgstr "Color de texto igual a selección"
 
 #: ../../src/wxMaxima.cpp:7962
 msgid "Column number:"
-msgstr ""
+msgstr "Número de columna:"
 
 #: ../../src/wxMaxima.cpp:7978
 msgid "Column numbers:"
-msgstr ""
+msgstr "Números de columna:"
 
 #: ../../src/wxMaxima.cpp:8202
+#, fuzzy
 msgid "Columns"
-msgstr ""
+msgstr "Números de columna:"
 
 #: ../../src/wxMaximaFrame.cpp:1584
 msgid "Combine factorials in an expression"
-msgstr ""
+msgstr "Combinar factoriales en una expresión"
 
 #: ../../src/wxMaxima.cpp:10454
 msgid "Comma directly followed by a closing parenthesis"
-msgstr ""
+msgstr "Coma seguida de paréntesis que cierra"
 
 #: ../../src/wxMaxima.cpp:7259
 msgid "Comma-separated arguments"
-msgstr ""
+msgstr "Argumentos separados por comas"
 
 #: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
 msgid "Comma-separated commands"
-msgstr ""
+msgstr "Instrucciones separadas por comas"
 
 #: ../../src/wxMaxima.cpp:8458
 msgid "Comma-separated elements"
-msgstr ""
+msgstr "Elementos separados por comas"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 #: ../../src/wxMaxima.cpp:10031
 msgid "Comma-separated equations"
-msgstr ""
+msgstr "Ecuaciones separadas por comas"
 
 #: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
 #: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
 #: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
 msgid "Comma-separated expressions"
-msgstr ""
+msgstr "Expresiones separadas por comas"
 
 #: ../../src/wxMaxima.cpp:7215
 msgid "Comma-separated expressions that shall be converted to a string"
-msgstr ""
+msgstr "Expresiones separadas por comas que serán convertidas a una cadena"
 
 #: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
 msgid "Comma-separated expressions."
-msgstr ""
+msgstr "Expresiones separadas por comas."
 
 #: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
 msgid "Comma-separated function names"
-msgstr ""
+msgstr "Nombres de función separadas por comas"
 
 #: ../../src/wxMaxima.cpp:7086
 msgid "Comma-separated function names."
-msgstr ""
+msgstr "Nombres de función separadas por comas."
 
 #: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
 #: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
 msgid "Comma-separated list entry in the format val1=1,val2=2"
-msgstr ""
+msgstr "Apunte de listado separado por coma con formato val1=1,val2=2"
 
 #: ../../src/wxMaxima.cpp:7205
 msgid "Comma-separated names of the elements that shall be written"
-msgstr ""
+msgstr "Nombres separados por comas de los elementos que serán escritos"
 
 #: ../../src/wxMaxima.cpp:7099
 msgid "Comma-separated names the parameters will be referenced by later."
 msgstr ""
+"Nombres separados por coma los parámetros serán referenciados más tarde."
 
 #: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
 msgid "Comma-separated numbers from 0 to 255"
-msgstr ""
+msgstr "Número separados por comas desde 0 a 255"
 
 #: ../../src/wxMaxima.cpp:8770
 msgid "Comma-separated numbers of the terms to substitute in"
-msgstr ""
+msgstr "Números separados por coma de los términos a sustituir"
 
 #: ../../src/wxMaxima.cpp:7137 ../../src/wxMaxima.cpp:7150
 msgid ""
 "Comma-separated parameter names. A parameter in square brackets [] will be "
 "filled with the list of any additional arguments the function gets."
 msgstr ""
+"Nombres de parámetro separados por coma. Un parámetro es corchetes [] será "
+"rellenado con el listado de cualquiera de los argumentos adicionales que la "
+"función obtenga."
 
 #: ../../src/wxMaxima.cpp:7054
 msgid "Comma-separated variable names, can be initialized by the \":\" operator."
 msgstr ""
+"Nombres de variable separados por coma, puede ser inicializado por el "
+"operador «:»."
 
 #: ../../src/wxMaxima.cpp:7753 ../../src/wxMaxima.cpp:7767
 #: ../../src/wxMaxima.cpp:8719 ../../src/wxMaxima.cpp:8785
 #: ../../src/wxMaxima.cpp:10032
 msgid "Comma-separated variables"
-msgstr ""
+msgstr "Variables separadas por comas"
 
 #: ../../src/wxMaxima.cpp:9469
 msgid "Command:"
-msgstr ""
+msgstr "Instrucción:"
 
 #: ../../src/Worksheet.cpp:1692
 msgid "Comment Selection"
-msgstr ""
+msgstr "Comentario de Selección"
 
 #: ../../src/wxMaximaFrame.cpp:681
 msgid "Comment out the currently selected text"
-msgstr ""
+msgstr "Descomentar el texto seleccionado"
 
 #: ../../src/wxMaximaFrame.cpp:680
 msgid "Comment selection\tCtrl+/"
-msgstr ""
+msgstr "Comentar selección\tCtrl+/"
 
 #: ../../src/Worksheet.cpp:2004
 msgid "Commutative function"
-msgstr ""
+msgstr "Función conmutativa"
 
 #: ../../src/wxMaximaFrame.cpp:1396
 msgid "Compile a QR decomposition using dgeqrf"
-msgstr ""
+msgstr "Compila una descomposición QR utilizando dgeqrf"
 
 #: ../../src/wxMaxima.cpp:7162
 msgid "Compile a function"
-msgstr ""
+msgstr "Compila una función"
 
 #: ../../src/wxMaximaFrame.cpp:1188
+#, fuzzy
 msgid "Compile a regular expression"
-msgstr ""
+msgstr "Compila una expreg"
 
 #: ../../src/wxMaximaFrame.cpp:1385
 msgid "Compile eigenvalues using dgeev"
-msgstr ""
+msgstr "Compila valores utilizando dgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1388
 msgid "Compile eigenvalues using zgeev"
-msgstr ""
+msgstr "Compila valores utilizando zgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1391
 msgid "Compile eigenvalues+eigenvectors using dgeev"
-msgstr ""
+msgstr "Compile valores+vectores utilizando dgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1394
 msgid "Compile eigenvalues+eigenvectors using zgeev"
-msgstr ""
+msgstr "Compila valores+vectores utilizando zgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1076
 msgid "Compile function..."
-msgstr ""
+msgstr "Compilar función…"
 
 #: ../../src/wxMaxima.cpp:7511
 msgid "Compile regex"
-msgstr ""
+msgstr "Compila exreg"
 
 #: ../../src/wxMathml.cpp:53
 msgid "Compiler-Bug? wxMathml.lisp is shorter than expected!"
-msgstr ""
+msgstr "¿Defecto-compilador? ¡wxMathml.lisp es más corto que lo esperado!"
 
 #: ../../src/wxMaxima.cpp:2234
 #, c-format
 msgid "Compiling %s"
-msgstr ""
+msgstr "Compilando %s"
 
 #: ../../src/wxMaxima.cpp:7163
 msgid ""
@@ -1464,440 +1542,459 @@ msgid ""
 " the function parameters are made known to the function before it is "
 "compiled. Else the generated code has to be hideously generic."
 msgstr ""
+"Compilando una función puede generar una aceleración de velocidad "
+"considerable si los tipos de los parámetros de la función son hechos conocer"
+" a la función antes de ser compilada. Por otro caso el código generado tiene"
+" que ser feamente genérico."
 
 #: ../../src/wxMaximaFrame.cpp:892
 msgid "Complete Word\tCtrl+Space"
-msgstr ""
+msgstr "Palabra completa\tCtrl+Espacio"
 
 #: ../../src/wxMaximaFrame.cpp:893
 msgid "Complete word"
-msgstr ""
+msgstr "Palabra completa"
 
 #: ../../src/ToolBar.cpp:230
 msgid "Completely stop maxima and restart it"
-msgstr ""
+msgstr "Detiene completamente 'maxima' y reinícielo"
 
 #: ../../src/wxMaximaFrame.cpp:1503
 msgid "Compute continued fraction of a value"
-msgstr ""
+msgstr "Procesa fracción continua de un valor"
 
 #: ../../src/wxMaximaFrame.cpp:1372
 msgid "Compute the adjoint matrix"
-msgstr ""
+msgstr "Procesa la matriz adjunta"
 
 #: ../../src/wxMaximaFrame.cpp:1359
 msgid "Compute the characteristic polynomial of a matrix"
-msgstr ""
+msgstr "Procesa el polinomio característico de una matriz"
 
 #: ../../src/wxMaximaFrame.cpp:1363
 msgid "Compute the determinant of a matrix"
-msgstr ""
+msgstr "Procesa el determinante de una matriz"
 
 #: ../../src/wxMaximaFrame.cpp:1491
 msgid "Compute the greatest common divisor"
-msgstr ""
+msgstr "Procesa el máximo común divisor"
 
 #: ../../src/wxMaximaFrame.cpp:1356
 msgid "Compute the inverse of a matrix"
-msgstr ""
+msgstr "Procesa la inversa de una matriz"
 
 #: ../../src/wxMaximaFrame.cpp:1494
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
+"Procesa el mínimo común múltiplo (cargar(funciones) antes de emplearlo)"
 
 #: ../../src/wxMaximaFrame.cpp:1374
 msgid "Compute the rank of a matrix"
-msgstr ""
+msgstr "Calcula el rengo de una matriz"
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Condition:"
-msgstr ""
+msgstr "Condición:"
 
 #: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "Configure wxMaxima"
-msgstr ""
+msgstr "Configurar wxMaxima"
 
 #: ../../src/wxMaxima.cpp:2504
 msgid "Connection attempt, but connection failed."
-msgstr ""
+msgstr "Intento de conexión, pero la conexión ha fallado."
 
 #: ../../src/wxMaxima.cpp:2459
 msgid "Connection to Maxima lost."
-msgstr ""
+msgstr "Conexión a ‘Maxima’ perdida."
 
 #: ../../src/wxMaxima.cpp:7921
 msgid "Construct a fraction"
-msgstr ""
+msgstr "Construye una fracción"
 
 #: ../../src/wxMaximaFrame.cpp:1305
 msgid "Construct fraction..."
-msgstr ""
+msgstr "Construir fracción…"
 
 #: ../../src/wxMaxima.cpp:7158
 msgid "Contents:"
-msgstr ""
+msgstr "Contenido:"
 
 #: ../../src/wxMaximaFrame.cpp:1877
 msgid "Context-sensitive &Help\tCtrl+?"
-msgstr ""
+msgstr "&Ayuda distinguiendo contexto\tCtrl+?"
 
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Context-sensitive &Help\tF1"
-msgstr ""
+msgstr "&Ayuda distinguiendo contexto\tF1"
 
 #: ../../src/wxMaximaFrame.cpp:1542
 msgid "Contract Logarithms"
-msgstr ""
+msgstr "Contraer logaritmos"
 
 #: ../../src/wxMaximaFrame.cpp:1161
 msgid "Conversions"
-msgstr ""
+msgstr "Conversiones"
 
 #: ../../src/wxMaximaFrame.cpp:1229
 msgid "Convert"
-msgstr ""
+msgstr "Convertir"
 
 #: ../../src/wxMaximaFrame.cpp:1230
 msgid "Convert + Write to file"
-msgstr ""
+msgstr "Convertir + Escribir a archivo"
 
 #: ../../src/wxMaximaFrame.cpp:1434
 msgid "Convert Column to list..."
-msgstr ""
+msgstr "Convertir Columna a listado…"
 
 #: ../../src/wxMaximaFrame.cpp:1430
 msgid "Convert Row to list..."
-msgstr ""
+msgstr "Convierte Fila a listado…"
 
 #: ../../src/wxMaximaFrame.cpp:1044
 msgid "Convert a command to maxima code"
-msgstr ""
+msgstr "Convierte una instrucción a código ‘maxima’"
 
 #: ../../src/wxMaximaFrame.cpp:1321
 msgid "Convert a list of lists to a matrix"
-msgstr ""
+msgstr "Convierte un listado de listas a una matriz"
 
 #: ../../src/wxMaximaFrame.cpp:1574
 msgid "Convert binomials, beta and gamma function to factorials"
-msgstr ""
+msgstr "Convierte binomiales, funciones beta y gamma a factoriales"
 
 #: ../../src/wxMaximaFrame.cpp:1578
 msgid "Convert binomials, factorials and beta function to gamma function"
-msgstr ""
+msgstr "Convierte binomiales, funciones factoriales y beta a función gamma"
 
 #: ../../src/wxMaximaFrame.cpp:1613
 msgid "Convert complex expression to polar form"
-msgstr ""
+msgstr "Convierte expresión compleja a forma polar"
 
 #: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert complex expression to rect form"
-msgstr ""
+msgstr "Convierte expresión compleja a forma cartesiana"
 
 #: ../../src/wxMaximaFrame.cpp:1622
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
+"Convierte función exponencial de argumento imaginario a forma trigonométrica"
 
 #: ../../src/wxMaxima.cpp:7411
 msgid "Convert string to lowercase"
-msgstr ""
+msgstr "Convierte cadena a minúsculas"
 
 #: ../../src/wxMaxima.cpp:7543
 msgid "Convert string to matching regex"
-msgstr ""
+msgstr "Convierte cadena a expreg coincidente"
 
 #: ../../src/wxMaximaFrame.cpp:1543
 msgid "Convert sum of logarithms to logarithm of product"
-msgstr ""
+msgstr "Convierte suma de logaritmos en logaritmo de un producto"
 
 #: ../../src/wxMaximaFrame.cpp:1573
 msgid "Convert to &Factorials"
-msgstr ""
+msgstr "Convertir a &factoriales"
 
 #: ../../src/wxMaximaFrame.cpp:1577
 msgid "Convert to &Gamma"
-msgstr ""
+msgstr "Convierte a &gamma"
 
 #: ../../src/wxMaximaFrame.cpp:1612
 msgid "Convert to &Polarform"
-msgstr ""
+msgstr "Convierte a forma &polar"
 
 #: ../../src/wxMaximaFrame.cpp:1609
 msgid "Convert to &Rectform"
-msgstr ""
+msgstr "Convierte a forma &cartesiana"
 
 #: ../../src/wxMaximaFrame.cpp:1166
 msgid "Convert to downcase..."
-msgstr ""
+msgstr "Convierte a minúsculas…"
 
 #: ../../src/wxMaxima.cpp:7016
 msgid "Convert to programming language"
-msgstr ""
+msgstr "Convierte a lenguaje de programación"
 
 #: ../../src/wxMaxima.cpp:7022
 msgid "Convert to programming language file"
-msgstr ""
+msgstr "Convierte a archivo del lenguaje de programación"
 
 #: ../../src/wxMaximaFrame.cpp:1602
 msgid "Convert trigonometric expression to canonical quasilinear form"
-msgstr ""
+msgstr "Convierte expresión trigonométrica a forma canónica casi lineal"
 
 #: ../../src/wxMaximaFrame.cpp:1627
 msgid "Convert trigonometric functions to exponential form"
-msgstr ""
+msgstr "Convierte funciones trigonométricas a forma exponencial"
 
 #: ../../src/wxMaximaFrame.cpp:1762
 msgid "Converts a matrix to a list of lists"
-msgstr ""
+msgstr "Convierte una matriz a un listado de listas"
 
 #: ../../src/wxMaximaFrame.cpp:1760
 msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
-msgstr ""
+msgstr "Convierte un listado anidada como [[1,2],[3,4]] a una matriz"
 
 #: ../../src/ToolBar.cpp:209 ../../src/Worksheet.cpp:1290
 #: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
 #: ../../src/Worksheet.cpp:1684
 msgid "Copy"
-msgstr ""
+msgstr "Copiar"
 
 #: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
 #: ../../src/Worksheet.cpp:1514
 msgid "Copy Animation"
-msgstr ""
+msgstr "Copiar Animación"
 
 #: ../../src/wxMaximaFrame.cpp:887
 msgid "Copy Previous Input\tCtrl+I"
-msgstr ""
+msgstr "Copiar entrada anterior\tCtrl+I"
 
 #: ../../src/wxMaximaFrame.cpp:890
 msgid "Copy Previous Output\tCtrl+U"
-msgstr ""
+msgstr "Copiar resultado anterior\tCtrl+U"
 
 #: ../../src/wxMaxima.cpp:7992
 msgid "Copy a matrix"
-msgstr ""
+msgstr "Copia una matriz"
 
 #: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
 #: ../../src/wxMaximaFrame.cpp:663
 msgid "Copy as EMF"
-msgstr ""
+msgstr "Copiar como EMF"
 
 #: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Copy as Image"
-msgstr ""
+msgstr "Copiar como imagen"
 
 #: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
 #: ../../src/wxMaximaFrame.cpp:645
 msgid "Copy as LaTeX"
-msgstr ""
+msgstr "Copiar como LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:648
 msgid "Copy as MathML"
-msgstr ""
+msgstr "Copiar como MathML"
 
 #: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
 msgid "Copy as MathML (e.g. to word processor)"
-msgstr ""
+msgstr "Copiar como MathML (p.e. a un procesador de texto)"
 
 #: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
 #: ../../src/wxMaximaFrame.cpp:658
 msgid "Copy as RTF"
-msgstr ""
+msgstr "Copiar como RTF"
 
 #: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "Copy as SVG"
-msgstr ""
+msgstr "Copiar como SVG"
 
 #: ../../src/wxMaximaFrame.cpp:640
 msgid "Copy as Text\tCtrl+Shift+C"
-msgstr ""
+msgstr "Copiar como texto\tCtrl+Mayús+C"
 
 #: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
 msgid "Copy as plain text"
-msgstr ""
+msgstr "Copiar como un texto simple"
 
 #: ../../src/wxMaxima.cpp:7576
 msgid "Copy file"
-msgstr ""
+msgstr "Copiar archivo"
 
 #: ../../src/wxMaximaFrame.cpp:1214
 msgid "Copy file..."
-msgstr ""
+msgstr "Copiar archivo…"
 
 #: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
 #: ../../src/wxMaximaFrame.cpp:643
 msgid "Copy for Octave/Matlab"
-msgstr ""
+msgstr "Copiar para Octave/Matlab"
 
 #: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
 msgid "Copy selection"
-msgstr ""
+msgstr "Copiar selección"
 
 #: ../../src/wxMaximaFrame.cpp:664
 msgid "Copy selection from document as an Enhanced Metafile"
-msgstr ""
+msgstr "Copia una selección del documento como un formato Metafile Mejorado"
 
 #: ../../src/wxMaximaFrame.cpp:656
 msgid "Copy selection from document as an SVG image"
-msgstr ""
+msgstr "Copia una selección del documento como una imagen SVG"
 
 #: ../../src/wxMaximaFrame.cpp:653
 msgid "Copy selection from document as an image"
-msgstr ""
+msgstr "Copia una selección del documento como una imagen"
 
 #: ../../src/wxMaximaFrame.cpp:659
 msgid ""
 "Copy selection from document as rtf that a word processor might understand"
 msgstr ""
+"Copia una selección del documento como RTF que un procesador de texto quizá "
+"entienda"
 
 #: ../../src/wxMaximaFrame.cpp:641
 msgid "Copy selection from document as text"
-msgstr ""
+msgstr "Copia una selección del documento como texto"
 
 #: ../../src/wxMaximaFrame.cpp:646
 msgid "Copy selection from document in LaTeX format"
-msgstr ""
+msgstr "Copia una selección del documento en formato LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:644
 msgid "Copy selection from document in Matlab format"
-msgstr ""
+msgstr "Copia selección desde documento en formato Matlab"
 
 #: ../../src/wxMaximaFrame.cpp:649
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
+"Copia una selección del documento en formato MathML muchos procesamientos de"
+" texto pueden ver como ecuación de 2d"
 
 #: ../../src/wxMaxima.cpp:7403
 msgid "Copy string"
-msgstr ""
+msgstr "Copiar cadena"
 
 #: ../../src/wxMaximaFrame.cpp:1165
 msgid "Copy string..."
-msgstr ""
+msgstr "Copiar cadena…"
 
 #: ../../src/ToolBar.cpp:623
 msgid "Copy, Cut and Paste button"
-msgstr ""
+msgstr "Botón de Copiar, Cortar y Pegar"
 
 #: ../../src/WXMXformat.cpp:295
 msgid "Could not create the backup file during saving => aborting."
 msgstr ""
+"No se pudo crear el archivo del respaldo durante el guardado ⇒ se aborta."
 
 #: ../../src/wxMaxima.cpp:3294 ../../src/wxMaxima.cpp:3306
 msgid ""
 "Could not make sure that we talk to the maxima we started => discarding all "
 "data it sends."
 msgstr ""
+"No se pudo asegurar que hablamos a la maxima iniciada ⇒ descartando todos "
+"los datos que envía."
 
 #: ../../src/wxMaxima.cpp:2783
 msgid ""
 "Could not map view of the file needed in order to send an interrupt signal "
 "to maxima."
 msgstr ""
+"No se pudo distribuir vista del fichero necesitado en la instrucción para "
+"enviar una señal interruptora a ‘maxima’."
 
 #: ../../src/wxMaxima.cpp:2763 ../../src/wxMaxima.cpp:2805
 msgid "Could not send an interrupt signal to maxima."
-msgstr ""
+msgstr "No se pudo enviar una señal de interrupción a ‘maxima’."
 
 #: ../../src/WXMXformat.cpp:287
 msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
+"No se pudo escribir el contenido del archivo durante el guardado ⇒ "
+"interrumpir."
 
 #: ../../src/wxMaximaFrame.cpp:1325
 msgid "Create Matrix"
-msgstr ""
+msgstr "Generar Matriz"
 
 #: ../../src/wxMaximaFrame.cpp:1688
 msgid "Create a list"
-msgstr ""
+msgstr "Crea un listado"
 
 #: ../../src/wxMaxima.cpp:8487
 msgid "Create a list as a storage for the values of variables"
-msgstr ""
+msgstr "Crea un listado como un almacén para los valores de variables"
 
 #: ../../src/wxMaxima.cpp:8463 ../../src/wxMaxima.cpp:8476
 msgid "Create a list from a rule"
-msgstr ""
+msgstr "Crea un listado desde una regla"
 
 #: ../../src/wxMaximaFrame.cpp:1670
 msgid "Create a list from comma-separated elements"
-msgstr ""
+msgstr "Crea un listado desde elementos separados por coma"
 
 #: ../../src/wxMaximaFrame.cpp:888
 msgid "Create a new cell with previous input"
-msgstr ""
+msgstr "Crea una celda con la anterior entrada"
 
 #: ../../src/wxMaximaFrame.cpp:891
 msgid "Create a new cell with previous output"
-msgstr ""
+msgstr "Crea una celda con la anterior salida"
 
 #: ../../src/wxMaximaFrame.cpp:1348
 msgid "Create copy, not clone..."
-msgstr ""
+msgstr "Crear copia, no clon…"
 
 #: ../../src/wxMaxima.cpp:7561
 msgid "Create directory"
-msgstr ""
+msgstr "Crear directorio"
 
 #: ../../src/wxMaximaFrame.cpp:1203
 msgid "Create directory..."
-msgstr ""
+msgstr "Crear directorio…"
 
 #: ../../src/wxMaxima.cpp:7419
 msgid "Create empty string"
-msgstr ""
+msgstr "Crear cadena vacía"
 
 #: ../../src/wxMaximaFrame.cpp:1168
 msgid "Create empty string..."
-msgstr ""
+msgstr "Crear cadena vacía…"
 
 #: ../../src/wxMaximaFrame.cpp:1687
 msgid "Create list"
-msgstr ""
+msgstr "Crear listado"
 
 #: ../../src/wxMaxima.cpp:8457
 msgid "Create list from comma-separated elements"
-msgstr ""
+msgstr "Crea un listado desde elementos separados por comas"
 
 #: ../../src/wxMaximaFrame.cpp:1082
 msgid "Create struct..."
-msgstr ""
+msgstr "Crear estructura…"
 
 #: ../../src/WXMXformat.cpp:80
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
 msgstr ""
+"Ha creado un archivador .zip (el archivo .wxmx técnicamente es un fichero "
+".zip)"
 
 #: ../../src/wxMaximaFrame.cpp:1349
 msgid "Creates an independent matrix with the same contents"
-msgstr ""
+msgstr "Crea una matriz independiente con el mismo contenido"
 
 #: ../../src/Configuration.cpp:97
 msgid "Cursor color"
-msgstr ""
+msgstr "Color del cursor"
 
 #: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
 msgid "Cut"
-msgstr ""
+msgstr "Cortar"
 
 #: ../../src/wxMaximaFrame.cpp:636
 msgid "Cut\tCtrl+X"
-msgstr ""
+msgstr "Cortar\tCtrl+X"
 
 #: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
 msgid "Cut selection"
-msgstr ""
+msgstr "Cortar selección"
 
 #: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
 msgid "Data Matrix:"
-msgstr ""
+msgstr "Matriz de datos:"
 
 #: ../../src/wxMaxima.cpp:9599
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
-msgstr ""
+msgstr "Fichero de datos (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wxMaxima.cpp:9529 ../../src/wxMaxima.cpp:9534
 #: ../../src/wxMaxima.cpp:9539 ../../src/wxMaxima.cpp:9543
@@ -1906,402 +2003,410 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9563 ../../src/wxMaxima.cpp:9577
 #: ../../src/wxMaxima.cpp:9582 ../../src/wxMaxima.cpp:10030
 msgid "Data:"
-msgstr ""
+msgstr "Datos:"
 
 #: ../../src/wxMaximaFrame.cpp:1057
 msgid "Debugger trigger"
-msgstr ""
+msgstr "Disparador de depurador"
 
 #: ../../src/wxMaximaFrame.cpp:779
 msgid "Declare Text to always be displayed as subscript"
-msgstr ""
+msgstr "Declara Texto para siempre estar desplegado como subíndice"
 
 #: ../../src/wxMaxima.cpp:7069
 msgid "Declare a function local to a Program"
-msgstr ""
+msgstr "Declare una función local para un Programa"
 
 #: ../../src/wxMaxima.cpp:6539
 msgid "Declare a text snippet to always be displayed as subscript"
 msgstr ""
+"Declara un fragmento de texto para siempre ser desplegado como subíndice"
 
 #: ../../src/Worksheet.cpp:2044
 #, c-format
 msgid "Declare facts about %s"
-msgstr ""
+msgstr "Declara factores acerca de %s"
 
 #: ../../src/wxMaxima.cpp:8800
 msgid "Declare main variable:"
-msgstr ""
+msgstr "Declara una variable principal:"
 
 #: ../../src/wxMaxima.cpp:7171
 msgid "Declare the type of a function parameter"
-msgstr ""
+msgstr "Declara el tipo de una parámetro de función"
 
 #: ../../src/Worksheet.cpp:2038
 msgid "Declare these chars as ordinary letters"
-msgstr ""
+msgstr "Declara estos caracteres como letras ordinarias"
 
 #: ../../src/wxMaximaFrame.cpp:1500 ../../src/wxMaximaFrame.cpp:1536
 msgid "Decompose rational function to partial fractions"
-msgstr ""
+msgstr "Descomponer función racional en fracciones simples"
 
 #: ../../src/Worksheet.cpp:2010
 msgid "Decreasing function f(x)<x"
-msgstr ""
+msgstr "Decrementa función f(x)<x"
 
 #: ../../src/wxMaxima.cpp:7134
 msgid "Define a function"
-msgstr ""
+msgstr "Define una función"
 
 #: ../../src/wxMaxima.cpp:7147
 msgid "Define a macro"
-msgstr ""
+msgstr "Define una macro"
 
 #: ../../src/wxMaxima.cpp:7189
 msgid "Define a structure"
-msgstr ""
+msgstr "Define una estructura"
 
 #: ../../src/wxMaxima.cpp:7183
 msgid "Define a structure type"
-msgstr ""
+msgstr "Define un tipo estructurado"
 
 #: ../../src/wxMaxima.cpp:7156
 msgid "Define a variable"
-msgstr ""
+msgstr "Define una variable"
 
 #: ../../src/wxMaximaFrame.cpp:1072
 msgid "Define function..."
-msgstr ""
+msgstr "Definir función…"
 
 #: ../../src/wxMaximaFrame.cpp:1079
 msgid "Define macro..."
-msgstr ""
+msgstr "Definir macro…"
 
 #: ../../src/wxMaximaFrame.cpp:1077
 msgid "Define parameter type..."
-msgstr ""
+msgstr "Definir tipo paramétrico…"
 
 #: ../../src/wxMaximaFrame.cpp:1081
 msgid "Define struct..."
-msgstr ""
+msgstr "Definir estructura…"
 
 #: ../../src/wxMaximaFrame.cpp:1080
 msgid "Define variable..."
-msgstr ""
+msgstr "Definir variable…"
 
 #: ../../src/wxMaximaFrame.cpp:1776
 msgid ""
 "Defines if an animation is automatically started or only by clicking on it."
-msgstr ""
+msgstr "Define si una animación está autoiniciada o solo pulsándola."
 
 #: ../../src/wxMaxima.cpp:8935
 msgid "Degree:"
-msgstr ""
+msgstr "Grado:"
 
 #: ../../src/wxMaximaFrame.cpp:985
 msgid "Delete F&unction..."
-msgstr ""
+msgstr "Borrar f&unción…"
 
 #: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
 msgid "Delete Selection"
-msgstr ""
+msgstr "Borrar Selección"
 
 #: ../../src/wxMaximaFrame.cpp:987
 msgid "Delete V&ariable..."
-msgstr ""
+msgstr "Borrar v&ariable…"
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Delete a function"
-msgstr ""
+msgstr "Borra una función"
 
 #: ../../src/wxMaximaFrame.cpp:988
 msgid "Delete a variable"
-msgstr ""
+msgstr "Borra una variable"
 
 #: ../../src/wxMaximaFrame.cpp:982
 msgid "Delete all objects with a given name"
-msgstr ""
+msgstr "Borra todos los objetos con un nombre dado"
 
 #: ../../src/wxMaximaFrame.cpp:991
 msgid "Delete all values from memory"
-msgstr ""
+msgstr "Borra todas las variables de la memoria"
 
 #: ../../src/wxMaxima.cpp:7588
 msgid "Delete file"
-msgstr ""
+msgstr "Borra archivo"
 
 #: ../../src/wxMaximaFrame.cpp:1216
 msgid "Delete file..."
-msgstr ""
+msgstr "Borrar archivo…"
 
 #: ../../src/wxMaxima.cpp:7683
 msgid "Delete function(s)"
-msgstr ""
+msgstr "Borrar función(es)"
 
 #: ../../src/wxMaxima.cpp:7679
 msgid "Delete named object(s)"
-msgstr ""
+msgstr "Borra objeto(s) nombrado(s)"
 
 #: ../../src/wxMaximaFrame.cpp:981
 msgid "Delete named object..."
-msgstr ""
+msgstr "Borrar objeto nombrado…"
 
 #: ../../src/wxMaxima.cpp:7674
 msgid "Delete variable(s)"
-msgstr ""
+msgstr "Borrar variable(s)"
 
 #: ../../src/wxMaxima.cpp:7430
 msgid "Delimiter:"
-msgstr ""
+msgstr "Delimitador:"
 
 #: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
 #, c-format
 msgid "Demo for \"%s\""
-msgstr ""
+msgstr "Demo para \"%s\""
 
 #: ../../src/wxMaximaFrame.cpp:1930
 msgid "Demos"
-msgstr ""
+msgstr "Demos"
 
 #: ../../src/wxMaxima.cpp:8927
 msgid "Denom. deg:"
-msgstr ""
+msgstr "Denom. deg:"
 
 #: ../../src/wxMaxima.cpp:7923
 msgid "Denominator:"
-msgstr ""
+msgstr "Denominador:"
 
 #: ../../src/wxMaximaFrame.cpp:1030
 msgid "Dependencies"
-msgstr ""
+msgstr "Dependencias"
 
 #: ../../src/wxMaxima.cpp:7813
 msgid "Derivate of y at that point:"
-msgstr ""
+msgstr "Derivada de y en ese punto:"
 
 #: ../../src/wxMaximaFrame.cpp:1497
 msgid "Di&vide Polynomials..."
-msgstr ""
+msgstr "Di&vidir polinomios…"
 
 #: ../../src/MaximaManual.cpp:517
 msgid "Didn't find the maxima HTML manual."
-msgstr ""
+msgstr "No encontró el manual HTML de ‘maxima‘."
 
 #: ../../src/wxMaxima.cpp:4907
 msgid ""
 "Didn't get a help browser launch program command line, but can request the "
 "system's default help browser."
 msgstr ""
+"No obtuvo una línea de instrucciones del programa lanzado del examinador de "
+"ayuda, puede solicitar el explorador de ayuda predeterminada del sistema."
 
 #: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
 msgid "Differentiate"
-msgstr ""
+msgstr "Diferencial"
 
 #: ../../src/wxMaximaFrame.cpp:1467
 msgid "Differentiate expression"
-msgstr ""
+msgstr "Expresión diferencial"
 
 #: ../../src/Worksheet.cpp:1590
 msgid "Differentiate..."
-msgstr ""
+msgstr "Diferencial…"
 
 #: ../../src/wxMaxima.cpp:9010
 msgid "Differentiates an expression n times"
-msgstr ""
+msgstr "Diferencia una expresión n veces"
 
 #: ../../src/wxMaxima.cpp:10055
 msgid "Differentiates the expression n times"
-msgstr ""
+msgstr "Diferencia la expresión n veces"
 
 #: ../../src/wxMaximaFrame.cpp:1212
 msgid "Directory operations"
-msgstr ""
+msgstr "Operaciones del directorio"
 
 #: ../../src/wxMaximaFrame.cpp:1041
 msgid "Display Te&X Form"
-msgstr ""
+msgstr "Desplegar formato Te&X"
 
 #: ../../src/wxMaxima.cpp:6972
 msgid "Display algorithm"
-msgstr ""
+msgstr "Desplegar algoritmo"
 
 #: ../../src/wxMaximaFrame.cpp:751
 msgid "Display an expression as maxima's internal lisp representation"
-msgstr ""
+msgstr "Representa una expresión como representación lisp interna de maxima"
 
 #: ../../src/wxMaximaFrame.cpp:754
 msgid "Display an expression as wxMaxima's internal XML representation"
-msgstr ""
+msgstr "Representa una expresión como representación XML interna de wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:758
 msgid "Display equations"
-msgstr ""
+msgstr "Desplegar ecuaciones"
 
 #: ../../src/wxMaxima.cpp:6508
 msgid "Display expression in maxima's internal representation"
-msgstr ""
+msgstr "Despliega expresión en la representación interna de ‘maxima‘"
 
 #: ../../src/wxMaxima.cpp:6514
 msgid "Display expression in wxMaxima's internal representation"
-msgstr ""
+msgstr "Desplegar expresión en la representación interna de wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1042
 msgid "Display last result in TeX form"
-msgstr ""
+msgstr "Desplegar último resultado en formato TeX"
 
 #: ../../src/ToolBar.cpp:360
 #, c-format
 msgid "Display resolution according to wxWidgets: %li x %li ppi"
-msgstr ""
+msgstr "Desplegar resolución de acuerdo con wxWidgets: %li × %li ppp"
 
 #: ../../src/wxMaximaFrame.cpp:802
 msgid "Display string quotation marks"
-msgstr ""
+msgstr "Desplegar marcas de entrecomillado de cadena"
 
 #: ../../src/wxMaximaFrame.cpp:1036
 msgid "Display time used for evaluation"
-msgstr ""
+msgstr "Desplegar tiempo empleado para evaluar"
 
 #: ../../src/wxMaxima.cpp:9206
 msgid "Displayed Precision"
-msgstr ""
+msgstr "Desplegar Precisión"
 
 #: ../../src/wxMaximaFrame.cpp:1913
 msgid "Displaying 3d curves"
-msgstr ""
+msgstr "Desplegando curvas 3D"
 
 #: ../../src/wxMaximaFrame.cpp:1462
 msgid "Dito, and evaluate the result..."
-msgstr ""
+msgstr "Dito, y evalúa el resultado…"
 
 #: ../../src/wxMaximaFrame.cpp:1445
 msgid "Dito, but affect all clones of the Matrix..."
-msgstr ""
+msgstr "Dito, pero afecta todos los clones de la Matriz…"
 
 #: ../../src/wxMaximaFrame.cpp:1255
 msgid "Dito, but as fraction (real only)..."
-msgstr ""
+msgstr "Dito, pero como fracción (solo lectura)…"
 
 #: ../../src/wxMaximaFrame.cpp:1532
 msgid "Dito, including denominator"
-msgstr ""
+msgstr "Dito, incluyendo denominador"
 
 #: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
 msgid "Divide Cell"
-msgstr ""
+msgstr "Dividir Celda"
 
 #: ../../src/wxMaximaFrame.cpp:1498
 msgid "Divide numbers or polynomials"
-msgstr ""
+msgstr "Dividir números o polinomios"
 
 #: ../../src/wxMaxima.cpp:8578
 msgid "Do for each list element"
-msgstr ""
+msgstr "Hace para cada elmento de lista"
 
 #: ../../src/wxMaxima.cpp:11197
 #, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
-msgstr ""
+msgstr "¿Quiere guardar las modificaciones hechas al documento «%s»?"
 
 #: ../../src/wxMaximaFrame.cpp:724
 msgid "Dock all Sidebars"
-msgstr ""
+msgstr "Muelle en todas las barras laterales"
 
 #: ../../src/Configuration.cpp:94
 msgid "Document background"
-msgstr ""
+msgstr "Fondo del documento"
 
 #: ../../src/wxMaxima.cpp:4611
 msgid ""
 "Document was saved using a newer version of wxMaxima so it may not load "
 "correctly. Please update your wxMaxima."
 msgstr ""
+"El documento ha sido guardado empleando una versión más moderna de wxMaxima,"
+" por lo que es posible que no se cargue correctamente. Por favor, actualice "
+"wxMaxima."
 
 #: ../../src/wxMaxima.cpp:4603
 msgid ""
 "Document was saved using a newer version of wxMaxima. Please update your "
 "wxMaxima."
 msgstr ""
+"El documento ha sido guardado empleando una versión más moderna de wxMaxima."
+" Por favor, actualice wxMaxima."
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "Don't autosubscript after an underscore"
-msgstr ""
+msgstr "Nunca autosuscribir tras un guión bajo"
 
 #: ../../src/wxMaximaFrame.cpp:1086
 msgid "Don't evaluate Expression..."
-msgstr ""
+msgstr "No evaluar Expresión…"
 
 #: ../../src/wxMaxima.cpp:7117
 msgid "Don't evaluate one command"
-msgstr ""
+msgstr "No evaluar una instrucción"
 
 #: ../../src/wxMaxima.cpp:7129
 msgid "Don't evaluate one whole expression"
-msgstr ""
+msgstr "No evaluar una extensión completa"
 
 #: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
 msgid "Don't mark cells that contain tooltips in yellow"
-msgstr ""
+msgstr "No marca celdas amarillas que contengan consejos"
 
 #: ../../src/Worksheet.cpp:1938 ../../src/Worksheet.cpp:2070
 msgid "Don't mark this message text in yellow"
-msgstr ""
+msgstr "No marcar este texto del mensaje en amarillo"
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Don't save"
-msgstr ""
+msgstr "No Guardar"
 
 #: ../../src/Worksheet.cpp:1620
 msgid "Don't show labels"
-msgstr ""
+msgstr "No mostrar etiquetas"
 
 #: ../../src/Worksheet.cpp:1979
 msgid "Don't use if unassigned"
-msgstr ""
+msgstr "No utilizar si está desasignado"
 
 #: ../../src/wxMaximaFrame.cpp:797
 msgid "Don't use parenthesis for matrices"
-msgstr ""
+msgstr "No emplee paréntesis para matrices"
 
 #: ../../src/wxMaxima.cpp:8525
 msgid "Drop the first n list elements"
-msgstr ""
+msgstr "Soltar los primeros n elementos del listado"
 
 #: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
 msgid "Drop the last n list elements"
-msgstr ""
+msgstr "Soltar los últimos n elementos del listado"
 
 #: ../../src/wxMaximaFrame.cpp:1306
 msgid "E&quations"
-msgstr ""
+msgstr "Ecuaciones (&Q)"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "E&xit\tCtrl+Q"
-msgstr ""
+msgstr "&Salir\tCtrl+Q"
 
 #: ../../src/wxMaximaFrame.cpp:1368
 msgid "Eige&nvectors"
-msgstr ""
+msgstr "Ve&ctores propios"
 
 #: ../../src/wxMaximaFrame.cpp:1365
 msgid "Eigen&values"
-msgstr ""
+msgstr "&Valores propios"
 
 #: ../../src/wxMaximaFrame.cpp:1387
 msgid "Eigenvalues (complex)"
-msgstr ""
+msgstr "Valores propios (complejo)"
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Eigenvalues (real)"
-msgstr ""
+msgstr "Valores propios (real)"
 
 #: ../../src/wxMaximaFrame.cpp:1393
 msgid "Eigenvalues, left+right eigenvectors (complex)"
-msgstr ""
+msgstr "Valores, Vectores izq.+der. (complejo)"
 
 #: ../../src/wxMaximaFrame.cpp:1390
 msgid "Eigenvalues, left+right eigenvectors (real)"
-msgstr ""
+msgstr "Valores, Vectores izq.+der. (real)"
 
 #: ../../src/wxMaxima.cpp:8584
 msgid ""
@@ -2309,130 +2414,135 @@ msgid ""
 "parenthesis. In the latter case the result of the last expression in the "
 "parenthesis is used."
 msgstr ""
+"O una expresión simple o un listado separada por comas de expresiones entre "
+"paréntesis. Dentro del último caso el resultado de expresión listada dentro "
+"del paréntesis es utilizado."
 
 #: ../../src/wxMaxima.cpp:8593
 msgid "Element"
-msgstr ""
+msgstr "Elemento"
 
 #: ../../src/wxMaxima.cpp:8549
 msgid "Element number"
-msgstr ""
+msgstr "Elemento número"
 
 #: ../../src/wxMaxima.cpp:8005
 msgid ""
 "Element-by-element Product of matrices of the same size (Hadamard product)"
 msgstr ""
+"Elemento-por-elemento Producto de matrices del mismo tamaño (producto "
+"Hadamard)"
 
 #: ../../src/wxMaxima.cpp:8012
 msgid "Element-by-element exponentiation of two matrices"
-msgstr ""
+msgstr "Exponenciación elemento-por-elemento de dos matrices"
 
 #: ../../src/wxMaximaFrame.cpp:1342
 msgid "Element-by-element multiplication"
-msgstr ""
+msgstr "Multiplicación elemento-por-elemento"
 
 #: ../../src/wxMaxima.cpp:8510
 msgid "Element:"
-msgstr ""
+msgstr "Elemento:"
 
 #: ../../src/wxMaxima.cpp:7204
 msgid "Elements:"
-msgstr ""
+msgstr "Elementos:"
 
 #: ../../src/wxMaxima.cpp:7847
 msgid "Eliminate a variable"
-msgstr ""
+msgstr "Elimina una variable"
 
 #: ../../src/wxMaximaFrame.cpp:1247
 msgid "Eliminate a variable from a system of equations"
-msgstr ""
+msgstr "Elimina una variable de un sistema de ecuaciones"
 
 #: ../../src/wxMaxima.cpp:10651
 msgid "Empty command => re-triggering evaluation"
-msgstr ""
+msgstr "Instrucción vacía ⇒ evaluación re-disparada"
 
 #: ../../src/wxMaxima.cpp:9225
 msgid "Enable:"
-msgstr ""
+msgstr "Habilitar:"
 
 #: ../../src/MathParser.cpp:99
 #, c-format
 msgid "Encountered an unknown XML tag: <%s>"
-msgstr ""
+msgstr "Encontrado una etiqueta XML desconocida: <%s>"
 
 #: ../../src/wxMaxima.cpp:2476
 msgid "Encountered an unknown socket event."
-msgstr ""
+msgstr "Encontrado una evento de zócalo desconocida."
 
 #: ../../src/wxMaxima.cpp:7843
 msgid "End of t:"
-msgstr ""
+msgstr "Final de t:"
 
 #: ../../src/wxMaxima.cpp:4097
 msgid "Ended lisp mode after receiving a maxima prompt!"
-msgstr ""
+msgstr "¡Modo de lisp finalizado recibiendo una petición de ‘maxima’!"
 
 #: ../../src/wxMaximaFrame.cpp:1828
 msgid "Engineering format (12.1e6 etc.)"
-msgstr ""
+msgstr "Formato de ingeniería  (12.1e6 etc.)"
 
 #: ../../src/wxMaximaFrame.cpp:1319
 msgid "Enter a matrix"
-msgstr ""
+msgstr "Introduzca una matriz"
 
 #: ../../src/wxMaxima.cpp:8866
 msgid "Enter an equation for rational simplification:"
-msgstr ""
+msgstr "Introduce una ecuación para simplificación racional:"
 
 #: ../../src/wxMaxima.cpp:8169
 msgid "Enter matrix"
-msgstr ""
+msgstr "Introducir matriz"
 
 #: ../../src/wxMaxima.cpp:9095
 msgid "Enter new animation frame rate [Hz, integer]:"
-msgstr ""
+msgstr "Introduzca una diapositiva animada [Hz, entero]"
 
 #: ../../src/wxMaxima.cpp:9201
 msgid "Enter new precision for bigfloats:"
-msgstr ""
+msgstr "Introduzca una nueva precisión para reales grandes:"
 
 #: ../../src/wxMaxima.cpp:7922
 msgid "Enumerator:"
-msgstr ""
+msgstr "Iterador:"
 
 #: ../../src/wxMaximaFrame.cpp:1220
 msgid "Environment variables"
-msgstr ""
+msgstr "Variables del entorno"
 
 #: ../../src/wxMaxima.cpp:9045
 msgid "Epsilon:"
-msgstr ""
+msgstr "Épsilon:"
 
 #: ../../src/wxMaximaFrame.cpp:1124 ../../src/wxMaximaFrame.cpp:1135
 msgid "Equal, ignoring case?..."
-msgstr ""
+msgstr "¿Igual, ignorando MAYUS/minus?…"
 
 #: ../../src/wxMaximaFrame.cpp:1133
 msgid "Equal?..."
-msgstr ""
+msgstr "¿Igual?…"
 
 #: ../../src/wxMaxima.cpp:8561
 msgid "Equation"
-msgstr ""
+msgstr "Ecuación"
 
 #: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
 msgid "Equation(s)"
-msgstr ""
+msgstr "Ecuación(es)"
 
 #: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
 msgid "Equation(s):"
-msgstr ""
+msgstr "Ecuación(s):"
 
 #: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
 #: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
 #: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
 msgid "Equation:"
-msgstr ""
+msgstr "Ecuación:"
 
 #: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
 #: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
@@ -2444,22 +2554,22 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
 #: ../../src/wxMaxima.cpp:11166
 msgid "Error"
-msgstr ""
+msgstr "Error"
 
 #: ../../src/wxMaxima.cpp:2456
 msgid "Error writing to Maxima"
-msgstr ""
+msgstr "Error al escribir a ‘Maxima’"
 
 #: ../../src/wxMaxima.cpp:6164 ../../src/wxMaxima.cpp:6176
 #: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
 #: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
 msgid "Error!"
-msgstr ""
+msgstr "¡Error!"
 
 #: ../../src/Image.cpp:696
 #, c-format
 msgid "Error: Cannot render %s."
-msgstr ""
+msgstr "Error: no se puede interpretar %s."
 
 #: ../../src/Image.cpp:699
 #, c-format
@@ -2467,10 +2577,12 @@ msgid ""
 "Error: Cannot render %s:\n"
 "%s"
 msgstr ""
+"Error: no se puede representar %s:\n"
+"%s"
 
 #: ../../src/Image.cpp:704
 msgid "Error: Cannot render the image."
-msgstr ""
+msgstr "Error: no se puede interpretar la imagen."
 
 #: ../../src/Image.cpp:706
 #, c-format
@@ -2478,248 +2590,254 @@ msgid ""
 "Error: Cannot render the image:\n"
 "%s"
 msgstr ""
+"Error: no se puede representar la imagen:\n"
+"%s"
 
 #: ../../src/wxMaxima.cpp:7544
 msgid ""
 "Escapes all special characters in a string. The result is a regex that "
 "matches this string exactly."
 msgstr ""
+"Escape a todos los caracteres especiales en una cadena. El resultado es una "
+"expreg que coincida esta cadena exactamente."
 
 #: ../../src/wxMaximaFrame.cpp:1652
 msgid "Evaluate &Noun Forms..."
-msgstr ""
+msgstr "Evaluar formas &nominales…"
 
 #: ../../src/wxMaximaFrame.cpp:856
 msgid "Evaluate All Cells\tCtrl+Shift+R"
-msgstr ""
+msgstr "Evaluar todas las celdas\tCtrl+Mayús+R"
 
 #: ../../src/wxMaximaFrame.cpp:851
 msgid "Evaluate All Visible Cells\tCtrl+R"
-msgstr ""
+msgstr "Evaluar todas las celdas visibles\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1395
+#, fuzzy
 msgid "Evaluate Cell"
-msgstr ""
+msgstr "Evaluar Celda(s)"
 
 #: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
 msgid "Evaluate Cell(s)"
-msgstr ""
+msgstr "Evaluar Celda(s)"
 
 #: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
 msgid "Evaluate Cells Above"
-msgstr ""
+msgstr "Evaluar Celdas Superiores"
 
 #: ../../src/wxMaximaFrame.cpp:866
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
-msgstr ""
+msgstr "Evaluar celdas superiores\tCtrl+Mayús+P"
 
 #: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
 #: ../../src/wxMaximaFrame.cpp:876
 msgid "Evaluate Cells Below"
-msgstr ""
+msgstr "Evaluar Celdas Inferiores"
 
 #: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
 #: ../../src/Worksheet.cpp:1890
 msgid "Evaluate Heading 5\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Evaluar Cabecera 5\tMayús+Ctrl+Intro"
 
 #: ../../src/Worksheet.cpp:1457 ../../src/Worksheet.cpp:1761
 #: ../../src/Worksheet.cpp:1901
 msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Evaluar Cabecera 6\tMayús+Ctrl+Intro"
 
 #: ../../src/wxMaxima.cpp:8626
 msgid "Evaluate Nouns"
-msgstr ""
+msgstr "Evaluar Nominales"
 
 #: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
 msgid "Evaluate Part\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Evaluar parte\tMayús+Ctrl+Intro"
 
 #: ../../src/Worksheet.cpp:1431 ../../src/Worksheet.cpp:1741
 msgid "Evaluate Section\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Evaluar sección\t\tMayús+Ctrl+Intro"
 
 #: ../../src/Worksheet.cpp:1445 ../../src/Worksheet.cpp:1751
 #: ../../src/Worksheet.cpp:1879
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Evaluar sub-subsección\tMayús+Ctrl+Intro"
 
 #: ../../src/Worksheet.cpp:1438 ../../src/Worksheet.cpp:1746
 #: ../../src/Worksheet.cpp:1868
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Evaluar subsección\tMayús+Ctrl+Intro"
 
 #: ../../src/wxMaximaFrame.cpp:845
 msgid "Evaluate active or selected cell(s)"
-msgstr ""
+msgstr "Evalúa celda(s) activas o seleccionada"
 
 #: ../../src/ToolBar.cpp:251
 msgid "Evaluate all"
-msgstr ""
+msgstr "Evaluar todo"
 
 #: ../../src/wxMaximaFrame.cpp:857
 msgid "Evaluate all cells in the document"
-msgstr ""
+msgstr "Evalúa todas las celdas del documento"
 
 #: ../../src/wxMaximaFrame.cpp:1653
 msgid "Evaluate all noun forms in expression"
-msgstr ""
+msgstr "Evalúa todas las formas nominales en una expresión"
 
 #: ../../src/wxMaximaFrame.cpp:852
 msgid "Evaluate all visible cells in the document"
-msgstr ""
+msgstr "Evalúa todas las celdas visibles del documento"
 
 #: ../../src/ToolBar.cpp:248
 msgid "Evaluate current cell"
-msgstr ""
+msgstr "Evaluar celda actual"
 
 #: ../../src/wxMaxima.cpp:7395
 msgid "Evaluate string"
-msgstr ""
+msgstr "Evalúa cadena"
 
 #: ../../src/wxMaximaFrame.cpp:1151
 msgid "Evaluate string..."
-msgstr ""
+msgstr "Evaluar cadena…"
 
 #: ../../src/ToolBar.cpp:256
 msgid "Evaluate the file from its beginning to the cell above the cursor"
-msgstr ""
+msgstr "Evalúa el fichero desde su comienzo hasta la celda sobre el cursor"
 
 #: ../../src/ToolBar.cpp:259
 msgid "Evaluate the file from the cursor to its end"
-msgstr ""
+msgstr "Evaluar el listado desde el cursor hasta si final"
 
 #: ../../src/ToolBar.cpp:258
 msgid "Evaluate the rest"
-msgstr ""
+msgstr "Evalúa el resto"
 
 #: ../../src/ToolBar.cpp:255
 msgid "Evaluate to point"
-msgstr ""
+msgstr "Evaluar hasta el punto"
 
 #: ../../src/wxMaxima.cpp:10518
 msgid "Evaluation ended, since evaluation queue is empty."
-msgstr ""
+msgstr "Evaluación finalizada, ya que la cola de evaluación está vacía."
 
 #: ../../src/Worksheet.cpp:1957
 msgid "Even number"
-msgstr ""
+msgstr "Número par"
 
 #: ../../src/wxMaximaFrame.cpp:1703
 msgid "Execute a command for each element of the list"
-msgstr ""
+msgstr "Ejecuta una instrucción para cada elemento del listado"
 
 #: ../../src/main.cpp:438
 msgid "Exit"
-msgstr ""
+msgstr "Salir"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "Exit wxMaxima"
-msgstr ""
+msgstr "Salir de wxMaxima"
 
 #: ../../src/Worksheet.cpp:1583
 msgid "Expand Expression"
-msgstr ""
+msgstr "Expandir Expresión"
 
 #: ../../src/wxMaximaFrame.cpp:1525
 msgid "Expand an expression"
-msgstr ""
+msgstr "Expande una expresión"
 
 #: ../../src/wxMaximaFrame.cpp:1531
 msgid "Expand for given variables"
-msgstr ""
+msgstr "Expande para variables dadas"
 
 #: ../../src/wxMaxima.cpp:8781
 msgid "Expand for variable(s) including denominator:"
-msgstr ""
+msgstr "Expande para variable(s) incluyendo denominador:"
 
 #: ../../src/wxMaxima.cpp:8716
 msgid "Expand for variable(s):"
-msgstr ""
+msgstr "Expande para variable(s):"
 
 #: ../../src/wxMaximaFrame.cpp:1545
 msgid "Expand log in previous expression"
-msgstr ""
+msgstr "Expande logaritmo en expresión anterior"
 
 #: ../../src/wxMaximaFrame.cpp:1598
 msgid "Expand trigonometric expression"
-msgstr ""
+msgstr "Expande expresión trigonométrica"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Expect numbers harder to be complex"
-msgstr ""
+msgstr "Espera números más difíciles de ser complejos"
 
 #: ../../src/wxMaximaFrame.cpp:1789
 msgid "Expect variables to contain complex numbers"
-msgstr ""
+msgstr "Espera variables para contener números complejos"
 
 #: ../../src/wxMaxima.cpp:6121
 msgid "Export"
-msgstr ""
+msgstr "Exportar"
 
 #: ../../src/wxMaximaFrame.cpp:1705
 msgid "Export List to csv file..."
-msgstr ""
+msgstr "Exportar Listado al archivo csv…"
 
 #: ../../src/wxMaximaFrame.cpp:1706
 msgid "Export a list to a csv file"
-msgstr ""
+msgstr "Exporta un listado a un fichero cvs"
 
 #: ../../src/wxMaximaFrame.cpp:1332
 msgid "Export a matrix to a csv file"
-msgstr ""
+msgstr "Exporta una matriz a un fichero csv"
 
 #: ../../src/wxMaximaFrame.cpp:619
 msgid "Export document to a HTML or LaTeX file"
-msgstr ""
+msgstr "Exportar documento a un fichero HTML o LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:579
 msgid "Export failed."
-msgstr ""
+msgstr "Exportación fallada."
 
 #: ../../src/wxMaximaFrame.cpp:567
 msgid "Export successful."
-msgstr ""
+msgstr "Exportación correcta."
 
 #: ../../src/wxMaxima.cpp:6187
 msgid "Exporting to HTML failed!"
-msgstr ""
+msgstr "¡Ha fallado la exportación a HTML!"
 
 #: ../../src/wxMaxima.cpp:6164
 msgid "Exporting to TeX failed!"
-msgstr ""
+msgstr "¡Ha fallado la exportación a TeX!"
 
 #: ../../src/wxMaxima.cpp:6175
 msgid "Exporting to maxima batch file failed!"
-msgstr ""
+msgstr "¡Ha fallado la exportación a fichero por lotes de ‘maxima’!"
 
 #: ../../src/wxMaximaFrame.cpp:561
 msgid "Exporting..."
-msgstr ""
+msgstr "Exportando…"
 
 #: ../../src/wxMaxima.cpp:6510 ../../src/wxMaxima.cpp:6516
 #: ../../src/wxMaxima.cpp:8218 ../../src/wxMaxima.cpp:8633
 #: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
 #: ../../src/wxMaxima.cpp:10065
 msgid "Expression"
-msgstr ""
+msgstr "Expresión"
 
 #: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
 msgid "Expression or a list of comma-separated expressions"
-msgstr ""
+msgstr "Expresión o una enumeración de expresiones separadas por coma"
 
 #: ../../src/wxMaximaFrame.cpp:1088
 msgid "Expression to string..."
-msgstr ""
+msgstr "Expresión a cadena…"
 
 #: ../../src/wxMaxima.cpp:7113
 msgid "Expression whose output is to be used as maxima's input."
 msgstr ""
+"Expresión cuya salida está para ser utilizada como entrada de ‘maxima‘."
 
 #: ../../src/wxMaxima.cpp:7214
 msgid "Expression(s):"
-msgstr ""
+msgstr "Expresión(es):"
 
 #: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
 #: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
@@ -2728,385 +2846,392 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
 #: ../../src/wxMaxima.cpp:10056
 msgid "Expression:"
-msgstr ""
+msgstr "Expresión:"
 
 #: ../../src/wxMaximaFrame.cpp:1423
 msgid "Extract Column..."
-msgstr ""
+msgstr "Extraer columna…"
 
 #: ../../src/wxMaximaFrame.cpp:1726
 msgid "Extract Elements"
-msgstr ""
+msgstr "Extraer elementos"
 
 #: ../../src/wxMaximaFrame.cpp:1421
 msgid "Extract Row..."
-msgstr ""
+msgstr "Extraer fila…"
 
 #: ../../src/wxMaximaFrame.cpp:1424
 msgid "Extract a column from the matrix"
-msgstr ""
+msgstr "Extrae una columna desde la matriz"
 
 #: ../../src/wxMaximaFrame.cpp:1435
 msgid "Extract a column from the matrix and convert it to a list"
-msgstr ""
+msgstr "Extrae una columna desde la matriz y la convierte en un listado"
 
 #: ../../src/wxMaxima.cpp:7960
 msgid "Extract a matrix column"
-msgstr ""
+msgstr "Extrae una columna matricial"
 
 #: ../../src/wxMaxima.cpp:7970
 msgid "Extract a matrix column as a list"
-msgstr ""
+msgstr "Extrae una columna matricial como un listado"
 
 #: ../../src/wxMaximaFrame.cpp:1313
 msgid "Extract a matrix from a 2-dimensional array"
-msgstr ""
+msgstr "Extrae una matriz a partir de un repertorio de 2 dimensiones"
 
 #: ../../src/wxMaxima.cpp:7955
 msgid "Extract a matrix row"
-msgstr ""
+msgstr "Extrae una fila de matriz"
 
 #: ../../src/wxMaxima.cpp:7965
 msgid "Extract a matrix row as a list"
-msgstr ""
+msgstr "Extrae una fila de matriz como un listado"
 
 #: ../../src/wxMaximaFrame.cpp:1422
 msgid "Extract a row from the matrix"
-msgstr ""
+msgstr "Extrae una fila desde la matriz"
 
 #: ../../src/wxMaximaFrame.cpp:1431
 msgid "Extract a row from the matrix and convert it to a list"
-msgstr ""
+msgstr "Extrae una fila desde la matriz y la convierte a un listado"
 
 #: ../../src/wxMaxima.cpp:8564
 msgid "Extract a variable's value from a list of variable values"
-msgstr ""
+msgstr "Extrae un valor de variable desde un listado de valores variables"
 
 #: ../../src/wxMaximaFrame.cpp:1723
 msgid "Extract an actual value for a variable"
-msgstr ""
+msgstr "Extrae un valor actual para una variable"
 
 #: ../../src/wxMaximaFrame.cpp:1163
 msgid "Extract char..."
-msgstr ""
+msgstr "Extraer carácter…"
 
 #: ../../src/wxMaximaFrame.cpp:1207
 msgid "Extract dir from path..."
-msgstr ""
+msgstr "Extraer un dir desde ruta…"
 
 #: ../../src/wxMaxima.cpp:7605
 msgid "Extract directory part"
-msgstr ""
+msgstr "Extrae parte de directorio"
 
 #: ../../src/wxMaxima.cpp:7617
 msgid "Extract file type extension"
-msgstr ""
+msgstr "Extraer extensión del tipo de archivo"
 
 #: ../../src/wxMaximaFrame.cpp:1209
 msgid "Extract filename from path..."
-msgstr ""
+msgstr "Extraer un nombre de archivo desde ruta…"
 
 #: ../../src/wxMaxima.cpp:7611
 msgid "Extract filename part"
-msgstr ""
+msgstr "Extraer parte de nombre del archivo"
 
 #: ../../src/wxMaximaFrame.cpp:1211
 msgid "Extract filetype from path..."
-msgstr ""
+msgstr "Extraer un tipo de archivo desde ruta…"
 
 #: ../../src/wxMaxima.cpp:8445
 msgid "Extract function arguments"
-msgstr ""
+msgstr "Extrae argumentos de función"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "Extract list Elements"
-msgstr ""
+msgstr "Extraer Elementos de lista"
 
 #: ../../src/wxMaxima.cpp:8187
 msgid "Extract matrix from 2D array"
-msgstr ""
+msgstr "Extrae matriz desde repertorio de 2D"
 
 #: ../../src/wxMaximaFrame.cpp:1686
 msgid "Extract the argument list from a function call"
-msgstr ""
+msgstr "Extrae el listado de argumento desde una invocación a función"
 
 #: ../../src/wxMaxima.cpp:8538
 msgid "Extract the last n elements from a list"
-msgstr ""
+msgstr "Extrae los últimos n elementos desde un listado"
 
 #: ../../src/wxMaxima.cpp:7376
 msgid "Extract the nth char of a string"
-msgstr ""
+msgstr "Extrae el n-ésimo carácter de una cadena"
 
 #: ../../src/wxMaxima.cpp:8544
 msgid "Extract the nth list elements"
-msgstr ""
+msgstr "Extrae el n-ésimo listado de elementos"
 
 #: ../../src/wxMaximaFrame.cpp:1724
 msgid "Extract the value for one variable assigned in a list"
-msgstr ""
+msgstr "Extraer el valor para una variable asignada dentro de un listado"
 
 #: ../../src/wxMaximaFrame.cpp:1439
 msgid "Extract, append or delete rows or columns"
-msgstr ""
+msgstr "Extrae, adjunta o borra filas o columnas"
 
 #: ../../src/wxMaxima.cpp:8188
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
 msgstr ""
+"Extrae un rectángulo desde un repertorio de 2D y lo convierte a una matriz"
 
 #: ../../src/wxMaximaFrame.cpp:1521
 msgid "Factor Complex"
-msgstr ""
+msgstr "Factorización compleja"
 
 #: ../../src/Worksheet.cpp:1581
 msgid "Factor Expression"
-msgstr ""
+msgstr "Factorizar Expresión"
 
 #: ../../src/wxMaximaFrame.cpp:1519
 msgid "Factor Expression including subexpressions"
-msgstr ""
+msgstr "Expresión Factorial incluyendo sub-expresiones"
 
 #: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
 msgid "Factor an expression"
-msgstr ""
+msgstr "Factorizar una expresión"
 
 #: ../../src/wxMaximaFrame.cpp:1522
 msgid "Factor an expression in Gaussian numbers"
-msgstr ""
+msgstr "Factorizar una expresión en números gausianos"
 
 #: ../../src/wxMaximaFrame.cpp:1587
 msgid "Factorials and &Gamma"
-msgstr ""
+msgstr "Factoriales y &Gamma"
 
 #: ../../src/Image.cpp:137
 #, c-format
 msgid "Failed to delete gnuplot data file %s"
-msgstr ""
+msgstr "Fallo al borrar el archivo %s de datos gnuplot"
 
 #: ../../src/Image.cpp:121 ../../src/Image.cpp:128
 #, c-format
 msgid "Failed to delete gnuplot file %s"
-msgstr ""
+msgstr "Fallo al borrar el archivo %s de gnuplot"
 
 #: ../../src/wxMaxima.cpp:2667
+#, fuzzy
 msgid "Failed to start Maxima"
-msgstr ""
+msgstr "Reiniciar ‘Maxima’"
 
 #: ../../src/wxMaximaFrame.cpp:1418
 msgid "Fast fortran routines that perform numerical tasks"
-msgstr ""
+msgstr "Rutinas rápidas de Fortran que realizan tareas numéricas"
 
 #: ../../src/wxMaximaFrame.cpp:1922
 msgid "Fast list access"
-msgstr ""
+msgstr "Listado de accesos rápido"
 
 #: ../../src/wxMaxima.cpp:2553
 msgid "Fatal error"
-msgstr ""
+msgstr "Error fatal"
 
 #: ../../src/wxMaxima.cpp:7191
 msgid "Field contents:"
-msgstr ""
+msgstr "Contenido de campo:"
 
 #: ../../src/wxMaxima.cpp:7198
 msgid "Field name:"
-msgstr ""
+msgstr "Nombre del campo:"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "Fields:"
-msgstr ""
+msgstr "Campos:"
 
 #: ../../src/main.cpp:439
 msgid "File"
-msgstr ""
+msgstr "Fichero"
 
 #: ../../src/wxMaximaFrame.cpp:1333
 msgid "File I/O"
-msgstr ""
+msgstr "E/S de archivo"
 
 #: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
 #: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
 #: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
 #: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
 msgid "File could not be opened"
-msgstr ""
+msgstr "El fichero no se ha podido abrir"
 
 #: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
 #: ../../src/wxMaxima.cpp:7251
 msgid "File name:"
-msgstr ""
+msgstr "Nombre de fichero:"
 
 #: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
 msgid "File not found"
-msgstr ""
+msgstr "Fichero no encontrado"
 
 #: ../../src/wxMaxima.cpp:5631
 msgid "File opened"
-msgstr ""
+msgstr "Fichero abierto"
 
 #: ../../src/wxMaximaFrame.cpp:1217
 msgid "File operations"
-msgstr ""
+msgstr "Operaciones de archivo"
 
 #: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
 msgid "File you tried to open does not exist."
-msgstr ""
+msgstr "El fichero que ha intentado abrir no existe."
 
 #: ../../src/wxMaximaFrame.cpp:1221
+#, fuzzy
 msgid "File/directory functions"
-msgstr ""
+msgstr "Operaciones del directorio"
 
 #: ../../src/wxMaxima.cpp:7027
 msgid "Filename or a list of comma-separated file names"
 msgstr ""
+"Nombre de archivo o un listado de nombres de archivos separados por comas"
 
 #: ../../src/ToolBar.cpp:222
 msgid "Find"
-msgstr ""
+msgstr "Encontrar"
 
 #: ../../src/wxMaximaFrame.cpp:670
 msgid "Find\tCtrl+F"
-msgstr ""
+msgstr "Encontrar\tCtrl+F"
 
 #: ../../src/wxMaximaFrame.cpp:1468
 msgid "Find &Limit..."
-msgstr ""
+msgstr "Calcular &límite…"
 
 #: ../../src/wxMaximaFrame.cpp:1470
 msgid "Find Minimum..."
-msgstr ""
+msgstr "Calcular mínimo…"
 
 #: ../../src/Worksheet.cpp:1576
 msgid "Find Root..."
-msgstr ""
+msgstr "Calcular raíz…"
 
 #: ../../src/wxMaximaFrame.cpp:1471
 msgid "Find a (unconstrained) minimum of an expression"
-msgstr ""
+msgstr "Encuentra un mínimo (sin restricciones) de una expresión"
 
 #: ../../src/wxMaximaFrame.cpp:1804
 msgid "Find a fraction that represents this float exactly"
-msgstr ""
+msgstr "Encuentra una fracción que representa este flotante exactamente"
 
 #: ../../src/wxMaximaFrame.cpp:1469
 msgid "Find a limit of an expression"
-msgstr ""
+msgstr "Encuentra un límite de una expresión"
 
 #: ../../src/wxMaximaFrame.cpp:1807
 msgid "Find a nice fraction that is similar to this float"
-msgstr ""
+msgstr "Encuentra una fracción buena que es similar a este flotante"
 
 #: ../../src/wxMaximaFrame.cpp:1283
 msgid "Find a numerical solution for a first degree ODE"
-msgstr ""
+msgstr "Encuentra una solución numérica para un primer grado de EDO"
 
 #: ../../src/wxMaximaFrame.cpp:1252
 msgid "Find a root of an equation on an interval"
-msgstr ""
+msgstr "Encuentra una raíz de una ecuación en un intervalo"
 
 #: ../../src/wxMaximaFrame.cpp:1259
 msgid "Find all roots of a polynomial"
-msgstr ""
+msgstr "Encuentra todas las raíces de un polinomio"
 
 #: ../../src/wxMaximaFrame.cpp:1262
 msgid "Find all roots of a polynomial (bfloat)"
-msgstr ""
+msgstr "Encuentra todas las raíces reales de un polinomio (real doble)"
 
 #: ../../src/wxMaxima.cpp:6589
 msgid "Find and Replace"
-msgstr ""
+msgstr "Encontrar y Sustituir"
 
 #: ../../src/ToolBar.cpp:222 ../../src/wxMaximaFrame.cpp:670
 msgid "Find and replace"
-msgstr ""
+msgstr "Encuentra y sustituye"
 
 #: ../../src/wxMaxima.cpp:7434
 msgid "Find char in string"
-msgstr ""
+msgstr "Encuentra carácter dentro de cadena"
 
 #: ../../src/wxMaximaFrame.cpp:1172
 msgid "Find char in string..."
-msgstr ""
+msgstr "Encontrar carácter dentro de cadena…"
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Find common denominator"
-msgstr ""
+msgstr "Encontrar denominador común"
 
 #: ../../src/wxMaximaFrame.cpp:1366
 msgid "Find eigenvalues of a matrix"
-msgstr ""
+msgstr "Encuentra los valores propios de una matriz"
 
 #: ../../src/wxMaximaFrame.cpp:1369
 msgid "Find eigenvectors of a matrix"
-msgstr ""
+msgstr "Encuentra los vectores propios de una matriz"
 
 #: ../../src/wxMaxima.cpp:7424
 msgid "Find first difference"
-msgstr ""
+msgstr "Encuentra la primera diferencia"
 
 #: ../../src/wxMaximaFrame.cpp:1170
 msgid "Find first difference..."
-msgstr ""
+msgstr "Encontrar primera diferencia…"
 
 #: ../../src/wxMaximaFrame.cpp:1256
 msgid "Find fractions that real roots of a polynomial and "
-msgstr ""
+msgstr "Encuentra fracciones que las raíces reales de un polinomio y "
 
 #: ../../src/wxMaxima.cpp:9039
 msgid "Find minimum"
-msgstr ""
+msgstr "Encuentra mínimo"
 
 #: ../../src/wxMaximaFrame.cpp:1251
 msgid "Find numerical solution..."
-msgstr ""
+msgstr "Encontrar solución numérica…"
 
 #: ../../src/wxMaxima.cpp:10035
 msgid "Find root (solve numerically)"
-msgstr ""
+msgstr "Encontrar raíz (resolver numéricamente)"
 
 #: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
 msgid "Find the maximum absolute value of a matrix entry"
-msgstr ""
+msgstr "Encuentra el valor absoluto máximo de un apunte de matriz"
 
 #: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
 msgid "Find the maximum sum of the absolute values of a matrix column"
 msgstr ""
+"Encuentra el sumatorio máximo de los valores absolutos de una columna de "
+"matriz"
 
 #: ../../src/wxMaxima.cpp:8073 ../../src/wxMaxima.cpp:8094
 msgid "Find the maximum sum of the absolute values of a matrix row"
 msgstr ""
+"Encuentra el sumatorio máximo de los valores absolutos de una fila de matriz"
 
 #: ../../src/wxMaximaFrame.cpp:1832
 msgid "Fine-tune the display of engineering-format numbers"
-msgstr ""
+msgstr "Ajuste fino del despliegue de números en formato de ingeniería"
 
 #: ../../src/wxMaximaFrame.cpp:1712
 msgid "First"
-msgstr ""
+msgstr "Primero"
 
 #: ../../src/wxMaximaFrame.cpp:1918
 msgid "Fitting curves to measurement data"
-msgstr ""
+msgstr "Ajustando curvas a medición de datos"
 
 #: ../../src/wxMaxima.cpp:7227
 msgid "Flush stream"
-msgstr ""
+msgstr "Purgar flujo"
 
 #: ../../src/wxMaximaFrame.cpp:1103
 msgid "Flush..."
-msgstr ""
+msgstr "Purgar…"
 
 #: ../../src/wxMaximaFrame.cpp:922
 msgid "Fold All\tCtrl+Alt+["
-msgstr ""
+msgstr "Encarpetar todo\tCtrl+Alt+["
 
 #: ../../src/wxMaximaFrame.cpp:923
 msgid "Fold all sections"
-msgstr ""
+msgstr "Encarpeta todas las secciones"
 
 #: ../../src/ToolBar.cpp:240
 msgid "Follow"
-msgstr ""
+msgstr "Seguir"
 
 #: ../../src/ToolBar.cpp:285
 msgid ""
@@ -3121,123 +3246,138 @@ msgid ""
 "   Ctrl+6: Heading5 cell\n"
 "   Ctrl+7: Heading6 cell\n"
 msgstr ""
+"Para una creación más rápida de celdas existe los enlaces siguientes:\n"
+"\n"
+"  Ctrl+0: Celda matemática\n"
+"  Ctrl+1: Celda textual\n"
+"  Ctrl+2: Celda titular\n"
+"  Ctrl+3: Celda seccional\n"
+"  Ctrl+4: Celda subseccional\n"
+"  Ctrl+5: Celda Sub-subseccional\n"
+"  Ctrl+6: Celda Cabecera5\n"
+"  Ctrl+7: Celda Cabecera6\n"
 
 #: ../../src/wxMaxima.cpp:7038
 msgid "For loop"
-msgstr ""
+msgstr "Para bucle"
 
 #: ../../src/wxMaximaFrame.cpp:1062
 msgid "For loop..."
-msgstr ""
+msgstr "Para bucle…"
 
 #: ../../src/Worksheet.cpp:237 ../../src/wxMaxima.cpp:11217
 msgid "Forwarding the keyboard focus to a text control"
-msgstr ""
+msgstr "Continuando el foco del teclado a un control de texto"
 
 #: ../../src/wxMaxima.cpp:11220
 msgid "Forwarding the keyboard focus to the worksheet"
-msgstr ""
+msgstr "Continuando el foco del teclado a una hoja de trabajo"
 
 #: ../../src/MaximaManual.cpp:452
 #, c-format
 msgid ""
 "Found %li anchors, URLs (individual files): %li, URLs (singlepage): %li"
 msgstr ""
+"Ha encontrado %li anclas, las URL (archivos individuales): %li, URL (página "
+"única): %li"
 
 #: ../../src/MaximaManual.cpp:313
 #, c-format
 msgid "Found only %li keywords in maxima's manual. Not caching them to disc."
 msgstr ""
+"Solamente %li palabras clave encontradas dentro del manual de ‘maxima’.  No "
+"se cachea al disco."
 
 #: ../../src/MaximaManual.cpp:513
 #, c-format
 msgid "Found the maxima HTML manual in the folder %s."
-msgstr ""
+msgstr "Encontrado el manual HTML de ‘maxima‘ en la carpeta %s."
 
 #: ../../src/wxMaxima.cpp:8948
 msgid "Fourier coefficients"
-msgstr ""
+msgstr "Coeficientes de Fourier"
 
 #: ../../src/wxMaximaFrame.cpp:1476
 msgid "Fourier coefficients..."
-msgstr ""
+msgstr "Coeficientes de Fourier…"
 
 #: ../../src/ToolBar.cpp:137
 #, c-format
 msgid "Frame %li of %li"
-msgstr ""
+msgstr "Marco %li de %li"
 
 #: ../../src/wxMaxima.cpp:9097
 msgid "Frame rate"
-msgstr ""
+msgstr "Tipo de marco"
 
 #: ../../src/wxMaximaFrame.cpp:1005 ../../src/wxMaximaFrame.cpp:1009
 msgid "Free all unused items now"
-msgstr ""
+msgstr "Libera todos los ítemes no utilizado ahora"
 
 #: ../../src/wxMaximaFrame.cpp:1413
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
-msgstr ""
+msgstr "Frobenius Normal sqrt(sum((A(i,j))^2)) (complejo)"
 
 #: ../../src/wxMaximaFrame.cpp:1411
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (real)"
-msgstr ""
+msgstr "Frobenius Normal sqrt(sum((A(i,j))^2)) (real)"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "From:"
-msgstr ""
+msgstr "Origen:"
 
 #: ../../src/wxMaximaFrame.cpp:827
+#, fuzzy
 msgid "Full Screen\tAlt+Enter"
-msgstr ""
+msgstr "Pantalla completa\tAlt+Intro"
 
 #: ../../src/wxMaximaFrame.cpp:824
 msgid "Full Screen\tF11"
-msgstr ""
+msgstr "Pantalla Completa\tF11"
 
 #: ../../src/wxMaxima.cpp:7140
 msgid "Function contents:"
-msgstr ""
+msgstr "Contenido de función:"
 
 #: ../../src/wxMaxima.cpp:7908
 msgid "Function f(x):"
-msgstr ""
+msgstr "Función f(x):"
 
 #: ../../src/wxMaxima.cpp:8572
 msgid "Function name"
-msgstr ""
+msgstr "Nombre de función"
 
 #: ../../src/wxMaxima.cpp:7167
 msgid "Function name(s):"
-msgstr ""
+msgstr "Nombre(s) de función:"
 
 #: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
 msgid "Function name:"
-msgstr ""
+msgstr "Nombre de función:"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Function:"
-msgstr ""
+msgstr "Función:"
 
 #: ../../src/wxMaximaFrame.cpp:1630
 msgid "Functions for complex simplification"
-msgstr ""
+msgstr "Funciones para la simplificación compleja"
 
 #: ../../src/wxMaximaFrame.cpp:1588
 msgid "Functions for simplifying factorials and gamma function"
-msgstr ""
+msgstr "Funciones para simplificar factoriales y función gamma"
 
 #: ../../src/wxMaximaFrame.cpp:1606
 msgid "Functions for simplifying trigonometric expressions"
-msgstr ""
+msgstr "Funciones para simplificar expresiones trigonométricas"
 
 #: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
 msgid "GCD"
-msgstr ""
+msgstr "MCD"
 
 #: ../../src/wxMaxima.cpp:10186
 msgid "GIF image (*.gif)|*.gif"
-msgstr ""
+msgstr "Imagen GIF (*.gif)|*.gif"
 
 #: ../../src/Worksheet.cpp:103
 msgid ""
@@ -3245,169 +3385,181 @@ msgid ""
 " hotkeys to be broken, see for example "
 "https://trac.wxwidgets.org/ticket/18462."
 msgstr ""
+"GTK_IM_MODULE está establecido a «xim».  Espere que el programa parpadee "
+"horriblemente y que se rompan las teclas de acceso rápido, vea por ejemplo "
+"https://trac.wxwidgets.org/ticket/18462."
 
 #: ../../src/wxMaximaFrame.cpp:295
 msgid "General Math"
-msgstr ""
+msgstr "Matemática Común"
 
 #: ../../src/wxMaximaFrame.cpp:699
 msgid "General Math\tAlt+Shift+M"
-msgstr ""
+msgstr "Matemática común\tAlt+Mayús+M"
 
 #: ../../src/wxMaximaFrame.cpp:1316
 msgid "Generate Matrix from Expression..."
-msgstr ""
+msgstr "Generar matriz a partir de expresión…"
 
 #: ../../src/wxMaximaFrame.cpp:1317
 msgid "Generate a matrix from a lambda expression"
-msgstr ""
+msgstr "Genera una matriz a partir de una expresión lambda"
 
 #: ../../src/wxMaximaFrame.cpp:1675
 msgid "Generate a new list using a lists' elements"
-msgstr ""
+msgstr "Genera un listado nueva empleando elementos de lista"
 
 #: ../../src/wxMaximaFrame.cpp:1681
 msgid ""
 "Generate a storage for variable values that can be introduced into equations"
 " at any time"
 msgstr ""
+"Genera un almacén para valores variables que pueden ser introducidos dentro "
+"de ecuaciones en cualquier momento"
 
 #: ../../src/wxMaximaFrame.cpp:1672
 msgid "Generate list elements using a rule"
-msgstr ""
+msgstr "Genera elementos de lista empleando una regla"
 
 #: ../../src/wxMaxima.cpp:8196
 msgid "Generate matrix from a rule"
-msgstr ""
+msgstr "Genera matriz desde una regla"
 
 #: ../../src/wxMaximaFrame.cpp:1094
 msgid "Generate unused symbol name"
-msgstr ""
+msgstr "Genera nombre de símbolo no utilizado"
 
 #: ../../src/WXMXformat.cpp:231
 msgid "Generated the XML representation of the document"
-msgstr ""
+msgstr "Ha generado la representación XML del documento"
 
 #: ../../src/wxMaxima.cpp:8197
+#, fuzzy
 msgid ""
 "Generates a matrix and fills each element with the result of the expression "
 "\"Rule\"."
 msgstr ""
+"Genera una matriz rectangular y rellena cada elemento con el resultado de la"
+" expresión «Regla»."
 
 #: ../../src/wxMaximaFrame.cpp:1619
 msgid "Get &Imaginary Part"
-msgstr ""
+msgstr "Calcular parte &imaginaria"
 
 #: ../../src/wxMaximaFrame.cpp:1485
 msgid "Get Laplace transformation of an expression"
-msgstr ""
+msgstr "Obtiene la transformada de Laplace de una expresión"
 
 #: ../../src/wxMaximaFrame.cpp:1615
 msgid "Get Real P&art"
-msgstr ""
+msgstr "Calcular parte &real"
 
 #: ../../src/wxMaximaFrame.cpp:1201
 msgid "Get current directory"
-msgstr ""
+msgstr "Obtener directorio actual"
 
 #: ../../src/wxMaximaFrame.cpp:1489
 msgid "Get inverse Laplace transformation of an expression"
-msgstr ""
+msgstr "Obtiene la transformada inversa de Laplace de una expresión"
 
 #: ../../src/wxMaxima.cpp:7223
 msgid "Get position in stream"
-msgstr ""
+msgstr "Obtener posición en flujo"
 
 #: ../../src/wxMaximaFrame.cpp:1102
 msgid "Get position..."
-msgstr ""
+msgstr "Obtener posición…"
 
 #: ../../src/wxMaximaFrame.cpp:1620
 msgid "Get the imaginary part of complex expression"
-msgstr ""
+msgstr "Obtiene la parte imaginaria de una expresión compleja"
 
 #: ../../src/wxMaximaFrame.cpp:1616
 msgid "Get the real part of complex expression"
-msgstr ""
+msgstr "Obtiene la parte real de una expresión compleja"
 
 #: ../../src/wxMaxima.cpp:3609
-#, c-format
+#, fuzzy, c-format
 msgid "Gnuplot (command line) found at: %s"
-msgstr ""
+msgstr "Gnuplot encontrado en: %s"
 
 #: ../../src/wxMaxima.cpp:3607
 #, c-format
 msgid "Gnuplot found at: %s"
-msgstr ""
+msgstr "Gnuplot encontrado en: %s"
 
 #: ../../src/wxMaxima.cpp:2974
 msgid "Gnuplot has closed."
-msgstr ""
+msgstr "Gnuplot ha sido cerrado."
 
 #: ../../src/wxMaxima.cpp:3598 ../../src/wxMaxima.cpp:3603
 #, c-format
 msgid "Gnuplot not found, using the default: %s"
-msgstr ""
+msgstr "Gnuplot no encontrado, utilizando el predet.: %s"
 
 #: ../../src/wxMaxima.cpp:9428 ../../src/wxMaximaFrame.cpp:1887
 msgid "Go to URL"
-msgstr ""
+msgstr "Ir a URL"
 
 #: ../../src/wxMaxima.cpp:3989
 msgid "Got a new input prompt!"
-msgstr ""
+msgstr "¡Obtuvo una solicitud de entrada nueva!"
 
 #: ../../src/Worksheet.cpp:6354
 msgid ""
 "Got a request to undo an action that involves a delete which isn't possible "
 "at this moment."
 msgstr ""
+"Se solicitó una acción de deshacer que requiere un borrado que no es posible"
+" realizar en este momento."
 
 #: ../../src/wxMaximaFrame.cpp:1031
 msgid "Gradefs"
-msgstr ""
+msgstr "Grados-fs"
 
 #: ../../src/Worksheet.cpp:1967
 msgid "Greater or less than a value"
-msgstr ""
+msgstr "Mayor o menor que un valor"
 
 #: ../../src/wxMaximaFrame.cpp:1130
 msgid "Greater, ignoring case?..."
-msgstr ""
+msgstr "¿Mayor, ignorando caso?…"
 
 #: ../../src/wxMaximaFrame.cpp:260
 msgid "Greek Letters"
-msgstr ""
+msgstr "Letras Griegas"
 
 #: ../../src/wxMaximaFrame.cpp:703
 msgid "Greek Letters\tAlt+Shift+G"
-msgstr ""
+msgstr "Letras griegas\tAlt+Mayús+G"
 
 #: ../../src/wxMaximaFrame.cpp:1815
 msgid "Guess an exact number that could be meant by this float"
-msgstr ""
+msgstr "Adivina un número exacto que pudo ser dicho por este flotante"
 
 #: ../../src/wxMaxima.cpp:6123
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file "
 "(*.tex)|*.tex"
 msgstr ""
+"Fichero HTML (*.html)|*.html|Fichero por lotes 'maxima' "
+"(*.mac)|*.mac|Fichero LaTeX (*.tex)|*.tex"
 
 #: ../../src/wxMaximaFrame.cpp:1341
 msgid "Hadamard (element-by-element) product..."
-msgstr ""
+msgstr "Producto Hadamard (elemento-por-elemento)…"
 
 #: ../../src/wxMaxima.cpp:8004
 msgid "Hadamard Product"
-msgstr ""
+msgstr "Producto Hadamard"
 
 #: ../../src/wxMaxima.cpp:8011
 msgid "Hadamard exponent"
-msgstr ""
+msgstr "Exponente Hadamard"
 
 #: ../../src/wxMaximaFrame.cpp:1345
 msgid "Hadamard exponent..."
-msgstr ""
+msgstr "Exponente Hadamard…"
 
 #: ../../src/MaximaManual.cpp:260
 #, c-format
@@ -3415,119 +3567,122 @@ msgid ""
 "Have only %li keyword anchors at the end of parsing the maxima manual => Not"
 " caching the result of using the built-in keyword list"
 msgstr ""
+"Solamente tiene %li anclas de palabra clave en el final de interpretar el "
+"manual de ‘maxima‘ ⇒ No cachea el resultado de utilizar el listado de "
+"palabra clave empotrada."
 
 #: ../../src/Configuration.cpp:88 ../../src/ToolBar.cpp:276
 msgid "Heading 5"
-msgstr ""
+msgstr "Cabecera 5"
 
 #: ../../src/Configuration.cpp:87 ../../src/ToolBar.cpp:277
 msgid "Heading 6"
-msgstr ""
+msgstr "Cabecera 6"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
 msgid "Help"
-msgstr ""
+msgstr "Ayuda"
 
 #: ../../src/ToolBar.cpp:635
 msgid "Help button"
-msgstr ""
+msgstr "Botón de Ayuda"
 
 #: ../../src/Worksheet.cpp:1340 ../../src/Worksheet.cpp:1778
 #, c-format
 msgid "Help on \"%s\""
-msgstr ""
+msgstr "Ayuda en \"%s\""
 
 #: ../../src/wxMaximaFrame.cpp:729
 msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr ""
+msgstr "Ocultar herramientas\tAlt+Mayús+-"
 
 #: ../../src/ToolBar.cpp:264
 msgid "Hide Code"
-msgstr ""
+msgstr "Ocultar Código"
 
 #: ../../src/wxMaximaFrame.cpp:727
 msgid "Hide Code Cells\tAlt+Ctrl+H"
-msgstr ""
+msgstr "Ocultar celda de códigos\tAlt+Mayús+H"
 
 #: ../../src/Worksheet.cpp:1896
 msgid "Hide Heading 5"
-msgstr ""
+msgstr "Ocultar Cabecera 5"
 
 #: ../../src/Worksheet.cpp:1907
 msgid "Hide Heading 6"
-msgstr ""
+msgstr "Ocultar Cabecera 6"
 
 #: ../../src/Worksheet.cpp:1855
 msgid "Hide Part"
-msgstr ""
+msgstr "Ocultar Parte"
 
 #: ../../src/Worksheet.cpp:1863
 msgid "Hide Section"
-msgstr ""
+msgstr "Ocultar Sección"
 
 #: ../../src/Worksheet.cpp:1874
 msgid "Hide Subsection"
-msgstr ""
+msgstr "Ocultar Subsección"
 
 #: ../../src/Worksheet.cpp:1885
 msgid "Hide Subsubsection"
-msgstr ""
+msgstr "Ocultar Subsubsección"
 
 #: ../../src/wxMaximaFrame.cpp:730
 msgid "Hide all panes"
-msgstr ""
+msgstr "Ocultar todos los paneles"
 
 #: ../../src/Worksheet.cpp:1491
 msgid "Hide cell brackets"
-msgstr ""
+msgstr "Ocultar corchetes de celda"
 
 #: ../../src/Worksheet.cpp:1915
 msgid "Hide contents"
-msgstr ""
+msgstr "Ocultar índice"
 
 #: ../../src/Worksheet.cpp:1552
 msgid "Hide multiplication dots"
-msgstr ""
+msgstr "Ocultar puntos de multiplicación"
 
 #: ../../src/Worksheet.cpp:1930 ../../src/Worksheet.cpp:2063
 msgid "Hide yellow tooltip marker for this cell"
-msgstr ""
+msgstr "Oculta el marcador amarillo de consejo para esta celda"
 
 #: ../../src/Worksheet.cpp:1937 ../../src/Worksheet.cpp:2069
 msgid "Hide yellow tooltip marker for this message type"
-msgstr ""
+msgstr "Oculta el marcador amarillo de consejo para este tipo de mensaje"
 
 #: ../../src/Configuration.cpp:82
 msgid "Highlight (box)"
-msgstr ""
+msgstr "Resaltado (caja)"
 
 #: ../../src/wxMaxima.cpp:9528
 msgid "Histogram"
-msgstr ""
+msgstr "Histograma"
 
 #: ../../src/wxMaximaFrame.cpp:232
 msgid "History"
-msgstr ""
+msgstr "Historia"
 
 #: ../../src/wxMaximaFrame.cpp:709
 msgid "History\tAlt+Shift+I"
-msgstr ""
+msgstr "Historia\tAlt+Mayús+I"
 
 #: ../../src/wxMaximaFrame.cpp:1526
 msgid "Horner's rule"
-msgstr ""
+msgstr "Regla de Horner"
 
 #: ../../src/wxMaxima.cpp:9207
 msgid "How many digits to show:"
-msgstr ""
+msgstr "Cantidad de dígitos a mostrar:"
 
 #: ../../src/wxMaximaFrame.cpp:759
 msgid "How to display new equations"
-msgstr ""
+msgstr "Como desplegar ecuaciones nuevas"
 
 #: ../../src/wxMaximaFrame.cpp:1113
 msgid "I/O"
-msgstr ""
+msgstr "E/S"
 
 #: ../../src/wxMaxima.cpp:7062
 msgid ""
@@ -3535,6 +3690,9 @@ msgid ""
 "between parenthesis. The result of the last operation is the return value of"
 " the program."
 msgstr ""
+"Si un programa no necesita variables local ‘maxima‘ permite poner las "
+"instrucciones entre paréntesis. El resultado de la última operación es el "
+"valor devuelto del programa."
 
 #: ../../src/wxMaxima.cpp:7172
 msgid ""
@@ -3543,240 +3701,254 @@ msgid ""
 "\n"
 "array, boolean, integer, fixnum (machine-length integer), float (machine-size floating-point numbers), real or any (which is useful for declaring arrays of any)"
 msgstr ""
+"Si es conocido el tipo de un parámetro de función cuando compile una función el código puede ser optimizado vastamente.\n"
+"Tipos conocidos:\n"
+"\n"
+"repertorio, booleano, entero, número fijo (entero de longitud de máquina), flotante (números de coma reales del tamaño de máquina), real o cualquiera (el cual es útil para declarar repertorios de cualquiera)"
 
 #: ../../src/MathParser.cpp:890
 msgid ""
 "If this isn't a function returning a lambda() expression a multiplication "
 "sign (*) between closing and opening parenthesis is missing here."
 msgstr ""
+"Si esto no es una función devolviendo una expresión lambda() un signo de "
+"multiplicación (*) entre cerrar o abrir paréntesis está marcado aquí."
 
 #: ../../src/MaximaManual.cpp:403
 msgid "Ignoring the cache version for the manual anchors."
-msgstr ""
+msgstr "Descartando la versión del caché para los anclajes manuales."
 
 #: ../../src/Image.cpp:79
 msgid "Image data had zero length!"
-msgstr ""
+msgstr "¡Los datos de la imagen tuvieron longitud cero!"
 
 #: ../../src/wxMaxima.cpp:10147 ../../src/wxMaxima.cpp:10855
 msgid ""
 "Image files (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, "
 "*.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
 msgstr ""
+"Ficheros de imagen (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, "
+"*.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
 
 #: ../../src/Worksheet.cpp:5509
 msgid "ImageCell without image."
-msgstr ""
+msgstr "ImageCell sin imagen."
 
 #: ../../src/MathParser.cpp:347
 msgid "Importing compressed gnuplot sources for an animation"
-msgstr ""
+msgstr "Importando fuentes gnuplot comprimidas para una animación"
 
 #: ../../src/MathParser.cpp:334
 msgid "Importing uncompressed gnuplot sources for an animation"
-msgstr ""
+msgstr "Importando fuentes gnuplot descomprimidas para una animación"
 
 #: ../../src/wxMaxima.cpp:7993
 msgid ""
 "In order to save memory the \":\" operator does clone the matrix, not copy it:\n"
 "If you change an element of one matrix the same element will change in all of its clones. copymatrix() instead generates a copy of a matrix: A new matrix that, if changed in any way, won't change the original."
 msgstr ""
+"Con el fin de ahorrar memoria el operador \":\" clona la matriz, no la copia:\n"
+"Si cambia un elemento de una matriz el mismo elemento cambiará en todos los clones. copymatriz() en su lugar genera una copia de una matriz: Una matriz nueva que, si cambió de cualquier manera, no cambió el original."
 
 #: ../../src/wxMaxima.cpp:7404
 msgid ""
 "In order to save memory the : operator doesn't create an individual copy of "
 "the string, but a clone that changes when the original string changes."
 msgstr ""
+"Con el fin de ahorrar memoria el operador \":\" no crea una copia individual"
+" de la cadena, sino que un clon que cambia cuando la cadena original cambia."
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Include columns:"
-msgstr ""
+msgstr "Incluir columnas:"
 
 #: ../../src/Worksheet.cpp:2008
 msgid "Increasing function f(x)>x"
-msgstr ""
+msgstr "Incrementa función f(x)>x"
 
 #: ../../src/wxMaxima.cpp:8470
 msgid "Index End:"
-msgstr ""
+msgstr "Final de índice:"
 
 #: ../../src/wxMaxima.cpp:8470
 msgid "Index Start:"
-msgstr ""
+msgstr "Inicio de índice:"
 
 #: ../../src/wxMaxima.cpp:8471
 msgid "Index Step:"
-msgstr ""
+msgstr "Paso de índice:"
 
 #: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
 msgid "Index variable:"
-msgstr ""
+msgstr "Índice de variable:"
 
 #: ../../src/wxMaximaFrame.cpp:1949
 msgid "Info about Maxima build"
-msgstr ""
+msgstr "Información relacionada a compilación de Maxima"
 
 #: ../../src/Worksheet.cpp:2046
 msgid "Inform maxima about facts you know for this symbol"
-msgstr ""
+msgstr "Informe a ‘maxima‘ acerca de hechos que conoce para este símbolo"
 
 #: ../../src/Worksheet.cpp:1988
 msgid ""
 "Inform maxima about the value of the function at a specific point, e.G. for "
 "declaring initial conditions"
 msgstr ""
+"Informe a ‘maxima‘ acerca del valor de la función en un punto específico, "
+"p.ej. para declarar condiciones iniciales"
 
 #: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
 msgid "Initial Condition"
-msgstr ""
+msgstr "Condición Inicial"
 
 #: ../../src/wxMaximaFrame.cpp:1270
 msgid "Initial Value Problem (&1)..."
-msgstr ""
+msgstr "Problema de valor inicial (&1)…"
 
 #: ../../src/wxMaximaFrame.cpp:1274
 msgid "Initial Value Problem (&2)..."
-msgstr ""
+msgstr "Problema de valor inicial (&2)…"
 
 #: ../../src/wxMaxima.cpp:9044
 msgid "Initial estimates:"
-msgstr ""
+msgstr "Estimaciones iniciales:"
 
 #: ../../src/wxMaxima.cpp:7840
 msgid "Initial x:"
-msgstr ""
+msgstr "Inicial x:"
 
 #: ../../src/Configuration.cpp:78
 msgid "Input labels"
-msgstr ""
+msgstr "Etiquetas entrantes"
 
 #: ../../src/wxMaximaFrame.cpp:314
 msgid "Insert"
-msgstr ""
+msgstr "Insertar"
 
 #: ../../src/wxMaximaFrame.cpp:905
 msgid "Insert &Section Cell\tCtrl+3"
-msgstr ""
+msgstr "Insertar celda de &sección\tCtrl+3"
 
 #: ../../src/wxMaximaFrame.cpp:901
 msgid "Insert &Text Cell\tCtrl+1"
-msgstr ""
+msgstr "Insertar celda de &texto\tCtrl+1"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Insert Cell\tAlt+Shift+C"
-msgstr ""
+msgstr "Insertar celda\tAlt+Mayús+C"
 
 #: ../../src/Worksheet.cpp:1669
 msgid "Insert Heading5 Cell"
-msgstr ""
+msgstr "Inserción de Cabecera5 en Celda"
 
 #: ../../src/Worksheet.cpp:1671
 msgid "Insert Heading6 Cell"
-msgstr ""
+msgstr "Inserción de Cabecera6 en Celda"
 
 #: ../../src/wxMaxima.cpp:10854
 msgid "Insert Image"
-msgstr ""
+msgstr "Insertar Imagen"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert Image..."
-msgstr ""
+msgstr "Insertar imagen…"
 
 #: ../../src/wxMaximaFrame.cpp:899
 msgid "Insert Input &Cell\tCtrl+0"
-msgstr ""
+msgstr "Insertar &celda de entrada\tCtrl+0"
 
 #: ../../src/wxMaximaFrame.cpp:919
 msgid "Insert Page Break"
-msgstr ""
+msgstr "Insertar Salto de Página"
 
 #: ../../src/wxMaximaFrame.cpp:907
 msgid "Insert S&ubsection Cell\tCtrl+4"
-msgstr ""
+msgstr "Insertar celda de s&ubsección\tCtrl+4"
 
 #: ../../src/wxMaximaFrame.cpp:910
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
-msgstr ""
+msgstr "Insertar celda de s&ubsubsección\tCtrl+5"
 
 #: ../../src/Worksheet.cpp:1662
 msgid "Insert Section Cell"
-msgstr ""
+msgstr "Insertar celda de sección"
 
 #: ../../src/Worksheet.cpp:1664
 msgid "Insert Subsection Cell"
-msgstr ""
+msgstr "Insertar celda de subsección"
 
 #: ../../src/Worksheet.cpp:1667
 msgid "Insert Subsubsection Cell"
-msgstr ""
+msgstr "Insertar celda de subsubsección"
 
 #: ../../src/wxMaximaFrame.cpp:903
 msgid "Insert T&itle Cell\tCtrl+2"
-msgstr ""
+msgstr "Insertar celda de t&ítulo\tCtrl+2"
 
 #: ../../src/Worksheet.cpp:1658
 msgid "Insert Text Cell"
-msgstr ""
+msgstr "Insertar Celda de Texto"
 
 #: ../../src/Worksheet.cpp:1660
 msgid "Insert Title Cell"
-msgstr ""
+msgstr "Insertar Celda de Título"
 
 #: ../../src/wxMaximaFrame.cpp:913
 msgid "Insert a new heading5 cell"
-msgstr ""
+msgstr "Inserta una ‘cabecera5’ de celda nueva"
 
 #: ../../src/wxMaximaFrame.cpp:915
 msgid "Insert a new heading6 cell"
-msgstr ""
+msgstr "Inserta una ‘cabecera6’ de celda nueva"
 
 #: ../../src/wxMaximaFrame.cpp:900
 msgid "Insert a new input cell"
-msgstr ""
+msgstr "Inserta una nueva celda de entrada"
 
 #: ../../src/wxMaximaFrame.cpp:906
 msgid "Insert a new section cell"
-msgstr ""
+msgstr "Inserta una nueva celda de sección"
 
 #: ../../src/wxMaximaFrame.cpp:908
 msgid "Insert a new subsection cell"
-msgstr ""
+msgstr "Inserta una nueva celda de subsección"
 
 #: ../../src/wxMaximaFrame.cpp:911
 msgid "Insert a new subsubsection cell"
-msgstr ""
+msgstr "Inserta una nueva celda de subsubsección"
 
 #: ../../src/wxMaximaFrame.cpp:902
 msgid "Insert a new text cell"
-msgstr ""
+msgstr "Inserta una celda de texto"
 
 #: ../../src/wxMaximaFrame.cpp:904
 msgid "Insert a new title cell"
-msgstr ""
+msgstr "Inserta una celda de título"
 
 #: ../../src/wxMaximaFrame.cpp:920
 msgid "Insert a page break"
-msgstr ""
+msgstr "Inserta un salto de página"
 
 #: ../../src/wxMaximaFrame.cpp:1164
 msgid "Insert char..."
-msgstr ""
+msgstr "Insertar carácter…"
 
 #: ../../src/wxMaximaFrame.cpp:912
 msgid "Insert heading5 Cell\tCtrl+6"
-msgstr ""
+msgstr "Insertar ‘cabecera5’ en celda\tCtrl+6"
 
 #: ../../src/wxMaximaFrame.cpp:914
 msgid "Insert heading6 Cell\tCtrl+7"
-msgstr ""
+msgstr "Inserción de ‘cabecera6’ en celda\tCtrl+7"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert image"
-msgstr ""
+msgstr "Insertar imagen"
 
 #: ../../src/wxMaximaFrame.cpp:916
 msgid "Insert textbased cell"
-msgstr ""
+msgstr "Insertar celda de texto"
 
 #: ../../src/wxMaxima.cpp:3566
 msgid "Instructed to prefer gnuplot over wgnuplot"
@@ -3788,266 +3960,273 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
 msgid "Integral/Sum:"
-msgstr ""
+msgstr "Integral/Sumatorio:"
 
 #: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
 msgid "Integrate"
-msgstr ""
+msgstr "Integrar"
 
 #: ../../src/wxMaxima.cpp:8980
 msgid "Integrate (risch)"
-msgstr ""
+msgstr "Integrar (risch)"
 
 #: ../../src/wxMaximaFrame.cpp:1454
 msgid "Integrate expression"
-msgstr ""
+msgstr "Integrar expresión"
 
 #: ../../src/wxMaximaFrame.cpp:1456
 msgid "Integrate expression with Risch algorithm"
-msgstr ""
+msgstr "Integrar expresión con algoritmo Risch"
 
 #: ../../src/wxMaximaFrame.cpp:1869
 msgid "Integrate numerically"
-msgstr ""
+msgstr "Integrar numéricamente"
 
 #: ../../src/Worksheet.cpp:1588
 msgid "Integrate..."
-msgstr ""
+msgstr "Integrar…"
 
 #: ../../src/wxMaximaFrame.cpp:1737
 msgid "Interleave"
-msgstr ""
+msgstr "Interliniado"
 
 #: ../../src/wxMaximaFrame.cpp:1738
 msgid "Interleave the values of two lists"
-msgstr ""
+msgstr "Interlinear los valores de dos listas"
 
 #: ../../src/wxMaxima.cpp:8612
 msgid "Interleave two lists"
-msgstr ""
+msgstr "Interlinear dos listas"
 
 #: ../../src/wxMaximaFrame.cpp:1087
 msgid "Interpret like input..."
-msgstr ""
+msgstr "Interpreta como entrada…"
 
 #: ../../src/wxMaxima.cpp:7104
 msgid "Interpret maxima's output as input"
-msgstr ""
+msgstr "Interpreta salida de ‘maxima‘ como entrada"
 
 #: ../../src/wxMaxima.cpp:7502
 msgid "Interpret string as maxima code"
-msgstr ""
+msgstr "Interpreta cadenas como código de ‘maxima’"
 
 #: ../../src/wxMaximaFrame.cpp:1089
 msgid "Interpret string..."
-msgstr ""
+msgstr "Interpretar cadena…"
 
 #: ../../src/ToolBar.cpp:231
 msgid "Interrupt"
-msgstr ""
+msgstr "Interrumpir"
 
 #: ../../src/wxMaximaFrame.cpp:965
 msgid "Interrupt current computation"
-msgstr ""
+msgstr "Interrumpir el cálculo actual"
 
 #: ../../src/ToolBar.cpp:232
 msgid ""
 "Interrupt current computation. To completely restart maxima press the button"
 " left to this one."
 msgstr ""
+"Interrumpir cálculo actual. Para reiniciar la sesión de 'maxima' pulsar el "
+"botón a la izquierda de éste."
 
 #: ../../src/wxMaxima.cpp:2766
 #, c-format
 msgid "Interrupting maxima: %s"
-msgstr ""
+msgstr "Interrumpir ‘maxima’: %s"
 
 #: ../../src/wxMaxima.cpp:8557
 msgid "Introduce a list of actual values into an equation"
-msgstr ""
+msgstr "Introduce un listado de valores actuales dentor de una ecuación"
 
 #: ../../src/wxMaximaFrame.cpp:1697
 msgid "Introduce the actual values for variables stored in the list"
 msgstr ""
+"Introduce los valores actuales para variables almacenadas dentro del listado"
 
 #: ../../src/wxMaxima.cpp:10062
 msgid "Introduces one or more assignments into an expression"
-msgstr ""
+msgstr "Introduce una o más asignaciones en una expresión"
 
 #: ../../src/wxMaxima.cpp:9003
 msgid "Inverse Laplace"
-msgstr ""
+msgstr "Laplace inversa"
 
 #: ../../src/wxMaximaFrame.cpp:1488
 msgid "Inverse Laplace T&ransform..."
-msgstr ""
+msgstr "T&ransformada inversa de Laplace…"
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Invert worksheet brightness"
-msgstr ""
+msgstr "Invierte el brillo de hoja del cuaderno"
 
 #: ../../src/wxMaxima.cpp:7338
 msgid "Is Char 1 greater than Char2, if case is ignored?"
 msgstr ""
+"¿Es el Carácter 1 mayor que el Carácter 2, si MAYÚS/minús no se toma en "
+"cuenta?"
 
 #: ../../src/wxMaxima.cpp:7333
 msgid "Is Char 1 greater than Char2?"
-msgstr ""
+msgstr "¿Es el Carácter 1 mayor que el Carácter 2?"
 
 #: ../../src/wxMaxima.cpp:7327
 msgid "Is Char 1 less than Char2, if case is ignored?"
 msgstr ""
+"¿Es el Carácter 1 menor que el Carácter 2, si MAYÚS/minús no se toma en "
+"cuenta?"
 
 #: ../../src/wxMaxima.cpp:7322
 msgid "Is Char 1 less than Char2?"
-msgstr ""
+msgstr "¿Es el Carácter 1 menor que el Carácter 2?"
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Is a char?"
-msgstr ""
+msgstr "¿Es un carácter?"
 
 #: ../../src/wxMaximaFrame.cpp:1115
 msgid "Is a char?..."
-msgstr ""
+msgstr "¿Es un carácter?…"
 
 #: ../../src/Worksheet.cpp:1952
 msgid "Is a complex variable"
-msgstr ""
+msgstr "Es una variable compleja"
 
 #: ../../src/wxMaxima.cpp:7292
 msgid "Is a digit?"
-msgstr ""
+msgstr "¿Es un dígito?"
 
 #: ../../src/wxMaximaFrame.cpp:1118
 msgid "Is a digit?..."
-msgstr ""
+msgstr "¿Es un dígito?…"
 
 #: ../../src/wxMaxima.cpp:7304
 msgid "Is a lowercase char?"
-msgstr ""
+msgstr "¿Es un carácter minúsculo?"
 
 #: ../../src/wxMaxima.cpp:7296
 msgid "Is a printable char?"
-msgstr ""
+msgstr "¿Es un carácter imprimible?"
 
 #: ../../src/Worksheet.cpp:1949
 msgid "Is a real variable"
-msgstr ""
+msgstr "Es una variable real"
 
 #: ../../src/wxMaxima.cpp:7300
 msgid "Is a uppercase char?"
-msgstr ""
+msgstr "¿Es un carácter mayúscula?"
 
 #: ../../src/wxMaximaFrame.cpp:1116
 msgid "Is alphabetic?..."
-msgstr ""
+msgstr "¿Es alfabético?…"
 
 #: ../../src/wxMaximaFrame.cpp:1117
 msgid "Is alphanumeric?..."
-msgstr ""
+msgstr "¿Es alfanumérico?…"
 
 #: ../../src/wxMaxima.cpp:7284
 msgid "Is an alphabetic char?"
-msgstr ""
+msgstr "¿Es un carácter alfabético?"
 
 #: ../../src/wxMaxima.cpp:7288
 msgid "Is an alphanumeric char?"
-msgstr ""
+msgstr "¿Es un carácter alfanumérico?"
 
 #: ../../src/Worksheet.cpp:1991
 msgid "Is an even function"
-msgstr ""
+msgstr "Es una función par"
 
 #: ../../src/Worksheet.cpp:1955
 msgid "Is an imaginary variable"
-msgstr ""
+msgstr "Es una variable imaginaria"
 
 #: ../../src/Worksheet.cpp:1960
 msgid "Is an integer variable"
-msgstr ""
+msgstr "Es una variable entera"
 
 #: ../../src/Worksheet.cpp:1993
 msgid "Is an odd function"
-msgstr ""
+msgstr "Es una función extraña"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Is equal?..."
-msgstr ""
+msgstr "¿Es igual?…"
 
 #: ../../src/wxMaximaFrame.cpp:1128
 msgid "Is greater?..."
-msgstr ""
+msgstr "¿Es mayor?…"
 
 #: ../../src/wxMaximaFrame.cpp:1125
 msgid "Is lower?..."
-msgstr ""
+msgstr "¿Es menor?…"
 
 #: ../../src/wxMaximaFrame.cpp:1121
 msgid "Is lowercase?..."
-msgstr ""
+msgstr "¿Es minúscula?…"
 
 #: ../../src/Worksheet.cpp:1962
 msgid "Is no integer variable"
-msgstr ""
+msgstr "Es variable no entera"
 
 #: ../../src/wxMaximaFrame.cpp:1119
 msgid "Is printable?..."
-msgstr ""
+msgstr "¿Es imprimible?…"
 
 #: ../../src/wxMaximaFrame.cpp:1120
 msgid "Is uppercase?..."
-msgstr ""
+msgstr "¿Es mayúscula?…"
 
 #: ../../src/Worksheet.cpp:6256
 msgid "Issuing the active cell's undo function"
-msgstr ""
+msgstr "Emitiendo la función deshacer de la celda activa"
 
 #: ../../src/Worksheet.cpp:6261
 msgid "Issuing the worksheet's undo function"
-msgstr ""
+msgstr "Emitiendo la función deshacer del cuaderno"
 
 #: ../../src/wxMaxima.cpp:8598 ../../src/wxMaxima.cpp:8604
 msgid "Item"
-msgstr ""
+msgstr "Elemento"
 
 #: ../../src/wxMaxima.cpp:8581
 msgid "Iterator name:"
-msgstr ""
+msgstr "Nombre iterador:"
 
 #: ../../src/wxMaximaFrame.cpp:1048
 msgid "Jump to first error"
-msgstr ""
+msgstr "Omitir al primer error"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Jump to the first cell Maxima has reported an error in."
-msgstr ""
+msgstr "Ir a la primera celda Maxima dentro de la que ha comunicado un error."
 
 #: ../../src/wxMaxima.cpp:8960
 msgid "LCM"
-msgstr ""
+msgstr "MCM"
 
 #: ../../src/wxMaximaFrame.cpp:1407
 msgid "L[1] Norm (complex)"
-msgstr ""
+msgstr "L[1] Normal (complejo)"
 
 #: ../../src/wxMaximaFrame.cpp:1406
 msgid "L[1] Norm (real)"
-msgstr ""
+msgstr "L[1] Normal (real)"
 
 #: ../../src/wxMaximaFrame.cpp:1409
 msgid "L[inf] Norm (complex)"
-msgstr ""
+msgstr "L[inf] Normal (complejo)"
 
 #: ../../src/wxMaximaFrame.cpp:1408
 msgid "L[inf] Norm (real)"
-msgstr ""
+msgstr "L[inf] Normal (real)"
 
 #: ../../src/wxMaximaFrame.cpp:1025
 msgid "Labels"
-msgstr ""
+msgstr "Etiquetas"
 
 #: ../../src/wxMaxima.cpp:7090
 msgid "Lambda"
-msgstr ""
+msgstr "Lambda"
 
 #: ../../src/wxMaxima.cpp:7091
 msgid ""
@@ -4055,275 +4234,284 @@ msgid ""
 "This is useful if you want to use a function only once, perhaps as a parameter to another function and don't need it to be named.\n"
 "Also you can fill a variable with a lambda() construct, effectively generating a function pointer: A variable that can be used as a function, and filled with a different function, if needed."
 msgstr ""
+"Lamda genera una función, pero no proporciona un nombre.\n"
+"Esto es útil si desde utilizar una función solamente una vez, quizá como un parámetro para otra función y no lo necesita ser nombrado.\n"
+"Además puede rellenar una variable con un constructor lambda(), efectivamente generando un puntero de función: una variable que puede ser utilizado como una función, y rellenado con una función diferente, si es necesario."
 
 #: ../../src/wxMaxima.cpp:8997
 msgid "Laplace"
-msgstr ""
+msgstr "Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1484
 msgid "Laplace &Transform..."
-msgstr ""
+msgstr "&Transformada de Laplace…"
 
 #: ../../src/wxMaximaFrame.cpp:1718
 msgid "Last"
-msgstr ""
+msgstr "Último"
 
 #: ../../src/wxMaxima.cpp:3006
 #, c-format
 msgid "Last message from maxima's stderr: %s"
-msgstr ""
+msgstr "Último mensaje desde la salida errónea de ‘maxima’: %s"
 
 #: ../../src/wxMaxima.cpp:2993
 #, c-format
 msgid "Last message from maxima's stdout: %s"
-msgstr ""
+msgstr "Último mensaje desde la salida estándar de ‘maxima’: %s"
 
 #: ../../src/wxMaximaFrame.cpp:1720
 msgid "Last n"
-msgstr ""
+msgstr "Último n"
 
 #: ../../src/wxMaxima.cpp:10400
 msgid "Last non-whitespace is a question mark"
-msgstr ""
+msgstr "Último no-espacio en blanco es una marca de pregunta"
 
 #: ../../src/wxMaxima.cpp:4899
 #, c-format
 msgid "Launching the system's default help browser as %s."
-msgstr ""
+msgstr "Lanzando el explorador de ayuda predeterminado del sistema como %s."
 
 #: ../../src/wxMaxima.cpp:4909
 msgid "Launching the system's default help browser failed."
-msgstr ""
+msgstr "Error al lanzar el explorador de ayuda predeterminado del sistema."
 
 #: ../../src/wxMaximaFrame.cpp:1493
 msgid "Least Common Multiple..."
-msgstr ""
+msgstr "Mínimo común múltiplo…"
 
 #: ../../src/wxMaxima.cpp:9587
 msgid "Least Squares Fit"
-msgstr ""
+msgstr "Ajuste por Mínimos Cuadrados"
 
 #: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
 #: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
 msgid "Left Matrix:"
-msgstr ""
+msgstr "Matriz izq:"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Left end"
-msgstr ""
+msgstr "Final dejado"
 
 #: ../../src/wxMaximaFrame.cpp:1297
 msgid "Left side to the \"=\""
-msgstr ""
+msgstr "Lado izquierdo del “=”"
 
 #: ../../src/wxMaximaFrame.cpp:1741
 msgid "Length"
-msgstr ""
+msgstr "Longitud"
 
 #: ../../src/wxMaximaFrame.cpp:1104 ../../src/wxMaximaFrame.cpp:1167
 msgid "Length..."
-msgstr ""
+msgstr "Longitud…"
 
 #: ../../src/wxMaxima.cpp:7421
 msgid "Length:"
-msgstr ""
+msgstr "Longitud:"
 
 #: ../../src/wxMaximaFrame.cpp:1032
 msgid "Letrules"
-msgstr ""
+msgstr "Reglas"
 
 #: ../../src/Worksheet.cpp:1976
 msgid "Likely to be the main variable"
-msgstr ""
+msgstr "Como para ser la variable principal"
 
 #: ../../src/wxMaxima.cpp:9028
 msgid "Limit"
-msgstr ""
+msgstr "Límite"
 
 #: ../../src/wxMaxima.cpp:7256
 msgid "Lisp format string:"
-msgstr ""
+msgstr "Cadena en formato Lisp:"
 
 #: ../../src/wxMaxima.cpp:7258
 msgid "Lisp format strings are more powerful than c++ format strings"
 msgstr ""
+"Cadenas en formato Lisp son más potentes que las cadenas en formato c++"
 
 #: ../../src/wxMaxima.cpp:5066
 msgid "Lisp mode."
-msgstr ""
+msgstr "Modo Lisp."
 
 #: ../../src/wxMaximaFrame.cpp:1010 ../../src/wxMaximaFrame.cpp:1012
 msgid "Lisp normally frees memory only when it has time or runs out of space"
 msgstr ""
+"Lisp normalmente libera memoria solo cuando tiene tiempo o ejecuta fuera del"
+" espacio"
 
 #: ../../src/wxMaxima.cpp:3691
 #, c-format
 msgid "Lisp version: %s"
-msgstr ""
+msgstr "Versión Lisp: %s"
 
 #: ../../src/wxMaxima.cpp:8435 ../../src/wxMaxima.cpp:8539
 #: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
 #: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
 #: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
 msgid "List"
-msgstr ""
+msgstr "Listado"
 
 #: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
 msgid "List #1"
-msgstr ""
+msgstr "Listado nº1"
 
 #: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
 msgid "List #2"
-msgstr ""
+msgstr "Listado nº2"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "List directory"
-msgstr ""
+msgstr "Listado de directorio"
 
 #: ../../src/wxMaximaFrame.cpp:1205
 msgid "List directory..."
-msgstr ""
+msgstr "Índice de directorio…"
 
 #: ../../src/wxMaxima.cpp:7385 ../../src/wxMaxima.cpp:7389
 msgid "List of char to String"
-msgstr ""
+msgstr "Índice de carácter a Cadena"
 
 #: ../../src/wxMaximaFrame.cpp:1150
 msgid "List of chars to string..."
-msgstr ""
+msgstr "Índice de caracteres a cadena…"
 
 #: ../../src/wxMaxima.cpp:7386
 msgid "List of chars:"
-msgstr ""
+msgstr "Índice de caracteres:"
 
 #: ../../src/wxMaxima.cpp:8559
 msgid "List with values"
-msgstr ""
+msgstr "Listado con valores"
 
 #: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
 msgid "List:"
-msgstr ""
+msgstr "Listado:"
 
 #: ../../src/wxMaxima.cpp:6200
 msgid "Load Package"
-msgstr ""
+msgstr "Cargar Paquete"
 
 #: ../../src/wxMaximaFrame.cpp:613
 msgid "Load Recent Package"
-msgstr ""
+msgstr "Carga Paquete Reciente"
 
 #: ../../src/wxMaximaFrame.cpp:616
 msgid "Load a Maxima file using the batch command"
-msgstr ""
+msgstr "Carga un fichero ‘Maxima’ empleando la instrucciones del batch"
 
 #: ../../src/wxMaximaFrame.cpp:611
 msgid "Load a Maxima package file"
-msgstr ""
+msgstr "Carga un fichero ‘Maxima’ empaquetado"
 
 #: ../../src/wxMaximaFrame.cpp:1678
 msgid "Load a list from a csv file"
-msgstr ""
+msgstr "Cargar un listado desde un fichero csv"
 
 #: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
 msgid "Load a matrix from a csv file"
-msgstr ""
+msgstr "Carga una matriz desde un fichero cvs"
 
 #: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
 msgid "Load lapack"
-msgstr ""
+msgstr "Cargar lapack"
 
 #: ../../src/wxMaxima.cpp:7208
 msgid "Load lisp code"
-msgstr ""
+msgstr "Cargar código lisp"
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "Load lisp..."
-msgstr ""
+msgstr "Cargar lisp…"
 
 #: ../../src/wxMaximaFrame.cpp:1198
+#, fuzzy
 msgid "Load the file/dir operations (operatingsystem)"
-msgstr ""
+msgstr "Carga las operaciones archivo/dir"
 
 #: ../../src/wxMaximaFrame.cpp:1187
+#, fuzzy
 msgid "Load the regular expression package (sregex)"
-msgstr ""
+msgstr "Carga el procesador de exreg"
 
 #: ../../src/wxMaximaFrame.cpp:1224
+#, fuzzy
 msgid "Load the translation generator (gentran)"
-msgstr ""
+msgstr "Carga el generador de traducción"
 
 #: ../../src/wxMaxima.cpp:8219
 msgid "Loop variable"
-msgstr ""
+msgstr "Variable de bucle"
 
 #: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
 msgid "Lower bound:"
-msgstr ""
+msgstr "Cota inferior:"
 
 #: ../../src/wxMaximaFrame.cpp:1127
 msgid "Lower, ignoring case?..."
-msgstr ""
+msgstr "¿Menor, ignorando caso?…"
 
 #: ../../src/wxMaximaFrame.cpp:1448
 msgid "M&atrix"
-msgstr ""
+msgstr "M&atriz"
 
 #: ../../src/wxMaxima.cpp:7153
 msgid "Macro contents:"
-msgstr ""
+msgstr "Contenido de macro:"
 
 #: ../../src/wxMaxima.cpp:7148
 msgid "Macro name:"
-msgstr ""
+msgstr "Nombre de macro:"
 
 #: ../../src/wxMaximaFrame.cpp:1024
 msgid "Macros"
-msgstr ""
+msgstr "Macros"
 
 #: ../../src/wxMaximaFrame.cpp:697
 msgid "Main Toolbar\tAlt+Shift+B"
-msgstr ""
+msgstr "Barra de herramientas principal\tAlt+Mayús+B"
 
 #: ../../src/wxMaxima.cpp:7906
 msgid "Make a function value at a specific point known"
-msgstr ""
+msgstr "Crea un valor de función en un punto conocido específico"
 
 #: ../../src/Worksheet.cpp:2028
 msgid "Make an eventual ev() evaluate this"
-msgstr ""
+msgstr "Crea un ev() eventual evalúa éste"
 
 #: ../../src/wxMaximaFrame.cpp:1070
 msgid "Make function local..."
-msgstr ""
+msgstr "Crear función local…"
 
 #: ../../src/wxMaxima.cpp:8207
 msgid "Map"
-msgstr ""
+msgstr "Distribuir"
 
 #: ../../src/wxMaxima.cpp:8215
 msgid "Map an expression"
-msgstr ""
+msgstr "Distribuir una expresión"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "Map function to a matrix"
-msgstr ""
+msgstr "Distribuir una función a una matriz"
 
 #: ../../src/wxMaximaFrame.cpp:1446
 msgid "Map function to a matrix, affecting all of its clones"
-msgstr ""
+msgstr "Distribuir función a una matriz, afectando todo de sus clones"
 
 #: ../../src/Configuration.cpp:109
 msgid "Math Default"
-msgstr ""
+msgstr "Matemática Predet."
 
 #: ../../src/wxMaximaFrame.cpp:286
 msgid "Mathematical Symbols"
-msgstr ""
+msgstr "Símbolos Matemáticos"
 
 #: ../../src/ToolBar.cpp:270
 msgid "Maths"
-msgstr ""
+msgstr "Matemáticas"
 
 #: ../../src/wxMaxima.cpp:7945 ../../src/wxMaxima.cpp:8022
 #: ../../src/wxMaxima.cpp:8027 ../../src/wxMaxima.cpp:8032
@@ -4335,54 +4523,54 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
 #: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
 msgid "Matrix"
-msgstr ""
+msgstr "Matriz"
 
 #: ../../src/wxMaxima.cpp:7986
 msgid "Matrix Exponent"
-msgstr ""
+msgstr "Exponente Matricial"
 
 #: ../../src/wxMaximaFrame.cpp:1339
 msgid "Matrix exponent..."
-msgstr ""
+msgstr "Exponente matricial…"
 
 #: ../../src/wxMaximaFrame.cpp:1329
 msgid "Matrix from csv file"
-msgstr ""
+msgstr "Matriz desde estilo cvs"
 
 #: ../../src/wxMaximaFrame.cpp:1323
 msgid "Matrix from csv file..."
-msgstr ""
+msgstr "Matriz desde archivo cvs…"
 
 #: ../../src/wxMaxima.cpp:8137
 msgid "Matrix map"
-msgstr ""
+msgstr "Distribuir matriz"
 
 #: ../../src/wxMaxima.cpp:9630
 msgid "Matrix name:"
-msgstr ""
+msgstr "Nombre de matriz:"
 
 #: ../../src/wxMaximaFrame.cpp:798
 msgid "Matrix parenthesis"
-msgstr ""
+msgstr "Paréntesis matriciales"
 
 #: ../../src/wxMaximaFrame.cpp:1331
 msgid "Matrix to csv file"
-msgstr ""
+msgstr "Matriz a fichero csv"
 
 #: ../../src/wxMaximaFrame.cpp:1334
 msgid "Matrix to file or Matrix from file"
-msgstr ""
+msgstr "Matriz a archivo o Matriz desde archivo"
 
 #: ../../src/wxMaximaFrame.cpp:1761
 msgid "Matrix to nested List"
-msgstr ""
+msgstr "Matriz para lista anidada"
 
 #: ../../src/wxMaxima.cpp:7956 ../../src/wxMaxima.cpp:7961
 #: ../../src/wxMaxima.cpp:7966 ../../src/wxMaxima.cpp:7971
 #: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
 #: ../../src/wxMaxima.cpp:8136
 msgid "Matrix:"
-msgstr ""
+msgstr "Matriz:"
 
 #: ../../src/wxMaxima.cpp:8627
 msgid ""
@@ -4391,189 +4579,201 @@ msgid ""
 "\n"
 "This command tells maxima that the nouns in this expression shall now be evaluated, too."
 msgstr ""
+"‘Maxima‘ permite crear funciones \"sustantivos\", las cuales significan que no están evaluados automáticamente tan pronto como ‘maxima‘ los encontró.\n"
+"Maneras hacen una función un sustantivo incluye declarándolo un sustantivo, precediéndolo con una ' o poniéndolo entre los paréntesis de '().\n"
+"\n"
+"Esta instrucción dice a ‘maxima‘ que los sustantivos en esta expresión ahora serán evaluados, también."
 
 #: ../../src/wxMaxima.cpp:3473
 #, c-format
 msgid "Maxima architecture: %s"
-msgstr ""
+msgstr "Arquitectura ‘Maxima’: %s"
 
 #: ../../src/StatusBar.cpp:252
 msgid "Maxima asks a question"
-msgstr ""
+msgstr "‘Maxima’ pregunta una duda"
 
 #: ../../src/wxMaxima.cpp:4066
 msgid "Maxima asks a question!"
-msgstr ""
+msgstr "¡‘Maxima’ solicita una pregunta!"
 
 #: ../../src/wxMaxima.cpp:7118
 msgid ""
 "Maxima automatically simplifies expressions it gets as input and then tries to evaluate their value. The ' operator tells maxima that we want a command to be in noun form, which means: stand here as is, and unevaluated.\n"
 "The ' operator can be undone by using the '' operator."
 msgstr ""
+"‘Maxima‘ simplifica automáticamente expresiones que obtenga como entrada y entonces intenta evaluar su valor. El operador ' dice a ‘maxima‘ que deseamos una instrucción para estar dentro del formulario sustantivo, el cual significa: mantener aquí como es, y no evaluado.\n"
+"El operador ' puede ser deshecho utilizando el operador ''."
 
 #: ../../src/wxMaxima.cpp:3304
 msgid "Maxima didn't attempt to authenticate!"
-msgstr ""
+msgstr "¡‘Maxima‘ no atenta a autenticación!"
 
 #: ../../src/Configuration.cpp:84
 msgid "Maxima errors"
-msgstr ""
+msgstr "Errores ‘Maxima’"
 
 #: ../../src/wxMaxima.cpp:3289
 msgid "Maxima has authenticated!"
-msgstr ""
+msgstr "‘Maxima’ se ha autenticado."
 
 #: ../../src/wxMaxima.cpp:10533
 msgid "Maxima has finished calculating."
-msgstr ""
+msgstr "‘Maxima’ ha terminado el cálculo."
 
 #: ../../src/wxMaxima.cpp:5832
 msgid "Maxima has issued an error!"
-msgstr ""
+msgstr "¡‘Maxima’ ha emitido un error!"
 
 #: ../../src/wxMaxima.cpp:3696
 #, c-format
 msgid "Maxima has loaded the file %s."
-msgstr ""
+msgstr "‘Maxima’ ha cargado el fichero %s."
 
 #: ../../src/wxMaxima.cpp:3382
 msgid "Maxima has sent a new variable value."
-msgstr ""
+msgstr "‘Maxima’ ha enviado una variable de valor nuevo."
 
 #: ../../src/MaximaManual.cpp:552
 msgid "Maxima help file not found!"
-msgstr ""
+msgstr "¡No se encontró el archivo de ayuda de ‘Maxima‘!"
 
 #: ../../src/wxMaximaFrame.cpp:1043
 msgid "Maxima input"
-msgstr ""
+msgstr "Entrada de ‘Maxima’"
 
 #: ../../src/StatusBar.cpp:236
 msgid "Maxima is calculating"
-msgstr ""
+msgstr "‘Maxima’ está calculando"
 
 #: ../../src/wxMaxima.cpp:5068
 msgid "Maxima is ready for input."
-msgstr ""
+msgstr "‘Maxima’ preparada para la entrada."
 
 #: ../../src/Dirstructure.cpp:144
 #, c-format
 msgid "Maxima not found as %s"
-msgstr ""
+msgstr "’Maxima’ no se ha encontrado como %s"
 
 #: ../../src/wxMaxima.cpp:6211
 msgid "Maxima package (*.mac)|*.mac"
-msgstr ""
+msgstr "Paquete de ‘Maxima’ (*.mac)|*.mac"
 
 #: ../../src/wxMaxima.cpp:6202
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr ""
+"Paquete de ‘Maxima’ (*.mac)|*.mac|Paquete Lisp (*.lisp)|*.lisp|Todos|*"
 
 #: ../../src/wxMaxima.cpp:3012
 msgid "Maxima process terminated unexpectedly."
-msgstr ""
+msgstr "Proceso ‘Maxima’ terminado inesperadamente."
 
 #: ../../src/Configuration.cpp:79
 msgid "Maxima question labels"
-msgstr ""
+msgstr "Etiquetas de pregunta de Maxima"
 
 #: ../../src/wxMaxima.cpp:3380
 msgid "Maxima sends a new set of auto-completable symbols."
-msgstr ""
+msgstr "‘Maxima’ envía un conjunto nuevo de símbolos auto-completable."
 
 #: ../../src/wxMaxima.cpp:3908
 msgid "Maxima sends us a new set of variables for the watch list."
 msgstr ""
+"‘Maxima’ nos envía un conjunto de variables nuevo para el listado de vigía."
 
 #: ../../src/wxMaximaFrame.cpp:1944
 msgid "Maxima shows help in a browser"
-msgstr ""
+msgstr "‘Maxima’ muestra ayuda en un explorador"
 
 #: ../../src/wxMaximaFrame.cpp:1940
 msgid "Maxima shows help in a sidebar"
-msgstr ""
+msgstr "‘Maxima’ muestra ayuda en una barra lateral"
 
 #: ../../src/wxMaximaFrame.cpp:1935
 msgid "Maxima shows help in the console"
-msgstr ""
+msgstr "‘Maxima’ muestra ayuda en la consola"
 
 #: ../../src/StatusBar.cpp:232
 msgid "Maxima started. Waiting for authentication..."
-msgstr ""
+msgstr "‘Maxima’ ha arrancado. Esperando la autenticación…"
 
 #: ../../src/StatusBar.cpp:212
 msgid "Maxima started. Waiting for connection..."
-msgstr ""
+msgstr "‘Maxima’ iniciado. Esperando la conexión…"
 
 #: ../../src/StatusBar.cpp:228
 msgid "Maxima started. Waiting for initial prompt..."
-msgstr ""
+msgstr "‘Maxima’ arrancado. Esperando la solicitud inicial…"
 
 #: ../../src/wxMaximaFrame.cpp:1231
+#, fuzzy
 msgid "Maxima to other language"
-msgstr ""
+msgstr "‘maxima‘ a otro lenguaje"
 
 #: ../../src/wxMaxima.cpp:7213
 msgid "Maxima to string"
-msgstr ""
+msgstr "‘Maxima’ a cadena"
 
 #: ../../src/wxMaxima.cpp:3397
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima user configuration is located in directory %s"
 msgstr ""
+"La configuración del usuario de ‘Maxima’ se encuentra en el directorio %s"
 
 #: ../../src/wxMaxima.cpp:3443
 #, c-format
 msgid "Maxima uses temp directory %s"
-msgstr ""
+msgstr "‘Maxima’ emplea directorio temporal %s"
 
 #: ../../src/wxMaxima.cpp:3469
 #, c-format
 msgid "Maxima version: %s"
-msgstr ""
+msgstr "Versión ‘Maxima’: %s"
 
 #: ../../src/MaximaManual.cpp:390
 #, c-format
 msgid "Maxima version: %s, Anchors cache version"
-msgstr ""
+msgstr "Versión Maxima: %s, Versión de caché ancla"
 
 #: ../../src/wxMaximaFrame.cpp:1925
 msgid "Maxima vs. Programming languages"
-msgstr ""
+msgstr "Maxima vs. Lenguajes de programación"
 
 #: ../../src/Configuration.cpp:83
 msgid "Maxima warnings"
-msgstr ""
+msgstr "Advertencias ‘Maxima’"
 
 #: ../../src/wxMaxima.cpp:3687
 #, c-format
 msgid "Maxima was compiled using %s"
-msgstr ""
+msgstr "‘Maxima’ fue compilado utilizando %s"
 
 #: ../../src/wxMaxima.cpp:3487
 #, c-format
 msgid "Maxima's HTML manuals are in directory %s"
-msgstr ""
+msgstr "Los manuales de ‘Maxima’ en HTML se encuentran en el directorio %s"
 
 #: ../../src/wxMaxima.cpp:3099
 #, c-format
 msgid "Maxima's PID is %li"
-msgstr ""
+msgstr "PID de ‘Maxima’ es %li"
 
 #: ../../src/wxMaxima.cpp:3681
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's demo files are located in directory %s"
 msgstr ""
+"Los ficheros compartidos de ‘Maxima’ están situados en el directorio %s"
 
 #: ../../src/wxMaxima.cpp:3478
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's manual is located in directory %s"
-msgstr ""
+msgstr "El manual de ‘Maxima’ se encuentra en el directorio %s"
 
 #: ../../src/wxMaxima.cpp:3670
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's share files are located in directory %s"
 msgstr ""
+"Los ficheros compartidos de ‘Maxima’ están situados en el directorio %s"
 
 #: ../../src/StatusBar.cpp:66
 msgid ""
@@ -4585,6 +4785,14 @@ msgid ""
 "not only intercepts connections from the outside, but also to intercept "
 "connections between two programs that run on the same computer."
 msgstr ""
+"‘Maxima’, el programa que hace las matemáticas actuales y wxMaxima, la cual "
+"enseña el cuaderno de trabajo están utilizando procesos separados. Esto "
+"significa que incluso si ‘maxima’ bloquea a wxMaxima (y por lo tanto el "
+"cuaderno) se mantiene intacto. Ambos programas se comunican a través de un "
+"'enchufe' a la red local. Esta vez este 'enchufe' no ha podido crearse por "
+"lo cual quizá esto está causado por un cortafuego que se configura para no "
+"solo interceptar conexiones desde fuera, sino también interceptar las "
+"conexiones entre dos programas en la misma máquina."
 
 #: ../../src/StatusBar.cpp:75
 msgid ""
@@ -4599,480 +4807,507 @@ msgid ""
 "might be that maxima cannot be found (see wxMaxima's Configuration dialogue "
 "for a way to specify maxima's location) or isn't in a working order."
 msgstr ""
+"‘Maxima’, el programa que hace las matemáticas actuales y wxMaxima, la cual "
+"enseña el cuaderno están utilizando procesos separados. Esto significa que "
+"incluso si ‘maxima’ bloquea a wxMaxima (y por lo tanto el cuaderno) se "
+"mantiene intacto. Actualmente los dos programas no están comunicados con los"
+" otros lo cual significa que ‘maxima’ está aún iniciado  o no ha podido ser "
+"iniciado. Alternativamente puede ser causado por un cortafuegos que esté "
+"configurado para no esté configurado para conexión desde fuera, sino también"
+" para interceptar conexiones entre dos programas sean ejecutadas desde la "
+"misma máquina. Otra razón para que no se inicie ‘maxima’ quizá es que "
+"‘maxima’ no puede ser encontrado (vea el diálogo de Configuración de "
+"wxMaxima para una manera de especificar la ubicación de ‘maxima’) o no está "
+"dentro de un lugar de trabajo."
 
 #: ../../src/StatusBar.cpp:61
 msgid ""
 "Maxima, the program that does the actual mathematics is started as a separate process. This has the advantage that an eventual crash of maxima cannot harm wxMaxima, which displays the worksheet.\n"
 "This icon indicates if data is transferred between maxima and wxMaxima."
 msgstr ""
+"‘Maxima’, el programa que hace las matemáticas actuales está inicializado como un proceso separado. Esto tiene la ventaja que un cuelgue de ‘maxima’ no puede bloquear a wxMaxima, la cual enseña el cuaderno.\n"
+"Este icono indica si el dato está transferido entre ‘maxima’ y wxMaxima."
 
 #: ../../src/wxMaxima.cpp:9228
 msgid "Maximum absolute value printed without exponent"
-msgstr ""
+msgstr "Valor absoluto máximo escrito sin exponente"
 
 #: ../../src/wxMaxima.cpp:9230
 msgid "Maximum number of digits to be displayed:"
-msgstr ""
+msgstr "Número máximo de dígitos a ser enseñado:"
 
 #: ../../src/wxMaxima.cpp:9568
 msgid "Mean:"
-msgstr ""
+msgstr "Media:"
 
 #: ../../src/wxMaximaFrame.cpp:1924
 msgid "Memoizing"
-msgstr ""
+msgstr "Memorizando"
 
 #: ../../src/wxMaximaFrame.cpp:1013
 msgid "Memory"
-msgstr ""
+msgstr "Memoria"
 
 #: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
 msgid "Merge Cells"
-msgstr ""
+msgstr "Unión de Celdas"
 
 #: ../../src/wxMaxima.cpp:5780
 msgid "Message from the stdout of Maxima: "
-msgstr ""
+msgstr "Mensaje de la salida estándar de ‘Maxima’: "
 
 #: ../../src/wxMaximaFrame.cpp:1326
 msgid "Methods of generating a matrix"
-msgstr ""
+msgstr "Métodos de generación de una matriz"
 
 #: ../../src/Worksheet.cpp:6866
 #, c-format
 msgid "Middle-click clipboard data: %s"
-msgstr ""
+msgstr "Datos del portapapeles de pulsación central: %s"
 
 #: ../../src/wxMaxima.cpp:9226
 msgid "Minimum absolute value printed without exponent:"
-msgstr ""
+msgstr "Valor absoluto mínimo escrito sin exponente:"
 
 #: ../../src/wxMaxima.cpp:10449 ../../src/wxMaxima.cpp:10451
 msgid "Mismatched parenthesis"
-msgstr ""
+msgstr "Paréntesis no pareados"
 
 #: ../../src/wxMaximaFrame.cpp:1352
 msgid "Multiplication, exponent and similar"
-msgstr ""
+msgstr "Multiplicación, exponente y similar"
 
 #: ../../src/Worksheet.cpp:1998
 msgid "Multiplicative function: f(a*b)=f(a)*f(b)"
-msgstr ""
+msgstr "Función multiplicativa: f(a*b)=f(a)*f(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1338
 msgid "Multiply matrices..."
-msgstr ""
+msgstr "Multiplicar matrices…"
 
 #: ../../src/wxMaxima.cpp:7981
 msgid "Multiply two matrices"
-msgstr ""
+msgstr "Multiplica dos matrices"
 
 #: ../../src/wxMaxima.cpp:9581
 msgid "Multivariate linear regression"
-msgstr ""
+msgstr "Regresión lineal multivariante"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Name of t:"
-msgstr ""
+msgstr "Nombre de t:"
 
 #: ../../src/wxMaxima.cpp:7838
 msgid "Name of x:"
-msgstr ""
+msgstr "Nombre de x:"
 
 #: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
 msgid "Nested list to Matrix"
-msgstr ""
+msgstr "Listado anidado a Matriz"
 
 #: ../../src/wxMaximaFrame.cpp:769 ../../src/wxMaximaFrame.cpp:1053
 msgid "Never"
-msgstr ""
+msgstr "Nunca"
 
 #: ../../src/wxMaxima.cpp:6534
 msgid "Never autosubscript this variable"
-msgstr ""
+msgstr "Nunca autosuscribir esta variable"
 
 #: ../../src/wxMaximaFrame.cpp:776
 msgid "Never display this variable with subscript"
-msgstr ""
+msgstr "Nunca despliegar esta variable con subscript"
 
 #: ../../src/Worksheet.cpp:1469 ../../src/Worksheet.cpp:1843
 msgid "Never offer known answers"
-msgstr ""
+msgstr "Nunca ofrecer respuestas conocidas"
 
 #: ../../src/ToolBar.cpp:174
 msgid "New"
-msgstr ""
+msgstr "Crear"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "New\tCtrl+N"
-msgstr ""
+msgstr "Crear\tCtrl+N"
 
 #: ../../src/ToolBar.cpp:611
 msgid "New button"
-msgstr ""
+msgstr "Crear botón"
 
 #: ../../src/wxMaxima.cpp:2483
 msgid "New connection attempt whilst already connected."
-msgstr ""
+msgstr "Intento de conexión nueva mientras ya está conectada."
 
 #: ../../src/wxMaxima.cpp:2491
 msgid ""
 "New connection attempt, but no currently no socket maxima could connect to."
 msgstr ""
+"Intento de conexión nueva, pero actualmente sin ejecutar el proceso de "
+"‘maxima’."
 
 #: ../../src/wxMaxima.cpp:2487
 msgid "New connection attempt, but no currently running maxima process."
 msgstr ""
+"Intento de conexión nueva, pero actualmente sin ejecutar el proceso de "
+"‘maxima’."
 
 #: ../../src/ToolBar.cpp:174
 msgid "New document"
-msgstr ""
+msgstr "Crear documento"
 
 #: ../../src/wxMaxima.cpp:3899
 #, c-format
 msgid "New maxima Operators detected: %s"
-msgstr ""
+msgstr "Operadores detectados nuevos de ‘maxima‘.%s"
 
 #: ../../src/wxMaxima.cpp:7390
 msgid "New part:"
-msgstr ""
+msgstr "Parte nueva:"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
 #: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
 msgid "New variable:"
-msgstr ""
+msgstr "Crear variable:"
 
 #: ../../src/wxMaximaFrame.cpp:929
 msgid "Next Command\tAlt+Down"
-msgstr ""
+msgstr "Instrucción siguiente\tAlt+↓"
 
 #: ../../src/wxMaximaFrame.cpp:748
 msgid "Nice Graphical Equations"
-msgstr ""
+msgstr "Ecuaciones Gráficas Detalladas"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "No"
-msgstr ""
+msgstr "No"
 
 #: ../../src/Worksheet.cpp:1972
 msgid "No Array"
-msgstr ""
+msgstr "Sin Repertorio"
 
 #: ../../src/Worksheet.cpp:1974
 msgid "No Scalar"
-msgstr ""
+msgstr "No Escalar"
 
 #: ../../src/wxMaxima.cpp:10482
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
+"No hay símbolo de dólar ($) ni de punto y coma (;) al final de la "
+"instrucción"
 
 #: ../../src/MaximaManual.cpp:406
 msgid "No entries in the caches for the subjects the manual contains."
 msgstr ""
+"Sin apuntes dentro de la caché para los asuntos que contiene el manual."
 
 #: ../../src/MaximaManual.cpp:101
 msgid ""
 "No file with the subjects the manual contained in the last wxMaxima run."
 msgstr ""
+"Ningún fichero con el asunto el manual contenido dentro de la última "
+"ejecución de wxMaxima."
 
 #: ../../src/Image.cpp:495
 msgid "No gnuplot data!"
-msgstr ""
+msgstr "¡Sin datos gnuplot!"
 
 #: ../../src/Image.cpp:530
 msgid "No gnuplot source!"
-msgstr ""
+msgstr "¡Sin origen gnuplot!"
 
 #: ../../src/wxMaxima.cpp:6662 ../../src/wxMaxima.cpp:6668
 #: ../../src/wxMaxima.cpp:6687 ../../src/wxMaxima.cpp:6697
 msgid "No matches found!"
-msgstr ""
+msgstr "¡No se encontraron coincidencias!"
 
 #: ../../src/wxMaxima.cpp:3240
 msgid "No topics found in topic flag"
-msgstr ""
+msgstr "Ningún tópico encontrado en el indicador tópico"
 
 #: ../../src/wxMaxima.cpp:3227
 msgid "No topics found in topic tag"
-msgstr ""
+msgstr "Ningún tópico encontrado en la etiqueta tópica"
 
 #: ../../src/wxMaximaFrame.cpp:797
 msgid "None"
-msgstr ""
+msgstr "Ninguno"
 
 #: ../../src/wxMaxima.cpp:8163
 msgid "Not a valid matrix dimension!"
-msgstr ""
+msgstr "¡No una dimensión válida de la matriz!"
 
 #: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
 msgid "Not a valid number of equations!"
-msgstr ""
+msgstr "¡El número de ecuaciones es incorrecto!"
 
 #: ../../src/StatusBar.cpp:256
 msgid "Not connected to Maxima"
-msgstr ""
+msgstr "No conectado a ‘Maxima’"
 
 #: ../../src/wxMaxima.cpp:10496
 msgid "Not triggering evaluation as maxima is still busy!"
-msgstr ""
+msgstr "Ninguna evaluación de disparador como ‘maxima‘ aún está ocupada."
 
 #: ../../src/wxMaxima.cpp:10503
 msgid "Not triggering evaluation as maxima still asks a question!"
 msgstr ""
+"Ninguna evaluación de disparador como ‘maxima‘ aún solicita una pregunta."
 
 #: ../../src/wxMaxima.cpp:10511
 msgid "Not triggering evaluation as there is no working maxima process"
 msgstr ""
+"Ninguna evaluación de disparador como no esté funcionando ningún proceso de "
+"‘maxima‘"
 
 #: ../../src/wxMaxima.cpp:8926
 msgid "Num. deg:"
-msgstr ""
+msgstr "Num. deg:"
 
 #: ../../src/wxMaxima.cpp:8540
 msgid "Number of elements"
-msgstr ""
+msgstr "Número de elementos"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
 msgid "Number of equations:"
-msgstr ""
+msgstr "Número de ecuaciones:"
 
 #: ../../src/wxMaxima.cpp:7481
 msgid "Number to octets"
-msgstr ""
+msgstr "Número de octetos"
 
 #: ../../src/wxMaximaFrame.cpp:1154
 msgid "Number to octets..."
-msgstr ""
+msgstr "Número de octetos…"
 
 #: ../../src/wxMaximaFrame.cpp:1906
 msgid "Number types"
-msgstr ""
+msgstr "Teclas numéricas"
 
 #: ../../src/wxMaxima.cpp:7482
 msgid "Number:"
-msgstr ""
+msgstr "Números:"
 
 #: ../../src/wxMaximaFrame.cpp:1786
 msgid "Numeric output"
-msgstr ""
+msgstr "Salida numérica"
 
 #: ../../src/wxMaxima.cpp:8040
 msgid "Numerical QR decomposition of a matrix"
-msgstr ""
+msgstr "Descomposición QR numérica de una matriz"
 
 #: ../../src/wxMaximaFrame.cpp:1417
 msgid "Numerical operations (lapack)"
-msgstr ""
+msgstr "Operaciones numéricas (lapack)"
 
 #: ../../src/wxMaxima.cpp:7831
 msgid "Numerical solution for 1st degree ODE"
-msgstr ""
+msgstr "Solución numérica para EDO de 1° grado"
 
 #: ../../src/wxMaximaFrame.cpp:1282
 msgid "Numerical solution..."
-msgstr ""
+msgstr "Solución numérica…"
 
 #: ../../src/wxMaximaFrame.cpp:1261
+#, fuzzy
 msgid "Numerical solutions of polynomial (bfloat)..."
-msgstr ""
+msgstr "Soluciones numéricas de polinomio…"
 
 #: ../../src/wxMaximaFrame.cpp:1258
 msgid "Numerical solutions of polynomial..."
-msgstr ""
+msgstr "Soluciones numéricas de polinomio…"
 
 #: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
 msgid "OK"
-msgstr ""
+msgstr "Aceptar"
 
 #: ../../src/wxMaximaFrame.cpp:122
 #, c-format
 msgid "OS: %s Version %li.%li"
-msgstr ""
+msgstr "SO: %s Versión %li.%li"
 
 #: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
 msgid "Object composed of elements"
-msgstr ""
+msgstr "Objeto compuesto de elementos"
 
 #: ../../src/wxMaxima.cpp:7680
 msgid "Object name:"
-msgstr ""
+msgstr "Nombre de objeto:"
 
 #: ../../src/wxMaxima.cpp:7281
 msgid "Object:"
-msgstr ""
+msgstr "Objeto:"
 
 #: ../../src/wxMaxima.cpp:7486
 msgid "Octets to Number"
-msgstr ""
+msgstr "Octetos a número"
 
 #: ../../src/wxMaxima.cpp:7491
 msgid "Octets to String"
-msgstr ""
+msgstr "Octetos a cadena"
 
 #: ../../src/wxMaximaFrame.cpp:1156
 msgid "Octets to number..."
-msgstr ""
+msgstr "Octetos a número…"
 
 #: ../../src/wxMaximaFrame.cpp:1158
 msgid "Octets to string..."
-msgstr ""
+msgstr "Octetos a cadena…"
 
 #: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
 msgid "Octets:"
-msgstr ""
+msgstr "Octetos:"
 
 #: ../../src/Worksheet.cpp:1958
 msgid "Odd number"
-msgstr ""
+msgstr "Número impar"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
 #: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
 msgid "Old variable:"
-msgstr ""
+msgstr "Variable antigua:"
 
 #: ../../src/wxMaximaFrame.cpp:1055
 msgid "On all errors"
-msgstr ""
+msgstr "En todos los errores"
 
 #: ../../src/wxMaximaFrame.cpp:1054
 msgid "On lisp errors"
-msgstr ""
+msgstr "En errores lisp"
 
 #: ../../src/wxMaxima.cpp:9566
 msgid "One sample t-test"
-msgstr ""
+msgstr "Una muestra test-t"
 
 #: ../../src/wxMaximaFrame.cpp:1927
 msgid "Online tutorials"
-msgstr ""
+msgstr "Tutoriales por conexión"
 
 #: ../../src/wxMaximaFrame.cpp:766
 msgid "Only Integers and single letters"
-msgstr ""
+msgstr "Solamente Enteros y letras únicas"
 
 #: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593
 #: ../../src/wxMaxima.cpp:6074
 msgid "Open"
-msgstr ""
+msgstr "Abrir"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "Open a document"
-msgstr ""
+msgstr "Abre un documento"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "Open a new window"
-msgstr ""
+msgstr "Abre una ventana nueva"
 
 #: ../../src/ToolBar.cpp:617
 msgid "Open and save button"
-msgstr ""
+msgstr "Botón para abrir y guardar"
 
 #: ../../src/ToolBar.cpp:176
 msgid "Open document"
-msgstr ""
+msgstr "Abrir documento"
 
 #: ../../src/wxMaxima.cpp:7239
 msgid "Open for appending"
-msgstr ""
+msgstr "Abre para adjuntar"
 
 #: ../../src/wxMaximaFrame.cpp:1099
 msgid "Open for appending..."
-msgstr ""
+msgstr "Abrir para adjunto…"
 
 #: ../../src/wxMaxima.cpp:7244
 msgid "Open for reading"
-msgstr ""
+msgstr "Abrir para lectura"
 
 #: ../../src/wxMaximaFrame.cpp:1098
 msgid "Open for reading..."
-msgstr ""
+msgstr "Abrir para lectura…"
 
 #: ../../src/wxMaxima.cpp:7249
 msgid "Open for writing"
-msgstr ""
+msgstr "Abrir para escritura"
 
 #: ../../src/wxMaximaFrame.cpp:1100
 msgid "Open for writing..."
-msgstr ""
+msgstr "Abrir para escritura…"
 
 #: ../../src/wxMaxima.cpp:9598
 msgid "Open matrix"
-msgstr ""
+msgstr "Abrir matriz"
 
 #: ../../src/wxMaximaFrame.cpp:600
 msgid "Open recent"
-msgstr ""
+msgstr "Abrir recientes"
 
 #: ../../src/wxMaxima.cpp:4309
 msgid "Opening a wxmx file"
-msgstr ""
+msgstr "Abriendo un fichero wxmx"
 
 #: ../../src/wxMaxima.cpp:4153 ../../src/wxMaxima.cpp:4214
 #: ../../src/wxMaxima.cpp:4313 ../../src/wxMaxima.cpp:4622
 msgid "Opening file"
-msgstr ""
+msgstr "Abriendo fichero"
 
 #: ../../src/wxMaxima.cpp:5030
 #, c-format
 msgid "Opening help file %s"
-msgstr ""
+msgstr "Abriendo fichero %s de ayuda"
 
 #: ../../src/wxMaximaFrame.cpp:1530
 msgid "Optimize for CPU time"
-msgstr ""
+msgstr "Optimizar para tiempo de CPU"
 
 #: ../../src/wxMaximaFrame.cpp:1529
 msgid "Optimize for memory"
-msgstr ""
+msgstr "Optimizar para memoria"
 
 #: ../../src/ToolBar.cpp:199
 msgid "Options"
-msgstr ""
+msgstr "Opciones"
 
 #: ../../src/wxMaximaFrame.cpp:1225
 msgid "Output C"
-msgstr ""
+msgstr "Salida en C"
 
 #: ../../src/wxMaximaFrame.cpp:1226
 msgid "Output Fortran"
-msgstr ""
+msgstr "Salida Fortran"
 
 #: ../../src/wxMaximaFrame.cpp:1228
 msgid "Output Rational Fortran"
-msgstr ""
+msgstr "Salida Fortran Racional"
 
 #: ../../src/Configuration.cpp:80
 msgid "Output labels"
-msgstr ""
+msgstr "Etiquetas de salida"
 
 #: ../../src/Configuration.cpp:73
 msgid "Output: Function names"
-msgstr ""
+msgstr "Salida: nombres de función"
 
 #: ../../src/Configuration.cpp:75
 msgid "Output: Latin names as greek symbols"
-msgstr ""
+msgstr "Salida: nombres latinos como símbolos griegos"
 
 #: ../../src/Configuration.cpp:72
 msgid "Output: Numbers and Digits"
-msgstr ""
+msgstr "Salida: números y dígitos"
 
 #: ../../src/Configuration.cpp:71
 msgid "Output: Operators"
-msgstr ""
+msgstr "Salida: operadores"
 
 #: ../../src/Configuration.cpp:74
 #, c-format
 msgid "Output: Special constants (%e,%i)"
-msgstr ""
+msgstr "Salida: constantes especiales (%e,%i)"
 
 #: ../../src/Configuration.cpp:76
 msgid "Output: Strings"
-msgstr ""
+msgstr "Salida: cadenas"
 
 #: ../../src/Configuration.cpp:70
 msgid "Output: Variable names"
-msgstr ""
+msgstr "Salida: nombres de variable"
 
 #: ../../src/wxMaxima.cpp:6442
 msgid ""
@@ -5081,6 +5316,10 @@ msgid ""
 "(*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format "
 "(*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"Imagen PNG (*.png)|*.png|Imagen JPEG (*.jpg)|*.jpg|Imagen GIF "
+"(*.gif)|*.gif|Gráficos vectoriales escalables (*.svg)|*.svg|Bitmaps Windows "
+"(*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Formato de imagen etiquetada "
+"(*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:10117
 msgid ""
@@ -5088,321 +5327,328 @@ msgid ""
 "(*.bmp)|*.bmp|GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged "
 "image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"Imagen PNG (*.png)|*.png|Imagen JPEG (*.jpg)|*.jpg|Bitmap Windows "
+"(*.bmp)|*.bmp|Imagen GIF (*.gif)|*.gif|Dispersión portable "
+"(*.pnm)|*.pnm|Formato de imagen etiquetada (*.tif)|*.tif|X pixmap "
+"(*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:8924
 msgid "Pade approximation"
-msgstr ""
+msgstr "Aproximación de Padé"
 
 #: ../../src/wxMaximaFrame.cpp:1478
 msgid "Pade approximation of a Taylor series"
-msgstr ""
+msgstr "Aproximación de Padé de una serie de Taylor"
 
 #: ../../src/wxMaximaFrame.cpp:1637
 msgid "Parallel Substitute..."
-msgstr ""
+msgstr "Sustitución paralela…"
 
 #: ../../src/wxMaxima.cpp:8738
 msgid "Parallel substitution"
-msgstr ""
+msgstr "Sustitución paralela"
 
 #: ../../src/wxMaxima.cpp:7179
 msgid "Parameter name:"
-msgstr ""
+msgstr "Nombre de parámetro:"
 
 #: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
 msgid "Parameter(s):"
-msgstr ""
+msgstr "Parámetro(s):"
 
 #: ../../src/wxMaxima.cpp:7399
 msgid "Parse string"
-msgstr ""
+msgstr "Interpretar cadena"
 
 #: ../../src/wxMaximaFrame.cpp:1152
 msgid "Parse string only..."
-msgstr ""
+msgstr "Interpreta cadena solamente…"
 
 #: ../../src/StatusBar.cpp:240
 msgid "Parsing output"
-msgstr ""
+msgstr "Analizando salida"
 
 #: ../../src/wxMaxima.cpp:7464
 msgid "Part:"
-msgstr ""
+msgstr "Parte:"
 
 #: ../../src/wxMaximaFrame.cpp:1499 ../../src/wxMaximaFrame.cpp:1535
 msgid "Partial &Fractions..."
-msgstr ""
+msgstr "&Fracciones parciales…"
 
 #: ../../src/wxMaxima.cpp:8975
 msgid "Partial Fractions"
-msgstr ""
+msgstr "Fracciones parciales"
 
 #: ../../src/wxMaxima.cpp:4702
 msgid "Parts of the document will not be loaded correctly!"
-msgstr ""
+msgstr "¡Lectura del documento parcialmente correcta!"
 
 #: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
 #: ../../src/Worksheet.cpp:1685
 msgid "Paste"
-msgstr ""
+msgstr "Pegar"
 
 #: ../../src/wxMaximaFrame.cpp:667
 msgid "Paste\tCtrl+V"
-msgstr ""
+msgstr "Pegar\tCtrl+V"
 
 #: ../../src/ToolBar.cpp:211
 msgid "Paste from clipboard"
-msgstr ""
+msgstr "Pegar desde el portapapeles"
 
 #: ../../src/wxMaximaFrame.cpp:668
 msgid "Paste text from clipboard"
-msgstr ""
+msgstr "Pegar texto desde el portapapeles"
 
 #: ../../src/wxMaxima.cpp:4841
 msgid "Please configure wxMaxima with 'Edit->Configure'."
-msgstr ""
+msgstr "Configure wxMaxima con 'Editar→Configurar'."
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot &2d..."
-msgstr ""
+msgstr "Tramado &2d…"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot &3d..."
-msgstr ""
+msgstr "Tramado &3d…"
 
 #: ../../src/wxMaximaFrame.cpp:1772
 msgid "Plot &Format..."
-msgstr ""
+msgstr "&Formato de tramado…"
 
 #: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
 msgid "Plot 2D"
-msgstr ""
+msgstr "Tramado 2D"
 
 #: ../../src/Worksheet.cpp:1593
 msgid "Plot 2D..."
-msgstr ""
+msgstr "Tramado 2D…"
 
 #: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
 msgid "Plot 3D"
-msgstr ""
+msgstr "Tramado 3D"
 
 #: ../../src/Worksheet.cpp:1595
 msgid "Plot 3D..."
-msgstr ""
+msgstr "Tramado 3D…"
 
 #: ../../src/wxMaxima.cpp:9538
 msgid "Plot as bars"
-msgstr ""
+msgstr "Tramado como barras"
 
 #: ../../src/wxMaxima.cpp:9542
 msgid "Plot as error bars"
-msgstr ""
+msgstr "Tramado como barras de error"
 
 #: ../../src/wxMaxima.cpp:9546
 msgid "Plot as pie chart"
-msgstr ""
+msgstr "Tramado como tarta circular"
 
 #: ../../src/wxMaxima.cpp:9112
 msgid "Plot format"
-msgstr ""
+msgstr "Formato de tramados"
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot in 2 dimensions"
-msgstr ""
+msgstr "Tramado en 2 dimensiones"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot in 3 dimensions"
-msgstr ""
+msgstr "Tramado en 3 dimensiones"
 
 #: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
 msgid "Plot using Draw"
-msgstr ""
+msgstr "Tramado utilizando Dibujo"
 
 #: ../../src/wxMaxima.cpp:7824
 msgid "Point #1 with known value:"
-msgstr ""
+msgstr "Punto nº1 con valor conocido:"
 
 #: ../../src/wxMaxima.cpp:7826
 msgid "Point #2 with known value:"
-msgstr ""
+msgstr "Punto nº2 con valor conocido:"
 
 #: ../../src/wxMaxima.cpp:7800 ../../src/wxMaxima.cpp:7811
 msgid "Point the value is known at:"
-msgstr ""
+msgstr "Puntear el valor es conocido en:"
 
 #: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
 msgid "Point:"
-msgstr ""
+msgstr "Punto:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 1:"
-msgstr ""
+msgstr "Polinomio 1:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 2:"
-msgstr ""
+msgstr "Polinomio 2:"
 
 #: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
 #: ../../src/wxMaxima.cpp:7739
 msgid "Polynomial:"
-msgstr ""
+msgstr "Polinomio:"
 
 #: ../../src/wxMaximaFrame.cpp:1754
 msgid "Pop"
-msgstr ""
+msgstr "Tirar"
 
 #: ../../src/Worksheet.cpp:1331 ../../src/Worksheet.cpp:1485
 msgid "Popout interactively"
-msgstr ""
+msgstr "Soltar interactivamente"
 
 #: ../../src/wxMaximaFrame.cpp:1189
 msgid "Position of a match"
-msgstr ""
+msgstr "Posición de una coincidencia"
 
 #: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
 msgid "Position:"
-msgstr ""
+msgstr "Posición:"
 
 #: ../../src/wxMaxima.cpp:8939
 msgid "Power series"
-msgstr ""
+msgstr "Series de potencias"
 
 #: ../../src/wxMaximaFrame.cpp:1475
 msgid "Power series..."
-msgstr ""
+msgstr "Series de potencias…"
 
 #: ../../src/wxMaxima.cpp:9202
 msgid "Precision"
-msgstr ""
+msgstr "Precisión"
 
 #: ../../src/Worksheet.cpp:1616
 msgid "Prefer user labels"
-msgstr ""
+msgstr "Preferir etiquetado del usuario"
 
 #: ../../src/main.cpp:437
 msgid "Preferences"
-msgstr ""
+msgstr "Preferencias"
 
 #: ../../src/ToolBar.cpp:626
 msgid "Preferences button"
-msgstr ""
+msgstr "Botón de Preferencias"
 
 #: ../../src/wxMaximaFrame.cpp:685
 msgid "Preferences...\tCtrl+,"
-msgstr ""
+msgstr "Preferencias…\tCtrl+,"
 
 #: ../../src/wxMaximaFrame.cpp:1733
 msgid "Prepend an element"
-msgstr ""
+msgstr "Pretende un elemento"
 
 #: ../../src/wxMaximaFrame.cpp:927
 msgid "Previous Command\tAlt+Up"
-msgstr ""
+msgstr "Instrucción anterior\tAlt+↑"
 
 #: ../../src/ToolBar.cpp:184
 msgid "Print"
-msgstr ""
+msgstr "Imprimir"
 
 #: ../../src/ToolBar.cpp:620
 msgid "Print button"
-msgstr ""
+msgstr "Botón de Impresión"
 
 #: ../../src/Worksheet.cpp:1493
 msgid "Print cell brackets"
-msgstr ""
+msgstr "Imprimir corchetes de celda"
 
 #: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
 msgid "Print document"
-msgstr ""
+msgstr "Imprimir documento"
 
 #: ../../src/wxMaximaFrame.cpp:1829
 msgid "Print floating-point numbers with exponents dividable by 3"
-msgstr ""
+msgstr "Escribe números de coma-flotante con exponente divisible entre 3"
 
 #: ../../src/WXMXformat.cpp:255
 msgid ""
 "Produced invalid XML. The erroneous XML data has therefore not been saved "
 "but has been put on the clipboard in order to allow to debug it."
 msgstr ""
+"Produjo XML inválido. Los datos erróneos de XML no ha sigo guardado pero ha "
+"sido puesto sobre el portapapeles con el fin que permita depurarlo."
 
 #: ../../src/wxMaxima.cpp:9061
 msgid "Product"
-msgstr ""
+msgstr "Producto"
 
 #: ../../src/wxMaximaFrame.cpp:1095
 msgid "Program"
-msgstr ""
+msgstr "Programa"
 
 #: ../../src/wxMaxima.cpp:7061
 msgid "Program (no local variables)"
-msgstr ""
+msgstr "Programa (sin variables local)"
 
 #: ../../src/wxMaxima.cpp:7052
 msgid "Program block"
-msgstr ""
+msgstr "Bloque del programa"
 
 #: ../../src/wxMaximaFrame.cpp:1066
 msgid "Program block with local variables..."
-msgstr ""
+msgstr "Bloque del programa con variables locales…"
 
 #: ../../src/wxMaximaFrame.cpp:1068
 msgid "Program block, no local variables..."
-msgstr ""
+msgstr "Bloque del programa, ninguna variable local…"
 
 #: ../../src/wxMaximaFrame.cpp:1751
 msgid "Push"
-msgstr ""
+msgstr "Empujar"
 
 #: ../../src/wxMaxima.cpp:8508
 msgid "Push an element to a list"
-msgstr ""
+msgstr "Empuja un elemento a un listado"
 
 #: ../../src/wxMaximaFrame.cpp:1395
 msgid "QR decomposition"
-msgstr ""
+msgstr "Descomposición QR"
 
 #: ../../src/wxMaxima.cpp:3621
 msgid "Querying gnuplot which graphics drivers it supports."
-msgstr ""
+msgstr "Solicitud de gnuplot cuyos controladores de gráficos están admitidos."
 
 #: ../../src/wxMaxima.cpp:8953
 msgid "Range radius:"
-msgstr ""
+msgstr "Intervalo del radio:"
 
 #: ../../src/wxMaximaFrame.cpp:1374
 msgid "Rank"
-msgstr ""
+msgstr "Puntuación"
 
 #: ../../src/wxMaximaFrame.cpp:246 ../../src/wxMaximaFrame.cpp:722
 msgid "Raw XML monitor"
-msgstr ""
+msgstr "Monitor XML crudo"
 
 #: ../../src/wxMaximaFrame.cpp:2117
 #, c-format
 msgid "Re-Reading the config from %s."
-msgstr ""
+msgstr "Re-leyendo la configuración desde %s."
 
 #: ../../src/wxMaximaFrame.cpp:2114
 msgid "Re-Reading the config from the default location."
-msgstr ""
+msgstr "Re-leyendo la configuración desde la localización predeterminada."
 
 #: ../../src/wxMaximaFrame.cpp:867
 msgid "Re-evaluate all cells above the one the cursor is in"
-msgstr ""
+msgstr "Reevaluar todas las celdas por encima del cursor"
 
 #: ../../src/wxMaximaFrame.cpp:877
 msgid "Re-evaluate all cells below the one the cursor is in"
-msgstr ""
+msgstr "Reevaluar todas las celdas por debajo de la que está bajo el cursor"
 
 #: ../../src/main.cpp:366
 msgid "Re-opening STDERR failed."
 msgstr ""
 
 #: ../../src/main.cpp:367
+#, fuzzy
 msgid "Re-opening STDIN failed."
-msgstr ""
+msgstr "Abriendo fichero"
 
 #: ../../src/main.cpp:365
 msgid "Re-opening STDOUT failed."
@@ -5413,385 +5659,396 @@ msgid ""
 "Re-using a compiled regex is faster that using the same regex string "
 "multiple times."
 msgstr ""
+"Re-utilizar una exreg compilada es más rápido que utilizar la misma cadena "
+"de exreg múltiples veces."
 
 #: ../../src/Worksheet.cpp:6668
 msgid "Read .wxm data from clipboard"
-msgstr ""
+msgstr "Lee datos de .wxm desde el portapapeles"
 
 #: ../../src/wxMaxima.cpp:7599
 msgid "Read Directory"
-msgstr ""
+msgstr "Leer Directorio"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Read List from csv file..."
-msgstr ""
+msgstr "Leer Listado desde archivo csv…"
 
 #: ../../src/wxMaxima.cpp:7196
 msgid "Read a structure field"
-msgstr ""
+msgstr "Leer un campo de estructura"
 
 #: ../../src/wxMaxima.cpp:7270 ../../src/wxMaxima.cpp:7274
 msgid "Read byte"
-msgstr ""
+msgstr "Leer byte"
 
 #: ../../src/wxMaxima.cpp:7266
 msgid "Read char"
-msgstr ""
+msgstr "Leer carácter"
 
 #: ../../src/wxMaxima.cpp:7593
 msgid "Read environment variable"
-msgstr ""
+msgstr "Lee variables del entorno"
 
 #: ../../src/wxMaximaFrame.cpp:1219
 msgid "Read environment variable..."
-msgstr ""
+msgstr "Leer variable de entorno…"
 
 #: ../../src/wxMaxima.cpp:7262
 msgid "Read line"
-msgstr ""
+msgstr "Leer línea"
 
 #: ../../src/MaximaManual.cpp:113
 #, c-format
 msgid "Read the entries the maxima manual offers from %s"
-msgstr ""
+msgstr "Lea los apuntes del manual de ‘maxima’ que se ofrece desde %s"
 
 #: ../../src/StatusBar.cpp:245
 msgid "Reading Maxima output"
-msgstr ""
+msgstr "Leyendo salida de Maxima"
 
 #: ../../src/StatusBar.cpp:247
 #, c-format
 msgid "Reading Maxima output: %li bytes"
-msgstr ""
+msgstr "Leyendo salida de ‘Maxima’: %li bytes"
 
 #: ../../src/wxMathml.cpp:55
 #, c-format
 msgid "Reading the Lisp part of wxMaxima from the file %s"
-msgstr ""
+msgstr "Leyendo la parte Lisp de wxMaxima desde el archivo %s"
 
 #: ../../src/wxMathml.cpp:43
 msgid "Reading the Lisp part of wxMaxima from the included header file."
 msgstr ""
+"Leyendo la parte Lisp de wxMaxima desde la cabecera del archivo incluido."
 
 #: ../../src/wxMaximaFrame.cpp:148
 #, c-format
 msgid "Reading the config from %s."
-msgstr ""
+msgstr "Leyendo la configuración desde %s."
 
 #: ../../src/wxMaximaFrame.cpp:151
 msgid "Reading the config from the default location."
-msgstr ""
+msgstr "Leyendo la configuración desde la localización predeterminada."
 
 #: ../../src/StatusBar.cpp:224
 msgid "Ready for user input"
-msgstr ""
+msgstr "Preparado para la entrada de usuario"
 
 #: ../../src/Worksheet.cpp:960
 msgid "Recalculated the whole worksheet at once => Updating its size"
 msgstr ""
+"Recalculado la hoja de cálculo completa en uno ⇒ Actualizando su tamaño"
 
 #: ../../src/Worksheet.cpp:946
 msgid "Recalculation hit the end of the worksheet => Updating its size"
 msgstr ""
+"Recalculado golpea el final de la hoja de cálculo ⇒ Actualizando su tamaño"
 
 #: ../../src/wxMaximaFrame.cpp:930
 msgid "Recall next command from history"
-msgstr ""
+msgstr "Reinvoca a la instrucción siguiente del historial"
 
 #: ../../src/wxMaximaFrame.cpp:928
 msgid "Recall previous command from history"
-msgstr ""
+msgstr "Reinvoca a la instrucción anterior del historial"
 
 #: ../../src/wxMaxima.cpp:3235
 #, c-format
 msgid "Received manual topic request: %s"
-msgstr ""
+msgstr "Recibió una solicitud de tópico manual: %s"
 
 #: ../../src/wxMaxima.cpp:3097
 #, c-format
 msgid "Received maxima's first prompt: %s"
-msgstr ""
+msgstr "Recibió un promt de ‘maxima’: %s"
 
 #: ../../src/wxMaximaFrame.cpp:603
 msgid "Recover unsaved"
-msgstr ""
+msgstr "Cobertura no guardada"
 
 #: ../../src/wxMaximaFrame.cpp:1640
 msgid "Recursive Substitute..."
-msgstr ""
+msgstr "Sustitución recursiva…"
 
 #: ../../src/wxMaxima.cpp:8746
 msgid "Recursive substitution"
-msgstr ""
+msgstr "Sustitución recursiva"
 
 #: ../../src/ToolBar.cpp:192
 msgid "Redo"
-msgstr ""
+msgstr "Rehacer"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo\tCtrl+Y"
-msgstr ""
+msgstr "Rehacer\tCtrl+Y"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo last change"
-msgstr ""
+msgstr "Rehacer última modificación"
 
 #: ../../src/wxMaximaFrame.cpp:1595
 msgid "Reduce trigonometric expression"
-msgstr ""
+msgstr "Simplificar expresión trigonométrica"
 
 #: ../../src/wxMaxima.cpp:2366 ../../src/wxMaxima.cpp:10630
 msgid "Refusing to send cell to maxima: "
-msgstr ""
+msgstr "Rechazado enviar una celda a maxima: "
 
 #: ../../src/wxMaxima.cpp:7523
 msgid "Regex match"
-msgstr ""
+msgstr "ExReg coincide"
 
 #: ../../src/wxMaxima.cpp:7518
 msgid "Regex match position"
-msgstr ""
+msgstr "ExReg coincide posición"
 
 #: ../../src/wxMaximaFrame.cpp:1195
+#, fuzzy
 msgid "Regular expression that matches a string"
-msgstr ""
+msgstr "ExReg que coincide con una cadena"
 
 #: ../../src/wxMaximaFrame.cpp:1196
+#, fuzzy
 msgid "Regular expressions"
-msgstr ""
+msgstr "Integrar expresión"
 
 #: ../../src/Worksheet.cpp:1314
 msgid "Reload Image"
-msgstr ""
+msgstr "Recargar Imagen"
 
 #: ../../src/Worksheet.cpp:1320
 #, c-format
 msgid "Reload Image \"%s\""
-msgstr ""
+msgstr "Recargar imagen «%s»"
 
 #: ../../src/wxMaxima.cpp:9809
 #, c-format
 msgid "Reloading image file %s."
-msgstr ""
+msgstr "Recargando archivo de imagen %s."
 
 #: ../../src/wxMaximaFrame.cpp:883
 msgid "Remove All Output"
-msgstr ""
+msgstr "Quitar todas los resultados"
 
 #: ../../src/wxMaximaFrame.cpp:1426
 msgid "Remove Rows or Columns..."
-msgstr ""
+msgstr "Retirar filas o columnas…"
 
 #: ../../src/wxMaximaFrame.cpp:1748
 msgid ""
 "Remove all list elements that appear twice in a row. Normally used in "
 "conjunction with sort."
 msgstr ""
+"Quita todos los elementos que aparecen dos veces en una fila. Normalmente "
+"empleados en conjunción con ordenación."
 
 #: ../../src/wxMaximaFrame.cpp:1174
 msgid "Remove all occurrences of a word..."
-msgstr ""
+msgstr "Retirar todas las apariciones de una palabra…"
 
 #: ../../src/wxMaxima.cpp:7439
 msgid "Remove all occurrences of part"
-msgstr ""
+msgstr "Retira todas las apariciones de parte"
 
 #: ../../src/wxMaxima.cpp:8592
 msgid "Remove an element from a list"
-msgstr ""
+msgstr "Quita un elemento desde un listado"
 
 #: ../../src/wxMaxima.cpp:7566
 msgid "Remove directory"
-msgstr ""
+msgstr "Retira directorio"
 
 #: ../../src/wxMaximaFrame.cpp:1204
 msgid "Remove directory..."
-msgstr ""
+msgstr "Retirar directorio…"
 
 #: ../../src/wxMaximaFrame.cpp:1747
 msgid "Remove duplicates"
-msgstr ""
+msgstr "Quita duplicados"
 
 #: ../../src/wxMaximaFrame.cpp:1176
 msgid "Remove first occurrence of a word..."
-msgstr ""
+msgstr "Retirar la primera aparición de una palabra…"
 
 #: ../../src/wxMaxima.cpp:7444
 msgid "Remove first occurrence of part"
-msgstr ""
+msgstr "Retira la primera aparición de parte"
 
 #: ../../src/wxMaximaFrame.cpp:884
 msgid "Remove output from input cells"
-msgstr ""
+msgstr "Quitar resultados desde las celdas de entrada"
 
 #: ../../src/wxMaxima.cpp:7975
 msgid "Remove rows and/or columns"
-msgstr ""
+msgstr "Retira filas y/o columnas"
 
 #: ../../src/wxMaximaFrame.cpp:1427
 msgid "Remove rows and/or columns from the matrix"
-msgstr ""
+msgstr "Retira filas y/o columnas desde la matriz"
 
 #: ../../src/wxMaxima.cpp:7582
 msgid "Rename file"
-msgstr ""
+msgstr "Renombrar archivo"
 
 #: ../../src/wxMaximaFrame.cpp:1215
 msgid "Rename file..."
-msgstr ""
+msgstr "Renombrar archivo…"
 
 #: ../../src/wxMaximaFrame.cpp:1527
 msgid "Reorganize an expression using horner's rule"
-msgstr ""
+msgstr "Reorganiza una expresión utilizando reglas de Horner"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "Repetitive element-by-element multiplication"
-msgstr ""
+msgstr "Repetición de multiplicación elemento-por-elemento"
 
 #: ../../src/wxMaxima.cpp:7538
 msgid "Replace all regex matches"
-msgstr ""
+msgstr "Remplaza todas las exreg coincidentes"
 
 #: ../../src/wxMaxima.cpp:7533
 msgid "Replace first regex match"
-msgstr ""
+msgstr "Remplaza la primera exreg coincidente"
 
 #: ../../src/wxMaxima.cpp:7463
 msgid "Replace the first occurrence of Part"
-msgstr ""
+msgstr "Remplaza la primera coincidencia de Parte"
 
 #: ../../src/wxMaximaFrame.cpp:1180
 msgid "Replace..."
-msgstr ""
+msgstr "Remplazar…"
 
 #: ../../src/wxMaxima.cpp:6719
 #, c-format
 msgid "Replaced %li occurrences."
-msgstr ""
+msgstr "%li ocurrencias reemplazadas."
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "Report bug"
-msgstr ""
+msgstr "Enviar un defecto"
 
 #: ../../src/wxMaximaFrame.cpp:996
 msgid "Reset option variables"
-msgstr ""
+msgstr "Restablecer variables de opción"
 
 #: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
 msgid "Restart Maxima"
-msgstr ""
+msgstr "Reiniciar ‘Maxima’"
 
 #: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
 msgid "Restrict Maximum size"
-msgstr ""
+msgstr "Restringir tamaño Máximo"
 
 #: ../../src/wxMaxima.cpp:10031
 msgid "Result variables:"
-msgstr ""
+msgstr "Resultado de variables:"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Resulting Matrix name (may be empty):"
-msgstr ""
+msgstr "Resultando nombre Matriz (tal vez vacío):"
 
 #: ../../src/wxMaximaFrame.cpp:1190
 msgid "Return a match"
-msgstr ""
+msgstr "Devuelve una coincidencia"
 
 #: ../../src/wxMaxima.cpp:7077
 msgid "Return from a block or loop"
-msgstr ""
+msgstr "Devuelve desde un bloque o bucle"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "Return from current block/loop..."
-msgstr ""
+msgstr "Devuelve desde el bloque/bucle actual…"
 
 #: ../../src/wxMaximaFrame.cpp:1755
 msgid ""
 "Return the first item of the list and remove it from the list. Useful for "
 "creating stacks."
 msgstr ""
+"Devuelve el primer elemento del listado y quítalo desde el listado. Útil "
+"para crear pilas."
 
 #: ../../src/wxMaxima.cpp:8526
 msgid "Return the list without its first n elements"
-msgstr ""
+msgstr "Devuelve el listado sin sus primeros n elementos"
 
 #: ../../src/wxMaxima.cpp:8532
 msgid "Return the list without its last n elements"
-msgstr ""
+msgstr "Devuelve el listado sin sus n elementos últimos"
 
 #: ../../src/ToolBar.cpp:241
 msgid "Return to the cell that is currently being evaluated"
-msgstr ""
+msgstr "Devuelve a la celda que se está evaluando actualmente"
 
 #: ../../src/wxMaximaFrame.cpp:1711
 msgid "Returns an arbitrary list item"
-msgstr ""
+msgstr "Devuelve un elemento arbitrario del listado"
 
 #: ../../src/wxMaximaFrame.cpp:1713
 msgid "Returns the first item of the list"
-msgstr ""
+msgstr "Devuelve el primer elemento del listado"
 
 #: ../../src/wxMaximaFrame.cpp:1719
 msgid "Returns the last item of the list"
-msgstr ""
+msgstr "Devuelve el último elemento del listado"
 
 #: ../../src/wxMaximaFrame.cpp:1721
 msgid "Returns the last n items of the list"
-msgstr ""
+msgstr "Devuelve los últimos n elementos del listado"
 
 #: ../../src/wxMaximaFrame.cpp:1742
 msgid "Returns the length of the list"
-msgstr ""
+msgstr "Devuelve la longitud del listado"
 
 #: ../../src/wxMaximaFrame.cpp:1715
 msgid "Returns the list without its first n elements"
-msgstr ""
+msgstr "Devuelve el listado sin sus primeros n elementos"
 
 #: ../../src/wxMaximaFrame.cpp:1717
 msgid "Returns the list without its last n elements"
-msgstr ""
+msgstr "Devuelve el listado sin sus últimos n elementos"
 
 #: ../../src/wxMaximaFrame.cpp:1743
 msgid "Reverse"
-msgstr ""
+msgstr "Inverso"
 
 #: ../../src/wxMaximaFrame.cpp:1744
 msgid "Reverse the order of the list items"
-msgstr ""
+msgstr "Invierte el orden de los elementos del listado"
 
 #: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
 #: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
 msgid "Right Matrix:"
-msgstr ""
+msgstr "Matriz der:"
 
 #: ../../src/wxMaxima.cpp:8190
 msgid "Right end"
-msgstr ""
+msgstr "Derecha final"
 
 #: ../../src/wxMaximaFrame.cpp:1301
 msgid "Right side to the \"=\""
-msgstr ""
+msgstr "Lado derecho del \"=\""
 
 #: ../../src/wxMaximaFrame.cpp:1455
 msgid "Risch Integration..."
-msgstr ""
+msgstr "Integración Risch…"
 
 #: ../../src/wxMaximaFrame.cpp:785
 msgid "Rounded"
-msgstr ""
+msgstr "Redondeo"
 
 #: ../../src/wxMaximaFrame.cpp:1437
 msgid "Row and column operations"
-msgstr ""
+msgstr "Operaciones de fila y columna"
 
 #: ../../src/wxMaxima.cpp:7957 ../../src/wxMaxima.cpp:7967
 #: ../../src/wxMaxima.cpp:7972
 msgid "Row number:"
-msgstr ""
+msgstr "Número de fila:"
 
 #: ../../src/wxMaxima.cpp:7977
 msgid "Row numbers:"
-msgstr ""
+msgstr "Números de fila:"
 
 #: ../../src/wxMaxima.cpp:8203
 msgid "Rows"
@@ -5799,149 +6056,154 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Rule"
-msgstr ""
+msgstr "Regla"
 
 #: ../../src/wxMaxima.cpp:8464 ../../src/wxMaxima.cpp:8477
 msgid "Rule:"
-msgstr ""
+msgstr "Regla:"
 
 #: ../../src/wxMaximaFrame.cpp:1027
 msgid "Rules"
-msgstr ""
+msgstr "Reglas"
 
 #: ../../src/wxMaximaFrame.cpp:1693
 msgid "Run each element through an expression"
-msgstr ""
+msgstr "Ejecuta cada elemento a través de una expresión"
 
 #: ../../src/wxMaxima.cpp:6355
 #, c-format
 msgid "Running %s on the file %s: "
-msgstr ""
+msgstr "Ejecutando %s en el fichero %s: "
 
 #: ../../src/wxMaxima.cpp:2633
 #, c-format
 msgid "Running maxima as: %s"
-msgstr ""
+msgstr "Ejecutando ‘maxima’ como: %s"
 
 #: ../../src/wxMaximaFrame.cpp:130
 msgid "Running on DirectFB"
-msgstr ""
+msgstr "Ejecutando en DirectFB"
 
 #: ../../src/wxMaximaFrame.cpp:114
 msgid "Running on MS Windows"
-msgstr ""
+msgstr "Ejecutando en MS Windows"
 
 #: ../../src/wxMaximaFrame.cpp:116
 msgid "Running on MS Windows using DirectDraw"
-msgstr ""
+msgstr "Ejecutando en MS Windows utilizando DirectDraw"
 
 #: ../../src/wxMaximaFrame.cpp:136
 msgid "Running on Mac OS"
-msgstr ""
+msgstr "Ejecutando en Mac OS"
 
 #: ../../src/wxMaximaFrame.cpp:127
 msgid "Running on Motif"
-msgstr ""
+msgstr "Ejecutando en Motif"
 
 #: ../../src/wxMaximaFrame.cpp:133
 msgid "Running on the universal wxWidgets port"
-msgstr ""
+msgstr "Ejecutando sobre el puerto universal wxWidget"
 
 #: ../../src/wxMaxima.cpp:8208
 msgid ""
 "Runs each element of an object (list, matrix, equation,...) through a "
 "function individually"
 msgstr ""
+"Ejecuten cada elemento de un objeto (listado, matriz, ecuación,…) a través "
+"de una función individualmente"
 
 #: ../../src/wxMaxima.cpp:8216
 msgid ""
 "Runs each element of an object (list, matrix, equation,...) through an "
 "expression individually"
 msgstr ""
+"Ejecuten cada elemento de un objeto (listado, matriz, ecuación,…) a través "
+"de una expresión individualmente"
 
 #: ../../src/wxMaximaFrame.cpp:1691
 msgid "Runs each element through a function"
-msgstr ""
+msgstr "Ejecuta cada elemento a través de una función"
 
 #: ../../src/wxMaximaFrame.cpp:1694
 msgid "Runs each element through an expression"
-msgstr ""
+msgstr "Ejecuten cada elemento a través de una expresión"
 
 #: ../../src/wxMaxima.cpp:9572
 msgid "Sample 1:"
-msgstr ""
+msgstr "Muestra 1:"
 
 #: ../../src/wxMaxima.cpp:9573
 msgid "Sample 2:"
-msgstr ""
+msgstr "Muestra 2:"
 
 #: ../../src/wxMaxima.cpp:9567
 msgid "Sample:"
-msgstr ""
+msgstr "Muestra:"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
 msgid "Save"
-msgstr ""
+msgstr "Guardar"
 
 #: ../../src/Worksheet.cpp:1294
 msgid "Save Animation..."
-msgstr ""
+msgstr "Guardar animación…"
 
 #: ../../src/wxMaxima.cpp:5672
 msgid "Save As"
-msgstr ""
+msgstr "Guardar Como"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save As...\tShift+Ctrl+S"
-msgstr ""
+msgstr "Guardar como…\tMayús+Ctrl+S"
 
 #: ../../src/Worksheet.cpp:1291
 msgid "Save Image..."
-msgstr ""
+msgstr "Guardar imagen…"
 
 #: ../../src/wxMaxima.cpp:6440
 msgid "Save Selection to Image"
-msgstr ""
+msgstr "Guardar selección a imagen"
 
 #: ../../src/wxMaximaFrame.cpp:675
 msgid "Save Selection to Image..."
-msgstr ""
+msgstr "Guardar Selección como Imagen…"
 
 #: ../../src/wxMaxima.cpp:10184
 msgid "Save animation to file"
-msgstr ""
+msgstr "Guardar animación al fichero"
 
 #: ../../src/wxMaxima.cpp:7203
 msgid "Save as lisp code"
-msgstr ""
+msgstr "Guarda como código lisp"
 
 #: ../../src/wxMaximaFrame.cpp:1091
 msgid "Save as lisp..."
-msgstr ""
+msgstr "Guardar como lisp…"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
 msgid "Save document"
-msgstr ""
+msgstr "Guardar documento"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save document as"
-msgstr ""
+msgstr "Guardar documento como"
 
 #: ../../src/wxMaximaFrame.cpp:676
 msgid "Save selection from document to an image file"
-msgstr ""
+msgstr "Guardar selección del documento a un fichero de imagen"
 
 #: ../../src/wxMaxima.cpp:10125
 msgid "Save selection to file"
-msgstr ""
+msgstr "Guardar selección en un fichero"
 
 #: ../../src/wxMaximaFrame.cpp:573
 msgid "Saving failed."
-msgstr ""
+msgstr "Guardado fallado."
 
 #: ../../src/WXMXformat.cpp:310
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
 msgstr ""
+"Guardado correcto, pero los archivos resultantes han desaparecido ?!?."
 
 #: ../../src/wxMaxima.cpp:10107
 msgid ""
@@ -5950,337 +6212,354 @@ msgid ""
 "(*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|Portable anymap "
 "(*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"Imagen Vectorial Escalable (*.svg)|*.svg|Imagen Vectorial Escalable "
+"Comprimida (*.svgz)|*.svgz|Imagen PNG (*.png)|*.png|Imagen JPEG "
+"(*.jpg)|*.jpg|Imagen GIF (*.gif)|*.gif|Bitmap Windows "
+"(*.bmp)|*.bmp|Cualquiera Portable (*.pnm)|*.pnm|Formato de fichero de imagen"
+" Tagged (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:9533
 msgid "Scatterplot"
-msgstr ""
+msgstr "Trama de Dispersión"
 
 #: ../../src/Autocomplete.cpp:125
 msgid ""
 "Scheduling a background task that compiles a new list of autocompletable "
 "maxima commands."
 msgstr ""
+"Programar una tarea de segundo plano que compile un listado nuevo de "
+"instrucciones de ‘maxima’ autocompletable."
 
 #: ../../src/Autocomplete.cpp:458
 msgid ""
 "Scheduling a background task that scans for autocompletable file names."
 msgstr ""
+"Programar un tarea en segundo plano que analiza para nombres de fichero "
+"autocompletables."
 
 #: ../../src/ToolBar.cpp:632
 msgid "Search button"
-msgstr ""
+msgstr "Botón de Búsqueda"
 
 #: ../../src/wxMaxima.cpp:7454
 msgid "Search first occurrence of part"
-msgstr ""
+msgstr "Busca la primera aparición de parte"
 
 #: ../../src/wxMaximaFrame.cpp:1178
 msgid "Search..."
-msgstr ""
+msgstr "Buscar…"
 
 #: ../../src/ToolBar.cpp:273
 msgid "Section"
-msgstr ""
+msgstr "Sección"
 
 #: ../../src/Configuration.cpp:91
 msgid "Section cell (Heading 2)"
-msgstr ""
+msgstr "Celda de sección (Cabecera 2)"
 
 #: ../../src/wxMaxima.cpp:7218
 msgid "Seek to position"
-msgstr ""
+msgstr "Continuar a posición"
 
 #: ../../src/BTextCtrl.cpp:45
 msgid "Seems like something is broken with a font."
-msgstr ""
+msgstr "Parece como algo está roto con una tipografía."
 
 #: ../../src/Autocomplete.cpp:350
 msgid "Seems like the package with the maxima share files isn't installed."
 msgstr ""
+"Parece que el paquete con los ficheros compartidos de ‘maxima’ no están "
+"instalados."
 
 #: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
 msgid "Select All"
-msgstr ""
+msgstr "Seleccionar Todo"
 
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select All\tCtrl+A"
-msgstr ""
+msgstr "Seleccionar todo\tCtrl+A"
 
 #: ../../src/ToolBar.cpp:629
 msgid "Select All button"
-msgstr ""
+msgstr "Botón de Seleccionar todo"
 
 #: ../../src/wxMaxima.cpp:9631
 msgid "Select Subsample"
-msgstr ""
+msgstr "Seleccionar Submuestra"
 
 #: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select all"
-msgstr ""
+msgstr "Seleccionar todo"
 
 #: ../../src/wxMaxima.cpp:6971
 msgid "Select math display algorithm"
-msgstr ""
+msgstr "Seleccionar el algoritmo de vista matemática"
 
 #: ../../src/Configuration.cpp:98
 msgid "Selection color"
-msgstr ""
+msgstr "Color de selección"
 
 #: ../../src/ToolBar.cpp:252
 msgid "Send all cells to maxima"
-msgstr ""
+msgstr "Envíe todas las celdas a ‘maxima’"
 
 #: ../../src/ToolBar.cpp:249
 msgid "Send the current cell to maxima"
-msgstr ""
+msgstr "Envíe la celda actual a ‘maxima’"
 
 #: ../../src/wxMaxima.cpp:2810
 msgid "Sending Maxima a SIGINT signal."
-msgstr ""
+msgstr "Enviando una señal SIGINTa ‘Maxima’."
 
 #: ../../src/StatusBar.cpp:220
 msgid "Sending a command to Maxima"
-msgstr ""
+msgstr "Enviando una instrucción a ‘Maxima’"
 
 #: ../../src/wxMaxima.cpp:10598
 msgid "Sending a new command to Maxima."
-msgstr ""
+msgstr "Enviando una instrucción nueva a Maxima."
 
 #: ../../src/wxMaxima.cpp:2792
 msgid "Sending an interrupt signal to Maxima."
-msgstr ""
+msgstr "Enviando una señal de interrupción a ‘Maxima’."
 
 #: ../../src/wxMaxima.cpp:169
 msgid "Sending configuration data to maxima."
-msgstr ""
+msgstr "Enviando datos de configuración a ‘maxima’."
 
 #: ../../src/wxMaxima.cpp:4718
 msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
+"Enviando a ‘maxima’ la información relativa a como expresar matemáticas 2d "
+"como XML"
 
 #: ../../src/wxMaximaFrame.cpp:1533
 msgid "Sequential Comparative Simplification"
-msgstr ""
+msgstr "Simplificación Comparativa Secuencial"
 
 #: ../../src/wxMaxima.cpp:9016
 msgid "Series"
-msgstr ""
+msgstr "Series"
 
 #: ../../src/wxMaximaFrame.cpp:1479
 msgid "Series approximation"
-msgstr ""
+msgstr "Aproximación de series"
 
 #: ../../src/wxMaxima.cpp:2561
 msgid "Server started"
-msgstr ""
+msgstr "Servidor iniciado"
 
 #: ../../src/wxMaximaFrame.cpp:1824
 msgid "Set &displayed Precision..."
-msgstr ""
+msgstr "Ajustar &precisión enseñada…"
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Set Maxima option variable logexpand:all"
-msgstr ""
+msgstr "Fija la variable de opción Maxima en logexpand:all"
 
 #: ../../src/wxMaximaFrame.cpp:1567
 msgid "Set Maxima option variable logexpand:super"
-msgstr ""
+msgstr "Fija la variable de opción Maxima en logexpand:super"
 
 #: ../../src/wxMaximaFrame.cpp:1560
 msgid "Set Maxima option variable logexpand:true"
-msgstr ""
+msgstr "Fija la variable de opción Maxima en logexpand:true"
 
 #: ../../src/wxMaximaFrame.cpp:822
 msgid "Set Zoom"
-msgstr ""
+msgstr "Establecer Zoom"
 
 #: ../../src/wxMaximaFrame.cpp:1819
 msgid "Set bigfloat &Precision..."
-msgstr ""
+msgstr "Ajustar &precisión real grande…"
 
 #: ../../src/Worksheet.cpp:1306 ../../src/Worksheet.cpp:1479
 msgid "Set image resolution"
-msgstr ""
+msgstr "Ajustar resolución de imagen"
 
 #: ../../src/wxMaximaFrame.cpp:1510
 msgid "Set main variable..."
-msgstr ""
+msgstr "Fijar variable principal…"
 
 #: ../../src/wxMaximaFrame.cpp:1773
 msgid "Set plot format"
-msgstr ""
+msgstr "Ajustar formatos de tramas"
 
 #: ../../src/wxMaximaFrame.cpp:1101
 msgid "Set position..."
-msgstr ""
+msgstr "Ajustar posición…"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Set the \"algebraic\" flag"
-msgstr ""
+msgstr "Establece el marcaje «algebraico»"
 
 #: ../../src/wxMaxima.cpp:8314
 msgid "Set the diagram title"
-msgstr ""
+msgstr "Establece el título de diagrama"
 
 #: ../../src/wxMaximaFrame.cpp:1779
 msgid "Set the frame rate for animations."
-msgstr ""
+msgstr "Establece el tipo de marco para animaciones."
 
 #: ../../src/wxMaxima.cpp:8377
 msgid "Set the grid density."
-msgstr ""
+msgstr "Establece la densidad de cuadrícula."
 
 #: ../../src/wxMaxima.cpp:8327
 msgid "Set the next plot's title. Empty = no title."
-msgstr ""
+msgstr "Establece el título del tramado siguiente. Vacío = sin título."
 
 #: ../../src/wxMaximaFrame.cpp:1820
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can"
 " be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
+"Establece la precisión de los números que se define como real grande. Tales "
+"números se pueden generar escribiendo 1'5b12 o bfloat(1'234)"
 
 #: ../../src/wxMaximaFrame.cpp:811
 msgid "Set zoom to 100%"
-msgstr ""
+msgstr "Establecer ampliación al 100%"
 
 #: ../../src/wxMaximaFrame.cpp:813
 msgid "Set zoom to 120%"
-msgstr ""
+msgstr "Establecer ampliación al 120%"
 
 #: ../../src/wxMaximaFrame.cpp:815
 msgid "Set zoom to 150%"
-msgstr ""
+msgstr "Establecer ampliación al 150%"
 
 #: ../../src/wxMaximaFrame.cpp:817
 msgid "Set zoom to 200%"
-msgstr ""
+msgstr "Establecer ampliación al 200%"
 
 #: ../../src/wxMaximaFrame.cpp:819
 msgid "Set zoom to 300%"
-msgstr ""
+msgstr "Establecer ampliación al 300%"
 
 #: ../../src/wxMaximaFrame.cpp:809
 msgid "Set zoom to 80%"
-msgstr ""
+msgstr "Establecer disminución al 80%"
 
 #: ../../src/wxMaxima.cpp:4731
 #, c-format
 msgid "Setting gnuplot_binary to %s"
-msgstr ""
+msgstr "Ajustando gnuplot_binary a %s"
 
 #: ../../src/wxMaxima.cpp:4804
 msgid "Setting prompt and help format"
-msgstr ""
+msgstr "Ajustar intérprete y formatos de ayuda"
 
 #: ../../src/wxMaximaFrame.cpp:1292
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
+"Preparar condiciones iniciales para resolver EDO mediante la transformada de"
+" Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1661
 msgid "Setup modulus computation"
-msgstr ""
+msgstr "Preparar cálculo de módulo"
 
 #: ../../src/wxMaxima.cpp:9220
 msgid "Setup the engineering format"
-msgstr ""
+msgstr "Preparar el formato de ingeniería"
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "Setup the engineering format..."
-msgstr ""
+msgstr "Configura el formato de ingeniería…"
 
 #: ../../src/wxMaxima.cpp:9576
 msgid "Shapiro-Wilk test for normality"
-msgstr ""
+msgstr "Test Shapiro-Wilk de normalidad"
 
 #: ../../src/Worksheet.cpp:1543
 msgid "Show \"%\" in special constants"
-msgstr ""
+msgstr "Mostrar \"%\" en constantes especiales"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show &Tips..."
-msgstr ""
+msgstr "Mostrar &sugerencias…"
 
 #: ../../src/Worksheet.cpp:1556
 msgid "Show * as multiplication dot"
-msgstr ""
+msgstr "Mostrar * como punto de multiplicación"
 
 #: ../../src/wxMaximaFrame.cpp:895
 msgid "Show Template\tCtrl+Shift+Space"
-msgstr ""
+msgstr "Mostrar plantilla\tCtrl+Mayús+Espacio"
 
 #: ../../src/wxMaximaFrame.cpp:753
 msgid "Show XML representation"
-msgstr ""
+msgstr "Muestra la representación XML"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show a tip"
-msgstr ""
+msgstr "Mostrar una sugerencia"
 
 #: ../../src/Worksheet.cpp:1607
 msgid "Show all + allow linebreaks in long numbers"
-msgstr ""
+msgstr "Muestra todo + permite salto de líneas en números largos"
 
 #: ../../src/wxMaxima.cpp:9475
 msgid "Show all commands similar to:"
-msgstr ""
+msgstr "Mostrar todas las instrucciones similares a:"
 
 #: ../../src/wxMaxima.cpp:9468
 msgid "Show an example for the command:"
-msgstr ""
+msgstr "Muestra un ejemplo para la función:"
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "Show an example of usage"
-msgstr ""
+msgstr "Muestra un ejemplo de utilización"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "Show commands similar to"
-msgstr ""
+msgstr "Mostrar instrucciones similares a"
 
 #: ../../src/wxMaximaFrame.cpp:1020
 msgid "Show defined functions"
-msgstr ""
+msgstr "Muestra las funciones definidas"
 
 #: ../../src/wxMaximaFrame.cpp:1022
 msgid "Show defined variables"
-msgstr ""
+msgstr "Muestra las variables definidas"
 
 #: ../../src/wxMaximaFrame.cpp:1074
 msgid "Show definition of a function"
-msgstr ""
+msgstr "Muestra la definición de una función"
 
 #: ../../src/wxMaximaFrame.cpp:740
 msgid "Show equations in their linear form"
-msgstr ""
+msgstr "Mostrar ecuaciones en su formulario lineal"
 
 #: ../../src/wxMaximaFrame.cpp:1073
 msgid "Show function &Definition..."
-msgstr ""
+msgstr "Mostrar &definición de función…"
 
 #: ../../src/wxMaximaFrame.cpp:896
 msgid "Show function template"
-msgstr ""
+msgstr "Mostrar plantilla de función"
 
 #: ../../src/Worksheet.cpp:1614
 msgid "Show input labels"
-msgstr ""
+msgstr "Muestra etiquetas de entrada"
 
 #: ../../src/wxMaximaFrame.cpp:750
 msgid "Show lisp representation"
-msgstr ""
+msgstr "Muestra representación lisp"
 
 #: ../../src/Worksheet.cpp:1604
 msgid "Show max. 100 digits"
-msgstr ""
+msgstr "Mostar max. 100 dígitos"
 
 #: ../../src/Worksheet.cpp:1602
 msgid "Show max. 20 digits"
-msgstr ""
+msgstr "Mostrar max. 20 dígitos"
 
 #: ../../src/Worksheet.cpp:1603
 msgid "Show max. 50 digits"
-msgstr ""
+msgstr "Mostrar max. 50 dígitos"
 
 #: ../../src/wxMaximaFrame.cpp:835
 msgid "Show or hide the wxMaxima logging window"
@@ -6288,261 +6567,263 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:612
 msgid "Show the \"New\" button?"
-msgstr ""
+msgstr "¿Muestro el botón «Nuevo»?"
 
 #: ../../src/ToolBar.cpp:636
 msgid "Show the \"help\" button?"
-msgstr ""
+msgstr "¿Muestro el botón de «ayuda»?"
 
 #: ../../src/ToolBar.cpp:633
 msgid "Show the \"search\" button?"
-msgstr ""
+msgstr "¿Muestro el botón de «búsqueda»?"
 
 #: ../../src/ToolBar.cpp:630
 msgid "Show the \"select all\" button?"
-msgstr ""
+msgstr "¿Muestro el botón de «seleccionar todo»?"
 
 #: ../../src/ToolBar.cpp:624
 msgid "Show the Copy, Cut and the Paste button?"
-msgstr ""
+msgstr "¿Muestro el botón de Copiar, Cortar y Pegar?"
 
 #: ../../src/wxMaxima.cpp:7033
 msgid "Show the function's definition"
-msgstr ""
+msgstr "Muestra la definición de la función"
 
 #: ../../src/ToolBar.cpp:618
 msgid "Show the open and the save button?"
-msgstr ""
+msgstr "¿Muestro el botón de abrir y guardar?"
 
 #: ../../src/ToolBar.cpp:627
 msgid "Show the preferences button?"
-msgstr ""
+msgstr "¿Muestro el botón de «preferencias»?"
 
 #: ../../src/ToolBar.cpp:621
 msgid "Show the print button?"
-msgstr ""
+msgstr "¿Muestro el botón de «impresión»?"
 
 #: ../../src/ToolBar.cpp:615
 msgid "Show the undo and redo button?"
-msgstr ""
+msgstr "¿Muestro el botón deshacer y rehacer?"
 
 #: ../../src/wxMaximaFrame.cpp:1006 ../../src/wxMaximaFrame.cpp:1011
 msgid "Show used + to-be-freed memory"
-msgstr ""
+msgstr "Muestra memoria utilizada + ser-liberada"
 
 #: ../../src/wxMaximaFrame.cpp:1033
 msgid "Show user definitions"
-msgstr ""
+msgstr "Muestra definiciones del usuario"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Show wxMaxima help"
-msgstr ""
+msgstr "Ayuda de wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1825
 msgid "Shows how many digits of a numbers are displayed"
-msgstr ""
+msgstr "Muestra cuantos dígitos de un número son enseñados"
 
 #: ../../src/wxMaximaFrame.cpp:732
 msgid "Sidebars"
-msgstr ""
+msgstr "Barras laterales"
 
 #: ../../src/wxMaximaFrame.cpp:1513
 msgid "Simplify &Radicals..."
-msgstr ""
+msgstr "Simplificar &radicales…"
 
 #: ../../src/Worksheet.cpp:1579
 msgid "Simplify Expression"
-msgstr ""
+msgstr "Simplificar Expresión"
 
 #: ../../src/wxMaximaFrame.cpp:1568
 msgid "Simplify Logarithms"
-msgstr ""
+msgstr "Simplificar logaritmos"
 
 #: ../../src/wxMaximaFrame.cpp:1582
 msgid "Simplify an expression containing factorials"
-msgstr ""
+msgstr "Simplificar una expresión que contiene factoriales"
 
 #: ../../src/wxMaximaFrame.cpp:1539
 msgid "Simplify equations"
-msgstr ""
+msgstr "Simplificar ecuaciones"
 
 #: ../../src/wxMaximaFrame.cpp:1514
 msgid "Simplify expression containing radicals"
-msgstr ""
+msgstr "Simplificar una expresión que contiene radicales"
 
 #: ../../src/wxMaxima.cpp:8649
 msgid "Simplify radicals"
-msgstr ""
+msgstr "Simplificar radicales"
 
 #: ../../src/wxMaximaFrame.cpp:1512
 msgid "Simplify rational expression"
-msgstr ""
+msgstr "Simplificar expresión racional"
 
 #: ../../src/wxMaximaFrame.cpp:1538
 msgid "Simplify sum() commands..."
-msgstr ""
+msgstr "Simplificar instrucciones sum()…"
 
 #: ../../src/wxMaxima.cpp:8636
 msgid "Simplify sums"
-msgstr ""
+msgstr "Simplificar sumatorios"
 
 #: ../../src/wxMaximaFrame.cpp:1592
 msgid "Simplify trigonometric expression"
-msgstr ""
+msgstr "Simplificar una expresión trigonométrica"
 
 #: ../../src/wxMaximaFrame.cpp:1399
 msgid "Singular Values"
-msgstr ""
+msgstr "Valores Singulares"
 
 #: ../../src/wxMaximaFrame.cpp:1400 ../../src/wxMaximaFrame.cpp:1403
 msgid "Singular values using dgesvd"
-msgstr ""
+msgstr "Valores singulares utilizando dgesvd"
 
 #: ../../src/wxMaximaFrame.cpp:1402
 msgid "Singular values, left + right vectors"
-msgstr ""
+msgstr "Valores singulares, vectores izq + der"
 
 #: ../../src/wxMaximaFrame.cpp:1635
 msgid "Smart Substitute..."
-msgstr ""
+msgstr "Sustituto inteligente…"
 
 #: ../../src/wxMaxima.cpp:8730
 msgid "Smart substitution"
-msgstr ""
+msgstr "Sustitución inteligente"
 
 #: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
 #: ../../src/wxMaxima.cpp:7823
 msgid "Solution of the ODE:"
-msgstr ""
+msgstr "Solución del EDO:"
 
 #: ../../src/wxMaxima.cpp:10017
 msgid "Solve"
-msgstr ""
+msgstr "Resolver"
 
 #: ../../src/wxMaximaFrame.cpp:1244
 msgid "Solve &Algebraic System..."
-msgstr ""
+msgstr "Resolver sistema &algebraico…"
 
 #: ../../src/wxMaximaFrame.cpp:1242
 msgid "Solve &Linear System..."
-msgstr ""
+msgstr "Resolver sistema &lineal…"
 
 #: ../../src/wxMaximaFrame.cpp:1266
 msgid "Solve &ODE..."
-msgstr ""
+msgstr "Resolver &EDO…"
 
 #: ../../src/wxMaximaFrame.cpp:1240
 msgid "Solve (to_poly)..."
-msgstr ""
+msgstr "Resolver (polinomial)…"
 
 #: ../../src/wxMaxima.cpp:8045
 msgid "Solve A*x=b numerically"
-msgstr ""
+msgstr "Resolver A*x=b numéricamente"
 
 #: ../../src/wxMaximaFrame.cpp:1397
 msgid "Solve Ax=b"
-msgstr ""
+msgstr "Resolver Ax=b"
 
 #: ../../src/wxMaxima.cpp:7783
 msgid "Solve ODE"
-msgstr ""
+msgstr "Resolver EDO"
 
 #: ../../src/wxMaximaFrame.cpp:1287
 msgid "Solve ODE with Lapla&ce..."
-msgstr ""
+msgstr "Resolver EDO con Lapla&ce…"
 
 #: ../../src/wxMaximaFrame.cpp:1398
 msgid "Solve a linear equation system using dgesv"
-msgstr ""
+msgstr "Resolver un sistema de ecuación lineal utilizando dgesv"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
 msgid "Solve algebraic system"
-msgstr ""
+msgstr "Resolver sistema algebraico"
 
 #: ../../src/wxMaximaFrame.cpp:1245
 msgid "Solve algebraic system of equations"
-msgstr ""
+msgstr "Resolver sistema algebraico de ecuaciones"
 
 #: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve boundary value problem for second degree ODE"
-msgstr ""
+msgstr "Resolver problema de contorno para una EDO de segundo orden"
 
 #: ../../src/wxMaxima.cpp:7895
 msgid "Solve differential equations using laplace()"
-msgstr ""
+msgstr "Resolver ecuaciones diferenciales utilizando laplace()"
 
 #: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
 msgid "Solve equation(s)"
-msgstr ""
+msgstr "Resolver ecuación(s)"
 
 #: ../../src/wxMaximaFrame.cpp:1241
 msgid "Solve equation(s) with to_poly_solve"
-msgstr ""
+msgstr "Resolver ecuación(es) con to_poly_solve"
 
 #: ../../src/wxMaxima.cpp:7773
+#, fuzzy
 msgid "Solve equations numerically"
-msgstr ""
+msgstr "Resolver polinomiales numéricamente"
 
 #: ../../src/wxMaxima.cpp:7757
 msgid "Solve equations to polynom"
-msgstr ""
+msgstr "Resolver ecuaciones a polinomio"
 
 #: ../../src/wxMaximaFrame.cpp:1271
 msgid "Solve initial value problem for first degree ODE"
-msgstr ""
+msgstr "Resolver problema de valor inicial para EDO de primer grado"
 
 #: ../../src/wxMaximaFrame.cpp:1275
 msgid "Solve initial value problem for second degree ODE"
-msgstr ""
+msgstr "Resolver problema de valor inicial para EDO de segundo grado"
 
 #: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
 msgid "Solve linear system"
-msgstr ""
+msgstr "Resolver sistema lineal"
 
 #: ../../src/wxMaximaFrame.cpp:1243
 msgid "Solve linear system of equations"
-msgstr ""
+msgstr "Resolver sistema de ecuaciones lineales"
 
 #: ../../src/wxMaximaFrame.cpp:1263
 msgid "Solve numerical, 1 Variable"
-msgstr ""
+msgstr "Resolver numérica, 1 variable"
 
 #: ../../src/wxMaximaFrame.cpp:1267
 msgid "Solve ordinary differential equation of maximum degree 2"
-msgstr ""
+msgstr "Resolver ecuación diferencial ordinaria de grado máximo 2"
 
 #: ../../src/wxMaximaFrame.cpp:1288
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
+"Resolver ecuaciones diferenciales ordinarias con la transformada de Laplace"
 
 #: ../../src/wxMaxima.cpp:7708
 msgid "Solve polynomials numerically"
-msgstr ""
+msgstr "Resolver polinomiales numéricamente"
 
 #: ../../src/wxMaxima.cpp:7718
 msgid "Solve polynomials numerically (bfloats)"
-msgstr ""
+msgstr "Resolver polinomiales numéricamente (bfloats)"
 
 #: ../../src/wxMaxima.cpp:7729
 msgid "Solve polynomials numerically (real roots)"
-msgstr ""
+msgstr "Resolver polinomiales numéricamente (raíces reales)"
 
 #: ../../src/wxMaximaFrame.cpp:1249
 msgid "Solve symbolically"
-msgstr ""
+msgstr "Resolver simbólicamente"
 
 #: ../../src/Worksheet.cpp:1574
 msgid "Solve..."
-msgstr ""
+msgstr "Resolver…"
 
 #: ../../src/wxMaximaFrame.cpp:1916
 msgid "Solving differential equations"
-msgstr ""
+msgstr "Resolviendo ecuaciones diferenciales"
 
 #: ../../src/wxMaximaFrame.cpp:1904
 msgid "Solving equations with Maxima"
-msgstr ""
+msgstr "Resolviendo ecuaciones con ‘Maxima’"
 
 #: ../../src/wxMaxima.cpp:7105
 #, c-format
@@ -6550,116 +6831,120 @@ msgid ""
 "Sometimes one wants maxima to loose the information that a function name was used with the ' operator in order to make maxima not evaluate it. In other places one wants % to mean \"the last expression at the time this function was created\", not \"the last expression now\".\n"
 "In both cases the '' operator will do what is requested."
 msgstr ""
+"A veces uno desea que ‘maxima‘ pierda la información que un nombre de función fue utilizada con el operador ' con el fin de hacer que ‘maxima‘ no lo evalúe. En otros lugares uno desea que % to quisiera significar \"la última expresión en el tiempo que esta función fue creada\", no \"la última expresión ahora\".\n"
+"En ambos casos el operador '' hará que sea solicitado."
 
 #: ../../src/wxMaximaFrame.cpp:1746
 msgid "Sort"
-msgstr ""
+msgstr "Ordenar"
 
 #: ../../src/wxMaxima.cpp:8496
 msgid "Sort a list"
-msgstr ""
+msgstr "Ordena un listado"
 
 #: ../../src/wxMaxima.cpp:7459
 msgid "Sort all characters in string"
-msgstr ""
+msgstr "Ordena todos los caracteres dentro de una cadena"
 
 #: ../../src/wxMaximaFrame.cpp:1179
 msgid "Sort the characters..."
-msgstr ""
+msgstr "Ordena los caracteres…"
 
 #: ../../src/wxMaxima.cpp:8482
 msgid "Source list:"
-msgstr ""
+msgstr "Listado origen:"
 
 #: ../../src/wxMaxima.cpp:7429
 msgid "Split"
-msgstr ""
+msgstr "Escinidr"
 
 #: ../../src/wxMaximaFrame.cpp:1191
 msgid "Split on match"
-msgstr ""
+msgstr "Escindir en coincidente"
 
 #: ../../src/wxMaxima.cpp:7528
 msgid "Split on regex match"
-msgstr ""
+msgstr "Escindir en exreg coincidente"
 
 #: ../../src/wxMaxima.cpp:7449
 msgid "Split string into tokens"
-msgstr ""
+msgstr "Escindir cadena dentro de testigos"
 
 #: ../../src/wxMaximaFrame.cpp:1171
 msgid "Split..."
-msgstr ""
+msgstr "Desglosar…"
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Square"
-msgstr ""
+msgstr "Cuadrado"
 
 #: ../../src/Configuration.cpp:86
 msgid "Standard Text"
-msgstr ""
+msgstr "Texto normalizado"
 
 #: ../../src/Worksheet.cpp:1298
 msgid "Start Animation"
-msgstr ""
+msgstr "Iniciar Animación"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Start of t:"
-msgstr ""
+msgstr "Comienzo de t:"
 
 #: ../../src/ToolBar.cpp:305
 msgid "Start or Stop animation"
-msgstr ""
+msgstr "Iniciar o detener animación"
 
 #: ../../src/ToolBar.cpp:306
 msgid ""
 "Start or stop the currently selected animation that has been created with "
 "the with_slider class of commands"
 msgstr ""
+"Iniciar y detener la animación seleccionada que ha sido creada con la clase "
+"de instrucciones with_slider"
 
 #: ../../src/wxMaxima.cpp:386
 msgid "Starting Maxima process failed"
-msgstr ""
+msgstr "Inicialización del proceso ‘Maxima’ ha fallado"
 
 #: ../../src/main.cpp:667
 msgid "Starting a new wxMaxima process for a new window"
-msgstr ""
+msgstr "Inicializar un proceso wxMaxima nuevo para una ventana nueva"
 
 #: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:5633
 msgid "Starting evaluation of the document"
-msgstr ""
+msgstr "Iniciando evaluación del documento"
 
 #: ../../src/wxMaxima.cpp:2544
 msgid "Starting server failed"
-msgstr ""
+msgstr "Inicialización del servidor ha fallado"
 
 #: ../../src/WXMXformat.cpp:64
 msgid "Starting to save the worksheet as .wxmx"
-msgstr ""
+msgstr "Iniciando a guardar la hoja del cuaderno como .wxmx"
 
 #: ../../src/wxMaximaFrame.cpp:252
 msgid "Statistics"
-msgstr ""
+msgstr "Estadística"
 
 #: ../../src/wxMaximaFrame.cpp:701
 msgid "Statistics\tAlt+Shift+S"
-msgstr ""
+msgstr "Estadística\tAlt+Mayús+S"
 
 #: ../../src/wxMaxima.cpp:7844
 msgid "Step width:"
-msgstr ""
+msgstr "Anchura de paso:"
 
 #: ../../src/wxMaximaFrame.cpp:794
 msgid "Straight lines"
-msgstr ""
+msgstr "Líneas rectas"
 
 #: ../../src/wxMaximaFrame.cpp:1106
 msgid "Stream"
-msgstr ""
+msgstr "Flujo"
 
 #: ../../src/wxMaxima.cpp:7231
 msgid "Stream length"
-msgstr ""
+msgstr "Longitud de flujo"
 
 #: ../../src/wxMaxima.cpp:7219 ../../src/wxMaxima.cpp:7224
 #: ../../src/wxMaxima.cpp:7228 ../../src/wxMaxima.cpp:7232
@@ -6669,45 +6954,45 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7267 ../../src/wxMaxima.cpp:7271
 #: ../../src/wxMaxima.cpp:7276
 msgid "Stream:"
-msgstr ""
+msgstr "Flujo:"
 
 #: ../../src/wxMaximaFrame.cpp:1185
 msgid "String"
-msgstr ""
+msgstr "Cadena"
 
 #: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
 #: ../../src/wxMaxima.cpp:7425
 msgid "String #1:"
-msgstr ""
+msgstr "Cadena nº1:"
 
 #: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
 #: ../../src/wxMaxima.cpp:7426
 msgid "String #2:"
-msgstr ""
+msgstr "Cadena nº2:"
 
 #: ../../src/wxMaximaFrame.cpp:1136
 msgid "String Tests"
-msgstr ""
+msgstr "Pruebas de Cadena"
 
 #: ../../src/wxMaxima.cpp:7415
 msgid "String length"
-msgstr ""
+msgstr "Longitud de cadena"
 
 #: ../../src/wxMaxima.cpp:7381
 msgid "String to list of char"
-msgstr ""
+msgstr "Cadena para enumerado de carácter"
 
 #: ../../src/wxMaximaFrame.cpp:1148
 msgid "String to list of chars..."
-msgstr ""
+msgstr "Cadena para enumerado de caracteres…"
 
 #: ../../src/wxMaxima.cpp:7496
 msgid "String to octets"
-msgstr ""
+msgstr "Cadena para octetos"
 
 #: ../../src/wxMaximaFrame.cpp:1160
 msgid "String to octets..."
-msgstr ""
+msgstr "Cadena para octetos…"
 
 #: ../../src/wxMaxima.cpp:7377 ../../src/wxMaxima.cpp:7382
 #: ../../src/wxMaxima.cpp:7391 ../../src/wxMaxima.cpp:7396
@@ -6721,74 +7006,77 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
 #: ../../src/wxMaxima.cpp:7497
 msgid "String:"
-msgstr ""
+msgstr "Cadenas:"
 
 #: ../../src/wxMaxima.cpp:7197
 msgid "Struct :"
-msgstr ""
+msgstr "Estructura :"
 
 #: ../../src/wxMaxima.cpp:7184 ../../src/wxMaxima.cpp:7190
 msgid "Struct type name:"
-msgstr ""
+msgstr "Nombre de tipo de estructura:"
 
 #: ../../src/wxMaximaFrame.cpp:1029
 msgid "Structs"
-msgstr ""
+msgstr "Estructuras"
 
 #: ../../src/ToolBar.cpp:274
 msgid "Subsection"
-msgstr ""
+msgstr "Subsección"
 
 #: ../../src/Configuration.cpp:90
 msgid "Subsection cell (Heading 3)"
-msgstr ""
+msgstr "Celda subsubsección (Cabecera 3)"
 
 #: ../../src/wxMaximaFrame.cpp:1643
 msgid "Subst constant t into eq with diff(x,t)..."
-msgstr ""
+msgstr "Sustituye constante t en eq con diff(x,t)…"
 
 #: ../../src/wxMaxima.cpp:8724
 msgid "Subst is a better string-search-and-replace for expressions."
 msgstr ""
+"Sustitución es una mejor cadena-búsqueda-y-sustituir para expresiones."
 
 #: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
 #: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
 msgid "Substitute"
-msgstr ""
+msgstr "Sustituir"
 
 #: ../../src/wxMaximaFrame.cpp:1193
 msgid "Substitute all matches"
-msgstr ""
+msgstr "Sustituir todas las coincidencias"
 
 #: ../../src/wxMaximaFrame.cpp:1192
 msgid "Substitute first match"
-msgstr ""
+msgstr "Sustituir primera coincidencia"
 
 #: ../../src/wxMaximaFrame.cpp:1646
 msgid "Substitute only in parts..."
-msgstr ""
+msgstr "Sustituir solamente en partes…"
 
 #: ../../src/wxMaxima.cpp:8763
 msgid "Substitute only in specific parts"
-msgstr ""
+msgstr "Sustituir solamente en partes específicas"
 
 #: ../../src/wxMaximaFrame.cpp:1647
 msgid "Substitute only in the elements n_1, n_2,..."
-msgstr ""
+msgstr "Sustituir solamente en los elementos n_1, n_2,…"
 
 #: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
 msgid "Substitute..."
-msgstr ""
+msgstr "Sustituir…"
 
 #: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
 msgid "Substitutes until the equation no more changes"
-msgstr ""
+msgstr "Sustituye hasta que la ecuación no tanga más cambios"
 
 #: ../../src/wxMaxima.cpp:8747
 msgid ""
 "Substitutes up to lrats_max_iter times, or until the expression stops "
 "changing when substituting."
 msgstr ""
+"Sustituye hasta lrats_max_iter veces, o hasta que la expresión se detenga "
+"cambiando cuando sustituya."
 
 #: ../../src/wxMaxima.cpp:8756
 #, c-format
@@ -6796,259 +7084,288 @@ msgid ""
 "Substitutes, but makes sure that if substituting t=0 in diff(x,t) the result"
 " isn't 0 (as t no more changes), but %at(diff(x,t),t=0)."
 msgstr ""
+"Sustituye, pero asegúrese que si sustituye t=0 en diff(x,t) el resultado no "
+"es 0 (como t no más cambios), pero %at(diff(x,t),t=0)."
 
 #: ../../src/wxMaxima.cpp:8739
 msgid ""
 "Substitutes, but makes sure that nothing is substituted into the other "
 "substituents."
 msgstr ""
+"Sustituye, pero asegura que nada es sustituído en las otras sustituídas."
 
 #: ../../src/wxMaximaFrame.cpp:1638
 msgid "Substitutes, but not in the other substituents"
-msgstr ""
+msgstr "Sustituye, pero no en el otro sustituye"
 
 #: ../../src/wxMaxima.cpp:8764
 msgid ""
 "Substitutes, but only in the n_1th, n_2th and so on term of the equation."
 msgstr ""
+"Sustitutos, pero solo en la n_1th, n_2th y el resto por tanto en el terminal"
+" de la ecuación."
 
 #: ../../src/ToolBar.cpp:275
 msgid "Subsubsection"
-msgstr ""
+msgstr "Subsubsección"
 
 #: ../../src/Configuration.cpp:89
 msgid "Subsubsection cell (Heading 4)"
-msgstr ""
+msgstr "Celda de su&bsubsección (Cabecera 4)"
 
 #: ../../src/Worksheet.cpp:1831
+#, fuzzy
 msgid "Suggestion: "
-msgstr ""
+msgstr "Subsección"
 
 #: ../../src/Worksheet.cpp:2030
 msgid "Suitable as flag for ev()"
-msgstr ""
+msgstr "Apropiado como indicador para ev()"
 
 #: ../../src/wxMaxima.cpp:9049
 msgid "Sum"
-msgstr ""
+msgstr "Sumatorio"
 
 #: ../../src/wxMaximaFrame.cpp:1551
 msgid ""
 "Switch off simplifications of log(). Set Maxima option variable "
 "logexpand:false"
 msgstr ""
+"Apaga simplificaciones de log(). Fija variable de opción logexpand:false de "
+"‘Maxima‘"
 
 #: ../../src/wxMaxima.cpp:4090
 msgid "Switched to lisp mode after receiving a lisp debug prompt!"
 msgstr ""
+"¡Intercambiando al modo lisp tras recibir una solicitud de depuración lisp!"
 
 #: ../../src/wxMaxima.cpp:4092
 msgid "Switched to lisp mode after receiving a lisp prompt!"
-msgstr ""
+msgstr "¡Intercambiando al modo lisp tras recibir una solicitud lisp!"
 
 #: ../../src/Worksheet.cpp:1971
 msgid "Symbolic Constant"
-msgstr ""
+msgstr "Constante Simbólica"
 
 #: ../../src/wxMaximaFrame.cpp:705
 msgid "Symbols\tAlt+Shift+Y"
-msgstr ""
+msgstr "Símbolos\tAlt+Mayús+Y"
 
 #: ../../src/Worksheet.cpp:2006
 msgid "Symmetric function: f(x)=f(-x)"
-msgstr ""
+msgstr "Función simétrica: f(x)=f(-x)"
 
 #: ../../src/wxMaximaFrame.cpp:238
 msgid "Table of Contents"
-msgstr ""
+msgstr "Índice de Contenidos"
 
 #: ../../src/wxMaximaFrame.cpp:711
 msgid "Table of Contents\tAlt+Shift+T"
-msgstr ""
+msgstr "Índice de contenidos\tAlt+Mayús+T"
 
 #: ../../src/wxMaxima.cpp:8930
 msgid "Taylor series"
-msgstr ""
+msgstr "Series de Taylor"
 
 #: ../../src/wxMaximaFrame.cpp:1474
 msgid "Taylor series..."
-msgstr ""
+msgstr "Series de Taylor…"
 
 #: ../../src/wxMaxima.cpp:8925
 msgid "Taylor series:"
-msgstr ""
+msgstr "Series de Taylor:"
 
 #: ../../src/wxMaxima.cpp:4132
 msgid "Telling maxima about the new working directory."
-msgstr ""
+msgstr "Dice a ‘maxima’ acerca del nuevo directorio de trabajo."
 
 #: ../../src/wxMaxima.cpp:7907
 msgid "Tells maxima for an f(x), that f(x=t)=a"
-msgstr ""
+msgstr "Dice a ‘maxima‘ para una f(x), que f(x=t)=a"
 
 #: ../../src/wxMaximaFrame.cpp:1945
 msgid ""
 "Tells maxima to show the help for ?, ?? and describe() in a separate browser"
 " window"
 msgstr ""
+"Dice a ‘maxima‘ mostrar la ayuda para ?, ?? y describe() en una ventana de "
+"explorador separada"
 
 #: ../../src/wxMaximaFrame.cpp:1941
 msgid ""
 "Tells maxima to show the help for ?, ?? and describe() in a wxMaxima sidebar"
 msgstr ""
+"Dice a ‘maxima‘ mostrar la ayuda para ?, ?? y describe() en la barra lateral"
+" de wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1936
 msgid "Tells maxima to show the help for ?, ?? and describe() on the console"
 msgstr ""
+"Dice a ‘maxima‘ mostrar la ayuda para ?, ?? y describe() en la consola"
 
 #: ../../src/ToolBar.cpp:271
 msgid "Text"
-msgstr ""
+msgstr "Texto"
 
 #: ../../src/Configuration.cpp:93
 msgid "Text cell background"
-msgstr ""
+msgstr "Fondo de celda de texto"
 
 #: ../../src/wxMaxima.cpp:6541
 msgid "Text snippet"
-msgstr ""
+msgstr "Texto arrastrado"
 
 #: ../../src/wxMaxima.cpp:4632
 msgid ""
 "The .xml file doesn't seem to be valid xml or isn't a content.xml extracted "
 "from a .wxmx zip archive"
 msgstr ""
+"El fichero .xml no parece ser xml válido o no es un ‘content.xml’ extraído "
+"desde un archivo zip .wxmx"
 
 #: ../../src/wxMaxima.cpp:2734
 msgid ""
 "The Maxima process doesn't offer a shared memory segment we can send an "
 "interrupt signal to."
 msgstr ""
+"Los procesos de ‘Maxima’ no ofrecen un segmento de memoria compartida que "
+"podamos a la cual enviar una señal de interrupción."
 
 #: ../../src/MaximaManual.cpp:107
 msgid "The cache for the subjects the manual contains cannot be read."
-msgstr ""
+msgstr "El caché para los asuntos del manual contenidos no pueden ser leídos."
 
 #: ../../src/MaximaManual.cpp:378
 msgid "The cache for the subjects the manual contains has no head node."
 msgstr ""
+"La caché para los asuntos que contiene el manual no tiene nodo de cabecera."
 
 #: ../../src/MaximaManual.cpp:396
 msgid ""
 "The cache for the subjects the manual contains is from a different Maxima "
 "version."
 msgstr ""
+"La caché para los asuntos que el manual contiene está desde una versión "
+"diferente de ‘Maxima’."
 
 #: ../../src/wxMaximaFrame.cpp:1379
 msgid "The classic operations one typically uses matrices for"
-msgstr ""
+msgstr "Las operaciones clásicas de uno utiliza típicamente matrices para"
 
 #: ../../src/wxMaxima.cpp:7193
 msgid "The comma-separated contents of the struct fields"
-msgstr ""
+msgstr "Los contenidos separados por comas de los campos de estructura"
 
 #: ../../src/wxMaxima.cpp:7186
 msgid "The comma-separated names of the struct fields"
-msgstr ""
+msgstr "Los nombres separados por comas de los campos de estructura"
 
 #: ../../src/wxMaxima.cpp:7070
 msgid ""
 "The command local() allows to tell maxima which functions to make local to "
 "the current program when defined."
 msgstr ""
+"La instrucción local() permite decir a ‘maxima‘ cuales funciones a hacer "
+"local para el programa actual cuando se definió."
 
 #: ../../src/wxMaximaFrame.cpp:303
 msgid "The current Wizard"
-msgstr ""
+msgstr "El actual Asistente"
 
 #: ../../src/wxMaxima.cpp:9592
 msgid "The equation to fit the data to"
-msgstr ""
+msgstr "La ecuación para ajustar los datos a"
 
 #: ../../src/wxMaxima.cpp:8447
 msgid "The function call whose arguments to extract"
-msgstr ""
+msgstr "La invocación a función cuyos argumentos extraer"
 
 #: ../../src/wxMaximaFrame.cpp:1298
 msgid "The half of the equation that is to the left of the \"=\""
-msgstr ""
+msgstr "La mitad de la ecuación que está a la izquierda del “=”"
 
 #: ../../src/wxMaximaFrame.cpp:1302
 msgid "The half of the equation that is to the right of the \"=\""
-msgstr ""
+msgstr "La mitad de la ecuación que está a la derecha del “=”"
 
 #: ../../src/MaximaManual.cpp:399
 msgid "The help dir from the cache differs from the current one."
-msgstr ""
+msgstr "El directorio de ayuda desde la caché difiere desde el actual."
 
 #: ../../src/Image.cpp:985
 msgid ""
 "The image could not be displayed. It may be broken, in a wrong format or be the result of gnuplot not being able to write the image or not being able to understand what maxima wanted to plot.\n"
 "One example of the latter would be: Gnuplot refuses to plot entirely empty images"
 msgstr ""
+"La imagen no puedo ser enseñada. Quizá está estropeada, en un formato equivocado o es el resultado de gnuplot que no es capaz de escribir la imagen o no es capaz de entender qué quiera trazar “maxima”.\n"
+"Un ejemplo de la última podría ser: Gnuplot rechaza tramar imágenes completamente vacías"
 
 #: ../../src/wxMaxima.cpp:9799 ../../src/wxMaxima.cpp:10158
 #, c-format
 msgid "The image file \"%s\" cannot be found."
-msgstr ""
+msgstr "El archivo de imagen «%s» no puede ser encontrado."
 
 #: ../../src/wxMaximaFrame.cpp:718
 msgid "The integrated help browser"
-msgstr ""
+msgstr "El explorador de ayuda integrado"
 
 #: ../../src/wxMaxima.cpp:9591
 msgid "The list of variables contained in each matrix row"
-msgstr ""
+msgstr "El listado de variables contenidas en cada fila matricial"
 
 #: ../../src/wxMaximaFrame.cpp:214
 msgid "The main toolbar"
-msgstr ""
+msgstr "La barra de herramientas principal"
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "The manual of Maxima"
-msgstr ""
+msgstr "El manual de ‘Maxima’"
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "The manual of wxMaxima"
-msgstr ""
+msgstr "El manual de ‘wxMaxima‘"
 
 #: ../../src/wxMaxima.cpp:7125
 msgid "The name of a function we don't want to be evaluated here"
-msgstr ""
+msgstr "El nombre de una función que no queremos ser evaluada aquí"
 
 #: ../../src/wxMaxima.cpp:7131
 msgid "The name of an expression that we don't want to be evaluated."
-msgstr ""
+msgstr "El nombre de una expresión que no queremos ser evaluada."
 
 #: ../../src/wxMaxima.cpp:7199
 msgid "The name of the field to read"
-msgstr ""
+msgstr "El nombre del campo para leer"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "The name of the new struct type"
-msgstr ""
+msgstr "El nombre del tipo de estructura nueva"
 
 #: ../../src/wxMaxima.cpp:7198
 msgid "The name of the struct"
-msgstr ""
+msgstr "El nombre de la estructura"
 
 #: ../../src/wxMaxima.cpp:7191
 msgid "The name of the struct type"
-msgstr ""
+msgstr "El nombre del tipo de estructura"
 
 #: ../../src/wxMaxima.cpp:8220
 msgid "The name of the variable that shall contain the current element"
-msgstr ""
+msgstr "El nombre de la variable que contendrá el elemento actual"
 
 #: ../../src/wxMaxima.cpp:8468
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
 msgstr ""
+"El número del elemento el cual está dividido desde «Inicio de índice» hasta "
+"«Final de índice»."
 
 #: ../../src/wxMaxima.cpp:8465 ../../src/wxMaxima.cpp:8478
 msgid ""
 "The rule that explains how to generate the value of a list item.\n"
 "Might be something like \"i\", \"i^2\" or \"sin(i)\""
 msgstr ""
+"La regla que explica cómo generar el valor de un elemento listado.\n"
+"Quizá es algo como \"i\", \"i^2\" o \"sin(i)\""
 
 #: ../../src/wxMaxima.cpp:7785
 msgid ""
@@ -7056,18 +7373,25 @@ msgid ""
 "The actual height of that curve is defined by the initial condition or "
 "boundary values, later on."
 msgstr ""
+"La solución de un EDO describe la apariencia general de la curva resultante."
+" La densidad actual de esa curva está definida por la condición inicial o "
+"valores acotados, más tarde."
 
 #: ../../src/wxMaxima.cpp:7818
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's result is known at two points this function fills in the correct values for the  constants"
 msgstr ""
+"La solución de un EDO dice que la forma, pero no la altura de la solución.\n"
+"Si el resultado de EDO es conocido en dos puntos esta función rellena en los valores correcto para las constantes"
 
 #: ../../src/wxMaxima.cpp:7794 ../../src/wxMaxima.cpp:7805
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's state is known at a point this function fills in the correct values for the constants"
 msgstr ""
+"La solución de un EDO dice la manera, pero no la altura de la solución.\n"
+"Si el estado de EDO es conocido en un punto esta función rellena en los valores correctos para las constantes"
 
 #: ../../src/wxMaxima.cpp:7896
 msgid ""
@@ -7075,64 +7399,81 @@ msgid ""
 "   U(t)=1/2*U(t)+3*diff(U(t),t)\n"
 "for this to work; Initial conditions can be specified using atvalue()."
 msgstr ""
+"La solución de variable necesita ser en el formulario\n"
+"   U(t)=1/2*U(t)+3*diff(U(t),t)\n"
+"para que esto funcione; condiciones iniciales pueden ser especificadas utilizando atvalue()."
 
 #: ../../src/wxMaxima.cpp:8481 ../../src/wxMaxima.cpp:8582
 msgid "The variable the value of the current source item is stored in."
-msgstr ""
+msgstr "La variable del valor del elemento actual origen está almacenado ahí."
 
 #: ../../src/wxMaxima.cpp:9594
 msgid "The variables to search the optimum solution for"
-msgstr ""
+msgstr "Las variables para buscar la solución óptima para"
 
 #: ../../src/wxMaximaFrame.cpp:193
 msgid "The worksheet"
-msgstr ""
+msgstr "La hoja del cálculo"
 
 #: ../../src/Worksheet.cpp:8122
 msgid "The worksheet containing maxima's input and output"
-msgstr ""
+msgstr "La hoja del cuaderno conteniendo entradas y salidas de ‘maxima’"
 
 #: ../../src/MathParser.cpp:629
 msgid ""
 "The xml data from maxima or from the .wxmx file was missing data here.\n"
 "If you find a way how to reproduce this problem please file a bug report against wxMaxima."
 msgstr ""
+"Los datos xml desde ‘maxima’ o desde el fichero .wxmx eran datos ausentes aquí.\n"
+"Si encuentra una forma de  reproducir este problema, por favor informe un defecto a wxMaxima."
 
 #: ../../src/wxMaxima.cpp:2143
 msgid ""
 "There was an error in the XML maxima has generated.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Ha habido un error en el XML maxima que ha generado.\n"
+"Comunique esto como un defecto al proyecto wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3911
 msgid ""
 "There was an error in the XML that should contain a list of watch variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Hubo un error en la XML que contendría un listado de variables vistas.\n"
+"Informe esto como un gazapo para el proyecto wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3869
 msgid ""
 "There was an error in the XML that should contain the list of operators.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Hubo un error en el XML que contendría el listado de operadores.\n"
+"Informe esto como un gazapo para el proyecto wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3321
 msgid ""
 "There was an error in the XML that should describe the contents of some variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Hubo un error en el XML que describía el contenido de algunas variables.\n"
+"Informe de esto como un gazapo para el proyecto wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3257
 msgid ""
 "There was an error in the XML that should describe the manual topics.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Hubo un error en el XML que describiría los temas del manual.\n"
+"Comunique esto como un gazapo en el proyecto de wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3202
 msgid ""
 "There was an error in the XML that should describe the status bar message.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Hubo un error en el XML que describiría el mensaje de la barra de estado.\n"
+"Comunique esto como un gazapo al proyecto wxMaxima."
 
 #: ../../src/MaximaManual.cpp:363
 msgid ""
@@ -7140,110 +7481,116 @@ msgid ""
 "It caches the list of subjects maxima's manual offers and is automatically\n"
 "overwritten if maxima's version changes or the file cannot be read"
 msgstr ""
+"Este fichero está generado por wxMaxima\n"
+"Captura el listado de asuntos del manual de ‘maxima’ que ofrece y es sobrescrito\n"
+"automáticamente si la versión de ‘maxima’ se modifica o el fichero no puede ser\n"
+"leíble"
 
 #: ../../src/Worksheet.cpp:1992
 msgid "This function will return even integers"
-msgstr ""
+msgstr "Esta función devolverá enteros pares"
 
 #: ../../src/Worksheet.cpp:1994
 msgid "This function will return odd integers"
-msgstr ""
+msgstr "Esta función devolverá enteros impares"
 
 #: ../../src/Worksheet.cpp:1950
 msgid "This symbol has no imaginary part"
-msgstr ""
+msgstr "Este símbolo no tiene parte imaginaria"
 
 #: ../../src/Worksheet.cpp:1956
 msgid "This symbol has no real part"
-msgstr ""
+msgstr "Este símbolo no tiene parte real"
 
 #: ../../src/Worksheet.cpp:1953
 msgid "This symbol might have both real and imaginary part"
-msgstr ""
+msgstr "Este símbolo quizá tenga ambas partes real e imaginaria"
 
 #: ../../src/Worksheet.cpp:1980
 msgid "Throw an error if this symbol is used before assigning it any contents"
 msgstr ""
+"Lanza un error si este símbolo es utilizado antes de asignarlo en cualquier "
+"contenido"
 
 #: ../../src/wxMaxima.cpp:9013 ../../src/wxMaxima.cpp:10058
 msgid "Times:"
-msgstr ""
+msgstr "Veces:"
 
 #: ../../src/ToolBar.cpp:272
 msgid "Title"
-msgstr ""
+msgstr "Título"
 
 #: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
-msgstr ""
+msgstr "Titular (Sub- y superguiones como x_{10} o x^{10})"
 
 #: ../../src/Configuration.cpp:92
 msgid "Title cell (Heading 1)"
-msgstr ""
+msgstr "Celda títular (Cabecera 1)"
 
 #: ../../src/wxMaximaFrame.cpp:1794
 msgid "To &Bigfloat"
-msgstr ""
+msgstr "Destino real grande (&bigfloat)"
 
 #: ../../src/wxMaximaFrame.cpp:1791
 msgid "To &Float"
-msgstr ""
+msgstr "Destino &real"
 
 #: ../../src/Worksheet.cpp:1571
 msgid "To Float"
-msgstr ""
+msgstr "Destino Real"
 
 #: ../../src/wxMaximaFrame.cpp:1797
 msgid "To Numeri&c\tCtrl+Shift+N"
-msgstr ""
+msgstr "Destino numéri&co\tCtrl+Mayús+N"
 
 #: ../../src/wxMaximaFrame.cpp:1803
 msgid "To exact fraction"
-msgstr ""
+msgstr "Para fracción exacta"
 
 #: ../../src/wxMaximaFrame.cpp:1814
 msgid "To exact number"
-msgstr ""
+msgstr "Para número exacto"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "To:"
-msgstr ""
+msgstr "Destino:"
 
 #: ../../src/wxMaximaFrame.cpp:825 ../../src/wxMaximaFrame.cpp:828
 msgid "Toggle full screen editing"
-msgstr ""
+msgstr "Conmutar edición de pantalla completa"
 
 #: ../../src/ToolBar.cpp:265
 msgid "Toggle the visibility of code cells"
-msgstr ""
+msgstr "Conmuta la visibilidad de celdas de código"
 
 #: ../../src/wxMaximaFrame.cpp:1177
 msgid "Tokenize..."
-msgstr ""
+msgstr "Vales…"
 
 #: ../../src/wxMaximaFrame.cpp:1909
 msgid "Tolerance calculations with Maxima"
-msgstr ""
+msgstr "Cálculos de tolerancia con ‘Maxima’"
 
 #: ../../src/wxMaxima.cpp:8192
 msgid "Top end"
-msgstr ""
+msgstr "Cima final"
 
 #: ../../src/wxMaximaFrame.cpp:1078
 msgid "Trace a function..."
-msgstr ""
+msgstr "Traza una función…"
 
 #: ../../src/wxMaxima.cpp:7084
 msgid "Trace function(s)"
-msgstr ""
+msgstr "Traza función(es)"
 
 #: ../../src/wxMaximaFrame.cpp:1184
 msgid "Transformations"
-msgstr ""
+msgstr "Transformaciones"
 
 #: ../../src/wxMaximaFrame.cpp:1376
 msgid "Transpose a matrix"
-msgstr ""
+msgstr "Trasponer una matriz"
 
 #: ../../src/wxMaxima.cpp:7832
 msgid ""
@@ -7251,17 +7598,25 @@ msgid ""
 " equation of the format depends(x,t);diff(x,t)=(something containing x and "
 "t)"
 msgstr ""
+"Intenta encontrar una solución numérica para la orden 1º EDO (o en otras "
+"palabras: una ecuación de formato depends(x,t);diff(x,t)=(algo conteniendo x"
+" y t)"
 
 #: ../../src/wxMaxima.cpp:10036
 msgid ""
 "Tries to find a solution of the equation that lies between the two bounds."
 msgstr ""
+"Intente encontrar una solución de la ecuación que yazca entre las dos "
+"acotaciones."
 
 #: ../../src/wxMaxima.cpp:7774
+#, fuzzy
 msgid ""
 "Tries to find a value of the variable that solves the equation between the "
 "two bonds"
 msgstr ""
+"Intente encontrar una solución de la ecuación que yazca entre las dos "
+"acotaciones."
 
 #: ../../src/wxMaxima.cpp:7719
 msgid ""
@@ -7270,6 +7625,10 @@ msgid ""
 "\n"
 "    bfallroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
+"Prueba encontrar todas las soluciones de un polinomio numérico utilizando flotante grande.\n"
+"Quizá sea capaz de detectar soluciones en no-polinomiales, así como, si la expresión es aproximada por un polinomial, antemano:\n"
+"\n"
+"    bfallroots(ratdisrep(taylor(expression,0,30)));"
 
 #: ../../src/wxMaxima.cpp:7709
 msgid ""
@@ -7278,6 +7637,10 @@ msgid ""
 "\n"
 "    allroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
+"Intenta encontrar todas las soluciones de un polinomio numérico.\n"
+"Tal vez sea capaz de detectar soluciones en no-polinomiales, así como, si la expresión está aproximada por un polinomio, antemano:\n"
+"\n"
+"    allroots(ratdisrep(taylor(expression,0,30)));"
 
 #: ../../src/wxMaxima.cpp:7730
 #, c-format
@@ -7290,361 +7653,382 @@ msgid ""
 "\n"
 "See also guess_exact_value()"
 msgstr ""
+"Intenta encontrar fracciones exactas que coincidan las soluciones numéricas de un polinomio.\n"
+"No es capaz de tratar con soluciones con una parte imaginaria. Constantes numéricas como %pi% necesitan ser eliminadas utilizando float() o similar\n"
+"Quizá es capaz de detectar soluciones en no polinomiales, así como, si la expresión es aproximadamente por una polinomial, por lo tanto:\n"
+"\n"
+"    realroots(ratdisrep(taylor(expression,0,30)));\n"
+"\n"
+"Consulte además guess_exact_value()"
 
 #: ../../src/wxMaximaFrame.cpp:1181
 msgid "Trim both ends..."
-msgstr ""
+msgstr "Recortar ambos finales…"
 
 #: ../../src/wxMaximaFrame.cpp:1182
 msgid "Trim left..."
-msgstr ""
+msgstr "Recortar izquierdo…"
 
 #: ../../src/wxMaximaFrame.cpp:1183
 msgid "Trim right..."
-msgstr ""
+msgstr "Recortar derecho…"
 
 #: ../../src/wxMaxima.cpp:7473
 msgid "Trim string left"
-msgstr ""
+msgstr "Recorta la cadena izquierda"
 
 #: ../../src/wxMaxima.cpp:7469
 msgid "Trim string on both ends"
-msgstr ""
+msgstr "Recorta cadena en ambos finales"
 
 #: ../../src/wxMaxima.cpp:7477
 msgid "Trim string right"
-msgstr ""
+msgstr "Recorta la cadena derecha"
 
 #: ../../src/wxMaximaFrame.cpp:1511
 msgid "Try to guess which form is &simple"
-msgstr ""
+msgstr "Intente adivinar cual formulario es &simple"
 
 #: ../../src/wxMaxima.cpp:8637
 msgid "Try to simplify sums that result from sum() commands."
 msgstr ""
+"Intenta simplificar sumatorios que resulten desde instrucciones sum()."
 
 #: ../../src/MaximaManual.cpp:369
 #, c-format
 msgid ""
 "Trying to cache the list of subjects the manual contains in the file %s."
 msgstr ""
+"Intentando cachear el listado de asuntos del manual contenidos dentro del "
+"fichero %s."
 
 #: ../../src/wxMaxima.cpp:4423
 msgid "Trying to discard all output."
-msgstr ""
+msgstr "Intentando descartar todas las salidas."
 
 #: ../../src/wxMaxima.cpp:4380
 msgid "Trying to extract content.xml out of a broken .zip file."
-msgstr ""
+msgstr "Intentando extraer content.xml fuera de un archivo .zip partido."
 
 #: ../../src/wxMaxima.cpp:5519
 msgid "Trying to open a file with an empty name!"
-msgstr ""
+msgstr "¡Intentando abrir un fichero con un nombre vacío!"
 
 #: ../../src/wxMaxima.cpp:5523
 #, c-format
 msgid "Trying to open the non-existing file %s"
-msgstr ""
+msgstr "Intentando abrir el fichero %s no existente"
 
 #: ../../src/wxMaxima.cpp:4457
 msgid "Trying to reconstruct the xml closing markers."
-msgstr ""
+msgstr "Intentando reconstruir los marcadores de cierre xml."
 
 #: ../../src/wxMaxima.cpp:4376
 msgid "Trying to recover a broken .wxmx file."
-msgstr ""
+msgstr "Intentando recuperar un fichero .wxmx corrupto."
 
 #: ../../src/wxMaxima.cpp:6026
 #, c-format
 msgid "Trying to remove the old temp file %s"
-msgstr ""
+msgstr "Intentando retirar el fichero temporal %s"
 
 #: ../../src/wxMaxima.cpp:2507
 msgid "Trying to restart maxima."
-msgstr ""
+msgstr "Intentando reiniciar 'maxima'."
 
 #: ../../src/wxMaxima.cpp:2523
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Trying to start the socket a Maxima on the local machine can connect to on "
 "port %i"
 msgstr ""
+"Intentando iniciar el zócalo un ‘maxima‘ en la máquina local puede conectar "
+"a un puerto %li"
 
 #: ../../src/wxMaximaFrame.cpp:1928
 msgid "Tutorials"
-msgstr ""
+msgstr "Tutoriales"
 
 #: ../../src/wxMaxima.cpp:9571
 msgid "Two sample t-test"
-msgstr ""
+msgstr "Test t de dos muestras"
 
 #: ../../src/Worksheet.cpp:8013
 msgid "Type"
-msgstr ""
+msgstr "Tipo"
 
 #: ../../src/wxMaxima.cpp:7180
 msgid "Type:"
-msgstr ""
+msgstr "Tipo:"
 
 #: ../../src/wxMaxima.cpp:9429
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 #: ../../src/wxMaximaFrame.cpp:1146
 msgid "UTF8 to Unicode code point..."
-msgstr ""
+msgstr "UTF8 a código Unicode apunta…"
 
 #: ../../src/wxMaxima.cpp:10479
 msgid "Un-closed parenthesis"
-msgstr ""
+msgstr "Paréntesis no cerrado"
 
 #: ../../src/wxMaxima.cpp:10467
 msgid "Un-closed parenthesis on encountering ; or $"
-msgstr ""
+msgstr "Paréntesis mal pareado o ha escrito ; o $ antes de tiempo"
 
 #: ../../src/wxMaxima.cpp:11160
 msgid ""
 "Unable to interpret the version info I got from http://wxMaxima-"
 "developers.github.io/wxmaxima/version.txt: "
 msgstr ""
+"Incapaz de interpretar la versión del informe que obtuvo desde "
+"http://wxMaxima-developers.github.io/wxmaxima/version.txt: "
 
 #: ../../src/wxMaximaFrame.cpp:1007
 msgid "Undefine"
-msgstr ""
+msgstr "Indefinido"
 
 #: ../../src/ToolBar.cpp:191
 msgid "Undo"
-msgstr ""
+msgstr "Deshacer"
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo\tCtrl+Z"
-msgstr ""
+msgstr "Deshacer\tCtrl+Z"
 
 #: ../../src/ToolBar.cpp:614
 msgid "Undo and redo button"
-msgstr ""
+msgstr "Botón para deshacer y rehacer"
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo last change"
-msgstr ""
+msgstr "Deshacer último cambio"
 
 #: ../../src/wxMaximaFrame.cpp:924
 msgid "Unfold All\tCtrl+Alt+]"
-msgstr ""
+msgstr "Desplegar todo\tCtrl+Alt+]"
 
 #: ../../src/wxMaximaFrame.cpp:925
 msgid "Unfold all folded sections"
-msgstr ""
+msgstr "Desplegar todas las secciones"
 
 #: ../../src/Worksheet.cpp:1893
 msgid "Unhide Heading 5"
-msgstr ""
+msgstr "Desocultar Cabecera 5"
 
 #: ../../src/Worksheet.cpp:1904
 msgid "Unhide Heading 6"
-msgstr ""
+msgstr "Desocultar Cabecera 6"
 
 #: ../../src/Worksheet.cpp:1852
 msgid "Unhide Part"
-msgstr ""
+msgstr "Desocultar Parte"
 
 #: ../../src/Worksheet.cpp:1860
 msgid "Unhide Section"
-msgstr ""
+msgstr "Desocultar Sección"
 
 #: ../../src/Worksheet.cpp:1871
 msgid "Unhide Subsection"
-msgstr ""
+msgstr "Desocultar Subsección"
 
 #: ../../src/Worksheet.cpp:1882
 msgid "Unhide Subsubsection"
-msgstr ""
+msgstr "Desocultar Subsubsección"
 
 #: ../../src/Worksheet.cpp:1912
 msgid "Unhide contents"
-msgstr ""
+msgstr "Desocultar constantes griegas"
 
 #: ../../src/wxMaximaFrame.cpp:266
 msgid "Unicode characters"
-msgstr ""
+msgstr "Caracteres Unicode"
 
 #: ../../src/wxMaximaFrame.cpp:707
 msgid "Unicode chars\tAlt+Shift+U"
-msgstr ""
+msgstr "Caracteres Unicode\tAlt+Mayús+U"
 
 #: ../../src/wxMaximaFrame.cpp:1144
 msgid "Unicode code point to UTF8..."
-msgstr ""
+msgstr "Código Unicode apunta a UTF8…"
 
 #: ../../src/wxMaxima.cpp:7366
 msgid "Unicode code point to char"
-msgstr ""
+msgstr "Código Unicode apunta a carácter"
 
 #: ../../src/wxMaximaFrame.cpp:1142
 msgid "Unicode code point to char..."
-msgstr ""
+msgstr "Código Unicode apunta a carácter…"
 
 #: ../../src/wxMaxima.cpp:7371
 msgid "Unicode code point to utf8 numbers"
-msgstr ""
+msgstr "Código Unicode apunta a números UTF8"
 
 #: ../../src/wxMaxima.cpp:7078
 msgid ""
 "Unlike in other programming language return() only exits from the current "
 "loop or block(), not from the whole function."
 msgstr ""
+"A diferencia de otros lenguajes de programación return() solo existe desde "
+"el bucle actual o block(), no desde la función completa."
 
 #: ../../src/wxMaxima.cpp:10418
 msgid "Unterminated comment."
-msgstr ""
+msgstr "Comentario no terminado."
 
 #: ../../src/wxMaxima.cpp:10461
 msgid "Unterminated string."
-msgstr ""
+msgstr "Cadena de texto sin terminar."
 
 #: ../../src/wxMaxima.cpp:4786
 msgid "Updating maxima's configuration"
-msgstr ""
+msgstr "Actualizando configuración de ‘maxima’"
 
 #: ../../src/wxMaxima.cpp:11150 ../../src/wxMaxima.cpp:11157
 #: ../../src/wxMaxima.cpp:11163
 msgid "Upgrade"
-msgstr ""
+msgstr "Modernizar"
 
 #: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
 msgid "Upper bound:"
-msgstr ""
+msgstr "Cota superior:"
 
 #: ../../src/wxMaximaFrame.cpp:792
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
-msgstr ""
+msgstr "Emplee \"<\" y \">\" como paréntesis para matrices"
 
 #: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
 msgid "Use a list"
-msgstr ""
+msgstr "Emplea un listado"
 
 #: ../../src/wxMaxima.cpp:8571
 msgid "Use a list as parameter list for a function"
-msgstr ""
+msgstr "Emplee un listado como listado paramétrico para una función"
 
 #: ../../src/wxMaximaFrame.cpp:1708
 msgid "Use list"
-msgstr ""
+msgstr "Emplear listado"
 
 #: ../../src/wxMaximaFrame.cpp:1701
 msgid "Use list as the arguments of a function"
-msgstr ""
+msgstr "Emplear listado como argumentos de una función"
 
 #: ../../src/wxMaximaFrame.cpp:786
 msgid "Use rounded parenthesis for matrices"
-msgstr ""
+msgstr "Emplee paréntesis para matrices"
 
 #: ../../src/wxMaximaFrame.cpp:789
 msgid "Use square parenthesis for matrices"
-msgstr ""
+msgstr "Emplee corchetes para matrices"
 
 #: ../../src/wxMaximaFrame.cpp:1083
 msgid "Use struct field..."
-msgstr ""
+msgstr "Utilizar campo de estructura…"
 
 #: ../../src/wxMaximaFrame.cpp:795
 msgid "Use vertical lines instead of parenthesis for matrices"
-msgstr ""
+msgstr "Emplee líneas verticales en vez de paréntesis para matrices"
 
 #: ../../src/Worksheet.cpp:1619
 msgid "User labels only"
-msgstr ""
+msgstr "Solo etiquetas usuario"
 
 #: ../../src/Configuration.cpp:81
 msgid "User-defined labels"
-msgstr ""
+msgstr "Etiquetas definidas por el usuario"
 
 #: ../../src/MaximaManual.cpp:483
 msgid ""
 "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
 msgstr ""
+"Utilizando el archivo de ayuda de Maxima desde archivo de configuración "
+"wxMaxima (helpFile=…))"
 
 #: ../../src/wxMaxima.cpp:4825
 msgid "Using Maxima path from command line."
-msgstr ""
+msgstr "Utilizando ruta de ‘Maxima‘ desde la línea de instrucción."
 
 #: ../../src/wxMaxima.cpp:4822
 msgid "Using configured Maxima path."
-msgstr ""
+msgstr "Utilizando ruta configurada de Maxima."
 
 #: ../../src/wxMaxima.cpp:2961
 msgid ""
 "Using gnuplot's antialiassing-less png driver for embedded plots as pngcairo"
 " could not be found"
 msgstr ""
+"Utilizando controlador png sin antialias de gnuplot para tramas empotradas "
+"como pngcairo no pudo ser encontrado"
 
 #: ../../src/wxMaxima.cpp:2956
 msgid "Using gnuplot's pngcairo driver for embedded plots"
-msgstr ""
+msgstr "Utilizando controlador pngcairo de gnuplot para empotrar tramas"
 
 #: ../../src/MaximaManual.cpp:88
 msgid "Using the built-in list of manual anchors."
-msgstr ""
+msgstr "Utilizando el listado empotrado de las anclas del manual."
 
 #: ../../src/WXMXformat.cpp:266
 msgid ""
 "Validated that the XML representation of the document actually is valid XML"
 msgstr ""
+"Validado que la representación del documento XML actualmente es XML válido"
 
 #: ../../src/wxMaxima.cpp:8755
 msgid "Value at a given point"
-msgstr ""
+msgstr "Valor en un punto dado"
 
 #: ../../src/Worksheet.cpp:1987
 msgid "Value at a specific point"
-msgstr ""
+msgstr "Valor en un punto específico"
 
 #: ../../src/wxMaxima.cpp:7801
 msgid "Value at that point:"
-msgstr ""
+msgstr "Valor en ese punto:"
 
 #: ../../src/wxMaxima.cpp:7812 ../../src/wxMaxima.cpp:7825
 #: ../../src/wxMaxima.cpp:7827
 msgid "Value y at that point:"
-msgstr ""
+msgstr "Valor y en ese punto:"
 
 #: ../../src/wxMaxima.cpp:7910
 msgid "Value:"
-msgstr ""
+msgstr "Valor:"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Var #1"
-msgstr ""
+msgstr "Var nº1"
 
 #: ../../src/wxMaxima.cpp:8202
 msgid "Var #2"
-msgstr ""
+msgstr "Var nº2"
 
 #: ../../src/wxMaxima.cpp:6852 ../../src/wxMaxima.cpp:8183
 msgid "Variable"
-msgstr ""
+msgstr "Variable"
 
 #: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
 #: ../../src/wxMaxima.cpp:8568
 msgid "Variable name"
-msgstr ""
+msgstr "Nombres de variable"
 
 #: ../../src/wxMaximaFrame.cpp:1085
 msgid "Variable name, not contents..."
-msgstr ""
+msgstr "Nombre de variable, no contenido…"
 
 #: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
 msgid "Variable name:"
-msgstr ""
+msgstr "Nombre de la variable:"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 msgid "Variable(s)"
-msgstr ""
+msgstr "Variable(s)"
 
 #: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
 #: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
 msgid "Variable(s):"
-msgstr ""
+msgstr "Variable(s):"
 
 #: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
 #: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
@@ -7652,49 +8036,51 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
 #: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
 msgid "Variable:"
-msgstr ""
+msgstr "Variable:"
 
 #: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
 msgid "Variables"
-msgstr ""
+msgstr "Variables"
 
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
 msgid "Variables:"
-msgstr ""
+msgstr "Variables:"
 
 #: ../../src/WXMXformat.cpp:337
 msgid "Verified that we are able to read the whole .zip archive we produced."
 msgstr ""
+"Ha verificado que somos capaces de leer el archivador .zip completo que "
+"produjo."
 
 #: ../../src/wxMaximaFrame.cpp:836
 msgid "View"
-msgstr ""
+msgstr "Vista"
 
 #: ../../src/Autocomplete.cpp:235
 msgid "Waiting for m_addFiles_backgroundThread to finish"
-msgstr ""
+msgstr "Esperando a m_addFiles_backgroundThread para finalizar"
 
 #: ../../src/Autocomplete.cpp:122 ../../src/Autocomplete.cpp:240
 msgid "Waiting for m_addSymbols_backgroundThread to finish"
-msgstr ""
+msgstr "Esperando a m_addSymbols_backgroundThread para finalizar"
 
 #: ../../src/MaximaManual.cpp:533
 msgid "Waiting for the Manual anchors background task."
-msgstr ""
+msgstr "Esperando que la tarea en segundo plano de anclajes del Manual."
 
 #: ../../src/MaximaManual.cpp:562
 msgid "Waiting for the thread that parses the maxima manual to finish"
-msgstr ""
+msgstr "Esperando que el hilo que interpreta el manual de ‘maxima’ termine"
 
 #: ../../src/MathParser.cpp:1229 ../../src/wxMaxima.cpp:3296
 #: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
 #: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
 msgid "Warning"
-msgstr ""
+msgstr "Aviso"
 
 #: ../../src/wxMaximaFrame.cpp:1556
 msgid "Warning:"
-msgstr ""
+msgstr "Aviso:"
 
 #: ../../src/Dirstructure.cpp:72
 #, c-format
@@ -7702,65 +8088,72 @@ msgid ""
 "Warning: Cannot create %s, the directory maxima keeps configuration, user packages and caches in.\n"
 "Make sure that your system's home directory is set up correctly"
 msgstr ""
+"Aviso: no puede crear %s, el directorio de ‘maxima‘ conserva configuración, paquetes de usuario y caché.\n"
+"Asegure que su directorio inicial del sistema está configurado correctamente"
 
 #: ../../src/wxMaximaFrame.cpp:1546
 msgid ""
 "Warning: No test if the argument of the log is complex, positive or negative"
 msgstr ""
+"Aviso: ningún test si el argumento del boletín es complejo, positivo o "
+"negativo"
 
 #: ../../src/wxMaxima.cpp:5063
 msgid "Welcome to wxMaxima"
-msgstr ""
+msgstr "Bienvenido a wxMaxima"
 
 #: ../../src/wxMaxima.cpp:8583
 msgid "What to do:"
-msgstr ""
+msgstr "Qué hacer:"
 
 #: ../../src/wxMaximaFrame.cpp:1058
 msgid "When to invoke the lisp compiler's debugger"
-msgstr ""
+msgstr "Cuando invoque el depurador del compilador lisp"
 
 #: ../../src/wxMaxima.cpp:7046
 msgid "While loop"
-msgstr ""
+msgstr "Mientras bucle"
 
 #: ../../src/wxMaximaFrame.cpp:1063
 msgid "While loop..."
-msgstr ""
+msgstr "Mientras bucle…"
 
 #: ../../src/wxMaxima.cpp:5673
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38)"
 " (*.wxm)|*.wxm|All Files (*.*)|*"
 msgstr ""
+"Documento completo (*.wxmx)|*.wxmx| La entrada, leíble por load() (maxima > "
+"5.38) (*.wxm)|*.wxm|Todos los archivos (*.*)|*"
 
 #: ../../src/wxMaxima.cpp:210
 msgid "Will try to generate a stack backtrace, if the program ever crashes"
-msgstr ""
+msgstr "Intentará generar una pila de traza, si el programa revienta"
 
 #: ../../src/Worksheet.cpp:6920
 msgid "Worksheet got activated"
-msgstr ""
+msgstr "Hoja de cálculo obtuvo activada"
 
 #: ../../src/Worksheet.cpp:6840
 msgid "Worksheet got the mouse focus"
-msgstr ""
+msgstr "Hoja de cálculo obtuvo el foco del ratón"
 
 #: ../../src/Worksheet.cpp:7191 ../../src/Worksheet.cpp:7279
 msgid "Wrapped search"
-msgstr ""
+msgstr "Búsqueda envuelta"
 
 #: ../../src/WXMXformat.cpp:282
 msgid "Wrote all image and gnuplot files to the zip archive"
 msgstr ""
+"Ha escrito todos los archivos de gnuplot e imagen para el archivador zip"
 
 #: ../../src/WXMXformat.cpp:272
 msgid "Wrote the XML representation of the document to the zip archive"
-msgstr ""
+msgstr "Ha escrito la representación XML del documento para el archivador zip"
 
 #: ../../src/WXMXformat.cpp:116
 msgid "Wrote the mimetype info"
-msgstr ""
+msgstr "Ha escrito el informe de tipo mime"
 
 #: ../../src/wxMaxima.cpp:11147
 #, c-format
@@ -7769,178 +8162,181 @@ msgid ""
 "\n"
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
+"Tiene instalada la versión %s. La versión actual es %s.\n"
+"\n"
+"Selecciónese Aceptar para acceder a la página de wxMaxima."
 
 #: ../../src/wxMaxima.cpp:11202
 msgid "Your changes will be lost if you don't save them."
-msgstr ""
+msgstr "Se perderán los cambios si no se guardan."
 
 #: ../../src/wxMaxima.cpp:11156
 msgid "Your version of wxMaxima is up to date."
-msgstr ""
+msgstr "La versión de wxMaxima está actualizada."
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom &In\tCtrl++"
-msgstr ""
+msgstr "&Ampliar\tCtrl++"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom Ou&t\tCtrl+-"
-msgstr ""
+msgstr "&Reducir\tCtrl+-"
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom in 10%"
-msgstr ""
+msgstr "Ampliar 10%"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom out 10%"
-msgstr ""
+msgstr "Reducir 10%"
 
 #: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
 msgid "[ unsaved ]"
-msgstr ""
+msgstr "[ no guardado ]"
 
 #: ../../src/wxMaxima.cpp:10920
 msgid "[ unsaved* ]"
-msgstr ""
+msgstr "[ no guardado* ]"
 
 #: ../../src/Worksheet.cpp:5278
-#, c-format
+#, fuzzy, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" loading=\"lazy\" style=\"max-width:90%%;\">\n"
-msgstr ""
+msgstr "_%d.gif\"  alt=\"Diagrama Animado\" loading=\"lazy\" style=\"max-width:90%%;\" />\n"
 
 #: ../../src/Worksheet.cpp:5484
-#, c-format
+#, fuzzy, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"lazy\">"
-msgstr ""
+msgstr "_%d.gif\" alt=\"Diagrama Animado\" style=\"max-width:90%%;\" loading=\"lazy\" />"
 
 #: ../../src/wxMaximaFrame.cpp:1690
 msgid "apply function to each element"
-msgstr ""
+msgstr "aplicando función a cada elemento"
 
 #: ../../src/wxMaximaFrame.cpp:739
 msgid "as 1D ASCII"
-msgstr ""
+msgstr "como 1D ASCII"
 
 #: ../../src/wxMaximaFrame.cpp:742
 msgid "as ASCII Art"
-msgstr ""
+msgstr "como Arte ASCII"
 
 #: ../../src/wxMaximaFrame.cpp:745
 msgid "as ASCII+Unicode Art"
-msgstr ""
+msgstr "como Arte ASCII+Unicode"
 
 #: ../../src/wxMaximaFrame.cpp:1680
 msgid "as storage for actual values for variables"
-msgstr ""
+msgstr "como almacén para valores actuales desde variables"
 
 #: ../../src/wxMaximaFrame.cpp:1139
 msgid "char to Ascii code..."
-msgstr ""
+msgstr "caracter a código ASCII…"
 
 #: ../../src/wxMaxima.cpp:7836
 msgid "diff(x,t)="
-msgstr ""
+msgstr "diff(x,t)="
 
 #: ../../src/wxMaximaFrame.cpp:1064 ../../src/wxMaximaFrame.cpp:1702
 msgid "do for each element"
-msgstr ""
+msgstr "hacer por cada elemento"
 
 #: ../../src/Worksheet.cpp:2027
 msgid "ev() shall evaluate this automatically"
-msgstr ""
+msgstr "ev() evaluará esto automáticamente"
 
 #: ../../src/wxMaxima.cpp:7130
 msgid "expression:"
-msgstr ""
+msgstr "expresión:"
 
 #: ../../src/Worksheet.cpp:2025
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
-msgstr ""
+msgstr "f(x) mantiene f(x) incluso si el valor de f(x) es computable"
 
 #: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
 msgid "filename:"
-msgstr ""
+msgstr "nombre fichero:"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "from a list"
-msgstr ""
+msgstr "desde un listado"
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "from a rule"
-msgstr ""
+msgstr "desde una regla"
 
 #: ../../src/wxMaximaFrame.cpp:1685
 msgid "from function arguments"
-msgstr ""
+msgstr "desde argumentos de función"
 
 #: ../../src/wxMaximaFrame.cpp:1669
 msgid "from individual elements"
-msgstr ""
+msgstr "desde elementos individuales"
 
 #: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
 msgid "function"
-msgstr ""
+msgstr "función"
 
 #: ../../src/wxMaximaFrame.cpp:747
 msgid "in 2D"
-msgstr ""
+msgstr "en 2D"
 
 #: ../../src/wxMaxima.cpp:8554
 msgid "list"
-msgstr ""
+msgstr "enumeración"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "max(abs(A(i,j))) (complex)"
-msgstr ""
+msgstr "max(abs(A(i,j))) (complejo)"
 
 #: ../../src/wxMaximaFrame.cpp:1404
 msgid "max(abs(A(i,j))) (real)"
-msgstr ""
+msgstr "max(abs(A(i,j))) (real)"
 
 #: ../../src/wxMaxima.cpp:8046
 msgid "m×n Matrix A:"
-msgstr ""
+msgstr "Matriz A m×n:"
 
 #: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533
 msgid "n:"
-msgstr ""
+msgstr "n:"
 
 #: ../../src/Worksheet.cpp:2000
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
-msgstr ""
+msgstr "nada: f(x, f(y,z)) = foo(x,y,z)"
 
 #: ../../src/Worksheet.cpp:2024
 msgid "noun: Not evaluated by default"
-msgstr ""
+msgstr "nombre: no evaluado por defecto"
 
 #: ../../src/wxMaximaFrame.cpp:1710
 msgid "nth"
-msgstr ""
+msgstr "enésimo"
 
 #: ../../src/Worksheet.cpp:2021
 msgid "outative: f(2*x) = 2*f(x)"
-msgstr ""
+msgstr "outativo: f(2*x) = 2*f(x)"
 
 #: ../../src/wxMaxima.cpp:7440 ../../src/wxMaxima.cpp:7445
 #: ../../src/wxMaxima.cpp:7455
 msgid "part:"
-msgstr ""
+msgstr "parte:"
 
 #: ../../src/wxMaxima.cpp:8942
 msgid "point:"
-msgstr ""
+msgstr "punto:"
 
 #: ../../src/wxMaxima.cpp:7740
 msgid "precision:"
-msgstr ""
+msgstr "precisión:"
 
 #: ../../src/wxMaxima.cpp:7255
 msgid "printf"
-msgstr ""
+msgstr "printf"
 
 #: ../../src/wxMaximaFrame.cpp:1108
 msgid "printf..."
-msgstr ""
+msgstr "printf…"
 
 #: ../../src/wxMaxima.cpp:8650
 msgid ""
@@ -7950,22 +8346,29 @@ msgid ""
 " makes sense for the problem that resulted in the Expression that is to be "
 "simplified."
 msgstr ""
+"radcan() es una poderosa herramienta para simplificar funciones "
+"trigonométricas pero necesita ser tomado con precaución: si una función "
+"tiene más de una rama radcan utiliza la una que parezca que podría caber de "
+"la mejor manera, no necesariamente una que tenga sentido para el programa "
+"que resulte en la Expresión que es ser simplificado."
 
 #: ../../src/wxMaxima.cpp:8731
 msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
+"ŕatsubst funciona como sustracción, pero conoce algunas matemáticas básicas,"
+" si se necesita."
 
 #: ../../src/wxMaximaFrame.cpp:1111
 msgid "readbyte..."
-msgstr ""
+msgstr "readbyte…"
 
 #: ../../src/wxMaximaFrame.cpp:1110
 msgid "readchar..."
-msgstr ""
+msgstr "readchar…"
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "readline..."
-msgstr ""
+msgstr "readline…"
 
 #: ../../src/wxMaxima.cpp:10018
 msgid ""
@@ -7973,67 +8376,74 @@ msgid ""
 "If only one result variable is of interest the other result variables can be used to to tell solve() which variables to eliminate from the solution\n"
 "solve() searches for a global solution. If a problem has different solutions depending on the range its variables are in one way to successfully use solve() is to use solve() to eliminate variables one by one and to manually choose which of the solutions solve() found matches the current problem."
 msgstr ""
+"solve() solucionará un listado de ecuaciones solo si para n ecuaciones independientes hay n variables para resolver.\n"
+"Si solo un resultado variable es de interés los otros resultados variables necesitan hacer su proceso puede ser empleado para decir al solve() cuales\n"
+"variables a eliminar desde la solución solve() busca para una solución global. Si un problema tiene diferentes soluciones dependiendo en el intervalo sus variables están dentro de una manara para utilizar correctamente solve() es utilizar solve() para eliminar variables una a una y para elegir manualmente cual de las soluciones solve() encontró coincidentes al problema actual."
 
 #: ../../src/wxMaxima.cpp:7745
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables solve needs to do its work can be used to tell solve() which variables to eliminate in the solution for the interesting variable."
 msgstr ""
+"solve() solucionará un listado de ecuaciones solo si para n ecuaciones independientes hay n variables para resolver.\n"
+"Si solo un resultado variable es de interés los otros resultados variables necesitan hacer su proceso puede ser empleado para decir al solve() cuales variables a eliminar dentro de la solución para la variable que interesa."
 
 #: ../../src/wxMaxima.cpp:7784
 msgid ""
 "solves an equation of the form\n"
 "    'diff(y,t) = -y;"
 msgstr ""
+"resuelve una ecuación de la forma\n"
+"    'diff(y,t) = -y;"
 
 #: ../../src/wxMaxima.cpp:7789
 msgid "t:"
-msgstr ""
+msgstr "t:"
 
 #: ../../src/wxMaximaFrame.cpp:1075
 msgid "unnamed function (lambda)..."
-msgstr ""
+msgstr "función no nombrada (lambda)…"
 
 #: ../../src/wxMaxima.cpp:11190
 msgid "unsaved"
-msgstr ""
+msgstr "no guardado"
 
 #: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
 #: ../../src/wxMaximaFrame.cpp:189
 msgid "untitled"
-msgstr ""
+msgstr "sin título"
 
 #: ../../src/wxMaximaFrame.cpp:1700
 msgid "use as function arguments"
-msgstr ""
+msgstr "emplar como argumentos de función"
 
 #: ../../src/wxMaximaFrame.cpp:1696
 msgid "use the actual values stored"
-msgstr ""
+msgstr "emplea los valores actuales almacenados"
 
 #: ../../src/wxMaximaFrame.cpp:1112
 msgid "writebyte..."
-msgstr ""
+msgstr "escribirbyte…"
 
 #: ../../src/main.cpp:509
 msgid "wxMaxima"
-msgstr ""
+msgstr "wxMaxima"
 
 #: ../../src/main.cpp:516
 #, c-format
 msgid "wxMaxima %ld"
-msgstr ""
+msgstr "wxMaxima %ld"
 
 #: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
 #: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
 #: ../../src/wxMaximaFrame.cpp:185
 #, c-format
 msgid "wxMaxima %s (%s) "
-msgstr ""
+msgstr "wxMaxima %s (%s) "
 
 #: ../../src/wxMaxima.cpp:4490
 msgid "wxMaxima cannot read the xml contents of "
-msgstr ""
+msgstr "wxMaxima no puede leer el contenido xml de "
 
 #: ../../src/wxMaxima.cpp:2546
 msgid ""
@@ -8045,77 +8455,81 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5285
 msgid "wxMaxima document"
-msgstr ""
+msgstr "Documento wxMaxima"
 
 #: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
 #: ../../src/wxMaxima.cpp:4230
 msgid "wxMaxima encountered an error loading "
-msgstr ""
+msgstr "wxMaxima encontró un error durante la carga "
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "wxMaxima help"
-msgstr ""
+msgstr "Ayuda wxMaxima"
 
 #: ../../src/Worksheet.cpp:1465 ../../src/Worksheet.cpp:1839
 msgid ""
 "wxMaxima remembers answers from the last run and is able to automatically "
 "send them to maxima, if requested"
 msgstr ""
+"wxMaxima recuerda respuestas desde la última ejecución y es capaz de enviar "
+"automáticamente a ‘maxima’, si se solicita"
 
 #: ../../src/Worksheet.cpp:1470 ../../src/Worksheet.cpp:1844
 msgid ""
 "wxMaxima remembers answers from the last run and is able to offer them as "
 "the default answer"
 msgstr ""
+"wxMaxima recuerda respuestas desde la última ejecución y es capaz de "
+"ofrecerlas como la respuesta predeterminada"
 
 #: ../../src/wxMaximaFrame.cpp:1896
 msgid "wxMaxima shows help in a browser"
-msgstr ""
+msgstr "wxMaxima muestra ayuda en un explorador"
 
 #: ../../src/wxMaximaFrame.cpp:1894
 msgid "wxMaxima shows help in the sidebar"
-msgstr ""
+msgstr "wxMaxima muestra ayuda en la barra lateral"
 
 #: ../../src/wxMaximaFrame.cpp:111
 #, c-format
 msgid "wxMaxima version %s"
-msgstr ""
+msgstr "Versión %s de wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1954
 msgid "wxMaxima's ChangeLog"
-msgstr ""
+msgstr "Boletín de Cambios de wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "wxMaxima's license"
-msgstr ""
+msgstr "Licencia de wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:144
 msgid "wxWidgets is using GTK 2"
-msgstr ""
+msgstr "wxWidgets está utilizando GTK 2"
 
 #: ../../src/wxMaximaFrame.cpp:142
 msgid "wxWidgets is using GTK 3"
-msgstr ""
+msgstr "wxWidgets está utilizando GTK 3"
 
 #: ../../src/WXMXformat.cpp:367
 msgid "wxmx file saved"
-msgstr ""
+msgstr "fichero wxmx guardado"
 
 #: ../../src/wxMaxima.cpp:8375
 msgid "x direction [in multiples of the tick frequency]"
-msgstr ""
+msgstr "dirección x"
 
 #: ../../src/wxMaxima.cpp:4500 ../../src/wxMaxima.cpp:4643
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
-msgstr ""
+msgstr "xml contenido en el fichero dice que no es un cuaderno de wxMaxima. "
 
 #: ../../src/wxMaxima.cpp:8376
 msgid "y direction [in multiples of the tick frequency]"
-msgstr ""
+msgstr "dirección y"
 
 #: ../../src/wxMaxima.cpp:7789
 msgid "y:"
-msgstr ""
+msgstr "y:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:2
@@ -8480,8 +8894,9 @@ msgstr "salida de, o una pregunta desde, _Maxima_"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Image cells."
-msgstr ""
+msgstr "Unión de Celdas"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
@@ -8500,8 +8915,9 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Page breaks."
-msgstr ""
+msgstr "Insertar Salto de Página"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:65
@@ -11426,8 +11842,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:837
+#, fuzzy
 msgid "Example:"
-msgstr ""
+msgstr "Muestra:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:842
@@ -11490,8 +11907,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:856
+#, fuzzy
 msgid "## Output rendering."
-msgstr ""
+msgstr "Salida: cadenas"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:858

--- a/locales/wxMaxima/fi.po
+++ b/locales/wxMaxima/fi.po
@@ -58,9 +58,9 @@ msgid "\"..\" means \"one directory up\"."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:5053
-#, c-format
+#, fuzzy, c-format
 msgid "%i cells in evaluation queue"
-msgstr ""
+msgstr "%i solua arviointijonossa"
 
 #: ../../src/Worksheet.cpp:330
 #, c-format
@@ -73,20 +73,21 @@ msgid "%s: Can't interpret line: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1655
+#, fuzzy
 msgid "&Algebraic Mode"
-msgstr ""
+msgstr "&Algebra "
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "&Apropos..."
-msgstr ""
+msgstr "&Etsi merkkijono..."
 
 #: ../../src/wxMaximaFrame.cpp:615
 msgid "&Batch File...\tCtrl+B"
-msgstr ""
+msgstr "&Komentojonotiedosto...\tCtrl+B"
 
 #: ../../src/wxMaximaFrame.cpp:1278
 msgid "&Boundary Value Problem..."
-msgstr ""
+msgstr "&Raja-arvotehtävä"
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "&Bug Report"
@@ -94,191 +95,197 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1505
 msgid "&Calculus"
-msgstr ""
+msgstr "&Analyysi"
 
 #: ../../src/wxMaximaFrame.cpp:1601
 msgid "&Canonical Form"
-msgstr ""
+msgstr "&Kanoninen muoto"
 
 #: ../../src/wxMaximaFrame.cpp:1358
 msgid "&Characteristic Polynomial..."
-msgstr ""
+msgstr "&Karakteristinen polynomi..."
 
 #: ../../src/wxMaximaFrame.cpp:990
 msgid "&Clear Memory"
-msgstr ""
+msgstr "&Tyhjennä muisti"
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "&Combine Factorials"
-msgstr ""
+msgstr "&Yhdistä kertomat"
 
 #: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Complex Simplification"
-msgstr ""
+msgstr "&Kompleksi Sieventäminen"
 
 #: ../../src/wxMaximaFrame.cpp:1502
 msgid "&Continued Fraction"
-msgstr ""
+msgstr "&Ketjumurtoluku"
 
 #: ../../src/wxMaximaFrame.cpp:638
 msgid "&Copy\tCtrl+C"
-msgstr ""
+msgstr "&Kopioi\tCtrl+C"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "&Demoivre"
-msgstr ""
+msgstr "&Demoivre"
 
 #: ../../src/wxMaximaFrame.cpp:1362
 msgid "&Determinant"
-msgstr ""
+msgstr "&Determinantti"
 
 #: ../../src/wxMaximaFrame.cpp:1466
 msgid "&Differentiate..."
-msgstr ""
+msgstr "Derivoi..."
 
 #: ../../src/wxMaximaFrame.cpp:689
 msgid "&Edit"
-msgstr ""
+msgstr "&Muokkaa"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "&Eliminate Variable..."
-msgstr ""
+msgstr "&Poista muuttuja..."
 
 #: ../../src/wxMaximaFrame.cpp:1318
 msgid "&Enter Matrix..."
-msgstr ""
+msgstr "&Syötä Matriisi..."
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "&Example..."
-msgstr ""
+msgstr "&Esimerkki..."
 
 #: ../../src/wxMaximaFrame.cpp:1524
 msgid "&Expand Expression"
-msgstr ""
+msgstr "&Laajenna lauseke"
 
 #: ../../src/wxMaximaFrame.cpp:1597
 msgid "&Expand Trigonometric"
-msgstr ""
+msgstr "&Laajenna trigonometrinen"
 
 #: ../../src/wxMaximaFrame.cpp:1626
 msgid "&Exponentialize"
-msgstr ""
+msgstr "&Muunna eksponenttimuotoon"
 
 #: ../../src/wxMaximaFrame.cpp:618
 msgid "&Export..."
-msgstr ""
+msgstr "&Vie..."
 
 #: ../../src/wxMaximaFrame.cpp:1516
 msgid "&Factor Expression"
-msgstr ""
+msgstr "&Jaa tekijöihin"
 
 #: ../../src/wxMaximaFrame.cpp:626
 msgid "&File"
-msgstr ""
+msgstr "&Tiedosto"
 
 #: ../../src/wxMaximaFrame.cpp:1019
+#, fuzzy
 msgid "&Functions"
-msgstr ""
+msgstr "Funktio:"
 
 #: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Greatest Common Divisor..."
-msgstr ""
+msgstr "&Suurin yhteinen tekijä"
 
 #: ../../src/wxMaximaFrame.cpp:1968
 msgid "&Help"
-msgstr ""
+msgstr "O&hje"
 
 #: ../../src/wxMaximaFrame.cpp:1453
 msgid "&Integrate..."
-msgstr ""
+msgstr "&Integroi..."
 
 #: ../../src/wxMaximaFrame.cpp:964
 msgid "&Interrupt\tCtrl+G"
-msgstr ""
+msgstr "&Keskeytä\tCtrl+G"
 
 #: ../../src/wxMaximaFrame.cpp:1355
 msgid "&Invert Matrix"
-msgstr ""
+msgstr "&Käännä Matriisi"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "&License"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1763
+#, fuzzy
 msgid "&List"
-msgstr ""
+msgstr "Lista:"
 
 #: ../../src/wxMaximaFrame.cpp:610
 msgid "&Load Package...\tCtrl+L"
-msgstr ""
+msgstr "&Lataa Pakettu...\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "&Maxima"
-msgstr ""
+msgstr "&Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "&Maxima help"
-msgstr ""
+msgstr "&Maximan ohje"
 
 #: ../../src/wxMaximaFrame.cpp:1660
 msgid "&Modulus Computation..."
-msgstr ""
+msgstr "&Modulo-laskenta..."
 
 #: ../../src/main.cpp:435
+#, fuzzy
 msgid "&New\tCtrl+N"
-msgstr ""
+msgstr "Uusi\tCtrl+N"
 
 #: ../../src/wxMaximaFrame.cpp:1870
 msgid "&Numeric"
-msgstr ""
+msgstr "&Numeerinen"
 
 #: ../../src/wxMaximaFrame.cpp:1785
+#, fuzzy
 msgid "&Numeric Output"
-msgstr ""
+msgstr "&Numeerinen"
 
 #: ../../src/main.cpp:436
+#, fuzzy
 msgid "&Open\tCtrl+O"
-msgstr ""
+msgstr "&Avaa\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "&Open...\tCtrl+O"
-msgstr ""
+msgstr "&Avaa...\tCtrl+0"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "&Plot"
-msgstr ""
+msgstr "&Kuvaaja"
 
 #: ../../src/wxMaximaFrame.cpp:622
 msgid "&Print...\tCtrl+P"
-msgstr ""
+msgstr "&Tulosta...\tCtrl+P"
 
 #: ../../src/wxMaximaFrame.cpp:1594
 msgid "&Reduce Trigonometric"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:974
+#, fuzzy
 msgid "&Restart Maxima\tCtrl+Alt+R"
-msgstr ""
+msgstr "&Käynnistä Maxima uudelleen"
 
 #: ../../src/wxMaximaFrame.cpp:608
 msgid "&Save\tCtrl+S"
-msgstr ""
+msgstr "&Tallenna\tCtrl+S"
 
 #: ../../src/wxMaximaFrame.cpp:1662
 msgid "&Simplify"
-msgstr ""
+msgstr "&Sievennä"
 
 #: ../../src/wxMaximaFrame.cpp:1581
 msgid "&Simplify Factorials"
-msgstr ""
+msgstr "&Sievennä kertomat"
 
 #: ../../src/wxMaximaFrame.cpp:1591
 msgid "&Simplify Trigonometric"
-msgstr ""
+msgstr "&Sievennä trigonometriset"
 
 #: ../../src/wxMaximaFrame.cpp:1238
 msgid "&Solve..."
-msgstr ""
+msgstr "&Ratkaise..."
 
 #: ../../src/wxMaximaFrame.cpp:1035
 msgid "&Time Display"
@@ -286,15 +293,16 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1375
 msgid "&Transpose Matrix"
-msgstr ""
+msgstr "&Transponoi matriisi"
 
 #: ../../src/wxMaximaFrame.cpp:1605
 msgid "&Trigonometric Simplification"
-msgstr ""
+msgstr "&Trigonometrinen sieventäminen"
 
 #: ../../src/wxMaximaFrame.cpp:1021
+#, fuzzy
 msgid "&Variables"
-msgstr ""
+msgstr "Muuttujat"
 
 #: ../../src/wxMaxima.cpp:2443
 msgid "(Config tells to suppress the output of long cells)"
@@ -337,22 +345,27 @@ msgid "(f(x),x,y) with singularities+discontinuities"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:2065
+#, fuzzy
 msgid ""
 "... [suppressed additional lines as the output is longer than allowed in the"
 " wxMaxima configuration] "
 msgstr ""
+"...[piilotettu lisärivejä sillä tuloste on pidempi kuin asetuksissa "
+"sallitaan] "
 
 #: ../../src/Worksheet.cpp:6666
 msgid ".wxm clipboard data with unusual header"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8047
+#, fuzzy
 msgid "1×n Matrix b:"
-msgstr ""
+msgstr "Matriisi:"
 
 #: ../../src/wxMaximaFrame.cpp:1312
+#, fuzzy
 msgid "2D Array to Matrix..."
-msgstr ""
+msgstr "&Luo matriisi..."
 
 #: ../../src/wxMaximaFrame.cpp:743
 msgid "2D equations using ASCII Art"
@@ -393,24 +406,27 @@ msgid "A function returning positive numbers"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1965
+#, fuzzy
 msgid "A irrational variable"
-msgstr ""
+msgstr "Vaihda muuttuja"
 
 #: ../../src/Worksheet.cpp:2016
 msgid "A left-associative function"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:2019
+#, fuzzy
 msgid "A linear function"
-msgstr ""
+msgstr "Poistaa funktion"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "A matrix in which each row is a set of variables"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1963
+#, fuzzy
 msgid "A rational variable"
-msgstr ""
+msgstr "Vaihda muuttuja"
 
 #: ../../src/Worksheet.cpp:2018
 msgid "A right-associative function"
@@ -429,12 +445,13 @@ msgid "A text control got the mouse focus"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1442
+#, fuzzy
 msgid "A&pply function to each Matrix element..."
-msgstr ""
+msgstr "Sovella funktiota listaan"
 
 #: ../../src/wxMaximaFrame.cpp:1291
 msgid "A&t Value..."
-msgstr ""
+msgstr "&Kohdassa..."
 
 #: ../../src/Configuration.cpp:85
 msgid "ASCII maths"
@@ -442,11 +459,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1963
 msgid "About"
-msgstr ""
+msgstr "Tietoja"
 
 #: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
 msgid "About wxMaxima"
-msgstr ""
+msgstr "Tietoja wxMaximasta"
 
 #: ../../src/wxMaxima.cpp:7837
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
@@ -462,7 +479,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1371
 msgid "Ad&joint Matrix"
-msgstr ""
+msgstr "&Adjungoi matriisi"
 
 #: ../../src/wxMaximaFrame.cpp:1657
 msgid "Add Algebraic E&quality..."
@@ -470,7 +487,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add a directory to search path"
-msgstr ""
+msgstr "Lisää hakemisto hakupolkuun"
 
 #: ../../src/wxMaximaFrame.cpp:1752
 msgid ""
@@ -478,16 +495,18 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8602
+#, fuzzy
 msgid "Add an element to the end of a list"
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaxima.cpp:8597
+#, fuzzy
 msgid "Add an element to the start of a list"
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaxima.cpp:7625
 msgid "Add dir to path:"
-msgstr ""
+msgstr "Lisää hakemisto polkuu:"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "Add equality to the rational simplifier"
@@ -495,7 +514,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add to &Path..."
-msgstr ""
+msgstr "Lisää &Polkuun..."
 
 #: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
 #: ../../src/Worksheet.cpp:1704
@@ -537,12 +556,14 @@ msgid "Aliases"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1714
+#, fuzzy
 msgid "All but the 1st n elements"
-msgstr ""
+msgstr "Sovella funktiota listaan"
 
 #: ../../src/wxMaximaFrame.cpp:1716
+#, fuzzy
 msgid "All but the last n elements"
-msgstr ""
+msgstr "Sovella funktiota listaan"
 
 #: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
 msgid ""
@@ -553,8 +574,9 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:733
+#, fuzzy
 msgid "All visible sidebars"
-msgstr ""
+msgstr "Kaikki muuttujanimet"
 
 #: ../../src/wxMaximaFrame.cpp:1650
 msgid "Allow to substitute operators"
@@ -596,8 +618,9 @@ msgid "Angles"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1775
+#, fuzzy
 msgid "Animation autoplay"
-msgstr ""
+msgstr "Tallenna animaatio tiedostoksi"
 
 #: ../../src/wxMaximaFrame.cpp:1778
 msgid "Animation framerate..."
@@ -616,28 +639,34 @@ msgid "Append a list"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1736
+#, fuzzy
 msgid "Append a list to an existing list"
-msgstr ""
+msgstr "Etsi lausekkeen raja-arvo"
 
 #: ../../src/wxMaxima.cpp:8607
+#, fuzzy
 msgid "Append a list to another list"
-msgstr ""
+msgstr "Etsi lausekkeen raja-arvo"
 
 #: ../../src/wxMaximaFrame.cpp:1729
+#, fuzzy
 msgid "Append an element"
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaximaFrame.cpp:1734
+#, fuzzy
 msgid "Append an element to the beginning an existing list"
-msgstr ""
+msgstr "Etsi lausekkeen raja-arvo"
 
 #: ../../src/wxMaximaFrame.cpp:1730
+#, fuzzy
 msgid "Append an element to the end of an existing list"
-msgstr ""
+msgstr "Etsi lausekkeen raja-arvo"
 
 #: ../../src/wxMaxima.cpp:8552
+#, fuzzy
 msgid "Apply a function to each list element"
-msgstr ""
+msgstr "Sovella funktiota listaan"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 #, c-format
@@ -662,15 +691,16 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9474
 msgid "Apropos"
-msgstr ""
+msgstr "Etsi merkkijono"
 
 #: ../../src/wxMaxima.cpp:7317
 msgid "Are the chars equal, if case is ignored?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7312
+#, fuzzy
 msgid "Are the chars equal?"
-msgstr ""
+msgstr "suurempi tai yhtä suuri kuin"
 
 #: ../../src/wxMaxima.cpp:7349
 msgid "Are these strings equal if case is ignored?"
@@ -685,12 +715,14 @@ msgid "Arguments:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8189
+#, fuzzy
 msgid "Array"
-msgstr ""
+msgstr "Taulukko:"
 
 #: ../../src/wxMaximaFrame.cpp:1023
+#, fuzzy
 msgid "Arrays"
-msgstr ""
+msgstr "Taulukko:"
 
 #: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
 msgid "Ascii code to char"
@@ -770,7 +802,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6210
 msgid "Batch File"
-msgstr ""
+msgstr "Komentojonotiedosto"
 
 #: ../../src/wxMaxima.cpp:5318
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -781,8 +813,9 @@ msgid "Bottom end"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7817
+#, fuzzy
 msgid "Boundary value problem"
-msgstr ""
+msgstr "&Raja-arvotehtävä"
 
 #: ../../src/wxMathml.cpp:101
 msgid ""
@@ -813,7 +846,7 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:3112
 msgid "Bug: Got a question but no cell to answer it in"
-msgstr ""
+msgstr "Virhe: Kysymykselle ei ole vastaussolua"
 
 #: ../../src/Worksheet.cpp:6378
 msgid ""
@@ -863,8 +896,9 @@ msgid ""
 msgstr ""
 
 #: ../../src/Worksheet.h:247 ../../src/Worksheet.h:252
+#, fuzzy
 msgid "Bug: Trying to record a cell contents change for undo without a cell."
-msgstr ""
+msgstr "Virhe: Yrittää tallentaa solun sisällön muutoksen ilman solua."
 
 #: ../../src/Worksheet.cpp:6417
 msgid "Bug: Undo action with both cell contents change and cell addition."
@@ -876,23 +910,24 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1948
 msgid "Build &Info"
-msgstr ""
+msgstr "Versio&tiedot"
 
 #: ../../src/wxMaxima.cpp:7275
 msgid "Byte:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1458
+#, fuzzy
 msgid "C&hange Variable in Integrate..."
-msgstr ""
+msgstr "&Vaihda muuttuja"
 
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "C&onfigure"
-msgstr ""
+msgstr "&Määritä"
 
 #: ../../src/wxMaximaFrame.cpp:1482
 msgid "Calculate &Product..."
-msgstr ""
+msgstr "Laske &tulo..."
 
 #: ../../src/wxMaxima.cpp:8057
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
@@ -906,7 +941,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate Su&m..."
-msgstr ""
+msgstr "Laske &summa..."
 
 #: ../../src/wxMaximaFrame.cpp:1795
 msgid "Calculate bigfloat value of the last result"
@@ -917,24 +952,26 @@ msgid "Calculate float value of the last result"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9550
+#, fuzzy
 msgid "Calculate mean value"
-msgstr ""
+msgstr "Laske modulus:"
 
 #: ../../src/wxMaxima.cpp:9554
+#, fuzzy
 msgid "Calculate median value"
-msgstr ""
+msgstr "Laske modulus:"
 
 #: ../../src/wxMaxima.cpp:8871
 msgid "Calculate modulus:"
-msgstr ""
+msgstr "Laske modulus:"
 
 #: ../../src/wxMaximaFrame.cpp:1798
 msgid "Calculate numeric value of the last result"
-msgstr ""
+msgstr "Laske likiarvo edelliselle tulokselle"
 
 #: ../../src/wxMaximaFrame.cpp:1483
 msgid "Calculate products"
-msgstr ""
+msgstr "Laske tulot"
 
 #: ../../src/wxMaxima.cpp:9562
 msgid "Calculate standard deviation"
@@ -942,23 +979,25 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate sums"
-msgstr ""
+msgstr "Laske summat"
 
 #: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
 msgid "Calculate the eigenvalues and eigenvectors numerically"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
+#, fuzzy
 msgid "Calculate the eigenvalues of a matrix numerically"
-msgstr ""
+msgstr "Laske käänteismatriisi"
 
 #: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
 msgid "Calculate the root of the sum of squares of matrix entries"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9558
+#, fuzzy
 msgid "Calculate variation"
-msgstr ""
+msgstr "Laske tulot"
 
 #: ../../src/wxMaxima.cpp:8949
 msgid "Calculates the fourier coefficients for the expression from -p to p"
@@ -974,11 +1013,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11125
 msgid "Can not connect to the web server."
-msgstr ""
+msgstr "Ei yhteyttä palvelimeen"
 
 #: ../../src/wxMaxima.cpp:11166
 msgid "Can not download version info."
-msgstr ""
+msgstr "Versiotiedon lataaminen ei onnistu"
 
 #: ../../src/wxMaxima.cpp:3016 ../../src/wxMaxima.cpp:4836
 msgid ""
@@ -989,7 +1028,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Cancel"
-msgstr ""
+msgstr "Peruuta"
 
 #: ../../src/wxMaxima.cpp:3292
 msgid "Cannot authenticate Maxima!"
@@ -1043,7 +1082,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:955
 msgid "Ce&ll"
-msgstr ""
+msgstr "Solu"
 
 #: ../../src/Configuration.cpp:96
 msgid "Cell bracket fill, Active"
@@ -1055,31 +1094,35 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10395
 msgid "Cell ends in a backslash"
-msgstr ""
+msgstr "Solu päättyy kenoviivaan"
 
 #: ../../src/wxMaximaFrame.cpp:1038
 msgid "Change &2d Display"
-msgstr ""
+msgstr "Vaihda &2d Näyttö"
 
 #: ../../src/wxMaxima.cpp:10146
+#, fuzzy
 msgid "Change Image"
-msgstr ""
+msgstr "Vaihda muuttuja"
 
 #: ../../src/Worksheet.cpp:1324
+#, fuzzy
 msgid "Change Image..."
-msgstr ""
+msgstr "Tallenna kuva..."
 
 #: ../../src/wxMaximaFrame.cpp:1954
+#, fuzzy
 msgid "Change Log"
-msgstr ""
+msgstr "Vaihda muuttuja"
 
 #: ../../src/wxMaxima.cpp:7555
 msgid "Change directory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1202
+#, fuzzy
 msgid "Change directory..."
-msgstr ""
+msgstr "Tallenna kuva..."
 
 #: ../../src/wxMaximaFrame.cpp:1039
 msgid "Change the 2d display algorithm used to display math output"
@@ -1087,23 +1130,26 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8885
 msgid "Change variable"
-msgstr ""
+msgstr "Vaihda muuttuja"
 
 #: ../../src/wxMaxima.cpp:8905
+#, fuzzy
 msgid "Change variable and evaluate"
-msgstr ""
+msgstr "Vaihda muuttujaa integroinnissa tai summaamisessa"
 
 #: ../../src/wxMaximaFrame.cpp:1459
 msgid "Change variable in integral or sum"
-msgstr ""
+msgstr "Vaihda muuttujaa integroinnissa tai summaamisessa"
 
 #: ../../src/wxMaximaFrame.cpp:1463
+#, fuzzy
 msgid "Change variable in integral or sum and evaluate the result"
-msgstr ""
+msgstr "Vaihda muuttujaa integroinnissa tai summaamisessa"
 
 #: ../../src/wxMaximaFrame.cpp:1026
+#, fuzzy
 msgid "Changed option variables"
-msgstr ""
+msgstr "Vaihda muuttuja"
 
 #: ../../src/wxMaxima.cpp:10170
 #, c-format
@@ -1119,8 +1165,9 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
 #: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
+#, fuzzy
 msgid "Char #2:"
-msgstr ""
+msgstr "Matriisi:"
 
 #: ../../src/wxMaximaFrame.cpp:1140
 msgid "Char to Unicode code point..."
@@ -1143,8 +1190,9 @@ msgid "Character Tests"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8181
+#, fuzzy
 msgid "Characteristic polynom"
-msgstr ""
+msgstr "&Karakteristinen polynomi..."
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Chars are strings that are one character long"
@@ -1152,11 +1200,12 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1957
 msgid "Check for Updates"
-msgstr ""
+msgstr "Tarkista päivitykset"
 
 #: ../../src/wxMaximaFrame.cpp:1958
+#, fuzzy
 msgid "Check if a newer version of wxMaxima is available."
-msgstr ""
+msgstr "Tarkista, onko wxMaximasta/Maximasta uudempaa versiota."
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Choose the parenthesis type for Matrices"
@@ -1164,63 +1213,74 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9530 ../../src/wxMaxima.cpp:9535
 msgid "Classes:"
-msgstr ""
+msgstr "Luokat:"
 
 #: ../../src/wxMaximaFrame.cpp:1378
 msgid "Classic matrix operations"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:998
+#, fuzzy
 msgid "Clear all aliases"
-msgstr ""
+msgstr "&Tyhjennä muisti"
 
 #: ../../src/wxMaximaFrame.cpp:995
+#, fuzzy
 msgid "Clear all arrays"
-msgstr ""
+msgstr "&Tyhjennä muisti"
 
 #: ../../src/wxMaximaFrame.cpp:992
+#, fuzzy
 msgid "Clear all dependencies"
-msgstr ""
+msgstr "&Tyhjennä muisti"
 
 #: ../../src/wxMaximaFrame.cpp:994
+#, fuzzy
 msgid "Clear all functions"
-msgstr ""
+msgstr "Poistaa funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1001
+#, fuzzy
 msgid "Clear all gradefs"
-msgstr ""
+msgstr "&Tyhjennä muisti"
 
 #: ../../src/wxMaximaFrame.cpp:1000
+#, fuzzy
 msgid "Clear all labels"
-msgstr ""
+msgstr "&Tyhjennä muisti"
 
 #: ../../src/wxMaximaFrame.cpp:1004
 msgid "Clear all let rule packages"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1003
+#, fuzzy
 msgid "Clear all macros"
-msgstr ""
+msgstr "&Tyhjennä muisti"
 
 #: ../../src/wxMaximaFrame.cpp:1002
+#, fuzzy
 msgid "Clear all props"
-msgstr ""
+msgstr "&Tyhjennä muisti"
 
 #: ../../src/wxMaximaFrame.cpp:997
+#, fuzzy
 msgid "Clear all rules"
-msgstr ""
+msgstr "&Tyhjennä muisti"
 
 #: ../../src/wxMaximaFrame.cpp:999
+#, fuzzy
 msgid "Clear all structures"
-msgstr ""
+msgstr "&Tyhjennä muisti"
 
 #: ../../src/wxMaximaFrame.cpp:993
+#, fuzzy
 msgid "Clear all variables"
-msgstr ""
+msgstr "Poistaa muuttujan"
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close\tCtrl+W"
-msgstr ""
+msgstr "Sulje\tCtrl+W"
 
 #: ../../src/wxMaxima.cpp:7235
 msgid "Close Stream"
@@ -1228,11 +1288,12 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close window"
-msgstr ""
+msgstr "Sulkee ikkunan"
 
 #: ../../src/wxMaximaFrame.cpp:1105
+#, fuzzy
 msgid "Close..."
-msgstr ""
+msgstr "Ratkaise..."
 
 #: ../../src/WXMXformat.cpp:301
 msgid "Closed the zip archive"
@@ -1244,15 +1305,16 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:103
 msgid "Code highlighting: Comments"
-msgstr ""
+msgstr "Koodin korostus: Kommentit"
 
 #: ../../src/Configuration.cpp:108
+#, fuzzy
 msgid "Code highlighting: End of line markers"
-msgstr ""
+msgstr "Koodin korotus: Rivin loppu"
 
 #: ../../src/Configuration.cpp:102
 msgid "Code highlighting: Functions"
-msgstr ""
+msgstr "Koodin korostus: Funktiot"
 
 #: ../../src/Configuration.cpp:107
 msgid "Code highlighting: Lisp"
@@ -1260,51 +1322,58 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:104
 msgid "Code highlighting: Numbers"
-msgstr ""
+msgstr "Koodin korostus: Numerot"
 
 #: ../../src/Configuration.cpp:106
 msgid "Code highlighting: Operators"
-msgstr ""
+msgstr "Koodin korostus: Operaattorit"
 
 #: ../../src/Configuration.cpp:105
 msgid "Code highlighting: Strings"
-msgstr ""
+msgstr "Koodin korostus: Merkkijonot"
 
 #: ../../src/Configuration.cpp:101
 msgid "Code highlighting: Variables"
-msgstr ""
+msgstr "Koodin korotus: Muuttujat"
 
 #: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
+#, fuzzy
 msgid "Code number:"
-msgstr ""
+msgstr "Sarakkeet:"
 
 #: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
+#, fuzzy
 msgid "Codepoint number:"
-msgstr ""
+msgstr "Sarakkeet:"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "Col. names:"
-msgstr ""
+msgstr "Sarakkeiden nimet:"
 
 #: ../../src/Configuration.cpp:100
+#, fuzzy
 msgid "Color of Outdated cells"
-msgstr ""
+msgstr "Vanhentuneet solut"
 
 #: ../../src/Configuration.cpp:99
+#, fuzzy
 msgid "Color of text equal to selection"
-msgstr ""
+msgstr "Teksti vastaa valintaa"
 
 #: ../../src/wxMaxima.cpp:7962
+#, fuzzy
 msgid "Column number:"
-msgstr ""
+msgstr "Sarakkeet:"
 
 #: ../../src/wxMaxima.cpp:7978
+#, fuzzy
 msgid "Column numbers:"
-msgstr ""
+msgstr "Sarakkeet:"
 
 #: ../../src/wxMaxima.cpp:8202
+#, fuzzy
 msgid "Columns"
-msgstr ""
+msgstr "Sarakkeet:"
 
 #: ../../src/wxMaximaFrame.cpp:1584
 msgid "Combine factorials in an expression"
@@ -1315,43 +1384,52 @@ msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7259
+#, fuzzy
 msgid "Comma-separated arguments"
-msgstr ""
+msgstr "Pilkuilla erotetut x-koordinaatit"
 
 #: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
+#, fuzzy
 msgid "Comma-separated commands"
-msgstr ""
+msgstr "Pilkuilla erotetut x-koordinaatit"
 
 #: ../../src/wxMaxima.cpp:8458
+#, fuzzy
 msgid "Comma-separated elements"
-msgstr ""
+msgstr "Pilkuilla erotetut x-koordinaatit"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 #: ../../src/wxMaxima.cpp:10031
+#, fuzzy
 msgid "Comma-separated equations"
-msgstr ""
+msgstr "Pilkuilla erotetut x-koordinaatit"
 
 #: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
 #: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
 #: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
+#, fuzzy
 msgid "Comma-separated expressions"
-msgstr ""
+msgstr "Pilkuilla erotetut x-koordinaatit"
 
 #: ../../src/wxMaxima.cpp:7215
+#, fuzzy
 msgid "Comma-separated expressions that shall be converted to a string"
-msgstr ""
+msgstr "Pilkuilla erotetut x-koordinaatit"
 
 #: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
+#, fuzzy
 msgid "Comma-separated expressions."
-msgstr ""
+msgstr "Pilkuilla erotetut x-koordinaatit"
 
 #: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
+#, fuzzy
 msgid "Comma-separated function names"
-msgstr ""
+msgstr "Pilkuilla erotetut x-koordinaatit"
 
 #: ../../src/wxMaxima.cpp:7086
+#, fuzzy
 msgid "Comma-separated function names."
-msgstr ""
+msgstr "Pilkuilla erotetut x-koordinaatit"
 
 #: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
 #: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
@@ -1367,8 +1445,9 @@ msgid "Comma-separated names the parameters will be referenced by later."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
+#, fuzzy
 msgid "Comma-separated numbers from 0 to 255"
-msgstr ""
+msgstr "Pilkuilla erotetut x-koordinaatit"
 
 #: ../../src/wxMaxima.cpp:8770
 msgid "Comma-separated numbers of the terms to substitute in"
@@ -1415,12 +1494,14 @@ msgid "Compile a QR decomposition using dgeqrf"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7162
+#, fuzzy
 msgid "Compile a function"
-msgstr ""
+msgstr "Poistaa funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1188
+#, fuzzy
 msgid "Compile a regular expression"
-msgstr ""
+msgstr "Poistaa funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1385
 msgid "Compile eigenvalues using dgeev"
@@ -1439,12 +1520,14 @@ msgid "Compile eigenvalues+eigenvectors using zgeev"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1076
+#, fuzzy
 msgid "Compile function..."
-msgstr ""
+msgstr "Poista f&unktio..."
 
 #: ../../src/wxMaxima.cpp:7511
+#, fuzzy
 msgid "Compile regex"
-msgstr ""
+msgstr "Täydennä sana"
 
 #: ../../src/wxMathml.cpp:53
 msgid "Compiler-Bug? wxMathml.lisp is shorter than expected!"
@@ -1463,16 +1546,17 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:892
+#, fuzzy
 msgid "Complete Word\tCtrl+Space"
-msgstr ""
+msgstr "Täydennä sana\tCtrl+K"
 
 #: ../../src/wxMaximaFrame.cpp:893
 msgid "Complete word"
-msgstr ""
+msgstr "Täydennä sana"
 
 #: ../../src/ToolBar.cpp:230
 msgid "Completely stop maxima and restart it"
-msgstr ""
+msgstr "Pysäytä maxima kokonaan ja käynnistä se uudelleen"
 
 #: ../../src/wxMaximaFrame.cpp:1503
 msgid "Compute continued fraction of a value"
@@ -1480,7 +1564,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1372
 msgid "Compute the adjoint matrix"
-msgstr ""
+msgstr "Laske adjungoitu matriisi"
 
 #: ../../src/wxMaximaFrame.cpp:1359
 msgid "Compute the characteristic polynomial of a matrix"
@@ -1488,32 +1572,33 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1363
 msgid "Compute the determinant of a matrix"
-msgstr ""
+msgstr "Laske matriisin determinantti"
 
 #: ../../src/wxMaximaFrame.cpp:1491
 msgid "Compute the greatest common divisor"
-msgstr ""
+msgstr "Laske suurin yhteinen tekijä"
 
 #: ../../src/wxMaximaFrame.cpp:1356
 msgid "Compute the inverse of a matrix"
-msgstr ""
+msgstr "Laske käänteismatriisi"
 
 #: ../../src/wxMaximaFrame.cpp:1494
 msgid "Compute the least common multiple (do load(functs) before using)"
-msgstr ""
+msgstr "Laske pienin yhteinen jaettava (lataa (load) funktiot ennen käyttöä)"
 
 #: ../../src/wxMaximaFrame.cpp:1374
+#, fuzzy
 msgid "Compute the rank of a matrix"
-msgstr ""
+msgstr "Laske matriisin determinantti"
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Condition:"
-msgstr ""
+msgstr "Ehto:"
 
 #: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "Configure wxMaxima"
-msgstr ""
+msgstr "Määrittele wxMaxima"
 
 #: ../../src/wxMaxima.cpp:2504
 msgid "Connection attempt, but connection failed."
@@ -1524,16 +1609,19 @@ msgid "Connection to Maxima lost."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7921
+#, fuzzy
 msgid "Construct a fraction"
-msgstr ""
+msgstr "&Ketjumurtoluku"
 
 #: ../../src/wxMaximaFrame.cpp:1305
+#, fuzzy
 msgid "Construct fraction..."
-msgstr ""
+msgstr "&Ketjumurtoluku"
 
 #: ../../src/wxMaxima.cpp:7158
+#, fuzzy
 msgid "Contents:"
-msgstr ""
+msgstr "Kreikkalaiset vakiot"
 
 #: ../../src/wxMaximaFrame.cpp:1877
 msgid "Context-sensitive &Help\tCtrl+?"
@@ -1548,24 +1636,29 @@ msgid "Contract Logarithms"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1161
+#, fuzzy
 msgid "Conversions"
-msgstr ""
+msgstr "Lisää alikappalesolu"
 
 #: ../../src/wxMaximaFrame.cpp:1229
+#, fuzzy
 msgid "Convert"
-msgstr ""
+msgstr "Lisää alikappalesolu"
 
 #: ../../src/wxMaximaFrame.cpp:1230
+#, fuzzy
 msgid "Convert + Write to file"
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaximaFrame.cpp:1434
+#, fuzzy
 msgid "Convert Column to list..."
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaximaFrame.cpp:1430
+#, fuzzy
 msgid "Convert Row to list..."
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaximaFrame.cpp:1044
 msgid "Convert a command to maxima code"
@@ -1577,15 +1670,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1574
 msgid "Convert binomials, beta and gamma function to factorials"
-msgstr ""
+msgstr "Muunna binomit, beta- ja gamma funktiot kertomiksi"
 
 #: ../../src/wxMaximaFrame.cpp:1578
 msgid "Convert binomials, factorials and beta function to gamma function"
-msgstr ""
+msgstr "Muunna binomit, kertoimet ja betafunktiot gammafunktioksi"
 
 #: ../../src/wxMaximaFrame.cpp:1613
 msgid "Convert complex expression to polar form"
-msgstr ""
+msgstr "Muunna kompleksilauseke polaarimuotoon"
 
 #: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert complex expression to rect form"
@@ -1597,16 +1690,18 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7411
+#, fuzzy
 msgid "Convert string to lowercase"
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaxima.cpp:7543
+#, fuzzy
 msgid "Convert string to matching regex"
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaximaFrame.cpp:1543
 msgid "Convert sum of logarithms to logarithm of product"
-msgstr ""
+msgstr "Muunna logaritmien summa tulon logaritmiksi"
 
 #: ../../src/wxMaximaFrame.cpp:1573
 msgid "Convert to &Factorials"
@@ -1625,12 +1720,14 @@ msgid "Convert to &Rectform"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1166
+#, fuzzy
 msgid "Convert to downcase..."
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaxima.cpp:7016
+#, fuzzy
 msgid "Convert to programming language"
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaxima.cpp:7022
 msgid "Convert to programming language file"
@@ -1642,7 +1739,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1627
 msgid "Convert trigonometric functions to exponential form"
-msgstr ""
+msgstr "Muunna trigonometrinen funktio eksponenttimuotoon"
 
 #: ../../src/wxMaximaFrame.cpp:1762
 msgid "Converts a matrix to a list of lists"
@@ -1656,24 +1753,26 @@ msgstr ""
 #: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
 #: ../../src/Worksheet.cpp:1684
 msgid "Copy"
-msgstr ""
+msgstr "Kopioi"
 
 #: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
 #: ../../src/Worksheet.cpp:1514
+#, fuzzy
 msgid "Copy Animation"
-msgstr ""
+msgstr "Aloita animaatio"
 
 #: ../../src/wxMaximaFrame.cpp:887
 msgid "Copy Previous Input\tCtrl+I"
-msgstr ""
+msgstr "Kopioi aiempi syöte\tCtrl+I"
 
 #: ../../src/wxMaximaFrame.cpp:890
 msgid "Copy Previous Output\tCtrl+U"
-msgstr ""
+msgstr "Kopioi aiempi tuloste\tCtrl+I"
 
 #: ../../src/wxMaxima.cpp:7992
+#, fuzzy
 msgid "Copy a matrix"
-msgstr ""
+msgstr "Kopioi kuvana"
 
 #: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
 #: ../../src/wxMaximaFrame.cpp:663
@@ -1683,16 +1782,17 @@ msgstr ""
 #: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Copy as Image"
-msgstr ""
+msgstr "Kopioi kuvana"
 
 #: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
 #: ../../src/wxMaximaFrame.cpp:645
 msgid "Copy as LaTeX"
-msgstr ""
+msgstr "Kopioi LaTeXina"
 
 #: ../../src/wxMaximaFrame.cpp:648
+#, fuzzy
 msgid "Copy as MathML"
-msgstr ""
+msgstr "Kopioi kuvana"
 
 #: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
 msgid "Copy as MathML (e.g. to word processor)"
@@ -1700,29 +1800,34 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
 #: ../../src/wxMaximaFrame.cpp:658
+#, fuzzy
 msgid "Copy as RTF"
-msgstr ""
+msgstr "Kopioi LaTeXina"
 
 #: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
 #: ../../src/wxMaximaFrame.cpp:655
+#, fuzzy
 msgid "Copy as SVG"
-msgstr ""
+msgstr "Kopioi LaTeXina"
 
 #: ../../src/wxMaximaFrame.cpp:640
 msgid "Copy as Text\tCtrl+Shift+C"
-msgstr ""
+msgstr "Kopioi tekstinä"
 
 #: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
+#, fuzzy
 msgid "Copy as plain text"
-msgstr ""
+msgstr "Kopioi kuvana"
 
 #: ../../src/wxMaxima.cpp:7576
+#, fuzzy
 msgid "Copy file"
-msgstr ""
+msgstr "Kopioi"
 
 #: ../../src/wxMaximaFrame.cpp:1214
+#, fuzzy
 msgid "Copy file..."
-msgstr ""
+msgstr "Ratkaise..."
 
 #: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
 #: ../../src/wxMaximaFrame.cpp:643
@@ -1731,32 +1836,34 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
 msgid "Copy selection"
-msgstr ""
+msgstr "Kopioi valitun"
 
 #: ../../src/wxMaximaFrame.cpp:664
 msgid "Copy selection from document as an Enhanced Metafile"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:656
+#, fuzzy
 msgid "Copy selection from document as an SVG image"
-msgstr ""
+msgstr "Kopioi valitun osan dokumenttia kuvaksi"
 
 #: ../../src/wxMaximaFrame.cpp:653
 msgid "Copy selection from document as an image"
-msgstr ""
+msgstr "Kopioi valitun osan dokumenttia kuvaksi"
 
 #: ../../src/wxMaximaFrame.cpp:659
+#, fuzzy
 msgid ""
 "Copy selection from document as rtf that a word processor might understand"
-msgstr ""
+msgstr "Kopioi valitun osan dokumenttia kuvaksi"
 
 #: ../../src/wxMaximaFrame.cpp:641
 msgid "Copy selection from document as text"
-msgstr ""
+msgstr "Kopioi valitun osan dokumenttia tekstiksi"
 
 #: ../../src/wxMaximaFrame.cpp:646
 msgid "Copy selection from document in LaTeX format"
-msgstr ""
+msgstr "Tallenna valinta asiakirjasta LaTeX-muotoon"
 
 #: ../../src/wxMaximaFrame.cpp:644
 msgid "Copy selection from document in Matlab format"
@@ -1769,12 +1876,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7403
+#, fuzzy
 msgid "Copy string"
-msgstr ""
+msgstr "Kopioi valitun"
 
 #: ../../src/wxMaximaFrame.cpp:1165
+#, fuzzy
 msgid "Copy string..."
-msgstr ""
+msgstr "Päättymätön merkkijono."
 
 #: ../../src/ToolBar.cpp:623
 msgid "Copy, Cut and Paste button"
@@ -1805,12 +1914,14 @@ msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1325
+#, fuzzy
 msgid "Create Matrix"
-msgstr ""
+msgstr "Luo matriisi"
 
 #: ../../src/wxMaximaFrame.cpp:1688
+#, fuzzy
 msgid "Create a list"
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaxima.cpp:8487
 msgid "Create a list as a storage for the values of variables"
@@ -1826,43 +1937,49 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:888
 msgid "Create a new cell with previous input"
-msgstr ""
+msgstr "Luo uusi solu aiemmalla syötteellä"
 
 #: ../../src/wxMaximaFrame.cpp:891
 msgid "Create a new cell with previous output"
-msgstr ""
+msgstr "Luo uusi solu aiemmalla tulosteella"
 
 #: ../../src/wxMaximaFrame.cpp:1348
 msgid "Create copy, not clone..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7561
+#, fuzzy
 msgid "Create directory"
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaximaFrame.cpp:1203
+#, fuzzy
 msgid "Create directory..."
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaxima.cpp:7419
+#, fuzzy
 msgid "Create empty string"
-msgstr ""
+msgstr "Luo matriisi"
 
 #: ../../src/wxMaximaFrame.cpp:1168
+#, fuzzy
 msgid "Create empty string..."
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaximaFrame.cpp:1687
+#, fuzzy
 msgid "Create list"
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaxima.cpp:8457
 msgid "Create list from comma-separated elements"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1082
+#, fuzzy
 msgid "Create struct..."
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/WXMXformat.cpp:80
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
@@ -1873,28 +1990,29 @@ msgid "Creates an independent matrix with the same contents"
 msgstr ""
 
 #: ../../src/Configuration.cpp:97
+#, fuzzy
 msgid "Cursor color"
-msgstr ""
+msgstr "Kursori"
 
 #: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
 msgid "Cut"
-msgstr ""
+msgstr "Leikkaa"
 
 #: ../../src/wxMaximaFrame.cpp:636
 msgid "Cut\tCtrl+X"
-msgstr ""
+msgstr "Cut\tCtrl+X"
 
 #: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
 msgid "Cut selection"
-msgstr ""
+msgstr "Leikkaa valitun"
 
 #: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
 msgid "Data Matrix:"
-msgstr ""
+msgstr "Datamatriisi:"
 
 #: ../../src/wxMaxima.cpp:9599
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
-msgstr ""
+msgstr "Datatiedosto  (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wxMaxima.cpp:9529 ../../src/wxMaxima.cpp:9534
 #: ../../src/wxMaxima.cpp:9539 ../../src/wxMaxima.cpp:9543
@@ -1903,7 +2021,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9563 ../../src/wxMaxima.cpp:9577
 #: ../../src/wxMaxima.cpp:9582 ../../src/wxMaxima.cpp:10030
 msgid "Data:"
-msgstr ""
+msgstr "Data:"
 
 #: ../../src/wxMaximaFrame.cpp:1057
 msgid "Debugger trigger"
@@ -1927,8 +2045,9 @@ msgid "Declare facts about %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8800
+#, fuzzy
 msgid "Declare main variable:"
-msgstr ""
+msgstr "Poistaa muuttujan"
 
 #: ../../src/wxMaxima.cpp:7171
 msgid "Declare the type of a function parameter"
@@ -1943,12 +2062,14 @@ msgid "Decompose rational function to partial fractions"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:2010
+#, fuzzy
 msgid "Decreasing function f(x)<x"
-msgstr ""
+msgstr "Poista funktio(t):"
 
 #: ../../src/wxMaxima.cpp:7134
+#, fuzzy
 msgid "Define a function"
-msgstr ""
+msgstr "Poistaa funktion"
 
 #: ../../src/wxMaxima.cpp:7147
 msgid "Define a macro"
@@ -1963,12 +2084,14 @@ msgid "Define a structure type"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7156
+#, fuzzy
 msgid "Define a variable"
-msgstr ""
+msgstr "Poistaa muuttujan"
 
 #: ../../src/wxMaximaFrame.cpp:1072
+#, fuzzy
 msgid "Define function..."
-msgstr ""
+msgstr "Poista f&unktio..."
 
 #: ../../src/wxMaximaFrame.cpp:1079
 msgid "Define macro..."
@@ -1983,8 +2106,9 @@ msgid "Define struct..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1080
+#, fuzzy
 msgid "Define variable..."
-msgstr ""
+msgstr "Poistaa muuttujan"
 
 #: ../../src/wxMaximaFrame.cpp:1776
 msgid ""
@@ -1997,23 +2121,23 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:985
 msgid "Delete F&unction..."
-msgstr ""
+msgstr "Poista f&unktio..."
 
 #: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
 msgid "Delete Selection"
-msgstr ""
+msgstr "Poista valittu"
 
 #: ../../src/wxMaximaFrame.cpp:987
 msgid "Delete V&ariable..."
-msgstr ""
+msgstr "Poista &muuttuja..."
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Delete a function"
-msgstr ""
+msgstr "Poistaa funktion"
 
 #: ../../src/wxMaximaFrame.cpp:988
 msgid "Delete a variable"
-msgstr ""
+msgstr "Poistaa muuttujan"
 
 #: ../../src/wxMaximaFrame.cpp:982
 msgid "Delete all objects with a given name"
@@ -2021,35 +2145,42 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:991
 msgid "Delete all values from memory"
-msgstr ""
+msgstr "Poista kaikki arvot muistista"
 
 #: ../../src/wxMaxima.cpp:7588
+#, fuzzy
 msgid "Delete file"
-msgstr ""
+msgstr "Poistaa muuttujan"
 
 #: ../../src/wxMaximaFrame.cpp:1216
+#, fuzzy
 msgid "Delete file..."
-msgstr ""
+msgstr "Poista &muuttuja..."
 
 #: ../../src/wxMaxima.cpp:7683
+#, fuzzy
 msgid "Delete function(s)"
-msgstr ""
+msgstr "Poista funktio(t):"
 
 #: ../../src/wxMaxima.cpp:7679
+#, fuzzy
 msgid "Delete named object(s)"
-msgstr ""
+msgstr "Poista funktio(t):"
 
 #: ../../src/wxMaximaFrame.cpp:981
+#, fuzzy
 msgid "Delete named object..."
-msgstr ""
+msgstr "Poista f&unktio..."
 
 #: ../../src/wxMaxima.cpp:7674
+#, fuzzy
 msgid "Delete variable(s)"
-msgstr ""
+msgstr "Poista muuttuja(t):"
 
 #: ../../src/wxMaxima.cpp:7430
+#, fuzzy
 msgid "Delimiter:"
-msgstr ""
+msgstr "Eliminoi"
 
 #: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
 #, c-format
@@ -2078,7 +2209,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1497
 msgid "Di&vide Polynomials..."
-msgstr ""
+msgstr "&Jaa polynomit..."
 
 #: ../../src/MaximaManual.cpp:517
 msgid "Didn't find the maxima HTML manual."
@@ -2092,35 +2223,38 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
 msgid "Differentiate"
-msgstr ""
+msgstr "Derivoi"
 
 #: ../../src/wxMaximaFrame.cpp:1467
 msgid "Differentiate expression"
-msgstr ""
+msgstr "Derivoi lauseke"
 
 #: ../../src/Worksheet.cpp:1590
 msgid "Differentiate..."
-msgstr ""
+msgstr "Derivoi..."
 
 #: ../../src/wxMaxima.cpp:9010
+#, fuzzy
 msgid "Differentiates an expression n times"
-msgstr ""
+msgstr "Derivoi lauseke"
 
 #: ../../src/wxMaxima.cpp:10055
+#, fuzzy
 msgid "Differentiates the expression n times"
-msgstr ""
+msgstr "Derivoi lauseke"
 
 #: ../../src/wxMaximaFrame.cpp:1212
+#, fuzzy
 msgid "Directory operations"
-msgstr ""
+msgstr "Suunta:"
 
 #: ../../src/wxMaximaFrame.cpp:1041
 msgid "Display Te&X Form"
-msgstr ""
+msgstr "Näytä Te&X muoto"
 
 #: ../../src/wxMaxima.cpp:6972
 msgid "Display algorithm"
-msgstr ""
+msgstr "Näytä algoritmi"
 
 #: ../../src/wxMaximaFrame.cpp:751
 msgid "Display an expression as maxima's internal lisp representation"
@@ -2131,8 +2265,9 @@ msgid "Display an expression as wxMaxima's internal XML representation"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:758
+#, fuzzy
 msgid "Display equations"
-msgstr ""
+msgstr "Ratkaise yhtälö(t)"
 
 #: ../../src/wxMaxima.cpp:6508
 msgid "Display expression in maxima's internal representation"
@@ -2144,7 +2279,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1042
 msgid "Display last result in TeX form"
-msgstr ""
+msgstr "Näytä viimeisin tulos TeX-muodossa"
 
 #: ../../src/ToolBar.cpp:360
 #, c-format
@@ -2152,24 +2287,27 @@ msgid "Display resolution according to wxWidgets: %li x %li ppi"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:802
+#, fuzzy
 msgid "Display string quotation marks"
-msgstr ""
+msgstr "Ratkaise yhtälö(t)"
 
 #: ../../src/wxMaximaFrame.cpp:1036
 msgid "Display time used for evaluation"
-msgstr ""
+msgstr "Näytä evaluointiin käytetty aika"
 
 #: ../../src/wxMaxima.cpp:9206
+#, fuzzy
 msgid "Displayed Precision"
-msgstr ""
+msgstr "Ratkaise yhtälö(t)"
 
 #: ../../src/wxMaximaFrame.cpp:1913
 msgid "Displaying 3d curves"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1462
+#, fuzzy
 msgid "Dito, and evaluate the result..."
-msgstr ""
+msgstr "Laske Solu(t)"
 
 #: ../../src/wxMaximaFrame.cpp:1445
 msgid "Dito, but affect all clones of the Matrix..."
@@ -2185,20 +2323,21 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
 msgid "Divide Cell"
-msgstr ""
+msgstr "Jaa solu"
 
 #: ../../src/wxMaximaFrame.cpp:1498
 msgid "Divide numbers or polynomials"
-msgstr ""
+msgstr "Jaa luvut tai polynomit"
 
 #: ../../src/wxMaxima.cpp:8578
+#, fuzzy
 msgid "Do for each list element"
-msgstr ""
+msgstr "Sovella funktiota listaan"
 
 #: ../../src/wxMaxima.cpp:11197
-#, c-format
+#, fuzzy, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
-msgstr ""
+msgstr "Haluatko tallentaa asiakirjaan tekemäsi muutokset? \""
 
 #: ../../src/wxMaximaFrame.cpp:724
 msgid "Dock all Sidebars"
@@ -2206,35 +2345,41 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:94
 msgid "Document background"
-msgstr ""
+msgstr "Asiakirjan tausta"
 
 #: ../../src/wxMaxima.cpp:4611
+#, fuzzy
 msgid ""
 "Document was saved using a newer version of wxMaxima so it may not load "
 "correctly. Please update your wxMaxima."
 msgstr ""
+" tallennettiin uudemmalla wxMaximan versiolla, joten se ei avautunut "
+"kunnolla. Päivitä wxMaximasi."
 
 #: ../../src/wxMaxima.cpp:4603
+#, fuzzy
 msgid ""
 "Document was saved using a newer version of wxMaxima. Please update your "
 "wxMaxima."
-msgstr ""
+msgstr " tallennettiin uudemmalla wxMaximan versiolla. Päivitä wxMaximasi."
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "Don't autosubscript after an underscore"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1086
+#, fuzzy
 msgid "Don't evaluate Expression..."
-msgstr ""
+msgstr "Integroi lauseke"
 
 #: ../../src/wxMaxima.cpp:7117
 msgid "Don't evaluate one command"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7129
+#, fuzzy
 msgid "Don't evaluate one whole expression"
-msgstr ""
+msgstr "Integroi lauseke"
 
 #: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
 msgid "Don't mark cells that contain tooltips in yellow"
@@ -2246,7 +2391,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Don't save"
-msgstr ""
+msgstr "Älä tallenna"
 
 #: ../../src/Worksheet.cpp:1620
 msgid "Don't show labels"
@@ -2261,36 +2406,40 @@ msgid "Don't use parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8525
+#, fuzzy
 msgid "Drop the first n list elements"
-msgstr ""
+msgstr "Sovella funktiota listaan"
 
 #: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
+#, fuzzy
 msgid "Drop the last n list elements"
-msgstr ""
+msgstr "Sovella funktiota listaan"
 
 #: ../../src/wxMaximaFrame.cpp:1306
 msgid "E&quations"
-msgstr ""
+msgstr "&Yhtälöt"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "E&xit\tCtrl+Q"
-msgstr ""
+msgstr "&Poistu\tCtrl+Q"
 
 #: ../../src/wxMaximaFrame.cpp:1368
 msgid "Eige&nvectors"
-msgstr ""
+msgstr "Omi&naisvektrorit"
 
 #: ../../src/wxMaximaFrame.cpp:1365
 msgid "Eigen&values"
-msgstr ""
+msgstr "Ominaisar&vot"
 
 #: ../../src/wxMaximaFrame.cpp:1387
+#, fuzzy
 msgid "Eigenvalues (complex)"
-msgstr ""
+msgstr "Ominaisar&vot"
 
 #: ../../src/wxMaximaFrame.cpp:1384
+#, fuzzy
 msgid "Eigenvalues (real)"
-msgstr ""
+msgstr "Ominaisar&vot"
 
 #: ../../src/wxMaximaFrame.cpp:1393
 msgid "Eigenvalues, left+right eigenvectors (complex)"
@@ -2337,20 +2486,22 @@ msgid "Elements:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7847
+#, fuzzy
 msgid "Eliminate a variable"
-msgstr ""
+msgstr "&Poista muuttuja..."
 
 #: ../../src/wxMaximaFrame.cpp:1247
 msgid "Eliminate a variable from a system of equations"
-msgstr ""
+msgstr "Eliminoi muuttuja yhtälöryhmästä"
 
 #: ../../src/wxMaxima.cpp:10651
 msgid "Empty command => re-triggering evaluation"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9225
+#, fuzzy
 msgid "Enable:"
-msgstr ""
+msgstr "Muuttuja"
 
 #: ../../src/MathParser.cpp:99
 #, c-format
@@ -2362,8 +2513,9 @@ msgid "Encountered an unknown socket event."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7843
+#, fuzzy
 msgid "End of t:"
-msgstr ""
+msgstr "Todistuksen loppu"
 
 #: ../../src/wxMaxima.cpp:4097
 msgid "Ended lisp mode after receiving a maxima prompt!"
@@ -2375,7 +2527,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1319
 msgid "Enter a matrix"
-msgstr ""
+msgstr "Syötä matriisi"
 
 #: ../../src/wxMaxima.cpp:8866
 msgid "Enter an equation for rational simplification:"
@@ -2383,7 +2535,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8169
 msgid "Enter matrix"
-msgstr ""
+msgstr "Syötä matriisi"
 
 #: ../../src/wxMaxima.cpp:9095
 msgid "Enter new animation frame rate [Hz, integer]:"
@@ -2398,8 +2550,9 @@ msgid "Enumerator:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1220
+#, fuzzy
 msgid "Environment variables"
-msgstr ""
+msgstr "Lisäparametreja maximaan"
 
 #: ../../src/wxMaxima.cpp:9045
 msgid "Epsilon:"
@@ -2414,22 +2567,24 @@ msgid "Equal?..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8561
+#, fuzzy
 msgid "Equation"
-msgstr ""
+msgstr "Yhtälö:"
 
 #: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
+#, fuzzy
 msgid "Equation(s)"
-msgstr ""
+msgstr "Yhtälö(t):"
 
 #: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
 msgid "Equation(s):"
-msgstr ""
+msgstr "Yhtälö(t):"
 
 #: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
 #: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
 #: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
 msgid "Equation:"
-msgstr ""
+msgstr "Yhtälö:"
 
 #: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
 #: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
@@ -2441,7 +2596,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
 #: ../../src/wxMaxima.cpp:11166
 msgid "Error"
-msgstr ""
+msgstr "Virhe"
 
 #: ../../src/wxMaxima.cpp:2456
 msgid "Error writing to Maxima"
@@ -2451,7 +2606,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
 #: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
 msgid "Error!"
-msgstr ""
+msgstr "Virhe!"
 
 #: ../../src/Image.cpp:696
 #, c-format
@@ -2483,37 +2638,42 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1652
+#, fuzzy
 msgid "Evaluate &Noun Forms..."
-msgstr ""
+msgstr "Laske Solu(t)"
 
 #: ../../src/wxMaximaFrame.cpp:856
 msgid "Evaluate All Cells\tCtrl+Shift+R"
-msgstr ""
+msgstr "Evaluoi kaikki solut\tCtrl+R"
 
 #: ../../src/wxMaximaFrame.cpp:851
 msgid "Evaluate All Visible Cells\tCtrl+R"
-msgstr ""
+msgstr "Evaluoi kaikki näkyvät solut\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1395
+#, fuzzy
 msgid "Evaluate Cell"
-msgstr ""
+msgstr "Laske Solu(t)"
 
 #: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
 msgid "Evaluate Cell(s)"
-msgstr ""
+msgstr "Laske Solu(t)"
 
 #: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
+#, fuzzy
 msgid "Evaluate Cells Above"
-msgstr ""
+msgstr "Laske Solu(t)"
 
 #: ../../src/wxMaximaFrame.cpp:866
+#, fuzzy
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
-msgstr ""
+msgstr "Evaluoi kaikki solut\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
 #: ../../src/wxMaximaFrame.cpp:876
+#, fuzzy
 msgid "Evaluate Cells Below"
-msgstr ""
+msgstr "Laske Solu(t)"
 
 #: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
 #: ../../src/Worksheet.cpp:1890
@@ -2526,8 +2686,9 @@ msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8626
+#, fuzzy
 msgid "Evaluate Nouns"
-msgstr ""
+msgstr "Laske Solu(t)"
 
 #: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
 msgid "Evaluate Part\tShift+Ctrl+Enter"
@@ -2549,7 +2710,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:845
 msgid "Evaluate active or selected cell(s)"
-msgstr ""
+msgstr "Laske aktiivinen tai valitut solu(t)"
 
 #: ../../src/ToolBar.cpp:251
 msgid "Evaluate all"
@@ -2557,7 +2718,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:857
 msgid "Evaluate all cells in the document"
-msgstr ""
+msgstr "Laske asiakirjan kaikki solut"
 
 #: ../../src/wxMaximaFrame.cpp:1653
 msgid "Evaluate all noun forms in expression"
@@ -2565,31 +2726,35 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:852
 msgid "Evaluate all visible cells in the document"
-msgstr ""
+msgstr "Laske kaikki näkyvät solut\tCtrl+R"
 
 #: ../../src/ToolBar.cpp:248
 msgid "Evaluate current cell"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7395
+#, fuzzy
 msgid "Evaluate string"
-msgstr ""
+msgstr "Laske Solu(t)"
 
 #: ../../src/wxMaximaFrame.cpp:1151
+#, fuzzy
 msgid "Evaluate string..."
-msgstr ""
+msgstr "Päättymätön merkkijono."
 
 #: ../../src/ToolBar.cpp:256
 msgid "Evaluate the file from its beginning to the cell above the cursor"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:259
+#, fuzzy
 msgid "Evaluate the file from the cursor to its end"
-msgstr ""
+msgstr "Laske asiakirjan kaikki solut"
 
 #: ../../src/ToolBar.cpp:258
+#, fuzzy
 msgid "Evaluate the rest"
-msgstr ""
+msgstr "Laske Solu(t)"
 
 #: ../../src/ToolBar.cpp:255
 msgid "Evaluate to point"
@@ -2617,31 +2782,34 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1583
 msgid "Expand Expression"
-msgstr ""
+msgstr "Laajenna lauseke"
 
 #: ../../src/wxMaximaFrame.cpp:1525
 msgid "Expand an expression"
-msgstr ""
+msgstr "Laajenna lauseke"
 
 #: ../../src/wxMaximaFrame.cpp:1531
+#, fuzzy
 msgid "Expand for given variables"
-msgstr ""
+msgstr "Vaihda muuttuja"
 
 #: ../../src/wxMaxima.cpp:8781
 msgid "Expand for variable(s) including denominator:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8716
+#, fuzzy
 msgid "Expand for variable(s):"
-msgstr ""
+msgstr "Uusi muuttuja:"
 
 #: ../../src/wxMaximaFrame.cpp:1545
+#, fuzzy
 msgid "Expand log in previous expression"
-msgstr ""
+msgstr "Laajenna lauseke"
 
 #: ../../src/wxMaximaFrame.cpp:1598
 msgid "Expand trigonometric expression"
-msgstr ""
+msgstr "Laajenna trigonometrinen lauseke"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Expect numbers harder to be complex"
@@ -2653,19 +2821,22 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6121
 msgid "Export"
-msgstr ""
+msgstr "Vie"
 
 #: ../../src/wxMaximaFrame.cpp:1705
+#, fuzzy
 msgid "Export List to csv file..."
-msgstr ""
+msgstr "Lataa tyyli tiedostosta"
 
 #: ../../src/wxMaximaFrame.cpp:1706
+#, fuzzy
 msgid "Export a list to a csv file"
-msgstr ""
+msgstr "Lataa tyyli tiedostosta"
 
 #: ../../src/wxMaximaFrame.cpp:1332
+#, fuzzy
 msgid "Export a matrix to a csv file"
-msgstr ""
+msgstr "Lataa tyyli tiedostosta"
 
 #: ../../src/wxMaximaFrame.cpp:619
 msgid "Export document to a HTML or LaTeX file"
@@ -2700,15 +2871,17 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
 #: ../../src/wxMaxima.cpp:10065
 msgid "Expression"
-msgstr ""
+msgstr "Lauseke"
 
 #: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
+#, fuzzy
 msgid "Expression or a list of comma-separated expressions"
-msgstr ""
+msgstr "Pilkuilla erotetut x-koordinaatit"
 
 #: ../../src/wxMaximaFrame.cpp:1088
+#, fuzzy
 msgid "Expression to string..."
-msgstr ""
+msgstr "Lauseke"
 
 #: ../../src/wxMaxima.cpp:7113
 msgid "Expression whose output is to be used as maxima's input."
@@ -2716,7 +2889,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7214
 msgid "Expression(s):"
-msgstr ""
+msgstr "Lauseke/lausekkeet:"
 
 #: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
 #: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
@@ -2725,19 +2898,21 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
 #: ../../src/wxMaxima.cpp:10056
 msgid "Expression:"
-msgstr ""
+msgstr "Lauseke:"
 
 #: ../../src/wxMaximaFrame.cpp:1423
+#, fuzzy
 msgid "Extract Column..."
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaximaFrame.cpp:1726
 msgid "Extract Elements"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1421
+#, fuzzy
 msgid "Extract Row..."
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaximaFrame.cpp:1424
 msgid "Extract a column from the matrix"
@@ -2748,32 +2923,38 @@ msgid "Extract a column from the matrix and convert it to a list"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7960
+#, fuzzy
 msgid "Extract a matrix column"
-msgstr ""
+msgstr "Syötä matriisi"
 
 #: ../../src/wxMaxima.cpp:7970
+#, fuzzy
 msgid "Extract a matrix column as a list"
-msgstr ""
+msgstr "Syötä matriisi"
 
 #: ../../src/wxMaximaFrame.cpp:1313
+#, fuzzy
 msgid "Extract a matrix from a 2-dimensional array"
-msgstr ""
+msgstr "Muodosta matriisi 2-ulotteisesta taulukosta"
 
 #: ../../src/wxMaxima.cpp:7955
+#, fuzzy
 msgid "Extract a matrix row"
-msgstr ""
+msgstr "Syötä matriisi"
 
 #: ../../src/wxMaxima.cpp:7965
+#, fuzzy
 msgid "Extract a matrix row as a list"
-msgstr ""
+msgstr "Syötä matriisi"
 
 #: ../../src/wxMaximaFrame.cpp:1422
 msgid "Extract a row from the matrix"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1431
+#, fuzzy
 msgid "Extract a row from the matrix and convert it to a list"
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaxima.cpp:8564
 msgid "Extract a variable's value from a list of variable values"
@@ -2784,60 +2965,72 @@ msgid "Extract an actual value for a variable"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1163
+#, fuzzy
 msgid "Extract char..."
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaximaFrame.cpp:1207
+#, fuzzy
 msgid "Extract dir from path..."
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaxima.cpp:7605
+#, fuzzy
 msgid "Extract directory part"
-msgstr ""
+msgstr "Funktioiden nimet"
 
 #: ../../src/wxMaxima.cpp:7617
+#, fuzzy
 msgid "Extract file type extension"
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaximaFrame.cpp:1209
 msgid "Extract filename from path..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7611
+#, fuzzy
 msgid "Extract filename part"
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaximaFrame.cpp:1211
 msgid "Extract filetype from path..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8445
+#, fuzzy
 msgid "Extract function arguments"
-msgstr ""
+msgstr "Funktioiden nimet"
 
 #: ../../src/wxMaximaFrame.cpp:1727
+#, fuzzy
 msgid "Extract list Elements"
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaxima.cpp:8187
+#, fuzzy
 msgid "Extract matrix from 2D array"
-msgstr ""
+msgstr "Syötä matriisi"
 
 #: ../../src/wxMaximaFrame.cpp:1686
+#, fuzzy
 msgid "Extract the argument list from a function call"
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaxima.cpp:8538
+#, fuzzy
 msgid "Extract the last n elements from a list"
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaxima.cpp:7376
+#, fuzzy
 msgid "Extract the nth char of a string"
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaxima.cpp:8544
+#, fuzzy
 msgid "Extract the nth list elements"
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaximaFrame.cpp:1724
 msgid "Extract the value for one variable assigned in a list"
@@ -2848,24 +3041,26 @@ msgid "Extract, append or delete rows or columns"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8188
+#, fuzzy
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaximaFrame.cpp:1521
 msgid "Factor Complex"
-msgstr ""
+msgstr "Kompleksitekijä"
 
 #: ../../src/Worksheet.cpp:1581
 msgid "Factor Expression"
-msgstr ""
+msgstr "Lauseketekijä"
 
 #: ../../src/wxMaximaFrame.cpp:1519
+#, fuzzy
 msgid "Factor Expression including subexpressions"
-msgstr ""
+msgstr "Lausekkeen tekijä"
 
 #: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
 msgid "Factor an expression"
-msgstr ""
+msgstr "Lausekkeen tekijä"
 
 #: ../../src/wxMaximaFrame.cpp:1522
 msgid "Factor an expression in Gaussian numbers"
@@ -2886,8 +3081,9 @@ msgid "Failed to delete gnuplot file %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:2667
+#, fuzzy
 msgid "Failed to start Maxima"
-msgstr ""
+msgstr "Uudelleenkäynnistä Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1418
 msgid "Fast fortran routines that perform numerical tasks"
@@ -2902,12 +3098,14 @@ msgid "Fatal error"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7191
+#, fuzzy
 msgid "Field contents:"
-msgstr ""
+msgstr "Kreikkalaiset vakiot"
 
 #: ../../src/wxMaxima.cpp:7198
+#, fuzzy
 msgid "Field name:"
-msgstr ""
+msgstr "Kaikki muuttujanimet"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "Fields:"
@@ -2915,43 +3113,47 @@ msgstr ""
 
 #: ../../src/main.cpp:439
 msgid "File"
-msgstr ""
+msgstr "Tiedosto"
 
 #: ../../src/wxMaximaFrame.cpp:1333
+#, fuzzy
 msgid "File I/O"
-msgstr ""
+msgstr "Tiedosto"
 
 #: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
 #: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
 #: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
 #: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
 msgid "File could not be opened"
-msgstr ""
+msgstr "Tiedostoa ei voi avata"
 
 #: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
 #: ../../src/wxMaxima.cpp:7251
+#, fuzzy
 msgid "File name:"
-msgstr ""
+msgstr "Kaikki muuttujanimet"
 
 #: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
 msgid "File not found"
-msgstr ""
+msgstr "Tiedosto ei löydy"
 
 #: ../../src/wxMaxima.cpp:5631
 msgid "File opened"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1217
+#, fuzzy
 msgid "File operations"
-msgstr ""
+msgstr "Ratkaise yhtälö(t)"
 
 #: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
 msgid "File you tried to open does not exist."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1221
+#, fuzzy
 msgid "File/directory functions"
-msgstr ""
+msgstr "Suunta:"
 
 #: ../../src/wxMaxima.cpp:7027
 msgid "Filename or a list of comma-separated file names"
@@ -2959,23 +3161,23 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:222
 msgid "Find"
-msgstr ""
+msgstr "Etsi"
 
 #: ../../src/wxMaximaFrame.cpp:670
 msgid "Find\tCtrl+F"
-msgstr ""
+msgstr "Etsi\tCtrl+F"
 
 #: ../../src/wxMaximaFrame.cpp:1468
 msgid "Find &Limit..."
-msgstr ""
+msgstr "&Etsi raja-arvo..."
 
 #: ../../src/wxMaximaFrame.cpp:1470
 msgid "Find Minimum..."
-msgstr ""
+msgstr "Etsi minimi..."
 
 #: ../../src/Worksheet.cpp:1576
 msgid "Find Root..."
-msgstr ""
+msgstr "Etsi juuri..."
 
 #: ../../src/wxMaximaFrame.cpp:1471
 msgid "Find a (unconstrained) minimum of an expression"
@@ -2987,7 +3189,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1469
 msgid "Find a limit of an expression"
-msgstr ""
+msgstr "Etsi lausekkeen raja-arvo"
 
 #: ../../src/wxMaximaFrame.cpp:1807
 msgid "Find a nice fraction that is similar to this float"
@@ -3003,19 +3205,19 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1259
 msgid "Find all roots of a polynomial"
-msgstr ""
+msgstr "Etsi kaikki polynomin juuret"
 
 #: ../../src/wxMaximaFrame.cpp:1262
 msgid "Find all roots of a polynomial (bfloat)"
-msgstr ""
+msgstr "Etsi kaikki polynomin juuret (bfloat)"
 
 #: ../../src/wxMaxima.cpp:6589
 msgid "Find and Replace"
-msgstr ""
+msgstr "Etsi ja korvaa"
 
 #: ../../src/ToolBar.cpp:222 ../../src/wxMaximaFrame.cpp:670
 msgid "Find and replace"
-msgstr ""
+msgstr "Etsi ja korvaa"
 
 #: ../../src/wxMaxima.cpp:7434
 msgid "Find char in string"
@@ -3031,11 +3233,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1366
 msgid "Find eigenvalues of a matrix"
-msgstr ""
+msgstr "Etsi matriisin ominaisarvot"
 
 #: ../../src/wxMaximaFrame.cpp:1369
 msgid "Find eigenvectors of a matrix"
-msgstr ""
+msgstr "Etsi matriisin ominaisvektorit"
 
 #: ../../src/wxMaxima.cpp:7424
 msgid "Find first difference"
@@ -3046,12 +3248,13 @@ msgid "Find first difference..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1256
+#, fuzzy
 msgid "Find fractions that real roots of a polynomial and "
-msgstr ""
+msgstr "Ratkaise polynomin reaalijuuret "
 
 #: ../../src/wxMaxima.cpp:9039
 msgid "Find minimum"
-msgstr ""
+msgstr "Etsi minimi"
 
 #: ../../src/wxMaximaFrame.cpp:1251
 msgid "Find numerical solution..."
@@ -3062,8 +3265,9 @@ msgid "Find root (solve numerically)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
+#, fuzzy
 msgid "Find the maximum absolute value of a matrix entry"
-msgstr ""
+msgstr "Etsi matriisin ominaisarvot"
 
 #: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
 msgid "Find the maximum sum of the absolute values of a matrix column"
@@ -3095,15 +3299,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:922
 msgid "Fold All\tCtrl+Alt+["
-msgstr ""
+msgstr "Piilota kaikki\tCtrl+Alt+["
 
 #: ../../src/wxMaximaFrame.cpp:923
 msgid "Fold all sections"
-msgstr ""
+msgstr "Piilota kaikki kappaleet"
 
 #: ../../src/ToolBar.cpp:240
 msgid "Follow"
-msgstr ""
+msgstr "Seuraa"
 
 #: ../../src/ToolBar.cpp:285
 msgid ""
@@ -3182,39 +3386,44 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "From:"
-msgstr ""
+msgstr "Mistä:"
 
 #: ../../src/wxMaximaFrame.cpp:827
 msgid "Full Screen\tAlt+Enter"
-msgstr ""
+msgstr "Koko ruutu\tAlt+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:824
 msgid "Full Screen\tF11"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7140
+#, fuzzy
 msgid "Function contents:"
-msgstr ""
+msgstr "Funktioiden nimet"
 
 #: ../../src/wxMaxima.cpp:7908
+#, fuzzy
 msgid "Function f(x):"
-msgstr ""
+msgstr "Funktio(t):"
 
 #: ../../src/wxMaxima.cpp:8572
+#, fuzzy
 msgid "Function name"
-msgstr ""
+msgstr "Funktioiden nimet"
 
 #: ../../src/wxMaxima.cpp:7167
+#, fuzzy
 msgid "Function name(s):"
-msgstr ""
+msgstr "Funktioiden nimet"
 
 #: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
+#, fuzzy
 msgid "Function name:"
-msgstr ""
+msgstr "Funktioiden nimet"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Function:"
-msgstr ""
+msgstr "Funktio:"
 
 #: ../../src/wxMaximaFrame.cpp:1630
 msgid "Functions for complex simplification"
@@ -3230,11 +3439,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
 msgid "GCD"
-msgstr ""
+msgstr "SYT"
 
 #: ../../src/wxMaxima.cpp:10186
 msgid "GIF image (*.gif)|*.gif"
-msgstr ""
+msgstr "GIF kuva (*.gif)|*.gif"
 
 #: ../../src/Worksheet.cpp:103
 msgid ""
@@ -3245,15 +3454,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:295
 msgid "General Math"
-msgstr ""
+msgstr "Yleinen Matematiikka"
 
 #: ../../src/wxMaximaFrame.cpp:699
 msgid "General Math\tAlt+Shift+M"
-msgstr ""
+msgstr "Yleinen Matematiikka\tAlt+Shift+M"
 
 #: ../../src/wxMaximaFrame.cpp:1316
 msgid "Generate Matrix from Expression..."
-msgstr ""
+msgstr "Luo matriisi lausekkeesta..."
 
 #: ../../src/wxMaximaFrame.cpp:1317
 msgid "Generate a matrix from a lambda expression"
@@ -3274,8 +3483,9 @@ msgid "Generate list elements using a rule"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8196
+#, fuzzy
 msgid "Generate matrix from a rule"
-msgstr ""
+msgstr "Luo matriisi lausekkeesta..."
 
 #: ../../src/wxMaximaFrame.cpp:1094
 msgid "Generate unused symbol name"
@@ -3316,8 +3526,9 @@ msgid "Get position in stream"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1102
+#, fuzzy
 msgid "Get position..."
-msgstr ""
+msgstr "Derivointi..."
 
 #: ../../src/wxMaximaFrame.cpp:1620
 msgid "Get the imaginary part of complex expression"
@@ -3351,8 +3562,9 @@ msgid "Go to URL"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3989
+#, fuzzy
 msgid "Got a new input prompt!"
-msgstr ""
+msgstr "Lisää uusi syötesolu"
 
 #: ../../src/Worksheet.cpp:6354
 msgid ""
@@ -3365,20 +3577,23 @@ msgid "Gradefs"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1967
+#, fuzzy
 msgid "Greater or less than a value"
-msgstr ""
+msgstr "suurempi tai yhtä suuri kuin"
 
 #: ../../src/wxMaximaFrame.cpp:1130
 msgid "Greater, ignoring case?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:260
+#, fuzzy
 msgid "Greek Letters"
-msgstr ""
+msgstr "Kreikkalaiset kirjaimet"
 
 #: ../../src/wxMaximaFrame.cpp:703
+#, fuzzy
 msgid "Greek Letters\tAlt+Shift+G"
-msgstr ""
+msgstr "Kreikkalaiset kirjaimet\tAlt+Shift+G"
 
 #: ../../src/wxMaximaFrame.cpp:1815
 msgid "Guess an exact number that could be meant by this float"
@@ -3395,16 +3610,18 @@ msgid "Hadamard (element-by-element) product..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8004
+#, fuzzy
 msgid "Hadamard Product"
-msgstr ""
+msgstr "Matriisi"
 
 #: ../../src/wxMaxima.cpp:8011
 msgid "Hadamard exponent"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1345
+#, fuzzy
 msgid "Hadamard exponent..."
-msgstr ""
+msgstr "Matriisin nimi:"
 
 #: ../../src/MaximaManual.cpp:260
 #, c-format
@@ -3423,7 +3640,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
 msgid "Help"
-msgstr ""
+msgstr "Ohje"
 
 #: ../../src/ToolBar.cpp:635
 msgid "Help button"
@@ -3436,15 +3653,17 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:729
 msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr ""
+msgstr "Piilota kaikki työkalupalkit\tAlt+Shift+-"
 
 #: ../../src/ToolBar.cpp:264
+#, fuzzy
 msgid "Hide Code"
-msgstr ""
+msgstr "Jaa solu"
 
 #: ../../src/wxMaximaFrame.cpp:727
+#, fuzzy
 msgid "Hide Code Cells\tAlt+Ctrl+H"
-msgstr ""
+msgstr "Lisää solu\tAlt+Shift+C"
 
 #: ../../src/Worksheet.cpp:1896
 msgid "Hide Heading 5"
@@ -3455,32 +3674,38 @@ msgid "Hide Heading 6"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1855
+#, fuzzy
 msgid "Hide Part"
-msgstr ""
+msgstr "Jaa solu"
 
 #: ../../src/Worksheet.cpp:1863
+#, fuzzy
 msgid "Hide Section"
-msgstr ""
+msgstr "leikkaus"
 
 #: ../../src/Worksheet.cpp:1874
+#, fuzzy
 msgid "Hide Subsection"
-msgstr ""
+msgstr "leikkaus"
 
 #: ../../src/Worksheet.cpp:1885
+#, fuzzy
 msgid "Hide Subsubsection"
-msgstr ""
+msgstr "Lisää alialikapplesolu"
 
 #: ../../src/wxMaximaFrame.cpp:730
 msgid "Hide all panes"
-msgstr ""
+msgstr "Piilota kaikki paneelit"
 
 #: ../../src/Worksheet.cpp:1491
+#, fuzzy
 msgid "Hide cell brackets"
-msgstr ""
+msgstr "Piilota kaikki paneelit"
 
 #: ../../src/Worksheet.cpp:1915
+#, fuzzy
 msgid "Hide contents"
-msgstr ""
+msgstr "Kreikkalaiset vakiot"
 
 #: ../../src/Worksheet.cpp:1552
 msgid "Hide multiplication dots"
@@ -3495,20 +3720,21 @@ msgid "Hide yellow tooltip marker for this message type"
 msgstr ""
 
 #: ../../src/Configuration.cpp:82
+#, fuzzy
 msgid "Highlight (box)"
-msgstr ""
+msgstr "Korosta (dpart)"
 
 #: ../../src/wxMaxima.cpp:9528
 msgid "Histogram"
-msgstr ""
+msgstr "Histogrammi"
 
 #: ../../src/wxMaximaFrame.cpp:232
 msgid "History"
-msgstr ""
+msgstr "Historia"
 
 #: ../../src/wxMaximaFrame.cpp:709
 msgid "History\tAlt+Shift+I"
-msgstr ""
+msgstr "Historia\tAlt+Shift+H"
 
 #: ../../src/wxMaximaFrame.cpp:1526
 msgid "Horner's rule"
@@ -3606,12 +3832,13 @@ msgid "Index Step:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
+#, fuzzy
 msgid "Index variable:"
-msgstr ""
+msgstr "Uusi muuttuja:"
 
 #: ../../src/wxMaximaFrame.cpp:1949
 msgid "Info about Maxima build"
-msgstr ""
+msgstr "Tietoa Maximan versiosta"
 
 #: ../../src/Worksheet.cpp:2046
 msgid "Inform maxima about facts you know for this symbol"
@@ -3624,8 +3851,9 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
+#, fuzzy
 msgid "Initial Condition"
-msgstr ""
+msgstr "Ehto:"
 
 #: ../../src/wxMaximaFrame.cpp:1270
 msgid "Initial Value Problem (&1)..."
@@ -3649,19 +3877,19 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:314
 msgid "Insert"
-msgstr ""
+msgstr "Lisää"
 
 #: ../../src/wxMaximaFrame.cpp:905
 msgid "Insert &Section Cell\tCtrl+3"
-msgstr ""
+msgstr "Lisää &kappalesolu\tCtrl+3"
 
 #: ../../src/wxMaximaFrame.cpp:901
 msgid "Insert &Text Cell\tCtrl+1"
-msgstr ""
+msgstr "Lisää tekstisolu\tCtrl+1"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Insert Cell\tAlt+Shift+C"
-msgstr ""
+msgstr "Lisää solu\tAlt+Shift+C"
 
 #: ../../src/Worksheet.cpp:1669
 msgid "Insert Heading5 Cell"
@@ -3673,51 +3901,52 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10854
 msgid "Insert Image"
-msgstr ""
+msgstr "Lisää kuva"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert Image..."
-msgstr ""
+msgstr "Lisää kuva..."
 
 #: ../../src/wxMaximaFrame.cpp:899
+#, fuzzy
 msgid "Insert Input &Cell\tCtrl+0"
-msgstr ""
+msgstr "Lisää &syötesolu"
 
 #: ../../src/wxMaximaFrame.cpp:919
 msgid "Insert Page Break"
-msgstr ""
+msgstr "Lisää sivunvaihto"
 
 #: ../../src/wxMaximaFrame.cpp:907
 msgid "Insert S&ubsection Cell\tCtrl+4"
-msgstr ""
+msgstr "Lisää &alikappalesolu\tCtrl+4"
 
 #: ../../src/wxMaximaFrame.cpp:910
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
-msgstr ""
+msgstr "Lisää &alialikappalesolu\tCtrl+4"
 
 #: ../../src/Worksheet.cpp:1662
 msgid "Insert Section Cell"
-msgstr ""
+msgstr "Lisää kappalesolu"
 
 #: ../../src/Worksheet.cpp:1664
 msgid "Insert Subsection Cell"
-msgstr ""
+msgstr "Lisää alikappalesolu"
 
 #: ../../src/Worksheet.cpp:1667
 msgid "Insert Subsubsection Cell"
-msgstr ""
+msgstr "Lisää alialikapplesolu"
 
 #: ../../src/wxMaximaFrame.cpp:903
 msgid "Insert T&itle Cell\tCtrl+2"
-msgstr ""
+msgstr "Lisää O&tsikkosolu\tCtrl+2"
 
 #: ../../src/Worksheet.cpp:1658
 msgid "Insert Text Cell"
-msgstr ""
+msgstr "Lisää tekstisolu"
 
 #: ../../src/Worksheet.cpp:1660
 msgid "Insert Title Cell"
-msgstr ""
+msgstr "Lisää otsikkosolu"
 
 #: ../../src/wxMaximaFrame.cpp:913
 msgid "Insert a new heading5 cell"
@@ -3729,35 +3958,36 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:900
 msgid "Insert a new input cell"
-msgstr ""
+msgstr "Lisää uusi syötesolu"
 
 #: ../../src/wxMaximaFrame.cpp:906
 msgid "Insert a new section cell"
-msgstr ""
+msgstr "Lisää uusi kappalesolu"
 
 #: ../../src/wxMaximaFrame.cpp:908
 msgid "Insert a new subsection cell"
-msgstr ""
+msgstr "Lisää uusi alikapplesolu"
 
 #: ../../src/wxMaximaFrame.cpp:911
 msgid "Insert a new subsubsection cell"
-msgstr ""
+msgstr "Lisää uusi alialikappalesolu"
 
 #: ../../src/wxMaximaFrame.cpp:902
 msgid "Insert a new text cell"
-msgstr ""
+msgstr "Lisää uusi tekstisolu"
 
 #: ../../src/wxMaximaFrame.cpp:904
 msgid "Insert a new title cell"
-msgstr ""
+msgstr "Lisää uusi otsikkosolu"
 
 #: ../../src/wxMaximaFrame.cpp:920
 msgid "Insert a page break"
-msgstr ""
+msgstr "Lisää sivunvaihto"
 
 #: ../../src/wxMaximaFrame.cpp:1164
+#, fuzzy
 msgid "Insert char..."
-msgstr ""
+msgstr "Lisää kuva..."
 
 #: ../../src/wxMaximaFrame.cpp:912
 msgid "Insert heading5 Cell\tCtrl+6"
@@ -3772,8 +4002,9 @@ msgid "Insert image"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:916
+#, fuzzy
 msgid "Insert textbased cell"
-msgstr ""
+msgstr "Lisää tekstisolu"
 
 #: ../../src/wxMaxima.cpp:3566
 msgid "Instructed to prefer gnuplot over wgnuplot"
@@ -3785,43 +4016,47 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
 msgid "Integral/Sum:"
-msgstr ""
+msgstr "Integraali/Summa:"
 
 #: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
 msgid "Integrate"
-msgstr ""
+msgstr "Integroi"
 
 #: ../../src/wxMaxima.cpp:8980
 msgid "Integrate (risch)"
-msgstr ""
+msgstr "Integroi (risch)"
 
 #: ../../src/wxMaximaFrame.cpp:1454
 msgid "Integrate expression"
-msgstr ""
+msgstr "Integroi lauseke"
 
 #: ../../src/wxMaximaFrame.cpp:1456
 msgid "Integrate expression with Risch algorithm"
-msgstr ""
+msgstr "Integroi lauseke Rischin algoritmilla"
 
 #: ../../src/wxMaximaFrame.cpp:1869
+#, fuzzy
 msgid "Integrate numerically"
-msgstr ""
+msgstr "Integroi (risch)"
 
 #: ../../src/Worksheet.cpp:1588
 msgid "Integrate..."
-msgstr ""
+msgstr "Integroi..."
 
 #: ../../src/wxMaximaFrame.cpp:1737
+#, fuzzy
 msgid "Interleave"
-msgstr ""
+msgstr "Integroi"
 
 #: ../../src/wxMaximaFrame.cpp:1738
+#, fuzzy
 msgid "Interleave the values of two lists"
-msgstr ""
+msgstr "Integroi"
 
 #: ../../src/wxMaxima.cpp:8612
+#, fuzzy
 msgid "Interleave two lists"
-msgstr ""
+msgstr "Integroi"
 
 #: ../../src/wxMaximaFrame.cpp:1087
 msgid "Interpret like input..."
@@ -3836,16 +4071,17 @@ msgid "Interpret string as maxima code"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1089
+#, fuzzy
 msgid "Interpret string..."
-msgstr ""
+msgstr "Päättymätön merkkijono."
 
 #: ../../src/ToolBar.cpp:231
 msgid "Interrupt"
-msgstr ""
+msgstr "Keskeytä"
 
 #: ../../src/wxMaximaFrame.cpp:965
 msgid "Interrupt current computation"
-msgstr ""
+msgstr "Keskeytä laskutoimitus"
 
 #: ../../src/ToolBar.cpp:232
 msgid ""
@@ -3887,8 +4123,9 @@ msgid "Is Char 1 greater than Char2, if case is ignored?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7333
+#, fuzzy
 msgid "Is Char 1 greater than Char2?"
-msgstr ""
+msgstr "paljon suurempi kuin"
 
 #: ../../src/wxMaxima.cpp:7327
 msgid "Is Char 1 less than Char2, if case is ignored?"
@@ -3907,12 +4144,14 @@ msgid "Is a char?..."
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1952
+#, fuzzy
 msgid "Is a complex variable"
-msgstr ""
+msgstr "Uusi muuttuja:"
 
 #: ../../src/wxMaxima.cpp:7292
+#, fuzzy
 msgid "Is a digit?"
-msgstr ""
+msgstr "Näytä algoritmi"
 
 #: ../../src/wxMaximaFrame.cpp:1118
 msgid "Is a digit?..."
@@ -3927,8 +4166,9 @@ msgid "Is a printable char?"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1949
+#, fuzzy
 msgid "Is a real variable"
-msgstr ""
+msgstr "Vaihda muuttuja"
 
 #: ../../src/wxMaxima.cpp:7300
 msgid "Is a uppercase char?"
@@ -3951,28 +4191,33 @@ msgid "Is an alphanumeric char?"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1991
+#, fuzzy
 msgid "Is an even function"
-msgstr ""
+msgstr "Poistaa funktion"
 
 #: ../../src/Worksheet.cpp:1955
+#, fuzzy
 msgid "Is an imaginary variable"
-msgstr ""
+msgstr "Vaihda muuttuja"
 
 #: ../../src/Worksheet.cpp:1960
+#, fuzzy
 msgid "Is an integer variable"
-msgstr ""
+msgstr "Vaihda muuttuja"
 
 #: ../../src/Worksheet.cpp:1993
+#, fuzzy
 msgid "Is an odd function"
-msgstr ""
+msgstr "Poistaa funktion"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Is equal?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1128
+#, fuzzy
 msgid "Is greater?..."
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaximaFrame.cpp:1125
 msgid "Is lower?..."
@@ -3983,8 +4228,9 @@ msgid "Is lowercase?..."
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1962
+#, fuzzy
 msgid "Is no integer variable"
-msgstr ""
+msgstr "Vaihda muuttuja"
 
 #: ../../src/wxMaximaFrame.cpp:1119
 msgid "Is printable?..."
@@ -4007,8 +4253,9 @@ msgid "Item"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8581
+#, fuzzy
 msgid "Iterator name:"
-msgstr ""
+msgstr "Matriisin nimi:"
 
 #: ../../src/wxMaximaFrame.cpp:1048
 msgid "Jump to first error"
@@ -4020,7 +4267,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8960
 msgid "LCM"
-msgstr ""
+msgstr "pyj"
 
 #: ../../src/wxMaximaFrame.cpp:1407
 msgid "L[1] Norm (complex)"
@@ -4039,12 +4286,13 @@ msgid "L[inf] Norm (real)"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1025
+#, fuzzy
 msgid "Labels"
-msgstr ""
+msgstr "Näytä &Muuttujat"
 
 #: ../../src/wxMaxima.cpp:7090
 msgid "Lambda"
-msgstr ""
+msgstr "lambda"
 
 #: ../../src/wxMaxima.cpp:7091
 msgid ""
@@ -4055,7 +4303,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8997
 msgid "Laplace"
-msgstr ""
+msgstr "Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1484
 msgid "Laplace &Transform..."
@@ -4076,8 +4324,9 @@ msgid "Last message from maxima's stdout: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1720
+#, fuzzy
 msgid "Last n"
-msgstr ""
+msgstr "Lista:"
 
 #: ../../src/wxMaxima.cpp:10400
 msgid "Last non-whitespace is a question mark"
@@ -4094,16 +4343,17 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1493
 msgid "Least Common Multiple..."
-msgstr ""
+msgstr "Pienin yhteinen jaettava..."
 
 #: ../../src/wxMaxima.cpp:9587
 msgid "Least Squares Fit"
-msgstr ""
+msgstr "Pienimmän neliösumman sovitus"
 
 #: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
 #: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
+#, fuzzy
 msgid "Left Matrix:"
-msgstr ""
+msgstr "Avaa matriisi"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Left end"
@@ -4130,16 +4380,18 @@ msgid "Letrules"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1976
+#, fuzzy
 msgid "Likely to be the main variable"
-msgstr ""
+msgstr "Poistaa muuttujan"
 
 #: ../../src/wxMaxima.cpp:9028
 msgid "Limit"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7256
+#, fuzzy
 msgid "Lisp format string:"
-msgstr ""
+msgstr "Maxima-kysymykset"
 
 #: ../../src/wxMaxima.cpp:7258
 msgid "Lisp format strings are more powerful than c++ format strings"
@@ -4162,16 +4414,19 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
 #: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
 #: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
+#, fuzzy
 msgid "List"
-msgstr ""
+msgstr "Lista:"
 
 #: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
+#, fuzzy
 msgid "List #1"
-msgstr ""
+msgstr "Lista:"
 
 #: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
+#, fuzzy
 msgid "List #2"
-msgstr ""
+msgstr "Lista:"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "List directory"
@@ -4186,12 +4441,14 @@ msgid "List of char to String"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1150
+#, fuzzy
 msgid "List of chars to string..."
-msgstr ""
+msgstr "Lauseke"
 
 #: ../../src/wxMaxima.cpp:7386
+#, fuzzy
 msgid "List of chars:"
-msgstr ""
+msgstr "Näytä &Muuttujat"
 
 #: ../../src/wxMaxima.cpp:8559
 msgid "List with values"
@@ -4200,7 +4457,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
 msgid "List:"
-msgstr ""
+msgstr "Lista:"
 
 #: ../../src/wxMaxima.cpp:6200
 msgid "Load Package"
@@ -4219,12 +4476,14 @@ msgid "Load a Maxima package file"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1678
+#, fuzzy
 msgid "Load a list from a csv file"
-msgstr ""
+msgstr "Lataa tyyli tiedostosta"
 
 #: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
+#, fuzzy
 msgid "Load a matrix from a csv file"
-msgstr ""
+msgstr "Lataa tyyli tiedostosta"
 
 #: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
 msgid "Load lapack"
@@ -4251,8 +4510,9 @@ msgid "Load the translation generator (gentran)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8219
+#, fuzzy
 msgid "Loop variable"
-msgstr ""
+msgstr "Uusi muuttuja:"
 
 #: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
 msgid "Lower bound:"
@@ -4263,16 +4523,19 @@ msgid "Lower, ignoring case?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1448
+#, fuzzy
 msgid "M&atrix"
-msgstr ""
+msgstr "Matriisi"
 
 #: ../../src/wxMaxima.cpp:7153
+#, fuzzy
 msgid "Macro contents:"
-msgstr ""
+msgstr "Kreikkalaiset vakiot"
 
 #: ../../src/wxMaxima.cpp:7148
+#, fuzzy
 msgid "Macro name:"
-msgstr ""
+msgstr "Matriisin nimi:"
 
 #: ../../src/wxMaximaFrame.cpp:1024
 msgid "Macros"
@@ -4280,7 +4543,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:697
 msgid "Main Toolbar\tAlt+Shift+B"
-msgstr ""
+msgstr "Päätyökalupalkki\tAlt+Shift+B"
 
 #: ../../src/wxMaxima.cpp:7906
 msgid "Make a function value at a specific point known"
@@ -4299,8 +4562,9 @@ msgid "Map"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8215
+#, fuzzy
 msgid "Map an expression"
-msgstr ""
+msgstr "Laajenna lauseke"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "Map function to a matrix"
@@ -4311,12 +4575,13 @@ msgid "Map function to a matrix, affecting all of its clones"
 msgstr ""
 
 #: ../../src/Configuration.cpp:109
+#, fuzzy
 msgid "Math Default"
-msgstr ""
+msgstr "Oletus"
 
 #: ../../src/wxMaximaFrame.cpp:286
 msgid "Mathematical Symbols"
-msgstr ""
+msgstr "Matemaattiset merkit"
 
 #: ../../src/ToolBar.cpp:270
 msgid "Maths"
@@ -4332,23 +4597,27 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
 #: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
 msgid "Matrix"
-msgstr ""
+msgstr "Matriisi"
 
 #: ../../src/wxMaxima.cpp:7986
+#, fuzzy
 msgid "Matrix Exponent"
-msgstr ""
+msgstr "Matriisin nimi:"
 
 #: ../../src/wxMaximaFrame.cpp:1339
+#, fuzzy
 msgid "Matrix exponent..."
-msgstr ""
+msgstr "Matriisin nimi:"
 
 #: ../../src/wxMaximaFrame.cpp:1329
+#, fuzzy
 msgid "Matrix from csv file"
-msgstr ""
+msgstr "Lataa tyyli tiedostosta"
 
 #: ../../src/wxMaximaFrame.cpp:1323
+#, fuzzy
 msgid "Matrix from csv file..."
-msgstr ""
+msgstr "Lataa tyyli tiedostosta"
 
 #: ../../src/wxMaxima.cpp:8137
 msgid "Matrix map"
@@ -4356,15 +4625,17 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9630
 msgid "Matrix name:"
-msgstr ""
+msgstr "Matriisin nimi:"
 
 #: ../../src/wxMaximaFrame.cpp:798
+#, fuzzy
 msgid "Matrix parenthesis"
-msgstr ""
+msgstr "Matriisin nimi:"
 
 #: ../../src/wxMaximaFrame.cpp:1331
+#, fuzzy
 msgid "Matrix to csv file"
-msgstr ""
+msgstr "Lataa tyyli tiedostosta"
 
 #: ../../src/wxMaximaFrame.cpp:1334
 msgid "Matrix to file or Matrix from file"
@@ -4379,7 +4650,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
 #: ../../src/wxMaxima.cpp:8136
 msgid "Matrix:"
-msgstr ""
+msgstr "Matriisi:"
 
 #: ../../src/wxMaxima.cpp:8627
 msgid ""
@@ -4395,12 +4666,14 @@ msgid "Maxima architecture: %s"
 msgstr ""
 
 #: ../../src/StatusBar.cpp:252
+#, fuzzy
 msgid "Maxima asks a question"
-msgstr ""
+msgstr "Maxima-kysymykset"
 
 #: ../../src/wxMaxima.cpp:4066
+#, fuzzy
 msgid "Maxima asks a question!"
-msgstr ""
+msgstr "Maxima-kysymykset"
 
 #: ../../src/wxMaxima.cpp:7118
 msgid ""
@@ -4417,16 +4690,19 @@ msgid "Maxima errors"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3289
+#, fuzzy
 msgid "Maxima has authenticated!"
-msgstr ""
+msgstr "Maxima-kysymykset"
 
 #: ../../src/wxMaxima.cpp:10533
+#, fuzzy
 msgid "Maxima has finished calculating."
-msgstr ""
+msgstr "Maxima laskee"
 
 #: ../../src/wxMaxima.cpp:5832
+#, fuzzy
 msgid "Maxima has issued an error!"
-msgstr ""
+msgstr "Maxima-kysymykset"
 
 #: ../../src/wxMaxima.cpp:3696
 #, c-format
@@ -4438,8 +4714,9 @@ msgid "Maxima has sent a new variable value."
 msgstr ""
 
 #: ../../src/MaximaManual.cpp:552
+#, fuzzy
 msgid "Maxima help file not found!"
-msgstr ""
+msgstr "Tiedosto ei löydy"
 
 #: ../../src/wxMaximaFrame.cpp:1043
 msgid "Maxima input"
@@ -4447,7 +4724,7 @@ msgstr ""
 
 #: ../../src/StatusBar.cpp:236
 msgid "Maxima is calculating"
-msgstr ""
+msgstr "Maxima laskee"
 
 #: ../../src/wxMaxima.cpp:5068
 msgid "Maxima is ready for input."
@@ -4471,8 +4748,9 @@ msgid "Maxima process terminated unexpectedly."
 msgstr ""
 
 #: ../../src/Configuration.cpp:79
+#, fuzzy
 msgid "Maxima question labels"
-msgstr ""
+msgstr "Maxima-kysymykset"
 
 #: ../../src/wxMaxima.cpp:3380
 msgid "Maxima sends a new set of auto-completable symbols."
@@ -4491,8 +4769,9 @@ msgid "Maxima shows help in a sidebar"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1935
+#, fuzzy
 msgid "Maxima shows help in the console"
-msgstr ""
+msgstr "Tiedosto ei löydy"
 
 #: ../../src/StatusBar.cpp:232
 msgid "Maxima started. Waiting for authentication..."
@@ -4507,12 +4786,14 @@ msgid "Maxima started. Waiting for initial prompt..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1231
+#, fuzzy
 msgid "Maxima to other language"
-msgstr ""
+msgstr "Maxima-kysymykset"
 
 #: ../../src/wxMaxima.cpp:7213
+#, fuzzy
 msgid "Maxima to string"
-msgstr ""
+msgstr "Maxima-kysymykset"
 
 #: ../../src/wxMaxima.cpp:3397
 #, c-format
@@ -4535,12 +4816,14 @@ msgid "Maxima version: %s, Anchors cache version"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1925
+#, fuzzy
 msgid "Maxima vs. Programming languages"
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/Configuration.cpp:83
+#, fuzzy
 msgid "Maxima warnings"
-msgstr ""
+msgstr "Maxima-kysymykset"
 
 #: ../../src/wxMaxima.cpp:3687
 #, c-format
@@ -4568,9 +4851,9 @@ msgid "Maxima's manual is located in directory %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3670
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's share files are located in directory %s"
-msgstr ""
+msgstr "Aloita animaatio"
 
 #: ../../src/StatusBar.cpp:66
 msgid ""
@@ -4620,12 +4903,13 @@ msgid "Memoizing"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1013
+#, fuzzy
 msgid "Memory"
-msgstr ""
+msgstr "&Tyhjennä muisti"
 
 #: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
 msgid "Merge Cells"
-msgstr ""
+msgstr "Yhdistä solut"
 
 #: ../../src/wxMaxima.cpp:5780
 msgid "Message from the stdout of Maxima: "
@@ -4665,16 +4949,19 @@ msgid "Multiply two matrices"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9581
+#, fuzzy
 msgid "Multivariate linear regression"
-msgstr ""
+msgstr "Lineaarinen regressio..."
 
 #: ../../src/wxMaxima.cpp:7842
+#, fuzzy
 msgid "Name of t:"
-msgstr ""
+msgstr "Nimi:"
 
 #: ../../src/wxMaxima.cpp:7838
+#, fuzzy
 msgid "Name of x:"
-msgstr ""
+msgstr "Nimi:"
 
 #: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
 msgid "Nested list to Matrix"
@@ -4698,11 +4985,11 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:174
 msgid "New"
-msgstr ""
+msgstr "Uusi"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "New\tCtrl+N"
-msgstr ""
+msgstr "Uusi\tCtrl+N"
 
 #: ../../src/ToolBar.cpp:611
 msgid "New button"
@@ -4723,7 +5010,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:174
 msgid "New document"
-msgstr ""
+msgstr "Uusi asiakirja"
 
 #: ../../src/wxMaxima.cpp:3899
 #, c-format
@@ -4731,17 +5018,18 @@ msgid "New maxima Operators detected: %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7390
+#, fuzzy
 msgid "New part:"
-msgstr ""
+msgstr "Uusi muuttuja:"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
 #: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
 msgid "New variable:"
-msgstr ""
+msgstr "Uusi muuttuja:"
 
 #: ../../src/wxMaximaFrame.cpp:929
 msgid "Next Command\tAlt+Down"
-msgstr ""
+msgstr "Seuraava komento\tAlt+Down"
 
 #: ../../src/wxMaximaFrame.cpp:748
 msgid "Nice Graphical Equations"
@@ -4749,11 +5037,12 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "No"
-msgstr ""
+msgstr "Ei"
 
 #: ../../src/Worksheet.cpp:1972
+#, fuzzy
 msgid "No Array"
-msgstr ""
+msgstr "Taulukko:"
 
 #: ../../src/Worksheet.cpp:1974
 msgid "No Scalar"
@@ -4761,7 +5050,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10482
 msgid "No dollar ($) or semicolon (;) at the end of command"
-msgstr ""
+msgstr "Ei dollarimerkkiä ($) tai puolipistettä (;) komennon loppuun"
 
 #: ../../src/MaximaManual.cpp:406
 msgid "No entries in the caches for the subjects the manual contains."
@@ -4799,7 +5088,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8163
 msgid "Not a valid matrix dimension!"
-msgstr ""
+msgstr "Kelvoton matriisin dimensio!"
 
 #: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
 msgid "Not a valid number of equations!"
@@ -4826,60 +5115,69 @@ msgid "Num. deg:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8540
+#, fuzzy
 msgid "Number of elements"
-msgstr ""
+msgstr "Yhtälöiden lukumäärä:"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
 msgid "Number of equations:"
-msgstr ""
+msgstr "Yhtälöiden lukumäärä:"
 
 #: ../../src/wxMaxima.cpp:7481
+#, fuzzy
 msgid "Number to octets"
-msgstr ""
+msgstr "Yhtälöiden lukumäärä:"
 
 #: ../../src/wxMaximaFrame.cpp:1154
+#, fuzzy
 msgid "Number to octets..."
-msgstr ""
+msgstr "Yhtälöiden lukumäärä:"
 
 #: ../../src/wxMaximaFrame.cpp:1906
 msgid "Number types"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7482
+#, fuzzy
 msgid "Number:"
-msgstr ""
+msgstr "Näytä &Funktiot"
 
 #: ../../src/wxMaximaFrame.cpp:1786
+#, fuzzy
 msgid "Numeric output"
-msgstr ""
+msgstr "&Numeerinen"
 
 #: ../../src/wxMaxima.cpp:8040
 msgid "Numerical QR decomposition of a matrix"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1417
+#, fuzzy
 msgid "Numerical operations (lapack)"
-msgstr ""
+msgstr "&Numeerinen integrointi"
 
 #: ../../src/wxMaxima.cpp:7831
 msgid "Numerical solution for 1st degree ODE"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1282
+#, fuzzy
 msgid "Numerical solution..."
-msgstr ""
+msgstr "&Numeerinen"
 
 #: ../../src/wxMaximaFrame.cpp:1261
+#, fuzzy
 msgid "Numerical solutions of polynomial (bfloat)..."
-msgstr ""
+msgstr "Etsi kaikki polynomin juuret"
 
 #: ../../src/wxMaximaFrame.cpp:1258
+#, fuzzy
 msgid "Numerical solutions of polynomial..."
-msgstr ""
+msgstr "Etsi kaikki polynomin juuret"
 
 #: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
 msgid "OK"
-msgstr ""
+msgstr "Ok"
 
 #: ../../src/wxMaximaFrame.cpp:122
 #, c-format
@@ -4887,16 +5185,19 @@ msgid "OS: %s Version %li.%li"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
+#, fuzzy
 msgid "Object composed of elements"
-msgstr ""
+msgstr "Yhtälöiden lukumäärä:"
 
 #: ../../src/wxMaxima.cpp:7680
+#, fuzzy
 msgid "Object name:"
-msgstr ""
+msgstr "Lista:"
 
 #: ../../src/wxMaxima.cpp:7281
+#, fuzzy
 msgid "Object:"
-msgstr ""
+msgstr "Lista:"
 
 #: ../../src/wxMaxima.cpp:7486
 msgid "Octets to Number"
@@ -4911,8 +5212,9 @@ msgid "Octets to number..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1158
+#, fuzzy
 msgid "Octets to string..."
-msgstr ""
+msgstr "Lauseke"
 
 #: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
 msgid "Octets:"
@@ -4925,7 +5227,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
 #: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
 msgid "Old variable:"
-msgstr ""
+msgstr "Vanha muuttuja:"
 
 #: ../../src/wxMaximaFrame.cpp:1055
 msgid "On all errors"
@@ -4950,15 +5252,15 @@ msgstr ""
 #: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593
 #: ../../src/wxMaxima.cpp:6074
 msgid "Open"
-msgstr ""
+msgstr "Avaa"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "Open a document"
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "Open a new window"
-msgstr ""
+msgstr "Avaa uusi ikkuna"
 
 #: ../../src/ToolBar.cpp:617
 msgid "Open and save button"
@@ -4966,7 +5268,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:176
 msgid "Open document"
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaxima.cpp:7239
 msgid "Open for appending"
@@ -4981,24 +5283,27 @@ msgid "Open for reading"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1098
+#, fuzzy
 msgid "Open for reading..."
-msgstr ""
+msgstr "Lauseke"
 
 #: ../../src/wxMaxima.cpp:7249
 msgid "Open for writing"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1100
+#, fuzzy
 msgid "Open for writing..."
-msgstr ""
+msgstr "Lauseke"
 
 #: ../../src/wxMaxima.cpp:9598
 msgid "Open matrix"
-msgstr ""
+msgstr "Avaa matriisi"
 
 #: ../../src/wxMaximaFrame.cpp:600
+#, fuzzy
 msgid "Open recent"
-msgstr ""
+msgstr "Avaa viimeisin"
 
 #: ../../src/wxMaxima.cpp:4309
 msgid "Opening a wxmx file"
@@ -5043,8 +5348,9 @@ msgid "Output labels"
 msgstr ""
 
 #: ../../src/Configuration.cpp:73
+#, fuzzy
 msgid "Output: Function names"
-msgstr ""
+msgstr "Funktioiden nimet"
 
 #: ../../src/Configuration.cpp:75
 msgid "Output: Latin names as greek symbols"
@@ -5064,12 +5370,14 @@ msgid "Output: Special constants (%e,%i)"
 msgstr ""
 
 #: ../../src/Configuration.cpp:76
+#, fuzzy
 msgid "Output: Strings"
-msgstr ""
+msgstr "Merkkijonot"
 
 #: ../../src/Configuration.cpp:70
+#, fuzzy
 msgid "Output: Variable names"
-msgstr ""
+msgstr "Kaikki muuttujanimet"
 
 #: ../../src/wxMaxima.cpp:6442
 msgid ""
@@ -5095,28 +5403,33 @@ msgid "Pade approximation of a Taylor series"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1637
+#, fuzzy
 msgid "Parallel Substitute..."
-msgstr ""
+msgstr "Korvaa..."
 
 #: ../../src/wxMaxima.cpp:8738
+#, fuzzy
 msgid "Parallel substitution"
-msgstr ""
+msgstr "Yhdensuuntaiset"
 
 #: ../../src/wxMaxima.cpp:7179
+#, fuzzy
 msgid "Parameter name:"
-msgstr ""
+msgstr "Matriisin nimi:"
 
 #: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
+#, fuzzy
 msgid "Parameter(s):"
-msgstr ""
+msgstr "Muuttuja(t)"
 
 #: ../../src/wxMaxima.cpp:7399
 msgid "Parse string"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1152
+#, fuzzy
 msgid "Parse string only..."
-msgstr ""
+msgstr "Päättymätön merkkijono."
 
 #: ../../src/StatusBar.cpp:240
 msgid "Parsing output"
@@ -5131,8 +5444,9 @@ msgid "Partial &Fractions..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8975
+#, fuzzy
 msgid "Partial Fractions"
-msgstr ""
+msgstr "&Ketjumurtoluku"
 
 #: ../../src/wxMaxima.cpp:4702
 msgid "Parts of the document will not be loaded correctly!"
@@ -5141,19 +5455,19 @@ msgstr ""
 #: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
 #: ../../src/Worksheet.cpp:1685
 msgid "Paste"
-msgstr ""
+msgstr "Liitä"
 
 #: ../../src/wxMaximaFrame.cpp:667
 msgid "Paste\tCtrl+V"
-msgstr ""
+msgstr "Liitä\tCtrl+V"
 
 #: ../../src/ToolBar.cpp:211
 msgid "Paste from clipboard"
-msgstr ""
+msgstr "Liitä leikepöydältä"
 
 #: ../../src/wxMaximaFrame.cpp:668
 msgid "Paste text from clipboard"
-msgstr ""
+msgstr "Liitä teksti leikepöydältä"
 
 #: ../../src/wxMaxima.cpp:4841
 msgid "Please configure wxMaxima with 'Edit->Configure'."
@@ -5161,31 +5475,31 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot &2d..."
-msgstr ""
+msgstr "Kuvaaja &2d..."
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot &3d..."
-msgstr ""
+msgstr "Kuvaaja &3d..."
 
 #: ../../src/wxMaximaFrame.cpp:1772
 msgid "Plot &Format..."
-msgstr ""
+msgstr "&Kuvaajamuoto"
 
 #: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
 msgid "Plot 2D"
-msgstr ""
+msgstr "Kuvaaja 2D"
 
 #: ../../src/Worksheet.cpp:1593
 msgid "Plot 2D..."
-msgstr ""
+msgstr "Kuvaaja 2D..."
 
 #: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
 msgid "Plot 3D"
-msgstr ""
+msgstr "Kuvaaja 3D"
 
 #: ../../src/Worksheet.cpp:1595
 msgid "Plot 3D..."
-msgstr ""
+msgstr "Kuvaaja 3D..."
 
 #: ../../src/wxMaxima.cpp:9538
 msgid "Plot as bars"
@@ -5201,15 +5515,15 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9112
 msgid "Plot format"
-msgstr ""
+msgstr "Kuvaajamuoto"
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot in 2 dimensions"
-msgstr ""
+msgstr "Kaksiulotteinen kuvaaja"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot in 3 dimensions"
-msgstr ""
+msgstr "Kolmiulotteinen kuvaaja"
 
 #: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
 msgid "Plot using Draw"
@@ -5229,22 +5543,23 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
 msgid "Point:"
-msgstr ""
+msgstr "Piste:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 1:"
-msgstr ""
+msgstr "Polynomi 1:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 2:"
-msgstr ""
+msgstr "Polynomi 2:"
 
 #: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
 #: ../../src/wxMaxima.cpp:7739
+#, fuzzy
 msgid "Polynomial:"
-msgstr ""
+msgstr "Polynomi 1:"
 
 #: ../../src/wxMaximaFrame.cpp:1754
 msgid "Pop"
@@ -5259,20 +5574,23 @@ msgid "Position of a match"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
+#, fuzzy
 msgid "Position:"
-msgstr ""
+msgstr "Ehto:"
 
 #: ../../src/wxMaxima.cpp:8939
+#, fuzzy
 msgid "Power series"
-msgstr ""
+msgstr "&Potenssisarja"
 
 #: ../../src/wxMaximaFrame.cpp:1475
+#, fuzzy
 msgid "Power series..."
-msgstr ""
+msgstr "&Potenssisarja"
 
 #: ../../src/wxMaxima.cpp:9202
 msgid "Precision"
-msgstr ""
+msgstr "Tarkkuus"
 
 #: ../../src/Worksheet.cpp:1616
 msgid "Prefer user labels"
@@ -5291,8 +5609,9 @@ msgid "Preferences...\tCtrl+,"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1733
+#, fuzzy
 msgid "Prepend an element"
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaximaFrame.cpp:927
 msgid "Previous Command\tAlt+Up"
@@ -5300,7 +5619,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:184
 msgid "Print"
-msgstr ""
+msgstr "Tulosta"
 
 #: ../../src/ToolBar.cpp:620
 msgid "Print button"
@@ -5312,7 +5631,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
 msgid "Print document"
-msgstr ""
+msgstr "Tulosta asiakirja"
 
 #: ../../src/wxMaximaFrame.cpp:1829
 msgid "Print floating-point numbers with exponents dividable by 3"
@@ -5329,12 +5648,14 @@ msgid "Product"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1095
+#, fuzzy
 msgid "Program"
-msgstr ""
+msgstr "Histogrammi"
 
 #: ../../src/wxMaxima.cpp:7061
+#, fuzzy
 msgid "Program (no local variables)"
-msgstr ""
+msgstr "Vaihda muuttuja"
 
 #: ../../src/wxMaxima.cpp:7052
 msgid "Program block"
@@ -5353,8 +5674,9 @@ msgid "Push"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8508
+#, fuzzy
 msgid "Push an element to a list"
-msgstr ""
+msgstr "Avaa asiakirja"
 
 #: ../../src/wxMaximaFrame.cpp:1395
 msgid "QR decomposition"
@@ -5390,8 +5712,9 @@ msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:877
+#, fuzzy
 msgid "Re-evaluate all cells below the one the cursor is in"
-msgstr ""
+msgstr "Laske asiakirjan kaikki solut"
 
 #: ../../src/main.cpp:366
 msgid "Re-opening STDERR failed."
@@ -5412,16 +5735,18 @@ msgid ""
 msgstr ""
 
 #: ../../src/Worksheet.cpp:6668
+#, fuzzy
 msgid "Read .wxm data from clipboard"
-msgstr ""
+msgstr "Liitä teksti leikepöydältä"
 
 #: ../../src/wxMaxima.cpp:7599
 msgid "Read Directory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1677
+#, fuzzy
 msgid "Read List from csv file..."
-msgstr ""
+msgstr "Lataa tyyli tiedostosta"
 
 #: ../../src/wxMaxima.cpp:7196
 msgid "Read a structure field"
@@ -5436,12 +5761,14 @@ msgid "Read char"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7593
+#, fuzzy
 msgid "Read environment variable"
-msgstr ""
+msgstr "Lisäparametreja maximaan"
 
 #: ../../src/wxMaximaFrame.cpp:1219
+#, fuzzy
 msgid "Read environment variable..."
-msgstr ""
+msgstr "Poistaa muuttujan"
 
 #: ../../src/wxMaxima.cpp:7262
 msgid "Read line"
@@ -5510,12 +5837,14 @@ msgid "Received maxima's first prompt: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:603
+#, fuzzy
 msgid "Recover unsaved"
-msgstr ""
+msgstr "tallentamaton"
 
 #: ../../src/wxMaximaFrame.cpp:1640
+#, fuzzy
 msgid "Recursive Substitute..."
-msgstr ""
+msgstr "Korvaa..."
 
 #: ../../src/wxMaxima.cpp:8746
 msgid "Recursive substitution"
@@ -5527,11 +5856,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo\tCtrl+Y"
-msgstr ""
+msgstr "Tee uudelleen\tCtrl+Y"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo last change"
-msgstr ""
+msgstr "Tekee edellisen muutoksen uudelleen"
 
 #: ../../src/wxMaximaFrame.cpp:1595
 msgid "Reduce trigonometric expression"
@@ -5550,16 +5879,19 @@ msgid "Regex match position"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1195
+#, fuzzy
 msgid "Regular expression that matches a string"
-msgstr ""
+msgstr "Pilkuilla erotetut x-koordinaatit"
 
 #: ../../src/wxMaximaFrame.cpp:1196
+#, fuzzy
 msgid "Regular expressions"
-msgstr ""
+msgstr "Integroi lauseke"
 
 #: ../../src/Worksheet.cpp:1314
+#, fuzzy
 msgid "Reload Image"
-msgstr ""
+msgstr "Kopioi kuvana"
 
 #: ../../src/Worksheet.cpp:1320
 #, c-format
@@ -5634,12 +5966,14 @@ msgid "Rename file"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1215
+#, fuzzy
 msgid "Rename file..."
-msgstr ""
+msgstr "Poistaa muuttujan"
 
 #: ../../src/wxMaximaFrame.cpp:1527
+#, fuzzy
 msgid "Reorganize an expression using horner's rule"
-msgstr ""
+msgstr "Derivoi lauseke"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "Repetitive element-by-element multiplication"
@@ -5658,8 +5992,9 @@ msgid "Replace the first occurrence of Part"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1180
+#, fuzzy
 msgid "Replace..."
-msgstr ""
+msgstr "Valitse kaikki"
 
 #: ../../src/wxMaxima.cpp:6719
 #, c-format
@@ -5671,20 +6006,23 @@ msgid "Report bug"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:996
+#, fuzzy
 msgid "Reset option variables"
-msgstr ""
+msgstr "Vaihda muuttuja"
 
 #: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
 msgid "Restart Maxima"
-msgstr ""
+msgstr "Uudelleenkäynnistä Maxima"
 
 #: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
+#, fuzzy
 msgid "Restrict Maximum size"
-msgstr ""
+msgstr "Uudelleenkäynnistä Maxima"
 
 #: ../../src/wxMaxima.cpp:10031
+#, fuzzy
 msgid "Result variables:"
-msgstr ""
+msgstr "Poista muuttuja(t):"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Resulting Matrix name (may be empty):"
@@ -5758,8 +6096,9 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
 #: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
+#, fuzzy
 msgid "Right Matrix:"
-msgstr ""
+msgstr "Syötä matriisi"
 
 #: ../../src/wxMaxima.cpp:8190
 msgid "Right end"
@@ -5787,12 +6126,14 @@ msgid "Row number:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7977
+#, fuzzy
 msgid "Row numbers:"
-msgstr ""
+msgstr "Näytä &Funktiot"
 
 #: ../../src/wxMaxima.cpp:8203
+#, fuzzy
 msgid "Rows"
-msgstr ""
+msgstr "Rivit:"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Rule"
@@ -5807,8 +6148,9 @@ msgid "Rules"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1693
+#, fuzzy
 msgid "Run each element through an expression"
-msgstr ""
+msgstr "Etsi lausekkeen raja-arvo"
 
 #: ../../src/wxMaxima.cpp:6355
 #, c-format
@@ -5861,68 +6203,70 @@ msgid "Runs each element through a function"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1694
+#, fuzzy
 msgid "Runs each element through an expression"
-msgstr ""
+msgstr "Etsi lausekkeen raja-arvo"
 
 #: ../../src/wxMaxima.cpp:9572
 msgid "Sample 1:"
-msgstr ""
+msgstr "Esimerkki 1:"
 
 #: ../../src/wxMaxima.cpp:9573
 msgid "Sample 2:"
-msgstr ""
+msgstr "Esimerkki 2:"
 
 #: ../../src/wxMaxima.cpp:9567
 msgid "Sample:"
-msgstr ""
+msgstr "Esimerkki:"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
 msgid "Save"
-msgstr ""
+msgstr "Tallenna"
 
 #: ../../src/Worksheet.cpp:1294
 msgid "Save Animation..."
-msgstr ""
+msgstr "Tallenna animaatio..."
 
 #: ../../src/wxMaxima.cpp:5672
 msgid "Save As"
-msgstr ""
+msgstr "Tallenna nimellä"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save As...\tShift+Ctrl+S"
-msgstr ""
+msgstr "Tallenna nimellä...\tShift+Ctrl+S"
 
 #: ../../src/Worksheet.cpp:1291
 msgid "Save Image..."
-msgstr ""
+msgstr "Tallenna kuva..."
 
 #: ../../src/wxMaxima.cpp:6440
 msgid "Save Selection to Image"
-msgstr ""
+msgstr "Tallenna valinta kuvaksi"
 
 #: ../../src/wxMaximaFrame.cpp:675
 msgid "Save Selection to Image..."
-msgstr ""
+msgstr "Tallenna valinta kuvaksi..."
 
 #: ../../src/wxMaxima.cpp:10184
 msgid "Save animation to file"
-msgstr ""
+msgstr "Tallenna animaatio tiedostoksi"
 
 #: ../../src/wxMaxima.cpp:7203
 msgid "Save as lisp code"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1091
+#, fuzzy
 msgid "Save as lisp..."
-msgstr ""
+msgstr "Tallenna kuva..."
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
 msgid "Save document"
-msgstr ""
+msgstr "Tallenna asiakirja"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save document as"
-msgstr ""
+msgstr "Tallenna asiakirja nimellä"
 
 #: ../../src/wxMaximaFrame.cpp:676
 msgid "Save selection from document to an image file"
@@ -5930,11 +6274,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10125
 msgid "Save selection to file"
-msgstr ""
+msgstr "Tallenna valinta tiedostoksi"
 
 #: ../../src/wxMaximaFrame.cpp:573
 msgid "Saving failed."
-msgstr ""
+msgstr "Tallentaminen epäonnistui."
 
 #: ../../src/WXMXformat.cpp:310
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
@@ -5997,11 +6341,11 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
 msgid "Select All"
-msgstr ""
+msgstr "Valitse kaikki"
 
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select All\tCtrl+A"
-msgstr ""
+msgstr "Valitse kaikki\tCtrl+A"
 
 #: ../../src/ToolBar.cpp:629
 msgid "Select All button"
@@ -6014,15 +6358,16 @@ msgstr ""
 #: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select all"
-msgstr ""
+msgstr "Valitse kaikki"
 
 #: ../../src/wxMaxima.cpp:6971
 msgid "Select math display algorithm"
 msgstr ""
 
 #: ../../src/Configuration.cpp:98
+#, fuzzy
 msgid "Selection color"
-msgstr ""
+msgstr "Tallenna valinta tiedostoksi"
 
 #: ../../src/ToolBar.cpp:252
 msgid "Send all cells to maxima"
@@ -6057,8 +6402,9 @@ msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1533
+#, fuzzy
 msgid "Sequential Comparative Simplification"
-msgstr ""
+msgstr "&Kompleksi Sieventäminen"
 
 #: ../../src/wxMaxima.cpp:9016
 msgid "Series"
@@ -6090,7 +6436,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:822
 msgid "Set Zoom"
-msgstr ""
+msgstr "Suurennos"
 
 #: ../../src/wxMaximaFrame.cpp:1819
 msgid "Set bigfloat &Precision..."
@@ -6101,16 +6447,18 @@ msgid "Set image resolution"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1510
+#, fuzzy
 msgid "Set main variable..."
-msgstr ""
+msgstr "Poistaa muuttujan"
 
 #: ../../src/wxMaximaFrame.cpp:1773
 msgid "Set plot format"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1101
+#, fuzzy
 msgid "Set position..."
-msgstr ""
+msgstr "Tallenna animaatio..."
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Set the \"algebraic\" flag"
@@ -6121,8 +6469,9 @@ msgid "Set the diagram title"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1779
+#, fuzzy
 msgid "Set the frame rate for animations."
-msgstr ""
+msgstr "Aloita tai lopeta animaatio"
 
 #: ../../src/wxMaxima.cpp:8377
 msgid "Set the grid density."
@@ -6140,27 +6489,27 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:811
 msgid "Set zoom to 100%"
-msgstr ""
+msgstr "Suurennos 100%"
 
 #: ../../src/wxMaximaFrame.cpp:813
 msgid "Set zoom to 120%"
-msgstr ""
+msgstr "Suurennos 120%"
 
 #: ../../src/wxMaximaFrame.cpp:815
 msgid "Set zoom to 150%"
-msgstr ""
+msgstr "Suurennos 150%"
 
 #: ../../src/wxMaximaFrame.cpp:817
 msgid "Set zoom to 200%"
-msgstr ""
+msgstr "Suurennos 200%"
 
 #: ../../src/wxMaximaFrame.cpp:819
 msgid "Set zoom to 300%"
-msgstr ""
+msgstr "Suurennos 300%"
 
 #: ../../src/wxMaximaFrame.cpp:809
 msgid "Set zoom to 80%"
-msgstr ""
+msgstr "Suurennos 80%"
 
 #: ../../src/wxMaxima.cpp:4731
 #, c-format
@@ -6177,7 +6526,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1661
 msgid "Setup modulus computation"
-msgstr ""
+msgstr "Aseta modulo-laskenta"
 
 #: ../../src/wxMaxima.cpp:9220
 msgid "Setup the engineering format"
@@ -6197,23 +6546,25 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show &Tips..."
-msgstr ""
+msgstr "Näytä &Vinkit..."
 
 #: ../../src/Worksheet.cpp:1556
 msgid "Show * as multiplication dot"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:895
+#, fuzzy
 msgid "Show Template\tCtrl+Shift+Space"
-msgstr ""
+msgstr "Kopioi tekstinä"
 
 #: ../../src/wxMaximaFrame.cpp:753
+#, fuzzy
 msgid "Show XML representation"
-msgstr ""
+msgstr "Lausekkeen tekijä"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show a tip"
-msgstr ""
+msgstr "Näytä vihje"
 
 #: ../../src/Worksheet.cpp:1607
 msgid "Show all + allow linebreaks in long numbers"
@@ -6221,7 +6572,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9475
 msgid "Show all commands similar to:"
-msgstr ""
+msgstr "Näytä kaikki samanlaiset komennot:"
 
 #: ../../src/wxMaxima.cpp:9468
 msgid "Show an example for the command:"
@@ -6233,39 +6584,42 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "Show commands similar to"
-msgstr ""
+msgstr "Näytä kaikki samanlaiset komennot"
 
 #: ../../src/wxMaximaFrame.cpp:1020
 msgid "Show defined functions"
-msgstr ""
+msgstr "Näytä määritellyt funktiot"
 
 #: ../../src/wxMaximaFrame.cpp:1022
 msgid "Show defined variables"
-msgstr ""
+msgstr "Näytä määritellyt muuttujat"
 
 #: ../../src/wxMaximaFrame.cpp:1074
 msgid "Show definition of a function"
-msgstr ""
+msgstr "Näytä funktion määrittely"
 
 #: ../../src/wxMaximaFrame.cpp:740
 msgid "Show equations in their linear form"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1073
+#, fuzzy
 msgid "Show function &Definition..."
-msgstr ""
+msgstr "Näytä &Määritelmä..."
 
 #: ../../src/wxMaximaFrame.cpp:896
 msgid "Show function template"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1614
+#, fuzzy
 msgid "Show input labels"
-msgstr ""
+msgstr "Näytä &Muuttujat"
 
 #: ../../src/wxMaximaFrame.cpp:750
+#, fuzzy
 msgid "Show lisp representation"
-msgstr ""
+msgstr "Lausekkeen tekijä"
 
 #: ../../src/Worksheet.cpp:1604
 msgid "Show max. 100 digits"
@@ -6304,8 +6658,9 @@ msgid "Show the Copy, Cut and the Paste button?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7033
+#, fuzzy
 msgid "Show the function's definition"
-msgstr ""
+msgstr "Näytä funktion määrittely"
 
 #: ../../src/ToolBar.cpp:618
 msgid "Show the open and the save button?"
@@ -6328,13 +6683,14 @@ msgid "Show used + to-be-freed memory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1033
+#, fuzzy
 msgid "Show user definitions"
-msgstr ""
+msgstr "Näytä funktion määrittely"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Show wxMaxima help"
-msgstr ""
+msgstr "Näytä Maxima ohje"
 
 #: ../../src/wxMaximaFrame.cpp:1825
 msgid "Shows how many digits of a numbers are displayed"
@@ -6345,48 +6701,53 @@ msgid "Sidebars"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1513
+#, fuzzy
 msgid "Simplify &Radicals..."
-msgstr ""
+msgstr "Sievennä &juuret"
 
 #: ../../src/Worksheet.cpp:1579
 msgid "Simplify Expression"
-msgstr ""
+msgstr "Sievennä lauseke"
 
 #: ../../src/wxMaximaFrame.cpp:1568
+#, fuzzy
 msgid "Simplify Logarithms"
-msgstr ""
+msgstr "Sievennä summa"
 
 #: ../../src/wxMaximaFrame.cpp:1582
 msgid "Simplify an expression containing factorials"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1539
+#, fuzzy
 msgid "Simplify equations"
-msgstr ""
+msgstr "Ratkaise yhtälö(t)"
 
 #: ../../src/wxMaximaFrame.cpp:1514
 msgid "Simplify expression containing radicals"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8649
+#, fuzzy
 msgid "Simplify radicals"
-msgstr ""
+msgstr "Sievennä &juuret"
 
 #: ../../src/wxMaximaFrame.cpp:1512
 msgid "Simplify rational expression"
-msgstr ""
+msgstr "Sievennä rationaalilauseke"
 
 #: ../../src/wxMaximaFrame.cpp:1538
 msgid "Simplify sum() commands..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8636
+#, fuzzy
 msgid "Simplify sums"
-msgstr ""
+msgstr "Sievennä"
 
 #: ../../src/wxMaximaFrame.cpp:1592
 msgid "Simplify trigonometric expression"
-msgstr ""
+msgstr "Sievennä trigonometrinen lauseke"
 
 #: ../../src/wxMaximaFrame.cpp:1399
 msgid "Singular Values"
@@ -6401,29 +6762,32 @@ msgid "Singular values, left + right vectors"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1635
+#, fuzzy
 msgid "Smart Substitute..."
-msgstr ""
+msgstr "Korvaa..."
 
 #: ../../src/wxMaxima.cpp:8730
+#, fuzzy
 msgid "Smart substitution"
-msgstr ""
+msgstr "Korvaa"
 
 #: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
 #: ../../src/wxMaxima.cpp:7823
+#, fuzzy
 msgid "Solution of the ODE:"
-msgstr ""
+msgstr "Ratkaisu:"
 
 #: ../../src/wxMaxima.cpp:10017
 msgid "Solve"
-msgstr ""
+msgstr "Ratkaise"
 
 #: ../../src/wxMaximaFrame.cpp:1244
 msgid "Solve &Algebraic System..."
-msgstr ""
+msgstr "Ratkaise algebrallinen &yhtälöryhmä"
 
 #: ../../src/wxMaximaFrame.cpp:1242
 msgid "Solve &Linear System..."
-msgstr ""
+msgstr "Ratkaise lineaarinen &yhtälöryhmä"
 
 #: ../../src/wxMaximaFrame.cpp:1266
 msgid "Solve &ODE..."
@@ -6431,15 +6795,16 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1240
 msgid "Solve (to_poly)..."
-msgstr ""
+msgstr "Ratkaise (to_poly)..."
 
 #: ../../src/wxMaxima.cpp:8045
 msgid "Solve A*x=b numerically"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1397
+#, fuzzy
 msgid "Solve Ax=b"
-msgstr ""
+msgstr "Ratkaise"
 
 #: ../../src/wxMaxima.cpp:7783
 msgid "Solve ODE"
@@ -6450,12 +6815,13 @@ msgid "Solve ODE with Lapla&ce..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1398
+#, fuzzy
 msgid "Solve a linear equation system using dgesv"
-msgstr ""
+msgstr "Ratkaise lineaarinen yhtälöryhmä"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
 msgid "Solve algebraic system"
-msgstr ""
+msgstr "Ratkaise algebrallinen &yhtälöryhmä"
 
 #: ../../src/wxMaximaFrame.cpp:1245
 msgid "Solve algebraic system of equations"
@@ -6471,19 +6837,21 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
 msgid "Solve equation(s)"
-msgstr ""
+msgstr "Ratkaise yhtälö(t)"
 
 #: ../../src/wxMaximaFrame.cpp:1241
 msgid "Solve equation(s) with to_poly_solve"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7773
+#, fuzzy
 msgid "Solve equations numerically"
-msgstr ""
+msgstr "Ratkaise yhtälö(t)"
 
 #: ../../src/wxMaxima.cpp:7757
+#, fuzzy
 msgid "Solve equations to polynom"
-msgstr ""
+msgstr "Ratkaise yhtälö(t)"
 
 #: ../../src/wxMaximaFrame.cpp:1271
 msgid "Solve initial value problem for first degree ODE"
@@ -6495,11 +6863,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
 msgid "Solve linear system"
-msgstr ""
+msgstr "Ratkaise lineaarinen &yhtälöryhmä"
 
 #: ../../src/wxMaximaFrame.cpp:1243
 msgid "Solve linear system of equations"
-msgstr ""
+msgstr "Ratkaise lineaarinen yhtälöryhmä"
 
 #: ../../src/wxMaximaFrame.cpp:1263
 msgid "Solve numerical, 1 Variable"
@@ -6514,24 +6882,28 @@ msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7708
+#, fuzzy
 msgid "Solve polynomials numerically"
-msgstr ""
+msgstr "Ratkaise yhtälö(t)"
 
 #: ../../src/wxMaxima.cpp:7718
+#, fuzzy
 msgid "Solve polynomials numerically (bfloats)"
-msgstr ""
+msgstr "Ratkaise yhtälö(t)"
 
 #: ../../src/wxMaxima.cpp:7729
+#, fuzzy
 msgid "Solve polynomials numerically (real roots)"
-msgstr ""
+msgstr "Ratkaise yhtälö(t)"
 
 #: ../../src/wxMaximaFrame.cpp:1249
+#, fuzzy
 msgid "Solve symbolically"
-msgstr ""
+msgstr "Ratkaise yhtälö(t)"
 
 #: ../../src/Worksheet.cpp:1574
 msgid "Solve..."
-msgstr ""
+msgstr "Ratkaise..."
 
 #: ../../src/wxMaximaFrame.cpp:1916
 msgid "Solving differential equations"
@@ -6553,20 +6925,23 @@ msgid "Sort"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8496
+#, fuzzy
 msgid "Sort a list"
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaxima.cpp:7459
 msgid "Sort all characters in string"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1179
+#, fuzzy
 msgid "Sort the characters..."
-msgstr ""
+msgstr "Kreikkalaiset vakiot"
 
 #: ../../src/wxMaxima.cpp:8482
+#, fuzzy
 msgid "Source list:"
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaxima.cpp:7429
 msgid "Split"
@@ -6585,8 +6960,9 @@ msgid "Split string into tokens"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1171
+#, fuzzy
 msgid "Split..."
-msgstr ""
+msgstr "Laatikkokaavio..."
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Square"
@@ -6598,7 +6974,7 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1298
 msgid "Start Animation"
-msgstr ""
+msgstr "Aloita animaatio"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Start of t:"
@@ -6606,7 +6982,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:305
 msgid "Start or Stop animation"
-msgstr ""
+msgstr "Aloita tai lopeta animaatio"
 
 #: ../../src/ToolBar.cpp:306
 msgid ""
@@ -6636,15 +7012,16 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:252
 msgid "Statistics"
-msgstr ""
+msgstr "Tilastot"
 
 #: ../../src/wxMaximaFrame.cpp:701
 msgid "Statistics\tAlt+Shift+S"
-msgstr ""
+msgstr "Tilastot\tAlt+Shift+ S"
 
 #: ../../src/wxMaxima.cpp:7844
+#, fuzzy
 msgid "Step width:"
-msgstr ""
+msgstr "Matriisi"
 
 #: ../../src/wxMaximaFrame.cpp:794
 msgid "Straight lines"
@@ -6669,26 +7046,31 @@ msgid "Stream:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1185
+#, fuzzy
 msgid "String"
-msgstr ""
+msgstr "Merkkijonot"
 
 #: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
 #: ../../src/wxMaxima.cpp:7425
+#, fuzzy
 msgid "String #1:"
-msgstr ""
+msgstr "Merkkijonot"
 
 #: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
 #: ../../src/wxMaxima.cpp:7426
+#, fuzzy
 msgid "String #2:"
-msgstr ""
+msgstr "Merkkijonot"
 
 #: ../../src/wxMaximaFrame.cpp:1136
+#, fuzzy
 msgid "String Tests"
-msgstr ""
+msgstr "Merkkijonot"
 
 #: ../../src/wxMaxima.cpp:7415
+#, fuzzy
 msgid "String length"
-msgstr ""
+msgstr "Merkkijonot"
 
 #: ../../src/wxMaxima.cpp:7381
 msgid "String to list of char"
@@ -6699,8 +7081,9 @@ msgid "String to list of chars..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7496
+#, fuzzy
 msgid "String to octets"
-msgstr ""
+msgstr "Merkkijonot"
 
 #: ../../src/wxMaximaFrame.cpp:1160
 msgid "String to octets..."
@@ -6717,8 +7100,9 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7465 ../../src/wxMaxima.cpp:7470
 #: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
 #: ../../src/wxMaxima.cpp:7497
+#, fuzzy
 msgid "String:"
-msgstr ""
+msgstr "Merkkijonot"
 
 #: ../../src/wxMaxima.cpp:7197
 msgid "Struct :"
@@ -6751,19 +7135,21 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
 #: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
 msgid "Substitute"
-msgstr ""
+msgstr "Korvaa"
 
 #: ../../src/wxMaximaFrame.cpp:1193
+#, fuzzy
 msgid "Substitute all matches"
-msgstr ""
+msgstr "Korvaa..."
 
 #: ../../src/wxMaximaFrame.cpp:1192
 msgid "Substitute first match"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1646
+#, fuzzy
 msgid "Substitute only in parts..."
-msgstr ""
+msgstr "Korvaa..."
 
 #: ../../src/wxMaxima.cpp:8763
 msgid "Substitute only in specific parts"
@@ -6775,7 +7161,7 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
 msgid "Substitute..."
-msgstr ""
+msgstr "Korvaa..."
 
 #: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
 msgid "Substitutes until the equation no more changes"
@@ -6827,7 +7213,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9049
 msgid "Sum"
-msgstr ""
+msgstr "Summa"
 
 #: ../../src/wxMaximaFrame.cpp:1551
 msgid ""
@@ -6844,8 +7230,9 @@ msgid "Switched to lisp mode after receiving a lisp prompt!"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1971
+#, fuzzy
 msgid "Symbolic Constant"
-msgstr ""
+msgstr "Valitse vakio"
 
 #: ../../src/wxMaximaFrame.cpp:705
 msgid "Symbols\tAlt+Shift+Y"
@@ -6857,23 +7244,26 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:238
 msgid "Table of Contents"
-msgstr ""
+msgstr "Sisällysluettelo"
 
 #: ../../src/wxMaximaFrame.cpp:711
+#, fuzzy
 msgid "Table of Contents\tAlt+Shift+T"
-msgstr ""
+msgstr "Sisällysluettelo\tAlt+Shift+T"
 
 #: ../../src/wxMaxima.cpp:8930
+#, fuzzy
 msgid "Taylor series"
-msgstr ""
+msgstr "Taylorin sarjat:"
 
 #: ../../src/wxMaximaFrame.cpp:1474
+#, fuzzy
 msgid "Taylor series..."
-msgstr ""
+msgstr "Taylorin sarjat:"
 
 #: ../../src/wxMaxima.cpp:8925
 msgid "Taylor series:"
-msgstr ""
+msgstr "Taylorin sarjat:"
 
 #: ../../src/wxMaxima.cpp:4132
 msgid "Telling maxima about the new working directory."
@@ -6900,7 +7290,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:271
 msgid "Text"
-msgstr ""
+msgstr "Teksti"
 
 #: ../../src/Configuration.cpp:93
 msgid "Text cell background"
@@ -7002,12 +7392,14 @@ msgid "The main toolbar"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1882
+#, fuzzy
 msgid "The manual of Maxima"
-msgstr ""
+msgstr "Maximan offline-käsikirja"
 
 #: ../../src/wxMaximaFrame.cpp:1881
+#, fuzzy
 msgid "The manual of wxMaxima"
-msgstr ""
+msgstr "Maximan offline-käsikirja"
 
 #: ../../src/wxMaxima.cpp:7125
 msgid "The name of a function we don't want to be evaluated here"
@@ -7082,8 +7474,9 @@ msgid "The variables to search the optimum solution for"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:193
+#, fuzzy
 msgid "The worksheet"
-msgstr ""
+msgstr "Työkirja"
 
 #: ../../src/Worksheet.cpp:8122
 msgid "The worksheet containing maxima's input and output"
@@ -7168,7 +7561,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:272
 msgid "Title"
-msgstr ""
+msgstr "Otsikko"
 
 #: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
@@ -7180,27 +7573,28 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1794
 msgid "To &Bigfloat"
-msgstr ""
+msgstr "&Liukuluvuksi (Bigfloat)"
 
 #: ../../src/wxMaximaFrame.cpp:1791
 msgid "To &Float"
-msgstr ""
+msgstr "&Liukuluvuksi (Float)"
 
 #: ../../src/Worksheet.cpp:1571
 msgid "To Float"
-msgstr ""
+msgstr "Liukuluvuksi (Float)"
 
 #: ../../src/wxMaximaFrame.cpp:1797
 msgid "To Numeri&c\tCtrl+Shift+N"
-msgstr ""
+msgstr "N&umeeriseksi\tCtrl+Shift+N"
 
 #: ../../src/wxMaximaFrame.cpp:1803
 msgid "To exact fraction"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1814
+#, fuzzy
 msgid "To exact number"
-msgstr ""
+msgstr "Näytä &Funktiot"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "To:"
@@ -7227,20 +7621,23 @@ msgid "Top end"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1078
+#, fuzzy
 msgid "Trace a function..."
-msgstr ""
+msgstr "Poistaa funktion"
 
 #: ../../src/wxMaxima.cpp:7084
+#, fuzzy
 msgid "Trace function(s)"
-msgstr ""
+msgstr "Poista funktio(t):"
 
 #: ../../src/wxMaximaFrame.cpp:1184
+#, fuzzy
 msgid "Transformations"
-msgstr ""
+msgstr "Transponoi matriisi"
 
 #: ../../src/wxMaximaFrame.cpp:1376
 msgid "Transpose a matrix"
-msgstr ""
+msgstr "Transponoi matriisi"
 
 #: ../../src/wxMaxima.cpp:7832
 msgid ""
@@ -7369,19 +7766,20 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1928
 msgid "Tutorials"
-msgstr ""
+msgstr "Oppaat"
 
 #: ../../src/wxMaxima.cpp:9571
 msgid "Two sample t-test"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:8013
+#, fuzzy
 msgid "Type"
-msgstr ""
+msgstr "Tyyppi:"
 
 #: ../../src/wxMaxima.cpp:7180
 msgid "Type:"
-msgstr ""
+msgstr "Tyyppi:"
 
 #: ../../src/wxMaxima.cpp:9429
 msgid "URL"
@@ -7406,8 +7804,9 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1007
+#, fuzzy
 msgid "Undefine"
-msgstr ""
+msgstr "Alleviivattu"
 
 #: ../../src/ToolBar.cpp:191
 msgid "Undo"
@@ -7415,7 +7814,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo\tCtrl+Z"
-msgstr ""
+msgstr "Kumoa\tCtrl+Z"
 
 #: ../../src/ToolBar.cpp:614
 msgid "Undo and redo button"
@@ -7423,15 +7822,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo last change"
-msgstr ""
+msgstr "Kumoa viimeisin muutos"
 
 #: ../../src/wxMaximaFrame.cpp:924
 msgid "Unfold All\tCtrl+Alt+]"
-msgstr ""
+msgstr "Näytä kaikki\tCtrl+Alt+]"
 
 #: ../../src/wxMaximaFrame.cpp:925
 msgid "Unfold all folded sections"
-msgstr ""
+msgstr "Näytä piilotetut kappaleet\tCtrl+Alt+]"
 
 #: ../../src/Worksheet.cpp:1893
 msgid "Unhide Heading 5"
@@ -7446,24 +7845,29 @@ msgid "Unhide Part"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1860
+#, fuzzy
 msgid "Unhide Section"
-msgstr ""
+msgstr "leikkaus"
 
 #: ../../src/Worksheet.cpp:1871
+#, fuzzy
 msgid "Unhide Subsection"
-msgstr ""
+msgstr "Lisää alikappalesolu"
 
 #: ../../src/Worksheet.cpp:1882
+#, fuzzy
 msgid "Unhide Subsubsection"
-msgstr ""
+msgstr "Lisää alialikapplesolu"
 
 #: ../../src/Worksheet.cpp:1912
+#, fuzzy
 msgid "Unhide contents"
-msgstr ""
+msgstr "Kreikkalaiset vakiot"
 
 #: ../../src/wxMaximaFrame.cpp:266
+#, fuzzy
 msgid "Unicode characters"
-msgstr ""
+msgstr "Kreikkalaiset vakiot"
 
 #: ../../src/wxMaximaFrame.cpp:707
 msgid "Unicode chars\tAlt+Shift+U"
@@ -7497,7 +7901,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10461
 msgid "Unterminated string."
-msgstr ""
+msgstr "Päättymätön merkkijono."
 
 #: ../../src/wxMaxima.cpp:4786
 msgid "Updating maxima's configuration"
@@ -7506,27 +7910,29 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:11150 ../../src/wxMaxima.cpp:11157
 #: ../../src/wxMaxima.cpp:11163
 msgid "Upgrade"
-msgstr ""
+msgstr "Päivitä"
 
 #: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
 msgid "Upper bound:"
-msgstr ""
+msgstr "Yläraja:"
 
 #: ../../src/wxMaximaFrame.cpp:792
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
+#, fuzzy
 msgid "Use a list"
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaxima.cpp:8571
 msgid "Use a list as parameter list for a function"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1708
+#, fuzzy
 msgid "Use list"
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaximaFrame.cpp:1701
 msgid "Use list as the arguments of a function"
@@ -7541,8 +7947,9 @@ msgid "Use square parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1083
+#, fuzzy
 msgid "Use struct field..."
-msgstr ""
+msgstr "&Ketjumurtoluku"
 
 #: ../../src/wxMaximaFrame.cpp:795
 msgid "Use vertical lines instead of parenthesis for matrices"
@@ -7566,8 +7973,9 @@ msgid "Using Maxima path from command line."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:4822
+#, fuzzy
 msgid "Using configured Maxima path."
-msgstr ""
+msgstr "Määrittele wxMaxima"
 
 #: ../../src/wxMaxima.cpp:2961
 msgid ""
@@ -7607,7 +8015,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7910
 msgid "Value:"
-msgstr ""
+msgstr "Arvo"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Var #1"
@@ -7623,25 +8031,29 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
 #: ../../src/wxMaxima.cpp:8568
+#, fuzzy
 msgid "Variable name"
-msgstr ""
+msgstr "Kaikki muuttujanimet"
 
 #: ../../src/wxMaximaFrame.cpp:1085
+#, fuzzy
 msgid "Variable name, not contents..."
-msgstr ""
+msgstr "Kaikki muuttujanimet"
 
 #: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
+#, fuzzy
 msgid "Variable name:"
-msgstr ""
+msgstr "Kaikki muuttujanimet"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
+#, fuzzy
 msgid "Variable(s)"
-msgstr ""
+msgstr "Muuttuja(t)"
 
 #: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
 #: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
 msgid "Variable(s):"
-msgstr ""
+msgstr "Muuttuja(t)"
 
 #: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
 #: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
@@ -7649,15 +8061,15 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
 #: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
 msgid "Variable:"
-msgstr ""
+msgstr "Muuttuja"
 
 #: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
 msgid "Variables"
-msgstr ""
+msgstr "Muuttujat"
 
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
 msgid "Variables:"
-msgstr ""
+msgstr "Muuttujat:"
 
 #: ../../src/WXMXformat.cpp:337
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -7665,7 +8077,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:836
 msgid "View"
-msgstr ""
+msgstr "Näkymä"
 
 #: ../../src/Autocomplete.cpp:235
 msgid "Waiting for m_addFiles_backgroundThread to finish"
@@ -7687,11 +8099,12 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
 #: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
 msgid "Warning"
-msgstr ""
+msgstr "Varoitus"
 
 #: ../../src/wxMaximaFrame.cpp:1556
+#, fuzzy
 msgid "Warning:"
-msgstr ""
+msgstr "Varoitus"
 
 #: ../../src/Dirstructure.cpp:72
 #, c-format
@@ -7707,7 +8120,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5063
 msgid "Welcome to wxMaxima"
-msgstr ""
+msgstr "Tervetuloa wxMaximaan"
 
 #: ../../src/wxMaxima.cpp:8583
 msgid "What to do:"
@@ -7726,10 +8139,11 @@ msgid "While loop..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:5673
+#, fuzzy
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38)"
 " (*.wxm)|*.wxm|All Files (*.*)|*"
-msgstr ""
+msgstr "Koko tiedosto (*.wxmx)|*.wxmx|Syöte ilman kuvia (*.wxm)|*.wxm"
 
 #: ../../src/wxMaxima.cpp:210
 msgid "Will try to generate a stack backtrace, if the program ever crashes"
@@ -7760,44 +8174,47 @@ msgid "Wrote the mimetype info"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:11147
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have version %s. The newest version source code is available for is %s.\n"
 "\n"
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
+"Tämä versio on %s. Viimeisin julkaistuversio on %s.\n"
+"\n"
+"Valitse OK käydäksesi wxMaximan sivustolla."
 
 #: ../../src/wxMaxima.cpp:11202
 msgid "Your changes will be lost if you don't save them."
-msgstr ""
+msgstr "Tekemäsi muutokset häviävät ellet tallenna niitä."
 
 #: ../../src/wxMaxima.cpp:11156
 msgid "Your version of wxMaxima is up to date."
-msgstr ""
+msgstr "wxMaximassasi on viimeisin päivitys."
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom &In\tCtrl++"
-msgstr ""
+msgstr "Suurenna \tCtrl++"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom Ou&t\tCtrl+-"
-msgstr ""
+msgstr "Pienennä\tCtrl+-"
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom in 10%"
-msgstr ""
+msgstr "Suurenna 10%"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom out 10%"
-msgstr ""
+msgstr "Pienennä 10%"
 
 #: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
 msgid "[ unsaved ]"
-msgstr ""
+msgstr "[ tallentamaton ]"
 
 #: ../../src/wxMaxima.cpp:10920
 msgid "[ unsaved* ]"
-msgstr ""
+msgstr "[ tallentamaton* ]"
 
 #: ../../src/Worksheet.cpp:5278
 #, c-format
@@ -7810,8 +8227,9 @@ msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"la
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1690
+#, fuzzy
 msgid "apply function to each element"
-msgstr ""
+msgstr "Sovella funktiota listaan"
 
 #: ../../src/wxMaximaFrame.cpp:739
 msgid "as 1D ASCII"
@@ -7846,44 +8264,50 @@ msgid "ev() shall evaluate this automatically"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7130
+#, fuzzy
 msgid "expression:"
-msgstr ""
+msgstr "Lauseke:"
 
 #: ../../src/Worksheet.cpp:2025
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
+#, fuzzy
 msgid "filename:"
-msgstr ""
+msgstr "Kaikki muuttujanimet"
 
 #: ../../src/wxMaximaFrame.cpp:1674
+#, fuzzy
 msgid "from a list"
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "from a rule"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1685
+#, fuzzy
 msgid "from function arguments"
-msgstr ""
+msgstr "Funktioiden nimet"
 
 #: ../../src/wxMaximaFrame.cpp:1669
 msgid "from individual elements"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
+#, fuzzy
 msgid "function"
-msgstr ""
+msgstr "Funktio"
 
 #: ../../src/wxMaximaFrame.cpp:747
 msgid "in 2D"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8554
+#, fuzzy
 msgid "list"
-msgstr ""
+msgstr "Tee lista"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "max(abs(A(i,j))) (complex)"
@@ -7894,13 +8318,15 @@ msgid "max(abs(A(i,j))) (real)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8046
+#, fuzzy
 msgid "m×n Matrix A:"
-msgstr ""
+msgstr "Matriisi:"
 
 #: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533
+#, fuzzy
 msgid "n:"
-msgstr ""
+msgstr "ei"
 
 #: ../../src/Worksheet.cpp:2000
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -7911,8 +8337,9 @@ msgid "noun: Not evaluated by default"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1710
+#, fuzzy
 msgid "nth"
-msgstr ""
+msgstr "ei"
 
 #: ../../src/Worksheet.cpp:2021
 msgid "outative: f(2*x) = 2*f(x)"
@@ -7924,20 +8351,24 @@ msgid "part:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8942
+#, fuzzy
 msgid "point:"
-msgstr ""
+msgstr "Piste:"
 
 #: ../../src/wxMaxima.cpp:7740
+#, fuzzy
 msgid "precision:"
-msgstr ""
+msgstr "Tarkkuus"
 
 #: ../../src/wxMaxima.cpp:7255
+#, fuzzy
 msgid "printf"
-msgstr ""
+msgstr "Tulosta"
 
 #: ../../src/wxMaximaFrame.cpp:1108
+#, fuzzy
 msgid "printf..."
-msgstr ""
+msgstr "Deri..."
 
 #: ../../src/wxMaxima.cpp:8650
 msgid ""
@@ -7953,16 +8384,19 @@ msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1111
+#, fuzzy
 msgid "readbyte..."
-msgstr ""
+msgstr "Integroi..."
 
 #: ../../src/wxMaximaFrame.cpp:1110
+#, fuzzy
 msgid "readchar..."
-msgstr ""
+msgstr "Sektoridiagrammi..."
 
 #: ../../src/wxMaximaFrame.cpp:1109
+#, fuzzy
 msgid "readline..."
-msgstr ""
+msgstr "Varianssi..."
 
 #: ../../src/wxMaxima.cpp:10018
 msgid ""
@@ -7993,16 +8427,17 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11190
 msgid "unsaved"
-msgstr ""
+msgstr "tallentamaton"
 
 #: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
 #: ../../src/wxMaximaFrame.cpp:189
 msgid "untitled"
-msgstr ""
+msgstr "nimetön"
 
 #: ../../src/wxMaximaFrame.cpp:1700
+#, fuzzy
 msgid "use as function arguments"
-msgstr ""
+msgstr "Funktioiden nimet"
 
 #: ../../src/wxMaximaFrame.cpp:1696
 msgid "use the actual values stored"
@@ -8017,16 +8452,16 @@ msgid "wxMaxima"
 msgstr ""
 
 #: ../../src/main.cpp:516
-#, c-format
+#, fuzzy, c-format
 msgid "wxMaxima %ld"
-msgstr ""
+msgstr "wxMaxima %s"
 
 #: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
 #: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
 #: ../../src/wxMaximaFrame.cpp:185
-#, c-format
+#, fuzzy, c-format
 msgid "wxMaxima %s (%s) "
-msgstr ""
+msgstr "wxMaxima %s"
 
 #: ../../src/wxMaxima.cpp:4490
 msgid "wxMaxima cannot read the xml contents of "
@@ -8042,12 +8477,12 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5285
 msgid "wxMaxima document"
-msgstr ""
+msgstr "wxMaxima asiakirja"
 
 #: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
 #: ../../src/wxMaxima.cpp:4230
 msgid "wxMaxima encountered an error loading "
-msgstr ""
+msgstr "wxMaximalle tapahtui latausvirhe"
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "wxMaxima help"
@@ -8066,12 +8501,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1896
+#, fuzzy
 msgid "wxMaxima shows help in a browser"
-msgstr ""
+msgstr "Tiedosto ei löydy"
 
 #: ../../src/wxMaximaFrame.cpp:1894
+#, fuzzy
 msgid "wxMaxima shows help in the sidebar"
-msgstr ""
+msgstr "Tiedosto ei löydy"
 
 #: ../../src/wxMaximaFrame.cpp:111
 #, c-format
@@ -8079,8 +8516,9 @@ msgid "wxMaxima version %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1954
+#, fuzzy
 msgid "wxMaxima's ChangeLog"
-msgstr ""
+msgstr "wxMaxima kuvake"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "wxMaxima's license"
@@ -8144,8 +8582,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:10
+#, fuzzy
 msgid "# Introduction to wxMaxima"
-msgstr ""
+msgstr "Tervetuloa wxMaximaan"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:12
@@ -8184,8 +8623,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:18
+#, fuzzy
 msgid "### _Maxima_"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:20
@@ -8220,8 +8660,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:26
+#, fuzzy
 msgid "### WxMaxima"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:28
@@ -8344,8 +8785,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:54
+#, fuzzy
 msgid "### Cells"
-msgstr ""
+msgstr "Yhdistä solut"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:56
@@ -8366,8 +8808,9 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Image cells."
-msgstr ""
+msgstr "Yhdistä solut"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
@@ -8383,8 +8826,9 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Page breaks."
-msgstr ""
+msgstr "Sivunvaihto"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:65
@@ -8538,8 +8982,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:102
+#, fuzzy
 msgid "#### Greek characters"
-msgstr ""
+msgstr "Kreikkalaiset vakiot"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:104
@@ -8954,8 +9399,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:282
+#, fuzzy
 msgid "## File Formats"
-msgstr ""
+msgstr "Ratkaise yhtälö(t)"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:284
@@ -9392,8 +9838,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:432
+#, fuzzy
 msgid "## Subscripted variables"
-msgstr ""
+msgstr "Näytä määritellyt muuttujat"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:434
@@ -10041,8 +10488,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:704
+#, fuzzy
 msgid "#### Expression"
-msgstr ""
+msgstr "Lauseke"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:706
@@ -10083,8 +10531,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:716
+#, fuzzy
 msgid "#### Points"
-msgstr ""
+msgstr "Piste:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:718
@@ -10131,8 +10580,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:732
+#, fuzzy
 msgid "#### Plot name"
-msgstr ""
+msgstr "Lista:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:734
@@ -10168,8 +10618,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:744
+#, fuzzy
 msgid "#### Grid"
-msgstr ""
+msgstr "Ruudukko"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:746
@@ -10308,8 +10759,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:794
+#, fuzzy
 msgid "## Special variables wx..."
-msgstr ""
+msgstr "Poistaa muuttujan"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:805
@@ -10481,8 +10933,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:837
+#, fuzzy
 msgid "Example:"
-msgstr ""
+msgstr "Esimerkki"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:842
@@ -10533,8 +10986,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:856
+#, fuzzy
 msgid "## Output rendering."
-msgstr ""
+msgstr "Merkkijonot"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:858
@@ -10612,8 +11066,11 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:885
+#, fuzzy
 msgid "## Cannot connect to _Maxima_"
 msgstr ""
+"\n"
+"Ei yhdistetty."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:887
@@ -10960,8 +11417,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:988
+#, fuzzy
 msgid "E.g. start wxMaxima with:"
-msgstr ""
+msgstr "Uudelleenkäynnistä Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:990
@@ -11321,8 +11779,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1140
+#, fuzzy
 msgid "# Command-line arguments"
-msgstr ""
+msgstr "Pilkuilla erotetut x-koordinaatit"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1142

--- a/locales/wxMaxima/fr.po
+++ b/locales/wxMaxima/fr.po
@@ -25,524 +25,545 @@ msgid ""
 "\n"
 "Maxima is currently using %3.3f%% of all available CPUs."
 msgstr ""
+"\n"
+"\n"
+"Maxima utilise actuellement  %3.3f%% de tous les processeurs disponibles."
 
 #: ../../src/Image.cpp:690
 msgid ""
 "\n"
 "Image was loaded from a .wxmx file"
 msgstr ""
+"\n"
+"L'image a été chargée depuis un fichier .wxmx"
 
 #: ../../src/wxMaxima.cpp:5153
 msgid ""
 "\n"
 "Use the menu \"View->Toggle log window\" to show/hide a log window with all debug messages."
 msgstr ""
+"\n"
+"Utilisez le menu \"Affichage -> Basculer la fenêtre des logs\" pour afficher/masquer une fenêtre de journal contenant tous les messages de débogage."
 
 #: ../../src/wxMaxima.cpp:4230
 msgid " (File format (WXM version 1, first line of the file) not recognized)"
 msgstr ""
+" (Format de fichier non reconnu (version WXM 1, première ligne du fichier))"
 
 #: ../../src/wxMaximaFrame.cpp:1559
 msgid " Wrong, if a is complex"
-msgstr ""
+msgstr " Faux, si a est complexe"
 
 #: ../../src/wxMaxima.cpp:7601
 msgid ""
 "\".\" = \"The current directory\"\n"
 "\"..\" = \"One directory up\""
 msgstr ""
+"\".\" = \"Le répertoire courant\"\n"
+"\"..\" = \"Le répertoire parent\""
 
 #: ../../src/wxMaxima.cpp:7557 ../../src/wxMaxima.cpp:7563
 #: ../../src/wxMaxima.cpp:7568
 msgid "\"..\" means \"one directory up\"."
-msgstr ""
+msgstr "\"..\" signifie \"remonter d'un niveau dans l'arborescence\"."
 
 #: ../../src/wxMaxima.cpp:5053
 #, c-format
 msgid "%i cells in evaluation queue"
-msgstr ""
+msgstr "%i cellules dans la file d'évaluation"
 
 #: ../../src/Worksheet.cpp:330
 #, c-format
 msgid "%s image, %li×%li, %li ppi"
-msgstr ""
+msgstr "%s image, %li×%li, %li ppi"
 
 #: ../../src/Autocomplete.cpp:319
 #, c-format
 msgid "%s: Can't interpret line: %s"
-msgstr ""
+msgstr "%s : Impossible d’interpréter la ligne : %s"
 
 #: ../../src/wxMaximaFrame.cpp:1655
 msgid "&Algebraic Mode"
-msgstr ""
+msgstr "&Mode algébrique"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "&Apropos..."
-msgstr ""
+msgstr "&À propos…"
 
 #: ../../src/wxMaximaFrame.cpp:615
 msgid "&Batch File...\tCtrl+B"
-msgstr ""
+msgstr "&Traiter un fichier de commandes...\tCTRL+B"
 
 #: ../../src/wxMaximaFrame.cpp:1278
 msgid "&Boundary Value Problem..."
-msgstr ""
+msgstr "Pro&blème aux limites…"
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "&Bug Report"
-msgstr ""
+msgstr "&Signalement de bug"
 
 #: ../../src/wxMaximaFrame.cpp:1505
 msgid "&Calculus"
-msgstr ""
+msgstr "&Analyse"
 
 #: ../../src/wxMaximaFrame.cpp:1601
 msgid "&Canonical Form"
-msgstr ""
+msgstr "Forme &canonique"
 
 #: ../../src/wxMaximaFrame.cpp:1358
 msgid "&Characteristic Polynomial..."
-msgstr ""
+msgstr "Polynôme &caractéristique…"
 
 #: ../../src/wxMaximaFrame.cpp:990
 msgid "&Clear Memory"
-msgstr ""
+msgstr "Lib&érer la mémoire"
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "&Combine Factorials"
-msgstr ""
+msgstr "&Combiner les factorielles"
 
 #: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Complex Simplification"
-msgstr ""
+msgstr "Simplification &complexe"
 
 #: ../../src/wxMaximaFrame.cpp:1502
 msgid "&Continued Fraction"
-msgstr ""
+msgstr "Fraction &continue"
 
 #: ../../src/wxMaximaFrame.cpp:638
 msgid "&Copy\tCtrl+C"
-msgstr ""
+msgstr "&Copier\tCtrl+C"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "&Demoivre"
-msgstr ""
+msgstr "&Demoivre"
 
 #: ../../src/wxMaximaFrame.cpp:1362
 msgid "&Determinant"
-msgstr ""
+msgstr "&Déterminant"
 
 #: ../../src/wxMaximaFrame.cpp:1466
 msgid "&Differentiate..."
-msgstr ""
+msgstr "&Dériver…"
 
 #: ../../src/wxMaximaFrame.cpp:689
 msgid "&Edit"
-msgstr ""
+msgstr "&Édition"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "&Eliminate Variable..."
-msgstr ""
+msgstr "&Éliminer une variable…"
 
 #: ../../src/wxMaximaFrame.cpp:1318
 msgid "&Enter Matrix..."
-msgstr ""
+msgstr "&Entrer une matrice…"
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "&Example..."
-msgstr ""
+msgstr "&Exemple..."
 
 #: ../../src/wxMaximaFrame.cpp:1524
 msgid "&Expand Expression"
-msgstr ""
+msgstr "Dév&elopper une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1597
 msgid "&Expand Trigonometric"
-msgstr ""
+msgstr "Dév&elopper une expression trigonométrique"
 
 #: ../../src/wxMaximaFrame.cpp:1626
 msgid "&Exponentialize"
-msgstr ""
+msgstr "&Mettre sous forme exponentielle"
 
 #: ../../src/wxMaximaFrame.cpp:618
 msgid "&Export..."
-msgstr ""
+msgstr "&Exporter..."
 
 #: ../../src/wxMaximaFrame.cpp:1516
 msgid "&Factor Expression"
-msgstr ""
+msgstr "&Factoriser une expression"
 
 #: ../../src/wxMaximaFrame.cpp:626
 msgid "&File"
-msgstr ""
+msgstr "&Fichier"
 
 #: ../../src/wxMaximaFrame.cpp:1019
 msgid "&Functions"
-msgstr ""
+msgstr "Fonctions"
 
 #: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Greatest Common Divisor..."
-msgstr ""
+msgstr "Plus &grand diviseur commun…"
 
 #: ../../src/wxMaximaFrame.cpp:1968
 msgid "&Help"
-msgstr ""
+msgstr "&Aide"
 
 #: ../../src/wxMaximaFrame.cpp:1453
 msgid "&Integrate..."
-msgstr ""
+msgstr "&Intégrer…"
 
 #: ../../src/wxMaximaFrame.cpp:964
 msgid "&Interrupt\tCtrl+G"
-msgstr ""
+msgstr "&Interrompre\tCtrl+G"
 
 #: ../../src/wxMaximaFrame.cpp:1355
 msgid "&Invert Matrix"
-msgstr ""
+msgstr "&Inverser la matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "&License"
-msgstr ""
+msgstr "&Licence"
 
 #: ../../src/wxMaximaFrame.cpp:1763
 msgid "&List"
-msgstr ""
+msgstr "&Liste"
 
 #: ../../src/wxMaximaFrame.cpp:610
 msgid "&Load Package...\tCtrl+L"
-msgstr ""
+msgstr "&Charger un paquetage\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "&Maxima"
-msgstr ""
+msgstr "&Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "&Maxima help"
-msgstr ""
+msgstr "&Aide de Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1660
 msgid "&Modulus Computation..."
-msgstr ""
+msgstr "Calcul &modulaire…"
 
 #: ../../src/main.cpp:435
 msgid "&New\tCtrl+N"
-msgstr ""
+msgstr "&Nouveau\tCtrl+N"
 
 #: ../../src/wxMaximaFrame.cpp:1870
 msgid "&Numeric"
-msgstr ""
+msgstr "&Numérique"
 
 #: ../../src/wxMaximaFrame.cpp:1785
 msgid "&Numeric Output"
-msgstr ""
+msgstr "&Sortie numérique"
 
 #: ../../src/main.cpp:436
 msgid "&Open\tCtrl+O"
-msgstr ""
+msgstr "&Ouvrir une session\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "&Open...\tCtrl+O"
-msgstr ""
+msgstr "&Ouvrir une session\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "&Plot"
-msgstr ""
+msgstr "Tracé de courbes"
 
 #: ../../src/wxMaximaFrame.cpp:622
 msgid "&Print...\tCtrl+P"
-msgstr ""
+msgstr "Im&primer\tCtrl+P"
 
 #: ../../src/wxMaximaFrame.cpp:1594
 msgid "&Reduce Trigonometric"
-msgstr ""
+msgstr "&Réduire une expression trigonométrique"
 
 #: ../../src/wxMaximaFrame.cpp:974
 msgid "&Restart Maxima\tCtrl+Alt+R"
-msgstr ""
+msgstr "&Redémarrer Maxima\tCtrl+Alt+R"
 
 #: ../../src/wxMaximaFrame.cpp:608
 msgid "&Save\tCtrl+S"
-msgstr ""
+msgstr "&Sauvegarder la session\tCtrl+S"
 
 #: ../../src/wxMaximaFrame.cpp:1662
 msgid "&Simplify"
-msgstr ""
+msgstr "&Simplifier"
 
 #: ../../src/wxMaximaFrame.cpp:1581
 msgid "&Simplify Factorials"
-msgstr ""
+msgstr "&Simplifier les factorielles"
 
 #: ../../src/wxMaximaFrame.cpp:1591
 msgid "&Simplify Trigonometric"
-msgstr ""
+msgstr "&Simplifier une expression trigonométrique"
 
 #: ../../src/wxMaximaFrame.cpp:1238
 msgid "&Solve..."
-msgstr ""
+msgstr "&Résoudre…"
 
 #: ../../src/wxMaximaFrame.cpp:1035
 msgid "&Time Display"
-msgstr ""
+msgstr "Affichage du &temps"
 
 #: ../../src/wxMaximaFrame.cpp:1375
 msgid "&Transpose Matrix"
-msgstr ""
+msgstr "&Transposer une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1605
 msgid "&Trigonometric Simplification"
-msgstr ""
+msgstr "Simplification &trigonométrique"
 
 #: ../../src/wxMaximaFrame.cpp:1021
 msgid "&Variables"
-msgstr ""
+msgstr "&Variables"
 
 #: ../../src/wxMaxima.cpp:2443
 msgid "(Config tells to suppress the output of long cells)"
 msgstr ""
+"(La configuration indique de supprimer la sortie des cellules longues)"
 
 #: ../../src/MathParser.cpp:1288
 msgid "(Invalid XML from maxima)"
-msgstr ""
+msgstr "(XML invalide provenant de maxima)"
 
 #: ../../src/wxMaxima.cpp:4221
 msgid "(Maybe a permission problem?)"
-msgstr ""
+msgstr "(Peut-être un problème de permission ?)"
 
 #: ../../src/wxMaxima.cpp:9248
 msgid "(f(x),x,a,b)), Epsilon algorithm"
-msgstr ""
+msgstr "(f(x), x, a, b), Algorithme Epsilon"
 
 #: ../../src/wxMaxima.cpp:9235
 msgid "(f(x),x,a,b)), Strategy of Aind"
-msgstr ""
+msgstr "(f(x), x, a, b), Stratégie de Aitken"
 
 #: ../../src/wxMaxima.cpp:9258
 msgid "(f(x),x,a,b), (semi-) infinite interval"
-msgstr ""
+msgstr "(f(x), x, a, b), intervalle (semi-)infini"
 
 #: ../../src/wxMaximaFrame.cpp:1841
 msgid "(f(x),x,a,b), Epsilon algorithm"
-msgstr ""
+msgstr "(f(x),x,a,b), algorithme Epsilon"
 
 #: ../../src/wxMaximaFrame.cpp:1843
 msgid "(f(x),x,a,b), infinite interval"
-msgstr ""
+msgstr "(f(x), x, a, b), intervalle infini"
 
 #: ../../src/wxMaximaFrame.cpp:1839
 msgid "(f(x),x,a,b), strategy of Aind"
-msgstr ""
+msgstr "(f(x), x, a, b), Stratégie de Aitken"
 
 #: ../../src/wxMaxima.cpp:9361 ../../src/wxMaximaFrame.cpp:1867
 msgid "(f(x),x,y) with singularities+discontinuities"
-msgstr ""
+msgstr "(f(x), x, y) avec singularités+discontinuités"
 
 #: ../../src/wxMaxima.cpp:2065
 msgid ""
 "... [suppressed additional lines as the output is longer than allowed in the"
 " wxMaxima configuration] "
 msgstr ""
+"... [lignes supplémentaires masquées car la sortie dépasse la limite "
+"autorisée dans la configuration de wxMaxima] "
 
 #: ../../src/Worksheet.cpp:6666
 msgid ".wxm clipboard data with unusual header"
-msgstr ""
+msgstr "Données du presse-papiers .wxm avec un en-tête inhabituel"
 
 #: ../../src/wxMaxima.cpp:8047
 msgid "1×n Matrix b:"
-msgstr ""
+msgstr "Matrice b de taille 1×n :"
 
 #: ../../src/wxMaximaFrame.cpp:1312
 msgid "2D Array to Matrix..."
-msgstr ""
+msgstr "Tableau 2D vers Matrice..."
 
 #: ../../src/wxMaximaFrame.cpp:743
 msgid "2D equations using ASCII Art"
-msgstr ""
+msgstr "Équations 2D utilisant ASCII-Art"
 
 #: ../../src/wxMaximaFrame.cpp:746
 msgid "2D equations using ASCII Art with unicode characters, if available"
 msgstr ""
+"Équations 2D utilisant ASCII-Art avec caractères Unicode, si disponibles"
 
 #: ../../src/wxMaxima.cpp:5057
 #, c-format
 msgid "; %i commands left in the current cell"
-msgstr ""
+msgstr "; commandes %i restantes dans la cellule actuelle"
 
 #: ../../src/wxMaxima.cpp:10617
 msgid "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
+"Un \" :lisp \" en tant que première commande peut échouer à envoyer un "
+"signal \"terminé\"."
 
 #: ../../src/wxMaxima.cpp:6585
 msgid "A Ctrl-F event"
-msgstr ""
+msgstr "Un événement Ctrl-F"
 
 #: ../../src/Worksheet.cpp:1973
 msgid "A Scalar"
-msgstr ""
+msgstr "Un scalaire"
 
 #: ../../src/wxMaxima.cpp:6653
 #, c-format
 msgid "A find event, %s"
-msgstr ""
+msgstr "Un événement de recherche, %s"
 
 #: ../../src/Worksheet.cpp:2012
 msgid "A function returning integers"
-msgstr ""
+msgstr "Une fonction qui renvoie des entiers"
 
 #: ../../src/Worksheet.cpp:2014
 msgid "A function returning positive numbers"
-msgstr ""
+msgstr "Une fonction qui renvoie des entiers positifs"
 
 #: ../../src/Worksheet.cpp:1965
 msgid "A irrational variable"
-msgstr ""
+msgstr "Une variable irrationnelle"
 
 #: ../../src/Worksheet.cpp:2016
 msgid "A left-associative function"
-msgstr ""
+msgstr "Une fonction associative à gauche"
 
 #: ../../src/Worksheet.cpp:2019
 msgid "A linear function"
-msgstr ""
+msgstr "Une fonction linéaire"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "A matrix in which each row is a set of variables"
 msgstr ""
+"Une matrice dans laquelle chaque ligne représente un ensemble de variables"
 
 #: ../../src/Worksheet.cpp:1963
 msgid "A rational variable"
-msgstr ""
+msgstr "Une variable rationnelle"
 
 #: ../../src/Worksheet.cpp:2018
 msgid "A right-associative function"
-msgstr ""
+msgstr "Une fonction associative à droite"
 
 #: ../../src/wxMaximaFrame.cpp:1634
 msgid "A search-and-replace for equations"
-msgstr ""
+msgstr "Un recherche-remplacer pour les équations"
 
 #: ../../src/wxMaximaFrame.cpp:1636
 msgid "A subst with basic maths knowledge"
-msgstr ""
+msgstr "Un subst avec des connaissances de base en mathématiques"
 
 #: ../../src/BTextCtrl.cpp:64
 msgid "A text control got the mouse focus"
-msgstr ""
+msgstr "Un contrôle de texte a reçu le focus de la souris"
 
 #: ../../src/wxMaximaFrame.cpp:1442
 msgid "A&pply function to each Matrix element..."
-msgstr ""
+msgstr "A&ppliquer une fonction à chaque élément d'une matrice..."
 
 #: ../../src/wxMaximaFrame.cpp:1291
 msgid "A&t Value..."
-msgstr ""
+msgstr "A la valeur..."
 
 #: ../../src/Configuration.cpp:85
 msgid "ASCII maths"
-msgstr ""
+msgstr "Maths au format ASCII"
 
 #: ../../src/wxMaximaFrame.cpp:1963
 msgid "About"
-msgstr ""
+msgstr "À propos"
 
 #: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
 msgid "About wxMaxima"
-msgstr ""
+msgstr "À propos de wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7837
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
-msgstr ""
+msgstr "Accepte une expression ou une liste au format [ode1, ode2, ...]"
 
 #: ../../src/wxMaxima.cpp:7841
 msgid "Accepts one variable or a list in the format [1,4,...]"
-msgstr ""
+msgstr "Accepte une variable ou une liste au format [1, 4, ...]"
 
 #: ../../src/wxMaxima.cpp:7839
 msgid "Accepts one variable or a list in the format [var1,var2,...]"
-msgstr ""
+msgstr "Accepte une variable ou une liste au format [var1,var2,...]"
 
 #: ../../src/wxMaximaFrame.cpp:1371
 msgid "Ad&joint Matrix"
-msgstr ""
+msgstr "Matrice ad&jointe"
 
 #: ../../src/wxMaximaFrame.cpp:1657
 msgid "Add Algebraic E&quality..."
-msgstr ""
+msgstr "Ajouter une égalité algébri&que..."
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add a directory to search path"
-msgstr ""
+msgstr "Ajouter un répertoire au chemin de recherche"
 
 #: ../../src/wxMaximaFrame.cpp:1752
 msgid ""
 "Add a new item to the beginning of the list. Useful for creating stacks."
 msgstr ""
+"Ajouter un nouvel élément au début de la liste. Utile pour créer des piles."
 
 #: ../../src/wxMaxima.cpp:8602
 msgid "Add an element to the end of a list"
-msgstr ""
+msgstr "Ajouter un élément à la fin d'une liste"
 
 #: ../../src/wxMaxima.cpp:8597
 msgid "Add an element to the start of a list"
-msgstr ""
+msgstr "Ajouter un élément au début d'une liste."
 
 #: ../../src/wxMaxima.cpp:7625
 msgid "Add dir to path:"
-msgstr ""
+msgstr "Ajouter le répertoire au chemin:"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "Add equality to the rational simplifier"
-msgstr ""
+msgstr "Prendre en compte l’égalité dans la simplification rationnelle"
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add to &Path..."
-msgstr ""
+msgstr "Ajouter au &chemin..."
 
 #: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
 #: ../../src/Worksheet.cpp:1704
 msgid "Add to watchlist"
-msgstr ""
+msgstr "Ajouter à la liste de surveillance"
 
 #: ../../src/wxMaximaFrame.cpp:1562
 msgid "Additionally: log(a*b)=log(a)+log(b)"
-msgstr ""
+msgstr "De plus : log(a*b)=log(a)+log(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1566
 msgid "Additionally: log(a/b)=log(a)-log(b), a and b positive integers"
 msgstr ""
+"De plus : log(a/b) = log(a) – log(b), où a et b sont des entiers positifs"
 
 #: ../../src/Worksheet.cpp:1996
 msgid "Additive function: f(a+b)=f(a)+f(b)"
-msgstr ""
+msgstr "Fonction additive : f(a+b)=f(a)+f(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1911
 msgid "Advanced 2d plotting"
-msgstr ""
+msgstr "Tracé avancé en 2D"
 
 #: ../../src/wxMaximaFrame.cpp:1809
 msgid "Advanced guess (PSLQ algorithm)"
-msgstr ""
+msgstr "Estimation avancée (algorithme PSLQ)"
 
 #: ../../src/wxMaximaFrame.cpp:1920
 msgid "Advanced variable names"
-msgstr ""
+msgstr "Noms de variables avancés"
 
 #: ../../src/ToolBar.cpp:321 ../../src/ToolBar.cpp:589
 msgid ""
 "After clicking on animations created with with_slider_draw() or similar this"
 " slider allows to change the current frame."
 msgstr ""
+"Après avoir cliqué sur les animations créées avec with_slider_draw() ou "
+"similaires, ce curseur permet de changer l'image actuelle."
 
 #: ../../src/wxMaximaFrame.cpp:1028
 msgid "Aliases"
-msgstr ""
+msgstr "Alias"
 
 #: ../../src/wxMaximaFrame.cpp:1714
 msgid "All but the 1st n elements"
-msgstr ""
+msgstr "Tous les éléments sauf les n premiers"
 
 #: ../../src/wxMaximaFrame.cpp:1716
 msgid "All but the last n elements"
-msgstr ""
+msgstr "Tous les éléments sauf les n derniers"
 
 #: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
 msgid ""
@@ -551,93 +572,101 @@ msgid ""
 "*.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session "
 "(*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr ""
+"Tous les types de documents pouvant être ouverts (*.wxm, *.wxmx, *.mac, "
+"*.out, *.xml)|*.wxm;*.wxmx;*.mac;*.out;*.xml|wxMaxima document (*.wxm, "
+"*.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session "
+"(*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 
 #: ../../src/wxMaximaFrame.cpp:733
 msgid "All visible sidebars"
-msgstr ""
+msgstr "Toutes les barres latérales visibles"
 
 #: ../../src/wxMaximaFrame.cpp:1650
 msgid "Allow to substitute operators"
-msgstr ""
+msgstr "Autoriser la substitution des opérateurs"
 
 #: ../../src/wxMaxima.cpp:9040
 msgid ""
 "Allows to vary the parameters of a function until it fits experimental data."
 msgstr ""
+"Permet de faire varier les paramètres d'une fonction jusqu'à ce qu'elle "
+"corresponde aux données expérimentales."
 
 #: ../../src/wxMaximaFrame.cpp:763
 msgid "Always after underscores"
-msgstr ""
+msgstr "Toujours après les tirets bas"
 
 #: ../../src/wxMaximaFrame.cpp:764
 msgid "Always autosubscript after an underscore"
-msgstr ""
+msgstr "Toujours mettre en indice automatiquement après un tiret bas"
 
 #: ../../src/wxMaximaFrame.cpp:774
 msgid "Always display this variable with subscript"
-msgstr ""
+msgstr "Toujours afficher cette variable avec un indice"
 
 #: ../../src/Worksheet.cpp:1605
 msgid "Always show all digits"
-msgstr ""
+msgstr "Montrer toujours tous les chiffres"
 
 #: ../../src/wxMaxima.cpp:9241
 msgid ""
 "An integer between 1..6; Higher numbers work better for oscillating "
 "integrands"
 msgstr ""
+"Un entier entre 1 et 6 ; les valeurs plus élevées fonctionnent mieux pour "
+"les intégrandes oscillantes"
 
 #: ../../src/MaximaManual.cpp:385
 msgid "Anchors file has no top node."
-msgstr ""
+msgstr "Le fichier d'ancrages ne contient pas de nœud racine."
 
 #: ../../src/wxMaximaFrame.cpp:791
 msgid "Angles"
-msgstr ""
+msgstr "Angles"
 
 #: ../../src/wxMaximaFrame.cpp:1775
 msgid "Animation autoplay"
-msgstr ""
+msgstr "Lecture automatique de l'animation"
 
 #: ../../src/wxMaximaFrame.cpp:1778
 msgid "Animation framerate..."
-msgstr ""
+msgstr "Fréquence des images pour les animations..."
 
 #: ../../src/Worksheet.cpp:2002
 msgid "Antisymmetric function: f(x)=-f(-x)"
-msgstr ""
+msgstr "Fonction impaire : f(x)=-f(-x)"
 
 #: ../../src/wxMaximaFrame.cpp:1739
 msgid "Append"
-msgstr ""
+msgstr "Ajouter"
 
 #: ../../src/wxMaximaFrame.cpp:1735
 msgid "Append a list"
-msgstr ""
+msgstr "Ajouter une liste à la fin"
 
 #: ../../src/wxMaximaFrame.cpp:1736
 msgid "Append a list to an existing list"
-msgstr ""
+msgstr "Ajouter une liste à une liste existante"
 
 #: ../../src/wxMaxima.cpp:8607
 msgid "Append a list to another list"
-msgstr ""
+msgstr "Ajouter une liste à une autre liste"
 
 #: ../../src/wxMaximaFrame.cpp:1729
 msgid "Append an element"
-msgstr ""
+msgstr "Ajouter un élément"
 
 #: ../../src/wxMaximaFrame.cpp:1734
 msgid "Append an element to the beginning an existing list"
-msgstr ""
+msgstr "Ajouter un élément au début d'une liste existante"
 
 #: ../../src/wxMaximaFrame.cpp:1730
 msgid "Append an element to the end of an existing list"
-msgstr ""
+msgstr "Ajouter un élément à la fin d'une liste existante"
 
 #: ../../src/wxMaxima.cpp:8552
 msgid "Apply a function to each list element"
-msgstr ""
+msgstr "Appliquer une fonction à chaque élément d'une liste"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 #, c-format
@@ -645,204 +674,228 @@ msgid ""
 "Approximate by a fraction using log(), sqrt() and %pi, when needed. Only "
 "available in maxima > 5.46.0"
 msgstr ""
+"Approximation par une fraction en utilisant log(), sqrt() et %pi, si "
+"nécessaire. Disponible uniquement dans Maxima > 5.46.0"
 
 #: ../../src/wxMaximaFrame.cpp:1806
 msgid "Approximate by nice fraction"
-msgstr ""
+msgstr "Approximation par une fraction simple"
 
 #: ../../src/wxMaxima.cpp:8931
 msgid ""
 "Approximates a expression around a point as a polynom\n"
 "The trailing \"...\" can be removed by using ratdisrep()"
 msgstr ""
+"Approximation d'une expression autour d'un point par un polynôme.\n"
+"Les points de suspension finaux  \"...\" peuvent être supprimés en utilisant ratdisrep()"
 
 #: ../../src/wxMaxima.cpp:8939
 msgid "Approximates a expression as a polynom"
-msgstr ""
+msgstr "Approximation d'une expression par un polynôme"
 
 #: ../../src/wxMaxima.cpp:9474
 msgid "Apropos"
-msgstr ""
+msgstr "À propos"
 
 #: ../../src/wxMaxima.cpp:7317
 msgid "Are the chars equal, if case is ignored?"
-msgstr ""
+msgstr "Les caractères sont-ils égaux, si la casse est ignorée ?"
 
 #: ../../src/wxMaxima.cpp:7312
 msgid "Are the chars equal?"
-msgstr ""
+msgstr "Les caractères sont-ils égaux ?"
 
 #: ../../src/wxMaxima.cpp:7349
 msgid "Are these strings equal if case is ignored?"
-msgstr ""
+msgstr "Ces chaînes de caractères sont-elles égales si on ignore la casse ?"
 
 #: ../../src/wxMaxima.cpp:7344
 msgid "Are these strings equal?"
-msgstr ""
+msgstr "Ces chaînes de caractères sont-elles égales ?"
 
 #: ../../src/wxMaxima.cpp:7259
 msgid "Arguments:"
-msgstr ""
+msgstr "Arguments :"
 
 #: ../../src/wxMaxima.cpp:8189
 msgid "Array"
-msgstr ""
+msgstr "Tableau"
 
 #: ../../src/wxMaximaFrame.cpp:1023
 msgid "Arrays"
-msgstr ""
+msgstr "Tableaux"
 
 #: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
 msgid "Ascii code to char"
-msgstr ""
+msgstr "Code ASCII pour le caractère"
 
 #: ../../src/wxMaximaFrame.cpp:1138
 msgid "Ascii code to char..."
-msgstr ""
+msgstr "Code ASCII pour le caractère..."
 
 #: ../../src/wxMaxima.cpp:10063
 msgid "Assignment(s):"
-msgstr ""
+msgstr "Affectation(s) :"
 
 #: ../../src/wxMaxima.cpp:10064
 msgid "Assignments of the format a=10,b=20"
-msgstr ""
+msgstr "Affectations au format a=10, b=20"
 
 #: ../../src/wxMaxima.cpp:6851
 msgid "Assume a value range for a variable"
-msgstr ""
+msgstr "Préciser l'intervalle de valeurs pour une variable"
 
 #: ../../src/wxMaxima.cpp:8545
 msgid ""
 "Attention: Extracting a random list element isn't efficient for long "
 "lists.Iterating over lists using makelist() or for loops is way faster."
 msgstr ""
+"Attention : extraire un élément aléatoire d'une liste n'est pas efficace "
+"pour les longues listes. Parcourir les listes avec makelist() ou des boucles"
+" `for` est bien plus rapide."
 
 #: ../../src/Worksheet.cpp:1618
 msgid "Automatic labels"
-msgstr ""
+msgstr "Étiquettes automatiques"
 
 #: ../../src/wxMaximaFrame.cpp:952
 msgid "Automatically answer questions"
-msgstr ""
+msgstr "Répondre automatiquement aux questions"
 
 #: ../../src/wxMaximaFrame.cpp:953
 msgid "Automatically fill in answers known from the last run"
 msgstr ""
+"Remplir automatiquement les réponses connues à partir de la dernière "
+"exécution"
 
 #: ../../src/Worksheet.cpp:1464 ../../src/Worksheet.cpp:1838
 msgid "Automatically send known answers"
-msgstr ""
+msgstr "Envoyer automatiquement les réponses connues"
 
 #: ../../src/wxMaxima.cpp:6021
 #, c-format
 msgid "Autosaving as temp file %s"
-msgstr ""
+msgstr "Sauvegarde automatique dans un fichier temporaire %s"
 
 #: ../../src/wxMaxima.cpp:6033
 #, c-format
 msgid "Autosaving the .wxmx file as %s"
-msgstr ""
+msgstr "Sauvegarde automatique du fichier .wxmx sous %s"
 
 #: ../../src/wxMaximaFrame.cpp:781
 msgid "Autosubscript"
-msgstr ""
+msgstr "Mettre en indice de manière automatique"
 
 #: ../../src/wxMaximaFrame.cpp:782
 msgid "Autosubscript chars after an underscore"
-msgstr ""
+msgstr "Mettre en indice automatiquement les caractères après un tiret bas"
 
 #: ../../src/wxMaximaFrame.cpp:767
 msgid "Autosubscript numbers and text following single letters"
 msgstr ""
+"Mettre en indice automatiquement les nombres et le texte suivant des lettres"
+" simples"
 
 #: ../../src/wxMaxima.cpp:6529
 msgid "Autosubscript this variable"
-msgstr ""
+msgstr "Mettre en indice cette variable"
 
 #: ../../src/MaximaManual.cpp:536
 msgid "Background task that compiles the Manual anchors scheduled."
-msgstr ""
+msgstr "Tâche en arrière-plan qui compile les ancres du manuel planifiée."
 
 #: ../../src/wxMaximaFrame.cpp:1350
 msgid "Basic matrix operations"
-msgstr ""
+msgstr "Opérations de base sur les matrices"
 
 #: ../../src/wxMaxima.cpp:6210
 msgid "Batch File"
-msgstr ""
+msgstr "Fichier batch"
 
 #: ../../src/wxMaxima.cpp:5318
 msgid "Both horizontal and vertical cursor active at the same time"
-msgstr ""
+msgstr "Les curseurs horizontal et vertical sont actifs simultanément"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Bottom end"
-msgstr ""
+msgstr "Extrémité inférieure"
 
 #: ../../src/wxMaxima.cpp:7817
 msgid "Boundary value problem"
-msgstr ""
+msgstr "Problème aux limites"
 
 #: ../../src/wxMathml.cpp:101
 msgid ""
 "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
 msgstr ""
+"Bug : Après la suppression des espaces blancs, wxMathml.lisp est plus court "
+"que prévu !"
 
 #: ../../src/Autocomplete.cpp:509
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
+"Bug : Complétion automatique est demandée pour un type d'élément inconnu."
 
 #: ../../src/Worksheet.cpp:2992
 msgid "Bug: Cell left but not entered."
-msgstr ""
+msgstr "Bug : Cellule quittée mais non validée."
 
 #: ../../src/Worksheet.cpp:6203
 msgid "Bug: Cell with negative y position!"
-msgstr ""
+msgstr "Bug : Cellule avec une position y négative !"
 
 #: ../../src/Worksheet.cpp:7723
 msgid ""
 "Bug: Encountered a heading I don't know how to move in one sectioning unit"
 msgstr ""
+"Bug : wxMaxima rencontre un titre qu'il ne sait pas comment déplacer dans "
+"une unité de sectionnement"
 
 #: ../../src/Worksheet.cpp:7766
 msgid ""
 "Bug: Encountered a heading I don't know how to move out one sectioning unit"
 msgstr ""
+"Bug : wxMaxima rencontre un titre qu'il ne sait pas comment enlever d'une "
+"unité de sectionnement"
 
 #: ../../src/Worksheet.cpp:3112
 msgid "Bug: Got a question but no cell to answer it in"
-msgstr ""
+msgstr "Bug : Question reçue mais aucune cellule pour y répondre"
 
 #: ../../src/Worksheet.cpp:6378
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of"
 " the worksheet."
 msgstr ""
+"Bug : wxMaxima a reçu une demande  pour modifier les contenus de la cellule "
+"avant le début du notebook."
 
 #: ../../src/Worksheet.cpp:6346
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
+"Bug : wxMaxima a reçu une demande  pour supprimer la cellule avant le début "
+"du notebook."
 
 #: ../../src/Worksheet.cpp:6415
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
 msgstr ""
+"Bug : wxMaxima a reçu une demande pour modifier le contenu d'une cellule "
+"puis supprimer cette modification."
 
 #: ../../src/Worksheet.cpp:5578
 msgid "Bug: HTML output is no valid XML"
-msgstr ""
+msgstr "Bug : La sortie HTML n'est pas au format XML valide"
 
 #: ../../src/Configuration.h:615
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
-msgstr ""
+msgstr "Bug : Le nombre maximal de chiffres à afficher est trop petit !"
 
 #: ../../src/MathParser.cpp:523
 msgid "Bug: Missing contents"
-msgstr ""
+msgstr "Bug : contenus manquants"
 
 #: ../../src/Worksheet.cpp:2597 ../../src/Worksheet.cpp:2711
 #: ../../src/Worksheet.cpp:2753 ../../src/Worksheet.cpp:2787
@@ -850,135 +903,147 @@ msgstr ""
 #: ../../src/Worksheet.cpp:4442 ../../src/Worksheet.cpp:6650
 #: ../../src/Worksheet.cpp:6863
 msgid "Bug: The clipboard is already opened"
-msgstr ""
+msgstr "Le presse-papiers est déjà ouvert"
 
 #: ../../src/Worksheet.cpp:7763
 msgid "Bug: Trying to move a title out by one sectioning unit"
 msgstr ""
+"Bug : Tentative de déplacer un titre en dehors de l’une unité de "
+"sectionnement"
 
 #: ../../src/Worksheet.cpp:6934
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
+"Bug : Tentative de déplacer le curseur horizontal l’intérieur d’un "
+"groupement de cellules."
 
 #: ../../src/Worksheet.h:247 ../../src/Worksheet.h:252
 msgid "Bug: Trying to record a cell contents change for undo without a cell."
 msgstr ""
+"Bug : Tentative d’enregistrer une modification du contenu d'une cellule en "
+"l'annulant sans cellule associée."
 
 #: ../../src/Worksheet.cpp:6417
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
+"Bug : Demande d'annulation combinant une modification du contenu d'une "
+"cellule et simultanément un ajout de cellule."
 
 #: ../../src/Worksheet.cpp:6383
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
+"Bug : Demande d'annulation pour une cellule qui n'est pas dans le notebook."
 
 #: ../../src/wxMaximaFrame.cpp:1948
 msgid "Build &Info"
-msgstr ""
+msgstr "Informations sur la compilation"
 
 #: ../../src/wxMaxima.cpp:7275
 msgid "Byte:"
-msgstr ""
+msgstr "Octet :"
 
 #: ../../src/wxMaximaFrame.cpp:1458
 msgid "C&hange Variable in Integrate..."
-msgstr ""
+msgstr "C&hanger de variable dans l'intégrale…"
 
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "C&onfigure"
-msgstr ""
+msgstr "C&onfigurer"
 
 #: ../../src/wxMaximaFrame.cpp:1482
 msgid "Calculate &Product..."
-msgstr ""
+msgstr "Calculer le &produit…"
 
 #: ../../src/wxMaxima.cpp:8057
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
 msgstr ""
+"Calculer numériquement la décomposition en valeurs singulières d'une matrice"
 
 #: ../../src/wxMaxima.cpp:8050
 msgid ""
 "Calculate Singular Value Decomposition, left and right singular vectors "
 "numerically"
 msgstr ""
+"Calculer numériquement la décomposition en valeurs singulières, ainsi que "
+"les vecteurs singuliers gauche et droit"
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate Su&m..."
-msgstr ""
+msgstr "Calculer la som&me…"
 
 #: ../../src/wxMaximaFrame.cpp:1795
 msgid "Calculate bigfloat value of the last result"
-msgstr ""
+msgstr "Calculer la valeur approchée (bigfloat) du dernier résultat"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Calculate float value of the last result"
-msgstr ""
+msgstr "Calculer une valeur approchée du dernier résultat"
 
 #: ../../src/wxMaxima.cpp:9550
 msgid "Calculate mean value"
-msgstr ""
+msgstr "Calculer la valeur moyenne"
 
 #: ../../src/wxMaxima.cpp:9554
 msgid "Calculate median value"
-msgstr ""
+msgstr "Calculer la valeur de la médiane"
 
 #: ../../src/wxMaxima.cpp:8871
 msgid "Calculate modulus:"
-msgstr ""
+msgstr "Calculer le module :"
 
 #: ../../src/wxMaximaFrame.cpp:1798
 msgid "Calculate numeric value of the last result"
-msgstr ""
+msgstr "Calculer une valeur approchée du dernier résultat"
 
 #: ../../src/wxMaximaFrame.cpp:1483
 msgid "Calculate products"
-msgstr ""
+msgstr "Calculer les produits"
 
 #: ../../src/wxMaxima.cpp:9562
 msgid "Calculate standard deviation"
-msgstr ""
+msgstr "Calculer l'écart type"
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate sums"
-msgstr ""
+msgstr "Calculer les sommes"
 
 #: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
 msgid "Calculate the eigenvalues and eigenvectors numerically"
-msgstr ""
+msgstr "Calculer numériquement les valeurs propres et les vecteurs propres"
 
 #: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
 msgid "Calculate the eigenvalues of a matrix numerically"
-msgstr ""
+msgstr "Calculer numériquement les valeurs propres"
 
 #: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
 msgid "Calculate the root of the sum of squares of matrix entries"
-msgstr ""
+msgstr "Calculer la racine de la somme des carrés des éléments d'une matrice"
 
 #: ../../src/wxMaxima.cpp:9558
 msgid "Calculate variation"
-msgstr ""
+msgstr "Calculer la variation"
 
 #: ../../src/wxMaxima.cpp:8949
 msgid "Calculates the fourier coefficients for the expression from -p to p"
-msgstr ""
+msgstr "Calculer les coefficients de Fourier de l'expression entre -p et p"
 
 #: ../../src/Worksheet.cpp:1968
 msgid "Calls assume() in order to tell maxima about the variable's range"
-msgstr ""
+msgstr "Appeller assume() pour indiquer à Maxima la plage pour la variable"
 
 #: ../../src/Worksheet.cpp:2031
 msgid "Can be specified as flag in ev(exp, flag)"
-msgstr ""
+msgstr "Peut être spécifié comme indicateur dans ev(exp, indicateur)"
 
 #: ../../src/wxMaxima.cpp:11125
 msgid "Can not connect to the web server."
-msgstr ""
+msgstr "Impossible de se connecter au serveur web."
 
 #: ../../src/wxMaxima.cpp:11166
 msgid "Can not download version info."
-msgstr ""
+msgstr "Impossible de télécharger les informations de cette version."
 
 #: ../../src/wxMaxima.cpp:3016 ../../src/wxMaxima.cpp:4836
 msgid ""
@@ -986,149 +1051,157 @@ msgid ""
 " (it can be downloaded from https://maxima.sourceforge.io) or in wxMaxima's "
 "config dialogue the setting for Maxima's location is wrong."
 msgstr ""
+"Impossible de démarrer Maxima. La cause la plus probable est que Maxima "
+"n'est pas installé (il peut être téléchargé depuis "
+"[maxima.sourceforge.io](https://maxima.sourceforge.io)) ou que le chemin "
+"d'accès à Maxima est incorrect dans la configuration de wxMaxima."
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Cancel"
-msgstr ""
+msgstr "Annuler"
 
 #: ../../src/wxMaxima.cpp:3292
 msgid "Cannot authenticate Maxima!"
-msgstr ""
+msgstr "Impossible d'authentifier Maxima !"
 
 #: ../../src/wxMaxima.cpp:2677
 msgid ""
 "Cannot find a maxima binary and no binary chosen in the config dialogue."
 msgstr ""
+"Impossible de trouver l'exécutable pour Maxima et aucun fichier exécutable "
+"n'a été sélectionné dans la boîte de dialogue de configuration."
 
 #: ../../src/Autocomplete.cpp:583
 #, c-format
 msgid "Cannot interpret template %s"
-msgstr ""
+msgstr "Impossible d'interpréter le modèle \"%s\""
 
 #: ../../src/wxMaxima.cpp:3082
 #, c-format
 msgid "Cannot interpret the numeric value of pid %s"
-msgstr ""
+msgstr "Impossible d'interpréter la valeur numérique du pid %s"
 
 #: ../../src/wxMaxima.cpp:11066 ../../src/wxMaxima.cpp:11073
 #: ../../src/wxMaxima.cpp:11080
 #, c-format
 msgid "Cannot interpret version number component %s"
-msgstr ""
+msgstr "Impossible d'interpréter le composant du numéro de version %s"
 
 #: ../../src/wxMaxima.cpp:2530
 msgid "Cannot set the communication address to localhost."
-msgstr ""
+msgstr "Impossible de définir l’adresse de communication pour localhost."
 
 #: ../../src/wxMaxima.cpp:2532
 #, c-format
 msgid "Cannot set the communication port to %i."
-msgstr ""
+msgstr "Impossible de définir le port de communication pour %i."
 
 #: ../../src/wxMaxima.cpp:3656 ../../src/wxMaxima.cpp:6359
 msgid "Cannot start gnuplot"
-msgstr ""
+msgstr "Imposssible de démarrer gnuplot"
 
 #: ../../src/StatusBar.cpp:216 ../../src/wxMaxima.cpp:2662
 msgid "Cannot start the maxima binary"
-msgstr ""
+msgstr "Impossible de démarrer l'exécutable de maxima"
 
 #: ../../src/wxMaxima.cpp:9268
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
-msgstr ""
+msgstr "Valeur principale de Cauchy de f(x)/(x-c), intervalle fini"
 
 #: ../../src/wxMaximaFrame.cpp:1845
 msgid "Cauchy principal value, finite interval"
-msgstr ""
+msgstr "Valeur principale de Cauchy, intervalle fini"
 
 #: ../../src/wxMaximaFrame.cpp:955
 msgid "Ce&ll"
-msgstr ""
+msgstr "Ce&llule"
 
 #: ../../src/Configuration.cpp:96
 msgid "Cell bracket fill, Active"
-msgstr ""
+msgstr "Remplissage des crochets de cellule, Actif"
 
 #: ../../src/Configuration.cpp:95
 msgid "Cell bracket fill, Inactive"
-msgstr ""
+msgstr "Remplissage des crochets de cellule, Inactif"
 
 #: ../../src/wxMaxima.cpp:10395
 msgid "Cell ends in a backslash"
-msgstr ""
+msgstr "La cellule se termine par un antislash"
 
 #: ../../src/wxMaximaFrame.cpp:1038
 msgid "Change &2d Display"
-msgstr ""
+msgstr "Basculer en affichage &2d"
 
 #: ../../src/wxMaxima.cpp:10146
 msgid "Change Image"
-msgstr ""
+msgstr "Changer l'image"
 
 #: ../../src/Worksheet.cpp:1324
 msgid "Change Image..."
-msgstr ""
+msgstr "Changer l'image..."
 
 #: ../../src/wxMaximaFrame.cpp:1954
 msgid "Change Log"
-msgstr ""
+msgstr "Journal des modifications"
 
 #: ../../src/wxMaxima.cpp:7555
 msgid "Change directory"
-msgstr ""
+msgstr "Changer de répertoire"
 
 #: ../../src/wxMaximaFrame.cpp:1202
 msgid "Change directory..."
-msgstr ""
+msgstr "Changer de répertoire..."
 
 #: ../../src/wxMaximaFrame.cpp:1039
 msgid "Change the 2d display algorithm used to display math output"
-msgstr ""
+msgstr "Modifier l'algorithme d'affichage 2d utilisé pour les mathématiques"
 
 #: ../../src/wxMaxima.cpp:8885
 msgid "Change variable"
-msgstr ""
+msgstr "Changer la variable"
 
 #: ../../src/wxMaxima.cpp:8905
 msgid "Change variable and evaluate"
-msgstr ""
+msgstr "Changer la variable et calculer"
 
 #: ../../src/wxMaximaFrame.cpp:1459
 msgid "Change variable in integral or sum"
-msgstr ""
+msgstr "Change la variable dans l'intégrale ou la somme"
 
 #: ../../src/wxMaximaFrame.cpp:1463
 msgid "Change variable in integral or sum and evaluate the result"
 msgstr ""
+"Remplacer la variable dans l'intégrale ou la somme et évaluer le résultat"
 
 #: ../../src/wxMaximaFrame.cpp:1026
 msgid "Changed option variables"
-msgstr ""
+msgstr "Options pour les variables modifiées"
 
 #: ../../src/wxMaxima.cpp:10170
 #, c-format
 msgid "Changing image originally loaded from file %s to %s."
 msgstr ""
+"Modification de l'image initialement chargée depuis le fichier %s en %s."
 
 #: ../../src/wxMaxima.cpp:7313 ../../src/wxMaxima.cpp:7318
 #: ../../src/wxMaxima.cpp:7323 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7334 ../../src/wxMaxima.cpp:7340
 msgid "Char #1:"
-msgstr ""
+msgstr "Caractère n°1 :"
 
 #: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
 #: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
 msgid "Char #2:"
-msgstr ""
+msgstr "Caractère n°2 :"
 
 #: ../../src/wxMaximaFrame.cpp:1140
 msgid "Char to Unicode code point..."
-msgstr ""
+msgstr "Caractère vers un point de code Unicode..."
 
 #: ../../src/wxMaxima.cpp:7358 ../../src/wxMaxima.cpp:7362
 msgid "Char to unicode code point"
-msgstr ""
+msgstr "Caractère vers un point de code Unicode"
 
 #: ../../src/wxMaxima.cpp:7285 ../../src/wxMaxima.cpp:7289
 #: ../../src/wxMaxima.cpp:7293 ../../src/wxMaxima.cpp:7297
@@ -1136,324 +1209,334 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7359 ../../src/wxMaxima.cpp:7363
 #: ../../src/wxMaxima.cpp:7435
 msgid "Char:"
-msgstr ""
+msgstr "Caractère :"
 
 #: ../../src/wxMaximaFrame.cpp:1131
 msgid "Character Tests"
-msgstr ""
+msgstr "Tests de caractère"
 
 #: ../../src/wxMaxima.cpp:8181
 msgid "Characteristic polynom"
-msgstr ""
+msgstr "Polynôme &caractéristique"
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Chars are strings that are one character long"
 msgstr ""
+"Les caractères sont des chaînes dont la longueur fait un seul caractère"
 
 #: ../../src/wxMaximaFrame.cpp:1957
 msgid "Check for Updates"
-msgstr ""
+msgstr "Rechercher des mises à jour"
 
 #: ../../src/wxMaximaFrame.cpp:1958
 msgid "Check if a newer version of wxMaxima is available."
-msgstr ""
+msgstr "Vérifier si une nouvelle version de wxMaxima est disponible."
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Choose the parenthesis type for Matrices"
-msgstr ""
+msgstr "Choisir le type de parenthèses pour les matrices"
 
 #: ../../src/wxMaxima.cpp:9530 ../../src/wxMaxima.cpp:9535
 msgid "Classes:"
-msgstr ""
+msgstr "Classes :"
 
 #: ../../src/wxMaximaFrame.cpp:1378
 msgid "Classic matrix operations"
-msgstr ""
+msgstr "Opérations de base sur les matrices"
 
 #: ../../src/wxMaximaFrame.cpp:998
 msgid "Clear all aliases"
-msgstr ""
+msgstr "Effacer tous les alias"
 
 #: ../../src/wxMaximaFrame.cpp:995
 msgid "Clear all arrays"
-msgstr ""
+msgstr "Effacer tous les tableaux"
 
 #: ../../src/wxMaximaFrame.cpp:992
 msgid "Clear all dependencies"
-msgstr ""
+msgstr "Effacer toutes les dépendances"
 
 #: ../../src/wxMaximaFrame.cpp:994
 msgid "Clear all functions"
-msgstr ""
+msgstr "Effacer toutes les fonctions"
 
 #: ../../src/wxMaximaFrame.cpp:1001
 msgid "Clear all gradefs"
-msgstr ""
+msgstr "Effacer tous les gradients"
 
 #: ../../src/wxMaximaFrame.cpp:1000
 msgid "Clear all labels"
-msgstr ""
+msgstr "Effacer toutes les étiquettes"
 
 #: ../../src/wxMaximaFrame.cpp:1004
 msgid "Clear all let rule packages"
-msgstr ""
+msgstr "Effacer tous les paquets de règles let"
 
 #: ../../src/wxMaximaFrame.cpp:1003
 msgid "Clear all macros"
-msgstr ""
+msgstr "Effacer toutes les macros"
 
 #: ../../src/wxMaximaFrame.cpp:1002
 msgid "Clear all props"
-msgstr ""
+msgstr "Effacer toutes les propriétés"
 
 #: ../../src/wxMaximaFrame.cpp:997
 msgid "Clear all rules"
-msgstr ""
+msgstr "Effacer toutes les règles"
 
 #: ../../src/wxMaximaFrame.cpp:999
 msgid "Clear all structures"
-msgstr ""
+msgstr "Effacer toutes les structures"
 
 #: ../../src/wxMaximaFrame.cpp:993
 msgid "Clear all variables"
-msgstr ""
+msgstr "Effacer toutes les variables"
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close\tCtrl+W"
-msgstr ""
+msgstr "Fermer\tCtrl+W"
 
 #: ../../src/wxMaxima.cpp:7235
 msgid "Close Stream"
-msgstr ""
+msgstr "Fermer le flux"
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close window"
-msgstr ""
+msgstr "Fermer la fenêtre"
 
 #: ../../src/wxMaximaFrame.cpp:1105
 msgid "Close..."
-msgstr ""
+msgstr "Fermer..."
 
 #: ../../src/WXMXformat.cpp:301
 msgid "Closed the zip archive"
-msgstr ""
+msgstr "Fermer l'archive zip"
 
 #: ../../src/Configuration.cpp:77
 msgid "Code Default (Maxima input)"
-msgstr ""
+msgstr "Entrée par défaut (code Maxima)"
 
 #: ../../src/Configuration.cpp:103
 msgid "Code highlighting: Comments"
-msgstr ""
+msgstr "Surlignage du code : Commentaires"
 
 #: ../../src/Configuration.cpp:108
 msgid "Code highlighting: End of line markers"
-msgstr ""
+msgstr "Surlignage du code : Marqueurs de fin de ligne"
 
 #: ../../src/Configuration.cpp:102
 msgid "Code highlighting: Functions"
-msgstr ""
+msgstr "Surlignage du code : Fonctions"
 
 #: ../../src/Configuration.cpp:107
 msgid "Code highlighting: Lisp"
-msgstr ""
+msgstr "Surlignage du code : Lisp"
 
 #: ../../src/Configuration.cpp:104
 msgid "Code highlighting: Numbers"
-msgstr ""
+msgstr "Surlignage du code : Nombres"
 
 #: ../../src/Configuration.cpp:106
 msgid "Code highlighting: Operators"
-msgstr ""
+msgstr "Surlignage du code : Opérateurs"
 
 #: ../../src/Configuration.cpp:105
 msgid "Code highlighting: Strings"
-msgstr ""
+msgstr "Surlignage du code : Chaines de caractères"
 
 #: ../../src/Configuration.cpp:101
 msgid "Code highlighting: Variables"
-msgstr ""
+msgstr "Surlignage du code : Variables"
 
 #: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
 msgid "Code number:"
-msgstr ""
+msgstr "Numéro de code :"
 
 #: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
 msgid "Codepoint number:"
-msgstr ""
+msgstr "Numéro de point de code :"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "Col. names:"
-msgstr ""
+msgstr "Noms des colonnes :"
 
 #: ../../src/Configuration.cpp:100
 msgid "Color of Outdated cells"
-msgstr ""
+msgstr "Couleur des cellules obsolètes"
 
 #: ../../src/Configuration.cpp:99
 msgid "Color of text equal to selection"
-msgstr ""
+msgstr "Couleur du texte identique à la sélection"
 
 #: ../../src/wxMaxima.cpp:7962
 msgid "Column number:"
-msgstr ""
+msgstr "Numéro de colonne :"
 
 #: ../../src/wxMaxima.cpp:7978
 msgid "Column numbers:"
-msgstr ""
+msgstr "Numéros des colonnes :"
 
 #: ../../src/wxMaxima.cpp:8202
 msgid "Columns"
-msgstr ""
+msgstr "Colonnes"
 
 #: ../../src/wxMaximaFrame.cpp:1584
 msgid "Combine factorials in an expression"
-msgstr ""
+msgstr "Combiner les factorielles dans une expression"
 
 #: ../../src/wxMaxima.cpp:10454
 msgid "Comma directly followed by a closing parenthesis"
-msgstr ""
+msgstr "Virgule directement suivie d’une parenthèse fermante"
 
 #: ../../src/wxMaxima.cpp:7259
 msgid "Comma-separated arguments"
-msgstr ""
+msgstr "Arguments séparés par des virgules"
 
 #: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
 msgid "Comma-separated commands"
-msgstr ""
+msgstr "Commandes séparées par des virgules"
 
 #: ../../src/wxMaxima.cpp:8458
 msgid "Comma-separated elements"
-msgstr ""
+msgstr "Eléments séparés par des virgules"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 #: ../../src/wxMaxima.cpp:10031
 msgid "Comma-separated equations"
-msgstr ""
+msgstr "Equations séparées par des virgules"
 
 #: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
 #: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
 #: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
 msgid "Comma-separated expressions"
-msgstr ""
+msgstr "Expressions séparées par des virgules"
 
 #: ../../src/wxMaxima.cpp:7215
 msgid "Comma-separated expressions that shall be converted to a string"
 msgstr ""
+"Expressions séparées par des virgules devant être converties en chaîne de "
+"caractères"
 
 #: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
 msgid "Comma-separated expressions."
-msgstr ""
+msgstr "Expressions séparées par des virgules."
 
 #: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
 msgid "Comma-separated function names"
-msgstr ""
+msgstr "Noms de fonctions séparés par des virgules"
 
 #: ../../src/wxMaxima.cpp:7086
 msgid "Comma-separated function names."
-msgstr ""
+msgstr "Noms de fonctions séparés par des virgules."
 
 #: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
 #: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
 msgid "Comma-separated list entry in the format val1=1,val2=2"
-msgstr ""
+msgstr "Entrée de liste séparée par des virgules au format val1=1,val2=2"
 
 #: ../../src/wxMaxima.cpp:7205
 msgid "Comma-separated names of the elements that shall be written"
-msgstr ""
+msgstr "Noms des éléments à écrire, séparés par des virgules"
 
 #: ../../src/wxMaxima.cpp:7099
 msgid "Comma-separated names the parameters will be referenced by later."
 msgstr ""
+"Les noms des paramètres, séparés par des virgules, seront référencés par la "
+"suite."
 
 #: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
 msgid "Comma-separated numbers from 0 to 255"
-msgstr ""
+msgstr "Nombres de 0 à 255, séparés par des virgules"
 
 #: ../../src/wxMaxima.cpp:8770
 msgid "Comma-separated numbers of the terms to substitute in"
-msgstr ""
+msgstr "Numéros des termes à substituer, séparés par des virgules"
 
 #: ../../src/wxMaxima.cpp:7137 ../../src/wxMaxima.cpp:7150
 msgid ""
 "Comma-separated parameter names. A parameter in square brackets [] will be "
 "filled with the list of any additional arguments the function gets."
 msgstr ""
+"Noms des paramètres, séparés par des virgules. Un paramètre entre crochets "
+"[] sera rempli avec la liste des arguments supplémentaires passés à la "
+"fonction."
 
 #: ../../src/wxMaxima.cpp:7054
 msgid "Comma-separated variable names, can be initialized by the \":\" operator."
 msgstr ""
+"Noms de variables séparés par des virgules, pouvant être initialisés avec "
+"l'opérateur \":\"."
 
 #: ../../src/wxMaxima.cpp:7753 ../../src/wxMaxima.cpp:7767
 #: ../../src/wxMaxima.cpp:8719 ../../src/wxMaxima.cpp:8785
 #: ../../src/wxMaxima.cpp:10032
 msgid "Comma-separated variables"
-msgstr ""
+msgstr "Variables séparées par des virgules"
 
 #: ../../src/wxMaxima.cpp:9469
 msgid "Command:"
-msgstr ""
+msgstr "Commande :"
 
 #: ../../src/Worksheet.cpp:1692
 msgid "Comment Selection"
-msgstr ""
+msgstr "Commenter la sélection"
 
 #: ../../src/wxMaximaFrame.cpp:681
 msgid "Comment out the currently selected text"
-msgstr ""
+msgstr "Commenter le texte actuellement sélectionné"
 
 #: ../../src/wxMaximaFrame.cpp:680
 msgid "Comment selection\tCtrl+/"
-msgstr ""
+msgstr "Commenter la sélection \tCtrl+/"
 
 #: ../../src/Worksheet.cpp:2004
 msgid "Commutative function"
-msgstr ""
+msgstr "Fonction commutative"
 
 #: ../../src/wxMaximaFrame.cpp:1396
 msgid "Compile a QR decomposition using dgeqrf"
-msgstr ""
+msgstr "Calculer une décomposition QR en utilisant dgeqrf"
 
 #: ../../src/wxMaxima.cpp:7162
 msgid "Compile a function"
-msgstr ""
+msgstr "Compiler une fonction"
 
 #: ../../src/wxMaximaFrame.cpp:1188
 msgid "Compile a regular expression"
-msgstr ""
+msgstr "Compiler une expression régulière"
 
 #: ../../src/wxMaximaFrame.cpp:1385
 msgid "Compile eigenvalues using dgeev"
-msgstr ""
+msgstr "Calculer les valeurs propres en utilisant dgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1388
 msgid "Compile eigenvalues using zgeev"
-msgstr ""
+msgstr "Calculer les valeurs propres en utilisant zgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1391
 msgid "Compile eigenvalues+eigenvectors using dgeev"
-msgstr ""
+msgstr "Calculer les valeurs propres et vecteurs propres à l'aide de dgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1394
 msgid "Compile eigenvalues+eigenvectors using zgeev"
-msgstr ""
+msgstr "Calculer les valeurs propres et vecteurs propres à l'aide de zgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1076
 msgid "Compile function..."
-msgstr ""
+msgstr "Compiler la fonction ..."
 
 #: ../../src/wxMaxima.cpp:7511
 msgid "Compile regex"
-msgstr ""
+msgstr "Compiler l'expression régulière"
 
 #: ../../src/wxMathml.cpp:53
 msgid "Compiler-Bug? wxMathml.lisp is shorter than expected!"
-msgstr ""
+msgstr "Bug de compilation ? wxMathml.lisp est plus court que prévu !"
 
 #: ../../src/wxMaxima.cpp:2234
 #, c-format
 msgid "Compiling %s"
-msgstr ""
+msgstr "Compiler %s"
 
 #: ../../src/wxMaxima.cpp:7163
 msgid ""
@@ -1461,440 +1544,464 @@ msgid ""
 " the function parameters are made known to the function before it is "
 "compiled. Else the generated code has to be hideously generic."
 msgstr ""
+"La compilation d'une fonction peut apporter un gain de vitesse considérable "
+"si les types des paramètres de la fonction sont connus avant la compilation."
+" Sinon, le code généré devient trop générique et inefficace."
 
 #: ../../src/wxMaximaFrame.cpp:892
 msgid "Complete Word\tCtrl+Space"
-msgstr ""
+msgstr "Compléter le mot\tCtrl+Espace"
 
 #: ../../src/wxMaximaFrame.cpp:893
 msgid "Complete word"
-msgstr ""
+msgstr "Compléter le mot"
 
 #: ../../src/ToolBar.cpp:230
 msgid "Completely stop maxima and restart it"
-msgstr ""
+msgstr "Arrêter complètement Maxima et le redémarrer"
 
 #: ../../src/wxMaximaFrame.cpp:1503
 msgid "Compute continued fraction of a value"
-msgstr ""
+msgstr "Calculer la fraction continue d'une valeur"
 
 #: ../../src/wxMaximaFrame.cpp:1372
 msgid "Compute the adjoint matrix"
-msgstr ""
+msgstr "Calculer la matrice adjointe"
 
 #: ../../src/wxMaximaFrame.cpp:1359
 msgid "Compute the characteristic polynomial of a matrix"
-msgstr ""
+msgstr "Calculer le polynôme caractéristique d'une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1363
 msgid "Compute the determinant of a matrix"
-msgstr ""
+msgstr "Calculer le déterminant d'une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1491
 msgid "Compute the greatest common divisor"
-msgstr ""
+msgstr "Calculer le plus grand diviseur commun"
 
 #: ../../src/wxMaximaFrame.cpp:1356
 msgid "Compute the inverse of a matrix"
-msgstr ""
+msgstr "Calculer l'inverse d'une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1494
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
+"Calculer le plus petit multiple commun (charger load(functs) avant "
+"utilisation)"
 
 #: ../../src/wxMaximaFrame.cpp:1374
 msgid "Compute the rank of a matrix"
-msgstr ""
+msgstr "Calculer le rang d'une matrice"
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Condition:"
-msgstr ""
+msgstr "Condition :"
 
 #: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "Configure wxMaxima"
-msgstr ""
+msgstr "Configurer wxMaxima"
 
 #: ../../src/wxMaxima.cpp:2504
 msgid "Connection attempt, but connection failed."
-msgstr ""
+msgstr "Tentative de connexion, mais la connexion a échoué."
 
 #: ../../src/wxMaxima.cpp:2459
 msgid "Connection to Maxima lost."
-msgstr ""
+msgstr "La connexion à Maxima est perdue."
 
 #: ../../src/wxMaxima.cpp:7921
 msgid "Construct a fraction"
-msgstr ""
+msgstr "Construire une fraction"
 
 #: ../../src/wxMaximaFrame.cpp:1305
 msgid "Construct fraction..."
-msgstr ""
+msgstr "Construire une fraction..."
 
 #: ../../src/wxMaxima.cpp:7158
 msgid "Contents:"
-msgstr ""
+msgstr "Contenus :"
 
 #: ../../src/wxMaximaFrame.cpp:1877
 msgid "Context-sensitive &Help\tCtrl+?"
-msgstr ""
+msgstr "Aide contextuelle &Aide\tCtrl+?"
 
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Context-sensitive &Help\tF1"
-msgstr ""
+msgstr "Aide contextuelle &Aide\tF1"
 
 #: ../../src/wxMaximaFrame.cpp:1542
 msgid "Contract Logarithms"
-msgstr ""
+msgstr "Regrouper les logarithmes"
 
 #: ../../src/wxMaximaFrame.cpp:1161
 msgid "Conversions"
-msgstr ""
+msgstr "Conversions"
 
 #: ../../src/wxMaximaFrame.cpp:1229
 msgid "Convert"
-msgstr ""
+msgstr "Convertir"
 
 #: ../../src/wxMaximaFrame.cpp:1230
 msgid "Convert + Write to file"
-msgstr ""
+msgstr "Convertir et enregistrer dans un fichier"
 
 #: ../../src/wxMaximaFrame.cpp:1434
 msgid "Convert Column to list..."
-msgstr ""
+msgstr "Convertir la colonne en liste..."
 
 #: ../../src/wxMaximaFrame.cpp:1430
 msgid "Convert Row to list..."
-msgstr ""
+msgstr "Convertir la ligne en liste..."
 
 #: ../../src/wxMaximaFrame.cpp:1044
 msgid "Convert a command to maxima code"
-msgstr ""
+msgstr "Convertir une commande en code Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1321
 msgid "Convert a list of lists to a matrix"
-msgstr ""
+msgstr "Convertir une liste de listes en matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1574
 msgid "Convert binomials, beta and gamma function to factorials"
-msgstr ""
+msgstr "Convertir combinaisons, fonctions beta et gamma en factorielles"
 
 #: ../../src/wxMaximaFrame.cpp:1578
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
+"Convertir combinaisons, factorielles et fonctions beta en fonction gamma"
 
 #: ../../src/wxMaximaFrame.cpp:1613
 msgid "Convert complex expression to polar form"
-msgstr ""
+msgstr "Transformer une expression complexe sous forme polaire"
 
 #: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert complex expression to rect form"
-msgstr ""
+msgstr "Transformer une expression complexe sous forme cartésienne"
 
 #: ../../src/wxMaximaFrame.cpp:1622
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
+"Convertir une fonction exponentielle d'argument imaginaire sous forme "
+"trigonométrique"
 
 #: ../../src/wxMaxima.cpp:7411
 msgid "Convert string to lowercase"
-msgstr ""
+msgstr "Convertir la chaîne en minuscules"
 
 #: ../../src/wxMaxima.cpp:7543
 msgid "Convert string to matching regex"
-msgstr ""
+msgstr "Convertir la chaîne en expression régulière correspondante"
 
 #: ../../src/wxMaximaFrame.cpp:1543
 msgid "Convert sum of logarithms to logarithm of product"
-msgstr ""
+msgstr "Convertir une somme de logarithmes en un logarithme d'un produit"
 
 #: ../../src/wxMaximaFrame.cpp:1573
 msgid "Convert to &Factorials"
-msgstr ""
+msgstr "Convertir en &factorielles"
 
 #: ../../src/wxMaximaFrame.cpp:1577
 msgid "Convert to &Gamma"
-msgstr ""
+msgstr "Convertir en &Gamma"
 
 #: ../../src/wxMaximaFrame.cpp:1612
 msgid "Convert to &Polarform"
-msgstr ""
+msgstr "Convertir sous forme &polaire"
 
 #: ../../src/wxMaximaFrame.cpp:1609
 msgid "Convert to &Rectform"
-msgstr ""
+msgstr "Convertir sous forme ca&rtésienne"
 
 #: ../../src/wxMaximaFrame.cpp:1166
 msgid "Convert to downcase..."
-msgstr ""
+msgstr "Convertir en minuscules…"
 
 #: ../../src/wxMaxima.cpp:7016
 msgid "Convert to programming language"
-msgstr ""
+msgstr "Convertir en langage de programmation"
 
 #: ../../src/wxMaxima.cpp:7022
 msgid "Convert to programming language file"
-msgstr ""
+msgstr "Convertir en un fichier de langage de programmation"
 
 #: ../../src/wxMaximaFrame.cpp:1602
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr ""
+"Convertir une expression trigonométrique en forme quasi-linéaire canonique"
 
 #: ../../src/wxMaximaFrame.cpp:1627
 msgid "Convert trigonometric functions to exponential form"
-msgstr ""
+msgstr "Convertir les fonctions trigonométriques en forme exponentielle"
 
 #: ../../src/wxMaximaFrame.cpp:1762
 msgid "Converts a matrix to a list of lists"
-msgstr ""
+msgstr "Convertir une matrice en liste de listes"
 
 #: ../../src/wxMaximaFrame.cpp:1760
 msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
-msgstr ""
+msgstr "Convertit une liste imbriquée comme [[1,2],[3,4]] en matrice"
 
 #: ../../src/ToolBar.cpp:209 ../../src/Worksheet.cpp:1290
 #: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
 #: ../../src/Worksheet.cpp:1684
 msgid "Copy"
-msgstr ""
+msgstr "Copier"
 
 #: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
 #: ../../src/Worksheet.cpp:1514
 msgid "Copy Animation"
-msgstr ""
+msgstr "Copier l'animation"
 
 #: ../../src/wxMaximaFrame.cpp:887
 msgid "Copy Previous Input\tCtrl+I"
-msgstr ""
+msgstr "Copier l'entrée précédente\tCtrl+I"
 
 #: ../../src/wxMaximaFrame.cpp:890
 msgid "Copy Previous Output\tCtrl+U"
-msgstr ""
+msgstr "Copier la sortie précédente\tCtrl+U"
 
 #: ../../src/wxMaxima.cpp:7992
 msgid "Copy a matrix"
-msgstr ""
+msgstr "Copier comme matrice"
 
 #: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
 #: ../../src/wxMaximaFrame.cpp:663
 msgid "Copy as EMF"
-msgstr ""
+msgstr "Copier au format EMF"
 
 #: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Copy as Image"
-msgstr ""
+msgstr "Copier comme image"
 
 #: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
 #: ../../src/wxMaximaFrame.cpp:645
 msgid "Copy as LaTeX"
-msgstr ""
+msgstr "Copier comme code LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:648
 msgid "Copy as MathML"
-msgstr ""
+msgstr "Copier en MathML"
 
 #: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
 msgid "Copy as MathML (e.g. to word processor)"
-msgstr ""
+msgstr "Copier en MathML (par exemple vers un traitement de texte)"
 
 #: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
 #: ../../src/wxMaximaFrame.cpp:658
 msgid "Copy as RTF"
-msgstr ""
+msgstr "Copier en RTF"
 
 #: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "Copy as SVG"
-msgstr ""
+msgstr "Copier au format SVG"
 
 #: ../../src/wxMaximaFrame.cpp:640
 msgid "Copy as Text\tCtrl+Shift+C"
-msgstr ""
+msgstr "Copier comme texte\tCtrl+Maj+C"
 
 #: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
 msgid "Copy as plain text"
-msgstr ""
+msgstr "Copier en texte brut"
 
 #: ../../src/wxMaxima.cpp:7576
 msgid "Copy file"
-msgstr ""
+msgstr "Copier le fichier"
 
 #: ../../src/wxMaximaFrame.cpp:1214
 msgid "Copy file..."
-msgstr ""
+msgstr "Copier le fichier..."
 
 #: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
 #: ../../src/wxMaximaFrame.cpp:643
 msgid "Copy for Octave/Matlab"
-msgstr ""
+msgstr "Copier pour Octave/Matlab"
 
 #: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
 msgid "Copy selection"
-msgstr ""
+msgstr "Copier la sélection"
 
 #: ../../src/wxMaximaFrame.cpp:664
 msgid "Copy selection from document as an Enhanced Metafile"
 msgstr ""
+"Copier la sélection du document en tant que métafichier amélioré (EMF)"
 
 #: ../../src/wxMaximaFrame.cpp:656
 msgid "Copy selection from document as an SVG image"
-msgstr ""
+msgstr "Copier la sélection du document en tant qu'image SVG"
 
 #: ../../src/wxMaximaFrame.cpp:653
 msgid "Copy selection from document as an image"
-msgstr ""
+msgstr "Copier la sélection du document en tant qu' image"
 
 #: ../../src/wxMaximaFrame.cpp:659
 msgid ""
 "Copy selection from document as rtf that a word processor might understand"
 msgstr ""
+"Copier la sélection du document en tant que RTF (compatible avec les "
+"traitements de texte)"
 
 #: ../../src/wxMaximaFrame.cpp:641
 msgid "Copy selection from document as text"
-msgstr ""
+msgstr "Copier la sélection du document au format texte"
 
 #: ../../src/wxMaximaFrame.cpp:646
 msgid "Copy selection from document in LaTeX format"
-msgstr ""
+msgstr "Copier la sélection du document au format LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:644
 msgid "Copy selection from document in Matlab format"
-msgstr ""
+msgstr "Copier la sélection du document au format Matlab"
 
 #: ../../src/wxMaximaFrame.cpp:649
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
+"Copier la sélection du document au format MathML (affichable comme équation "
+"2D par la plupart des traitements de texte)"
 
 #: ../../src/wxMaxima.cpp:7403
 msgid "Copy string"
-msgstr ""
+msgstr "Copier la chaine de caractères"
 
 #: ../../src/wxMaximaFrame.cpp:1165
 msgid "Copy string..."
-msgstr ""
+msgstr "Copier la chaine de caractères..."
 
 #: ../../src/ToolBar.cpp:623
 msgid "Copy, Cut and Paste button"
-msgstr ""
+msgstr "Boutons Copier, Couper et Coller"
 
 #: ../../src/WXMXformat.cpp:295
 msgid "Could not create the backup file during saving => aborting."
 msgstr ""
+"Impossible de créer le fichier de sauvegarde pendant "
+"l’enregistrement =>opération annulée."
 
 #: ../../src/wxMaxima.cpp:3294 ../../src/wxMaxima.cpp:3306
 msgid ""
 "Could not make sure that we talk to the maxima we started => discarding all "
 "data it sends."
 msgstr ""
+"Impossible de vérifier que nous communiquons avec le processus Maxima que "
+"nous avons lancé => toutes les données reçues sont ignorées."
 
 #: ../../src/wxMaxima.cpp:2783
 msgid ""
 "Could not map view of the file needed in order to send an interrupt signal "
 "to maxima."
 msgstr ""
+"Impossible de mapper la vue du fichier nécessaire pour envoyer un signal "
+"d'interruption à Maxima."
 
 #: ../../src/wxMaxima.cpp:2763 ../../src/wxMaxima.cpp:2805
 msgid "Could not send an interrupt signal to maxima."
-msgstr ""
+msgstr "Impossible d'envoyer un signal d'interruption à Maxima."
 
 #: ../../src/WXMXformat.cpp:287
 msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
+"Impossible d'écrire le contenu du fichier pendant "
+"l'enregistrement =>opération annulée."
 
 #: ../../src/wxMaximaFrame.cpp:1325
 msgid "Create Matrix"
-msgstr ""
+msgstr "Générer une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1688
 msgid "Create a list"
-msgstr ""
+msgstr "Générer une liste"
 
 #: ../../src/wxMaxima.cpp:8487
 msgid "Create a list as a storage for the values of variables"
-msgstr ""
+msgstr "Créer une liste pour stocker les valeurs des variables"
 
 #: ../../src/wxMaxima.cpp:8463 ../../src/wxMaxima.cpp:8476
 msgid "Create a list from a rule"
-msgstr ""
+msgstr "Créer une liste à partir d'une règle"
 
 #: ../../src/wxMaximaFrame.cpp:1670
 msgid "Create a list from comma-separated elements"
-msgstr ""
+msgstr "Créer une liste à partir d'éléments séparés par des virgules"
 
 #: ../../src/wxMaximaFrame.cpp:888
 msgid "Create a new cell with previous input"
-msgstr ""
+msgstr "Créer une nouvelle cellule avec l'entrée précédente"
 
 #: ../../src/wxMaximaFrame.cpp:891
 msgid "Create a new cell with previous output"
-msgstr ""
+msgstr "Créer une nouvelle cellule avec la sortie précédente"
 
 #: ../../src/wxMaximaFrame.cpp:1348
 msgid "Create copy, not clone..."
-msgstr ""
+msgstr "Créer une copie, pas un clone…"
 
 #: ../../src/wxMaxima.cpp:7561
 msgid "Create directory"
-msgstr ""
+msgstr "Créer un répertoire"
 
 #: ../../src/wxMaximaFrame.cpp:1203
 msgid "Create directory..."
-msgstr ""
+msgstr "Créer un répertoire..."
 
 #: ../../src/wxMaxima.cpp:7419
 msgid "Create empty string"
-msgstr ""
+msgstr "Créer une chaîne vide"
 
 #: ../../src/wxMaximaFrame.cpp:1168
 msgid "Create empty string..."
-msgstr ""
+msgstr "Créer une chaîne vide..."
 
 #: ../../src/wxMaximaFrame.cpp:1687
 msgid "Create list"
-msgstr ""
+msgstr "Générer une liste"
 
 #: ../../src/wxMaxima.cpp:8457
 msgid "Create list from comma-separated elements"
-msgstr ""
+msgstr "Créer une liste à partir d'éléments séparés par des virgules"
 
 #: ../../src/wxMaximaFrame.cpp:1082
 msgid "Create struct..."
-msgstr ""
+msgstr "Générer une structure..."
 
 #: ../../src/WXMXformat.cpp:80
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
 msgstr ""
+"Un fichier .zip a été créé (un fichier .wxmx est techniquement un fichier "
+".zip)"
 
 #: ../../src/wxMaximaFrame.cpp:1349
 msgid "Creates an independent matrix with the same contents"
-msgstr ""
+msgstr "Crée une matrice indépendante avec les mêmes contenus"
 
 #: ../../src/Configuration.cpp:97
 msgid "Cursor color"
-msgstr ""
+msgstr "Couleur du curseur"
 
 #: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
 msgid "Cut"
-msgstr ""
+msgstr "Couper"
 
 #: ../../src/wxMaximaFrame.cpp:636
 msgid "Cut\tCtrl+X"
-msgstr ""
+msgstr "Couper\tCtrl+X"
 
 #: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
 msgid "Cut selection"
-msgstr ""
+msgstr "Couper la sélection"
 
 #: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
 msgid "Data Matrix:"
-msgstr ""
+msgstr "Matrice des données :"
 
 #: ../../src/wxMaxima.cpp:9599
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
-msgstr ""
+msgstr "Fichier de données (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wxMaxima.cpp:9529 ../../src/wxMaxima.cpp:9534
 #: ../../src/wxMaxima.cpp:9539 ../../src/wxMaxima.cpp:9543
@@ -1903,402 +2010,410 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9563 ../../src/wxMaxima.cpp:9577
 #: ../../src/wxMaxima.cpp:9582 ../../src/wxMaxima.cpp:10030
 msgid "Data:"
-msgstr ""
+msgstr "Données :"
 
 #: ../../src/wxMaximaFrame.cpp:1057
 msgid "Debugger trigger"
-msgstr ""
+msgstr "Démarrer le débogage"
 
 #: ../../src/wxMaximaFrame.cpp:779
 msgid "Declare Text to always be displayed as subscript"
-msgstr ""
+msgstr "Déclarer le texte pour qu'il s'affiche toujours en indice"
 
 #: ../../src/wxMaxima.cpp:7069
 msgid "Declare a function local to a Program"
-msgstr ""
+msgstr "Déclarer une fonction locale à un Programme"
 
 #: ../../src/wxMaxima.cpp:6539
 msgid "Declare a text snippet to always be displayed as subscript"
-msgstr ""
+msgstr "Déclarer un extrait de texte qui s'affiche toujours en indice"
 
 #: ../../src/Worksheet.cpp:2044
 #, c-format
 msgid "Declare facts about %s"
-msgstr ""
+msgstr "Déclarer des faits concernant %s"
 
 #: ../../src/wxMaxima.cpp:8800
 msgid "Declare main variable:"
-msgstr ""
+msgstr "Déclarer la variable principale :"
 
 #: ../../src/wxMaxima.cpp:7171
 msgid "Declare the type of a function parameter"
-msgstr ""
+msgstr "Déclarer le type d'un paramètre de fonction"
 
 #: ../../src/Worksheet.cpp:2038
 msgid "Declare these chars as ordinary letters"
-msgstr ""
+msgstr "Déclarer ces caractères comme des lettres ordinaires"
 
 #: ../../src/wxMaximaFrame.cpp:1500 ../../src/wxMaximaFrame.cpp:1536
 msgid "Decompose rational function to partial fractions"
-msgstr ""
+msgstr "Décomposer une fonction rationnelle en éléments simples"
 
 #: ../../src/Worksheet.cpp:2010
 msgid "Decreasing function f(x)<x"
-msgstr ""
+msgstr "Fonction décroissante f(x) < x"
 
 #: ../../src/wxMaxima.cpp:7134
 msgid "Define a function"
-msgstr ""
+msgstr "Définir une fonction"
 
 #: ../../src/wxMaxima.cpp:7147
 msgid "Define a macro"
-msgstr ""
+msgstr "Définir une macro"
 
 #: ../../src/wxMaxima.cpp:7189
 msgid "Define a structure"
-msgstr ""
+msgstr "Définir une structure"
 
 #: ../../src/wxMaxima.cpp:7183
 msgid "Define a structure type"
-msgstr ""
+msgstr "Définir un type de structure"
 
 #: ../../src/wxMaxima.cpp:7156
 msgid "Define a variable"
-msgstr ""
+msgstr "Définir une variable"
 
 #: ../../src/wxMaximaFrame.cpp:1072
 msgid "Define function..."
-msgstr ""
+msgstr "Définir une fonction..."
 
 #: ../../src/wxMaximaFrame.cpp:1079
 msgid "Define macro..."
-msgstr ""
+msgstr "Définir une macro..."
 
 #: ../../src/wxMaximaFrame.cpp:1077
 msgid "Define parameter type..."
-msgstr ""
+msgstr "Définir le type de paramètre..."
 
 #: ../../src/wxMaximaFrame.cpp:1081
 msgid "Define struct..."
-msgstr ""
+msgstr "Définir la structure..."
 
 #: ../../src/wxMaximaFrame.cpp:1080
 msgid "Define variable..."
-msgstr ""
+msgstr "Définir une variable..."
 
 #: ../../src/wxMaximaFrame.cpp:1776
 msgid ""
 "Defines if an animation is automatically started or only by clicking on it."
 msgstr ""
+"Définit si une animation est lancée automatiquement ou uniquement en "
+"cliquant dessus."
 
 #: ../../src/wxMaxima.cpp:8935
 msgid "Degree:"
-msgstr ""
+msgstr "Degré :"
 
 #: ../../src/wxMaximaFrame.cpp:985
 msgid "Delete F&unction..."
-msgstr ""
+msgstr "Supprimer la f&onction..."
 
 #: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
 msgid "Delete Selection"
-msgstr ""
+msgstr "Supprimer la sélection"
 
 #: ../../src/wxMaximaFrame.cpp:987
 msgid "Delete V&ariable..."
-msgstr ""
+msgstr "Supprimer la v&ariable..."
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Delete a function"
-msgstr ""
+msgstr "Supprimer une fonction"
 
 #: ../../src/wxMaximaFrame.cpp:988
 msgid "Delete a variable"
-msgstr ""
+msgstr "Supprimer une variable"
 
 #: ../../src/wxMaximaFrame.cpp:982
 msgid "Delete all objects with a given name"
-msgstr ""
+msgstr "Supprimer tous les objets portant un nom donné"
 
 #: ../../src/wxMaximaFrame.cpp:991
 msgid "Delete all values from memory"
-msgstr ""
+msgstr "Supprimer toutes les valeurs de la mémoire"
 
 #: ../../src/wxMaxima.cpp:7588
 msgid "Delete file"
-msgstr ""
+msgstr "Supprimer le fichier"
 
 #: ../../src/wxMaximaFrame.cpp:1216
 msgid "Delete file..."
-msgstr ""
+msgstr "Supprimer le fichier..."
 
 #: ../../src/wxMaxima.cpp:7683
 msgid "Delete function(s)"
-msgstr ""
+msgstr "Supprimer la (les) fonction(s):"
 
 #: ../../src/wxMaxima.cpp:7679
 msgid "Delete named object(s)"
-msgstr ""
+msgstr "Supprimer le(s) objet(s) nommé(s)"
 
 #: ../../src/wxMaximaFrame.cpp:981
 msgid "Delete named object..."
-msgstr ""
+msgstr "Supprimer l'objet nommé..."
 
 #: ../../src/wxMaxima.cpp:7674
 msgid "Delete variable(s)"
-msgstr ""
+msgstr "Supprimer la (les) variables(s):"
 
 #: ../../src/wxMaxima.cpp:7430
 msgid "Delimiter:"
-msgstr ""
+msgstr "Délimiteur:"
 
 #: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
 #, c-format
 msgid "Demo for \"%s\""
-msgstr ""
+msgstr "Démonstration pour \"%s\""
 
 #: ../../src/wxMaximaFrame.cpp:1930
 msgid "Demos"
-msgstr ""
+msgstr "Démonstrations"
 
 #: ../../src/wxMaxima.cpp:8927
 msgid "Denom. deg:"
-msgstr ""
+msgstr "Degré du dénominateur:"
 
 #: ../../src/wxMaxima.cpp:7923
 msgid "Denominator:"
-msgstr ""
+msgstr "Dénominateur :"
 
 #: ../../src/wxMaximaFrame.cpp:1030
 msgid "Dependencies"
-msgstr ""
+msgstr "Dépendances"
 
 #: ../../src/wxMaxima.cpp:7813
 msgid "Derivate of y at that point:"
-msgstr ""
+msgstr "Dérivée de y en ce point :"
 
 #: ../../src/wxMaximaFrame.cpp:1497
 msgid "Di&vide Polynomials..."
-msgstr ""
+msgstr "Di&vision de polynômes…"
 
 #: ../../src/MaximaManual.cpp:517
 msgid "Didn't find the maxima HTML manual."
-msgstr ""
+msgstr "Impossible de trouver le manuel HTML de Maxima."
 
 #: ../../src/wxMaxima.cpp:4907
 msgid ""
 "Didn't get a help browser launch program command line, but can request the "
 "system's default help browser."
 msgstr ""
+"Aucune commande en ligne ne lance le navigateur d'aide, mais il est possible"
+" d'utiliser le navigateur par défaut du système."
 
 #: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
 msgid "Differentiate"
-msgstr ""
+msgstr "Dériver"
 
 #: ../../src/wxMaximaFrame.cpp:1467
 msgid "Differentiate expression"
-msgstr ""
+msgstr "Dériver l'expression"
 
 #: ../../src/Worksheet.cpp:1590
 msgid "Differentiate..."
-msgstr ""
+msgstr "Dériver…"
 
 #: ../../src/wxMaxima.cpp:9010
 msgid "Differentiates an expression n times"
-msgstr ""
+msgstr "Dériver une expression n fois"
 
 #: ../../src/wxMaxima.cpp:10055
 msgid "Differentiates the expression n times"
-msgstr ""
+msgstr "Dériver l'expression n fois"
 
 #: ../../src/wxMaximaFrame.cpp:1212
 msgid "Directory operations"
-msgstr ""
+msgstr "Répertoire pour les opérations"
 
 #: ../../src/wxMaximaFrame.cpp:1041
 msgid "Display Te&X Form"
-msgstr ""
+msgstr "Afficher en Te&X"
 
 #: ../../src/wxMaxima.cpp:6972
 msgid "Display algorithm"
-msgstr ""
+msgstr "Afficher l'algorithme"
 
 #: ../../src/wxMaximaFrame.cpp:751
 msgid "Display an expression as maxima's internal lisp representation"
-msgstr ""
+msgstr "Afficher une expression sous sa représentation interne Lisp de Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:754
 msgid "Display an expression as wxMaxima's internal XML representation"
-msgstr ""
+msgstr "Afficher une expression sous sa représentation XML interne à wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:758
 msgid "Display equations"
-msgstr ""
+msgstr "Afficher les équations"
 
 #: ../../src/wxMaxima.cpp:6508
 msgid "Display expression in maxima's internal representation"
-msgstr ""
+msgstr "Afficher l'expression sous sa représentation interne à Maxima"
 
 #: ../../src/wxMaxima.cpp:6514
 msgid "Display expression in wxMaxima's internal representation"
-msgstr ""
+msgstr "Afficher l'expression sous sa représentation interne à wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1042
 msgid "Display last result in TeX form"
-msgstr ""
+msgstr "Afficher le dernier résultat en TeX"
 
 #: ../../src/ToolBar.cpp:360
 #, c-format
 msgid "Display resolution according to wxWidgets: %li x %li ppi"
-msgstr ""
+msgstr "Résolution d'affichage définie par wxWidgets : %li × %li ppi"
 
 #: ../../src/wxMaximaFrame.cpp:802
 msgid "Display string quotation marks"
-msgstr ""
+msgstr "Afficher les guillemets des chaînes de caractères"
 
 #: ../../src/wxMaximaFrame.cpp:1036
 msgid "Display time used for evaluation"
-msgstr ""
+msgstr "Afficher le temps d'exécution"
 
 #: ../../src/wxMaxima.cpp:9206
 msgid "Displayed Precision"
-msgstr ""
+msgstr "Précision affichée"
 
 #: ../../src/wxMaximaFrame.cpp:1913
 msgid "Displaying 3d curves"
-msgstr ""
+msgstr "Afficher les courbes 3d"
 
 #: ../../src/wxMaximaFrame.cpp:1462
 msgid "Dito, and evaluate the result..."
-msgstr ""
+msgstr "Idem, et évaluer le résultat…"
 
 #: ../../src/wxMaximaFrame.cpp:1445
 msgid "Dito, but affect all clones of the Matrix..."
-msgstr ""
+msgstr "De même, mais affecter tous les clones de la matrice…"
 
 #: ../../src/wxMaximaFrame.cpp:1255
 msgid "Dito, but as fraction (real only)..."
-msgstr ""
+msgstr "Idem, mais sous forme de fraction (réelle uniquement)…"
 
 #: ../../src/wxMaximaFrame.cpp:1532
 msgid "Dito, including denominator"
-msgstr ""
+msgstr "Idem, en incluant le dénominateur"
 
 #: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
 msgid "Divide Cell"
-msgstr ""
+msgstr "Diviser la cellule"
 
 #: ../../src/wxMaximaFrame.cpp:1498
 msgid "Divide numbers or polynomials"
-msgstr ""
+msgstr "Division de nombres ou de polynômes"
 
 #: ../../src/wxMaxima.cpp:8578
 msgid "Do for each list element"
-msgstr ""
+msgstr "Exécuter pour chaque élément de la liste"
 
 #: ../../src/wxMaxima.cpp:11197
 #, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
-msgstr ""
+msgstr "Sauvegarder les modifications apportées au document  \"%s\"?"
 
 #: ../../src/wxMaximaFrame.cpp:724
 msgid "Dock all Sidebars"
-msgstr ""
+msgstr "Ancrer toutes les barres latérales"
 
 #: ../../src/Configuration.cpp:94
 msgid "Document background"
-msgstr ""
+msgstr "Arrière-plan du document"
 
 #: ../../src/wxMaxima.cpp:4611
 msgid ""
 "Document was saved using a newer version of wxMaxima so it may not load "
 "correctly. Please update your wxMaxima."
 msgstr ""
+"Le document a été sauvegardé avec une version plus récente de wxMaxima, et "
+"peut ne pas se charger correctement. Veuillez mettre wxMaxima à jour."
 
 #: ../../src/wxMaxima.cpp:4603
 msgid ""
 "Document was saved using a newer version of wxMaxima. Please update your "
 "wxMaxima."
 msgstr ""
+"Ce document a été sauvegardé avec une version plus récente de wxMaxima. "
+"Veuillez mettre wxMaxima à jour."
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "Don't autosubscript after an underscore"
-msgstr ""
+msgstr "Ne pas mettre en indice automatiquement après un tiret bas"
 
 #: ../../src/wxMaximaFrame.cpp:1086
 msgid "Don't evaluate Expression..."
-msgstr ""
+msgstr "Ne pas évaluer l'expression…"
 
 #: ../../src/wxMaxima.cpp:7117
 msgid "Don't evaluate one command"
-msgstr ""
+msgstr "Ne pas exécuter une seule commande"
 
 #: ../../src/wxMaxima.cpp:7129
 msgid "Don't evaluate one whole expression"
-msgstr ""
+msgstr "Ne pas évaluer l'expression entière"
 
 #: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
 msgid "Don't mark cells that contain tooltips in yellow"
-msgstr ""
+msgstr "Ne pas marquer en jaune les cellules qui contiennent des infobulles"
 
 #: ../../src/Worksheet.cpp:1938 ../../src/Worksheet.cpp:2070
 msgid "Don't mark this message text in yellow"
-msgstr ""
+msgstr "Ne pas marquer ce texte de message en jaune"
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Don't save"
-msgstr ""
+msgstr "Ne pas sauvegarder"
 
 #: ../../src/Worksheet.cpp:1620
 msgid "Don't show labels"
-msgstr ""
+msgstr "Ne pas montrer les étiquettes"
 
 #: ../../src/Worksheet.cpp:1979
 msgid "Don't use if unassigned"
-msgstr ""
+msgstr "Ne pas utiliser si non assigné"
 
 #: ../../src/wxMaximaFrame.cpp:797
 msgid "Don't use parenthesis for matrices"
-msgstr ""
+msgstr "Ne pas mettre des parenthèses aux matrices"
 
 #: ../../src/wxMaxima.cpp:8525
 msgid "Drop the first n list elements"
-msgstr ""
+msgstr "Supprimer les n premiers éléments de la liste"
 
 #: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
 msgid "Drop the last n list elements"
-msgstr ""
+msgstr "Supprimer les n derniers éléments de la liste"
 
 #: ../../src/wxMaximaFrame.cpp:1306
 msgid "E&quations"
-msgstr ""
+msgstr "É&quations"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "E&xit\tCtrl+Q"
-msgstr ""
+msgstr "&Quitter\tCtrl+Q"
 
 #: ../../src/wxMaximaFrame.cpp:1368
 msgid "Eige&nvectors"
-msgstr ""
+msgstr "Vecteurs propres"
 
 #: ../../src/wxMaximaFrame.cpp:1365
 msgid "Eigen&values"
-msgstr ""
+msgstr "&Valeurs propres"
 
 #: ../../src/wxMaximaFrame.cpp:1387
 msgid "Eigenvalues (complex)"
-msgstr ""
+msgstr "Valeurs propres (complexes)"
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Eigenvalues (real)"
-msgstr ""
+msgstr "Valeurs propres (réelles)"
 
 #: ../../src/wxMaximaFrame.cpp:1393
 msgid "Eigenvalues, left+right eigenvectors (complex)"
-msgstr ""
+msgstr "Valeurs propres, vecteurs propres gauche+droite (complexes)"
 
 #: ../../src/wxMaximaFrame.cpp:1390
 msgid "Eigenvalues, left+right eigenvectors (real)"
-msgstr ""
+msgstr "Valeurs propres, vecteurs propres gauche+droite (réels)"
 
 #: ../../src/wxMaxima.cpp:8584
 msgid ""
@@ -2306,130 +2421,135 @@ msgid ""
 "parenthesis. In the latter case the result of the last expression in the "
 "parenthesis is used."
 msgstr ""
+"Soit une seule expression, soit une liste d'expressions séparées par des "
+"virgules entre parenthèses. Dans ce dernier cas, c'est le résultat de la "
+"dernière expression entre parenthèses qui est utilisé."
 
 #: ../../src/wxMaxima.cpp:8593
 msgid "Element"
-msgstr ""
+msgstr "Elément"
 
 #: ../../src/wxMaxima.cpp:8549
 msgid "Element number"
-msgstr ""
+msgstr "Numéro d'élément"
 
 #: ../../src/wxMaxima.cpp:8005
 msgid ""
 "Element-by-element Product of matrices of the same size (Hadamard product)"
 msgstr ""
+"Produit terme à terme de matrices de même taille (produit de Hadamard)"
 
 #: ../../src/wxMaxima.cpp:8012
 msgid "Element-by-element exponentiation of two matrices"
-msgstr ""
+msgstr "Exponentiation terme à terme de deux matrices"
 
 #: ../../src/wxMaximaFrame.cpp:1342
 msgid "Element-by-element multiplication"
-msgstr ""
+msgstr "Multiplication terme à terme"
 
 #: ../../src/wxMaxima.cpp:8510
 msgid "Element:"
-msgstr ""
+msgstr "Elément :"
 
 #: ../../src/wxMaxima.cpp:7204
 msgid "Elements:"
-msgstr ""
+msgstr "Eléments :"
 
 #: ../../src/wxMaxima.cpp:7847
 msgid "Eliminate a variable"
-msgstr ""
+msgstr "Éliminer une variabe"
 
 #: ../../src/wxMaximaFrame.cpp:1247
 msgid "Eliminate a variable from a system of equations"
-msgstr ""
+msgstr "Éliminer une variable dans un système d'équations"
 
 #: ../../src/wxMaxima.cpp:10651
 msgid "Empty command => re-triggering evaluation"
-msgstr ""
+msgstr "Commande vide => nouvelle évalution lancée"
 
 #: ../../src/wxMaxima.cpp:9225
 msgid "Enable:"
-msgstr ""
+msgstr "Autoriser :"
 
 #: ../../src/MathParser.cpp:99
 #, c-format
 msgid "Encountered an unknown XML tag: <%s>"
-msgstr ""
+msgstr "Tag XML inconnu rencontré : <%s>"
 
 #: ../../src/wxMaxima.cpp:2476
 msgid "Encountered an unknown socket event."
-msgstr ""
+msgstr "Événement de socket inconnu rencontré."
 
 #: ../../src/wxMaxima.cpp:7843
 msgid "End of t:"
-msgstr ""
+msgstr "Fin de t:"
 
 #: ../../src/wxMaxima.cpp:4097
 msgid "Ended lisp mode after receiving a maxima prompt!"
-msgstr ""
+msgstr "Mode Lisp terminé après réception de l’invite Maxima !"
 
 #: ../../src/wxMaximaFrame.cpp:1828
 msgid "Engineering format (12.1e6 etc.)"
-msgstr ""
+msgstr "Format technique (12,1e6, etc.)"
 
 #: ../../src/wxMaximaFrame.cpp:1319
 msgid "Enter a matrix"
-msgstr ""
+msgstr "Entrer une matrice"
 
 #: ../../src/wxMaxima.cpp:8866
 msgid "Enter an equation for rational simplification:"
-msgstr ""
+msgstr "Entrer une équation pour la simplification rationnelle :"
 
 #: ../../src/wxMaxima.cpp:8169
 msgid "Enter matrix"
-msgstr ""
+msgstr "Entrer une matrice"
 
 #: ../../src/wxMaxima.cpp:9095
 msgid "Enter new animation frame rate [Hz, integer]:"
 msgstr ""
+"Saisir la nouvelle fréquence d’images de l’animation [en Hz, entier] :"
 
 #: ../../src/wxMaxima.cpp:9201
 msgid "Enter new precision for bigfloats:"
-msgstr ""
+msgstr "Entrer la nouvelle précision pour les grands flottants :"
 
 #: ../../src/wxMaxima.cpp:7922
 msgid "Enumerator:"
-msgstr ""
+msgstr "Énumérateur :"
 
 #: ../../src/wxMaximaFrame.cpp:1220
 msgid "Environment variables"
-msgstr ""
+msgstr "Variables d’environnement"
 
 #: ../../src/wxMaxima.cpp:9045
 msgid "Epsilon:"
-msgstr ""
+msgstr "Epsilon :"
 
 #: ../../src/wxMaximaFrame.cpp:1124 ../../src/wxMaximaFrame.cpp:1135
 msgid "Equal, ignoring case?..."
-msgstr ""
+msgstr "Égal, en ignorant la casse ?…"
 
 #: ../../src/wxMaximaFrame.cpp:1133
 msgid "Equal?..."
-msgstr ""
+msgstr "Egal?..."
 
 #: ../../src/wxMaxima.cpp:8561
 msgid "Equation"
-msgstr ""
+msgstr "Équation"
 
 #: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
 msgid "Equation(s)"
-msgstr ""
+msgstr "Équation(s)"
 
 #: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
 msgid "Equation(s):"
-msgstr ""
+msgstr "Équation(s) :"
 
 #: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
 #: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
 #: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
 msgid "Equation:"
-msgstr ""
+msgstr "Équation :"
 
 #: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
 #: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
@@ -2441,22 +2561,22 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
 #: ../../src/wxMaxima.cpp:11166
 msgid "Error"
-msgstr ""
+msgstr "Erreur"
 
 #: ../../src/wxMaxima.cpp:2456
 msgid "Error writing to Maxima"
-msgstr ""
+msgstr "Erreur lors de l’écriture vers Maxima"
 
 #: ../../src/wxMaxima.cpp:6164 ../../src/wxMaxima.cpp:6176
 #: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
 #: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
 msgid "Error!"
-msgstr ""
+msgstr "Erreur !"
 
 #: ../../src/Image.cpp:696
 #, c-format
 msgid "Error: Cannot render %s."
-msgstr ""
+msgstr "Erreur : Impossible d'obtenir un rendu %s."
 
 #: ../../src/Image.cpp:699
 #, c-format
@@ -2464,10 +2584,12 @@ msgid ""
 "Error: Cannot render %s:\n"
 "%s"
 msgstr ""
+"Erreur : Impossible d'obtenir un rendu %s:\n"
+"%s"
 
 #: ../../src/Image.cpp:704
 msgid "Error: Cannot render the image."
-msgstr ""
+msgstr "Erreur : Impossible d'obtenir le rendu de l'image."
 
 #: ../../src/Image.cpp:706
 #, c-format
@@ -2475,248 +2597,254 @@ msgid ""
 "Error: Cannot render the image:\n"
 "%s"
 msgstr ""
+"Erreur : Impossible d'avoir le rendu de l'image\n"
+"%s"
 
 #: ../../src/wxMaxima.cpp:7544
 msgid ""
 "Escapes all special characters in a string. The result is a regex that "
 "matches this string exactly."
 msgstr ""
+"Échappe tous les caractères spéciaux d’une chaîne. Le résultat est une "
+"expression régulière qui correspond exactement à cette chaîne."
 
 #: ../../src/wxMaximaFrame.cpp:1652
 msgid "Evaluate &Noun Forms..."
-msgstr ""
+msgstr "Évaluer les formes &Nominales..."
 
 #: ../../src/wxMaximaFrame.cpp:856
 msgid "Evaluate All Cells\tCtrl+Shift+R"
-msgstr ""
+msgstr "Évaluer toutes les cellules\tCtrl+Shift+R"
 
 #: ../../src/wxMaximaFrame.cpp:851
 msgid "Evaluate All Visible Cells\tCtrl+R"
-msgstr ""
+msgstr "Évaluer toutes les cellules visibles\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1395
 msgid "Evaluate Cell"
-msgstr ""
+msgstr "Évaluer la cellule"
 
 #: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
 msgid "Evaluate Cell(s)"
-msgstr ""
+msgstr "Évaluer les cellules"
 
 #: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
 msgid "Evaluate Cells Above"
-msgstr ""
+msgstr "Évaluer les cellules au-dessus"
 
 #: ../../src/wxMaximaFrame.cpp:866
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
-msgstr ""
+msgstr "Evaluer les cellules au-dessus\tCtrl+Shift+P"
 
 #: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
 #: ../../src/wxMaximaFrame.cpp:876
 msgid "Evaluate Cells Below"
-msgstr ""
+msgstr "Évaluer les cellules au dessous"
 
 #: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
 #: ../../src/Worksheet.cpp:1890
 msgid "Evaluate Heading 5\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Evaluer le titre de niveau 5\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1457 ../../src/Worksheet.cpp:1761
 #: ../../src/Worksheet.cpp:1901
 msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Evaluer le titre de niveau 6\tShift+Ctrl+Enter"
 
 #: ../../src/wxMaxima.cpp:8626
 msgid "Evaluate Nouns"
-msgstr ""
+msgstr "Évaluer les formes nominales"
 
 #: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
 msgid "Evaluate Part\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Évaluer la partie\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1431 ../../src/Worksheet.cpp:1741
 msgid "Evaluate Section\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Evaluer la Section\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1445 ../../src/Worksheet.cpp:1751
 #: ../../src/Worksheet.cpp:1879
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Evaluer la sous-sous-section\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1438 ../../src/Worksheet.cpp:1746
 #: ../../src/Worksheet.cpp:1868
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Evaluer la sous-section\tShift+Ctrl+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:845
 msgid "Evaluate active or selected cell(s)"
-msgstr ""
+msgstr "Réévaluer la (les) cellule(s) active(s) ou bien sélectionnée(s)"
 
 #: ../../src/ToolBar.cpp:251
 msgid "Evaluate all"
-msgstr ""
+msgstr "Tout évaluer+"
 
 #: ../../src/wxMaximaFrame.cpp:857
 msgid "Evaluate all cells in the document"
-msgstr ""
+msgstr "Evaluer toutes les cellules du document"
 
 #: ../../src/wxMaximaFrame.cpp:1653
 msgid "Evaluate all noun forms in expression"
-msgstr ""
+msgstr "Evaluer toutes les formes nominales dans l'expression"
 
 #: ../../src/wxMaximaFrame.cpp:852
 msgid "Evaluate all visible cells in the document"
-msgstr ""
+msgstr "Evaluer toutes les cellules visibles du document"
 
 #: ../../src/ToolBar.cpp:248
 msgid "Evaluate current cell"
-msgstr ""
+msgstr "Evaluer la cellule courante"
 
 #: ../../src/wxMaxima.cpp:7395
 msgid "Evaluate string"
-msgstr ""
+msgstr "Évaluer la chaîne de caractères"
 
 #: ../../src/wxMaximaFrame.cpp:1151
 msgid "Evaluate string..."
-msgstr ""
+msgstr "Évaluer la chaîne de caractères..."
 
 #: ../../src/ToolBar.cpp:256
 msgid "Evaluate the file from its beginning to the cell above the cursor"
 msgstr ""
+"Évaluer le fichier depuis le début jusqu’à la cellule située avant le "
+"curseur"
 
 #: ../../src/ToolBar.cpp:259
 msgid "Evaluate the file from the cursor to its end"
-msgstr ""
+msgstr "Évaluer le fichier depuis le curseur jusqu’à la fin"
 
 #: ../../src/ToolBar.cpp:258
 msgid "Evaluate the rest"
-msgstr ""
+msgstr "Évaluer le reste"
 
 #: ../../src/ToolBar.cpp:255
 msgid "Evaluate to point"
-msgstr ""
+msgstr "Évaluer jusqu’au point d’insertion"
 
 #: ../../src/wxMaxima.cpp:10518
 msgid "Evaluation ended, since evaluation queue is empty."
-msgstr ""
+msgstr "Évaluation terminée, car la file d’attente d’évaluation est vide."
 
 #: ../../src/Worksheet.cpp:1957
 msgid "Even number"
-msgstr ""
+msgstr "Nombre pair"
 
 #: ../../src/wxMaximaFrame.cpp:1703
 msgid "Execute a command for each element of the list"
-msgstr ""
+msgstr "Exécuter une commande pour chaque élément de la liste"
 
 #: ../../src/main.cpp:438
 msgid "Exit"
-msgstr ""
+msgstr "Quitter"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "Exit wxMaxima"
-msgstr ""
+msgstr "Quitter wxMaxima"
 
 #: ../../src/Worksheet.cpp:1583
 msgid "Expand Expression"
-msgstr ""
+msgstr "Développer l'expression"
 
 #: ../../src/wxMaximaFrame.cpp:1525
 msgid "Expand an expression"
-msgstr ""
+msgstr "Développer une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1531
 msgid "Expand for given variables"
-msgstr ""
+msgstr "Développer pour les variables données"
 
 #: ../../src/wxMaxima.cpp:8781
 msgid "Expand for variable(s) including denominator:"
-msgstr ""
+msgstr "Développer pour la ou les variable(s), y compris le dénominateur :"
 
 #: ../../src/wxMaxima.cpp:8716
 msgid "Expand for variable(s):"
-msgstr ""
+msgstr "Développer pour la ou les variable(s) :"
 
 #: ../../src/wxMaximaFrame.cpp:1545
 msgid "Expand log in previous expression"
-msgstr ""
+msgstr "Développer le logarithme dans l'expression précédente"
 
 #: ../../src/wxMaximaFrame.cpp:1598
 msgid "Expand trigonometric expression"
-msgstr ""
+msgstr "Développer une expression trigonométrique"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Expect numbers harder to be complex"
-msgstr ""
+msgstr "Considérer les nombres comme complexes"
 
 #: ../../src/wxMaximaFrame.cpp:1789
 msgid "Expect variables to contain complex numbers"
-msgstr ""
+msgstr "Attente que les variables contiennent des nombres complexes"
 
 #: ../../src/wxMaxima.cpp:6121
 msgid "Export"
-msgstr ""
+msgstr "Exporter"
 
 #: ../../src/wxMaximaFrame.cpp:1705
 msgid "Export List to csv file..."
-msgstr ""
+msgstr "Exporter la liste vers un fichier CSV..."
 
 #: ../../src/wxMaximaFrame.cpp:1706
 msgid "Export a list to a csv file"
-msgstr ""
+msgstr "Exporter une liste vers un fichier CSV"
 
 #: ../../src/wxMaximaFrame.cpp:1332
 msgid "Export a matrix to a csv file"
-msgstr ""
+msgstr "Exporter une matrice vers un fichier CSV"
 
 #: ../../src/wxMaximaFrame.cpp:619
 msgid "Export document to a HTML or LaTeX file"
-msgstr ""
+msgstr "Exporter le document en un fichier HTML ou LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:579
 msgid "Export failed."
-msgstr ""
+msgstr "Échec de l'exportation."
 
 #: ../../src/wxMaximaFrame.cpp:567
 msgid "Export successful."
-msgstr ""
+msgstr "Succès de l'exportation."
 
 #: ../../src/wxMaxima.cpp:6187
 msgid "Exporting to HTML failed!"
-msgstr ""
+msgstr "Échec de l'exportation en HTML !"
 
 #: ../../src/wxMaxima.cpp:6164
 msgid "Exporting to TeX failed!"
-msgstr ""
+msgstr "Échec de l'exportation en TeX !"
 
 #: ../../src/wxMaxima.cpp:6175
 msgid "Exporting to maxima batch file failed!"
-msgstr ""
+msgstr "L'exportation vers le fichier batch Maxima a échoué !"
 
 #: ../../src/wxMaximaFrame.cpp:561
 msgid "Exporting..."
-msgstr ""
+msgstr "Exportation..."
 
 #: ../../src/wxMaxima.cpp:6510 ../../src/wxMaxima.cpp:6516
 #: ../../src/wxMaxima.cpp:8218 ../../src/wxMaxima.cpp:8633
 #: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
 #: ../../src/wxMaxima.cpp:10065
 msgid "Expression"
-msgstr ""
+msgstr "Expression"
 
 #: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
 msgid "Expression or a list of comma-separated expressions"
-msgstr ""
+msgstr "Expression ou liste d'expressions séparées par des virgules"
 
 #: ../../src/wxMaximaFrame.cpp:1088
 msgid "Expression to string..."
-msgstr ""
+msgstr "Expression vers chaîne de caractères..."
 
 #: ../../src/wxMaxima.cpp:7113
 msgid "Expression whose output is to be used as maxima's input."
-msgstr ""
+msgstr "Expression dont la sortie sera utilisée comme entrée pour Maxima."
 
 #: ../../src/wxMaxima.cpp:7214
 msgid "Expression(s):"
-msgstr ""
+msgstr "Expression(s) :"
 
 #: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
 #: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
@@ -2725,385 +2853,388 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
 #: ../../src/wxMaxima.cpp:10056
 msgid "Expression:"
-msgstr ""
+msgstr "Expression :"
 
 #: ../../src/wxMaximaFrame.cpp:1423
 msgid "Extract Column..."
-msgstr ""
+msgstr "Extraire la colonne..."
 
 #: ../../src/wxMaximaFrame.cpp:1726
 msgid "Extract Elements"
-msgstr ""
+msgstr "Extraire les éléments"
 
 #: ../../src/wxMaximaFrame.cpp:1421
 msgid "Extract Row..."
-msgstr ""
+msgstr "Extraire la ligne..."
 
 #: ../../src/wxMaximaFrame.cpp:1424
 msgid "Extract a column from the matrix"
-msgstr ""
+msgstr "Extraire une colonne de la matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1435
 msgid "Extract a column from the matrix and convert it to a list"
-msgstr ""
+msgstr "Extraire une colonne de la matrice et la convertir en liste"
 
 #: ../../src/wxMaxima.cpp:7960
 msgid "Extract a matrix column"
-msgstr ""
+msgstr "Extraie une colonne de matrice"
 
 #: ../../src/wxMaxima.cpp:7970
 msgid "Extract a matrix column as a list"
-msgstr ""
+msgstr "Extraie une colonne de matrice en tant que liste"
 
 #: ../../src/wxMaximaFrame.cpp:1313
 msgid "Extract a matrix from a 2-dimensional array"
-msgstr ""
+msgstr "Extraire une matrice à partir d'un tableau à deux dimensions"
 
 #: ../../src/wxMaxima.cpp:7955
 msgid "Extract a matrix row"
-msgstr ""
+msgstr "Extraire une ligne de matrice"
 
 #: ../../src/wxMaxima.cpp:7965
 msgid "Extract a matrix row as a list"
-msgstr ""
+msgstr "Extraire une ligne de matrice en tant que liste"
 
 #: ../../src/wxMaximaFrame.cpp:1422
 msgid "Extract a row from the matrix"
-msgstr ""
+msgstr "Extraire une ligne de la matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1431
 msgid "Extract a row from the matrix and convert it to a list"
-msgstr ""
+msgstr "Extraire une ligne de la matrice et la convertir en une liste"
 
 #: ../../src/wxMaxima.cpp:8564
 msgid "Extract a variable's value from a list of variable values"
-msgstr ""
+msgstr "Extraire la valeur d'une variable d'une liste de valeurs de variables"
 
 #: ../../src/wxMaximaFrame.cpp:1723
 msgid "Extract an actual value for a variable"
-msgstr ""
+msgstr "Extraire une valeur actuelle pour une variable"
 
 #: ../../src/wxMaximaFrame.cpp:1163
 msgid "Extract char..."
-msgstr ""
+msgstr "Extraire un caractère ..."
 
 #: ../../src/wxMaximaFrame.cpp:1207
 msgid "Extract dir from path..."
-msgstr ""
+msgstr "Extraire le répertoire du chemin..."
 
 #: ../../src/wxMaxima.cpp:7605
 msgid "Extract directory part"
-msgstr ""
+msgstr "Extraire la partie du répertoire"
 
 #: ../../src/wxMaxima.cpp:7617
 msgid "Extract file type extension"
-msgstr ""
+msgstr "Extraire l'extension du type de fichier"
 
 #: ../../src/wxMaximaFrame.cpp:1209
 msgid "Extract filename from path..."
-msgstr ""
+msgstr "Extraire le nom de fichier à partir du chemin..."
 
 #: ../../src/wxMaxima.cpp:7611
 msgid "Extract filename part"
-msgstr ""
+msgstr "Extraire la partie nom à partir du fichier"
 
 #: ../../src/wxMaximaFrame.cpp:1211
 msgid "Extract filetype from path..."
-msgstr ""
+msgstr "Extraire le type de fichier du chemin..."
 
 #: ../../src/wxMaxima.cpp:8445
 msgid "Extract function arguments"
-msgstr ""
+msgstr "Extraire les arguments de la fonction"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "Extract list Elements"
-msgstr ""
+msgstr "Extraire les éléments de la liste"
 
 #: ../../src/wxMaxima.cpp:8187
 msgid "Extract matrix from 2D array"
-msgstr ""
+msgstr "Extraire une matrice depuis un tableau 2D"
 
 #: ../../src/wxMaximaFrame.cpp:1686
 msgid "Extract the argument list from a function call"
-msgstr ""
+msgstr "Extraire la liste des arguments d'un appel de fonction"
 
 #: ../../src/wxMaxima.cpp:8538
 msgid "Extract the last n elements from a list"
-msgstr ""
+msgstr "Extraire les n derniers éléments d'une liste"
 
 #: ../../src/wxMaxima.cpp:7376
 msgid "Extract the nth char of a string"
-msgstr ""
+msgstr "Extraire le n-ième caractère d'une chaîne de caractères"
 
 #: ../../src/wxMaxima.cpp:8544
 msgid "Extract the nth list elements"
-msgstr ""
+msgstr "Extraire le n-ième élément de la liste"
 
 #: ../../src/wxMaximaFrame.cpp:1724
 msgid "Extract the value for one variable assigned in a list"
-msgstr ""
+msgstr "Extraire la valeur d'une variable assignée dans une liste"
 
 #: ../../src/wxMaximaFrame.cpp:1439
 msgid "Extract, append or delete rows or columns"
-msgstr ""
+msgstr "Extraire, ajouter ou supprimer des lignes ou des colonnes"
 
 #: ../../src/wxMaxima.cpp:8188
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
-msgstr ""
+msgstr "Extrait un rectangle d'un tableau 2D et le convertir en une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1521
 msgid "Factor Complex"
-msgstr ""
+msgstr "Factorisation complexe"
 
 #: ../../src/Worksheet.cpp:1581
 msgid "Factor Expression"
-msgstr ""
+msgstr "Factoriser l'expression"
 
 #: ../../src/wxMaximaFrame.cpp:1519
 msgid "Factor Expression including subexpressions"
-msgstr ""
+msgstr "Factoriser l'expression, en incluant les sous-expressions"
 
 #: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
 msgid "Factor an expression"
-msgstr ""
+msgstr "Factoriser une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1522
 msgid "Factor an expression in Gaussian numbers"
-msgstr ""
+msgstr "Factoriser une expression en nombres gaussiens"
 
 #: ../../src/wxMaximaFrame.cpp:1587
 msgid "Factorials and &Gamma"
-msgstr ""
+msgstr "Factorielles et &Gamma"
 
 #: ../../src/Image.cpp:137
 #, c-format
 msgid "Failed to delete gnuplot data file %s"
-msgstr ""
+msgstr "Échec de la suppression du fichier de données gnuplot %s"
 
 #: ../../src/Image.cpp:121 ../../src/Image.cpp:128
 #, c-format
 msgid "Failed to delete gnuplot file %s"
-msgstr ""
+msgstr "Échec de la suppression du fichier gnuplot %s"
 
 #: ../../src/wxMaxima.cpp:2667
 msgid "Failed to start Maxima"
-msgstr ""
+msgstr "Echec du lancement de Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1418
 msgid "Fast fortran routines that perform numerical tasks"
-msgstr ""
+msgstr "Routines Fortran rapides pour accomplir les tâches numériques"
 
 #: ../../src/wxMaximaFrame.cpp:1922
 msgid "Fast list access"
-msgstr ""
+msgstr "Accès rapide à la liste"
 
 #: ../../src/wxMaxima.cpp:2553
 msgid "Fatal error"
-msgstr ""
+msgstr "Erreur fatale"
 
 #: ../../src/wxMaxima.cpp:7191
 msgid "Field contents:"
-msgstr ""
+msgstr "Contenu du champ :"
 
 #: ../../src/wxMaxima.cpp:7198
 msgid "Field name:"
-msgstr ""
+msgstr "Nom du champ :"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "Fields:"
-msgstr ""
+msgstr "Champs :"
 
 #: ../../src/main.cpp:439
 msgid "File"
-msgstr ""
+msgstr "Fichier"
 
 #: ../../src/wxMaximaFrame.cpp:1333
 msgid "File I/O"
-msgstr ""
+msgstr "Fichier I/O"
 
 #: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
 #: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
 #: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
 #: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
 msgid "File could not be opened"
-msgstr ""
+msgstr "Le fichier n epeut pas être ouvert"
 
 #: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
 #: ../../src/wxMaxima.cpp:7251
 msgid "File name:"
-msgstr ""
+msgstr "Nom du fichier :"
 
 #: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
 msgid "File not found"
-msgstr ""
+msgstr "Fichier non trouvé"
 
 #: ../../src/wxMaxima.cpp:5631
 msgid "File opened"
-msgstr ""
+msgstr "Fichier chargé"
 
 #: ../../src/wxMaximaFrame.cpp:1217
 msgid "File operations"
-msgstr ""
+msgstr "Opérations sur le fichier"
 
 #: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
 msgid "File you tried to open does not exist."
-msgstr ""
+msgstr "Le fichier que vous tentez d'ouvrir n'existe pas."
 
 #: ../../src/wxMaximaFrame.cpp:1221
 msgid "File/directory functions"
-msgstr ""
+msgstr "Fonctions fichier/dossier"
 
 #: ../../src/wxMaxima.cpp:7027
 msgid "Filename or a list of comma-separated file names"
-msgstr ""
+msgstr "Nom de fichier ou liste de noms de fichiers séparés par des virgules"
 
 #: ../../src/ToolBar.cpp:222
 msgid "Find"
-msgstr ""
+msgstr "Chercher"
 
 #: ../../src/wxMaximaFrame.cpp:670
 msgid "Find\tCtrl+F"
-msgstr ""
+msgstr "Chercher\tCtrl+F"
 
 #: ../../src/wxMaximaFrame.cpp:1468
 msgid "Find &Limit..."
-msgstr ""
+msgstr "Rechercher une &Limite…"
 
 #: ../../src/wxMaximaFrame.cpp:1470
 msgid "Find Minimum..."
-msgstr ""
+msgstr "Trouver le minimum…"
 
 #: ../../src/Worksheet.cpp:1576
 msgid "Find Root..."
-msgstr ""
+msgstr "Trouver une racine…"
 
 #: ../../src/wxMaximaFrame.cpp:1471
 msgid "Find a (unconstrained) minimum of an expression"
-msgstr ""
+msgstr "Trouver un minimum (sans contrainte) d'une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1804
 msgid "Find a fraction that represents this float exactly"
-msgstr ""
+msgstr "Trouver une fraction représentant exactement ce nombre décimal"
 
 #: ../../src/wxMaximaFrame.cpp:1469
 msgid "Find a limit of an expression"
-msgstr ""
+msgstr "Trouver la limite d'une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1807
 msgid "Find a nice fraction that is similar to this float"
-msgstr ""
+msgstr "Trouver une fraction simple proche de ce nombre décimal"
 
 #: ../../src/wxMaximaFrame.cpp:1283
 msgid "Find a numerical solution for a first degree ODE"
 msgstr ""
+"Trouver une solution numérique pour une équation différentielle ordinaire du"
+" premier ordre"
 
 #: ../../src/wxMaximaFrame.cpp:1252
 msgid "Find a root of an equation on an interval"
-msgstr ""
+msgstr "Trouver une racine d'un polynôme dans un intervalle"
 
 #: ../../src/wxMaximaFrame.cpp:1259
 msgid "Find all roots of a polynomial"
-msgstr ""
+msgstr "Trouver toutes les racines d'un polynôme"
 
 #: ../../src/wxMaximaFrame.cpp:1262
 msgid "Find all roots of a polynomial (bfloat)"
-msgstr ""
+msgstr "Trouver toutes les racines d'un polynôme (bfloat)"
 
 #: ../../src/wxMaxima.cpp:6589
 msgid "Find and Replace"
-msgstr ""
+msgstr "Chercher et remplacer"
 
 #: ../../src/ToolBar.cpp:222 ../../src/wxMaximaFrame.cpp:670
 msgid "Find and replace"
-msgstr ""
+msgstr "Chercher et remplacer"
 
 #: ../../src/wxMaxima.cpp:7434
 msgid "Find char in string"
-msgstr ""
+msgstr "Trouver un caractère dans une chaîne"
 
 #: ../../src/wxMaximaFrame.cpp:1172
 msgid "Find char in string..."
-msgstr ""
+msgstr "Trouver un caractère dans une chaîne..."
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Find common denominator"
-msgstr ""
+msgstr "Trouver un dénominateur commun"
 
 #: ../../src/wxMaximaFrame.cpp:1366
 msgid "Find eigenvalues of a matrix"
-msgstr ""
+msgstr "Trouver les valeurs propres d'une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1369
 msgid "Find eigenvectors of a matrix"
-msgstr ""
+msgstr "Trouver les vecteurs propres d'une matrice"
 
 #: ../../src/wxMaxima.cpp:7424
 msgid "Find first difference"
-msgstr ""
+msgstr "Trouver la première différence"
 
 #: ../../src/wxMaximaFrame.cpp:1170
 msgid "Find first difference..."
-msgstr ""
+msgstr "Trouver la première différence..."
 
 #: ../../src/wxMaximaFrame.cpp:1256
 msgid "Find fractions that real roots of a polynomial and "
-msgstr ""
+msgstr "Trouver les fractions représentant les racines réelles d'un polynôme "
 
 #: ../../src/wxMaxima.cpp:9039
 msgid "Find minimum"
-msgstr ""
+msgstr "Trouver le minimum"
 
 #: ../../src/wxMaximaFrame.cpp:1251
 msgid "Find numerical solution..."
-msgstr ""
+msgstr "Trouver une solution numérique..."
 
 #: ../../src/wxMaxima.cpp:10035
 msgid "Find root (solve numerically)"
-msgstr ""
+msgstr "Trouver une racine (résolution numérique)"
 
 #: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
 msgid "Find the maximum absolute value of a matrix entry"
-msgstr ""
+msgstr "Trouver la valeur absolue maximale d'une entrée de matrice"
 
 #: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
 msgid "Find the maximum sum of the absolute values of a matrix column"
 msgstr ""
+"Trouver la somme maximale des valeurs absolues d'une colonne de matrice"
 
 #: ../../src/wxMaxima.cpp:8073 ../../src/wxMaxima.cpp:8094
 msgid "Find the maximum sum of the absolute values of a matrix row"
-msgstr ""
+msgstr "Trouver la somme maximale des valeurs absolues d'une ligne de matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1832
 msgid "Fine-tune the display of engineering-format numbers"
-msgstr ""
+msgstr "Ajuster l'affichage des nombres au format ingénieur"
 
 #: ../../src/wxMaximaFrame.cpp:1712
 msgid "First"
-msgstr ""
+msgstr "Premier"
 
 #: ../../src/wxMaximaFrame.cpp:1918
 msgid "Fitting curves to measurement data"
-msgstr ""
+msgstr "Ajuster les courbes à des données de mesure"
 
 #: ../../src/wxMaxima.cpp:7227
 msgid "Flush stream"
-msgstr ""
+msgstr "Vider le flux"
 
 #: ../../src/wxMaximaFrame.cpp:1103
 msgid "Flush..."
-msgstr ""
+msgstr "Flux..."
 
 #: ../../src/wxMaximaFrame.cpp:922
 msgid "Fold All\tCtrl+Alt+["
-msgstr ""
+msgstr "Tout replier\tCtrl+Alt+["
 
 #: ../../src/wxMaximaFrame.cpp:923
 msgid "Fold all sections"
-msgstr ""
+msgstr "Replier toutes les sections"
 
 #: ../../src/ToolBar.cpp:240
 msgid "Follow"
-msgstr ""
+msgstr "Suivre"
 
 #: ../../src/ToolBar.cpp:285
 msgid ""
@@ -3118,123 +3249,137 @@ msgid ""
 "   Ctrl+6: Heading5 cell\n"
 "   Ctrl+7: Heading6 cell\n"
 msgstr ""
+"Pour une création plus rapide des cellules, les raccourcis suivants existent :\n"
+"\n"
+"   Ctrl+0: Cellule Math\n"
+"   Ctrl+1: Cellule Texte\n"
+"   Ctrl+2: Cellule Titre\n"
+"   Ctrl+3: Cellule Section\n"
+"   Ctrl+4: Cellule Sous-section\n"
+"   Ctrl+5: Cellule Sous-sous-section\n"
+"   Ctrl+6: Cellule Titre niveau 5\n"
+"   Ctrl+7: Cellule Titre niveau 6\n"
 
 #: ../../src/wxMaxima.cpp:7038
 msgid "For loop"
-msgstr ""
+msgstr "Boucle « pour »"
 
 #: ../../src/wxMaximaFrame.cpp:1062
 msgid "For loop..."
-msgstr ""
+msgstr "Boucle « pour »..."
 
 #: ../../src/Worksheet.cpp:237 ../../src/wxMaxima.cpp:11217
 msgid "Forwarding the keyboard focus to a text control"
-msgstr ""
+msgstr "Transférer le focus clavier vers une zone de texte"
 
 #: ../../src/wxMaxima.cpp:11220
 msgid "Forwarding the keyboard focus to the worksheet"
-msgstr ""
+msgstr "Transférer le focus clavier vers la feuille de travail"
 
 #: ../../src/MaximaManual.cpp:452
 #, c-format
 msgid ""
 "Found %li anchors, URLs (individual files): %li, URLs (singlepage): %li"
 msgstr ""
+"%li ancres trouvées, URL (fichiers individuels) : %li, URL (page unique) : "
+"%li"
 
 #: ../../src/MaximaManual.cpp:313
 #, c-format
 msgid "Found only %li keywords in maxima's manual. Not caching them to disc."
 msgstr ""
+"Seulement %li mots-clés trouvés dans le manuel de Maxima. Ne seront pas mis "
+"en cache sur le disque."
 
 #: ../../src/MaximaManual.cpp:513
 #, c-format
 msgid "Found the maxima HTML manual in the folder %s."
-msgstr ""
+msgstr "Le manuel HTML de Maxima a été trouvé dans le dossier %s."
 
 #: ../../src/wxMaxima.cpp:8948
 msgid "Fourier coefficients"
-msgstr ""
+msgstr "Coefficients de Fourier"
 
 #: ../../src/wxMaximaFrame.cpp:1476
 msgid "Fourier coefficients..."
-msgstr ""
+msgstr "Coefficients de Fourier..."
 
 #: ../../src/ToolBar.cpp:137
 #, c-format
 msgid "Frame %li of %li"
-msgstr ""
+msgstr "Diapositive %li sur %li"
 
 #: ../../src/wxMaxima.cpp:9097
 msgid "Frame rate"
-msgstr ""
+msgstr "Fréquence d'images"
 
 #: ../../src/wxMaximaFrame.cpp:1005 ../../src/wxMaximaFrame.cpp:1009
 msgid "Free all unused items now"
-msgstr ""
+msgstr "Effacer maintenant tous les éléments inutilisés"
 
 #: ../../src/wxMaximaFrame.cpp:1413
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
-msgstr ""
+msgstr "Norme de Frobenius sqrt(sum((A(i,j))^2)) (complexe)"
 
 #: ../../src/wxMaximaFrame.cpp:1411
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (real)"
-msgstr ""
+msgstr "Norme de Frobenius sqrt(sum((A(i,j))^2)) (réelle)"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "From:"
-msgstr ""
+msgstr "A partir de :"
 
 #: ../../src/wxMaximaFrame.cpp:827
 msgid "Full Screen\tAlt+Enter"
-msgstr ""
+msgstr "Plein écran\tAlt+Entrée"
 
 #: ../../src/wxMaximaFrame.cpp:824
 msgid "Full Screen\tF11"
-msgstr ""
+msgstr "Plein écran\tF11"
 
 #: ../../src/wxMaxima.cpp:7140
 msgid "Function contents:"
-msgstr ""
+msgstr "Contenus de la fonction :"
 
 #: ../../src/wxMaxima.cpp:7908
 msgid "Function f(x):"
-msgstr ""
+msgstr "Fonction f(x) :"
 
 #: ../../src/wxMaxima.cpp:8572
 msgid "Function name"
-msgstr ""
+msgstr "Noms de la fonction"
 
 #: ../../src/wxMaxima.cpp:7167
 msgid "Function name(s):"
-msgstr ""
+msgstr "Nom(s) de la(ou des) fonctions :"
 
 #: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
 msgid "Function name:"
-msgstr ""
+msgstr "Nom de la fonction :"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Function:"
-msgstr ""
+msgstr "Fonction:"
 
 #: ../../src/wxMaximaFrame.cpp:1630
 msgid "Functions for complex simplification"
-msgstr ""
+msgstr "Fonctions pour une simplification complexe"
 
 #: ../../src/wxMaximaFrame.cpp:1588
 msgid "Functions for simplifying factorials and gamma function"
-msgstr ""
+msgstr "Fonctions pour simplifier les factorielles et la fonction gamma"
 
 #: ../../src/wxMaximaFrame.cpp:1606
 msgid "Functions for simplifying trigonometric expressions"
-msgstr ""
+msgstr "Fonctions pour simplifier les expressions trigonométriques"
 
 #: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
 msgid "GCD"
-msgstr ""
+msgstr "PGCD"
 
 #: ../../src/wxMaxima.cpp:10186
 msgid "GIF image (*.gif)|*.gif"
-msgstr ""
+msgstr "image GIF (*.gif)|*.gif"
 
 #: ../../src/Worksheet.cpp:103
 msgid ""
@@ -3242,169 +3387,182 @@ msgid ""
 " hotkeys to be broken, see for example "
 "https://trac.wxwidgets.org/ticket/18462."
 msgstr ""
+"\"GTK_IM_MODULE est défini sur \"xim\". Cela peut provoquer un scintillement"
+" important et rendre les raccourcis clavier inopérants. Voir par exemple : "
+"https://trac.wxwidgets.org/ticket/18462."
 
 #: ../../src/wxMaximaFrame.cpp:295
 msgid "General Math"
-msgstr ""
+msgstr "Mathématiques générales"
 
 #: ../../src/wxMaximaFrame.cpp:699
 msgid "General Math\tAlt+Shift+M"
-msgstr ""
+msgstr "Mathématiques générales\tAlt+Maj-M"
 
 #: ../../src/wxMaximaFrame.cpp:1316
 msgid "Generate Matrix from Expression..."
-msgstr ""
+msgstr "Générer une matrice à partir d'une expression…"
 
 #: ../../src/wxMaximaFrame.cpp:1317
 msgid "Generate a matrix from a lambda expression"
-msgstr ""
+msgstr "Générer une matrice à partir d'une expression lambda"
 
 #: ../../src/wxMaximaFrame.cpp:1675
 msgid "Generate a new list using a lists' elements"
-msgstr ""
+msgstr "Générer une nouvelle liste à partir des éléments d'une liste"
 
 #: ../../src/wxMaximaFrame.cpp:1681
 msgid ""
 "Generate a storage for variable values that can be introduced into equations"
 " at any time"
 msgstr ""
+"Créer un espace de stockage pour les valeurs de variables pouvant être "
+"insérées dans des équations à tout moment"
 
 #: ../../src/wxMaximaFrame.cpp:1672
 msgid "Generate list elements using a rule"
-msgstr ""
+msgstr "Générer les éléments d'une liste à l'aide d'une règle"
 
 #: ../../src/wxMaxima.cpp:8196
 msgid "Generate matrix from a rule"
-msgstr ""
+msgstr "Générer une matrice à partir d'une règle"
 
 #: ../../src/wxMaximaFrame.cpp:1094
 msgid "Generate unused symbol name"
-msgstr ""
+msgstr "Générer un nom de symbole inutilisé"
 
 #: ../../src/WXMXformat.cpp:231
 msgid "Generated the XML representation of the document"
-msgstr ""
+msgstr "Générer la représentation XML du document"
 
 #: ../../src/wxMaxima.cpp:8197
 msgid ""
 "Generates a matrix and fills each element with the result of the expression "
 "\"Rule\"."
 msgstr ""
+"Génèrer une matrice et remplir chaque élément avec le résultat de "
+"l'expression \"Règle\"."
 
 #: ../../src/wxMaximaFrame.cpp:1619
 msgid "Get &Imaginary Part"
-msgstr ""
+msgstr "Obtenir la Partie &imaginaire"
 
 #: ../../src/wxMaximaFrame.cpp:1485
 msgid "Get Laplace transformation of an expression"
-msgstr ""
+msgstr "Obtenir la transformée de Laplace d'une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1615
 msgid "Get Real P&art"
-msgstr ""
+msgstr "Obtenir la Partie &réelle"
 
 #: ../../src/wxMaximaFrame.cpp:1201
 msgid "Get current directory"
-msgstr ""
+msgstr "Obtenir le répertoire courant"
 
 #: ../../src/wxMaximaFrame.cpp:1489
 msgid "Get inverse Laplace transformation of an expression"
-msgstr ""
+msgstr "Obtenir la transformée de Laplace inverse d'une expression"
 
 #: ../../src/wxMaxima.cpp:7223
 msgid "Get position in stream"
-msgstr ""
+msgstr "Obtenir la position dans le flux"
 
 #: ../../src/wxMaximaFrame.cpp:1102
 msgid "Get position..."
-msgstr ""
+msgstr "Obtenir la position…"
 
 #: ../../src/wxMaximaFrame.cpp:1620
 msgid "Get the imaginary part of complex expression"
-msgstr ""
+msgstr "Obtenir la partie imaginaire d'une expression complexe"
 
 #: ../../src/wxMaximaFrame.cpp:1616
 msgid "Get the real part of complex expression"
-msgstr ""
+msgstr "Obtenir la partie réelle d'une expression complexe"
 
 #: ../../src/wxMaxima.cpp:3609
 #, c-format
 msgid "Gnuplot (command line) found at: %s"
-msgstr ""
+msgstr "Gnuplot (ligne de commande) trouvé à l'emplacement : %s"
 
 #: ../../src/wxMaxima.cpp:3607
 #, c-format
 msgid "Gnuplot found at: %s"
-msgstr ""
+msgstr "Gnuplot a été trouvé à : %s"
 
 #: ../../src/wxMaxima.cpp:2974
 msgid "Gnuplot has closed."
-msgstr ""
+msgstr "Gnuplot s'est fermé."
 
 #: ../../src/wxMaxima.cpp:3598 ../../src/wxMaxima.cpp:3603
 #, c-format
 msgid "Gnuplot not found, using the default: %s"
-msgstr ""
+msgstr "Gnuplot introuvable, utilisation de la valeur par défaut : %s"
 
 #: ../../src/wxMaxima.cpp:9428 ../../src/wxMaximaFrame.cpp:1887
 msgid "Go to URL"
-msgstr ""
+msgstr "Aller à l'URL"
 
 #: ../../src/wxMaxima.cpp:3989
 msgid "Got a new input prompt!"
-msgstr ""
+msgstr "Nouvelle invite de saisie reçue !"
 
 #: ../../src/Worksheet.cpp:6354
 msgid ""
 "Got a request to undo an action that involves a delete which isn't possible "
 "at this moment."
 msgstr ""
+"Reçu une demande d'annulation d'une action impliquant une suppression, ce "
+"qui n'est pas possible pour le moment."
 
 #: ../../src/wxMaximaFrame.cpp:1031
 msgid "Gradefs"
-msgstr ""
+msgstr "Gradefs"
 
 #: ../../src/Worksheet.cpp:1967
 msgid "Greater or less than a value"
-msgstr ""
+msgstr "Supérieur ou inférieur à une valeur"
 
 #: ../../src/wxMaximaFrame.cpp:1130
 msgid "Greater, ignoring case?..."
-msgstr ""
+msgstr "Supérieur, en ignorant la casse ?…"
 
 #: ../../src/wxMaximaFrame.cpp:260
 msgid "Greek Letters"
-msgstr ""
+msgstr "Lettres grecques"
 
 #: ../../src/wxMaximaFrame.cpp:703
 msgid "Greek Letters\tAlt+Shift+G"
-msgstr ""
+msgstr "Lettres Grecques\tAlt+Shift+G"
 
 #: ../../src/wxMaximaFrame.cpp:1815
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
+"Deviner un nombre exact qui pourrait correspondre à ce nombre à virgule "
+"flottante"
 
 #: ../../src/wxMaxima.cpp:6123
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file "
 "(*.tex)|*.tex"
 msgstr ""
+"Fichier HTML (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file "
+"(*.tex)|*.tex"
 
 #: ../../src/wxMaximaFrame.cpp:1341
 msgid "Hadamard (element-by-element) product..."
-msgstr ""
+msgstr "Produit de Hadamard (élément par élément)..."
 
 #: ../../src/wxMaxima.cpp:8004
 msgid "Hadamard Product"
-msgstr ""
+msgstr "Produit de Hadamard"
 
 #: ../../src/wxMaxima.cpp:8011
 msgid "Hadamard exponent"
-msgstr ""
+msgstr "Exposant de Hadamard"
 
 #: ../../src/wxMaximaFrame.cpp:1345
 msgid "Hadamard exponent..."
-msgstr ""
+msgstr "Exposant de Hadamard..."
 
 #: ../../src/MaximaManual.cpp:260
 #, c-format
@@ -3412,119 +3570,122 @@ msgid ""
 "Have only %li keyword anchors at the end of parsing the maxima manual => Not"
 " caching the result of using the built-in keyword list"
 msgstr ""
+"Seulement %li ancres de mots-clés trouvées à la fin de l'analyse du manuel "
+"Maxima => Le résultat de l'utilisation de la liste intégrée de mots-clés ne "
+"sera pas mis en cache"
 
 #: ../../src/Configuration.cpp:88 ../../src/ToolBar.cpp:276
 msgid "Heading 5"
-msgstr ""
+msgstr "En-tête de niveau 5"
 
 #: ../../src/Configuration.cpp:87 ../../src/ToolBar.cpp:277
 msgid "Heading 6"
-msgstr ""
+msgstr "En-tête de niveau 6"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
 msgid "Help"
-msgstr ""
+msgstr "Aide"
 
 #: ../../src/ToolBar.cpp:635
 msgid "Help button"
-msgstr ""
+msgstr "Bouton d'aide"
 
 #: ../../src/Worksheet.cpp:1340 ../../src/Worksheet.cpp:1778
 #, c-format
 msgid "Help on \"%s\""
-msgstr ""
+msgstr "Aide sur \"%s\""
 
 #: ../../src/wxMaximaFrame.cpp:729
 msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr ""
+msgstr "Masquer toutes les barres d’outils\tAlt+Maj+-"
 
 #: ../../src/ToolBar.cpp:264
 msgid "Hide Code"
-msgstr ""
+msgstr "Masquer le code"
 
 #: ../../src/wxMaximaFrame.cpp:727
 msgid "Hide Code Cells\tAlt+Ctrl+H"
-msgstr ""
+msgstr "Masquer les cellules de Code \tAlt+Ctrl+H"
 
 #: ../../src/Worksheet.cpp:1896
 msgid "Hide Heading 5"
-msgstr ""
+msgstr "Masquer l'en-tête de niveau 5"
 
 #: ../../src/Worksheet.cpp:1907
 msgid "Hide Heading 6"
-msgstr ""
+msgstr "Masquer l'en-tête de niveau 6"
 
 #: ../../src/Worksheet.cpp:1855
 msgid "Hide Part"
-msgstr ""
+msgstr "Masquer la partie"
 
 #: ../../src/Worksheet.cpp:1863
 msgid "Hide Section"
-msgstr ""
+msgstr "Masquer la Section"
 
 #: ../../src/Worksheet.cpp:1874
 msgid "Hide Subsection"
-msgstr ""
+msgstr "Masquer la Sous-section"
 
 #: ../../src/Worksheet.cpp:1885
 msgid "Hide Subsubsection"
-msgstr ""
+msgstr "Masquer la Sous-sous-section"
 
 #: ../../src/wxMaximaFrame.cpp:730
 msgid "Hide all panes"
-msgstr ""
+msgstr "Masquer tous les panneaux"
 
 #: ../../src/Worksheet.cpp:1491
 msgid "Hide cell brackets"
-msgstr ""
+msgstr "Masquer les crochets de la cellule"
 
 #: ../../src/Worksheet.cpp:1915
 msgid "Hide contents"
-msgstr ""
+msgstr "Masquer les contenus"
 
 #: ../../src/Worksheet.cpp:1552
 msgid "Hide multiplication dots"
-msgstr ""
+msgstr "Masquer les points des multiplications"
 
 #: ../../src/Worksheet.cpp:1930 ../../src/Worksheet.cpp:2063
 msgid "Hide yellow tooltip marker for this cell"
-msgstr ""
+msgstr "Masquer le marqueur d’info-bulle jaune pour cette cellule"
 
 #: ../../src/Worksheet.cpp:1937 ../../src/Worksheet.cpp:2069
 msgid "Hide yellow tooltip marker for this message type"
-msgstr ""
+msgstr "Masquer le marqueur d’info-bulle jaune pour ce type de message"
 
 #: ../../src/Configuration.cpp:82
 msgid "Highlight (box)"
-msgstr ""
+msgstr "Surligner (encadrer)"
 
 #: ../../src/wxMaxima.cpp:9528
 msgid "Histogram"
-msgstr ""
+msgstr "Histogramme"
 
 #: ../../src/wxMaximaFrame.cpp:232
 msgid "History"
-msgstr ""
+msgstr "Historique"
 
 #: ../../src/wxMaximaFrame.cpp:709
 msgid "History\tAlt+Shift+I"
-msgstr ""
+msgstr "Historique\tAlt+Shift+I"
 
 #: ../../src/wxMaximaFrame.cpp:1526
 msgid "Horner's rule"
-msgstr ""
+msgstr "Règle de Horner"
 
 #: ../../src/wxMaxima.cpp:9207
 msgid "How many digits to show:"
-msgstr ""
+msgstr "Nombre de chiffres à afficher :"
 
 #: ../../src/wxMaximaFrame.cpp:759
 msgid "How to display new equations"
-msgstr ""
+msgstr "Comment afficher les nouvelles équations"
 
 #: ../../src/wxMaximaFrame.cpp:1113
 msgid "I/O"
-msgstr ""
+msgstr "Entrée/Sortie"
 
 #: ../../src/wxMaxima.cpp:7062
 msgid ""
@@ -3532,6 +3693,9 @@ msgid ""
 "between parenthesis. The result of the last operation is the return value of"
 " the program."
 msgstr ""
+"Si un programme n'a pas besoin de variables locales, Maxima permet de placer"
+" les commandes entre parenthèses. Le résultat de la dernière opération est "
+"alors la valeur retournée par le programme."
 
 #: ../../src/wxMaxima.cpp:7172
 msgid ""
@@ -3540,511 +3704,530 @@ msgid ""
 "\n"
 "array, boolean, integer, fixnum (machine-length integer), float (machine-size floating-point numbers), real or any (which is useful for declaring arrays of any)"
 msgstr ""
+"Si le type d'un paramètre de fonction est connu lors de la compilation d'une fonction, le code peut être grandement optimisé.\n"
+"Types connus:\n"
+"tableau (*array*), booléen (*boolean*), entier (*integer*), entier machine (*fixnum*), nombre à virgule flottante (*float*), nombre réel (*real*) ou *any* (utile pour déclarer des tableaux de type quelconque)"
 
 #: ../../src/MathParser.cpp:890
 msgid ""
 "If this isn't a function returning a lambda() expression a multiplication "
 "sign (*) between closing and opening parenthesis is missing here."
 msgstr ""
+"Si ce n'est pas une fonction retournant une expression lambda(), il manque "
+"un signe de multiplication (*) entre la parenthèse fermante et la parenthèse"
+" ouvrante ici."
 
 #: ../../src/MaximaManual.cpp:403
 msgid "Ignoring the cache version for the manual anchors."
-msgstr ""
+msgstr "La version en cache des ancres du manuel est ignorée."
 
 #: ../../src/Image.cpp:79
 msgid "Image data had zero length!"
-msgstr ""
+msgstr "Les données de l'image sont de longueur nulle !"
 
 #: ../../src/wxMaxima.cpp:10147 ../../src/wxMaxima.cpp:10855
 msgid ""
 "Image files (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, "
 "*.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
 msgstr ""
+"Fichiers Image (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, "
+"*.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
 
 #: ../../src/Worksheet.cpp:5509
 msgid "ImageCell without image."
-msgstr ""
+msgstr "Cellule image sans image."
 
 #: ../../src/MathParser.cpp:347
 msgid "Importing compressed gnuplot sources for an animation"
-msgstr ""
+msgstr "Importation des sources gnuplot compressées pour une animation"
 
 #: ../../src/MathParser.cpp:334
 msgid "Importing uncompressed gnuplot sources for an animation"
-msgstr ""
+msgstr "Importation des sources gnuplot non compressées pour une animation"
 
 #: ../../src/wxMaxima.cpp:7993
 msgid ""
 "In order to save memory the \":\" operator does clone the matrix, not copy it:\n"
 "If you change an element of one matrix the same element will change in all of its clones. copymatrix() instead generates a copy of a matrix: A new matrix that, if changed in any way, won't change the original."
 msgstr ""
+"Pour économiser de la mémoire, l'opérateur \":\" cloner la matrice au lieu de la copier :  \n"
+"Si vous modifiez un élément d’une matrice, cet élément sera modifié dans tous ses clones.  copymatrix() génère quant à elle une copie d’une matrice : une nouvelle matrice qui, si elle est modifiée, ne modifiera pas l’originale."
 
 #: ../../src/wxMaxima.cpp:7404
 msgid ""
 "In order to save memory the : operator doesn't create an individual copy of "
 "the string, but a clone that changes when the original string changes."
 msgstr ""
+"Pour économiser de la mémoire, l’opérateur : ne crée pas une copie "
+"individuelle de la chaîne de caractères, mais un clone qui change lorsque la"
+" chaîne originale est modifiée."
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Include columns:"
-msgstr ""
+msgstr "Inclure les colonnes :"
 
 #: ../../src/Worksheet.cpp:2008
 msgid "Increasing function f(x)>x"
-msgstr ""
+msgstr "Fonction croissante f(x) > x"
 
 #: ../../src/wxMaxima.cpp:8470
 msgid "Index End:"
-msgstr ""
+msgstr "Fin d'index :"
 
 #: ../../src/wxMaxima.cpp:8470
 msgid "Index Start:"
-msgstr ""
+msgstr "Début d'index :"
 
 #: ../../src/wxMaxima.cpp:8471
 msgid "Index Step:"
-msgstr ""
+msgstr "Pas de l’index :"
 
 #: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
 msgid "Index variable:"
-msgstr ""
+msgstr "Variable d’index :"
 
 #: ../../src/wxMaximaFrame.cpp:1949
 msgid "Info about Maxima build"
-msgstr ""
+msgstr "Informations sur la compilation de Maxima"
 
 #: ../../src/Worksheet.cpp:2046
 msgid "Inform maxima about facts you know for this symbol"
-msgstr ""
+msgstr "Déclarer à Maxima des informations connues sur ce symbole"
 
 #: ../../src/Worksheet.cpp:1988
 msgid ""
 "Inform maxima about the value of the function at a specific point, e.G. for "
 "declaring initial conditions"
 msgstr ""
+"Définir pour Maxima la valeur de la fonction en un point donné, par ex. pour"
+" déclarer des conditions initiales"
 
 #: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
 msgid "Initial Condition"
-msgstr ""
+msgstr "Condition initiale"
 
 #: ../../src/wxMaximaFrame.cpp:1270
 msgid "Initial Value Problem (&1)..."
-msgstr ""
+msgstr "Condition initiale (&1)…"
 
 #: ../../src/wxMaximaFrame.cpp:1274
 msgid "Initial Value Problem (&2)..."
-msgstr ""
+msgstr "Condition initiale (&2)…"
 
 #: ../../src/wxMaxima.cpp:9044
 msgid "Initial estimates:"
-msgstr ""
+msgstr "Estimations initiales :"
 
 #: ../../src/wxMaxima.cpp:7840
 msgid "Initial x:"
-msgstr ""
+msgstr "Valeur initiale de x :"
 
 #: ../../src/Configuration.cpp:78
 msgid "Input labels"
-msgstr ""
+msgstr "Étiquettes d'entrée"
 
 #: ../../src/wxMaximaFrame.cpp:314
 msgid "Insert"
-msgstr ""
+msgstr "Insérer"
 
 #: ../../src/wxMaximaFrame.cpp:905
 msgid "Insert &Section Cell\tCtrl+3"
-msgstr ""
+msgstr "Insérer une cellule de section\tCtrl+3"
 
 #: ../../src/wxMaximaFrame.cpp:901
 msgid "Insert &Text Cell\tCtrl+1"
-msgstr ""
+msgstr "Insérer une cellule de texte \tCtrl+1"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Insert Cell\tAlt+Shift+C"
-msgstr ""
+msgstr "Insérer une cellule\tAlt+Maj-C"
 
 #: ../../src/Worksheet.cpp:1669
 msgid "Insert Heading5 Cell"
-msgstr ""
+msgstr "Insérer une cellule de titre niveau 5"
 
 #: ../../src/Worksheet.cpp:1671
 msgid "Insert Heading6 Cell"
-msgstr ""
+msgstr "Insérer une cellule de titre niveau 6"
 
 #: ../../src/wxMaxima.cpp:10854
 msgid "Insert Image"
-msgstr ""
+msgstr "Insérer une image"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert Image..."
-msgstr ""
+msgstr "Insérer une image…"
 
 #: ../../src/wxMaximaFrame.cpp:899
 msgid "Insert Input &Cell\tCtrl+0"
-msgstr ""
+msgstr "Insérer une cellule d'entrée\tCtrl+0"
 
 #: ../../src/wxMaximaFrame.cpp:919
 msgid "Insert Page Break"
-msgstr ""
+msgstr "Insérer un saut de page"
 
 #: ../../src/wxMaximaFrame.cpp:907
 msgid "Insert S&ubsection Cell\tCtrl+4"
-msgstr ""
+msgstr "Insérer une cellule de sous-section\tCtrl+4"
 
 #: ../../src/wxMaximaFrame.cpp:910
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
-msgstr ""
+msgstr "Insérer une cellule de sous-sous-section\tCtrl+5"
 
 #: ../../src/Worksheet.cpp:1662
 msgid "Insert Section Cell"
-msgstr ""
+msgstr "Insérer une cellule de section"
 
 #: ../../src/Worksheet.cpp:1664
 msgid "Insert Subsection Cell"
-msgstr ""
+msgstr "Insérer une cellule de sous-section"
 
 #: ../../src/Worksheet.cpp:1667
 msgid "Insert Subsubsection Cell"
-msgstr ""
+msgstr "Insérer une cellule de sous-sous-section"
 
 #: ../../src/wxMaximaFrame.cpp:903
 msgid "Insert T&itle Cell\tCtrl+2"
-msgstr ""
+msgstr "Insérer une cellule de titre\tCtrl+2"
 
 #: ../../src/Worksheet.cpp:1658
 msgid "Insert Text Cell"
-msgstr ""
+msgstr "Insérer une cellule de texte"
 
 #: ../../src/Worksheet.cpp:1660
 msgid "Insert Title Cell"
-msgstr ""
+msgstr "Insérer une cellule de titre"
 
 #: ../../src/wxMaximaFrame.cpp:913
 msgid "Insert a new heading5 cell"
-msgstr ""
+msgstr "Insérer une nouvelle cellule titre de niveau 5"
 
 #: ../../src/wxMaximaFrame.cpp:915
 msgid "Insert a new heading6 cell"
-msgstr ""
+msgstr "Insérer une nouvelle cellule titre de niveau 6"
 
 #: ../../src/wxMaximaFrame.cpp:900
 msgid "Insert a new input cell"
-msgstr ""
+msgstr "Insérer une nouvelle cellule d'entrée"
 
 #: ../../src/wxMaximaFrame.cpp:906
 msgid "Insert a new section cell"
-msgstr ""
+msgstr "Insérer une nouvelle cellule de section"
 
 #: ../../src/wxMaximaFrame.cpp:908
 msgid "Insert a new subsection cell"
-msgstr ""
+msgstr "Insérer une nouvelle cellule de sous-section"
 
 #: ../../src/wxMaximaFrame.cpp:911
 msgid "Insert a new subsubsection cell"
-msgstr ""
+msgstr "Insérer une nouvelle cellule de sous-sous-section"
 
 #: ../../src/wxMaximaFrame.cpp:902
 msgid "Insert a new text cell"
-msgstr ""
+msgstr "Insérer une nouvelle cellule de texte"
 
 #: ../../src/wxMaximaFrame.cpp:904
 msgid "Insert a new title cell"
-msgstr ""
+msgstr "Insérer une nouvelle cellule de titre"
 
 #: ../../src/wxMaximaFrame.cpp:920
 msgid "Insert a page break"
-msgstr ""
+msgstr "Insérer un saut de page"
 
 #: ../../src/wxMaximaFrame.cpp:1164
 msgid "Insert char..."
-msgstr ""
+msgstr "Insérer un caractère..."
 
 #: ../../src/wxMaximaFrame.cpp:912
 msgid "Insert heading5 Cell\tCtrl+6"
-msgstr ""
+msgstr "Insérer un titre de niveau 5\tCtrl+6"
 
 #: ../../src/wxMaximaFrame.cpp:914
 msgid "Insert heading6 Cell\tCtrl+7"
-msgstr ""
+msgstr "Insérer un titre de niveau 6\tCtrl+7"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert image"
-msgstr ""
+msgstr "Insérer une image"
 
 #: ../../src/wxMaximaFrame.cpp:916
 msgid "Insert textbased cell"
-msgstr ""
+msgstr "Insérer une cellule de texte"
 
 #: ../../src/wxMaxima.cpp:3566
 msgid "Instructed to prefer gnuplot over wgnuplot"
-msgstr ""
+msgstr "Configurer pour préférer gnuplot plutôt que wgnuplot"
 
 #: ../../src/wxMaxima.cpp:3554
 msgid "Instructed to prefer wgnuplot over gnuplot"
-msgstr ""
+msgstr "Configurer pour préférer wgnuplot plutôt que gnuplot"
 
 #: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
 msgid "Integral/Sum:"
-msgstr ""
+msgstr "Intégrale/Somme:"
 
 #: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
 msgid "Integrate"
-msgstr ""
+msgstr "Intégrer"
 
 #: ../../src/wxMaxima.cpp:8980
 msgid "Integrate (risch)"
-msgstr ""
+msgstr "Intégrer (Risch)"
 
 #: ../../src/wxMaximaFrame.cpp:1454
 msgid "Integrate expression"
-msgstr ""
+msgstr "Intégrer une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1456
 msgid "Integrate expression with Risch algorithm"
-msgstr ""
+msgstr "Intégrer une expression avec l'algorithme de Risch"
 
 #: ../../src/wxMaximaFrame.cpp:1869
 msgid "Integrate numerically"
-msgstr ""
+msgstr "Intégrer numériquement"
 
 #: ../../src/Worksheet.cpp:1588
 msgid "Integrate..."
-msgstr ""
+msgstr "Intégrer…"
 
 #: ../../src/wxMaximaFrame.cpp:1737
 msgid "Interleave"
-msgstr ""
+msgstr "Entrelacer"
 
 #: ../../src/wxMaximaFrame.cpp:1738
 msgid "Interleave the values of two lists"
-msgstr ""
+msgstr "Entrelacer les valeurs de deux listes"
 
 #: ../../src/wxMaxima.cpp:8612
 msgid "Interleave two lists"
-msgstr ""
+msgstr "Entrelacer deux listes"
 
 #: ../../src/wxMaximaFrame.cpp:1087
 msgid "Interpret like input..."
-msgstr ""
+msgstr "Interpréter comme saisie..."
 
 #: ../../src/wxMaxima.cpp:7104
 msgid "Interpret maxima's output as input"
-msgstr ""
+msgstr "Interpréter la sortie de Maxima comme entrée"
 
 #: ../../src/wxMaxima.cpp:7502
 msgid "Interpret string as maxima code"
-msgstr ""
+msgstr "Interpréter une chaîne comme du code Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1089
 msgid "Interpret string..."
-msgstr ""
+msgstr "Interpréter une chaîne..."
 
 #: ../../src/ToolBar.cpp:231
 msgid "Interrupt"
-msgstr ""
+msgstr "Interrompre"
 
 #: ../../src/wxMaximaFrame.cpp:965
 msgid "Interrupt current computation"
-msgstr ""
+msgstr "Interrompre le calcul en cours"
 
 #: ../../src/ToolBar.cpp:232
 msgid ""
 "Interrupt current computation. To completely restart maxima press the button"
 " left to this one."
 msgstr ""
+"Interrompre le calcul en cours.  Pour redémarrer complètement Maxima, "
+"appuyez sur le bouton situé à gauche de celui-ci."
 
 #: ../../src/wxMaxima.cpp:2766
 #, c-format
 msgid "Interrupting maxima: %s"
-msgstr ""
+msgstr "Interrompre maxima: %s"
 
 #: ../../src/wxMaxima.cpp:8557
 msgid "Introduce a list of actual values into an equation"
-msgstr ""
+msgstr "Introduire une liste de valeurs actuelles dans une équation"
 
 #: ../../src/wxMaximaFrame.cpp:1697
 msgid "Introduce the actual values for variables stored in the list"
-msgstr ""
+msgstr "Introduire les valeurs actuelles des variables stockées dans la liste"
 
 #: ../../src/wxMaxima.cpp:10062
 msgid "Introduces one or more assignments into an expression"
-msgstr ""
+msgstr "Introduire une ou plusieurs affectations dans une expression"
 
 #: ../../src/wxMaxima.cpp:9003
 msgid "Inverse Laplace"
-msgstr ""
+msgstr "Transformée de Laplace inverse"
 
 #: ../../src/wxMaximaFrame.cpp:1488
 msgid "Inverse Laplace T&ransform..."
-msgstr ""
+msgstr "Transformée de Laplace inverse..."
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Invert worksheet brightness"
-msgstr ""
+msgstr "Basculer mode clair/sombre"
 
 #: ../../src/wxMaxima.cpp:7338
 msgid "Is Char 1 greater than Char2, if case is ignored?"
 msgstr ""
+"Le caractère 1 est-il supérieur au caractère 2, si la casse est ignorée ?"
 
 #: ../../src/wxMaxima.cpp:7333
 msgid "Is Char 1 greater than Char2?"
-msgstr ""
+msgstr "Le caractère 1 est-il supérieur au caractère 2 ?"
 
 #: ../../src/wxMaxima.cpp:7327
 msgid "Is Char 1 less than Char2, if case is ignored?"
 msgstr ""
+"Le caractère 1 est-il inférieur au caractère 2, si la casse est ignorée ?"
 
 #: ../../src/wxMaxima.cpp:7322
 msgid "Is Char 1 less than Char2?"
-msgstr ""
+msgstr "Le caractère 1 est-il inférieur au caractère 2 ?"
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Is a char?"
-msgstr ""
+msgstr "Est-ce un caractère ?"
 
 #: ../../src/wxMaximaFrame.cpp:1115
 msgid "Is a char?..."
-msgstr ""
+msgstr "Est-ce un caractère ?..."
 
 #: ../../src/Worksheet.cpp:1952
 msgid "Is a complex variable"
-msgstr ""
+msgstr "Est-ce une variable complexe"
 
 #: ../../src/wxMaxima.cpp:7292
 msgid "Is a digit?"
-msgstr ""
+msgstr "Est-ce un chiffre ?"
 
 #: ../../src/wxMaximaFrame.cpp:1118
 msgid "Is a digit?..."
-msgstr ""
+msgstr "Est-ce un chiffre ?..."
 
 #: ../../src/wxMaxima.cpp:7304
 msgid "Is a lowercase char?"
-msgstr ""
+msgstr "Est-ce un caractère minuscule ?"
 
 #: ../../src/wxMaxima.cpp:7296
 msgid "Is a printable char?"
-msgstr ""
+msgstr "Est-ce un caractère imprimable ?"
 
 #: ../../src/Worksheet.cpp:1949
 msgid "Is a real variable"
-msgstr ""
+msgstr "Est-ce une variable réelle"
 
 #: ../../src/wxMaxima.cpp:7300
 msgid "Is a uppercase char?"
-msgstr ""
+msgstr "Est-ce un caractère majuscule ?"
 
 #: ../../src/wxMaximaFrame.cpp:1116
 msgid "Is alphabetic?..."
-msgstr ""
+msgstr "Est-ce alphabétique ?..."
 
 #: ../../src/wxMaximaFrame.cpp:1117
 msgid "Is alphanumeric?..."
-msgstr ""
+msgstr "Est-ce alphanumérique ?..."
 
 #: ../../src/wxMaxima.cpp:7284
 msgid "Is an alphabetic char?"
-msgstr ""
+msgstr "Est-ce un  caractère alphabétiques ?"
 
 #: ../../src/wxMaxima.cpp:7288
 msgid "Is an alphanumeric char?"
-msgstr ""
+msgstr "Est-ce un caractère alphanumérique ?"
 
 #: ../../src/Worksheet.cpp:1991
 msgid "Is an even function"
-msgstr ""
+msgstr "Est-ce une fonction paire"
 
 #: ../../src/Worksheet.cpp:1955
 msgid "Is an imaginary variable"
-msgstr ""
+msgstr "Est-ce une varialble imaginaire"
 
 #: ../../src/Worksheet.cpp:1960
 msgid "Is an integer variable"
-msgstr ""
+msgstr "Est-ce une variable entière"
 
 #: ../../src/Worksheet.cpp:1993
 msgid "Is an odd function"
-msgstr ""
+msgstr "Est-ce une fonction impaire"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Is equal?..."
-msgstr ""
+msgstr "Est-ce égal ?..."
 
 #: ../../src/wxMaximaFrame.cpp:1128
 msgid "Is greater?..."
-msgstr ""
+msgstr "Est-ce plus grand ?..."
 
 #: ../../src/wxMaximaFrame.cpp:1125
 msgid "Is lower?..."
-msgstr ""
+msgstr "Est-ce plus inférieur ?..."
 
 #: ../../src/wxMaximaFrame.cpp:1121
 msgid "Is lowercase?..."
-msgstr ""
+msgstr "Est-ce en minuscules ?..."
 
 #: ../../src/Worksheet.cpp:1962
 msgid "Is no integer variable"
-msgstr ""
+msgstr "N'est pas une variable entière"
 
 #: ../../src/wxMaximaFrame.cpp:1119
 msgid "Is printable?..."
-msgstr ""
+msgstr "Est-ce imprimable ?..."
 
 #: ../../src/wxMaximaFrame.cpp:1120
 msgid "Is uppercase?..."
-msgstr ""
+msgstr "Est-ce en majuscules ?..."
 
 #: ../../src/Worksheet.cpp:6256
 msgid "Issuing the active cell's undo function"
-msgstr ""
+msgstr "Exécution de la fonction annuler de la cellule active"
 
 #: ../../src/Worksheet.cpp:6261
 msgid "Issuing the worksheet's undo function"
-msgstr ""
+msgstr "Exécution de la fonction annuler du notebook"
 
 #: ../../src/wxMaxima.cpp:8598 ../../src/wxMaxima.cpp:8604
 msgid "Item"
-msgstr ""
+msgstr "Elément"
 
 #: ../../src/wxMaxima.cpp:8581
 msgid "Iterator name:"
-msgstr ""
+msgstr "Nom de l'itérateur :"
 
 #: ../../src/wxMaximaFrame.cpp:1048
 msgid "Jump to first error"
-msgstr ""
+msgstr "Aller à la première erreur"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Jump to the first cell Maxima has reported an error in."
-msgstr ""
+msgstr "Aller à la première cellule où Maxima a signalé une erreur."
 
 #: ../../src/wxMaxima.cpp:8960
 msgid "LCM"
-msgstr ""
+msgstr "PPCM"
 
 #: ../../src/wxMaximaFrame.cpp:1407
 msgid "L[1] Norm (complex)"
-msgstr ""
+msgstr "L[1] Norme (complexe)"
 
 #: ../../src/wxMaximaFrame.cpp:1406
 msgid "L[1] Norm (real)"
-msgstr ""
+msgstr "L[1] Norme (réelle)"
 
 #: ../../src/wxMaximaFrame.cpp:1409
 msgid "L[inf] Norm (complex)"
-msgstr ""
+msgstr "L[inf] Norme (complexe)"
 
 #: ../../src/wxMaximaFrame.cpp:1408
 msgid "L[inf] Norm (real)"
-msgstr ""
+msgstr "L[inf] Norme (réelle)"
 
 #: ../../src/wxMaximaFrame.cpp:1025
 msgid "Labels"
-msgstr ""
+msgstr "Étiquettes"
 
 #: ../../src/wxMaxima.cpp:7090
 msgid "Lambda"
-msgstr ""
+msgstr "Lambda"
 
 #: ../../src/wxMaxima.cpp:7091
 msgid ""
@@ -4052,275 +4235,283 @@ msgid ""
 "This is useful if you want to use a function only once, perhaps as a parameter to another function and don't need it to be named.\n"
 "Also you can fill a variable with a lambda() construct, effectively generating a function pointer: A variable that can be used as a function, and filled with a different function, if needed."
 msgstr ""
+"Lambda génère une fonction, mais ne lui donne pas de nom.\n"
+"Cela est utile si vous voulez utiliser une fonction seulement une fois, peut-être comme paramètre d'une autre fonction sans avoir besoin qu'elle soit nommée.\n"
+"Vous pouvez aussi remplir une variable avec une construction lambda(), créant ainsi un pointeur de fonction : une variable qui sera utilisable comme fonction et remplissable avec une autre fonction si nécessaire."
 
 #: ../../src/wxMaxima.cpp:8997
 msgid "Laplace"
-msgstr ""
+msgstr "Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1484
 msgid "Laplace &Transform..."
-msgstr ""
+msgstr "&Transformée de Laplace…"
 
 #: ../../src/wxMaximaFrame.cpp:1718
 msgid "Last"
-msgstr ""
+msgstr "Dernier"
 
 #: ../../src/wxMaxima.cpp:3006
 #, c-format
 msgid "Last message from maxima's stderr: %s"
-msgstr ""
+msgstr "Dernier message provenant du flux d’erreur standard de maxima : %s"
 
 #: ../../src/wxMaxima.cpp:2993
 #, c-format
 msgid "Last message from maxima's stdout: %s"
-msgstr ""
+msgstr "Dernier message du flux de sortie standard de maxima : %s"
 
 #: ../../src/wxMaximaFrame.cpp:1720
 msgid "Last n"
-msgstr ""
+msgstr "Dernier n"
 
 #: ../../src/wxMaxima.cpp:10400
 msgid "Last non-whitespace is a question mark"
-msgstr ""
+msgstr "Le dernier caractère non-vide est un point d'interrogation"
 
 #: ../../src/wxMaxima.cpp:4899
 #, c-format
 msgid "Launching the system's default help browser as %s."
-msgstr ""
+msgstr "Lancer le navigateur d'aide par défaut du système comme %s."
 
 #: ../../src/wxMaxima.cpp:4909
 msgid "Launching the system's default help browser failed."
-msgstr ""
+msgstr "Le lancement du navigateur d'aide par défaut a échoué."
 
 #: ../../src/wxMaximaFrame.cpp:1493
 msgid "Least Common Multiple..."
-msgstr ""
+msgstr "Plus petit commun multiple…"
 
 #: ../../src/wxMaxima.cpp:9587
 msgid "Least Squares Fit"
-msgstr ""
+msgstr "Ajustement par la méthode des moindres carrés"
 
 #: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
 #: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
 msgid "Left Matrix:"
-msgstr ""
+msgstr "Matrice gauche :"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Left end"
-msgstr ""
+msgstr "Extrémité gauche"
 
 #: ../../src/wxMaximaFrame.cpp:1297
 msgid "Left side to the \"=\""
-msgstr ""
+msgstr "Membre de gauche de \"=\""
 
 #: ../../src/wxMaximaFrame.cpp:1741
 msgid "Length"
-msgstr ""
+msgstr "Longueur"
 
 #: ../../src/wxMaximaFrame.cpp:1104 ../../src/wxMaximaFrame.cpp:1167
 msgid "Length..."
-msgstr ""
+msgstr "Longueur..."
 
 #: ../../src/wxMaxima.cpp:7421
 msgid "Length:"
-msgstr ""
+msgstr "Longueur :"
 
 #: ../../src/wxMaximaFrame.cpp:1032
 msgid "Letrules"
-msgstr ""
+msgstr "Letrules"
 
 #: ../../src/Worksheet.cpp:1976
 msgid "Likely to be the main variable"
-msgstr ""
+msgstr "Probablement la variable principale"
 
 #: ../../src/wxMaxima.cpp:9028
 msgid "Limit"
-msgstr ""
+msgstr "Limite"
 
 #: ../../src/wxMaxima.cpp:7256
 msgid "Lisp format string:"
-msgstr ""
+msgstr "Chaîne au format Lisp :"
 
 #: ../../src/wxMaxima.cpp:7258
 msgid "Lisp format strings are more powerful than c++ format strings"
 msgstr ""
+"Les chaînes au format Lisp sont plus puissantes que les chaînes au format "
+"C++"
 
 #: ../../src/wxMaxima.cpp:5066
 msgid "Lisp mode."
-msgstr ""
+msgstr "Mode Lisp."
 
 #: ../../src/wxMaximaFrame.cpp:1010 ../../src/wxMaximaFrame.cpp:1012
 msgid "Lisp normally frees memory only when it has time or runs out of space"
 msgstr ""
+"Lisp libère normalement la mémoire seulement lorsqu'il en a le temps ou "
+"lorsqu'il manque d'espace"
 
 #: ../../src/wxMaxima.cpp:3691
 #, c-format
 msgid "Lisp version: %s"
-msgstr ""
+msgstr "Version de Lisp : %s"
 
 #: ../../src/wxMaxima.cpp:8435 ../../src/wxMaxima.cpp:8539
 #: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
 #: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
 #: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
 msgid "List"
-msgstr ""
+msgstr "Liste"
 
 #: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
 msgid "List #1"
-msgstr ""
+msgstr "Liste #1"
 
 #: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
 msgid "List #2"
-msgstr ""
+msgstr "Liste #2"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "List directory"
-msgstr ""
+msgstr "Répertoire de la liste"
 
 #: ../../src/wxMaximaFrame.cpp:1205
 msgid "List directory..."
-msgstr ""
+msgstr "Répertoire de la liste..."
 
 #: ../../src/wxMaxima.cpp:7385 ../../src/wxMaxima.cpp:7389
 msgid "List of char to String"
-msgstr ""
+msgstr "Liste de caractères vers chaîne"
 
 #: ../../src/wxMaximaFrame.cpp:1150
 msgid "List of chars to string..."
-msgstr ""
+msgstr "Liste de caractères vers chaîne..."
 
 #: ../../src/wxMaxima.cpp:7386
 msgid "List of chars:"
-msgstr ""
+msgstr "Liste de caractères :"
 
 #: ../../src/wxMaxima.cpp:8559
 msgid "List with values"
-msgstr ""
+msgstr "Liste avec valeurs"
 
 #: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
 msgid "List:"
-msgstr ""
+msgstr "Liste:"
 
 #: ../../src/wxMaxima.cpp:6200
 msgid "Load Package"
-msgstr ""
+msgstr "Charger un paquetage"
 
 #: ../../src/wxMaximaFrame.cpp:613
 msgid "Load Recent Package"
-msgstr ""
+msgstr "Charger un paquetage récent"
 
 #: ../../src/wxMaximaFrame.cpp:616
 msgid "Load a Maxima file using the batch command"
-msgstr ""
+msgstr "Ouvrir un fichier Maxima en utilisant une commande batch"
 
 #: ../../src/wxMaximaFrame.cpp:611
 msgid "Load a Maxima package file"
-msgstr ""
+msgstr "Charger un paquetage Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1678
 msgid "Load a list from a csv file"
-msgstr ""
+msgstr "Remplir une liste à partir d'un fichier csv"
 
 #: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
 msgid "Load a matrix from a csv file"
-msgstr ""
+msgstr "Remplir une matrice à partir d'un fichier csv"
 
 #: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
 msgid "Load lapack"
-msgstr ""
+msgstr "Charger lapack"
 
 #: ../../src/wxMaxima.cpp:7208
 msgid "Load lisp code"
-msgstr ""
+msgstr "Charger le code lisp"
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "Load lisp..."
-msgstr ""
+msgstr "Charger lisp..."
 
 #: ../../src/wxMaximaFrame.cpp:1198
 msgid "Load the file/dir operations (operatingsystem)"
 msgstr ""
+"Charger les opérations sur les fichiers/répertoires (système d'exploitation)"
 
 #: ../../src/wxMaximaFrame.cpp:1187
 msgid "Load the regular expression package (sregex)"
-msgstr ""
+msgstr "Charger le paquet d'expressions régulières (sregex)"
 
 #: ../../src/wxMaximaFrame.cpp:1224
 msgid "Load the translation generator (gentran)"
-msgstr ""
+msgstr "Charger le générateur de traduction (gentran)"
 
 #: ../../src/wxMaxima.cpp:8219
 msgid "Loop variable"
-msgstr ""
+msgstr "Variable de boucle"
 
 #: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
 msgid "Lower bound:"
-msgstr ""
+msgstr "Borne inférieure :"
 
 #: ../../src/wxMaximaFrame.cpp:1127
 msgid "Lower, ignoring case?..."
-msgstr ""
+msgstr "En minuscules, en ignorant la casse ?..."
 
 #: ../../src/wxMaximaFrame.cpp:1448
 msgid "M&atrix"
-msgstr ""
+msgstr "M&atrice"
 
 #: ../../src/wxMaxima.cpp:7153
 msgid "Macro contents:"
-msgstr ""
+msgstr "Contenu de la macro :"
 
 #: ../../src/wxMaxima.cpp:7148
 msgid "Macro name:"
-msgstr ""
+msgstr "Nom de la macro :"
 
 #: ../../src/wxMaximaFrame.cpp:1024
 msgid "Macros"
-msgstr ""
+msgstr "Macros"
 
 #: ../../src/wxMaximaFrame.cpp:697
 msgid "Main Toolbar\tAlt+Shift+B"
-msgstr ""
+msgstr "Barre d'outils principale\tAlt+Maj+B"
 
 #: ../../src/wxMaxima.cpp:7906
 msgid "Make a function value at a specific point known"
-msgstr ""
+msgstr "Calculer la valeur d'une fonction en un point spécifique"
 
 #: ../../src/Worksheet.cpp:2028
 msgid "Make an eventual ev() evaluate this"
-msgstr ""
+msgstr "Faire évaluer ceci par ev() éventuellement"
 
 #: ../../src/wxMaximaFrame.cpp:1070
 msgid "Make function local..."
-msgstr ""
+msgstr "Rendre la fonction locale..."
 
 #: ../../src/wxMaxima.cpp:8207
 msgid "Map"
-msgstr ""
+msgstr "Appliquer"
 
 #: ../../src/wxMaxima.cpp:8215
 msgid "Map an expression"
-msgstr ""
+msgstr "Appliquer à l'expression"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "Map function to a matrix"
-msgstr ""
+msgstr "Appliquer une fonction à une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1446
 msgid "Map function to a matrix, affecting all of its clones"
-msgstr ""
+msgstr "Appliquer une fonction à une matrice ainsi qu'à toutes ses copies"
 
 #: ../../src/Configuration.cpp:109
 msgid "Math Default"
-msgstr ""
+msgstr "Mathématiques par défaut"
 
 #: ../../src/wxMaximaFrame.cpp:286
 msgid "Mathematical Symbols"
-msgstr ""
+msgstr "Symboles mathématiques"
 
 #: ../../src/ToolBar.cpp:270
 msgid "Maths"
-msgstr ""
+msgstr "Mathématiques"
 
 #: ../../src/wxMaxima.cpp:7945 ../../src/wxMaxima.cpp:8022
 #: ../../src/wxMaxima.cpp:8027 ../../src/wxMaxima.cpp:8032
@@ -4332,54 +4523,54 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
 #: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
 msgid "Matrix"
-msgstr ""
+msgstr "Matrice"
 
 #: ../../src/wxMaxima.cpp:7986
 msgid "Matrix Exponent"
-msgstr ""
+msgstr "Exponentielle de matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1339
 msgid "Matrix exponent..."
-msgstr ""
+msgstr "Exponentielle de matrice..."
 
 #: ../../src/wxMaximaFrame.cpp:1329
 msgid "Matrix from csv file"
-msgstr ""
+msgstr "Matrice à partir d'un fichier csv"
 
 #: ../../src/wxMaximaFrame.cpp:1323
 msgid "Matrix from csv file..."
-msgstr ""
+msgstr "Matrice à partir d'un fichier csv..."
 
 #: ../../src/wxMaxima.cpp:8137
 msgid "Matrix map"
-msgstr ""
+msgstr "Carte de la matrice"
 
 #: ../../src/wxMaxima.cpp:9630
 msgid "Matrix name:"
-msgstr ""
+msgstr "Nom de la matrice :"
 
 #: ../../src/wxMaximaFrame.cpp:798
 msgid "Matrix parenthesis"
-msgstr ""
+msgstr "Parenthèses pour la matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1331
 msgid "Matrix to csv file"
-msgstr ""
+msgstr "Matrice vers un fichier csv"
 
 #: ../../src/wxMaximaFrame.cpp:1334
 msgid "Matrix to file or Matrix from file"
-msgstr ""
+msgstr "Matrice vers un fichier ou Matrice à partir d'un fichier"
 
 #: ../../src/wxMaximaFrame.cpp:1761
 msgid "Matrix to nested List"
-msgstr ""
+msgstr "Matrice vers liste de listes"
 
 #: ../../src/wxMaxima.cpp:7956 ../../src/wxMaxima.cpp:7961
 #: ../../src/wxMaxima.cpp:7966 ../../src/wxMaxima.cpp:7971
 #: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
 #: ../../src/wxMaxima.cpp:8136
 msgid "Matrix:"
-msgstr ""
+msgstr "Matrice :"
 
 #: ../../src/wxMaxima.cpp:8627
 msgid ""
@@ -4388,189 +4579,200 @@ msgid ""
 "\n"
 "This command tells maxima that the nouns in this expression shall now be evaluated, too."
 msgstr ""
+"Maxima permet de transformer les fonctions en \"nouns\", ce qui signifie qu'elles ne sont pas évaluées automatiquement dès lors que Maxima les rencontre.\n"
+"Les moyens de transformer une fonction en \"noun\" incluent de la déclarer comme \"noun\", de la précéder d'une apostrophe ' ou de la placer entre les parenthèses de '().\n"
+"Cette commande indique à Maxima que les \"nouns\" dans cette expression doivent maintenant être évalués également."
 
 #: ../../src/wxMaxima.cpp:3473
 #, c-format
 msgid "Maxima architecture: %s"
-msgstr ""
+msgstr "Architecture de Maxima : %s"
 
 #: ../../src/StatusBar.cpp:252
 msgid "Maxima asks a question"
-msgstr ""
+msgstr "Maxima pose une question"
 
 #: ../../src/wxMaxima.cpp:4066
 msgid "Maxima asks a question!"
-msgstr ""
+msgstr "Maxima pose une question !"
 
 #: ../../src/wxMaxima.cpp:7118
 msgid ""
 "Maxima automatically simplifies expressions it gets as input and then tries to evaluate their value. The ' operator tells maxima that we want a command to be in noun form, which means: stand here as is, and unevaluated.\n"
 "The ' operator can be undone by using the '' operator."
 msgstr ""
+"Maxima simplifie automatiquement les expressions qu'il reçoit en entrée, puis essaie d'évaluer leur valeur. L'opérateur ' indique à Maxima que nous voulons qu'une commande soit sous forme de \"noun\", ce qui signifie : cette expression doit rester ici telle quelle, sans évaluation.\n"
+"L'opérateur ' peut être annulé en utilisant l'opérateur ''."
 
 #: ../../src/wxMaxima.cpp:3304
 msgid "Maxima didn't attempt to authenticate!"
-msgstr ""
+msgstr "Maxima n'a pas tenté de s'authentifier !"
 
 #: ../../src/Configuration.cpp:84
 msgid "Maxima errors"
-msgstr ""
+msgstr "Erreurs de Maxima"
 
 #: ../../src/wxMaxima.cpp:3289
 msgid "Maxima has authenticated!"
-msgstr ""
+msgstr "Maxima s'est authentifié !"
 
 #: ../../src/wxMaxima.cpp:10533
 msgid "Maxima has finished calculating."
-msgstr ""
+msgstr "Maxima a fini de calculer."
 
 #: ../../src/wxMaxima.cpp:5832
 msgid "Maxima has issued an error!"
-msgstr ""
+msgstr "Maxima a émis une erreur !"
 
 #: ../../src/wxMaxima.cpp:3696
 #, c-format
 msgid "Maxima has loaded the file %s."
-msgstr ""
+msgstr "Maxima a chargé le fichier %s."
 
 #: ../../src/wxMaxima.cpp:3382
 msgid "Maxima has sent a new variable value."
-msgstr ""
+msgstr "Maxima a envoyé une nouvelle valeur de variable."
 
 #: ../../src/MaximaManual.cpp:552
 msgid "Maxima help file not found!"
-msgstr ""
+msgstr "Le fichier d'aide de Maxima n'a pas été trouvé !"
 
 #: ../../src/wxMaximaFrame.cpp:1043
 msgid "Maxima input"
-msgstr ""
+msgstr "Entrée Maxima"
 
 #: ../../src/StatusBar.cpp:236
 msgid "Maxima is calculating"
-msgstr ""
+msgstr "Maxima est en train de calculer"
 
 #: ../../src/wxMaxima.cpp:5068
 msgid "Maxima is ready for input."
-msgstr ""
+msgstr "Maxima est prête pour la saisie."
 
 #: ../../src/Dirstructure.cpp:144
 #, c-format
 msgid "Maxima not found as %s"
-msgstr ""
+msgstr "Maxima introuvable sous %s"
 
 #: ../../src/wxMaxima.cpp:6211
 msgid "Maxima package (*.mac)|*.mac"
-msgstr ""
+msgstr "Paquetage Maxima (*.mac)|*.mac"
 
 #: ../../src/wxMaxima.cpp:6202
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
-msgstr ""
+msgstr "Paquetage Maxima (*.mac)|*.mac|Paquetage Lisp (*.lisp)|*.lisp|Tous|*"
 
 #: ../../src/wxMaxima.cpp:3012
 msgid "Maxima process terminated unexpectedly."
-msgstr ""
+msgstr "Le processus Maxima s’est terminé de manière inattendue."
 
 #: ../../src/Configuration.cpp:79
 msgid "Maxima question labels"
-msgstr ""
+msgstr "Étiquettes des questions surMaxima"
 
 #: ../../src/wxMaxima.cpp:3380
 msgid "Maxima sends a new set of auto-completable symbols."
 msgstr ""
+"Maxima envoie un nouvel ensemble de symboles dont la saisie est semi-"
+"automatique."
 
 #: ../../src/wxMaxima.cpp:3908
 msgid "Maxima sends us a new set of variables for the watch list."
 msgstr ""
+"Maxima nous envoie un nouvel ensemble de variables pour la liste de "
+"surveillance."
 
 #: ../../src/wxMaximaFrame.cpp:1944
 msgid "Maxima shows help in a browser"
-msgstr ""
+msgstr "Maxima affiche l’aide dans un navigateur"
 
 #: ../../src/wxMaximaFrame.cpp:1940
 msgid "Maxima shows help in a sidebar"
-msgstr ""
+msgstr "Maxima affiche l’aide dans une barre latérale"
 
 #: ../../src/wxMaximaFrame.cpp:1935
 msgid "Maxima shows help in the console"
-msgstr ""
+msgstr "Maxima affiche l’aide dans la console"
 
 #: ../../src/StatusBar.cpp:232
 msgid "Maxima started. Waiting for authentication..."
-msgstr ""
+msgstr "Maxima  a démarré. Attente de l'authentification..."
 
 #: ../../src/StatusBar.cpp:212
 msgid "Maxima started. Waiting for connection..."
-msgstr ""
+msgstr "Maxima  a démarré. Attente de la connection…"
 
 #: ../../src/StatusBar.cpp:228
 msgid "Maxima started. Waiting for initial prompt..."
-msgstr ""
+msgstr "Maxima  a démarré. En attente du premier prompt..."
 
 #: ../../src/wxMaximaFrame.cpp:1231
 msgid "Maxima to other language"
-msgstr ""
+msgstr "Mettre Maxima dans une autre langue"
 
 #: ../../src/wxMaxima.cpp:7213
 msgid "Maxima to string"
-msgstr ""
+msgstr "Maxima en chaîne de caractères"
 
 #: ../../src/wxMaxima.cpp:3397
 #, c-format
 msgid "Maxima user configuration is located in directory %s"
 msgstr ""
+"La configuration utilisateur de Maxima se trouve dans le répertoire %s"
 
 #: ../../src/wxMaxima.cpp:3443
 #, c-format
 msgid "Maxima uses temp directory %s"
-msgstr ""
+msgstr "Maxima utilise le répertoire temporaire %s"
 
 #: ../../src/wxMaxima.cpp:3469
 #, c-format
 msgid "Maxima version: %s"
-msgstr ""
+msgstr "Version de Maxima : %s"
 
 #: ../../src/MaximaManual.cpp:390
 #, c-format
 msgid "Maxima version: %s, Anchors cache version"
-msgstr ""
+msgstr "Version Maxima : %s, version du cache des ancres"
 
 #: ../../src/wxMaximaFrame.cpp:1925
 msgid "Maxima vs. Programming languages"
-msgstr ""
+msgstr "Maxima vs. Langages de programmation"
 
 #: ../../src/Configuration.cpp:83
 msgid "Maxima warnings"
-msgstr ""
+msgstr "Avertissements de Maxima"
 
 #: ../../src/wxMaxima.cpp:3687
 #, c-format
 msgid "Maxima was compiled using %s"
-msgstr ""
+msgstr "Maxima a été compilé en utilisant %s"
 
 #: ../../src/wxMaxima.cpp:3487
 #, c-format
 msgid "Maxima's HTML manuals are in directory %s"
-msgstr ""
+msgstr "Les manuels en HTML de Maxima se trouvent dans le dossier %s"
 
 #: ../../src/wxMaxima.cpp:3099
 #, c-format
 msgid "Maxima's PID is %li"
-msgstr ""
+msgstr "L’identifiant de processus (PID) de Maxima est %li"
 
 #: ../../src/wxMaxima.cpp:3681
 #, c-format
 msgid "Maxima's demo files are located in directory %s"
 msgstr ""
+"Les fichiers de démonstration de Maxima se trouvent dans le dossier %s"
 
 #: ../../src/wxMaxima.cpp:3478
 #, c-format
 msgid "Maxima's manual is located in directory %s"
-msgstr ""
+msgstr "Le manuel de Maxima se trouve dans le dossier %s"
 
 #: ../../src/wxMaxima.cpp:3670
 #, c-format
 msgid "Maxima's share files are located in directory %s"
-msgstr ""
+msgstr "Les fichiers partagés de Maxima se trouvent dans le répertoire %s"
 
 #: ../../src/StatusBar.cpp:66
 msgid ""
@@ -4582,6 +4784,14 @@ msgid ""
 "not only intercepts connections from the outside, but also to intercept "
 "connections between two programs that run on the same computer."
 msgstr ""
+"Maxima, le programme qui effectue les calculs mathématiques, et wxMaxima, "
+"qui affiche la feuille de travail, sont exécutés dans des processus séparés."
+" Cela signifie que même si Maxima plante, wxMaxima (et donc la feuille de "
+"travail) ne sera pas impactée. Les deux programmes communiquent via un "
+"socket réseau local. Cette fois, ce socket n’a pas pu être créé, ce qui peut"
+" être dû à un pare-feu configuré non seulement pour intercepter les "
+"connexions externes, mais aussi celles entre deux programmes s’exécutant sur"
+" le même ordinateur."
 
 #: ../../src/StatusBar.cpp:75
 msgid ""
@@ -4596,480 +4806,502 @@ msgid ""
 "might be that maxima cannot be found (see wxMaxima's Configuration dialogue "
 "for a way to specify maxima's location) or isn't in a working order."
 msgstr ""
+"Maxima, le programme qui effectue les calculs mathématiques, et wxMaxima, "
+"qui affiche la feuille de travail, sont maintenus dans des processus "
+"séparés. Cela signifie que même si Maxima plante, wxMaxima (et donc la "
+"feuille de travail) ne sera pas impacté. Actuellement, les deux programmes "
+"ne sont pas connectés l’un à l’autre, ce qui peut signifier que Maxima est "
+"encore en train de démarrer ou n’a pas pu être démarré. Alternativement, "
+"cela peut être dû à un pare-feu configuré non seulement pour intercepter les"
+" connexions externes, mais aussi celles entre deux programmes s’exécutant "
+"sur le même ordinateur. Une autre raison pour laquelle Maxima ne démarre pas"
+" pourrait être que l'exécutable  n’est pas trouvé (voir la boite de dialogue"
+" de configuration de wxMaxima pour spécifier l’emplacement de Maxima) ou "
+"qu’il n’est pas en état de fonctionner."
 
 #: ../../src/StatusBar.cpp:61
 msgid ""
 "Maxima, the program that does the actual mathematics is started as a separate process. This has the advantage that an eventual crash of maxima cannot harm wxMaxima, which displays the worksheet.\n"
 "This icon indicates if data is transferred between maxima and wxMaxima."
 msgstr ""
+"Maxima, le programme qui effectue les calculs mathématiques, est exécuté en tant que processus séparé. Cela a l’avantage qu’un éventuel plantage de Maxima ne peut pas entrainer celui de wxMaxima, qui affiche la feuille de travail.\n"
+"Cette icône indique si des données sont transférées entre Maxima et wxMaxima."
 
 #: ../../src/wxMaxima.cpp:9228
 msgid "Maximum absolute value printed without exponent"
-msgstr ""
+msgstr "La valeur absolue maximale est mprimée sans exposant"
 
 #: ../../src/wxMaxima.cpp:9230
 msgid "Maximum number of digits to be displayed:"
-msgstr ""
+msgstr "Nombre maximum de chiffres à afficher :"
 
 #: ../../src/wxMaxima.cpp:9568
 msgid "Mean:"
-msgstr ""
+msgstr "Moyenne :"
 
 #: ../../src/wxMaximaFrame.cpp:1924
 msgid "Memoizing"
-msgstr ""
+msgstr "Mémoïsation"
 
 #: ../../src/wxMaximaFrame.cpp:1013
 msgid "Memory"
-msgstr ""
+msgstr "Mémoire"
 
 #: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
 msgid "Merge Cells"
-msgstr ""
+msgstr "Fusionner les  cellules"
 
 #: ../../src/wxMaxima.cpp:5780
 msgid "Message from the stdout of Maxima: "
-msgstr ""
+msgstr "Message de la sortie standard de Maxima : "
 
 #: ../../src/wxMaximaFrame.cpp:1326
 msgid "Methods of generating a matrix"
-msgstr ""
+msgstr "Méthodes pour générer une matrice"
 
 #: ../../src/Worksheet.cpp:6866
 #, c-format
 msgid "Middle-click clipboard data: %s"
-msgstr ""
+msgstr "Données du presse-papiers lors d'un clic milieu : %s"
 
 #: ../../src/wxMaxima.cpp:9226
 msgid "Minimum absolute value printed without exponent:"
-msgstr ""
+msgstr "La valeur absolue minimale est imprimée sans exposant :"
 
 #: ../../src/wxMaxima.cpp:10449 ../../src/wxMaxima.cpp:10451
 msgid "Mismatched parenthesis"
-msgstr ""
+msgstr "Parenthèses non appariées"
 
 #: ../../src/wxMaximaFrame.cpp:1352
 msgid "Multiplication, exponent and similar"
-msgstr ""
+msgstr "Multiplication, exposant et similaires"
 
 #: ../../src/Worksheet.cpp:1998
 msgid "Multiplicative function: f(a*b)=f(a)*f(b)"
-msgstr ""
+msgstr "Fonction multiplicative : f(a*b)=f(a)*f(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1338
 msgid "Multiply matrices..."
-msgstr ""
+msgstr "Multiplier les matrices..."
 
 #: ../../src/wxMaxima.cpp:7981
 msgid "Multiply two matrices"
-msgstr ""
+msgstr "Multipllier deux matrices"
 
 #: ../../src/wxMaxima.cpp:9581
 msgid "Multivariate linear regression"
-msgstr ""
+msgstr "Régression linéaire multivariée"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Name of t:"
-msgstr ""
+msgstr "Nom pour t :"
 
 #: ../../src/wxMaxima.cpp:7838
 msgid "Name of x:"
-msgstr ""
+msgstr "Nom pour x :"
 
 #: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
 msgid "Nested list to Matrix"
-msgstr ""
+msgstr "Liste imbriquée vers Matrice"
 
 #: ../../src/wxMaximaFrame.cpp:769 ../../src/wxMaximaFrame.cpp:1053
 msgid "Never"
-msgstr ""
+msgstr "Jamais"
 
 #: ../../src/wxMaxima.cpp:6534
 msgid "Never autosubscript this variable"
-msgstr ""
+msgstr "Ne jamais mettre cette variable en indice de manière automatique"
 
 #: ../../src/wxMaximaFrame.cpp:776
 msgid "Never display this variable with subscript"
-msgstr ""
+msgstr "Ne jamais afficher cette variable avec indice"
 
 #: ../../src/Worksheet.cpp:1469 ../../src/Worksheet.cpp:1843
 msgid "Never offer known answers"
-msgstr ""
+msgstr "Ne jamais proposer les réponses connues"
 
 #: ../../src/ToolBar.cpp:174
 msgid "New"
-msgstr ""
+msgstr "Nouvelle session"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "New\tCtrl+N"
-msgstr ""
+msgstr "Nouvelle session\tCtrl+N"
 
 #: ../../src/ToolBar.cpp:611
 msgid "New button"
-msgstr ""
+msgstr "Nouveau bouton"
 
 #: ../../src/wxMaxima.cpp:2483
 msgid "New connection attempt whilst already connected."
 msgstr ""
+"Nouvelle tentative de connexion alors que la connextion est déjà active."
 
 #: ../../src/wxMaxima.cpp:2491
 msgid ""
 "New connection attempt, but no currently no socket maxima could connect to."
 msgstr ""
+"Nouvelle tentative de connexion, mais aucun socket Maxima n'est disponible "
+"actuellement pour se connecter."
 
 #: ../../src/wxMaxima.cpp:2487
 msgid "New connection attempt, but no currently running maxima process."
 msgstr ""
+"Nouvelle tentative de connexion, mais aucun processus Maxima n'est en cours "
+"actuellement."
 
 #: ../../src/ToolBar.cpp:174
 msgid "New document"
-msgstr ""
+msgstr "Nouveau document"
 
 #: ../../src/wxMaxima.cpp:3899
 #, c-format
 msgid "New maxima Operators detected: %s"
-msgstr ""
+msgstr "Nouveaux opérateurs Maxima détectés : %s"
 
 #: ../../src/wxMaxima.cpp:7390
 msgid "New part:"
-msgstr ""
+msgstr "Nouvelle partie :"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
 #: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
 msgid "New variable:"
-msgstr ""
+msgstr "Nouvelle variable :"
 
 #: ../../src/wxMaximaFrame.cpp:929
 msgid "Next Command\tAlt+Down"
-msgstr ""
+msgstr "Commande suivante\tAlt+Down"
 
 #: ../../src/wxMaximaFrame.cpp:748
 msgid "Nice Graphical Equations"
-msgstr ""
+msgstr "Équations graphiques harmonieuses"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "No"
-msgstr ""
+msgstr "Non"
 
 #: ../../src/Worksheet.cpp:1972
 msgid "No Array"
-msgstr ""
+msgstr "Pas de tableau"
 
 #: ../../src/Worksheet.cpp:1974
 msgid "No Scalar"
-msgstr ""
+msgstr "Pas de scalaire"
 
 #: ../../src/wxMaxima.cpp:10482
 msgid "No dollar ($) or semicolon (;) at the end of command"
-msgstr ""
+msgstr "Pas de dollar ($) ni de point-virgule (;) à la fin de la commande"
 
 #: ../../src/MaximaManual.cpp:406
 msgid "No entries in the caches for the subjects the manual contains."
-msgstr ""
+msgstr "Aucune entrée dans les caches pour les sujets que contient le manuel."
 
 #: ../../src/MaximaManual.cpp:101
 msgid ""
 "No file with the subjects the manual contained in the last wxMaxima run."
 msgstr ""
+"Aucun fichier avec les sujets que contenait le manuel lors de la dernière "
+"exécution de wxMaxima."
 
 #: ../../src/Image.cpp:495
 msgid "No gnuplot data!"
-msgstr ""
+msgstr "Pas de données gnuplot !"
 
 #: ../../src/Image.cpp:530
 msgid "No gnuplot source!"
-msgstr ""
+msgstr "Pas de source gnuplot !"
 
 #: ../../src/wxMaxima.cpp:6662 ../../src/wxMaxima.cpp:6668
 #: ../../src/wxMaxima.cpp:6687 ../../src/wxMaxima.cpp:6697
 msgid "No matches found!"
-msgstr ""
+msgstr "Aucune correspondance trouvée !"
 
 #: ../../src/wxMaxima.cpp:3240
 msgid "No topics found in topic flag"
-msgstr ""
+msgstr "Aucun sujet trouvé dans l'indicateur de sujet"
 
 #: ../../src/wxMaxima.cpp:3227
 msgid "No topics found in topic tag"
-msgstr ""
+msgstr "Aucun sujet trouvé dans l'indicateur de sujet"
 
 #: ../../src/wxMaximaFrame.cpp:797
 msgid "None"
-msgstr ""
+msgstr "Aucun"
 
 #: ../../src/wxMaxima.cpp:8163
 msgid "Not a valid matrix dimension!"
-msgstr ""
+msgstr "Dimension de matrice incorrecte !"
 
 #: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
 msgid "Not a valid number of equations!"
-msgstr ""
+msgstr "Nombre d'équations incorrect !"
 
 #: ../../src/StatusBar.cpp:256
 msgid "Not connected to Maxima"
-msgstr ""
+msgstr "Pas de connexion à Maxima"
 
 #: ../../src/wxMaxima.cpp:10496
 msgid "Not triggering evaluation as maxima is still busy!"
-msgstr ""
+msgstr "Ne pas déclencher l'évaluation car Maxima est encore occupé !"
 
 #: ../../src/wxMaxima.cpp:10503
 msgid "Not triggering evaluation as maxima still asks a question!"
-msgstr ""
+msgstr "Ne pas déclencher l'évaluation car Maxima pose encore une question !"
 
 #: ../../src/wxMaxima.cpp:10511
 msgid "Not triggering evaluation as there is no working maxima process"
 msgstr ""
+"Ne pas déclencher l'évaluation car il n'y a aucun processus Maxima en cours"
 
 #: ../../src/wxMaxima.cpp:8926
 msgid "Num. deg:"
-msgstr ""
+msgstr "Degré du numérateur:"
 
 #: ../../src/wxMaxima.cpp:8540
 msgid "Number of elements"
-msgstr ""
+msgstr "Nombre d'éléments"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
 msgid "Number of equations:"
-msgstr ""
+msgstr "Nombre d'équations :"
 
 #: ../../src/wxMaxima.cpp:7481
 msgid "Number to octets"
-msgstr ""
+msgstr "Nombre en octets"
 
 #: ../../src/wxMaximaFrame.cpp:1154
 msgid "Number to octets..."
-msgstr ""
+msgstr "Nombre en octets..."
 
 #: ../../src/wxMaximaFrame.cpp:1906
 msgid "Number types"
-msgstr ""
+msgstr "Types de nombres"
 
 #: ../../src/wxMaxima.cpp:7482
 msgid "Number:"
-msgstr ""
+msgstr "Nombres :"
 
 #: ../../src/wxMaximaFrame.cpp:1786
 msgid "Numeric output"
-msgstr ""
+msgstr "Sortie numérique"
 
 #: ../../src/wxMaxima.cpp:8040
 msgid "Numerical QR decomposition of a matrix"
-msgstr ""
+msgstr "Décomposition QR numérique d'une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1417
 msgid "Numerical operations (lapack)"
-msgstr ""
+msgstr "Opérations numériques (lapack)"
 
 #: ../../src/wxMaxima.cpp:7831
 msgid "Numerical solution for 1st degree ODE"
-msgstr ""
+msgstr "Solution numérique pour EDO du 1er degré"
 
 #: ../../src/wxMaximaFrame.cpp:1282
 msgid "Numerical solution..."
-msgstr ""
+msgstr "Solution numérique…"
 
 #: ../../src/wxMaximaFrame.cpp:1261
 msgid "Numerical solutions of polynomial (bfloat)..."
-msgstr ""
+msgstr "Solutions numériques pour les racines de ce polynôme (bfloat)..."
 
 #: ../../src/wxMaximaFrame.cpp:1258
 msgid "Numerical solutions of polynomial..."
-msgstr ""
+msgstr "Solutions numériques pour les racines de ce polynôme..."
 
 #: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: ../../src/wxMaximaFrame.cpp:122
 #, c-format
 msgid "OS: %s Version %li.%li"
-msgstr ""
+msgstr "OS: %s Version %li.%li"
 
 #: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
 msgid "Object composed of elements"
-msgstr ""
+msgstr "Objet composé d’éléments"
 
 #: ../../src/wxMaxima.cpp:7680
 msgid "Object name:"
-msgstr ""
+msgstr "Nom de l'objet :"
 
 #: ../../src/wxMaxima.cpp:7281
 msgid "Object:"
-msgstr ""
+msgstr "Objet :"
 
 #: ../../src/wxMaxima.cpp:7486
 msgid "Octets to Number"
-msgstr ""
+msgstr "Octets vers Nombre"
 
 #: ../../src/wxMaxima.cpp:7491
 msgid "Octets to String"
-msgstr ""
+msgstr "Octets vers Chaîne"
 
 #: ../../src/wxMaximaFrame.cpp:1156
 msgid "Octets to number..."
-msgstr ""
+msgstr "Octets vers nombre..."
 
 #: ../../src/wxMaximaFrame.cpp:1158
 msgid "Octets to string..."
-msgstr ""
+msgstr "Octets vers chaine..."
 
 #: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
 msgid "Octets:"
-msgstr ""
+msgstr "Octets :"
 
 #: ../../src/Worksheet.cpp:1958
 msgid "Odd number"
-msgstr ""
+msgstr "Nombre impair"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
 #: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
 msgid "Old variable:"
-msgstr ""
+msgstr "Ancienne variable :"
 
 #: ../../src/wxMaximaFrame.cpp:1055
 msgid "On all errors"
-msgstr ""
+msgstr "En cas d'erreurs"
 
 #: ../../src/wxMaximaFrame.cpp:1054
 msgid "On lisp errors"
-msgstr ""
+msgstr "En cas d'erreurs lisp"
 
 #: ../../src/wxMaxima.cpp:9566
 msgid "One sample t-test"
-msgstr ""
+msgstr "Test de Student (t-test) sur 1 échantillon"
 
 #: ../../src/wxMaximaFrame.cpp:1927
 msgid "Online tutorials"
-msgstr ""
+msgstr "Tutoriels en ligne"
 
 #: ../../src/wxMaximaFrame.cpp:766
 msgid "Only Integers and single letters"
-msgstr ""
+msgstr "Seulement des entiers et des lettres"
 
 #: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593
 #: ../../src/wxMaxima.cpp:6074
 msgid "Open"
-msgstr ""
+msgstr "Ouvrir"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "Open a document"
-msgstr ""
+msgstr "Ouvrir un document"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "Open a new window"
-msgstr ""
+msgstr "Ouvrir une nouvelle fenêtre"
 
 #: ../../src/ToolBar.cpp:617
 msgid "Open and save button"
-msgstr ""
+msgstr "Bouton Ouvrir et Enregistrer"
 
 #: ../../src/ToolBar.cpp:176
 msgid "Open document"
-msgstr ""
+msgstr "Ouvrir un document"
 
 #: ../../src/wxMaxima.cpp:7239
 msgid "Open for appending"
-msgstr ""
+msgstr "Ouverture pour ajout"
 
 #: ../../src/wxMaximaFrame.cpp:1099
 msgid "Open for appending..."
-msgstr ""
+msgstr "Ouverture pour ajout..."
 
 #: ../../src/wxMaxima.cpp:7244
 msgid "Open for reading"
-msgstr ""
+msgstr "Ouverture pour lecture"
 
 #: ../../src/wxMaximaFrame.cpp:1098
 msgid "Open for reading..."
-msgstr ""
+msgstr "Ouvrir pour lecture..."
 
 #: ../../src/wxMaxima.cpp:7249
 msgid "Open for writing"
-msgstr ""
+msgstr "Ouverture pour écriture"
 
 #: ../../src/wxMaximaFrame.cpp:1100
 msgid "Open for writing..."
-msgstr ""
+msgstr "Ouverture pour écriture..."
 
 #: ../../src/wxMaxima.cpp:9598
 msgid "Open matrix"
-msgstr ""
+msgstr "Charger une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:600
 msgid "Open recent"
-msgstr ""
+msgstr "Ouvrir un fichier récent"
 
 #: ../../src/wxMaxima.cpp:4309
 msgid "Opening a wxmx file"
-msgstr ""
+msgstr "Ouvrir un fichier wxmx"
 
 #: ../../src/wxMaxima.cpp:4153 ../../src/wxMaxima.cpp:4214
 #: ../../src/wxMaxima.cpp:4313 ../../src/wxMaxima.cpp:4622
 msgid "Opening file"
-msgstr ""
+msgstr "Ouverture du fichier"
 
 #: ../../src/wxMaxima.cpp:5030
 #, c-format
 msgid "Opening help file %s"
-msgstr ""
+msgstr "Ouverture du fichier d'aide %s"
 
 #: ../../src/wxMaximaFrame.cpp:1530
 msgid "Optimize for CPU time"
-msgstr ""
+msgstr "Optimiser pour le temps CPU"
 
 #: ../../src/wxMaximaFrame.cpp:1529
 msgid "Optimize for memory"
-msgstr ""
+msgstr "Optimiser pour la mémoire"
 
 #: ../../src/ToolBar.cpp:199
 msgid "Options"
-msgstr ""
+msgstr "Options"
 
 #: ../../src/wxMaximaFrame.cpp:1225
 msgid "Output C"
-msgstr ""
+msgstr "Sortie en C"
 
 #: ../../src/wxMaximaFrame.cpp:1226
 msgid "Output Fortran"
-msgstr ""
+msgstr "Sortie en Fortran"
 
 #: ../../src/wxMaximaFrame.cpp:1228
 msgid "Output Rational Fortran"
-msgstr ""
+msgstr "Sortie Fortran en nombres rationnels"
 
 #: ../../src/Configuration.cpp:80
 msgid "Output labels"
-msgstr ""
+msgstr "Étiquettes de sorties"
 
 #: ../../src/Configuration.cpp:73
 msgid "Output: Function names"
-msgstr ""
+msgstr "Sortie : noms des fonctions"
 
 #: ../../src/Configuration.cpp:75
 msgid "Output: Latin names as greek symbols"
-msgstr ""
+msgstr "Sortie : Noms latins en tant que symboles grecs"
 
 #: ../../src/Configuration.cpp:72
 msgid "Output: Numbers and Digits"
-msgstr ""
+msgstr "Sortie : Nombres et Chiffres"
 
 #: ../../src/Configuration.cpp:71
 msgid "Output: Operators"
-msgstr ""
+msgstr "Sortie : Opérateurs"
 
 #: ../../src/Configuration.cpp:74
 #, c-format
 msgid "Output: Special constants (%e,%i)"
-msgstr ""
+msgstr "Sortie : Constantes spéciales (%e, %i)"
 
 #: ../../src/Configuration.cpp:76
 msgid "Output: Strings"
-msgstr ""
+msgstr "Sortie : Chaines de caractères"
 
 #: ../../src/Configuration.cpp:70
 msgid "Output: Variable names"
-msgstr ""
+msgstr "Sortie : noms des variables"
 
 #: ../../src/wxMaxima.cpp:6442
 msgid ""
@@ -5078,6 +5310,10 @@ msgid ""
 "(*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format "
 "(*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image "
+"(*.gif)|*.gif|Scaleable vector graphics (*.svg)|*.svg|Windows bitmap "
+"(*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format "
+"(*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:10117
 msgid ""
@@ -5085,860 +5321,887 @@ msgid ""
 "(*.bmp)|*.bmp|GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged "
 "image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap "
+"(*.bmp)|*.bmp|GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged "
+"image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:8924
 msgid "Pade approximation"
-msgstr ""
+msgstr "Approximant de Padé"
 
 #: ../../src/wxMaximaFrame.cpp:1478
 msgid "Pade approximation of a Taylor series"
-msgstr ""
+msgstr "Approximant de Padé d'un développement en série de Taylor"
 
 #: ../../src/wxMaximaFrame.cpp:1637
 msgid "Parallel Substitute..."
-msgstr ""
+msgstr "Substitution parallèle..."
 
 #: ../../src/wxMaxima.cpp:8738
 msgid "Parallel substitution"
-msgstr ""
+msgstr "Substitution parallèle"
 
 #: ../../src/wxMaxima.cpp:7179
 msgid "Parameter name:"
-msgstr ""
+msgstr "Nom du paramètre :"
 
 #: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
 msgid "Parameter(s):"
-msgstr ""
+msgstr "Paramètre(s) :"
 
 #: ../../src/wxMaxima.cpp:7399
 msgid "Parse string"
-msgstr ""
+msgstr "Analyser la chaîne de caractères"
 
 #: ../../src/wxMaximaFrame.cpp:1152
 msgid "Parse string only..."
-msgstr ""
+msgstr "Analyser uniquement la chaîne..."
 
 #: ../../src/StatusBar.cpp:240
 msgid "Parsing output"
-msgstr ""
+msgstr "Analyse la sortie"
 
 #: ../../src/wxMaxima.cpp:7464
 msgid "Part:"
-msgstr ""
+msgstr "Partie :"
 
 #: ../../src/wxMaximaFrame.cpp:1499 ../../src/wxMaximaFrame.cpp:1535
 msgid "Partial &Fractions..."
-msgstr ""
+msgstr "Éléments simples…"
 
 #: ../../src/wxMaxima.cpp:8975
 msgid "Partial Fractions"
-msgstr ""
+msgstr "Éléments simples"
 
 #: ../../src/wxMaxima.cpp:4702
 msgid "Parts of the document will not be loaded correctly!"
-msgstr ""
+msgstr "Des parties du document ne seront pas chargées correctement !"
 
 #: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
 #: ../../src/Worksheet.cpp:1685
 msgid "Paste"
-msgstr ""
+msgstr "Coller"
 
 #: ../../src/wxMaximaFrame.cpp:667
 msgid "Paste\tCtrl+V"
-msgstr ""
+msgstr "Coller\tCtrl+V"
 
 #: ../../src/ToolBar.cpp:211
 msgid "Paste from clipboard"
-msgstr ""
+msgstr "Coller le contenu du presse-papier"
 
 #: ../../src/wxMaximaFrame.cpp:668
 msgid "Paste text from clipboard"
-msgstr ""
+msgstr "Coller le texte du presse-papier"
 
 #: ../../src/wxMaxima.cpp:4841
 msgid "Please configure wxMaxima with 'Edit->Configure'."
-msgstr ""
+msgstr "Configurer wxMaxima avec 'Édition->Configurer'."
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot &2d..."
-msgstr ""
+msgstr "Courbe &2d…"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot &3d..."
-msgstr ""
+msgstr "Courbe &3d…"
 
 #: ../../src/wxMaximaFrame.cpp:1772
 msgid "Plot &Format..."
-msgstr ""
+msgstr "&Format de la courbe…"
 
 #: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
 msgid "Plot 2D"
-msgstr ""
+msgstr "Courbe 2D"
 
 #: ../../src/Worksheet.cpp:1593
 msgid "Plot 2D..."
-msgstr ""
+msgstr "Courbe 2D..."
 
 #: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
 msgid "Plot 3D"
-msgstr ""
+msgstr "Courbe 3D"
 
 #: ../../src/Worksheet.cpp:1595
 msgid "Plot 3D..."
-msgstr ""
+msgstr "Courbe 3D..."
 
 #: ../../src/wxMaxima.cpp:9538
 msgid "Plot as bars"
-msgstr ""
+msgstr "Tracer sous forme de graphique en barres"
 
 #: ../../src/wxMaxima.cpp:9542
 msgid "Plot as error bars"
-msgstr ""
+msgstr "Tracer sous forme de graphique en barres d'erreur"
 
 #: ../../src/wxMaxima.cpp:9546
 msgid "Plot as pie chart"
-msgstr ""
+msgstr "Tracer sous forme de diagramme circulaire"
 
 #: ../../src/wxMaxima.cpp:9112
 msgid "Plot format"
-msgstr ""
+msgstr "Format de la courbe"
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot in 2 dimensions"
-msgstr ""
+msgstr "Courbe en 2 dimensions"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot in 3 dimensions"
-msgstr ""
+msgstr "Courbe en 3 dimensions"
 
 #: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
 msgid "Plot using Draw"
-msgstr ""
+msgstr "Tracer avec Draw"
 
 #: ../../src/wxMaxima.cpp:7824
 msgid "Point #1 with known value:"
-msgstr ""
+msgstr "Point #1 avec valeur connue :"
 
 #: ../../src/wxMaxima.cpp:7826
 msgid "Point #2 with known value:"
-msgstr ""
+msgstr "Point #2 avec valeur connue :"
 
 #: ../../src/wxMaxima.cpp:7800 ../../src/wxMaxima.cpp:7811
 msgid "Point the value is known at:"
-msgstr ""
+msgstr "Point où la valeur est connue :"
 
 #: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
 msgid "Point:"
-msgstr ""
+msgstr "Point :"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 1:"
-msgstr ""
+msgstr "Polynôme 1 :"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 2:"
-msgstr ""
+msgstr "Polynôme 2 :"
 
 #: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
 #: ../../src/wxMaxima.cpp:7739
 msgid "Polynomial:"
-msgstr ""
+msgstr "Polynôme :"
 
 #: ../../src/wxMaximaFrame.cpp:1754
 msgid "Pop"
-msgstr ""
+msgstr "Menu contextuel"
 
 #: ../../src/Worksheet.cpp:1331 ../../src/Worksheet.cpp:1485
 msgid "Popout interactively"
-msgstr ""
+msgstr "Extraire de manière interactive"
 
 #: ../../src/wxMaximaFrame.cpp:1189
 msgid "Position of a match"
-msgstr ""
+msgstr "Position d'une correspondance"
 
 #: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
 msgid "Position:"
-msgstr ""
+msgstr "Position :"
 
 #: ../../src/wxMaxima.cpp:8939
 msgid "Power series"
-msgstr ""
+msgstr "Séries entières"
 
 #: ../../src/wxMaximaFrame.cpp:1475
 msgid "Power series..."
-msgstr ""
+msgstr "Séries entières..."
 
 #: ../../src/wxMaxima.cpp:9202
 msgid "Precision"
-msgstr ""
+msgstr "Précision"
 
 #: ../../src/Worksheet.cpp:1616
 msgid "Prefer user labels"
-msgstr ""
+msgstr "Préférence pour les étiquettes utilisateur"
 
 #: ../../src/main.cpp:437
 msgid "Preferences"
-msgstr ""
+msgstr "Préférences"
 
 #: ../../src/ToolBar.cpp:626
 msgid "Preferences button"
-msgstr ""
+msgstr "Préférences pour le bouton"
 
 #: ../../src/wxMaximaFrame.cpp:685
 msgid "Preferences...\tCtrl+,"
-msgstr ""
+msgstr "Préférences...\tCtrl+,"
 
 #: ../../src/wxMaximaFrame.cpp:1733
 msgid "Prepend an element"
-msgstr ""
+msgstr "Ajouter un élément au début"
 
 #: ../../src/wxMaximaFrame.cpp:927
 msgid "Previous Command\tAlt+Up"
-msgstr ""
+msgstr "Commande précédente\tAlt+Up"
 
 #: ../../src/ToolBar.cpp:184
 msgid "Print"
-msgstr ""
+msgstr "Imprimer"
 
 #: ../../src/ToolBar.cpp:620
 msgid "Print button"
-msgstr ""
+msgstr "Bouton Imprimer"
 
 #: ../../src/Worksheet.cpp:1493
 msgid "Print cell brackets"
-msgstr ""
+msgstr "Afficher les crochets de cellule"
 
 #: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
 msgid "Print document"
-msgstr ""
+msgstr "Imprimer le document"
 
 #: ../../src/wxMaximaFrame.cpp:1829
 msgid "Print floating-point numbers with exponents dividable by 3"
 msgstr ""
+"Imprimer les nombres à virgule flottante dont les exposants sont divisibles "
+"par 3"
 
 #: ../../src/WXMXformat.cpp:255
 msgid ""
 "Produced invalid XML. The erroneous XML data has therefore not been saved "
 "but has been put on the clipboard in order to allow to debug it."
 msgstr ""
+"Le XML produit est  invalide. Les données XML erronées n'ont donc pas été "
+"enregistrées mais ont été mises dans le presse-papiers afin de permettre "
+"leur débogage."
 
 #: ../../src/wxMaxima.cpp:9061
 msgid "Product"
-msgstr ""
+msgstr "Produit"
 
 #: ../../src/wxMaximaFrame.cpp:1095
 msgid "Program"
-msgstr ""
+msgstr "Programme"
 
 #: ../../src/wxMaxima.cpp:7061
 msgid "Program (no local variables)"
-msgstr ""
+msgstr "Programme (sans variables locales)"
 
 #: ../../src/wxMaxima.cpp:7052
 msgid "Program block"
-msgstr ""
+msgstr "Bloc de programme"
 
 #: ../../src/wxMaximaFrame.cpp:1066
 msgid "Program block with local variables..."
-msgstr ""
+msgstr "Bloc de programme avec des variables locales..."
 
 #: ../../src/wxMaximaFrame.cpp:1068
 msgid "Program block, no local variables..."
-msgstr ""
+msgstr "Bloc de programme sans variables locales..."
 
 #: ../../src/wxMaximaFrame.cpp:1751
 msgid "Push"
-msgstr ""
+msgstr "Ajouter"
 
 #: ../../src/wxMaxima.cpp:8508
 msgid "Push an element to a list"
-msgstr ""
+msgstr "Ajouter un élément à une liste"
 
 #: ../../src/wxMaximaFrame.cpp:1395
 msgid "QR decomposition"
-msgstr ""
+msgstr "Décomposition QR"
 
 #: ../../src/wxMaxima.cpp:3621
 msgid "Querying gnuplot which graphics drivers it supports."
-msgstr ""
+msgstr "Interrogation de gnuplot sur les pilotes graphiques qu'il supporte."
 
 #: ../../src/wxMaxima.cpp:8953
 msgid "Range radius:"
-msgstr ""
+msgstr "Rayon de la zone :"
 
 #: ../../src/wxMaximaFrame.cpp:1374
 msgid "Rank"
-msgstr ""
+msgstr "Rang"
 
 #: ../../src/wxMaximaFrame.cpp:246 ../../src/wxMaximaFrame.cpp:722
 msgid "Raw XML monitor"
-msgstr ""
+msgstr "Moniteur XML brut"
 
 #: ../../src/wxMaximaFrame.cpp:2117
 #, c-format
 msgid "Re-Reading the config from %s."
-msgstr ""
+msgstr "Relecture de la configuration depuis %s."
 
 #: ../../src/wxMaximaFrame.cpp:2114
 msgid "Re-Reading the config from the default location."
-msgstr ""
+msgstr "Relecture de la configuration depuis l'emplacement par défaut."
 
 #: ../../src/wxMaximaFrame.cpp:867
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr ""
+"Réévaluer toutes les cellules situées au-dessus de celle où se trouve le "
+"curseur"
 
 #: ../../src/wxMaximaFrame.cpp:877
 msgid "Re-evaluate all cells below the one the cursor is in"
 msgstr ""
+"Réévaluer toutes les cellules situées en dessous de celle où se trouve le "
+"curseur"
 
 #: ../../src/main.cpp:366
 msgid "Re-opening STDERR failed."
-msgstr ""
+msgstr "La réouverture du flux standard d'erreur a échoué."
 
 #: ../../src/main.cpp:367
 msgid "Re-opening STDIN failed."
-msgstr ""
+msgstr "La réouverture du flux standard d'entrée a échoué."
 
 #: ../../src/main.cpp:365
 msgid "Re-opening STDOUT failed."
-msgstr ""
+msgstr "La réouverture de la sortie standard a échoué."
 
 #: ../../src/wxMaxima.cpp:7512
 msgid ""
 "Re-using a compiled regex is faster that using the same regex string "
 "multiple times."
 msgstr ""
+"Réutiliser une expression régulière compilée est plus rapide que d'utiliser "
+"la même expression régulière plusieurs fois."
 
 #: ../../src/Worksheet.cpp:6668
 msgid "Read .wxm data from clipboard"
-msgstr ""
+msgstr "Lire les données .wxm depuis le presse-papiers"
 
 #: ../../src/wxMaxima.cpp:7599
 msgid "Read Directory"
-msgstr ""
+msgstr "Lire le répertoire"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Read List from csv file..."
-msgstr ""
+msgstr "Lire la liste à partir depuis un fichier csv..."
 
 #: ../../src/wxMaxima.cpp:7196
 msgid "Read a structure field"
-msgstr ""
+msgstr "Lire un champ de structure"
 
 #: ../../src/wxMaxima.cpp:7270 ../../src/wxMaxima.cpp:7274
 msgid "Read byte"
-msgstr ""
+msgstr "Lire l'octet"
 
 #: ../../src/wxMaxima.cpp:7266
 msgid "Read char"
-msgstr ""
+msgstr "Lire le caractère"
 
 #: ../../src/wxMaxima.cpp:7593
 msgid "Read environment variable"
-msgstr ""
+msgstr "Lire la variable d'environnement"
 
 #: ../../src/wxMaximaFrame.cpp:1219
 msgid "Read environment variable..."
-msgstr ""
+msgstr "Lire la variable d'environnement..."
 
 #: ../../src/wxMaxima.cpp:7262
 msgid "Read line"
-msgstr ""
+msgstr "Lire la ligne"
 
 #: ../../src/MaximaManual.cpp:113
 #, c-format
 msgid "Read the entries the maxima manual offers from %s"
-msgstr ""
+msgstr "Lire les entrées que le manuel de Maxima a trouvé depuis %s"
 
 #: ../../src/StatusBar.cpp:245
 msgid "Reading Maxima output"
-msgstr ""
+msgstr "Lecture des résultats de Maxima"
 
 #: ../../src/StatusBar.cpp:247
 #, c-format
 msgid "Reading Maxima output: %li bytes"
-msgstr ""
+msgstr "Lecture de la sortie de Maxima : %li octets"
 
 #: ../../src/wxMathml.cpp:55
 #, c-format
 msgid "Reading the Lisp part of wxMaxima from the file %s"
-msgstr ""
+msgstr "Lecture de la partie Lisp de wxMaxima depuis le fichier %s"
 
 #: ../../src/wxMathml.cpp:43
 msgid "Reading the Lisp part of wxMaxima from the included header file."
 msgstr ""
+"Lecture de la partie Lisp de wxMaxima depuis le fichier d'en-tête inclus."
 
 #: ../../src/wxMaximaFrame.cpp:148
 #, c-format
 msgid "Reading the config from %s."
-msgstr ""
+msgstr "Lire la configuration à partir de %s."
 
 #: ../../src/wxMaximaFrame.cpp:151
 msgid "Reading the config from the default location."
-msgstr ""
+msgstr "Lecture de la configuration depuis l'emplacement par défaut."
 
 #: ../../src/StatusBar.cpp:224
 msgid "Ready for user input"
-msgstr ""
+msgstr "Prêt pour une entrée utilisateur"
 
 #: ../../src/Worksheet.cpp:960
 msgid "Recalculated the whole worksheet at once => Updating its size"
 msgstr ""
+"Recalcul de toute la feuille de travail en une seule fois => Mise à jour de "
+"sa taille"
 
 #: ../../src/Worksheet.cpp:946
 msgid "Recalculation hit the end of the worksheet => Updating its size"
 msgstr ""
+"Le recalcul a atteint la fin de la feuille de travail => Mise à jour de sa "
+"taille"
 
 #: ../../src/wxMaximaFrame.cpp:930
 msgid "Recall next command from history"
-msgstr ""
+msgstr "Rappeler la commande suivante dans l'historique"
 
 #: ../../src/wxMaximaFrame.cpp:928
 msgid "Recall previous command from history"
-msgstr ""
+msgstr "Rappeler la commande précédente dans l'historique"
 
 #: ../../src/wxMaxima.cpp:3235
 #, c-format
 msgid "Received manual topic request: %s"
-msgstr ""
+msgstr "Réception d'une demande de sujet du manuel : %s"
 
 #: ../../src/wxMaxima.cpp:3097
 #, c-format
 msgid "Received maxima's first prompt: %s"
-msgstr ""
+msgstr "Réception du premier prompt de Maxima : %s"
 
 #: ../../src/wxMaximaFrame.cpp:603
 msgid "Recover unsaved"
-msgstr ""
+msgstr "Récupération des données non sauvegardées"
 
 #: ../../src/wxMaximaFrame.cpp:1640
 msgid "Recursive Substitute..."
-msgstr ""
+msgstr "Substituer de manière récursive…"
 
 #: ../../src/wxMaxima.cpp:8746
 msgid "Recursive substitution"
-msgstr ""
+msgstr "Substitution récursive"
 
 #: ../../src/ToolBar.cpp:192
 msgid "Redo"
-msgstr ""
+msgstr "Refaire"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo\tCtrl+Y"
-msgstr ""
+msgstr "Refaire\tCtrl+Y"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo last change"
-msgstr ""
+msgstr "Refaire la dernière modification"
 
 #: ../../src/wxMaximaFrame.cpp:1595
 msgid "Reduce trigonometric expression"
-msgstr ""
+msgstr "Réduire une expression trigonométrique"
 
 #: ../../src/wxMaxima.cpp:2366 ../../src/wxMaxima.cpp:10630
 msgid "Refusing to send cell to maxima: "
-msgstr ""
+msgstr "Refus d'envoyer la cellule à Maxima : "
 
 #: ../../src/wxMaxima.cpp:7523
 msgid "Regex match"
-msgstr ""
+msgstr "Correspondance de l'expression régulière"
 
 #: ../../src/wxMaxima.cpp:7518
 msgid "Regex match position"
-msgstr ""
+msgstr "La position de l'expression régulière correspond"
 
 #: ../../src/wxMaximaFrame.cpp:1195
 msgid "Regular expression that matches a string"
-msgstr ""
+msgstr "L'expression régulière correspond à une chaîne"
 
 #: ../../src/wxMaximaFrame.cpp:1196
 msgid "Regular expressions"
-msgstr ""
+msgstr "Expressions régulières"
 
 #: ../../src/Worksheet.cpp:1314
 msgid "Reload Image"
-msgstr ""
+msgstr "Recharger l'image"
 
 #: ../../src/Worksheet.cpp:1320
 #, c-format
 msgid "Reload Image \"%s\""
-msgstr ""
+msgstr "Recharger l'image  \"%s\""
 
 #: ../../src/wxMaxima.cpp:9809
 #, c-format
 msgid "Reloading image file %s."
-msgstr ""
+msgstr "Recharger le fichier image  %s."
 
 #: ../../src/wxMaximaFrame.cpp:883
 msgid "Remove All Output"
-msgstr ""
+msgstr "Supprimer tous les résultats"
 
 #: ../../src/wxMaximaFrame.cpp:1426
 msgid "Remove Rows or Columns..."
-msgstr ""
+msgstr "Supprimer des lignes ou des colonnes..."
 
 #: ../../src/wxMaximaFrame.cpp:1748
 msgid ""
 "Remove all list elements that appear twice in a row. Normally used in "
 "conjunction with sort."
 msgstr ""
+"Supprimer tous les éléments de la liste qui apparaissent deux fois sur une "
+"ligne. A utiliser normalement en conjonction avec sort."
 
 #: ../../src/wxMaximaFrame.cpp:1174
 msgid "Remove all occurrences of a word..."
-msgstr ""
+msgstr "Supprimer toutes les occurrences d'un mot..."
 
 #: ../../src/wxMaxima.cpp:7439
 msgid "Remove all occurrences of part"
-msgstr ""
+msgstr "Supprimer toutes les occurrences de la partie"
 
 #: ../../src/wxMaxima.cpp:8592
 msgid "Remove an element from a list"
-msgstr ""
+msgstr "Supprimer un élément d'une liste"
 
 #: ../../src/wxMaxima.cpp:7566
 msgid "Remove directory"
-msgstr ""
+msgstr "Supprimer le répertoire"
 
 #: ../../src/wxMaximaFrame.cpp:1204
 msgid "Remove directory..."
-msgstr ""
+msgstr "Supprimer le répertoire..."
 
 #: ../../src/wxMaximaFrame.cpp:1747
 msgid "Remove duplicates"
-msgstr ""
+msgstr "Supprimer les doublons"
 
 #: ../../src/wxMaximaFrame.cpp:1176
 msgid "Remove first occurrence of a word..."
-msgstr ""
+msgstr "Supprimer la première occurrence d'un mot..."
 
 #: ../../src/wxMaxima.cpp:7444
 msgid "Remove first occurrence of part"
-msgstr ""
+msgstr "Supprimer la première occurrence de la partie"
 
 #: ../../src/wxMaximaFrame.cpp:884
 msgid "Remove output from input cells"
-msgstr ""
+msgstr "Supprimer les résultats des cellules en entrée"
 
 #: ../../src/wxMaxima.cpp:7975
 msgid "Remove rows and/or columns"
-msgstr ""
+msgstr "Supprimer les lignes et/ou les colonnes"
 
 #: ../../src/wxMaximaFrame.cpp:1427
 msgid "Remove rows and/or columns from the matrix"
-msgstr ""
+msgstr "Supprimer les lignes et/ou les colonnes de la matrice"
 
 #: ../../src/wxMaxima.cpp:7582
 msgid "Rename file"
-msgstr ""
+msgstr "Renommer le fichier"
 
 #: ../../src/wxMaximaFrame.cpp:1215
 msgid "Rename file..."
-msgstr ""
+msgstr "Renommer le fichier..."
 
 #: ../../src/wxMaximaFrame.cpp:1527
 msgid "Reorganize an expression using horner's rule"
-msgstr ""
+msgstr "Réorganiser une expression en utilisant la règle de Horner"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "Repetitive element-by-element multiplication"
-msgstr ""
+msgstr "Répétition de la multiplication élément par élément"
 
 #: ../../src/wxMaxima.cpp:7538
 msgid "Replace all regex matches"
-msgstr ""
+msgstr "Remplacer toutes les expressions régulières qui correspondent"
 
 #: ../../src/wxMaxima.cpp:7533
 msgid "Replace first regex match"
-msgstr ""
+msgstr "Remplacer la première expression régulière qui correspond"
 
 #: ../../src/wxMaxima.cpp:7463
 msgid "Replace the first occurrence of Part"
-msgstr ""
+msgstr "Remplacer la première occurrence de la partie"
 
 #: ../../src/wxMaximaFrame.cpp:1180
 msgid "Replace..."
-msgstr ""
+msgstr "Remplacer..."
 
 #: ../../src/wxMaxima.cpp:6719
 #, c-format
 msgid "Replaced %li occurrences."
-msgstr ""
+msgstr "%li occurrences remplacées."
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "Report bug"
-msgstr ""
+msgstr "Rapport de bogue"
 
 #: ../../src/wxMaximaFrame.cpp:996
 msgid "Reset option variables"
-msgstr ""
+msgstr "Réinitialiser les variables des options"
 
 #: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
 msgid "Restart Maxima"
-msgstr ""
+msgstr "Redémarrer Maxima"
 
 #: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
 msgid "Restrict Maximum size"
-msgstr ""
+msgstr "Restreindre la taille maximale"
 
 #: ../../src/wxMaxima.cpp:10031
 msgid "Result variables:"
-msgstr ""
+msgstr "Variables du résultat :"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Resulting Matrix name (may be empty):"
-msgstr ""
+msgstr "Nom de la matrice résultante (peut être vide) :"
 
 #: ../../src/wxMaximaFrame.cpp:1190
 msgid "Return a match"
-msgstr ""
+msgstr "Renvoie une correspondance"
 
 #: ../../src/wxMaxima.cpp:7077
 msgid "Return from a block or loop"
-msgstr ""
+msgstr "Retour d'un bloc ou d'une boucle"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "Return from current block/loop..."
-msgstr ""
+msgstr "Retour d'un bloc ou d'une boucle..."
 
 #: ../../src/wxMaximaFrame.cpp:1755
 msgid ""
 "Return the first item of the list and remove it from the list. Useful for "
 "creating stacks."
 msgstr ""
+"Retourner le premier élément de la liste et le supprimer de la liste. Utile "
+"pour créer des piles."
 
 #: ../../src/wxMaxima.cpp:8526
 msgid "Return the list without its first n elements"
-msgstr ""
+msgstr "Retourner la liste sans ses n premiers éléments"
 
 #: ../../src/wxMaxima.cpp:8532
 msgid "Return the list without its last n elements"
-msgstr ""
+msgstr "Retourner la liste sans ses n derniers éléments"
 
 #: ../../src/ToolBar.cpp:241
 msgid "Return to the cell that is currently being evaluated"
-msgstr ""
+msgstr "Retourner à la cellule qui est évaluée actuellement"
 
 #: ../../src/wxMaximaFrame.cpp:1711
 msgid "Returns an arbitrary list item"
-msgstr ""
+msgstr "Retourne un élément arbitraire de la liste"
 
 #: ../../src/wxMaximaFrame.cpp:1713
 msgid "Returns the first item of the list"
-msgstr ""
+msgstr "Retourne le premier élément de la liste"
 
 #: ../../src/wxMaximaFrame.cpp:1719
 msgid "Returns the last item of the list"
-msgstr ""
+msgstr "Retourne le dernier élément de la liste"
 
 #: ../../src/wxMaximaFrame.cpp:1721
 msgid "Returns the last n items of the list"
-msgstr ""
+msgstr "Retourne les n derniers éléments de la liste"
 
 #: ../../src/wxMaximaFrame.cpp:1742
 msgid "Returns the length of the list"
-msgstr ""
+msgstr "Retourne la longueur de la liste"
 
 #: ../../src/wxMaximaFrame.cpp:1715
 msgid "Returns the list without its first n elements"
-msgstr ""
+msgstr "Retourne la liste sans ses n premiers éléments"
 
 #: ../../src/wxMaximaFrame.cpp:1717
 msgid "Returns the list without its last n elements"
-msgstr ""
+msgstr "Retourne la liste sans ses n derniers éléments"
 
 #: ../../src/wxMaximaFrame.cpp:1743
 msgid "Reverse"
-msgstr ""
+msgstr "Renverser"
 
 #: ../../src/wxMaximaFrame.cpp:1744
 msgid "Reverse the order of the list items"
-msgstr ""
+msgstr "Renverser l'ordre des items de la liste"
 
 #: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
 #: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
 msgid "Right Matrix:"
-msgstr ""
+msgstr "Matrice de droite :"
 
 #: ../../src/wxMaxima.cpp:8190
 msgid "Right end"
-msgstr ""
+msgstr "Extrémité droite"
 
 #: ../../src/wxMaximaFrame.cpp:1301
 msgid "Right side to the \"=\""
-msgstr ""
+msgstr "Membre droit de \"=\""
 
 #: ../../src/wxMaximaFrame.cpp:1455
 msgid "Risch Integration..."
-msgstr ""
+msgstr "Intégration de Risch…"
 
 #: ../../src/wxMaximaFrame.cpp:785
 msgid "Rounded"
-msgstr ""
+msgstr "Arrondi"
 
 #: ../../src/wxMaximaFrame.cpp:1437
 msgid "Row and column operations"
-msgstr ""
+msgstr "Opérations sur les lignes et les colonnes"
 
 #: ../../src/wxMaxima.cpp:7957 ../../src/wxMaxima.cpp:7967
 #: ../../src/wxMaxima.cpp:7972
 msgid "Row number:"
-msgstr ""
+msgstr "Numéro de ligne :"
 
 #: ../../src/wxMaxima.cpp:7977
 msgid "Row numbers:"
-msgstr ""
+msgstr "Numéros de ligne :"
 
 #: ../../src/wxMaxima.cpp:8203
 msgid "Rows"
-msgstr ""
+msgstr "Lignes"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Rule"
-msgstr ""
+msgstr "Régle"
 
 #: ../../src/wxMaxima.cpp:8464 ../../src/wxMaxima.cpp:8477
 msgid "Rule:"
-msgstr ""
+msgstr "Régle :"
 
 #: ../../src/wxMaximaFrame.cpp:1027
 msgid "Rules"
-msgstr ""
+msgstr "Régles"
 
 #: ../../src/wxMaximaFrame.cpp:1693
 msgid "Run each element through an expression"
-msgstr ""
+msgstr "Evaluer l'expression pour chaque élément"
 
 #: ../../src/wxMaxima.cpp:6355
 #, c-format
 msgid "Running %s on the file %s: "
-msgstr ""
+msgstr "Exécution de %s sur le fichier %s : "
 
 #: ../../src/wxMaxima.cpp:2633
 #, c-format
 msgid "Running maxima as: %s"
-msgstr ""
+msgstr "Exéctution de maxima comme : %s"
 
 #: ../../src/wxMaximaFrame.cpp:130
 msgid "Running on DirectFB"
-msgstr ""
+msgstr "Exécution sur DirectFB"
 
 #: ../../src/wxMaximaFrame.cpp:114
 msgid "Running on MS Windows"
-msgstr ""
+msgstr "Exécution sur MS Windows"
 
 #: ../../src/wxMaximaFrame.cpp:116
 msgid "Running on MS Windows using DirectDraw"
-msgstr ""
+msgstr "Running on MS Windows using DirectDraw"
 
 #: ../../src/wxMaximaFrame.cpp:136
 msgid "Running on Mac OS"
-msgstr ""
+msgstr "Exécution sur Mac OS"
 
 #: ../../src/wxMaximaFrame.cpp:127
 msgid "Running on Motif"
-msgstr ""
+msgstr "Exécution sur Motif"
 
 #: ../../src/wxMaximaFrame.cpp:133
 msgid "Running on the universal wxWidgets port"
-msgstr ""
+msgstr "Exécution sur le port universel wxWidgets"
 
 #: ../../src/wxMaxima.cpp:8208
 msgid ""
 "Runs each element of an object (list, matrix, equation,...) through a "
 "function individually"
 msgstr ""
+"Calcul de chaque élément d'un objet (liste, matrice, équation,...) en "
+"utilisant une fonction"
 
 #: ../../src/wxMaxima.cpp:8216
 msgid ""
 "Runs each element of an object (list, matrix, equation,...) through an "
 "expression individually"
 msgstr ""
+"Calcul de chaque élément d'un objet (liste, matrice, équation,...) en "
+"utilisant une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1691
 msgid "Runs each element through a function"
-msgstr ""
+msgstr "Calcul de chaque élément en utilisant une fonction"
 
 #: ../../src/wxMaximaFrame.cpp:1694
 msgid "Runs each element through an expression"
-msgstr ""
+msgstr "Calcul de chaque élément en utilisant une expression"
 
 #: ../../src/wxMaxima.cpp:9572
 msgid "Sample 1:"
-msgstr ""
+msgstr "Échantillon 1 :"
 
 #: ../../src/wxMaxima.cpp:9573
 msgid "Sample 2:"
-msgstr ""
+msgstr "Échantillon 2 :"
 
 #: ../../src/wxMaxima.cpp:9567
 msgid "Sample:"
-msgstr ""
+msgstr "Échantillon:"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
 msgid "Save"
-msgstr ""
+msgstr "Enregistrer"
 
 #: ../../src/Worksheet.cpp:1294
 msgid "Save Animation..."
-msgstr ""
+msgstr "Sauvegarder l'animation…"
 
 #: ../../src/wxMaxima.cpp:5672
 msgid "Save As"
-msgstr ""
+msgstr "Enregistrer sous"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save As...\tShift+Ctrl+S"
-msgstr ""
+msgstr "Sauvegarder la session sous…\tMaj-Ctrl+S"
 
 #: ../../src/Worksheet.cpp:1291
 msgid "Save Image..."
-msgstr ""
+msgstr "Enregistrer l'image…"
 
 #: ../../src/wxMaxima.cpp:6440
 msgid "Save Selection to Image"
-msgstr ""
+msgstr "Sauvegarder la sélection comme image"
 
 #: ../../src/wxMaximaFrame.cpp:675
 msgid "Save Selection to Image..."
-msgstr ""
+msgstr "Sauvegarder la sélection comme image…"
 
 #: ../../src/wxMaxima.cpp:10184
 msgid "Save animation to file"
-msgstr ""
+msgstr "Enregistrer l'animation dans un fichier"
 
 #: ../../src/wxMaxima.cpp:7203
 msgid "Save as lisp code"
-msgstr ""
+msgstr "Sauvegarder comme code lisp"
 
 #: ../../src/wxMaximaFrame.cpp:1091
 msgid "Save as lisp..."
-msgstr ""
+msgstr "Sauvegarder en tant que lisp..."
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
 msgid "Save document"
-msgstr ""
+msgstr "Sauvegarder le document"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save document as"
-msgstr ""
+msgstr "Sauvegarder le document sous"
 
 #: ../../src/wxMaximaFrame.cpp:676
 msgid "Save selection from document to an image file"
-msgstr ""
+msgstr "Sauvegarder la sélection du document dans un fichier image"
 
 #: ../../src/wxMaxima.cpp:10125
 msgid "Save selection to file"
-msgstr ""
+msgstr "Enregistrer la sélection dans un fichier"
 
 #: ../../src/wxMaximaFrame.cpp:573
 msgid "Saving failed."
-msgstr ""
+msgstr "La sauvegarde a échoué."
 
 #: ../../src/WXMXformat.cpp:310
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
-msgstr ""
+msgstr "La sauvegarde a réussi, mais le fichier résultant a disparu ?!?."
 
 #: ../../src/wxMaxima.cpp:10107
 msgid ""
@@ -5947,599 +6210,618 @@ msgid ""
 "(*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|Portable anymap "
 "(*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"Image vectorielle redimensionnable (*.svg)|*.svg|Compressed Scalable Vector "
+"Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF "
+"image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|Portable anymap "
+"(*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:9533
 msgid "Scatterplot"
-msgstr ""
+msgstr "Nuage de points"
 
 #: ../../src/Autocomplete.cpp:125
 msgid ""
 "Scheduling a background task that compiles a new list of autocompletable "
 "maxima commands."
 msgstr ""
+"Planification d'une tâche en arrière-plan qui compile une nouvelle liste de "
+"commandes Maxima qui se complètent automatiquement."
 
 #: ../../src/Autocomplete.cpp:458
 msgid ""
 "Scheduling a background task that scans for autocompletable file names."
 msgstr ""
+"Planification d'une tâche en arrière-plan qui scanne les noms en auto-"
+"complétion des fichiers."
 
 #: ../../src/ToolBar.cpp:632
 msgid "Search button"
-msgstr ""
+msgstr "Bouton Rechercher"
 
 #: ../../src/wxMaxima.cpp:7454
 msgid "Search first occurrence of part"
-msgstr ""
+msgstr "Rechercher la première occurrence de la partie"
 
 #: ../../src/wxMaximaFrame.cpp:1178
 msgid "Search..."
-msgstr ""
+msgstr "Recherche..."
 
 #: ../../src/ToolBar.cpp:273
 msgid "Section"
-msgstr ""
+msgstr "Section"
 
 #: ../../src/Configuration.cpp:91
 msgid "Section cell (Heading 2)"
-msgstr ""
+msgstr "Cellule de section (Titre de niveau 2)"
 
 #: ../../src/wxMaxima.cpp:7218
 msgid "Seek to position"
-msgstr ""
+msgstr "Aller à la position"
 
 #: ../../src/BTextCtrl.cpp:45
 msgid "Seems like something is broken with a font."
-msgstr ""
+msgstr "Il semble que quelque chose ne fonctionne pas avec une police."
 
 #: ../../src/Autocomplete.cpp:350
 msgid "Seems like the package with the maxima share files isn't installed."
 msgstr ""
+"Il semble que le paquetage comportant les  fichiers partagés de Maxima ne "
+"soit pas installé."
 
 #: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
 msgid "Select All"
-msgstr ""
+msgstr "Tout sélectionner"
 
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select All\tCtrl+A"
-msgstr ""
+msgstr "Tout sélectionner\tCtrl+A"
 
 #: ../../src/ToolBar.cpp:629
 msgid "Select All button"
-msgstr ""
+msgstr "Bouton Tout sélectionner"
 
 #: ../../src/wxMaxima.cpp:9631
 msgid "Select Subsample"
-msgstr ""
+msgstr "Choisir un sous-échantillon"
 
 #: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select all"
-msgstr ""
+msgstr "Tout sélectionner"
 
 #: ../../src/wxMaxima.cpp:6971
 msgid "Select math display algorithm"
-msgstr ""
+msgstr "Choisir l'algorithme d'affichage mathématique"
 
 #: ../../src/Configuration.cpp:98
 msgid "Selection color"
-msgstr ""
+msgstr "Sélection de la couleur"
 
 #: ../../src/ToolBar.cpp:252
 msgid "Send all cells to maxima"
-msgstr ""
+msgstr "Envoyer toutes les cellules à Maxima"
 
 #: ../../src/ToolBar.cpp:249
 msgid "Send the current cell to maxima"
-msgstr ""
+msgstr "Envoyer la cellule actuelle à Maxima"
 
 #: ../../src/wxMaxima.cpp:2810
 msgid "Sending Maxima a SIGINT signal."
-msgstr ""
+msgstr "Envoi d'un signal SIGINT à Maxima."
 
 #: ../../src/StatusBar.cpp:220
 msgid "Sending a command to Maxima"
-msgstr ""
+msgstr "Envoyer une commande à Maxima"
 
 #: ../../src/wxMaxima.cpp:10598
 msgid "Sending a new command to Maxima."
-msgstr ""
+msgstr "Envoyer une nouvelle commande à Maxima."
 
 #: ../../src/wxMaxima.cpp:2792
 msgid "Sending an interrupt signal to Maxima."
-msgstr ""
+msgstr "Envoi d'un signal d'interruption à Maxima."
 
 #: ../../src/wxMaxima.cpp:169
 msgid "Sending configuration data to maxima."
-msgstr ""
+msgstr "Envoi des données de configuration à Maxima."
 
 #: ../../src/wxMaxima.cpp:4718
 msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
+"Envoi à Maxima des informations sur la façon de coder les maths 2D en XML"
 
 #: ../../src/wxMaximaFrame.cpp:1533
 msgid "Sequential Comparative Simplification"
-msgstr ""
+msgstr "Simplification séquentielle comparative"
 
 #: ../../src/wxMaxima.cpp:9016
 msgid "Series"
-msgstr ""
+msgstr "Série"
 
 #: ../../src/wxMaximaFrame.cpp:1479
 msgid "Series approximation"
-msgstr ""
+msgstr "Approximation par série"
 
 #: ../../src/wxMaxima.cpp:2561
 msgid "Server started"
-msgstr ""
+msgstr "Serveur démarré"
 
 #: ../../src/wxMaximaFrame.cpp:1824
 msgid "Set &displayed Precision..."
-msgstr ""
+msgstr "Définir la précision pour l'affichage..."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Set Maxima option variable logexpand:all"
-msgstr ""
+msgstr "Définir la variable d'option Maxima logexpand:all"
 
 #: ../../src/wxMaximaFrame.cpp:1567
 msgid "Set Maxima option variable logexpand:super"
-msgstr ""
+msgstr "Définir la variable d'option Maxima logexpand:super"
 
 #: ../../src/wxMaximaFrame.cpp:1560
 msgid "Set Maxima option variable logexpand:true"
-msgstr ""
+msgstr "Définir la variable d'option Maxima logexpand:true"
 
 #: ../../src/wxMaximaFrame.cpp:822
 msgid "Set Zoom"
-msgstr ""
+msgstr "Régler le zoom"
 
 #: ../../src/wxMaximaFrame.cpp:1819
 msgid "Set bigfloat &Precision..."
-msgstr ""
+msgstr "Régler la précision de la virgule flottante..."
 
 #: ../../src/Worksheet.cpp:1306 ../../src/Worksheet.cpp:1479
 msgid "Set image resolution"
-msgstr ""
+msgstr "Définir la résolution d'image"
 
 #: ../../src/wxMaximaFrame.cpp:1510
 msgid "Set main variable..."
-msgstr ""
+msgstr "Définir la variable principale..."
 
 #: ../../src/wxMaximaFrame.cpp:1773
 msgid "Set plot format"
-msgstr ""
+msgstr "Régler le format de courbe"
 
 #: ../../src/wxMaximaFrame.cpp:1101
 msgid "Set position..."
-msgstr ""
+msgstr "Définir la position..."
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Set the \"algebraic\" flag"
-msgstr ""
+msgstr "Définir l'option \"algébrique\""
 
 #: ../../src/wxMaxima.cpp:8314
 msgid "Set the diagram title"
-msgstr ""
+msgstr "Définir le titre du diagramme"
 
 #: ../../src/wxMaximaFrame.cpp:1779
 msgid "Set the frame rate for animations."
-msgstr ""
+msgstr "Définir la fréquence d'images pour les animations."
 
 #: ../../src/wxMaxima.cpp:8377
 msgid "Set the grid density."
-msgstr ""
+msgstr "Définir la densité de la grille."
 
 #: ../../src/wxMaxima.cpp:8327
 msgid "Set the next plot's title. Empty = no title."
-msgstr ""
+msgstr "Définir le prochain titre du  graphique. Vide =  pas de titre."
 
 #: ../../src/wxMaximaFrame.cpp:1820
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can"
 " be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
+"Définir la précision pour les nombres de type bigfloat. De tels nombres "
+"peuvent être générés en saisissant 1.5b12 ou bfloat(1.234)"
 
 #: ../../src/wxMaximaFrame.cpp:811
 msgid "Set zoom to 100%"
-msgstr ""
+msgstr "Régler le zoom à 100%"
 
 #: ../../src/wxMaximaFrame.cpp:813
 msgid "Set zoom to 120%"
-msgstr ""
+msgstr "Régler le zoom à 120%"
 
 #: ../../src/wxMaximaFrame.cpp:815
 msgid "Set zoom to 150%"
-msgstr ""
+msgstr "Régler le zoom à 150%"
 
 #: ../../src/wxMaximaFrame.cpp:817
 msgid "Set zoom to 200%"
-msgstr ""
+msgstr "Régler le zoom à 200%"
 
 #: ../../src/wxMaximaFrame.cpp:819
 msgid "Set zoom to 300%"
-msgstr ""
+msgstr "Régler le zoom à 300%"
 
 #: ../../src/wxMaximaFrame.cpp:809
 msgid "Set zoom to 80%"
-msgstr ""
+msgstr "Régler le zoom à 80%"
 
 #: ../../src/wxMaxima.cpp:4731
 #, c-format
 msgid "Setting gnuplot_binary to %s"
-msgstr ""
+msgstr "Définir gnuplot_binary à %s"
 
 #: ../../src/wxMaxima.cpp:4804
 msgid "Setting prompt and help format"
-msgstr ""
+msgstr "Définir le format de l'invite et de l'aide"
 
 #: ../../src/wxMaximaFrame.cpp:1292
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
+"Choisir à la valeur pour la résolution d'une é.d.o. avec la transformée de "
+"Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1661
 msgid "Setup modulus computation"
-msgstr ""
+msgstr "Configurer le calcul modulo"
 
 #: ../../src/wxMaxima.cpp:9220
 msgid "Setup the engineering format"
-msgstr ""
+msgstr "Configurer le format ingénieur"
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "Setup the engineering format..."
-msgstr ""
+msgstr "Configurer le format ingénieur..."
 
 #: ../../src/wxMaxima.cpp:9576
 msgid "Shapiro-Wilk test for normality"
-msgstr ""
+msgstr "Test de Shapiro-Wilk pour la normalité"
 
 #: ../../src/Worksheet.cpp:1543
 msgid "Show \"%\" in special constants"
-msgstr ""
+msgstr "Afficher \"%\" dans les constantes spéciales"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show &Tips..."
-msgstr ""
+msgstr "Montrer les as&tuces..."
 
 #: ../../src/Worksheet.cpp:1556
 msgid "Show * as multiplication dot"
-msgstr ""
+msgstr "Afficher * sous forme de point de multiplication"
 
 #: ../../src/wxMaximaFrame.cpp:895
 msgid "Show Template\tCtrl+Shift+Space"
-msgstr ""
+msgstr "Montrer le modèle\tCtrl+Shift+Space"
 
 #: ../../src/wxMaximaFrame.cpp:753
 msgid "Show XML representation"
-msgstr ""
+msgstr "Montrer la représentation en XML"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show a tip"
-msgstr ""
+msgstr "Montrer une astuce"
 
 #: ../../src/Worksheet.cpp:1607
 msgid "Show all + allow linebreaks in long numbers"
 msgstr ""
+"Afficher tout + autoriser les retours à la ligne dans les nombres de grande "
+"longueur"
 
 #: ../../src/wxMaxima.cpp:9475
 msgid "Show all commands similar to:"
-msgstr ""
+msgstr "Montrer toutes les commandes analogues à :"
 
 #: ../../src/wxMaxima.cpp:9468
 msgid "Show an example for the command:"
-msgstr ""
+msgstr "Montrer un exemple pour la commande :"
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "Show an example of usage"
-msgstr ""
+msgstr "Montrer un exemple d'utilisation"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "Show commands similar to"
-msgstr ""
+msgstr "Montrer les commandes analogues à"
 
 #: ../../src/wxMaximaFrame.cpp:1020
 msgid "Show defined functions"
-msgstr ""
+msgstr "Montrer les fonctions définies"
 
 #: ../../src/wxMaximaFrame.cpp:1022
 msgid "Show defined variables"
-msgstr ""
+msgstr "Montrer les variables déclarées"
 
 #: ../../src/wxMaximaFrame.cpp:1074
 msgid "Show definition of a function"
-msgstr ""
+msgstr "Montrer la définition d'une fonction"
 
 #: ../../src/wxMaximaFrame.cpp:740
 msgid "Show equations in their linear form"
-msgstr ""
+msgstr "Afficher les équations sous leur forme linéaire"
 
 #: ../../src/wxMaximaFrame.cpp:1073
 msgid "Show function &Definition..."
-msgstr ""
+msgstr "Montrer la &Définition de la fonction..."
 
 #: ../../src/wxMaximaFrame.cpp:896
 msgid "Show function template"
-msgstr ""
+msgstr "Montrer le modèle de la fonction"
 
 #: ../../src/Worksheet.cpp:1614
 msgid "Show input labels"
-msgstr ""
+msgstr "Montrer les étiquettes d'entrée"
 
 #: ../../src/wxMaximaFrame.cpp:750
 msgid "Show lisp representation"
-msgstr ""
+msgstr "Montrer la représentation en lisp"
 
 #: ../../src/Worksheet.cpp:1604
 msgid "Show max. 100 digits"
-msgstr ""
+msgstr "Afficher au maximum 100 chiffres"
 
 #: ../../src/Worksheet.cpp:1602
 msgid "Show max. 20 digits"
-msgstr ""
+msgstr "Afficher au maximum 20 chiffres"
 
 #: ../../src/Worksheet.cpp:1603
 msgid "Show max. 50 digits"
-msgstr ""
+msgstr "Afficher au maximum 50 chiffres"
 
 #: ../../src/wxMaximaFrame.cpp:835
 msgid "Show or hide the wxMaxima logging window"
-msgstr ""
+msgstr "Afficher ou masquer la fenêtre de journalisation de wxMaxima"
 
 #: ../../src/ToolBar.cpp:612
 msgid "Show the \"New\" button?"
-msgstr ""
+msgstr "Afficher le bouton \"Nouveau\" ?"
 
 #: ../../src/ToolBar.cpp:636
 msgid "Show the \"help\" button?"
-msgstr ""
+msgstr "Afficher le bouton \"Aide\" ?"
 
 #: ../../src/ToolBar.cpp:633
 msgid "Show the \"search\" button?"
-msgstr ""
+msgstr "Afficher le bouton \"Rechercher\" ?"
 
 #: ../../src/ToolBar.cpp:630
 msgid "Show the \"select all\" button?"
-msgstr ""
+msgstr "Afficher le bouton \"Tout sélectionner\" ?"
 
 #: ../../src/ToolBar.cpp:624
 msgid "Show the Copy, Cut and the Paste button?"
-msgstr ""
+msgstr "Afficher les boutons Copier, Couper et Coller ?"
 
 #: ../../src/wxMaxima.cpp:7033
 msgid "Show the function's definition"
-msgstr ""
+msgstr "Montrer la définition de la fonction"
 
 #: ../../src/ToolBar.cpp:618
 msgid "Show the open and the save button?"
-msgstr ""
+msgstr "Afficher les boutons Ouvrir et Enregistrer ?"
 
 #: ../../src/ToolBar.cpp:627
 msgid "Show the preferences button?"
-msgstr ""
+msgstr "Afficher le bouton Préférences ?"
 
 #: ../../src/ToolBar.cpp:621
 msgid "Show the print button?"
-msgstr ""
+msgstr "Afficher le bouton Imprimer ?"
 
 #: ../../src/ToolBar.cpp:615
 msgid "Show the undo and redo button?"
-msgstr ""
+msgstr "Afficher les boutons Annuler et Rétablir ?"
 
 #: ../../src/wxMaximaFrame.cpp:1006 ../../src/wxMaximaFrame.cpp:1011
 msgid "Show used + to-be-freed memory"
-msgstr ""
+msgstr "Afficher la mémoire utilisée et à libérer"
 
 #: ../../src/wxMaximaFrame.cpp:1033
 msgid "Show user definitions"
-msgstr ""
+msgstr "Afficher les définitions créées par l'utilisateur"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Show wxMaxima help"
-msgstr ""
+msgstr "Montrer l'aide de wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1825
 msgid "Shows how many digits of a numbers are displayed"
-msgstr ""
+msgstr "Indiquer combien de chiffres sont affichés pour un nombre"
 
 #: ../../src/wxMaximaFrame.cpp:732
 msgid "Sidebars"
-msgstr ""
+msgstr "Barres latérales"
 
 #: ../../src/wxMaximaFrame.cpp:1513
 msgid "Simplify &Radicals..."
-msgstr ""
+msgstr "Simplifier des &radicaux..."
 
 #: ../../src/Worksheet.cpp:1579
 msgid "Simplify Expression"
-msgstr ""
+msgstr "Simplifier une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1568
 msgid "Simplify Logarithms"
-msgstr ""
+msgstr "Simplifier des logarithmes"
 
 #: ../../src/wxMaximaFrame.cpp:1582
 msgid "Simplify an expression containing factorials"
-msgstr ""
+msgstr "Simplifier une expression contenant des factorielles"
 
 #: ../../src/wxMaximaFrame.cpp:1539
 msgid "Simplify equations"
-msgstr ""
+msgstr "Simplifier les équations"
 
 #: ../../src/wxMaximaFrame.cpp:1514
 msgid "Simplify expression containing radicals"
-msgstr ""
+msgstr "Simplifier une expression contenant des radicaux"
 
 #: ../../src/wxMaxima.cpp:8649
 msgid "Simplify radicals"
-msgstr ""
+msgstr "Simplifier des radicaux"
 
 #: ../../src/wxMaximaFrame.cpp:1512
 msgid "Simplify rational expression"
-msgstr ""
+msgstr "Simplifier une expression rationnelle"
 
 #: ../../src/wxMaximaFrame.cpp:1538
 msgid "Simplify sum() commands..."
-msgstr ""
+msgstr "Simplifier les commandes sum()..."
 
 #: ../../src/wxMaxima.cpp:8636
 msgid "Simplify sums"
-msgstr ""
+msgstr "Simplifier les sommes"
 
 #: ../../src/wxMaximaFrame.cpp:1592
 msgid "Simplify trigonometric expression"
-msgstr ""
+msgstr "Simplifier une expression trigonométrique"
 
 #: ../../src/wxMaximaFrame.cpp:1399
 msgid "Singular Values"
-msgstr ""
+msgstr "Valeurs singulières"
 
 #: ../../src/wxMaximaFrame.cpp:1400 ../../src/wxMaximaFrame.cpp:1403
 msgid "Singular values using dgesvd"
-msgstr ""
+msgstr "Valeurs singulières à l'aide de dgesvd"
 
 #: ../../src/wxMaximaFrame.cpp:1402
 msgid "Singular values, left + right vectors"
-msgstr ""
+msgstr "Valeurs singulières, vecteurs gauche + droite"
 
 #: ../../src/wxMaximaFrame.cpp:1635
 msgid "Smart Substitute..."
-msgstr ""
+msgstr "Substitution intelligente..."
 
 #: ../../src/wxMaxima.cpp:8730
 msgid "Smart substitution"
-msgstr ""
+msgstr "Substitution intelligente"
 
 #: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
 #: ../../src/wxMaxima.cpp:7823
 msgid "Solution of the ODE:"
-msgstr ""
+msgstr "Solution de l'EDO :"
 
 #: ../../src/wxMaxima.cpp:10017
 msgid "Solve"
-msgstr ""
+msgstr "Résoudre"
 
 #: ../../src/wxMaximaFrame.cpp:1244
 msgid "Solve &Algebraic System..."
-msgstr ""
+msgstr "Résoudre un système &algébrique…"
 
 #: ../../src/wxMaximaFrame.cpp:1242
 msgid "Solve &Linear System..."
-msgstr ""
+msgstr "Résoudre un système &linéaire…"
 
 #: ../../src/wxMaximaFrame.cpp:1266
 msgid "Solve &ODE..."
-msgstr ""
+msgstr "Résoudre &une équation différentielle…"
 
 #: ../../src/wxMaximaFrame.cpp:1240
 msgid "Solve (to_poly)..."
-msgstr ""
+msgstr "Résoudre (to_poly)…"
 
 #: ../../src/wxMaxima.cpp:8045
 msgid "Solve A*x=b numerically"
-msgstr ""
+msgstr "Résoudre A*x=b numériquement"
 
 #: ../../src/wxMaximaFrame.cpp:1397
 msgid "Solve Ax=b"
-msgstr ""
+msgstr "Résoudre Ax=b"
 
 #: ../../src/wxMaxima.cpp:7783
 msgid "Solve ODE"
-msgstr ""
+msgstr "Résoudre une équation différentielle"
 
 #: ../../src/wxMaximaFrame.cpp:1287
 msgid "Solve ODE with Lapla&ce..."
-msgstr ""
+msgstr "Résoudre une équation différentielle avec Lapla&ce…"
 
 #: ../../src/wxMaximaFrame.cpp:1398
 msgid "Solve a linear equation system using dgesv"
-msgstr ""
+msgstr "Résoudre un système d'équations linéaires avec dgesv"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
 msgid "Solve algebraic system"
-msgstr ""
+msgstr "Résoudre un système algébrique"
 
 #: ../../src/wxMaximaFrame.cpp:1245
 msgid "Solve algebraic system of equations"
-msgstr ""
+msgstr "Résoudre un système d'équations algébriques"
 
 #: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve boundary value problem for second degree ODE"
-msgstr ""
+msgstr "Résoudre un problème aux limites pour une EDO du second ordre"
 
 #: ../../src/wxMaxima.cpp:7895
 msgid "Solve differential equations using laplace()"
-msgstr ""
+msgstr "Résoudre des équations différentielles avec laplace()"
 
 #: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
 msgid "Solve equation(s)"
-msgstr ""
+msgstr "Résoudre une (des) équation(s)"
 
 #: ../../src/wxMaximaFrame.cpp:1241
 msgid "Solve equation(s) with to_poly_solve"
-msgstr ""
+msgstr "Résoudre une (des) équation(s) avec to_poly_solve"
 
 #: ../../src/wxMaxima.cpp:7773
 msgid "Solve equations numerically"
-msgstr ""
+msgstr "Résoudre des équations numériquement"
 
 #: ../../src/wxMaxima.cpp:7757
 msgid "Solve equations to polynom"
-msgstr ""
+msgstr "Résoudre les équations en polynôme"
 
 #: ../../src/wxMaximaFrame.cpp:1271
 msgid "Solve initial value problem for first degree ODE"
-msgstr ""
+msgstr "Résoudre une EDO du premier ordre avec condition initiale"
 
 #: ../../src/wxMaximaFrame.cpp:1275
 msgid "Solve initial value problem for second degree ODE"
-msgstr ""
+msgstr "Résoudre une EDO du second ordre avec conditions initiales"
 
 #: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
 msgid "Solve linear system"
-msgstr ""
+msgstr "Résoudre un système &linéaire"
 
 #: ../../src/wxMaximaFrame.cpp:1243
 msgid "Solve linear system of equations"
-msgstr ""
+msgstr "Résoudre un système d'équations linéaires"
 
 #: ../../src/wxMaximaFrame.cpp:1263
 msgid "Solve numerical, 1 Variable"
-msgstr ""
+msgstr "Résoudre numériquement, 1 variable"
 
 #: ../../src/wxMaximaFrame.cpp:1267
 msgid "Solve ordinary differential equation of maximum degree 2"
-msgstr ""
+msgstr "Résoudre une équation différentielle ordinaire de degré au plus 2"
 
 #: ../../src/wxMaximaFrame.cpp:1288
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
+"Résoudre une équation différentielle ordinaire avec la transformée de "
+"Laplace"
 
 #: ../../src/wxMaxima.cpp:7708
 msgid "Solve polynomials numerically"
-msgstr ""
+msgstr "Trouver les racines d'un polynome numériquement"
 
 #: ../../src/wxMaxima.cpp:7718
 msgid "Solve polynomials numerically (bfloats)"
-msgstr ""
+msgstr "Trouver les racines d'un polynome numériquement (bfloats)"
 
 #: ../../src/wxMaxima.cpp:7729
 msgid "Solve polynomials numerically (real roots)"
-msgstr ""
+msgstr "Trouver les racines d'un polynome numériquement (racines réelles)"
 
 #: ../../src/wxMaximaFrame.cpp:1249
 msgid "Solve symbolically"
-msgstr ""
+msgstr "Résoudre symboliquement"
 
 #: ../../src/Worksheet.cpp:1574
 msgid "Solve..."
-msgstr ""
+msgstr "Résoudre…"
 
 #: ../../src/wxMaximaFrame.cpp:1916
 msgid "Solving differential equations"
-msgstr ""
+msgstr "Résoudre des équations différentielles"
 
 #: ../../src/wxMaximaFrame.cpp:1904
 msgid "Solving equations with Maxima"
-msgstr ""
+msgstr "Résoudre des équations avec Maxima"
 
 #: ../../src/wxMaxima.cpp:7105
 #, c-format
@@ -6547,116 +6829,120 @@ msgid ""
 "Sometimes one wants maxima to loose the information that a function name was used with the ' operator in order to make maxima not evaluate it. In other places one wants % to mean \"the last expression at the time this function was created\", not \"the last expression now\".\n"
 "In both cases the '' operator will do what is requested."
 msgstr ""
+"Parfois, on souhaite que Maxima perde l'information qu'un nom de fonction a été utilisé avec l'opérateur ' afin que Maxima ne l'évalue pas. Dans d'autres commandes, on veut que% to  signifie \"l'expression précédente au moment où cette fonction a été créée\", et non \"l'expression précédente maintenant\".\n"
+" Dans les deux cas, l'opérateur '' fera ce qui est demandé."
 
 #: ../../src/wxMaximaFrame.cpp:1746
 msgid "Sort"
-msgstr ""
+msgstr "Trier"
 
 #: ../../src/wxMaxima.cpp:8496
 msgid "Sort a list"
-msgstr ""
+msgstr "Trier une liste"
 
 #: ../../src/wxMaxima.cpp:7459
 msgid "Sort all characters in string"
-msgstr ""
+msgstr "Trier tous les caractères dans la chaîne"
 
 #: ../../src/wxMaximaFrame.cpp:1179
 msgid "Sort the characters..."
-msgstr ""
+msgstr "Trier les caractères..."
 
 #: ../../src/wxMaxima.cpp:8482
 msgid "Source list:"
-msgstr ""
+msgstr "Liste des sources :"
 
 #: ../../src/wxMaxima.cpp:7429
 msgid "Split"
-msgstr ""
+msgstr "Diviser"
 
 #: ../../src/wxMaximaFrame.cpp:1191
 msgid "Split on match"
-msgstr ""
+msgstr "Diviser à la correspondance"
 
 #: ../../src/wxMaxima.cpp:7528
 msgid "Split on regex match"
-msgstr ""
+msgstr "Diviser lorsque l'expression régulière est trouvée"
 
 #: ../../src/wxMaxima.cpp:7449
 msgid "Split string into tokens"
-msgstr ""
+msgstr "Diviser la chaine en tokens"
 
 #: ../../src/wxMaximaFrame.cpp:1171
 msgid "Split..."
-msgstr ""
+msgstr "Diviser..."
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Square"
-msgstr ""
+msgstr "Carré"
 
 #: ../../src/Configuration.cpp:86
 msgid "Standard Text"
-msgstr ""
+msgstr "Texte standard"
 
 #: ../../src/Worksheet.cpp:1298
 msgid "Start Animation"
-msgstr ""
+msgstr "Démarrer l'animation"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Start of t:"
-msgstr ""
+msgstr "Début pour t :"
 
 #: ../../src/ToolBar.cpp:305
 msgid "Start or Stop animation"
-msgstr ""
+msgstr "Démarrer ou arrêter l'animation"
 
 #: ../../src/ToolBar.cpp:306
 msgid ""
 "Start or stop the currently selected animation that has been created with "
 "the with_slider class of commands"
 msgstr ""
+"Démarrer ou arrêter l’animation actuellement sélectionnée qui a été créée "
+"avec la classe de commandes with_slider"
 
 #: ../../src/wxMaxima.cpp:386
 msgid "Starting Maxima process failed"
-msgstr ""
+msgstr "Le lancement de Maxima a échoué"
 
 #: ../../src/main.cpp:667
 msgid "Starting a new wxMaxima process for a new window"
-msgstr ""
+msgstr "Démarrer un nouveau processus wxMaxima dans une nouvelle fenêtre"
 
 #: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:5633
 msgid "Starting evaluation of the document"
-msgstr ""
+msgstr "Commencer l'évalution du notebook"
 
 #: ../../src/wxMaxima.cpp:2544
 msgid "Starting server failed"
-msgstr ""
+msgstr "Échec du démarrage du serveur"
 
 #: ../../src/WXMXformat.cpp:64
 msgid "Starting to save the worksheet as .wxmx"
-msgstr ""
+msgstr "Commencer à sauvegarder la feuille de calcul au format .wxmx"
 
 #: ../../src/wxMaximaFrame.cpp:252
 msgid "Statistics"
-msgstr ""
+msgstr "Statistiques"
 
 #: ../../src/wxMaximaFrame.cpp:701
 msgid "Statistics\tAlt+Shift+S"
-msgstr ""
+msgstr "Statistiques\tAlt+Maj-S"
 
 #: ../../src/wxMaxima.cpp:7844
 msgid "Step width:"
-msgstr ""
+msgstr "Largeur du pas :"
 
 #: ../../src/wxMaximaFrame.cpp:794
 msgid "Straight lines"
-msgstr ""
+msgstr "Lignes droites"
 
 #: ../../src/wxMaximaFrame.cpp:1106
 msgid "Stream"
-msgstr ""
+msgstr "Flux"
 
 #: ../../src/wxMaxima.cpp:7231
 msgid "Stream length"
-msgstr ""
+msgstr "Taille du flux"
 
 #: ../../src/wxMaxima.cpp:7219 ../../src/wxMaxima.cpp:7224
 #: ../../src/wxMaxima.cpp:7228 ../../src/wxMaxima.cpp:7232
@@ -6666,45 +6952,45 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7267 ../../src/wxMaxima.cpp:7271
 #: ../../src/wxMaxima.cpp:7276
 msgid "Stream:"
-msgstr ""
+msgstr "Flux :"
 
 #: ../../src/wxMaximaFrame.cpp:1185
 msgid "String"
-msgstr ""
+msgstr "Chaîne"
 
 #: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
 #: ../../src/wxMaxima.cpp:7425
 msgid "String #1:"
-msgstr ""
+msgstr "Chaine #1:"
 
 #: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
 #: ../../src/wxMaxima.cpp:7426
 msgid "String #2:"
-msgstr ""
+msgstr "Chaine #2:"
 
 #: ../../src/wxMaximaFrame.cpp:1136
 msgid "String Tests"
-msgstr ""
+msgstr "Tests de la chaine"
 
 #: ../../src/wxMaxima.cpp:7415
 msgid "String length"
-msgstr ""
+msgstr "Longueur de la chaine"
 
 #: ../../src/wxMaxima.cpp:7381
 msgid "String to list of char"
-msgstr ""
+msgstr "Chaîne vers liste de caractères"
 
 #: ../../src/wxMaximaFrame.cpp:1148
 msgid "String to list of chars..."
-msgstr ""
+msgstr "Chaîne vers liste de caractères..."
 
 #: ../../src/wxMaxima.cpp:7496
 msgid "String to octets"
-msgstr ""
+msgstr "Chaîne vers octets+"
 
 #: ../../src/wxMaximaFrame.cpp:1160
 msgid "String to octets..."
-msgstr ""
+msgstr "Chaîne vers octets..."
 
 #: ../../src/wxMaxima.cpp:7377 ../../src/wxMaxima.cpp:7382
 #: ../../src/wxMaxima.cpp:7391 ../../src/wxMaxima.cpp:7396
@@ -6718,74 +7004,78 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
 #: ../../src/wxMaxima.cpp:7497
 msgid "String:"
-msgstr ""
+msgstr "Chaine :"
 
 #: ../../src/wxMaxima.cpp:7197
 msgid "Struct :"
-msgstr ""
+msgstr "Structure :"
 
 #: ../../src/wxMaxima.cpp:7184 ../../src/wxMaxima.cpp:7190
 msgid "Struct type name:"
-msgstr ""
+msgstr "Nom du type de structure :"
 
 #: ../../src/wxMaximaFrame.cpp:1029
 msgid "Structs"
-msgstr ""
+msgstr "Structures"
 
 #: ../../src/ToolBar.cpp:274
 msgid "Subsection"
-msgstr ""
+msgstr "Sous-section"
 
 #: ../../src/Configuration.cpp:90
 msgid "Subsection cell (Heading 3)"
-msgstr ""
+msgstr "Cellule de sous-section (niveau 3)"
 
 #: ../../src/wxMaximaFrame.cpp:1643
 msgid "Subst constant t into eq with diff(x,t)..."
-msgstr ""
+msgstr "Substituer la constante t dans l’équation contenant diff(x,t)..."
 
 #: ../../src/wxMaxima.cpp:8724
 msgid "Subst is a better string-search-and-replace for expressions."
 msgstr ""
+"Subst est une meilleure fonction de recherche-et-remplacement de chaînes "
+"pour les expressions."
 
 #: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
 #: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
 msgid "Substitute"
-msgstr ""
+msgstr "Substituer"
 
 #: ../../src/wxMaximaFrame.cpp:1193
 msgid "Substitute all matches"
-msgstr ""
+msgstr "Substituer toutes les occurences"
 
 #: ../../src/wxMaximaFrame.cpp:1192
 msgid "Substitute first match"
-msgstr ""
+msgstr "Remplacer la première occurrence"
 
 #: ../../src/wxMaximaFrame.cpp:1646
 msgid "Substitute only in parts..."
-msgstr ""
+msgstr "Substituer uniquement dans les parties..."
 
 #: ../../src/wxMaxima.cpp:8763
 msgid "Substitute only in specific parts"
-msgstr ""
+msgstr "Substituer uniquement dans des parties spécifiques"
 
 #: ../../src/wxMaximaFrame.cpp:1647
 msgid "Substitute only in the elements n_1, n_2,..."
-msgstr ""
+msgstr "Substituer uniquement dans les éléments n_1, n_2,..."
 
 #: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
 msgid "Substitute..."
-msgstr ""
+msgstr "Substituer…"
 
 #: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
 msgid "Substitutes until the equation no more changes"
-msgstr ""
+msgstr "Substituer jusqu'à ce que l'équation ne change plus"
 
 #: ../../src/wxMaxima.cpp:8747
 msgid ""
 "Substitutes up to lrats_max_iter times, or until the expression stops "
 "changing when substituting."
 msgstr ""
+"Substituer jusqu’à lrats_max_iter fois, ou jusqu’à ce que l’expression cesse"
+" de changer lors de la substitution."
 
 #: ../../src/wxMaxima.cpp:8756
 #, c-format
@@ -6793,259 +7083,283 @@ msgid ""
 "Substitutes, but makes sure that if substituting t=0 in diff(x,t) the result"
 " isn't 0 (as t no more changes), but %at(diff(x,t),t=0)."
 msgstr ""
+"Substituer, mais veiller à ce que si l’on substitue t=0 dans diff(x,t), le "
+"résultat ne soit pas 0 (car t ne change plus), mais %at(diff(x,t),t=0)."
 
 #: ../../src/wxMaxima.cpp:8739
 msgid ""
 "Substitutes, but makes sure that nothing is substituted into the other "
 "substituents."
 msgstr ""
+"Substituer, mais veiller à ce que rien ne soit substitué dans les autres "
+"substituants."
 
 #: ../../src/wxMaximaFrame.cpp:1638
 msgid "Substitutes, but not in the other substituents"
-msgstr ""
+msgstr "Substituer, mais pas dans les autres substituants"
 
 #: ../../src/wxMaxima.cpp:8764
 msgid ""
 "Substitutes, but only in the n_1th, n_2th and so on term of the equation."
-msgstr ""
+msgstr "Substituer, mais seulement dans les n_1ᵉ, n_2ᵉ, etc. termes."
 
 #: ../../src/ToolBar.cpp:275
 msgid "Subsubsection"
-msgstr ""
+msgstr "Sous-sous-section"
 
 #: ../../src/Configuration.cpp:89
 msgid "Subsubsection cell (Heading 4)"
-msgstr ""
+msgstr "Cellule de sous-sous-section (Niveau 4)"
 
 #: ../../src/Worksheet.cpp:1831
 msgid "Suggestion: "
-msgstr ""
+msgstr "Suggestion : "
 
 #: ../../src/Worksheet.cpp:2030
 msgid "Suitable as flag for ev()"
-msgstr ""
+msgstr "Adapté comme indicateur pour ev()"
 
 #: ../../src/wxMaxima.cpp:9049
 msgid "Sum"
-msgstr ""
+msgstr "Somme"
 
 #: ../../src/wxMaximaFrame.cpp:1551
 msgid ""
 "Switch off simplifications of log(). Set Maxima option variable "
 "logexpand:false"
 msgstr ""
+"Désactiver les simplifications de log(). Définit la variable d’option de "
+"Maxima logexpand:false"
 
 #: ../../src/wxMaxima.cpp:4090
 msgid "Switched to lisp mode after receiving a lisp debug prompt!"
-msgstr ""
+msgstr "Passage en mode Lisp après réception d’une invite de débogage Lisp !"
 
 #: ../../src/wxMaxima.cpp:4092
 msgid "Switched to lisp mode after receiving a lisp prompt!"
-msgstr ""
+msgstr "Passage en mode Lisp après réception d’une invite Lisp !"
 
 #: ../../src/Worksheet.cpp:1971
 msgid "Symbolic Constant"
-msgstr ""
+msgstr "Constante symbolique"
 
 #: ../../src/wxMaximaFrame.cpp:705
 msgid "Symbols\tAlt+Shift+Y"
-msgstr ""
+msgstr "Symboles\tAlt+Shift+Y"
 
 #: ../../src/Worksheet.cpp:2006
 msgid "Symmetric function: f(x)=f(-x)"
-msgstr ""
+msgstr "Fonction paire :  f(x)=f(-x)"
 
 #: ../../src/wxMaximaFrame.cpp:238
 msgid "Table of Contents"
-msgstr ""
+msgstr "Table des matières"
 
 #: ../../src/wxMaximaFrame.cpp:711
 msgid "Table of Contents\tAlt+Shift+T"
-msgstr ""
+msgstr "Table des matières\tAlt+Shift+T"
 
 #: ../../src/wxMaxima.cpp:8930
 msgid "Taylor series"
-msgstr ""
+msgstr "Séries de Taylor"
 
 #: ../../src/wxMaximaFrame.cpp:1474
 msgid "Taylor series..."
-msgstr ""
+msgstr "Séries de Taylor..."
 
 #: ../../src/wxMaxima.cpp:8925
 msgid "Taylor series:"
-msgstr ""
+msgstr "Séries de Taylor :"
 
 #: ../../src/wxMaxima.cpp:4132
 msgid "Telling maxima about the new working directory."
-msgstr ""
+msgstr "Informer Maxima du nouveau répertoire de travail."
 
 #: ../../src/wxMaxima.cpp:7907
 msgid "Tells maxima for an f(x), that f(x=t)=a"
-msgstr ""
+msgstr "Indiquer à Maxima, pour f(x), que f(x=t)=a"
 
 #: ../../src/wxMaximaFrame.cpp:1945
 msgid ""
 "Tells maxima to show the help for ?, ?? and describe() in a separate browser"
 " window"
 msgstr ""
+"Indiquer à Maxima d’afficher l’aide pour ?, ?? et describe() dans une "
+"fenêtre de navigateur séparée"
 
 #: ../../src/wxMaximaFrame.cpp:1941
 msgid ""
 "Tells maxima to show the help for ?, ?? and describe() in a wxMaxima sidebar"
 msgstr ""
+"Indiquer à Maxima d’afficher l’aide pour ?, ?? et describe() dans une barre "
+"latérale wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1936
 msgid "Tells maxima to show the help for ?, ?? and describe() on the console"
 msgstr ""
+"Indique à Maxima d’afficher l’aide pour ?, ?? et describe() dans la console"
 
 #: ../../src/ToolBar.cpp:271
 msgid "Text"
-msgstr ""
+msgstr "Texte"
 
 #: ../../src/Configuration.cpp:93
 msgid "Text cell background"
-msgstr ""
+msgstr "Arrière-plan de la cellule de texte"
 
 #: ../../src/wxMaxima.cpp:6541
 msgid "Text snippet"
-msgstr ""
+msgstr "Extrait de texte"
 
 #: ../../src/wxMaxima.cpp:4632
 msgid ""
 "The .xml file doesn't seem to be valid xml or isn't a content.xml extracted "
 "from a .wxmx zip archive"
 msgstr ""
+"Le fichier .xml ne semble pas être un xml valide ou n’est pas un content.xml"
+" extrait d’une archive zip .wxmx"
 
 #: ../../src/wxMaxima.cpp:2734
 msgid ""
 "The Maxima process doesn't offer a shared memory segment we can send an "
 "interrupt signal to."
 msgstr ""
+"Le processus Maxima ne propose pas de segment de mémoire partagée vers "
+"lequel nous pouvons envoyer un signal d’interruption."
 
 #: ../../src/MaximaManual.cpp:107
 msgid "The cache for the subjects the manual contains cannot be read."
-msgstr ""
+msgstr "Le cache des sujets que contient le manuel ne peut pas être lu."
 
 #: ../../src/MaximaManual.cpp:378
 msgid "The cache for the subjects the manual contains has no head node."
-msgstr ""
+msgstr "Le cache des sujets que contient le manuel n’a pas de nœud principal."
 
 #: ../../src/MaximaManual.cpp:396
 msgid ""
 "The cache for the subjects the manual contains is from a different Maxima "
 "version."
 msgstr ""
+"Le cache des sujets que contient le manuel provient d’une version différente"
+" de Maxima."
 
 #: ../../src/wxMaximaFrame.cpp:1379
 msgid "The classic operations one typically uses matrices for"
 msgstr ""
+"Les opérations classiques qui sont utilisées typiquement avec les matrices"
 
 #: ../../src/wxMaxima.cpp:7193
 msgid "The comma-separated contents of the struct fields"
-msgstr ""
+msgstr "Les contenus des champs de la structure, séparés par des virgules"
 
 #: ../../src/wxMaxima.cpp:7186
 msgid "The comma-separated names of the struct fields"
-msgstr ""
+msgstr "Les noms des champs de la structure, séparés par des virgules"
 
 #: ../../src/wxMaxima.cpp:7070
 msgid ""
 "The command local() allows to tell maxima which functions to make local to "
 "the current program when defined."
 msgstr ""
+"La commande local() permet d’indiquer à Maxima quelles fonctions rendre "
+"locales pour le programme courant lors de leur définition."
 
 #: ../../src/wxMaximaFrame.cpp:303
 msgid "The current Wizard"
-msgstr ""
+msgstr "L'assistant actuel"
 
 #: ../../src/wxMaxima.cpp:9592
 msgid "The equation to fit the data to"
-msgstr ""
+msgstr "L’équation à ajuster aux données"
 
 #: ../../src/wxMaxima.cpp:8447
 msgid "The function call whose arguments to extract"
-msgstr ""
+msgstr "Extraction des arguments pour cet appel de fonction"
 
 #: ../../src/wxMaximaFrame.cpp:1298
 msgid "The half of the equation that is to the left of the \"=\""
-msgstr ""
+msgstr "La moitié de l’équation qui se trouve à gauche du signe \"=\""
 
 #: ../../src/wxMaximaFrame.cpp:1302
 msgid "The half of the equation that is to the right of the \"=\""
-msgstr ""
+msgstr "La moitié de l’équation qui se trouve à droite du signe \"=\""
 
 #: ../../src/MaximaManual.cpp:399
 msgid "The help dir from the cache differs from the current one."
-msgstr ""
+msgstr "Le répertoire d’aide du cache diffère de l’actuel."
 
 #: ../../src/Image.cpp:985
 msgid ""
 "The image could not be displayed. It may be broken, in a wrong format or be the result of gnuplot not being able to write the image or not being able to understand what maxima wanted to plot.\n"
 "One example of the latter would be: Gnuplot refuses to plot entirely empty images"
 msgstr ""
+"L’image n’a pas pu être affichée. Elle peut être corrompue, au mauvais format ou être le résultat de l’impossibilité pour gnuplot d'écrire l’image ou d'interpréter ce que Maxima voulait tracer.\n"
+"Un exemple de ce dernier cas serait : Gnuplot refuse de tracer des images entièrement vides"
 
 #: ../../src/wxMaxima.cpp:9799 ../../src/wxMaxima.cpp:10158
 #, c-format
 msgid "The image file \"%s\" cannot be found."
-msgstr ""
+msgstr "Le fichier image \"%s\" est introuvable."
 
 #: ../../src/wxMaximaFrame.cpp:718
 msgid "The integrated help browser"
-msgstr ""
+msgstr "Navigateur d’aide intégré"
 
 #: ../../src/wxMaxima.cpp:9591
 msgid "The list of variables contained in each matrix row"
-msgstr ""
+msgstr "La liste des variables contenues dans chaque ligne de la matrice"
 
 #: ../../src/wxMaximaFrame.cpp:214
 msgid "The main toolbar"
-msgstr ""
+msgstr "La barre d'outils principale"
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "The manual of Maxima"
-msgstr ""
+msgstr "Le manuel de Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "The manual of wxMaxima"
-msgstr ""
+msgstr "Le manuel de wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7125
 msgid "The name of a function we don't want to be evaluated here"
-msgstr ""
+msgstr "Le nom d’une fonction que l’on ne veut pas voir évaluée ici"
 
 #: ../../src/wxMaxima.cpp:7131
 msgid "The name of an expression that we don't want to be evaluated."
-msgstr ""
+msgstr "Le nom d’une expression que l’on ne veut pas voir évaluée."
 
 #: ../../src/wxMaxima.cpp:7199
 msgid "The name of the field to read"
-msgstr ""
+msgstr "Le nom du champ à lire"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "The name of the new struct type"
-msgstr ""
+msgstr "Le nom du nouveau type de structure"
 
 #: ../../src/wxMaxima.cpp:7198
 msgid "The name of the struct"
-msgstr ""
+msgstr "Le nom de la structure"
 
 #: ../../src/wxMaxima.cpp:7191
 msgid "The name of the struct type"
-msgstr ""
+msgstr "Le nom du type de la structure+"
 
 #: ../../src/wxMaxima.cpp:8220
 msgid "The name of the variable that shall contain the current element"
-msgstr ""
+msgstr "Le nom de la variable qui doit contenir l’élément courant"
 
 #: ../../src/wxMaxima.cpp:8468
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
-msgstr ""
+msgstr "Le numéro de l’élément qui est parcouru de \"Index Start\" à \"Index End\"."
 
 #: ../../src/wxMaxima.cpp:8465 ../../src/wxMaxima.cpp:8478
 msgid ""
 "The rule that explains how to generate the value of a list item.\n"
 "Might be something like \"i\", \"i^2\" or \"sin(i)\""
 msgstr ""
+"La règle qui explique comment générer la valeur d’un élément de liste.\n"
+"Elle pourrait ressembler à \"i\", \"i^2\" ou \"sin(i)\""
 
 #: ../../src/wxMaxima.cpp:7785
 msgid ""
@@ -7053,18 +7367,25 @@ msgid ""
 "The actual height of that curve is defined by the initial condition or "
 "boundary values, later on."
 msgstr ""
+"La solution d’une EDO décrit la forme générale de la courbe résultante. La "
+"hauteur réelle de cette courbe est définie par la condition initiale ou les "
+"valeurs aux limites, plus tard."
 
 #: ../../src/wxMaxima.cpp:7818
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's result is known at two points this function fills in the correct values for the  constants"
 msgstr ""
+"La solution d’une EDO donne la forme générale , qui ne tient pas compte des conditions initiales.\n"
+"Si la valeur de l’EDO est connue en deux points, cette fonction renvoie les valeurs correctes des constantes"
 
 #: ../../src/wxMaxima.cpp:7794 ../../src/wxMaxima.cpp:7805
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's state is known at a point this function fills in the correct values for the constants"
 msgstr ""
+"La solution d’une EDO donne la forme générale , qui ne tient pas compte des conditions initiales.\n"
+"Si la valeur de l’EDO est connue en deux points, cette fonction renvoie les valeurs correctes des constantes"
 
 #: ../../src/wxMaxima.cpp:7896
 msgid ""
@@ -7072,64 +7393,82 @@ msgid ""
 "   U(t)=1/2*U(t)+3*diff(U(t),t)\n"
 "for this to work; Initial conditions can be specified using atvalue()."
 msgstr ""
+"La variable pour la solution doit être sous la forme\n"
+"   U(t)=1/2*U(t)+3*diff(U(t),t)\n"
+"pour que cela fonctionne ; les conditions initiales peuvent être spécifiées à l’aide de atvalue()."
 
 #: ../../src/wxMaxima.cpp:8481 ../../src/wxMaxima.cpp:8582
 msgid "The variable the value of the current source item is stored in."
 msgstr ""
+"La variable dans laquelle la valeur de l’élément source actuel est stockée."
 
 #: ../../src/wxMaxima.cpp:9594
 msgid "The variables to search the optimum solution for"
-msgstr ""
+msgstr "Les variables pour lesquelles on recherche la solution optimale"
 
 #: ../../src/wxMaximaFrame.cpp:193
 msgid "The worksheet"
-msgstr ""
+msgstr "La feuille de calcul"
 
 #: ../../src/Worksheet.cpp:8122
 msgid "The worksheet containing maxima's input and output"
-msgstr ""
+msgstr "La feuille de calcul contenant les entrées et sorties de Maxima"
 
 #: ../../src/MathParser.cpp:629
 msgid ""
 "The xml data from maxima or from the .wxmx file was missing data here.\n"
 "If you find a way how to reproduce this problem please file a bug report against wxMaxima."
 msgstr ""
+"Les données XML de Maxima ou du fichier .wxmx manquaient ici.\n"
+"Si vous trouvez un moyen de reproduire ce problème, veuillez signaler un bogue à wxMaxima."
 
 #: ../../src/wxMaxima.cpp:2143
 msgid ""
 "There was an error in the XML maxima has generated.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Il y a eu une erreur dans le XML généré par Maxima.\n"
+"Veuillez signaler cela comme un bogue au projet wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3911
 msgid ""
 "There was an error in the XML that should contain a list of watch variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Il y a eu une erreur dans le XML qui devrait contenir une liste des variables surveillées.\n"
+"Veuillez signaler cela comme un bogue au projet wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3869
 msgid ""
 "There was an error in the XML that should contain the list of operators.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Il y a eu une erreur dans le XML qui devrait contenir la liste des opérateurs.\n"
+"Veuillez signaler cela comme un bogue au projet wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3321
 msgid ""
 "There was an error in the XML that should describe the contents of some variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Il y a eu une erreur dans le XML qui devrait décrire le contenu de certaines variables.\n"
+"Veuillez signaler cela comme un bogue au projet wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3257
 msgid ""
 "There was an error in the XML that should describe the manual topics.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Il y a eu une erreur dans le XML qui devrait décrire les sujets du manuel.\n"
+"Veuillez signaler cela comme un bogue au projet wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3202
 msgid ""
 "There was an error in the XML that should describe the status bar message.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Il y a eu une erreur dans le XML qui devrait décrire le message de la barre de statut.\n"
+"Veuillez signaler cela comme un bogue au projet wxMaxima."
 
 #: ../../src/MaximaManual.cpp:363
 msgid ""
@@ -7137,110 +7476,115 @@ msgid ""
 "It caches the list of subjects maxima's manual offers and is automatically\n"
 "overwritten if maxima's version changes or the file cannot be read"
 msgstr ""
+"Ce fichier est généré par wxMaxima.\n"
+"Il met en cache la liste des sujets se trouvant dans le manuel de Maxima et est automatiquement\n"
+"écrasé si la version de Maxima change ou si le fichier ne peut pas être lu"
 
 #: ../../src/Worksheet.cpp:1992
 msgid "This function will return even integers"
-msgstr ""
+msgstr "Cette fonction renverra des entiers pairs"
 
 #: ../../src/Worksheet.cpp:1994
 msgid "This function will return odd integers"
-msgstr ""
+msgstr "Cette fonction renverra des entiers impairs"
 
 #: ../../src/Worksheet.cpp:1950
 msgid "This symbol has no imaginary part"
-msgstr ""
+msgstr "Ce symbole n'a pas de partie imaginaire"
 
 #: ../../src/Worksheet.cpp:1956
 msgid "This symbol has no real part"
-msgstr ""
+msgstr "Ce symbole n'a pas de partie réelle"
 
 #: ../../src/Worksheet.cpp:1953
 msgid "This symbol might have both real and imaginary part"
-msgstr ""
+msgstr "Ce symbole peut avoir une partie réelle et imaginaire"
 
 #: ../../src/Worksheet.cpp:1980
 msgid "Throw an error if this symbol is used before assigning it any contents"
 msgstr ""
+"Indiquer une erreur si ce symbole est utilisé avant qu'il ne lui soit "
+"assigné un contenu"
 
 #: ../../src/wxMaxima.cpp:9013 ../../src/wxMaxima.cpp:10058
 msgid "Times:"
-msgstr ""
+msgstr "Fois :"
 
 #: ../../src/ToolBar.cpp:272
 msgid "Title"
-msgstr ""
+msgstr "Titre"
 
 #: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
-msgstr ""
+msgstr "Titre (Indices et exposants sous la forme x_{10} ou x^{10})"
 
 #: ../../src/Configuration.cpp:92
 msgid "Title cell (Heading 1)"
-msgstr ""
+msgstr "Cellule de Titre (niveau 1)"
 
 #: ../../src/wxMaximaFrame.cpp:1794
 msgid "To &Bigfloat"
-msgstr ""
+msgstr "Valeur approchée (bfloat)"
 
 #: ../../src/wxMaximaFrame.cpp:1791
 msgid "To &Float"
-msgstr ""
+msgstr "En virgule &flottante"
 
 #: ../../src/Worksheet.cpp:1571
 msgid "To Float"
-msgstr ""
+msgstr "En virgule flottante"
 
 #: ../../src/wxMaximaFrame.cpp:1797
 msgid "To Numeri&c\tCtrl+Shift+N"
-msgstr ""
+msgstr "En numé&rique\tCtrl+Shift+N"
 
 #: ../../src/wxMaximaFrame.cpp:1803
 msgid "To exact fraction"
-msgstr ""
+msgstr "En fraction exacte"
 
 #: ../../src/wxMaximaFrame.cpp:1814
 msgid "To exact number"
-msgstr ""
+msgstr "En  valeur exacte"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "To:"
-msgstr ""
+msgstr "Vers :"
 
 #: ../../src/wxMaximaFrame.cpp:825 ../../src/wxMaximaFrame.cpp:828
 msgid "Toggle full screen editing"
-msgstr ""
+msgstr "Basculer en plein écran d'édition"
 
 #: ../../src/ToolBar.cpp:265
 msgid "Toggle the visibility of code cells"
-msgstr ""
+msgstr "Basculer la visibilité des cellules de code"
 
 #: ../../src/wxMaximaFrame.cpp:1177
 msgid "Tokenize..."
-msgstr ""
+msgstr "Tokenizer..."
 
 #: ../../src/wxMaximaFrame.cpp:1909
 msgid "Tolerance calculations with Maxima"
-msgstr ""
+msgstr "Calculs de tolérance avec Maxima"
 
 #: ../../src/wxMaxima.cpp:8192
 msgid "Top end"
-msgstr ""
+msgstr "Borne supérieure"
 
 #: ../../src/wxMaximaFrame.cpp:1078
 msgid "Trace a function..."
-msgstr ""
+msgstr "Tracer une fonction..."
 
 #: ../../src/wxMaxima.cpp:7084
 msgid "Trace function(s)"
-msgstr ""
+msgstr "Tracer les fonction(s)"
 
 #: ../../src/wxMaximaFrame.cpp:1184
 msgid "Transformations"
-msgstr ""
+msgstr "Transformations"
 
 #: ../../src/wxMaximaFrame.cpp:1376
 msgid "Transpose a matrix"
-msgstr ""
+msgstr "Transposer une matrice"
 
 #: ../../src/wxMaxima.cpp:7832
 msgid ""
@@ -7248,17 +7592,24 @@ msgid ""
 " equation of the format depends(x,t);diff(x,t)=(something containing x and "
 "t)"
 msgstr ""
+"Essayer de trouver une solution numérique pour une EDO du premier ordre (ou "
+"en d’autres termes : une équation de la forme depends(x,t); diff(x,t) = "
+"(quelque chose contenant x et t))."
 
 #: ../../src/wxMaxima.cpp:10036
 msgid ""
 "Tries to find a solution of the equation that lies between the two bounds."
 msgstr ""
+"Essayer de trouver une solution de l’équation qui se situe entre les deux "
+"bornes."
 
 #: ../../src/wxMaxima.cpp:7774
 msgid ""
 "Tries to find a value of the variable that solves the equation between the "
 "two bonds"
 msgstr ""
+"Essayer de trouver une valeur de la variable qui résout l’équation entre les"
+" deux bornes"
 
 #: ../../src/wxMaxima.cpp:7719
 msgid ""
@@ -7267,6 +7618,10 @@ msgid ""
 "\n"
 "    bfallroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
+"Essayer de trouver numériquement toutes les racines d’un polynôme en utilisant des nombres de type bfloat.\n"
+"Cela peut également détecter des racines dans des expressions non polynomiales si celles‑ci ont été préalablement approximées par un polynôme :\n"
+"\n"
+"    bfallroots(ratdisrep(taylor(expression,0,30)));"
 
 #: ../../src/wxMaxima.cpp:7709
 msgid ""
@@ -7275,6 +7630,10 @@ msgid ""
 "\n"
 "    allroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
+"Essayer de trouver numériquement toutes les racines d’un polynôme.\n"
+"Cela peut également détecter des racines dans des expressions non polynomiales si celles‑ci ont été préalablement approximées par un polynôme :\n"
+"\n"
+"    allroots(ratdisrep(taylor(expression,0,30)));"
 
 #: ../../src/wxMaxima.cpp:7730
 #, c-format
@@ -7287,78 +7646,88 @@ msgid ""
 "\n"
 "See also guess_exact_value()"
 msgstr ""
+"Essayer de trouver les fractions exactes qui correspondent aux racines numériques du polynôme.\n"
+"Cette commande ne peut pas traiter les solutions comportant une partie imaginaire. Les constantes numériques comme %pi% n doivent être éliminées en se servant de float() ou de commandes similaires\n"
+"Cela peut éventuellement trouver des solutions dans des expressions non polynomiales, à condition que l'expression ait été auparavant approximée par un polynome:\n"
+"\n"
+"    realroots(ratdisrep(taylor(expression,0,30)));\n"
+"\n"
+"Voir aussi guess_exact_value()"
 
 #: ../../src/wxMaximaFrame.cpp:1181
 msgid "Trim both ends..."
-msgstr ""
+msgstr "Couper les deux extrémités..."
 
 #: ../../src/wxMaximaFrame.cpp:1182
 msgid "Trim left..."
-msgstr ""
+msgstr "Couper l'extrémité gauche..."
 
 #: ../../src/wxMaximaFrame.cpp:1183
 msgid "Trim right..."
-msgstr ""
+msgstr "Couper l'extrémité droite..."
 
 #: ../../src/wxMaxima.cpp:7473
 msgid "Trim string left"
-msgstr ""
+msgstr "Couper le début de la chaîne"
 
 #: ../../src/wxMaxima.cpp:7469
 msgid "Trim string on both ends"
-msgstr ""
+msgstr "Couper la chaîne aux deux extrémités"
 
 #: ../../src/wxMaxima.cpp:7477
 msgid "Trim string right"
-msgstr ""
+msgstr "Couper la fin de la chaine"
 
 #: ../../src/wxMaximaFrame.cpp:1511
 msgid "Try to guess which form is &simple"
-msgstr ""
+msgstr "Essayer de deviner quelle forme est &simple"
 
 #: ../../src/wxMaxima.cpp:8637
 msgid "Try to simplify sums that result from sum() commands."
-msgstr ""
+msgstr "Essayer de simplifier les sommes qui résultent des commandes sum()."
 
 #: ../../src/MaximaManual.cpp:369
 #, c-format
 msgid ""
 "Trying to cache the list of subjects the manual contains in the file %s."
 msgstr ""
+"Tentative de mise en cache de la liste des sujets que contient le manuel "
+"dans le fichier %s."
 
 #: ../../src/wxMaxima.cpp:4423
 msgid "Trying to discard all output."
-msgstr ""
+msgstr "Tentative de suppression de toutes les sorties."
 
 #: ../../src/wxMaxima.cpp:4380
 msgid "Trying to extract content.xml out of a broken .zip file."
 msgstr ""
+"Tentative d’extraction de content.xml à partir d’un fichier .zip corrompu."
 
 #: ../../src/wxMaxima.cpp:5519
 msgid "Trying to open a file with an empty name!"
-msgstr ""
+msgstr "Tentative d’ouverture d’un fichier avec un nom vide !"
 
 #: ../../src/wxMaxima.cpp:5523
 #, c-format
 msgid "Trying to open the non-existing file %s"
-msgstr ""
+msgstr "Tentative d’ouverture d'un fichier qui n'existe pas %s"
 
 #: ../../src/wxMaxima.cpp:4457
 msgid "Trying to reconstruct the xml closing markers."
-msgstr ""
+msgstr "Tentative de reconstruction des marqueurs de fermeture XML."
 
 #: ../../src/wxMaxima.cpp:4376
 msgid "Trying to recover a broken .wxmx file."
-msgstr ""
+msgstr "Tentative de récupération d’un fichier .wxmx corrompu."
 
 #: ../../src/wxMaxima.cpp:6026
 #, c-format
 msgid "Trying to remove the old temp file %s"
-msgstr ""
+msgstr "Tentative de suppression de l’ancien fichier temporaire %s"
 
 #: ../../src/wxMaxima.cpp:2507
 msgid "Trying to restart maxima."
-msgstr ""
+msgstr "Tentative pour redémarrer maxima."
 
 #: ../../src/wxMaxima.cpp:2523
 #, c-format
@@ -7366,282 +7735,295 @@ msgid ""
 "Trying to start the socket a Maxima on the local machine can connect to on "
 "port %i"
 msgstr ""
+"Tentative de démarrage du socket auquel Maxima peut se connecter sur la "
+"machine locale, sur le port %i"
 
 #: ../../src/wxMaximaFrame.cpp:1928
 msgid "Tutorials"
-msgstr ""
+msgstr "Tutoriels"
 
 #: ../../src/wxMaxima.cpp:9571
 msgid "Two sample t-test"
-msgstr ""
+msgstr "Test de Student (t-test) à 2 échantillons"
 
 #: ../../src/Worksheet.cpp:8013
 msgid "Type"
-msgstr ""
+msgstr "Type"
 
 #: ../../src/wxMaxima.cpp:7180
 msgid "Type:"
-msgstr ""
+msgstr "Type :"
 
 #: ../../src/wxMaxima.cpp:9429
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 #: ../../src/wxMaximaFrame.cpp:1146
 msgid "UTF8 to Unicode code point..."
-msgstr ""
+msgstr "UTF8 vers point de code Unicode..."
 
 #: ../../src/wxMaxima.cpp:10479
 msgid "Un-closed parenthesis"
-msgstr ""
+msgstr "Parenthèse non fermée"
 
 #: ../../src/wxMaxima.cpp:10467
 msgid "Un-closed parenthesis on encountering ; or $"
-msgstr ""
+msgstr "Parenthèse non fermée lors de la fin de commande ; ou $"
 
 #: ../../src/wxMaxima.cpp:11160
 msgid ""
 "Unable to interpret the version info I got from http://wxMaxima-"
 "developers.github.io/wxmaxima/version.txt: "
 msgstr ""
+"Impossible d’interpréter les informations de version obtenues depuis "
+"http://wxMaxima-developers.github.io/wxmaxima/version.txt : "
 
 #: ../../src/wxMaximaFrame.cpp:1007
 msgid "Undefine"
-msgstr ""
+msgstr "Supprimer ou effacer une définition"
 
 #: ../../src/ToolBar.cpp:191
 msgid "Undo"
-msgstr ""
+msgstr "Annuler"
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo\tCtrl+Z"
-msgstr ""
+msgstr "Annuler\tCtrl+Z"
 
 #: ../../src/ToolBar.cpp:614
 msgid "Undo and redo button"
-msgstr ""
+msgstr "Bouton Annuler et Rétablir"
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo last change"
-msgstr ""
+msgstr "Annuler la dernière modification"
 
 #: ../../src/wxMaximaFrame.cpp:924
 msgid "Unfold All\tCtrl+Alt+]"
-msgstr ""
+msgstr "Tout déplier\tCtrl+Alt+]"
 
 #: ../../src/wxMaximaFrame.cpp:925
 msgid "Unfold all folded sections"
-msgstr ""
+msgstr "Déplier toutes les sections qui sont repliées"
 
 #: ../../src/Worksheet.cpp:1893
 msgid "Unhide Heading 5"
-msgstr ""
+msgstr "Afficher le titre de niveau 5"
 
 #: ../../src/Worksheet.cpp:1904
 msgid "Unhide Heading 6"
-msgstr ""
+msgstr "Afficher le titre de niveau 6"
 
 #: ../../src/Worksheet.cpp:1852
 msgid "Unhide Part"
-msgstr ""
+msgstr "Afficher la partie"
 
 #: ../../src/Worksheet.cpp:1860
 msgid "Unhide Section"
-msgstr ""
+msgstr "Afficher la section"
 
 #: ../../src/Worksheet.cpp:1871
 msgid "Unhide Subsection"
-msgstr ""
+msgstr "Afficher la sous-section"
 
 #: ../../src/Worksheet.cpp:1882
 msgid "Unhide Subsubsection"
-msgstr ""
+msgstr "Afficher la sous-sous-section"
 
 #: ../../src/Worksheet.cpp:1912
 msgid "Unhide contents"
-msgstr ""
+msgstr "Afficher le contenu"
 
 #: ../../src/wxMaximaFrame.cpp:266
 msgid "Unicode characters"
-msgstr ""
+msgstr "Caractères Unicode"
 
 #: ../../src/wxMaximaFrame.cpp:707
 msgid "Unicode chars\tAlt+Shift+U"
-msgstr ""
+msgstr "Charactères Unicode\tAlt+Shift+U"
 
 #: ../../src/wxMaximaFrame.cpp:1144
 msgid "Unicode code point to UTF8..."
-msgstr ""
+msgstr "Point de code Unicode vers UTF8..."
 
 #: ../../src/wxMaxima.cpp:7366
 msgid "Unicode code point to char"
-msgstr ""
+msgstr "Point de code Unicode vers caractère"
 
 #: ../../src/wxMaximaFrame.cpp:1142
 msgid "Unicode code point to char..."
-msgstr ""
+msgstr "Point de code Unicode vers caractère..."
 
 #: ../../src/wxMaxima.cpp:7371
 msgid "Unicode code point to utf8 numbers"
-msgstr ""
+msgstr "Point de code Unicode vers les nombres UTF8"
 
 #: ../../src/wxMaxima.cpp:7078
 msgid ""
 "Unlike in other programming language return() only exits from the current "
 "loop or block(), not from the whole function."
 msgstr ""
+"Contrairement à d’autres langages de programmation, return() ne quitte que "
+"la boucle ou le bloc() actuel, et non pas toute la fonction."
 
 #: ../../src/wxMaxima.cpp:10418
 msgid "Unterminated comment."
-msgstr ""
+msgstr "Commentaire non terminé."
 
 #: ../../src/wxMaxima.cpp:10461
 msgid "Unterminated string."
-msgstr ""
+msgstr "Chaine non terminée."
 
 #: ../../src/wxMaxima.cpp:4786
 msgid "Updating maxima's configuration"
-msgstr ""
+msgstr "Mise à jour de la configuration de maxima"
 
 #: ../../src/wxMaxima.cpp:11150 ../../src/wxMaxima.cpp:11157
 #: ../../src/wxMaxima.cpp:11163
 msgid "Upgrade"
-msgstr ""
+msgstr "Mettre à jour"
 
 #: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
 msgid "Upper bound:"
-msgstr ""
+msgstr "Borne supérieure:"
 
 #: ../../src/wxMaximaFrame.cpp:792
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
-msgstr ""
+msgstr "Utiliser \"<\" et \">\" comme parenthèses pour les matrices"
 
 #: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
 msgid "Use a list"
-msgstr ""
+msgstr "Utiliser une liste"
 
 #: ../../src/wxMaxima.cpp:8571
 msgid "Use a list as parameter list for a function"
-msgstr ""
+msgstr "Utiliser une liste comme liste de paramètres pour une fonction"
 
 #: ../../src/wxMaximaFrame.cpp:1708
 msgid "Use list"
-msgstr ""
+msgstr "Utiliser une liste"
 
 #: ../../src/wxMaximaFrame.cpp:1701
 msgid "Use list as the arguments of a function"
-msgstr ""
+msgstr "Utiliser une liste comme arguments d'une fonction"
 
 #: ../../src/wxMaximaFrame.cpp:786
 msgid "Use rounded parenthesis for matrices"
-msgstr ""
+msgstr "Utiliser des parenthèses pour les matrices"
 
 #: ../../src/wxMaximaFrame.cpp:789
 msgid "Use square parenthesis for matrices"
-msgstr ""
+msgstr "Utiliser des crochets pour les matrices"
 
 #: ../../src/wxMaximaFrame.cpp:1083
 msgid "Use struct field..."
-msgstr ""
+msgstr "Utiliser le champ de la structure..."
 
 #: ../../src/wxMaximaFrame.cpp:795
 msgid "Use vertical lines instead of parenthesis for matrices"
 msgstr ""
+"Utiliser des barres verticales à la place des parenthèses pour les matrices"
 
 #: ../../src/Worksheet.cpp:1619
 msgid "User labels only"
-msgstr ""
+msgstr "Utiliser uniquement les étiquettes"
 
 #: ../../src/Configuration.cpp:81
 msgid "User-defined labels"
-msgstr ""
+msgstr "Étiquettes définies par l'utilisateur"
 
 #: ../../src/MaximaManual.cpp:483
 msgid ""
 "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
 msgstr ""
+"Utilisation du fichier d’aide de Maxima depuis le fichier de configuration "
+"de wxMaxima (helpFile=...))"
 
 #: ../../src/wxMaxima.cpp:4825
 msgid "Using Maxima path from command line."
-msgstr ""
+msgstr "Utilisation du chemin de Maxima depuis la ligne de commande."
 
 #: ../../src/wxMaxima.cpp:4822
 msgid "Using configured Maxima path."
-msgstr ""
+msgstr "Utilisation du chemin défini pour Maxima."
 
 #: ../../src/wxMaxima.cpp:2961
 msgid ""
 "Using gnuplot's antialiassing-less png driver for embedded plots as pngcairo"
 " could not be found"
 msgstr ""
+"Utilisation du pilote PNG de gnuplot sans anticrénelage pour les graphiques "
+"intégrés, car pngcairo est introuvable"
 
 #: ../../src/wxMaxima.cpp:2956
 msgid "Using gnuplot's pngcairo driver for embedded plots"
 msgstr ""
+"Utilisation du pilote pngcairo de gnuplot pour les graphiques intégrés"
 
 #: ../../src/MaximaManual.cpp:88
 msgid "Using the built-in list of manual anchors."
-msgstr ""
+msgstr "Utilisation de la liste intégrée des signets du manuel."
 
 #: ../../src/WXMXformat.cpp:266
 msgid ""
 "Validated that the XML representation of the document actually is valid XML"
 msgstr ""
+"Validation que la représentation XML du document est bien un XML valide"
 
 #: ../../src/wxMaxima.cpp:8755
 msgid "Value at a given point"
-msgstr ""
+msgstr "Valeur en un point donné"
 
 #: ../../src/Worksheet.cpp:1987
 msgid "Value at a specific point"
-msgstr ""
+msgstr "Valeur en un point spécifique"
 
 #: ../../src/wxMaxima.cpp:7801
 msgid "Value at that point:"
-msgstr ""
+msgstr "Valeur en ce point :"
 
 #: ../../src/wxMaxima.cpp:7812 ../../src/wxMaxima.cpp:7825
 #: ../../src/wxMaxima.cpp:7827
 msgid "Value y at that point:"
-msgstr ""
+msgstr "Valeur de y en ce point :"
 
 #: ../../src/wxMaxima.cpp:7910
 msgid "Value:"
-msgstr ""
+msgstr "Valeur :"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Var #1"
-msgstr ""
+msgstr "Variable #1"
 
 #: ../../src/wxMaxima.cpp:8202
 msgid "Var #2"
-msgstr ""
+msgstr "Variable #2"
 
 #: ../../src/wxMaxima.cpp:6852 ../../src/wxMaxima.cpp:8183
 msgid "Variable"
-msgstr ""
+msgstr "Variable"
 
 #: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
 #: ../../src/wxMaxima.cpp:8568
 msgid "Variable name"
-msgstr ""
+msgstr "Nom de la variable"
 
 #: ../../src/wxMaximaFrame.cpp:1085
 msgid "Variable name, not contents..."
-msgstr ""
+msgstr "Nom de la variable, pas des contenus..."
 
 #: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
 msgid "Variable name:"
-msgstr ""
+msgstr "Nom de la variable :"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 msgid "Variable(s)"
-msgstr ""
+msgstr "Variable(s)"
 
 #: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
 #: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
 msgid "Variable(s):"
-msgstr ""
+msgstr "Variable(s) :"
 
 #: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
 #: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
@@ -7649,49 +8031,51 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
 #: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
 msgid "Variable:"
-msgstr ""
+msgstr "Variable :"
 
 #: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
 msgid "Variables"
-msgstr ""
+msgstr "Variables"
 
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
 msgid "Variables:"
-msgstr ""
+msgstr "Variables :"
 
 #: ../../src/WXMXformat.cpp:337
 msgid "Verified that we are able to read the whole .zip archive we produced."
 msgstr ""
+"Vérification que la lecture de l’intégralité de l’archive .zip que nous "
+"avons générée est possible."
 
 #: ../../src/wxMaximaFrame.cpp:836
 msgid "View"
-msgstr ""
+msgstr "Vue"
 
 #: ../../src/Autocomplete.cpp:235
 msgid "Waiting for m_addFiles_backgroundThread to finish"
-msgstr ""
+msgstr "Attente de la fin de m_addFiles_backgroundThread"
 
 #: ../../src/Autocomplete.cpp:122 ../../src/Autocomplete.cpp:240
 msgid "Waiting for m_addSymbols_backgroundThread to finish"
-msgstr ""
+msgstr "Attente de la fin de m_addSymbols_backgroundThread"
 
 #: ../../src/MaximaManual.cpp:533
 msgid "Waiting for the Manual anchors background task."
-msgstr ""
+msgstr "Attente de la tâche en arrière-plan sur les signets du manuel."
 
 #: ../../src/MaximaManual.cpp:562
 msgid "Waiting for the thread that parses the maxima manual to finish"
-msgstr ""
+msgstr "Attente de la fin du thread qui analyse le manuel de Maxima"
 
 #: ../../src/MathParser.cpp:1229 ../../src/wxMaxima.cpp:3296
 #: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
 #: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
 msgid "Warning"
-msgstr ""
+msgstr "Alerte"
 
 #: ../../src/wxMaximaFrame.cpp:1556
 msgid "Warning:"
-msgstr ""
+msgstr "Alerte :"
 
 #: ../../src/Dirstructure.cpp:72
 #, c-format
@@ -7699,65 +8083,72 @@ msgid ""
 "Warning: Cannot create %s, the directory maxima keeps configuration, user packages and caches in.\n"
 "Make sure that your system's home directory is set up correctly"
 msgstr ""
+"Attention : Impossible de créer %s, le répertoire où maxima conserve la configuration, les paquets utilisateur et les caches.\n"
+"Assurez-vous que le répertoire personnel de votre système est correctement configuré"
 
 #: ../../src/wxMaximaFrame.cpp:1546
 msgid ""
 "Warning: No test if the argument of the log is complex, positive or negative"
 msgstr ""
+"Attention : Pas de test si l'argument du logarithme est complexe, positif ou"
+" négatif"
 
 #: ../../src/wxMaxima.cpp:5063
 msgid "Welcome to wxMaxima"
-msgstr ""
+msgstr "Bienvenue dans wxMaxima"
 
 #: ../../src/wxMaxima.cpp:8583
 msgid "What to do:"
-msgstr ""
+msgstr "Que faire :"
 
 #: ../../src/wxMaximaFrame.cpp:1058
 msgid "When to invoke the lisp compiler's debugger"
-msgstr ""
+msgstr "Quand appeler le débogueur du compilateur Lisp"
 
 #: ../../src/wxMaxima.cpp:7046
 msgid "While loop"
-msgstr ""
+msgstr "Boucle while"
 
 #: ../../src/wxMaximaFrame.cpp:1063
 msgid "While loop..."
-msgstr ""
+msgstr "Boucle while..."
 
 #: ../../src/wxMaxima.cpp:5673
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38)"
 " (*.wxm)|*.wxm|All Files (*.*)|*"
 msgstr ""
+"Document entier (*.wxmx)|*.wxmx|L'entrée, lisible par load() (maxima > 5.38)"
+" (*.wxm)|*.wxm|Tous les fichiers (*.*)|*"
 
 #: ../../src/wxMaxima.cpp:210
 msgid "Will try to generate a stack backtrace, if the program ever crashes"
 msgstr ""
+"Tentative de génération d'une trace de pile en cas de plantage du programme"
 
 #: ../../src/Worksheet.cpp:6920
 msgid "Worksheet got activated"
-msgstr ""
+msgstr "La feuille de calcul a été activée"
 
 #: ../../src/Worksheet.cpp:6840
 msgid "Worksheet got the mouse focus"
-msgstr ""
+msgstr "La feuille de travail a reçu le focus de la souris"
 
 #: ../../src/Worksheet.cpp:7191 ../../src/Worksheet.cpp:7279
 msgid "Wrapped search"
-msgstr ""
+msgstr "Recherche circulaire"
 
 #: ../../src/WXMXformat.cpp:282
 msgid "Wrote all image and gnuplot files to the zip archive"
-msgstr ""
+msgstr "Tous les fichiers image et gnuplot ont été ajoutés dans l'archive zip"
 
 #: ../../src/WXMXformat.cpp:272
 msgid "Wrote the XML representation of the document to the zip archive"
-msgstr ""
+msgstr "Représentation XML du document écrite dans l'archive zip"
 
 #: ../../src/WXMXformat.cpp:116
 msgid "Wrote the mimetype info"
-msgstr ""
+msgstr "Les informations de type MIME ont été écrites"
 
 #: ../../src/wxMaxima.cpp:11147
 #, c-format
@@ -7766,178 +8157,181 @@ msgid ""
 "\n"
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
+"Vous avez la version %s. La dernière version la plus récente est %s.\n"
+"\n"
+"Appuyez sur OK pour aller sur le site de wxMaxima."
 
 #: ../../src/wxMaxima.cpp:11202
 msgid "Your changes will be lost if you don't save them."
-msgstr ""
+msgstr "Les changements seront perdus si vous ne les enregistrez pas."
 
 #: ../../src/wxMaxima.cpp:11156
 msgid "Your version of wxMaxima is up to date."
-msgstr ""
+msgstr "Votre version de wxMaxima est à jour."
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom &In\tCtrl++"
-msgstr ""
+msgstr "Zoom avant\tCtrl++"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom Ou&t\tCtrl+-"
-msgstr ""
+msgstr "Zoom arrière\tCtrl+-"
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom in 10%"
-msgstr ""
+msgstr "Zoom avant de 10%"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom out 10%"
-msgstr ""
+msgstr "Zoom arrière de 10%"
 
 #: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
 msgid "[ unsaved ]"
-msgstr ""
+msgstr "[ non sauvegardé ]"
 
 #: ../../src/wxMaxima.cpp:10920
 msgid "[ unsaved* ]"
-msgstr ""
+msgstr "[ non sauvegardé* ]"
 
 #: ../../src/Worksheet.cpp:5278
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" loading=\"lazy\" style=\"max-width:90%%;\">\n"
-msgstr ""
+msgstr "_%d.gif\"  alt=\"Graphique animé\" loading=\"lazy\" style=\"max-width:90%%;\">\n"
 
 #: ../../src/Worksheet.cpp:5484
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"lazy\">"
-msgstr ""
+msgstr "_%d.gif\" alt=\"Graphique animé\" style=\"max-width:90%%;\" loading=\"lazy\">"
 
 #: ../../src/wxMaximaFrame.cpp:1690
 msgid "apply function to each element"
-msgstr ""
+msgstr "appliquer une fonction à chaque élément"
 
 #: ../../src/wxMaximaFrame.cpp:739
 msgid "as 1D ASCII"
-msgstr ""
+msgstr "en tant que code ASCII 1D"
 
 #: ../../src/wxMaximaFrame.cpp:742
 msgid "as ASCII Art"
-msgstr ""
+msgstr "en tant que code ASCII Art"
 
 #: ../../src/wxMaximaFrame.cpp:745
 msgid "as ASCII+Unicode Art"
-msgstr ""
+msgstr "en tant que code ASCII+Unicode Art"
 
 #: ../../src/wxMaximaFrame.cpp:1680
 msgid "as storage for actual values for variables"
-msgstr ""
+msgstr "comme stockage pour les valeurs actuelles des variables"
 
 #: ../../src/wxMaximaFrame.cpp:1139
 msgid "char to Ascii code..."
-msgstr ""
+msgstr "caractère vers code ASCII..."
 
 #: ../../src/wxMaxima.cpp:7836
 msgid "diff(x,t)="
-msgstr ""
+msgstr "diff(x,t)="
 
 #: ../../src/wxMaximaFrame.cpp:1064 ../../src/wxMaximaFrame.cpp:1702
 msgid "do for each element"
-msgstr ""
+msgstr "faire pour chaque élément"
 
 #: ../../src/Worksheet.cpp:2027
 msgid "ev() shall evaluate this automatically"
-msgstr ""
+msgstr "ev() évaluera ceci automatiquement"
 
 #: ../../src/wxMaxima.cpp:7130
 msgid "expression:"
-msgstr ""
+msgstr "expression :"
 
 #: ../../src/Worksheet.cpp:2025
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
-msgstr ""
+msgstr "f(x) reste f(x) même si la valeur de f(x) est calculable"
 
 #: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
 msgid "filename:"
-msgstr ""
+msgstr "nom du fichier :"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "from a list"
-msgstr ""
+msgstr "à partir d'une liste"
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "from a rule"
-msgstr ""
+msgstr "à partir d'une règle"
 
 #: ../../src/wxMaximaFrame.cpp:1685
 msgid "from function arguments"
-msgstr ""
+msgstr "provenant des arguments de la fonction"
 
 #: ../../src/wxMaximaFrame.cpp:1669
 msgid "from individual elements"
-msgstr ""
+msgstr "provenant des éléments individuels"
 
 #: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
 msgid "function"
-msgstr ""
+msgstr "fonction"
 
 #: ../../src/wxMaximaFrame.cpp:747
 msgid "in 2D"
-msgstr ""
+msgstr "en 2D"
 
 #: ../../src/wxMaxima.cpp:8554
 msgid "list"
-msgstr ""
+msgstr "liste"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "max(abs(A(i,j))) (complex)"
-msgstr ""
+msgstr "max(abs(A(i,j))) (complex)"
 
 #: ../../src/wxMaximaFrame.cpp:1404
 msgid "max(abs(A(i,j))) (real)"
-msgstr ""
+msgstr "max(abs(A(i,j))) (real)"
 
 #: ../../src/wxMaxima.cpp:8046
 msgid "m×n Matrix A:"
-msgstr ""
+msgstr "m×n Matrice A:"
 
 #: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533
 msgid "n:"
-msgstr ""
+msgstr "n:"
 
 #: ../../src/Worksheet.cpp:2000
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
-msgstr ""
+msgstr "nary: f(x, f(y,z)) = foo(x,y,z)"
 
 #: ../../src/Worksheet.cpp:2024
 msgid "noun: Not evaluated by default"
-msgstr ""
+msgstr "nom : Non évalué par défaut"
 
 #: ../../src/wxMaximaFrame.cpp:1710
 msgid "nth"
-msgstr ""
+msgstr "nième"
 
 #: ../../src/Worksheet.cpp:2021
 msgid "outative: f(2*x) = 2*f(x)"
-msgstr ""
+msgstr "nominatif : f(2*x) = 2*f(x)"
 
 #: ../../src/wxMaxima.cpp:7440 ../../src/wxMaxima.cpp:7445
 #: ../../src/wxMaxima.cpp:7455
 msgid "part:"
-msgstr ""
+msgstr "partie :"
 
 #: ../../src/wxMaxima.cpp:8942
 msgid "point:"
-msgstr ""
+msgstr "point :"
 
 #: ../../src/wxMaxima.cpp:7740
 msgid "precision:"
-msgstr ""
+msgstr "précision :"
 
 #: ../../src/wxMaxima.cpp:7255
 msgid "printf"
-msgstr ""
+msgstr "imprimer"
 
 #: ../../src/wxMaximaFrame.cpp:1108
 msgid "printf..."
-msgstr ""
+msgstr "imprimer..."
 
 #: ../../src/wxMaxima.cpp:8650
 msgid ""
@@ -7947,22 +8341,29 @@ msgid ""
 " makes sense for the problem that resulted in the Expression that is to be "
 "simplified."
 msgstr ""
+"radcan() est un outil puissant pour la simplification des fonctions "
+"trigonométriques mais doit être utilisé avec prudence : Si une fonction a "
+"plusieurs expressions, radcan utilise celle qui semble la mieux adaptée, pas"
+" nécessairement celle qui a du sens pour le problème qui a produit "
+"l'expression à simplifier."
 
 #: ../../src/wxMaxima.cpp:8731
 msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
+"ratsubst fonctionne comme subst, mais connaît quelques mathématiques de "
+"base, si nécessaire."
 
 #: ../../src/wxMaximaFrame.cpp:1111
 msgid "readbyte..."
-msgstr ""
+msgstr "lecture de l'octet..."
 
 #: ../../src/wxMaximaFrame.cpp:1110
 msgid "readchar..."
-msgstr ""
+msgstr "lecture de caractère..."
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "readline..."
-msgstr ""
+msgstr "lecture de la ligne..."
 
 #: ../../src/wxMaxima.cpp:10018
 msgid ""
@@ -7970,67 +8371,79 @@ msgid ""
 "If only one result variable is of interest the other result variables can be used to to tell solve() which variables to eliminate from the solution\n"
 "solve() searches for a global solution. If a problem has different solutions depending on the range its variables are in one way to successfully use solve() is to use solve() to eliminate variables one by one and to manually choose which of the solutions solve() found matches the current problem."
 msgstr ""
+"solve() ne résoudra un système d'équations qu'à la condition que pour n équations indépendantes il y ait n variables à résoudre.\n"
+"\n"
+"Si une seule variable peut être utilisée comme paramètre, les autres variables du système peuvent être utilisées pour indiquer à solve() quelles variables éliminer de la solution.\n"
+"\n"
+"solve() recherche une solution globale. Si un problème a des solutions différentes selon les intervalles pour ses variables, une façon d'utiliser solve() avec succès est d'utiliser solve() pour éliminer les variables une par une et de choisir manuellement laquelle des solutions trouvées par solve() répond au problème actuel."
 
 #: ../../src/wxMaxima.cpp:7745
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables solve needs to do its work can be used to tell solve() which variables to eliminate in the solution for the interesting variable."
 msgstr ""
+"solve() ne résoudra un système d'équations qu'à la condition que pour n équations indépendantes il y ait n variables à résoudre.\n"
+"\n"
+"Si une seule variable est intéressante, les autres variables du système peuvent être utilisées pour indiquer à solve() quelles variables éliminer de la solution.\n"
+"\n"
+"solve() effectue une solution globale. Si un problème a des solutions différentes selon les intervalles de ses variables, une façon d'utiliser solve() avec succès est d'utiliser solve() pour éliminer les variables une par une et de choisir manuellement laquelle des solutions trouvées par solve() correspond aux conditions imposées."
 
 #: ../../src/wxMaxima.cpp:7784
 msgid ""
 "solves an equation of the form\n"
 "    'diff(y,t) = -y;"
 msgstr ""
+"résoudre une équation de la forme \n"
+"    'diff(y,t) = -y;"
 
 #: ../../src/wxMaxima.cpp:7789
 msgid "t:"
-msgstr ""
+msgstr "t:"
 
 #: ../../src/wxMaximaFrame.cpp:1075
 msgid "unnamed function (lambda)..."
-msgstr ""
+msgstr "fonction sans nom (lambda)..."
 
 #: ../../src/wxMaxima.cpp:11190
 msgid "unsaved"
-msgstr ""
+msgstr "non sauvegardé"
 
 #: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
 #: ../../src/wxMaximaFrame.cpp:189
 msgid "untitled"
-msgstr ""
+msgstr "sans nom"
 
 #: ../../src/wxMaximaFrame.cpp:1700
 msgid "use as function arguments"
-msgstr ""
+msgstr "à utiliser comme arguments de fonction"
 
 #: ../../src/wxMaximaFrame.cpp:1696
 msgid "use the actual values stored"
-msgstr ""
+msgstr "utiliser les valeurs actuellement stockées"
 
 #: ../../src/wxMaximaFrame.cpp:1112
 msgid "writebyte..."
-msgstr ""
+msgstr "écrire un octet..."
 
 #: ../../src/main.cpp:509
 msgid "wxMaxima"
-msgstr ""
+msgstr "wxMaxima"
 
 #: ../../src/main.cpp:516
 #, c-format
 msgid "wxMaxima %ld"
-msgstr ""
+msgstr "wxMaxima %ld"
 
 #: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
 #: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
 #: ../../src/wxMaximaFrame.cpp:185
 #, c-format
 msgid "wxMaxima %s (%s) "
-msgstr ""
+msgstr "wxMaxima %s (%s) "
 
 #: ../../src/wxMaxima.cpp:4490
 msgid "wxMaxima cannot read the xml contents of "
-msgstr ""
+msgstr "wxMaxima ne peut pas lire le contenu xml de "
 
 #: ../../src/wxMaxima.cpp:2546
 msgid ""
@@ -8039,80 +8452,89 @@ msgid ""
 "Please check you have network support\n"
 "enabled, that no internet safety appliance is configured to intercept creation of servers even if said server only accepts connections from local application (maxima insists on the graphical frontend acting as a server it can connect on over a local socket) and try again!"
 msgstr ""
+"wxMaxima n'a pas pu démarrer un serveur.\n"
+"\n"
+"Veuillez vérifier que le support réseau est activé, qu'aucun parefeu internet n'est configuré pour intercepter la création de serveurs même si ce serveur n'accepte les connexions que depuis l'application locale (maxima insiste pour que l'interface graphique agisse comme un serveur auquel il peut se connecter via une socket locale) et réessayez !"
 
 #: ../../src/wxMaxima.cpp:5285
 msgid "wxMaxima document"
-msgstr ""
+msgstr "document wxMaxima"
 
 #: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
 #: ../../src/wxMaxima.cpp:4230
 msgid "wxMaxima encountered an error loading "
-msgstr ""
+msgstr "wxMaxima a rencontré une erreur lors du chargement "
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "wxMaxima help"
-msgstr ""
+msgstr "aide de wxMaxima"
 
 #: ../../src/Worksheet.cpp:1465 ../../src/Worksheet.cpp:1839
 msgid ""
 "wxMaxima remembers answers from the last run and is able to automatically "
 "send them to maxima, if requested"
 msgstr ""
+"wxMaxima se souvient des réponses de la dernière exécution et peut les "
+"envoyer automatiquement à Maxima, si demandé"
 
 #: ../../src/Worksheet.cpp:1470 ../../src/Worksheet.cpp:1844
 msgid ""
 "wxMaxima remembers answers from the last run and is able to offer them as "
 "the default answer"
 msgstr ""
+"wxMaxima se souvient des réponses de la dernière exécution et peut les "
+"proposer comme réponse par défaut"
 
 #: ../../src/wxMaximaFrame.cpp:1896
 msgid "wxMaxima shows help in a browser"
-msgstr ""
+msgstr "wxMaxima affiche l'aide dans un navigateur"
 
 #: ../../src/wxMaximaFrame.cpp:1894
 msgid "wxMaxima shows help in the sidebar"
-msgstr ""
+msgstr "wxMaxima affiche l'aide dans la barre latérale"
 
 #: ../../src/wxMaximaFrame.cpp:111
 #, c-format
 msgid "wxMaxima version %s"
-msgstr ""
+msgstr "wxMaxima version %s"
 
 #: ../../src/wxMaximaFrame.cpp:1954
 msgid "wxMaxima's ChangeLog"
-msgstr ""
+msgstr "journal des modifications de wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "wxMaxima's license"
-msgstr ""
+msgstr "wxMaxima licence"
 
 #: ../../src/wxMaximaFrame.cpp:144
 msgid "wxWidgets is using GTK 2"
-msgstr ""
+msgstr "wxWidgets utilise GTK 2"
 
 #: ../../src/wxMaximaFrame.cpp:142
 msgid "wxWidgets is using GTK 3"
-msgstr ""
+msgstr "wxWidgets utilise GTK 3"
 
 #: ../../src/WXMXformat.cpp:367
 msgid "wxmx file saved"
-msgstr ""
+msgstr "le fichier wxmx est sauvegardé"
 
 #: ../../src/wxMaxima.cpp:8375
 msgid "x direction [in multiples of the tick frequency]"
-msgstr ""
+msgstr "direction sur x [en multiples de la fréquence des ticks]"
 
 #: ../../src/wxMaxima.cpp:4500 ../../src/wxMaxima.cpp:4643
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
+"l'XML contenu dans le fichier prétend ne pas être une feuille de calcul "
+"wxMaxima. "
 
 #: ../../src/wxMaxima.cpp:8376
 msgid "y direction [in multiples of the tick frequency]"
-msgstr ""
+msgstr "direction sur y [en multiples de la fréquence des ticks]"
 
 #: ../../src/wxMaxima.cpp:7789
 msgid "y:"
-msgstr ""
+msgstr "y:"
 
 # SOME DESCRIPTIVE TITLE
 # Copyright (C) YEAR Free Software Foundation, Inc.
@@ -11723,8 +12145,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:837
+#, fuzzy
 msgid "Example:"
-msgstr ""
+msgstr "Exemple"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:842

--- a/locales/wxMaxima/hu.po
+++ b/locales/wxMaxima/hu.po
@@ -25,524 +25,544 @@ msgid ""
 "\n"
 "Maxima is currently using %3.3f%% of all available CPUs."
 msgstr ""
+"\n"
+"\n"
+"A Maxima jelenleg az összes elérhető CPU-ból %3.3f%%-t használ."
 
 #: ../../src/Image.cpp:690
+#, fuzzy
 msgid ""
 "\n"
 "Image was loaded from a .wxmx file"
-msgstr ""
+msgstr "Image was loaded from a .wxmx fájl"
 
 #: ../../src/wxMaxima.cpp:5153
+#, fuzzy
 msgid ""
 "\n"
 "Use the menu \"View->Toggle log window\" to show/hide a log window with all debug messages."
 msgstr ""
+"Use the menu \"View->Toggle log window\" to megjelenítés/elrejtés a log "
+"window with all debug messages."
 
 #: ../../src/wxMaxima.cpp:4230
+#, fuzzy
 msgid " (File format (WXM version 1, first line of the file) not recognized)"
-msgstr ""
+msgstr "(fájl format (WXM version 1, first line of the fájl) not recognized)"
 
 #: ../../src/wxMaximaFrame.cpp:1559
+#, fuzzy
 msgid " Wrong, if a is complex"
-msgstr ""
+msgstr "Rossz, ha a összetett"
 
 #: ../../src/wxMaxima.cpp:7601
 msgid ""
 "\".\" = \"The current directory\"\n"
 "\"..\" = \"One directory up\""
 msgstr ""
+"\".\" = \"Az aktuális könyvtár\"\n"
+"\"..\" = \"Egy könyvtárral feljebb\""
 
 #: ../../src/wxMaxima.cpp:7557 ../../src/wxMaxima.cpp:7563
 #: ../../src/wxMaxima.cpp:7568
 msgid "\"..\" means \"one directory up\"."
-msgstr ""
+msgstr "\"..\" azt jelenti, hogy \"egy könyvtárral feljebb\"."
 
 #: ../../src/wxMaxima.cpp:5053
 #, c-format
 msgid "%i cells in evaluation queue"
-msgstr ""
+msgstr "%i cella a kiértékelési sorban"
 
 #: ../../src/Worksheet.cpp:330
 #, c-format
 msgid "%s image, %li×%li, %li ppi"
-msgstr ""
+msgstr "%s kép, %li×%li, %li ppi"
 
 #: ../../src/Autocomplete.cpp:319
 #, c-format
 msgid "%s: Can't interpret line: %s"
-msgstr ""
+msgstr "%s: Nem értelmezhető a(z) %s sor"
 
 #: ../../src/wxMaximaFrame.cpp:1655
 msgid "&Algebraic Mode"
-msgstr ""
+msgstr "&Algebrai mód"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "&Apropos..."
-msgstr ""
+msgstr "&Apropó..."
 
 #: ../../src/wxMaximaFrame.cpp:615
 msgid "&Batch File...\tCtrl+B"
-msgstr ""
+msgstr "&Batch fájl...\tCtrl+B"
 
 #: ../../src/wxMaximaFrame.cpp:1278
 msgid "&Boundary Value Problem..."
-msgstr ""
+msgstr "Pe&remérték probléma..."
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "&Bug Report"
-msgstr ""
+msgstr "&Hibajelentés"
 
 #: ../../src/wxMaximaFrame.cpp:1505
 msgid "&Calculus"
-msgstr ""
+msgstr "Ana&lízis"
 
 #: ../../src/wxMaximaFrame.cpp:1601
 msgid "&Canonical Form"
-msgstr ""
+msgstr "&Kanonikus alak"
 
 #: ../../src/wxMaximaFrame.cpp:1358
 msgid "&Characteristic Polynomial..."
-msgstr ""
+msgstr "&Karakterisztikus polinom..."
 
 #: ../../src/wxMaximaFrame.cpp:990
 msgid "&Clear Memory"
-msgstr ""
+msgstr "M&emória törlése"
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "&Combine Factorials"
-msgstr ""
+msgstr "&Számolás faktoriálisokkal"
 
 #: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Complex Simplification"
-msgstr ""
+msgstr "Kom&plex átalakítás"
 
 #: ../../src/wxMaximaFrame.cpp:1502
 msgid "&Continued Fraction"
-msgstr ""
+msgstr "Lán&ctörtté alakítás"
 
 #: ../../src/wxMaximaFrame.cpp:638
 msgid "&Copy\tCtrl+C"
-msgstr ""
+msgstr "&Másolás\tCtrl+C"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "&Demoivre"
-msgstr ""
+msgstr "&Demoivre"
 
 #: ../../src/wxMaximaFrame.cpp:1362
 msgid "&Determinant"
-msgstr ""
+msgstr "&Determináns"
 
 #: ../../src/wxMaximaFrame.cpp:1466
 msgid "&Differentiate..."
-msgstr ""
+msgstr "&Differenciálás..."
 
 #: ../../src/wxMaximaFrame.cpp:689
 msgid "&Edit"
-msgstr ""
+msgstr "S&zerkesztés"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "&Eliminate Variable..."
-msgstr ""
+msgstr "&Változó kiküszöbölése..."
 
 #: ../../src/wxMaximaFrame.cpp:1318
 msgid "&Enter Matrix..."
-msgstr ""
+msgstr "Má&trix bevitele..."
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "&Example..."
-msgstr ""
+msgstr "&Példa..."
 
 #: ../../src/wxMaximaFrame.cpp:1524
 msgid "&Expand Expression"
-msgstr ""
+msgstr "Kifejezé&s felbontása"
 
 #: ../../src/wxMaximaFrame.cpp:1597
 msgid "&Expand Trigonometric"
-msgstr ""
+msgstr "Tr&igonometrikus felbontás"
 
 #: ../../src/wxMaximaFrame.cpp:1626
 msgid "&Exponentialize"
-msgstr ""
+msgstr "E&xponenciálissá alakítás"
 
 #: ../../src/wxMaximaFrame.cpp:618
 msgid "&Export..."
-msgstr ""
+msgstr "E&xportálás..."
 
 #: ../../src/wxMaximaFrame.cpp:1516
 msgid "&Factor Expression"
-msgstr ""
+msgstr "Kife&jezés faktorizálása"
 
 #: ../../src/wxMaximaFrame.cpp:626
 msgid "&File"
-msgstr ""
+msgstr "&Fájl"
 
 #: ../../src/wxMaximaFrame.cpp:1019
 msgid "&Functions"
-msgstr ""
+msgstr "&Függvények"
 
 #: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Greatest Common Divisor..."
-msgstr ""
+msgstr "&Legnagyobb közös osztó..."
 
 #: ../../src/wxMaximaFrame.cpp:1968
 msgid "&Help"
-msgstr ""
+msgstr "&Súgó"
 
 #: ../../src/wxMaximaFrame.cpp:1453
 msgid "&Integrate..."
-msgstr ""
+msgstr "&Integrálás..."
 
 #: ../../src/wxMaximaFrame.cpp:964
 msgid "&Interrupt\tCtrl+G"
-msgstr ""
+msgstr "&Megszakítás\tCtrl+G"
 
 #: ../../src/wxMaximaFrame.cpp:1355
 msgid "&Invert Matrix"
-msgstr ""
+msgstr "Mát&rix invertálás"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "&License"
-msgstr ""
+msgstr "&Licenc"
 
 #: ../../src/wxMaximaFrame.cpp:1763
 msgid "&List"
-msgstr ""
+msgstr "&Lista"
 
 #: ../../src/wxMaximaFrame.cpp:610
 msgid "&Load Package...\tCtrl+L"
-msgstr ""
+msgstr "&Csomag betöltése...\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "&Maxima"
-msgstr ""
+msgstr "&Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "&Maxima help"
-msgstr ""
+msgstr "&Maxima súgó"
 
 #: ../../src/wxMaximaFrame.cpp:1660
 msgid "&Modulus Computation..."
-msgstr ""
+msgstr "&Modulus beállítása..."
 
 #: ../../src/main.cpp:435
 msgid "&New\tCtrl+N"
-msgstr ""
+msgstr "Ú&j\tCtrl+N"
 
 #: ../../src/wxMaximaFrame.cpp:1870
 msgid "&Numeric"
-msgstr ""
+msgstr "&Numerikus"
 
 #: ../../src/wxMaximaFrame.cpp:1785
 msgid "&Numeric Output"
-msgstr ""
+msgstr "&Numerikus kimenet"
 
 #: ../../src/main.cpp:436
 msgid "&Open\tCtrl+O"
-msgstr ""
+msgstr "&Megnyitás\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "&Open...\tCtrl+O"
-msgstr ""
+msgstr "&Megnyitás...\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "&Plot"
-msgstr ""
+msgstr "Á&brázolás"
 
 #: ../../src/wxMaximaFrame.cpp:622
 msgid "&Print...\tCtrl+P"
-msgstr ""
+msgstr "&Nyomtatás...\tCtrl+P"
 
 #: ../../src/wxMaximaFrame.cpp:1594
 msgid "&Reduce Trigonometric"
-msgstr ""
+msgstr "T&rigonometrikus redukálás"
 
 #: ../../src/wxMaximaFrame.cpp:974
 msgid "&Restart Maxima\tCtrl+Alt+R"
-msgstr ""
+msgstr "&Maxima újraindítása\tCtrl+Alt+R"
 
 #: ../../src/wxMaximaFrame.cpp:608
 msgid "&Save\tCtrl+S"
-msgstr ""
+msgstr "M&entés\tCtrl+S"
 
 #: ../../src/wxMaximaFrame.cpp:1662
 msgid "&Simplify"
-msgstr ""
+msgstr "E&gyszerűsítés"
 
 #: ../../src/wxMaximaFrame.cpp:1581
 msgid "&Simplify Factorials"
-msgstr ""
+msgstr "F&aktoriális egyszerűsítése"
 
 #: ../../src/wxMaximaFrame.cpp:1591
 msgid "&Simplify Trigonometric"
-msgstr ""
+msgstr "&Trigonometrikus egyszerűsítés"
 
 #: ../../src/wxMaximaFrame.cpp:1238
 msgid "&Solve..."
-msgstr ""
+msgstr "&Megoldás..."
 
 #: ../../src/wxMaximaFrame.cpp:1035
 msgid "&Time Display"
-msgstr ""
+msgstr "&Idő megjelenítése"
 
 #: ../../src/wxMaximaFrame.cpp:1375
 msgid "&Transpose Matrix"
-msgstr ""
+msgstr "Mátri&x transzponálás"
 
 #: ../../src/wxMaximaFrame.cpp:1605
 msgid "&Trigonometric Simplification"
-msgstr ""
+msgstr "&Trigonometrikus átalakítás"
 
 #: ../../src/wxMaximaFrame.cpp:1021
 msgid "&Variables"
-msgstr ""
+msgstr "&Változók"
 
 #: ../../src/wxMaxima.cpp:2443
 msgid "(Config tells to suppress the output of long cells)"
-msgstr ""
+msgstr "(Config tells to suppress the output of long cells)"
 
 #: ../../src/MathParser.cpp:1288
 msgid "(Invalid XML from maxima)"
-msgstr ""
+msgstr "(Invalid XML from maxima)"
 
 #: ../../src/wxMaxima.cpp:4221
 msgid "(Maybe a permission problem?)"
-msgstr ""
+msgstr "(Maybe a permission problem?)"
 
 #: ../../src/wxMaxima.cpp:9248
 msgid "(f(x),x,a,b)), Epsilon algorithm"
-msgstr ""
+msgstr "(f(x),x,a,b)), Epszilon algoritmus"
 
 #: ../../src/wxMaxima.cpp:9235
 msgid "(f(x),x,a,b)), Strategy of Aind"
-msgstr ""
+msgstr "(f(x),x,a,b)), Aind stratégiája"
 
 #: ../../src/wxMaxima.cpp:9258
 msgid "(f(x),x,a,b), (semi-) infinite interval"
-msgstr ""
+msgstr "(f(x),x,a,b), (fél)végtelen intervallum"
 
 #: ../../src/wxMaximaFrame.cpp:1841
 msgid "(f(x),x,a,b), Epsilon algorithm"
-msgstr ""
+msgstr "(f(x),x,a,b), Epszilon algoritmus"
 
 #: ../../src/wxMaximaFrame.cpp:1843
 msgid "(f(x),x,a,b), infinite interval"
-msgstr ""
+msgstr "(f(x),x,a,b), végtelen intervallum"
 
 #: ../../src/wxMaximaFrame.cpp:1839
 msgid "(f(x),x,a,b), strategy of Aind"
-msgstr ""
+msgstr "(f(x),x,a,b), Aind stratégiája"
 
 #: ../../src/wxMaxima.cpp:9361 ../../src/wxMaximaFrame.cpp:1867
 msgid "(f(x),x,y) with singularities+discontinuities"
-msgstr ""
+msgstr "(f(x),x,y) szingularitásokkal+diszkontinuitásokkal"
 
 #: ../../src/wxMaxima.cpp:2065
 msgid ""
 "... [suppressed additional lines as the output is longer than allowed in the"
 " wxMaxima configuration] "
 msgstr ""
+"... [további sorok letiltva, mivel a kimenet hosszabb a wxMaxima "
+"konfigurációjában megengedettnél] "
 
 #: ../../src/Worksheet.cpp:6666
 msgid ".wxm clipboard data with unusual header"
-msgstr ""
+msgstr ".wxm vágólap adatai szokatlan fejléccel"
 
 #: ../../src/wxMaxima.cpp:8047
 msgid "1×n Matrix b:"
-msgstr ""
+msgstr "1×n-es b mátrix:"
 
 #: ../../src/wxMaximaFrame.cpp:1312
 msgid "2D Array to Matrix..."
-msgstr ""
+msgstr "2D tömb mátrixszá..."
 
 #: ../../src/wxMaximaFrame.cpp:743
 msgid "2D equations using ASCII Art"
-msgstr ""
+msgstr "2D-s egyenletek az ASCII Artot használják"
 
 #: ../../src/wxMaximaFrame.cpp:746
 msgid "2D equations using ASCII Art with unicode characters, if available"
-msgstr ""
+msgstr "2D equations using ASCII Art with unicode characters, if available"
 
 #: ../../src/wxMaxima.cpp:5057
 #, c-format
 msgid "; %i commands left in the current cell"
-msgstr ""
+msgstr "; %i parancs maradt az aktuális cellában"
 
 #: ../../src/wxMaxima.cpp:10617
 msgid "A \":lisp\" as the first command might fail to send a \"finished\" signal."
-msgstr ""
+msgstr "Egy \":lisp\", mint első parancs lehet, hogy nem küld \"kész\" jelet."
 
 #: ../../src/wxMaxima.cpp:6585
 msgid "A Ctrl-F event"
-msgstr ""
+msgstr "A Ctrl-F event"
 
 #: ../../src/Worksheet.cpp:1973
 msgid "A Scalar"
-msgstr ""
+msgstr "Egy skalár"
 
 #: ../../src/wxMaxima.cpp:6653
 #, c-format
 msgid "A find event, %s"
-msgstr ""
+msgstr "A find event, %s"
 
 #: ../../src/Worksheet.cpp:2012
 msgid "A function returning integers"
-msgstr ""
+msgstr "Egész számokat visszaadó függvény"
 
 #: ../../src/Worksheet.cpp:2014
 msgid "A function returning positive numbers"
-msgstr ""
+msgstr "Pozitív számokat visszaadó függvény"
 
 #: ../../src/Worksheet.cpp:1965
 msgid "A irrational variable"
-msgstr ""
+msgstr "Irracionális változó"
 
 #: ../../src/Worksheet.cpp:2016
 msgid "A left-associative function"
-msgstr ""
+msgstr "Balra asszociatív függvény"
 
 #: ../../src/Worksheet.cpp:2019
 msgid "A linear function"
-msgstr ""
+msgstr "Lineáris függvény"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "A matrix in which each row is a set of variables"
-msgstr ""
+msgstr "Egy mátrix, amelyben minden sor változók halmaza"
 
 #: ../../src/Worksheet.cpp:1963
 msgid "A rational variable"
-msgstr ""
+msgstr "Racionális változó"
 
 #: ../../src/Worksheet.cpp:2018
 msgid "A right-associative function"
-msgstr ""
+msgstr "Jobb-asszociatív függvény"
 
 #: ../../src/wxMaximaFrame.cpp:1634
 msgid "A search-and-replace for equations"
-msgstr ""
+msgstr "Egyenletek keresése és cseréje"
 
 #: ../../src/wxMaximaFrame.cpp:1636
 msgid "A subst with basic maths knowledge"
-msgstr ""
+msgstr "Alapvető matematikai ismeretekkel rendelkező rész"
 
 #: ../../src/BTextCtrl.cpp:64
 msgid "A text control got the mouse focus"
-msgstr ""
+msgstr "Szöveges vezérlőelem került az egér fókuszába"
 
 #: ../../src/wxMaximaFrame.cpp:1442
 msgid "A&pply function to each Matrix element..."
-msgstr ""
+msgstr "Függvény a&lkalmazása minden Mátrix elemre..."
 
 #: ../../src/wxMaximaFrame.cpp:1291
 msgid "A&t Value..."
-msgstr ""
+msgstr "Ér&tékadás..."
 
 #: ../../src/Configuration.cpp:85
 msgid "ASCII maths"
-msgstr ""
+msgstr "ASCII matematika"
 
 #: ../../src/wxMaximaFrame.cpp:1963
 msgid "About"
-msgstr ""
+msgstr "Névjegy"
 
 #: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
 msgid "About wxMaxima"
-msgstr ""
+msgstr "Névjegy: wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7837
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
 msgstr ""
+"Elfogad egy kifejezést vagy egy listát a következő formátumban: "
+"[ode1,ode2,...]"
 
 #: ../../src/wxMaxima.cpp:7841
 msgid "Accepts one variable or a list in the format [1,4,...]"
 msgstr ""
+"Elfogad egy változót vagy egy listát a következő formátumban: [1,4,...]"
 
 #: ../../src/wxMaxima.cpp:7839
 msgid "Accepts one variable or a list in the format [var1,var2,...]"
 msgstr ""
+"Elfogad egy változót vagy egy listát a következő formátumban: "
+"[var1,var2,...]"
 
 #: ../../src/wxMaximaFrame.cpp:1371
 msgid "Ad&joint Matrix"
-msgstr ""
+msgstr "Mátr&ix adjungálás"
 
 #: ../../src/wxMaximaFrame.cpp:1657
 msgid "Add Algebraic E&quality..."
-msgstr ""
+msgstr "Alg&ebrai egyenlet hozzáadása..."
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add a directory to search path"
-msgstr ""
+msgstr "Könyvtár hozzáadása a keresési úthoz"
 
 #: ../../src/wxMaximaFrame.cpp:1752
 msgid ""
 "Add a new item to the beginning of the list. Useful for creating stacks."
-msgstr ""
+msgstr "Új elem hozzáadása a lista elejéhez. Hasznos kötegek létrehozásánál."
 
 #: ../../src/wxMaxima.cpp:8602
 msgid "Add an element to the end of a list"
-msgstr ""
+msgstr "Hozzáad egy elemet egy lista végéhez"
 
 #: ../../src/wxMaxima.cpp:8597
 msgid "Add an element to the start of a list"
-msgstr ""
+msgstr "Hozzáad egy elemet egy lista elejéhez"
 
 #: ../../src/wxMaxima.cpp:7625
 msgid "Add dir to path:"
-msgstr ""
+msgstr "Könyvtár hozzáadása az elérési úthoz:"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "Add equality to the rational simplifier"
-msgstr ""
+msgstr "Egyenlőség hozzáadása racionális egyszerűsítéshez"
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add to &Path..."
-msgstr ""
+msgstr "&Hozzáadás az elérési úthoz..."
 
 #: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
 #: ../../src/Worksheet.cpp:1704
 msgid "Add to watchlist"
-msgstr ""
+msgstr "Add a megnézendők listájához"
 
 #: ../../src/wxMaximaFrame.cpp:1562
 msgid "Additionally: log(a*b)=log(a)+log(b)"
-msgstr ""
+msgstr "Továbbá: log(a*b)=log(a)+log(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1566
 msgid "Additionally: log(a/b)=log(a)-log(b), a and b positive integers"
-msgstr ""
+msgstr "Továbbá: log(a/b)=log(a)-log(b), a és b pozitív egész szám"
 
 #: ../../src/Worksheet.cpp:1996
 msgid "Additive function: f(a+b)=f(a)+f(b)"
-msgstr ""
+msgstr "Additív függvény: f(a+b)=f(a)+f(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1911
 msgid "Advanced 2d plotting"
-msgstr ""
+msgstr "Advanced 2d plotting"
 
 #: ../../src/wxMaximaFrame.cpp:1809
 msgid "Advanced guess (PSLQ algorithm)"
-msgstr ""
+msgstr "Speciális tipp (PSLQ algoritmus)"
 
 #: ../../src/wxMaximaFrame.cpp:1920
 msgid "Advanced variable names"
-msgstr ""
+msgstr "Speciális változónevek"
 
 #: ../../src/ToolBar.cpp:321 ../../src/ToolBar.cpp:589
 msgid ""
 "After clicking on animations created with with_slider_draw() or similar this"
 " slider allows to change the current frame."
 msgstr ""
+"A with_slider_draw() paranccsal készített animációra kattintva az aktuális "
+"kép megváltoztatható."
 
 #: ../../src/wxMaximaFrame.cpp:1028
 msgid "Aliases"
-msgstr ""
+msgstr "Álnevek"
 
 #: ../../src/wxMaximaFrame.cpp:1714
 msgid "All but the 1st n elements"
-msgstr ""
+msgstr "Mind, kivéve az 1. n elem"
 
 #: ../../src/wxMaximaFrame.cpp:1716
 msgid "All but the last n elements"
-msgstr ""
+msgstr "Mind, kivéve az utolsó n elem"
 
 #: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
 msgid ""
@@ -551,93 +571,101 @@ msgid ""
 "*.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session "
 "(*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr ""
+"Minden megnyitható típus (*.wxm, *.wxmx, *.mac, *.out, "
+"*.xml)|*.wxm;*.wxmx;*.mac;*.out;*.xml|wxMaxima dokumentum (*.wxm, "
+"*.wxmx)|*.wxm;*.wxmx|Maxima munkalap (*.mac)|*.mac|XMaxima munkalap "
+"(*.out)|*.out|xml problémás .wxmx (*.xml)|*.xml fájlokból"
 
 #: ../../src/wxMaximaFrame.cpp:733
 msgid "All visible sidebars"
-msgstr ""
+msgstr "Minden látható oldalsáv"
 
 #: ../../src/wxMaximaFrame.cpp:1650
 msgid "Allow to substitute operators"
-msgstr ""
+msgstr "Operátorok helyettesítésének engedélyezése"
 
 #: ../../src/wxMaxima.cpp:9040
 msgid ""
 "Allows to vary the parameters of a function until it fits experimental data."
 msgstr ""
+"Lehetővé teszi egy függvény paramétereinek változtatását, amíg az nem "
+"illeszkedik a kísérleti adatokhoz."
 
 #: ../../src/wxMaximaFrame.cpp:763
 msgid "Always after underscores"
-msgstr ""
+msgstr "Mindig aláhúzás után"
 
 #: ../../src/wxMaximaFrame.cpp:764
 msgid "Always autosubscript after an underscore"
-msgstr ""
+msgstr "Aláhúzás után mindig automatikusan indexel"
 
 #: ../../src/wxMaximaFrame.cpp:774
 msgid "Always display this variable with subscript"
-msgstr ""
+msgstr "Mindig jelenítse meg ezt a változót indexszel"
 
 #: ../../src/Worksheet.cpp:1605
 msgid "Always show all digits"
-msgstr ""
+msgstr "Mindig megmutatja az összes számjegyet"
 
 #: ../../src/wxMaxima.cpp:9241
 msgid ""
 "An integer between 1..6; Higher numbers work better for oscillating "
 "integrands"
 msgstr ""
+"1...6 közötti egész szám; A nagyobb számok jobban működnek az oszcilláló "
+"integrandusoknál"
 
 #: ../../src/MaximaManual.cpp:385
 msgid "Anchors file has no top node."
-msgstr ""
+msgstr "A horgonyfájlnak nincs felső csomópontja."
 
 #: ../../src/wxMaximaFrame.cpp:791
 msgid "Angles"
-msgstr ""
+msgstr "Szögek"
 
 #: ../../src/wxMaximaFrame.cpp:1775
 msgid "Animation autoplay"
-msgstr ""
+msgstr "Az animáció automatikus lejátszása"
 
 #: ../../src/wxMaximaFrame.cpp:1778
 msgid "Animation framerate..."
-msgstr ""
+msgstr "Az animáció framerátája..."
 
 #: ../../src/Worksheet.cpp:2002
 msgid "Antisymmetric function: f(x)=-f(-x)"
-msgstr ""
+msgstr "Antiszimmetrikus függvény: f(x)=-f(-x)"
 
 #: ../../src/wxMaximaFrame.cpp:1739
 msgid "Append"
-msgstr ""
+msgstr "Hozzáfűz"
 
 #: ../../src/wxMaximaFrame.cpp:1735
 msgid "Append a list"
-msgstr ""
+msgstr "Hozzáfűz egy listát"
 
 #: ../../src/wxMaximaFrame.cpp:1736
 msgid "Append a list to an existing list"
-msgstr ""
+msgstr "Hozzáfűz egy listát egy létező listához"
 
 #: ../../src/wxMaxima.cpp:8607
 msgid "Append a list to another list"
-msgstr ""
+msgstr "Hozzáfűz egy listát egy listához"
 
 #: ../../src/wxMaximaFrame.cpp:1729
 msgid "Append an element"
-msgstr ""
+msgstr "Hozzáfűz egy elemet"
 
 #: ../../src/wxMaximaFrame.cpp:1734
 msgid "Append an element to the beginning an existing list"
-msgstr ""
+msgstr "Hozzáfűz egy elemet egy létező lista elejéhez"
 
 #: ../../src/wxMaximaFrame.cpp:1730
 msgid "Append an element to the end of an existing list"
-msgstr ""
+msgstr "Hozzáfűz egy elemet egy létező lista végéhez"
 
 #: ../../src/wxMaxima.cpp:8552
 msgid "Apply a function to each list element"
-msgstr ""
+msgstr "Függvény alkalmazása az összes listaelemre"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 #, c-format
@@ -645,204 +673,223 @@ msgid ""
 "Approximate by a fraction using log(), sqrt() and %pi, when needed. Only "
 "available in maxima > 5.46.0"
 msgstr ""
+"Közelítés törttel a log(), sqrt() és %pi használatával, ha szükséges. Csak "
+"maximum > 5.46.0 esetén érhető el"
 
 #: ../../src/wxMaximaFrame.cpp:1806
 msgid "Approximate by nice fraction"
-msgstr ""
+msgstr "Hozzávetőlegesen szép törtszámmal"
 
 #: ../../src/wxMaxima.cpp:8931
 msgid ""
 "Approximates a expression around a point as a polynom\n"
 "The trailing \"...\" can be removed by using ratdisrep()"
 msgstr ""
+"Egy pont körüli kifejezést polinomként közelít\n"
+"A záró \"...\" a ratdisrep() segítségével eltávolítható"
 
 #: ../../src/wxMaxima.cpp:8939
 msgid "Approximates a expression as a polynom"
-msgstr ""
+msgstr "Egy kifejezést polinomként közelít"
 
 #: ../../src/wxMaxima.cpp:9474
 msgid "Apropos"
-msgstr ""
+msgstr "Apropó"
 
 #: ../../src/wxMaxima.cpp:7317
 msgid "Are the chars equal, if case is ignored?"
 msgstr ""
+"A karakterek egyenlőek, ha figyelmen kívül hagyjuk a kis- és nagybetűket?"
 
 #: ../../src/wxMaxima.cpp:7312
 msgid "Are the chars equal?"
-msgstr ""
+msgstr "Megegyeznek a karakterek ?"
 
 #: ../../src/wxMaxima.cpp:7349
 msgid "Are these strings equal if case is ignored?"
 msgstr ""
+"Egyenlőek ezek a karakterláncok, ha figyelmen kívül hagyjuk a kis- és "
+"nagybetűket?"
 
 #: ../../src/wxMaxima.cpp:7344
 msgid "Are these strings equal?"
-msgstr ""
+msgstr "Ezek a húrok egyenlőek?"
 
 #: ../../src/wxMaxima.cpp:7259
 msgid "Arguments:"
-msgstr ""
+msgstr "Érvek:"
 
 #: ../../src/wxMaxima.cpp:8189
 msgid "Array"
-msgstr ""
+msgstr "Sorozat"
 
 #: ../../src/wxMaximaFrame.cpp:1023
 msgid "Arrays"
-msgstr ""
+msgstr "Sorozatok"
 
 #: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
 msgid "Ascii code to char"
-msgstr ""
+msgstr "Ascii kód a karakterhez"
 
 #: ../../src/wxMaximaFrame.cpp:1138
 msgid "Ascii code to char..."
-msgstr ""
+msgstr "Ascii kód a karakterhez..."
 
 #: ../../src/wxMaxima.cpp:10063
 msgid "Assignment(s):"
-msgstr ""
+msgstr "Feladat(ok):"
 
 #: ../../src/wxMaxima.cpp:10064
 msgid "Assignments of the format a=10,b=20"
-msgstr ""
+msgstr "A=10,b=20 formátumú hozzárendelések"
 
 #: ../../src/wxMaxima.cpp:6851
 msgid "Assume a value range for a variable"
-msgstr ""
+msgstr "Egy változó értéktartományának megadása"
 
 #: ../../src/wxMaxima.cpp:8545
 msgid ""
 "Attention: Extracting a random list element isn't efficient for long "
 "lists.Iterating over lists using makelist() or for loops is way faster."
 msgstr ""
+"Figyelem: A véletlenszerű listaelemek kibontása nem hatékony hosszú listák "
+"esetén. A listákon való iteráció a makelist() vagy for loop használatával "
+"sokkal gyorsabb."
 
 #: ../../src/Worksheet.cpp:1618
 msgid "Automatic labels"
-msgstr ""
+msgstr "Automatikus címkék"
 
 #: ../../src/wxMaximaFrame.cpp:952
 msgid "Automatically answer questions"
-msgstr ""
+msgstr "Kérdések automatikus megválaszolása"
 
 #: ../../src/wxMaximaFrame.cpp:953
 msgid "Automatically fill in answers known from the last run"
 msgstr ""
+"Automatikusan kitöltött válaszok a legutóbbi futási eredmények alapján"
 
 #: ../../src/Worksheet.cpp:1464 ../../src/Worksheet.cpp:1838
 msgid "Automatically send known answers"
-msgstr ""
+msgstr "Automatikusan ajánlj ismert válaszokat"
 
 #: ../../src/wxMaxima.cpp:6021
 #, c-format
 msgid "Autosaving as temp file %s"
-msgstr ""
+msgstr "Automatikus mentés %s ideiglenes fájlként"
 
 #: ../../src/wxMaxima.cpp:6033
 #, c-format
 msgid "Autosaving the .wxmx file as %s"
-msgstr ""
+msgstr "Automatikus mentés .wxmx fájlként, mint %s"
 
 #: ../../src/wxMaximaFrame.cpp:781
 msgid "Autosubscript"
-msgstr ""
+msgstr "Automatikus indexelés"
 
 #: ../../src/wxMaximaFrame.cpp:782
 msgid "Autosubscript chars after an underscore"
-msgstr ""
+msgstr "Automatikusan indexeli a karaktereket"
 
 #: ../../src/wxMaximaFrame.cpp:767
 msgid "Autosubscript numbers and text following single letters"
-msgstr ""
+msgstr "Automatikusan indexel számokat és betűk utáni szöveget"
 
 #: ../../src/wxMaxima.cpp:6529
 msgid "Autosubscript this variable"
-msgstr ""
+msgstr "Automatikus feliratkozás erre a változóra"
 
 #: ../../src/MaximaManual.cpp:536
 msgid "Background task that compiles the Manual anchors scheduled."
-msgstr ""
+msgstr "A kézikönyv horgonyait fordító háttérfeladat ütemezve."
 
 #: ../../src/wxMaximaFrame.cpp:1350
 msgid "Basic matrix operations"
-msgstr ""
+msgstr "Alapvető mátrixműveletek"
 
 #: ../../src/wxMaxima.cpp:6210
 msgid "Batch File"
-msgstr ""
+msgstr "Batch fájl"
 
 #: ../../src/wxMaxima.cpp:5318
 msgid "Both horizontal and vertical cursor active at the same time"
-msgstr ""
+msgstr "A vízszintes és függőleges kurzor is legyen aktív egyidőben"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Bottom end"
-msgstr ""
+msgstr "Alsó vége"
 
 #: ../../src/wxMaxima.cpp:7817
 msgid "Boundary value problem"
-msgstr ""
+msgstr "Peremérték probléma"
 
 #: ../../src/wxMathml.cpp:101
 msgid ""
 "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
 msgstr ""
+"Hiba: Az üres helyek eltávolítása után a wxMathml.lisp a vártnál rövidebb!"
 
 #: ../../src/Autocomplete.cpp:509
 msgid "Bug: Autocompletion requested for unknown type of item."
-msgstr ""
+msgstr "Hiba: Automatikus kiegészítési kérés ismeretlen típusú elemhez."
 
 #: ../../src/Worksheet.cpp:2992
 msgid "Bug: Cell left but not entered."
-msgstr ""
+msgstr "Hiba: Cella elhagyása belépés nélkül."
 
 #: ../../src/Worksheet.cpp:6203
 msgid "Bug: Cell with negative y position!"
-msgstr ""
+msgstr "Hiba: Cella negatív y pozícióval!"
 
 #: ../../src/Worksheet.cpp:7723
 msgid ""
 "Bug: Encountered a heading I don't know how to move in one sectioning unit"
 msgstr ""
+"Hiba: Olyan rovattal találkoztam, hogy nem tudom, hogyan kell mozgatni egy "
+"szakaszoló egységben"
 
 #: ../../src/Worksheet.cpp:7766
 msgid ""
 "Bug: Encountered a heading I don't know how to move out one sectioning unit"
 msgstr ""
+"Hiba: Olyan rovattal találkoztam, hogy nem tudom, hogyan kell kimozdítani "
+"egy szelvényező egységet"
 
 #: ../../src/Worksheet.cpp:3112
 msgid "Bug: Got a question but no cell to answer it in"
-msgstr ""
+msgstr "Hiba: Kérdés merült fel, de nincs cella a válaszhoz"
 
 #: ../../src/Worksheet.cpp:6378
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of"
 " the worksheet."
 msgstr ""
+"Hiba: Kérés egy munkalap kezdete előtti cella tartalmának megváltoztatására."
 
 #: ../../src/Worksheet.cpp:6346
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
-msgstr ""
+msgstr "Hiba: Kérés egy munkalap kezdete előtti cella törlésére."
 
 #: ../../src/Worksheet.cpp:6415
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
 msgstr ""
+"Hiba: Kérés egy cella tartalmának megváltoztatására, majd a korábbi tartalom"
+" helyreállítására."
 
 #: ../../src/Worksheet.cpp:5578
 msgid "Bug: HTML output is no valid XML"
-msgstr ""
+msgstr "Hiba: A HTML kimenet nem érvényes XML"
 
 #: ../../src/Configuration.h:615
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
-msgstr ""
+msgstr "Hiba: A megjelenítendő számjegyek maximális száma túl alacsony!"
 
 #: ../../src/MathParser.cpp:523
 msgid "Bug: Missing contents"
-msgstr ""
+msgstr "Hiba: Hiányzó tartalmak"
 
 #: ../../src/Worksheet.cpp:2597 ../../src/Worksheet.cpp:2711
 #: ../../src/Worksheet.cpp:2753 ../../src/Worksheet.cpp:2787
@@ -850,135 +897,140 @@ msgstr ""
 #: ../../src/Worksheet.cpp:4442 ../../src/Worksheet.cpp:6650
 #: ../../src/Worksheet.cpp:6863
 msgid "Bug: The clipboard is already opened"
-msgstr ""
+msgstr "Hiba: A vágólap már meg van nyitva"
 
 #: ../../src/Worksheet.cpp:7763
 msgid "Bug: Trying to move a title out by one sectioning unit"
-msgstr ""
+msgstr "Hiba: Megpróbál egy címet egy szekcióegységgel kimozdítani"
 
 #: ../../src/Worksheet.cpp:6934
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
-msgstr ""
+msgstr "Hiba: Vízszintes kurzort nem lehet egy csoportcellába helyezni."
 
 #: ../../src/Worksheet.h:247 ../../src/Worksheet.h:252
 msgid "Bug: Trying to record a cell contents change for undo without a cell."
 msgstr ""
+"Hiba: Megkísérelte elmenteni egy cella tartalmának változását cella nélkül."
 
 #: ../../src/Worksheet.cpp:6417
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
+"Hiba: Visszavonási esemény cella tartalmának változásához és cella "
+"hozzáadásához."
 
 #: ../../src/Worksheet.cpp:6383
 msgid "Bug: Undo request for cell outside worksheet."
-msgstr ""
+msgstr "Hiba: Munkalapon kívüli cella visszaállítási kérelme."
 
 #: ../../src/wxMaximaFrame.cpp:1948
 msgid "Build &Info"
-msgstr ""
+msgstr "&Verzióinformációk"
 
 #: ../../src/wxMaxima.cpp:7275
 msgid "Byte:"
-msgstr ""
+msgstr "Byte:"
 
 #: ../../src/wxMaximaFrame.cpp:1458
 msgid "C&hange Variable in Integrate..."
-msgstr ""
+msgstr "Változó módosítása az integrálandóban..."
 
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "C&onfigure"
-msgstr ""
+msgstr "B&eállítás"
 
 #: ../../src/wxMaximaFrame.cpp:1482
 msgid "Calculate &Product..."
-msgstr ""
+msgstr "&Szorzat számítása..."
 
 #: ../../src/wxMaxima.cpp:8057
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
-msgstr ""
+msgstr "Számítsa ki egy mátrix szinguláris érték dekompozícióját numerikusan"
 
 #: ../../src/wxMaxima.cpp:8050
 msgid ""
 "Calculate Singular Value Decomposition, left and right singular vectors "
 "numerically"
 msgstr ""
+"Számítsa ki a szinguláris érték dekompozícióját, a bal és jobb oldali "
+"szinguláris vektorokat numerikusan"
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate Su&m..."
-msgstr ""
+msgstr "Öss&zeg számítása..."
 
 #: ../../src/wxMaximaFrame.cpp:1795
 msgid "Calculate bigfloat value of the last result"
-msgstr ""
+msgstr "Szám hosszú tizedes tört alakja"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Calculate float value of the last result"
-msgstr ""
+msgstr "Szám tizedes tört alakja"
 
 #: ../../src/wxMaxima.cpp:9550
 msgid "Calculate mean value"
-msgstr ""
+msgstr "Átlag kiszámítása"
 
 #: ../../src/wxMaxima.cpp:9554
 msgid "Calculate median value"
-msgstr ""
+msgstr "Medián kiszámítása"
 
 #: ../../src/wxMaxima.cpp:8871
 msgid "Calculate modulus:"
-msgstr ""
+msgstr "Modulus értékének beállítása:"
 
 #: ../../src/wxMaximaFrame.cpp:1798
 msgid "Calculate numeric value of the last result"
-msgstr ""
+msgstr "Az utolsó eredmény tizedes tört alakjának kiszámolása"
 
 #: ../../src/wxMaximaFrame.cpp:1483
 msgid "Calculate products"
-msgstr ""
+msgstr "Szorzat számítása"
 
 #: ../../src/wxMaxima.cpp:9562
 msgid "Calculate standard deviation"
-msgstr ""
+msgstr "Számítsa ki a szórást"
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate sums"
-msgstr ""
+msgstr "Összeg számítása"
 
 #: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
 msgid "Calculate the eigenvalues and eigenvectors numerically"
-msgstr ""
+msgstr "Számítsa ki a sajátértékeket és a sajátvektorokat numerikusan"
 
 #: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
 msgid "Calculate the eigenvalues of a matrix numerically"
-msgstr ""
+msgstr "Mátrix sajátértékeinek numerikus kiszámolása"
 
 #: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
 msgid "Calculate the root of the sum of squares of matrix entries"
-msgstr ""
+msgstr "Számítsa ki a mátrixbejegyzések négyzetösszegének gyökét"
 
 #: ../../src/wxMaxima.cpp:9558
 msgid "Calculate variation"
-msgstr ""
+msgstr "Variáció kiszámítása"
 
 #: ../../src/wxMaxima.cpp:8949
 msgid "Calculates the fourier coefficients for the expression from -p to p"
-msgstr ""
+msgstr "Kiszámítja a -p és p közötti kifejezés Fourier-együtthatóit"
 
 #: ../../src/Worksheet.cpp:1968
 msgid "Calls assume() in order to tell maxima about the variable's range"
-msgstr ""
+msgstr "A feltételezés() hívása a változó tartományának maximumát jelzi"
 
 #: ../../src/Worksheet.cpp:2031
 msgid "Can be specified as flag in ev(exp, flag)"
-msgstr ""
+msgstr "Megadható zászlóként az ev-ben (exp, flag)"
 
 #: ../../src/wxMaxima.cpp:11125
 msgid "Can not connect to the web server."
-msgstr ""
+msgstr "Nem lehet a webszerverhez kapcsolódni."
 
 #: ../../src/wxMaxima.cpp:11166
 msgid "Can not download version info."
-msgstr ""
+msgstr "A verzióinformáció nem elérhető."
 
 #: ../../src/wxMaxima.cpp:3016 ../../src/wxMaxima.cpp:4836
 msgid ""
@@ -986,149 +1038,157 @@ msgid ""
 " (it can be downloaded from https://maxima.sourceforge.io) or in wxMaxima's "
 "config dialogue the setting for Maxima's location is wrong."
 msgstr ""
+"Nem lehet elindítani a Maximát. A legvalószínűbb ok az, hogy a Maxima nincs "
+"telepítve (letölthető a https://maxima.sourceforge.io webhelyről), vagy a "
+"wxMaxima konfigurációs párbeszédablakban a Maxima helyének beállítása "
+"helytelen."
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Cancel"
-msgstr ""
+msgstr "Mégsem"
 
 #: ../../src/wxMaxima.cpp:3292
 msgid "Cannot authenticate Maxima!"
-msgstr ""
+msgstr "Maxima nem hitelesíthető!"
 
 #: ../../src/wxMaxima.cpp:2677
 msgid ""
 "Cannot find a maxima binary and no binary chosen in the config dialogue."
 msgstr ""
+"Nem található maximális bináris és nincs bináris kiválasztva a konfigurációs"
+" párbeszédablakban."
 
 #: ../../src/Autocomplete.cpp:583
 #, c-format
 msgid "Cannot interpret template %s"
-msgstr ""
+msgstr "A(z) %s sablon nem értelmezhető"
 
 #: ../../src/wxMaxima.cpp:3082
 #, c-format
 msgid "Cannot interpret the numeric value of pid %s"
-msgstr ""
+msgstr "Cannot interpret the numeric value of pid %s"
 
 #: ../../src/wxMaxima.cpp:11066 ../../src/wxMaxima.cpp:11073
 #: ../../src/wxMaxima.cpp:11080
 #, c-format
 msgid "Cannot interpret version number component %s"
-msgstr ""
+msgstr "Cannot interpret version number component %s"
 
 #: ../../src/wxMaxima.cpp:2530
 msgid "Cannot set the communication address to localhost."
-msgstr ""
+msgstr "A kommunikációs cím nem állítható localhost-ra."
 
 #: ../../src/wxMaxima.cpp:2532
 #, c-format
 msgid "Cannot set the communication port to %i."
-msgstr ""
+msgstr "A kommunikációs port nem állítható %i értékre."
 
 #: ../../src/wxMaxima.cpp:3656 ../../src/wxMaxima.cpp:6359
 msgid "Cannot start gnuplot"
-msgstr ""
+msgstr "A gnuplot nem futtatható"
 
 #: ../../src/StatusBar.cpp:216 ../../src/wxMaxima.cpp:2662
 msgid "Cannot start the maxima binary"
-msgstr ""
+msgstr "A Maxima bináris nem tudott elindulni"
 
 #: ../../src/wxMaxima.cpp:9268
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
-msgstr ""
+msgstr "Az f(x)/(x-c) Cauchy-főértéke, véges intervallum"
 
 #: ../../src/wxMaximaFrame.cpp:1845
 msgid "Cauchy principal value, finite interval"
-msgstr ""
+msgstr "Cauchy-főérték, véges intervallum"
 
 #: ../../src/wxMaximaFrame.cpp:955
 msgid "Ce&ll"
-msgstr ""
+msgstr "Ce&lla"
 
 #: ../../src/Configuration.cpp:96
 msgid "Cell bracket fill, Active"
-msgstr ""
+msgstr "Cellák zárójelének kitöltése, aktív"
 
 #: ../../src/Configuration.cpp:95
 msgid "Cell bracket fill, Inactive"
-msgstr ""
+msgstr "Cellák zárójelének kitöltése, inaktív"
 
 #: ../../src/wxMaxima.cpp:10395
 msgid "Cell ends in a backslash"
-msgstr ""
+msgstr "A cella visszaperre (backslash-re) végződik"
 
 #: ../../src/wxMaximaFrame.cpp:1038
 msgid "Change &2d Display"
-msgstr ""
+msgstr "&2d-s megjelenítés változtatása"
 
 #: ../../src/wxMaxima.cpp:10146
 msgid "Change Image"
-msgstr ""
+msgstr "Kép cseréje"
 
 #: ../../src/Worksheet.cpp:1324
 msgid "Change Image..."
-msgstr ""
+msgstr "Kép megváltoztatása..."
 
 #: ../../src/wxMaximaFrame.cpp:1954
 msgid "Change Log"
-msgstr ""
+msgstr "Napló cseréje"
 
 #: ../../src/wxMaxima.cpp:7555
 msgid "Change directory"
-msgstr ""
+msgstr "Címtár módosítása"
 
 #: ../../src/wxMaximaFrame.cpp:1202
 msgid "Change directory..."
-msgstr ""
+msgstr "Könyvtár módosítása..."
 
 #: ../../src/wxMaximaFrame.cpp:1039
 msgid "Change the 2d display algorithm used to display math output"
-msgstr ""
+msgstr "Matematikai jelek 2d-s megjelenítési algoritmusának megváltoztatása"
 
 #: ../../src/wxMaxima.cpp:8885
 msgid "Change variable"
-msgstr ""
+msgstr "Változócsere"
 
 #: ../../src/wxMaxima.cpp:8905
 msgid "Change variable and evaluate"
-msgstr ""
+msgstr "Változó módosítása és kiértékelése"
 
 #: ../../src/wxMaximaFrame.cpp:1459
 msgid "Change variable in integral or sum"
-msgstr ""
+msgstr "Változócsere integrálban vagy összegben"
 
 #: ../../src/wxMaximaFrame.cpp:1463
 msgid "Change variable in integral or sum and evaluate the result"
 msgstr ""
+"Módosítsa a változót integrálban vagy összegben, és értékelje ki az "
+"eredményt"
 
 #: ../../src/wxMaximaFrame.cpp:1026
 msgid "Changed option variables"
-msgstr ""
+msgstr "Módosult az opcióváltozók"
 
 #: ../../src/wxMaxima.cpp:10170
 #, c-format
 msgid "Changing image originally loaded from file %s to %s."
-msgstr ""
+msgstr "Az eredetileg betöltött kép módosítása %s fájlról %s fájlra."
 
 #: ../../src/wxMaxima.cpp:7313 ../../src/wxMaxima.cpp:7318
 #: ../../src/wxMaxima.cpp:7323 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7334 ../../src/wxMaxima.cpp:7340
 msgid "Char #1:"
-msgstr ""
+msgstr "1. karakter:"
 
 #: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
 #: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
 msgid "Char #2:"
-msgstr ""
+msgstr "2. karakter:"
 
 #: ../../src/wxMaximaFrame.cpp:1140
 msgid "Char to Unicode code point..."
-msgstr ""
+msgstr "Char a Unicode kódponthoz..."
 
 #: ../../src/wxMaxima.cpp:7358 ../../src/wxMaxima.cpp:7362
 msgid "Char to unicode code point"
-msgstr ""
+msgstr "Char a unicode kódponthoz"
 
 #: ../../src/wxMaxima.cpp:7285 ../../src/wxMaxima.cpp:7289
 #: ../../src/wxMaxima.cpp:7293 ../../src/wxMaxima.cpp:7297
@@ -1136,324 +1196,331 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7359 ../../src/wxMaxima.cpp:7363
 #: ../../src/wxMaxima.cpp:7435
 msgid "Char:"
-msgstr ""
+msgstr "Char:"
 
 #: ../../src/wxMaximaFrame.cpp:1131
 msgid "Character Tests"
-msgstr ""
+msgstr "Karakter tesztek"
 
 #: ../../src/wxMaxima.cpp:8181
 msgid "Characteristic polynom"
-msgstr ""
+msgstr "Karakterisztikus polinom"
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Chars are strings that are one character long"
-msgstr ""
+msgstr "A karakterek egy karakter hosszúságú karakterláncok"
 
 #: ../../src/wxMaximaFrame.cpp:1957
 msgid "Check for Updates"
-msgstr ""
+msgstr "&Frissítések keresése"
 
 #: ../../src/wxMaximaFrame.cpp:1958
 msgid "Check if a newer version of wxMaxima is available."
-msgstr ""
+msgstr "A wxMaxima újabb verziójának keresése."
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Choose the parenthesis type for Matrices"
-msgstr ""
+msgstr "Zárójel típusának kiválasztása mátrixok számára"
 
 #: ../../src/wxMaxima.cpp:9530 ../../src/wxMaxima.cpp:9535
 msgid "Classes:"
-msgstr ""
+msgstr "Osztályok:"
 
 #: ../../src/wxMaximaFrame.cpp:1378
 msgid "Classic matrix operations"
-msgstr ""
+msgstr "Klasszikus mátrixműveletek"
 
 #: ../../src/wxMaximaFrame.cpp:998
 msgid "Clear all aliases"
-msgstr ""
+msgstr "Összes álnevek törlése"
 
 #: ../../src/wxMaximaFrame.cpp:995
 msgid "Clear all arrays"
-msgstr ""
+msgstr "Összes tömbök törlése"
 
 #: ../../src/wxMaximaFrame.cpp:992
 msgid "Clear all dependencies"
-msgstr ""
+msgstr "Összes függőségek törlése"
 
 #: ../../src/wxMaximaFrame.cpp:994
 msgid "Clear all functions"
-msgstr ""
+msgstr "Összes függvények törlése"
 
 #: ../../src/wxMaximaFrame.cpp:1001
 msgid "Clear all gradefs"
-msgstr ""
+msgstr "Összes gradef-ek törlése"
 
 #: ../../src/wxMaximaFrame.cpp:1000
 msgid "Clear all labels"
-msgstr ""
+msgstr "Összes címkék törlése"
 
 #: ../../src/wxMaximaFrame.cpp:1004
 msgid "Clear all let rule packages"
-msgstr ""
+msgstr "Összes let-szabálycsomagok törlése"
 
 #: ../../src/wxMaximaFrame.cpp:1003
 msgid "Clear all macros"
-msgstr ""
+msgstr "Összes makrók törlése"
 
 #: ../../src/wxMaximaFrame.cpp:1002
 msgid "Clear all props"
-msgstr ""
+msgstr "Összes tulajdonságok törlése"
 
 #: ../../src/wxMaximaFrame.cpp:997
 msgid "Clear all rules"
-msgstr ""
+msgstr "Összes szabályok törlése"
 
 #: ../../src/wxMaximaFrame.cpp:999
 msgid "Clear all structures"
-msgstr ""
+msgstr "Összes struktúrák törlése"
 
 #: ../../src/wxMaximaFrame.cpp:993
 msgid "Clear all variables"
-msgstr ""
+msgstr "Összes változók törlése"
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close\tCtrl+W"
-msgstr ""
+msgstr "Bezárás\tCtrl+W"
 
 #: ../../src/wxMaxima.cpp:7235
 msgid "Close Stream"
-msgstr ""
+msgstr "Az adatfolyam bezárása"
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close window"
-msgstr ""
+msgstr "Ablak bezárása"
 
 #: ../../src/wxMaximaFrame.cpp:1105
 msgid "Close..."
-msgstr ""
+msgstr "Bezárás..."
 
 #: ../../src/WXMXformat.cpp:301
 msgid "Closed the zip archive"
-msgstr ""
+msgstr "A zip archívum bezárva"
 
 #: ../../src/Configuration.cpp:77
 msgid "Code Default (Maxima input)"
-msgstr ""
+msgstr "Alapértelmezett kód (Maxima bemenet)"
 
 #: ../../src/Configuration.cpp:103
 msgid "Code highlighting: Comments"
-msgstr ""
+msgstr "Kód kiemelése: Megjegyzések"
 
 #: ../../src/Configuration.cpp:108
 msgid "Code highlighting: End of line markers"
-msgstr ""
+msgstr "Kódkiemelés: Sorvég jelzők"
 
 #: ../../src/Configuration.cpp:102
 msgid "Code highlighting: Functions"
-msgstr ""
+msgstr "Kód kiemelése: Függvények"
 
 #: ../../src/Configuration.cpp:107
 msgid "Code highlighting: Lisp"
-msgstr ""
+msgstr "Kód kiemelése: Lisp"
 
 #: ../../src/Configuration.cpp:104
 msgid "Code highlighting: Numbers"
-msgstr ""
+msgstr "Kód kiemelése: Számok"
 
 #: ../../src/Configuration.cpp:106
 msgid "Code highlighting: Operators"
-msgstr ""
+msgstr "Kód kiemelése: Műveletek"
 
 #: ../../src/Configuration.cpp:105
 msgid "Code highlighting: Strings"
-msgstr ""
+msgstr "Kód kiemelése: Szövegek"
 
 #: ../../src/Configuration.cpp:101
 msgid "Code highlighting: Variables"
-msgstr ""
+msgstr "Kód kiemelése: Változók"
 
 #: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
 msgid "Code number:"
-msgstr ""
+msgstr "Kód száma:"
 
 #: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
 msgid "Codepoint number:"
-msgstr ""
+msgstr "Kódpont száma:"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "Col. names:"
-msgstr ""
+msgstr "Oszlopok nevei:"
 
 #: ../../src/Configuration.cpp:100
 msgid "Color of Outdated cells"
-msgstr ""
+msgstr "Elavult cellák színe"
 
 #: ../../src/Configuration.cpp:99
 msgid "Color of text equal to selection"
-msgstr ""
+msgstr "A szöveg színe megegyezik a kijelölés színével"
 
 #: ../../src/wxMaxima.cpp:7962
 msgid "Column number:"
-msgstr ""
+msgstr "Oszlop száma:"
 
 #: ../../src/wxMaxima.cpp:7978
 msgid "Column numbers:"
-msgstr ""
+msgstr "Oszlop számok:"
 
 #: ../../src/wxMaxima.cpp:8202
 msgid "Columns"
-msgstr ""
+msgstr "Oszlopok"
 
 #: ../../src/wxMaximaFrame.cpp:1584
 msgid "Combine factorials in an expression"
-msgstr ""
+msgstr "Faktoriálisokkal számol egy kifejezésben"
 
 #: ../../src/wxMaxima.cpp:10454
 msgid "Comma directly followed by a closing parenthesis"
-msgstr ""
+msgstr "A vesszőt közvetlenül egy bezáró zárójel követi"
 
 #: ../../src/wxMaxima.cpp:7259
 msgid "Comma-separated arguments"
-msgstr ""
+msgstr "Vesszővel elválasztott argomentumok"
 
 #: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
 msgid "Comma-separated commands"
-msgstr ""
+msgstr "Vesszővel elválasztott parancsok"
 
 #: ../../src/wxMaxima.cpp:8458
 msgid "Comma-separated elements"
-msgstr ""
+msgstr "Vesszővel elválasztott elemek"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 #: ../../src/wxMaxima.cpp:10031
 msgid "Comma-separated equations"
-msgstr ""
+msgstr "Vesszővel elválasztott egyenletek"
 
 #: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
 #: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
 #: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
 msgid "Comma-separated expressions"
-msgstr ""
+msgstr "Vesszővel elválasztott kifejezések"
 
 #: ../../src/wxMaxima.cpp:7215
 msgid "Comma-separated expressions that shall be converted to a string"
 msgstr ""
+"Vesszővel elválasztott kifejezések, amelyeket karakterlánccá kell "
+"konvertálni"
 
 #: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
 msgid "Comma-separated expressions."
-msgstr ""
+msgstr "Vesszővel elválasztott kifejezések."
 
 #: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
 msgid "Comma-separated function names"
-msgstr ""
+msgstr "Vesszővel elválasztott függvénynevek"
 
 #: ../../src/wxMaxima.cpp:7086
 msgid "Comma-separated function names."
-msgstr ""
+msgstr "Vesszővel elválasztott függvénynevek."
 
 #: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
 #: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
 msgid "Comma-separated list entry in the format val1=1,val2=2"
 msgstr ""
+"Vesszővel elválasztott listabejegyzés a következő formátumban: val1=1,val2=2"
 
 #: ../../src/wxMaxima.cpp:7205
 msgid "Comma-separated names of the elements that shall be written"
-msgstr ""
+msgstr "Az írandó elemek vesszővel elválasztott neve"
 
 #: ../../src/wxMaxima.cpp:7099
 msgid "Comma-separated names the parameters will be referenced by later."
-msgstr ""
+msgstr "Vesszővel elválasztott nevek, amelyekre később hivatkozni fogunk."
 
 #: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
 msgid "Comma-separated numbers from 0 to 255"
-msgstr ""
+msgstr "Vesszővel elválasztott számok 0 és 255 között"
 
 #: ../../src/wxMaxima.cpp:8770
 msgid "Comma-separated numbers of the terms to substitute in"
-msgstr ""
+msgstr "A helyettesítendő kifejezések vesszővel elválasztott számai"
 
 #: ../../src/wxMaxima.cpp:7137 ../../src/wxMaxima.cpp:7150
 msgid ""
 "Comma-separated parameter names. A parameter in square brackets [] will be "
 "filled with the list of any additional arguments the function gets."
 msgstr ""
+"Vesszővel elválasztott paraméternevek. A [] szögletes zárójelben lévő "
+"paraméter a függvény által kapott további argumentumok listájával lesz "
+"kitöltve."
 
 #: ../../src/wxMaxima.cpp:7054
 msgid "Comma-separated variable names, can be initialized by the \":\" operator."
 msgstr ""
+"Vesszővel elválasztott változónevek, inicializálhatók a \":\" operátorral."
 
 #: ../../src/wxMaxima.cpp:7753 ../../src/wxMaxima.cpp:7767
 #: ../../src/wxMaxima.cpp:8719 ../../src/wxMaxima.cpp:8785
 #: ../../src/wxMaxima.cpp:10032
 msgid "Comma-separated variables"
-msgstr ""
+msgstr "Vesszővel elválasztott változók"
 
 #: ../../src/wxMaxima.cpp:9469
 msgid "Command:"
-msgstr ""
+msgstr "Parancs:"
 
 #: ../../src/Worksheet.cpp:1692
 msgid "Comment Selection"
-msgstr ""
+msgstr "Megjegyzés kiválasztása"
 
 #: ../../src/wxMaximaFrame.cpp:681
 msgid "Comment out the currently selected text"
-msgstr ""
+msgstr "A megjegyzés a kiválasztott szövegen kívül van"
 
 #: ../../src/wxMaximaFrame.cpp:680
 msgid "Comment selection\tCtrl+/"
-msgstr ""
+msgstr "Megjegyzés kiválasztása\tCtrl+/"
 
 #: ../../src/Worksheet.cpp:2004
 msgid "Commutative function"
-msgstr ""
+msgstr "Kommutatív függvény"
 
 #: ../../src/wxMaximaFrame.cpp:1396
 msgid "Compile a QR decomposition using dgeqrf"
-msgstr ""
+msgstr "Állítson össze egy QR-felbontást a dgeqrf segítségével"
 
 #: ../../src/wxMaxima.cpp:7162
 msgid "Compile a function"
-msgstr ""
+msgstr "Függvény összeállítása"
 
 #: ../../src/wxMaximaFrame.cpp:1188
 msgid "Compile a regular expression"
-msgstr ""
+msgstr "Reguláris kifejezés összeállítása"
 
 #: ../../src/wxMaximaFrame.cpp:1385
 msgid "Compile eigenvalues using dgeev"
-msgstr ""
+msgstr "A sajátértékek fordítása a dgeev segítségével"
 
 #: ../../src/wxMaximaFrame.cpp:1388
 msgid "Compile eigenvalues using zgeev"
-msgstr ""
+msgstr "Fordítsa le a sajátértékeket a zgeev segítségével"
 
 #: ../../src/wxMaximaFrame.cpp:1391
 msgid "Compile eigenvalues+eigenvectors using dgeev"
-msgstr ""
+msgstr "Sajátértékek+sajátvektorok fordítása dgeev segítségével"
 
 #: ../../src/wxMaximaFrame.cpp:1394
 msgid "Compile eigenvalues+eigenvectors using zgeev"
-msgstr ""
+msgstr "Sajátértékek+sajátvektorok fordítása a zgeev segítségével"
 
 #: ../../src/wxMaximaFrame.cpp:1076
 msgid "Compile function..."
-msgstr ""
+msgstr "Függvény összeállítása..."
 
 #: ../../src/wxMaxima.cpp:7511
 msgid "Compile regex"
-msgstr ""
+msgstr "Állíts össze egy reguláris kifejezést"
 
 #: ../../src/wxMathml.cpp:53
 msgid "Compiler-Bug? wxMathml.lisp is shorter than expected!"
-msgstr ""
+msgstr "Fordító hiba? A wxMathml.lisp a vártnál rövidebb!"
 
 #: ../../src/wxMaxima.cpp:2234
 #, c-format
 msgid "Compiling %s"
-msgstr ""
+msgstr "%s fordítása"
 
 #: ../../src/wxMaxima.cpp:7163
 msgid ""
@@ -1461,440 +1528,456 @@ msgid ""
 " the function parameters are made known to the function before it is "
 "compiled. Else the generated code has to be hideously generic."
 msgstr ""
+"Egy függvény lefordítása jelentős sebességnövekedést generálhat, ha a "
+"függvény paramétereinek típusát a fordítás előtt megismertetjük a "
+"funkcióval. Ellenkező esetben a generált kódnak rettenetesen általánosnak "
+"kell lennie."
 
 #: ../../src/wxMaximaFrame.cpp:892
 msgid "Complete Word\tCtrl+Space"
-msgstr ""
+msgstr "Szó kiegészítése\tCtrl+Space"
 
 #: ../../src/wxMaximaFrame.cpp:893
 msgid "Complete word"
-msgstr ""
+msgstr "Szó automatikus kiegészítése"
 
 #: ../../src/ToolBar.cpp:230
 msgid "Completely stop maxima and restart it"
-msgstr ""
+msgstr "A Maxima teljes leállítása és újraindítása"
 
 #: ../../src/wxMaximaFrame.cpp:1503
 msgid "Compute continued fraction of a value"
-msgstr ""
+msgstr "Egy lista lánctörtté alakítása"
 
 #: ../../src/wxMaximaFrame.cpp:1372
 msgid "Compute the adjoint matrix"
-msgstr ""
+msgstr "Mátrix adjungáltjának kiszámolása"
 
 #: ../../src/wxMaximaFrame.cpp:1359
 msgid "Compute the characteristic polynomial of a matrix"
-msgstr ""
+msgstr "Mátrix karakterisztikus polinomjának kiszámolása"
 
 #: ../../src/wxMaximaFrame.cpp:1363
 msgid "Compute the determinant of a matrix"
-msgstr ""
+msgstr "Mátrix determinánsának kiszámolása"
 
 #: ../../src/wxMaximaFrame.cpp:1491
 msgid "Compute the greatest common divisor"
-msgstr ""
+msgstr "Legnagyobb közös osztó kiszámolása"
 
 #: ../../src/wxMaximaFrame.cpp:1356
 msgid "Compute the inverse of a matrix"
-msgstr ""
+msgstr "Mátrix inverzének kiszámolása"
 
 #: ../../src/wxMaximaFrame.cpp:1494
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
+"Legkisebb közös többszörös kiszámolása (használata előtt hajtsd végre a "
+"load(functs) parancsot)"
 
 #: ../../src/wxMaximaFrame.cpp:1374
 msgid "Compute the rank of a matrix"
-msgstr ""
+msgstr "Mátrix rangjának kiszámolása"
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Condition:"
-msgstr ""
+msgstr "Feltétel:"
 
 #: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "Configure wxMaxima"
-msgstr ""
+msgstr "A wxMaxima beállítása"
 
 #: ../../src/wxMaxima.cpp:2504
 msgid "Connection attempt, but connection failed."
-msgstr ""
+msgstr "Csatlakozási kísérlet történt, de nem sikerült."
 
 #: ../../src/wxMaxima.cpp:2459
 msgid "Connection to Maxima lost."
-msgstr ""
+msgstr "Megszakadt a kapcsolat a maximával."
 
 #: ../../src/wxMaxima.cpp:7921
 msgid "Construct a fraction"
-msgstr ""
+msgstr "Tört szerkesztése"
 
 #: ../../src/wxMaximaFrame.cpp:1305
 msgid "Construct fraction..."
-msgstr ""
+msgstr "Tört szerkesztése..."
 
 #: ../../src/wxMaxima.cpp:7158
 msgid "Contents:"
-msgstr ""
+msgstr "Tartalmak:"
 
 #: ../../src/wxMaximaFrame.cpp:1877
 msgid "Context-sensitive &Help\tCtrl+?"
-msgstr ""
+msgstr "Környezetfüggő &Súgó\tCtrl +?"
 
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Context-sensitive &Help\tF1"
-msgstr ""
+msgstr "Környezetfüggő &Súgó\tF1"
 
 #: ../../src/wxMaximaFrame.cpp:1542
 msgid "Contract Logarithms"
-msgstr ""
+msgstr "Loga&ritmikus összevonás"
 
 #: ../../src/wxMaximaFrame.cpp:1161
 msgid "Conversions"
-msgstr ""
+msgstr "Átalakítások"
 
 #: ../../src/wxMaximaFrame.cpp:1229
 msgid "Convert"
-msgstr ""
+msgstr "Átlakítás"
 
 #: ../../src/wxMaximaFrame.cpp:1230
 msgid "Convert + Write to file"
-msgstr ""
+msgstr "Konvertálás + írás fájlba"
 
 #: ../../src/wxMaximaFrame.cpp:1434
 msgid "Convert Column to list..."
-msgstr ""
+msgstr "Oszlop listává alakítása..."
 
 #: ../../src/wxMaximaFrame.cpp:1430
 msgid "Convert Row to list..."
-msgstr ""
+msgstr "Sor listává alakítása..."
 
 #: ../../src/wxMaximaFrame.cpp:1044
 msgid "Convert a command to maxima code"
-msgstr ""
+msgstr "Konvertálja a parancsot maxima kódra"
 
 #: ../../src/wxMaximaFrame.cpp:1321
 msgid "Convert a list of lists to a matrix"
-msgstr ""
+msgstr "Listák listájának alakítása mátrixszá"
 
 #: ../../src/wxMaximaFrame.cpp:1574
 msgid "Convert binomials, beta and gamma function to factorials"
-msgstr ""
+msgstr "Binomiális-, béta- és gamma-függvények faktoriálissá alakítása"
 
 #: ../../src/wxMaximaFrame.cpp:1578
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
+"Binomiális-, faktoriális- és béta-függvényeket gamma-függvénnyé alakít"
 
 #: ../../src/wxMaximaFrame.cpp:1613
 msgid "Convert complex expression to polar form"
-msgstr ""
+msgstr "Komplex kifejezés exponenciálissá alakítása"
 
 #: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert complex expression to rect form"
-msgstr ""
+msgstr "Komplex kifejezés algebraivá alakítása"
 
 #: ../../src/wxMaximaFrame.cpp:1622
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
-msgstr ""
+msgstr "Komplex exponenciális függvény alakítása trigonometrikus formává"
 
 #: ../../src/wxMaxima.cpp:7411
 msgid "Convert string to lowercase"
-msgstr ""
+msgstr "Karakterlánc átalakítása kisbetűssé"
 
 #: ../../src/wxMaxima.cpp:7543
 msgid "Convert string to matching regex"
-msgstr ""
+msgstr "Karakterlánc konvertálása megfelelő reguláris kifejezéssé"
 
 #: ../../src/wxMaximaFrame.cpp:1543
 msgid "Convert sum of logarithms to logarithm of product"
-msgstr ""
+msgstr "Logaritmusok összegének szorzat logaritmusává való alakítása"
 
 #: ../../src/wxMaximaFrame.cpp:1573
 msgid "Convert to &Factorials"
-msgstr ""
+msgstr "&Faktoriálisokká alakítás"
 
 #: ../../src/wxMaximaFrame.cpp:1577
 msgid "Convert to &Gamma"
-msgstr ""
+msgstr "&Gamma-függvénnyé alakítás"
 
 #: ../../src/wxMaximaFrame.cpp:1612
 msgid "Convert to &Polarform"
-msgstr ""
+msgstr "Polárformává alakítás"
 
 #: ../../src/wxMaximaFrame.cpp:1609
 msgid "Convert to &Rectform"
-msgstr ""
+msgstr "&Algebraivá alakítás"
 
 #: ../../src/wxMaximaFrame.cpp:1166
 msgid "Convert to downcase..."
-msgstr ""
+msgstr "Konvertálás kisbetűsre..."
 
 #: ../../src/wxMaxima.cpp:7016
 msgid "Convert to programming language"
-msgstr ""
+msgstr "Konvertálás programozási nyelvre"
 
 #: ../../src/wxMaxima.cpp:7022
 msgid "Convert to programming language file"
-msgstr ""
+msgstr "Konvertálás programozási nyelv fájllá"
 
 #: ../../src/wxMaximaFrame.cpp:1602
 msgid "Convert trigonometric expression to canonical quasilinear form"
-msgstr ""
+msgstr "Trigonometrikus kifejezés kanonikus kvázilineáris formává alakítása"
 
 #: ../../src/wxMaximaFrame.cpp:1627
 msgid "Convert trigonometric functions to exponential form"
-msgstr ""
+msgstr "Trigonometrikus függvény exponenciális formává alakítása"
 
 #: ../../src/wxMaximaFrame.cpp:1762
 msgid "Converts a matrix to a list of lists"
-msgstr ""
+msgstr "A mátrixot listák listájára konvertálja"
 
 #: ../../src/wxMaximaFrame.cpp:1760
 msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
 msgstr ""
+"Olyan beágyazott listává konvertál, mint az [[1,2], [3,4]] egy mátrix esetén"
 
 #: ../../src/ToolBar.cpp:209 ../../src/Worksheet.cpp:1290
 #: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
 #: ../../src/Worksheet.cpp:1684
 msgid "Copy"
-msgstr ""
+msgstr "Másolás"
 
 #: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
 #: ../../src/Worksheet.cpp:1514
 msgid "Copy Animation"
-msgstr ""
+msgstr "Animáció másolása"
 
 #: ../../src/wxMaximaFrame.cpp:887
 msgid "Copy Previous Input\tCtrl+I"
-msgstr ""
+msgstr "E&lőző bemenet másolása\tCtrl+I"
 
 #: ../../src/wxMaximaFrame.cpp:890
 msgid "Copy Previous Output\tCtrl+U"
-msgstr ""
+msgstr "E&lőző kimenet másolása\tCtrl+U"
 
 #: ../../src/wxMaxima.cpp:7992
 msgid "Copy a matrix"
-msgstr ""
+msgstr "Mátrix másolása"
 
 #: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
 #: ../../src/wxMaximaFrame.cpp:663
 msgid "Copy as EMF"
-msgstr ""
+msgstr "Másolás EMF-ként"
 
 #: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Copy as Image"
-msgstr ""
+msgstr "Másolás képként"
 
 #: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
 #: ../../src/wxMaximaFrame.cpp:645
 msgid "Copy as LaTeX"
-msgstr ""
+msgstr "&LaTeX másolás"
 
 #: ../../src/wxMaximaFrame.cpp:648
 msgid "Copy as MathML"
-msgstr ""
+msgstr "Másolás MathML-ként"
 
 #: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
 msgid "Copy as MathML (e.g. to word processor)"
-msgstr ""
+msgstr "Másolás MathML-ként (pl. szövegszerkesztőbe)"
 
 #: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
 #: ../../src/wxMaximaFrame.cpp:658
 msgid "Copy as RTF"
-msgstr ""
+msgstr "Másolás RTF-ként"
 
 #: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "Copy as SVG"
-msgstr ""
+msgstr "Másolás SVG-ként"
 
 #: ../../src/wxMaximaFrame.cpp:640
 msgid "Copy as Text\tCtrl+Shift+C"
-msgstr ""
+msgstr "&Szöveg másolása\tCtrl+Shift+C"
 
 #: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
 msgid "Copy as plain text"
-msgstr ""
+msgstr "Másolás egyszerű szövegként"
 
 #: ../../src/wxMaxima.cpp:7576
 msgid "Copy file"
-msgstr ""
+msgstr "Fájl másolása"
 
 #: ../../src/wxMaximaFrame.cpp:1214
 msgid "Copy file..."
-msgstr ""
+msgstr "Fájl másolása..."
 
 #: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
 #: ../../src/wxMaximaFrame.cpp:643
 msgid "Copy for Octave/Matlab"
-msgstr ""
+msgstr "Másolás Octave/Matlab számára"
 
 #: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
 msgid "Copy selection"
-msgstr ""
+msgstr "Kijelölt rész másolása"
 
 #: ../../src/wxMaximaFrame.cpp:664
 msgid "Copy selection from document as an Enhanced Metafile"
-msgstr ""
+msgstr "Másolás kiválasztása a dokumentumból, mint továbbfejlesztett metafájl"
 
 #: ../../src/wxMaximaFrame.cpp:656
 msgid "Copy selection from document as an SVG image"
-msgstr ""
+msgstr "Kijelölt rész SVG képként való másolása a dokumentumból"
 
 #: ../../src/wxMaximaFrame.cpp:653
 msgid "Copy selection from document as an image"
-msgstr ""
+msgstr "Kijelölt rész képként másolása a dokumentumból"
 
 #: ../../src/wxMaximaFrame.cpp:659
 msgid ""
 "Copy selection from document as rtf that a word processor might understand"
 msgstr ""
+"A kijelölést rtf-ként másolja. Ezt egy szövegszerkesztőben felhasználhatjuk"
 
 #: ../../src/wxMaximaFrame.cpp:641
 msgid "Copy selection from document as text"
-msgstr ""
+msgstr "Kijelölt rész másolása a dokumentumból"
 
 #: ../../src/wxMaximaFrame.cpp:646
 msgid "Copy selection from document in LaTeX format"
-msgstr ""
+msgstr "Kijelölt rész másolása a dokumentumból LaTeX formátumban"
 
 #: ../../src/wxMaximaFrame.cpp:644
 msgid "Copy selection from document in Matlab format"
-msgstr ""
+msgstr "Kiválasztás másolása a dokumentumból Matlab formátumban"
 
 #: ../../src/wxMaximaFrame.cpp:649
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
+"A dokumentumból MathML formátumban kimásolt részt sok szövegszerkesztő 2d-s "
+"egyenletként tudja megjeleníteni"
 
 #: ../../src/wxMaxima.cpp:7403
 msgid "Copy string"
-msgstr ""
+msgstr "Karakterlánc másolása"
 
 #: ../../src/wxMaximaFrame.cpp:1165
 msgid "Copy string..."
-msgstr ""
+msgstr "Karakterlánc másolása..."
 
 #: ../../src/ToolBar.cpp:623
 msgid "Copy, Cut and Paste button"
-msgstr ""
+msgstr "Másolás, Kivágás és Beillesztés gomb"
 
 #: ../../src/WXMXformat.cpp:295
 msgid "Could not create the backup file during saving => aborting."
 msgstr ""
+"Mentés közben nem sikerült létrehozni a biztonsági másolatot => megszakítás."
 
 #: ../../src/wxMaxima.cpp:3294 ../../src/wxMaxima.cpp:3306
 msgid ""
 "Could not make sure that we talk to the maxima we started => discarding all "
 "data it sends."
 msgstr ""
+"Nem sikerült megbizonyosodni arról, hogy a megkezdett maximumokkal beszélünk"
+" => az összes küldött adat elvetése."
 
 #: ../../src/wxMaxima.cpp:2783
 msgid ""
 "Could not map view of the file needed in order to send an interrupt signal "
 "to maxima."
 msgstr ""
+"Nem sikerült feltérképezni a fájlt a célból, hogy megszakítási jelet küldjön"
+" a Maxima számára."
 
 #: ../../src/wxMaxima.cpp:2763 ../../src/wxMaxima.cpp:2805
 msgid "Could not send an interrupt signal to maxima."
-msgstr ""
+msgstr "Nem sikerült megszakítási jelet küldeni a Maximának."
 
 #: ../../src/WXMXformat.cpp:287
 msgid "Could not write the file's contents during saving => aborting."
-msgstr ""
+msgstr "Mentés közben nem sikerült kiírni a fájl tartalmát => megszakítás."
 
 #: ../../src/wxMaximaFrame.cpp:1325
 msgid "Create Matrix"
-msgstr ""
+msgstr "Mátrix generálása"
 
 #: ../../src/wxMaximaFrame.cpp:1688
 msgid "Create a list"
-msgstr ""
+msgstr "Lista készítése"
 
 #: ../../src/wxMaxima.cpp:8487
 msgid "Create a list as a storage for the values of variables"
-msgstr ""
+msgstr "Lista létrehozása a változók értékeinek tárolására"
 
 #: ../../src/wxMaxima.cpp:8463 ../../src/wxMaxima.cpp:8476
 msgid "Create a list from a rule"
-msgstr ""
+msgstr "Lista készítése szabályból"
 
 #: ../../src/wxMaximaFrame.cpp:1670
 msgid "Create a list from comma-separated elements"
-msgstr ""
+msgstr "Lista létrehozása vesszővel elválasztott elemekből"
 
 #: ../../src/wxMaximaFrame.cpp:888
 msgid "Create a new cell with previous input"
-msgstr ""
+msgstr "Létrehoz egy új cellát az előző bemenet tartalmával"
 
 #: ../../src/wxMaximaFrame.cpp:891
 msgid "Create a new cell with previous output"
-msgstr ""
+msgstr "Létrehoz egy új cellát az előző kimenet tartalmával"
 
 #: ../../src/wxMaximaFrame.cpp:1348
 msgid "Create copy, not clone..."
-msgstr ""
+msgstr "Másolatot készíteni, nem klónozni..."
 
 #: ../../src/wxMaxima.cpp:7561
 msgid "Create directory"
-msgstr ""
+msgstr "Könyvtár létrehozása"
 
 #: ../../src/wxMaximaFrame.cpp:1203
 msgid "Create directory..."
-msgstr ""
+msgstr "Könyvtár létrehozása..."
 
 #: ../../src/wxMaxima.cpp:7419
 msgid "Create empty string"
-msgstr ""
+msgstr "Üres karakterlánc létrehozása"
 
 #: ../../src/wxMaximaFrame.cpp:1168
 msgid "Create empty string..."
-msgstr ""
+msgstr "Üres karakterlánc létrehozása..."
 
 #: ../../src/wxMaximaFrame.cpp:1687
 msgid "Create list"
-msgstr ""
+msgstr "Lista készítése"
 
 #: ../../src/wxMaxima.cpp:8457
 msgid "Create list from comma-separated elements"
-msgstr ""
+msgstr "Lista létrehozása vesszővel elválasztott elemekből"
 
 #: ../../src/wxMaximaFrame.cpp:1082
 msgid "Create struct..."
-msgstr ""
+msgstr "Struktúra létrehozása..."
 
 #: ../../src/WXMXformat.cpp:80
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
-msgstr ""
+msgstr "Létrehozott egy .zip archívumot (a .wxmx fájl technikailag .zip fájl)"
 
 #: ../../src/wxMaximaFrame.cpp:1349
 msgid "Creates an independent matrix with the same contents"
-msgstr ""
+msgstr "Létrehoz egy független mátrixot azonos tartalommal"
 
 #: ../../src/Configuration.cpp:97
 msgid "Cursor color"
-msgstr ""
+msgstr "Kurzor színe"
 
 #: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
 msgid "Cut"
-msgstr ""
+msgstr "Kivágás"
 
 #: ../../src/wxMaximaFrame.cpp:636
 msgid "Cut\tCtrl+X"
-msgstr ""
+msgstr "&Kivágás\tCtrl+X"
 
 #: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
 msgid "Cut selection"
-msgstr ""
+msgstr "Kijelölt rész kivágása"
 
 #: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
 msgid "Data Matrix:"
-msgstr ""
+msgstr "Adat mátrix:"
 
 #: ../../src/wxMaxima.cpp:9599
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
-msgstr ""
+msgstr "Adat fájlok (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wxMaxima.cpp:9529 ../../src/wxMaxima.cpp:9534
 #: ../../src/wxMaxima.cpp:9539 ../../src/wxMaxima.cpp:9543
@@ -1903,402 +1986,409 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9563 ../../src/wxMaxima.cpp:9577
 #: ../../src/wxMaxima.cpp:9582 ../../src/wxMaxima.cpp:10030
 msgid "Data:"
-msgstr ""
+msgstr "Adat:"
 
 #: ../../src/wxMaximaFrame.cpp:1057
 msgid "Debugger trigger"
-msgstr ""
+msgstr "Hibakereső trigger"
 
 #: ../../src/wxMaximaFrame.cpp:779
 msgid "Declare Text to always be displayed as subscript"
-msgstr ""
+msgstr "A szöveg deklarálása mindig alindexként jelenik meg"
 
 #: ../../src/wxMaxima.cpp:7069
 msgid "Declare a function local to a Program"
-msgstr ""
+msgstr "Egy program helyi függvényének deklarálása"
 
 #: ../../src/wxMaxima.cpp:6539
 msgid "Declare a text snippet to always be displayed as subscript"
-msgstr ""
+msgstr "Egy szövegrészlet mindig alindexként jelenjen meg"
 
 #: ../../src/Worksheet.cpp:2044
 #, c-format
 msgid "Declare facts about %s"
-msgstr ""
+msgstr "Tények bejelentése %s-ról"
 
 #: ../../src/wxMaxima.cpp:8800
 msgid "Declare main variable:"
-msgstr ""
+msgstr "Fő változó deklarálása:"
 
 #: ../../src/wxMaxima.cpp:7171
 msgid "Declare the type of a function parameter"
-msgstr ""
+msgstr "Adja meg egy függvényparaméter típusát"
 
 #: ../../src/Worksheet.cpp:2038
 msgid "Declare these chars as ordinary letters"
-msgstr ""
+msgstr "Ezeket a karaktereket közönséges betűkké nyilvánítsa"
 
 #: ../../src/wxMaximaFrame.cpp:1500 ../../src/wxMaximaFrame.cpp:1536
 msgid "Decompose rational function to partial fractions"
-msgstr ""
+msgstr "Racionális törtfüggvény parciális törtekre bontása"
 
 #: ../../src/Worksheet.cpp:2010
 msgid "Decreasing function f(x)<x"
-msgstr ""
+msgstr "Csökkenő f(x)<x függvény"
 
 #: ../../src/wxMaxima.cpp:7134
 msgid "Define a function"
-msgstr ""
+msgstr "Függvény definiálása"
 
 #: ../../src/wxMaxima.cpp:7147
 msgid "Define a macro"
-msgstr ""
+msgstr "Határozzon meg egy makrót"
 
 #: ../../src/wxMaxima.cpp:7189
 msgid "Define a structure"
-msgstr ""
+msgstr "Határozzon meg egy szerkezetet"
 
 #: ../../src/wxMaxima.cpp:7183
 msgid "Define a structure type"
-msgstr ""
+msgstr "Határozza meg a szerkezet típusát"
 
 #: ../../src/wxMaxima.cpp:7156
 msgid "Define a variable"
-msgstr ""
+msgstr "Változó definiálása"
 
 #: ../../src/wxMaximaFrame.cpp:1072
 msgid "Define function..."
-msgstr ""
+msgstr "Függvény definiálása..."
 
 #: ../../src/wxMaximaFrame.cpp:1079
 msgid "Define macro..."
-msgstr ""
+msgstr "Makró meghatározása..."
 
 #: ../../src/wxMaximaFrame.cpp:1077
 msgid "Define parameter type..."
-msgstr ""
+msgstr "Paraméter típusának meghatározása..."
 
 #: ../../src/wxMaximaFrame.cpp:1081
 msgid "Define struct..."
-msgstr ""
+msgstr "Struktúra meghatározása..."
 
 #: ../../src/wxMaximaFrame.cpp:1080
 msgid "Define variable..."
-msgstr ""
+msgstr "Változó definiálása..."
 
 #: ../../src/wxMaximaFrame.cpp:1776
 msgid ""
 "Defines if an animation is automatically started or only by clicking on it."
 msgstr ""
+"Megadja, hogy az animáció automatikusan induljon el, vagy csak rákattintva."
 
 #: ../../src/wxMaxima.cpp:8935
 msgid "Degree:"
-msgstr ""
+msgstr "Fokozat:"
 
 #: ../../src/wxMaximaFrame.cpp:985
 msgid "Delete F&unction..."
-msgstr ""
+msgstr "Fü&ggvény törlése..."
 
 #: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
 msgid "Delete Selection"
-msgstr ""
+msgstr "Kijelölt rész törlése"
 
 #: ../../src/wxMaximaFrame.cpp:987
 msgid "Delete V&ariable..."
-msgstr ""
+msgstr "Vá&ltozó törlése..."
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Delete a function"
-msgstr ""
+msgstr "Függvény törlése"
 
 #: ../../src/wxMaximaFrame.cpp:988
 msgid "Delete a variable"
-msgstr ""
+msgstr "Változó törlése"
 
 #: ../../src/wxMaximaFrame.cpp:982
 msgid "Delete all objects with a given name"
-msgstr ""
+msgstr "Törölje az összes adott nevű objektumot"
 
 #: ../../src/wxMaximaFrame.cpp:991
 msgid "Delete all values from memory"
-msgstr ""
+msgstr "Minden tartalom törlése a memóriából"
 
 #: ../../src/wxMaxima.cpp:7588
 msgid "Delete file"
-msgstr ""
+msgstr "Fájl törlése"
 
 #: ../../src/wxMaximaFrame.cpp:1216
 msgid "Delete file..."
-msgstr ""
+msgstr "Fájl törlése..."
 
 #: ../../src/wxMaxima.cpp:7683
 msgid "Delete function(s)"
-msgstr ""
+msgstr "Függvény(ek) törlése"
 
 #: ../../src/wxMaxima.cpp:7679
 msgid "Delete named object(s)"
-msgstr ""
+msgstr "Elnevezett objektum(ok) törlése"
 
 #: ../../src/wxMaximaFrame.cpp:981
 msgid "Delete named object..."
-msgstr ""
+msgstr "Elnevezett objektum törlése..."
 
 #: ../../src/wxMaxima.cpp:7674
 msgid "Delete variable(s)"
-msgstr ""
+msgstr "Változó(k) törlése"
 
 #: ../../src/wxMaxima.cpp:7430
 msgid "Delimiter:"
-msgstr ""
+msgstr "Kiküszöbölés:"
 
 #: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
 #, c-format
 msgid "Demo for \"%s\""
-msgstr ""
+msgstr "\"%s\" bemutató"
 
 #: ../../src/wxMaximaFrame.cpp:1930
 msgid "Demos"
-msgstr ""
+msgstr "Demók"
 
 #: ../../src/wxMaxima.cpp:8927
 msgid "Denom. deg:"
-msgstr ""
+msgstr "Nevező foka:"
 
 #: ../../src/wxMaxima.cpp:7923
 msgid "Denominator:"
-msgstr ""
+msgstr "Névadó:"
 
 #: ../../src/wxMaximaFrame.cpp:1030
 msgid "Dependencies"
-msgstr ""
+msgstr "Függőségek"
 
 #: ../../src/wxMaxima.cpp:7813
 msgid "Derivate of y at that point:"
-msgstr ""
+msgstr "y származéka azon a ponton:"
 
 #: ../../src/wxMaximaFrame.cpp:1497
 msgid "Di&vide Polynomials..."
-msgstr ""
+msgstr "P&olinomok osztása..."
 
 #: ../../src/MaximaManual.cpp:517
 msgid "Didn't find the maxima HTML manual."
-msgstr ""
+msgstr "Nem találtam a maxima HTML kézikönyvet."
 
 #: ../../src/wxMaxima.cpp:4907
 msgid ""
 "Didn't get a help browser launch program command line, but can request the "
 "system's default help browser."
 msgstr ""
+"Nem kapott súgóböngészőt a program indításához, de kérheti a rendszer "
+"alapértelmezett súgóböngészőjét."
 
 #: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
 msgid "Differentiate"
-msgstr ""
+msgstr "Differenciálás"
 
 #: ../../src/wxMaximaFrame.cpp:1467
 msgid "Differentiate expression"
-msgstr ""
+msgstr "Kifejezés differenciálása"
 
 #: ../../src/Worksheet.cpp:1590
 msgid "Differentiate..."
-msgstr ""
+msgstr "Differenciálás..."
 
 #: ../../src/wxMaxima.cpp:9010
 msgid "Differentiates an expression n times"
-msgstr ""
+msgstr "Egy kifejezést n-szer differenciál"
 
 #: ../../src/wxMaxima.cpp:10055
 msgid "Differentiates the expression n times"
-msgstr ""
+msgstr "A kifejezést n-szer differenciál"
 
 #: ../../src/wxMaximaFrame.cpp:1212
 msgid "Directory operations"
-msgstr ""
+msgstr "Könyvtárműveletek"
 
 #: ../../src/wxMaximaFrame.cpp:1041
 msgid "Display Te&X Form"
-msgstr ""
+msgstr "Meg&jelenítés TeX formátumban"
 
 #: ../../src/wxMaxima.cpp:6972
 msgid "Display algorithm"
-msgstr ""
+msgstr "Megjelenítő algoritmus"
 
 #: ../../src/wxMaximaFrame.cpp:751
 msgid "Display an expression as maxima's internal lisp representation"
-msgstr ""
+msgstr "Display an expression as maxima's internal lisp representation"
 
 #: ../../src/wxMaximaFrame.cpp:754
 msgid "Display an expression as wxMaxima's internal XML representation"
-msgstr ""
+msgstr "Display an expression as wxMaxima's internal XML representation"
 
 #: ../../src/wxMaximaFrame.cpp:758
 msgid "Display equations"
-msgstr ""
+msgstr "Egyenletek megjelenítése"
 
 #: ../../src/wxMaxima.cpp:6508
 msgid "Display expression in maxima's internal representation"
-msgstr ""
+msgstr "Display expression in maxima's internal representation"
 
 #: ../../src/wxMaxima.cpp:6514
 msgid "Display expression in wxMaxima's internal representation"
-msgstr ""
+msgstr "Display expression in wxMaxima's internal representation"
 
 #: ../../src/wxMaximaFrame.cpp:1042
 msgid "Display last result in TeX form"
-msgstr ""
+msgstr "Kifejezés megjelenítése TeX formátumban"
 
 #: ../../src/ToolBar.cpp:360
 #, c-format
 msgid "Display resolution according to wxWidgets: %li x %li ppi"
-msgstr ""
+msgstr "Megjelenítési felbontás a wxWidgets szerint: %li x %li ppi"
 
 #: ../../src/wxMaximaFrame.cpp:802
 msgid "Display string quotation marks"
-msgstr ""
+msgstr "Szöveg idézőjelek megjelenítése"
 
 #: ../../src/wxMaximaFrame.cpp:1036
 msgid "Display time used for evaluation"
-msgstr ""
+msgstr "Megjeleníti mennyi idő alatt fut le az eljárás"
 
 #: ../../src/wxMaxima.cpp:9206
 msgid "Displayed Precision"
-msgstr ""
+msgstr "Megjelenítés pontossága"
 
 #: ../../src/wxMaximaFrame.cpp:1913
 msgid "Displaying 3d curves"
-msgstr ""
+msgstr "3D görbék megjelenítése"
 
 #: ../../src/wxMaximaFrame.cpp:1462
 msgid "Dito, and evaluate the result..."
-msgstr ""
+msgstr "Ugyanúgy, és értékeld ki az eredményt..."
 
 #: ../../src/wxMaximaFrame.cpp:1445
 msgid "Dito, but affect all clones of the Matrix..."
-msgstr ""
+msgstr "Így van, de érintse a Mátrix összes klónját..."
 
 #: ../../src/wxMaximaFrame.cpp:1255
 msgid "Dito, but as fraction (real only)..."
-msgstr ""
+msgstr "Ugyanígy, de töredékként (csak valódi)..."
 
 #: ../../src/wxMaximaFrame.cpp:1532
 msgid "Dito, including denominator"
-msgstr ""
+msgstr "Ugyanez, nevezővel együtt"
 
 #: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
 msgid "Divide Cell"
-msgstr ""
+msgstr "Cella kettéosztása"
 
 #: ../../src/wxMaximaFrame.cpp:1498
 msgid "Divide numbers or polynomials"
-msgstr ""
+msgstr "Számok vagy polinomok osztása"
 
 #: ../../src/wxMaxima.cpp:8578
 msgid "Do for each list element"
-msgstr ""
+msgstr "Alkalmazás az összes listaelemre"
 
 #: ../../src/wxMaxima.cpp:11197
 #, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
-msgstr ""
+msgstr "Akarja menteni a változásokat az alábbi dokumentumban \"%s\"?"
 
 #: ../../src/wxMaximaFrame.cpp:724
 msgid "Dock all Sidebars"
-msgstr ""
+msgstr "Dokkolja az összes oldalsávot"
 
 #: ../../src/Configuration.cpp:94
 msgid "Document background"
-msgstr ""
+msgstr "Szöveg háttere"
 
 #: ../../src/wxMaxima.cpp:4611
 msgid ""
 "Document was saved using a newer version of wxMaxima so it may not load "
 "correctly. Please update your wxMaxima."
 msgstr ""
+"A dokumentumot a wxMaxima újabb verziójával mentették, ezért előfordulhat, "
+"hogy nem töltődik be megfelelően. Kérjük, frissítse wxMaximát."
 
 #: ../../src/wxMaxima.cpp:4603
 msgid ""
 "Document was saved using a newer version of wxMaxima. Please update your "
 "wxMaxima."
 msgstr ""
+"A dokumentum a wxMaxima újabb verziójával lett elmentve. Kérjük, frissítse "
+"wxMaximát."
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "Don't autosubscript after an underscore"
-msgstr ""
+msgstr "Aláhúzás után nem indexel automatikusan"
 
 #: ../../src/wxMaximaFrame.cpp:1086
 msgid "Don't evaluate Expression..."
-msgstr ""
+msgstr "Ne értékeld ki a kifejezést..."
 
 #: ../../src/wxMaxima.cpp:7117
 msgid "Don't evaluate one command"
-msgstr ""
+msgstr "Ne értékeljen egy parancsot"
 
 #: ../../src/wxMaxima.cpp:7129
 msgid "Don't evaluate one whole expression"
-msgstr ""
+msgstr "Ne értékeljen egy egész kifejezést"
 
 #: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
 msgid "Don't mark cells that contain tooltips in yellow"
-msgstr ""
+msgstr "Ne jelölje sárgával az eszköztippeket tartalmazó cellákat"
 
 #: ../../src/Worksheet.cpp:1938 ../../src/Worksheet.cpp:2070
 msgid "Don't mark this message text in yellow"
-msgstr ""
+msgstr "Ne jelölje sárgával az üzenet szövegét"
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Don't save"
-msgstr ""
+msgstr "Nem ment"
 
 #: ../../src/Worksheet.cpp:1620
 msgid "Don't show labels"
-msgstr ""
+msgstr "Nem mutat címkéket"
 
 #: ../../src/Worksheet.cpp:1979
 msgid "Don't use if unassigned"
-msgstr ""
+msgstr "Ne használja, ha nincs hozzárendelve"
 
 #: ../../src/wxMaximaFrame.cpp:797
 msgid "Don't use parenthesis for matrices"
-msgstr ""
+msgstr "Nem használ zárójelet mátrixoknál"
 
 #: ../../src/wxMaxima.cpp:8525
 msgid "Drop the first n list elements"
-msgstr ""
+msgstr "Dobja el az első n listaelemet"
 
 #: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
 msgid "Drop the last n list elements"
-msgstr ""
+msgstr "Dobja el az utolsó n listaelemet"
 
 #: ../../src/wxMaximaFrame.cpp:1306
 msgid "E&quations"
-msgstr ""
+msgstr "&Egyenletek"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "E&xit\tCtrl+Q"
-msgstr ""
+msgstr "&Kilépés\tCtrl+Q"
 
 #: ../../src/wxMaximaFrame.cpp:1368
 msgid "Eige&nvectors"
-msgstr ""
+msgstr "Saját&vektorok"
 
 #: ../../src/wxMaximaFrame.cpp:1365
 msgid "Eigen&values"
-msgstr ""
+msgstr "&Sajátértékek"
 
 #: ../../src/wxMaximaFrame.cpp:1387
 msgid "Eigenvalues (complex)"
-msgstr ""
+msgstr "Sajátértékek (komplex)"
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Eigenvalues (real)"
-msgstr ""
+msgstr "Sajátértékek (valós)"
 
 #: ../../src/wxMaximaFrame.cpp:1393
 msgid "Eigenvalues, left+right eigenvectors (complex)"
-msgstr ""
+msgstr "Sajátértékek, bal+jobb sajátvektorok (komplex)"
 
 #: ../../src/wxMaximaFrame.cpp:1390
 msgid "Eigenvalues, left+right eigenvectors (real)"
-msgstr ""
+msgstr "Sajátértékek, bal+jobb sajátvektorok (valós)"
 
 #: ../../src/wxMaxima.cpp:8584
 msgid ""
@@ -2306,130 +2396,133 @@ msgid ""
 "parenthesis. In the latter case the result of the last expression in the "
 "parenthesis is used."
 msgstr ""
+"Vagy egyetlen kifejezés vagy vesszővel elválasztott kifejezések listája a "
+"zárójelek között. Az utóbbi esetben a zárójel utolsó kifejezésének "
+"eredményét használjuk."
 
 #: ../../src/wxMaxima.cpp:8593
 msgid "Element"
-msgstr ""
+msgstr "Elem"
 
 #: ../../src/wxMaxima.cpp:8549
 msgid "Element number"
-msgstr ""
+msgstr "Elemszám"
 
 #: ../../src/wxMaxima.cpp:8005
 msgid ""
 "Element-by-element Product of matrices of the same size (Hadamard product)"
-msgstr ""
+msgstr "Azonos méretű mátrixok elemenkénti szorzata (Hadamard-szorzat)"
 
 #: ../../src/wxMaxima.cpp:8012
 msgid "Element-by-element exponentiation of two matrices"
-msgstr ""
+msgstr "Két mátrix elemenkénti hatványozása"
 
 #: ../../src/wxMaximaFrame.cpp:1342
 msgid "Element-by-element multiplication"
-msgstr ""
+msgstr "Elemenkénti szorzás"
 
 #: ../../src/wxMaxima.cpp:8510
 msgid "Element:"
-msgstr ""
+msgstr "Elem:"
 
 #: ../../src/wxMaxima.cpp:7204
 msgid "Elements:"
-msgstr ""
+msgstr "Elemek:"
 
 #: ../../src/wxMaxima.cpp:7847
 msgid "Eliminate a variable"
-msgstr ""
+msgstr "Változó kiküszöbölése"
 
 #: ../../src/wxMaximaFrame.cpp:1247
 msgid "Eliminate a variable from a system of equations"
-msgstr ""
+msgstr "Változó kiküszöbölése egyenletrendszerből"
 
 #: ../../src/wxMaxima.cpp:10651
 msgid "Empty command => re-triggering evaluation"
-msgstr ""
+msgstr "Empty command => re-triggering evaluation"
 
 #: ../../src/wxMaxima.cpp:9225
 msgid "Enable:"
-msgstr ""
+msgstr "Engedélyez:"
 
 #: ../../src/MathParser.cpp:99
 #, c-format
 msgid "Encountered an unknown XML tag: <%s>"
-msgstr ""
+msgstr "Ismeretlen XML-címke: <%s>"
 
 #: ../../src/wxMaxima.cpp:2476
 msgid "Encountered an unknown socket event."
-msgstr ""
+msgstr "Ismeretlen socket esemény."
 
 #: ../../src/wxMaxima.cpp:7843
 msgid "End of t:"
-msgstr ""
+msgstr "t vége:"
 
 #: ../../src/wxMaxima.cpp:4097
 msgid "Ended lisp mode after receiving a maxima prompt!"
-msgstr ""
+msgstr "Egy Maxima prompt megjelenése miatt a Lisp mód véget ért!"
 
 #: ../../src/wxMaximaFrame.cpp:1828
 msgid "Engineering format (12.1e6 etc.)"
-msgstr ""
+msgstr "Mérnöki formátum (12.1e6 stb.)"
 
 #: ../../src/wxMaximaFrame.cpp:1319
 msgid "Enter a matrix"
-msgstr ""
+msgstr "Mátrix bevitele"
 
 #: ../../src/wxMaxima.cpp:8866
 msgid "Enter an equation for rational simplification:"
-msgstr ""
+msgstr "Írja be a listába felvenni kívánt algebrai egyenletet:"
 
 #: ../../src/wxMaxima.cpp:8169
 msgid "Enter matrix"
-msgstr ""
+msgstr "Mátrix bevitele"
 
 #: ../../src/wxMaxima.cpp:9095
 msgid "Enter new animation frame rate [Hz, integer]:"
-msgstr ""
+msgstr "Az animáció új framerátája [Hz, egész]:"
 
 #: ../../src/wxMaxima.cpp:9201
 msgid "Enter new precision for bigfloats:"
-msgstr ""
+msgstr "Új pontosság bevitele:"
 
 #: ../../src/wxMaxima.cpp:7922
 msgid "Enumerator:"
-msgstr ""
+msgstr "Felsoroló:"
 
 #: ../../src/wxMaximaFrame.cpp:1220
 msgid "Environment variables"
-msgstr ""
+msgstr "Környezeti változók"
 
 #: ../../src/wxMaxima.cpp:9045
 msgid "Epsilon:"
-msgstr ""
+msgstr "Epszilon:"
 
 #: ../../src/wxMaximaFrame.cpp:1124 ../../src/wxMaximaFrame.cpp:1135
 msgid "Equal, ignoring case?..."
-msgstr ""
+msgstr "Egyenlő, kis- és nagybetűk figyelmen kívül hagyása?..."
 
 #: ../../src/wxMaximaFrame.cpp:1133
 msgid "Equal?..."
-msgstr ""
+msgstr "Egyenlő?..."
 
 #: ../../src/wxMaxima.cpp:8561
 msgid "Equation"
-msgstr ""
+msgstr "Egyenlet"
 
 #: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
 msgid "Equation(s)"
-msgstr ""
+msgstr "Egyenlet(ek)"
 
 #: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
 msgid "Equation(s):"
-msgstr ""
+msgstr "Egyenlet(ek):"
 
 #: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
 #: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
 #: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
 msgid "Equation:"
-msgstr ""
+msgstr "Egyenlet:"
 
 #: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
 #: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
@@ -2441,22 +2534,22 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
 #: ../../src/wxMaxima.cpp:11166
 msgid "Error"
-msgstr ""
+msgstr "Hiba"
 
 #: ../../src/wxMaxima.cpp:2456
 msgid "Error writing to Maxima"
-msgstr ""
+msgstr "Hibajelzés küldése a Maximának"
 
 #: ../../src/wxMaxima.cpp:6164 ../../src/wxMaxima.cpp:6176
 #: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
 #: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
 msgid "Error!"
-msgstr ""
+msgstr "Hiba!"
 
 #: ../../src/Image.cpp:696
 #, c-format
 msgid "Error: Cannot render %s."
-msgstr ""
+msgstr "Hiba: Nem lehet %s -t renderelni."
 
 #: ../../src/Image.cpp:699
 #, c-format
@@ -2464,10 +2557,12 @@ msgid ""
 "Error: Cannot render %s:\n"
 "%s"
 msgstr ""
+"Hiba: Nem lehet megjeleníteni: %s:\n"
+"%s"
 
 #: ../../src/Image.cpp:704
 msgid "Error: Cannot render the image."
-msgstr ""
+msgstr "Hiba: A képet nem lehet renderelni."
 
 #: ../../src/Image.cpp:706
 #, c-format
@@ -2475,248 +2570,252 @@ msgid ""
 "Error: Cannot render the image:\n"
 "%s"
 msgstr ""
+"Hiba: A kép nem jeleníthető meg:\n"
+"%s"
 
 #: ../../src/wxMaxima.cpp:7544
 msgid ""
 "Escapes all special characters in a string. The result is a regex that "
 "matches this string exactly."
 msgstr ""
+"Egy karakterlánc összes speciális karakterét megszökteti. Az eredmény egy "
+"regex, amely pontosan megegyezik ezzel a karakterlánccal."
 
 #: ../../src/wxMaximaFrame.cpp:1652
 msgid "Evaluate &Noun Forms..."
-msgstr ""
+msgstr "Formulák értékelése..."
 
 #: ../../src/wxMaximaFrame.cpp:856
 msgid "Evaluate All Cells\tCtrl+Shift+R"
-msgstr ""
+msgstr "&Minden cella újraszámolása\tCtrl+Shift+R"
 
 #: ../../src/wxMaximaFrame.cpp:851
 msgid "Evaluate All Visible Cells\tCtrl+R"
-msgstr ""
+msgstr "&Minden látható cella újraszámolása\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1395
 msgid "Evaluate Cell"
-msgstr ""
+msgstr "Cella kiértékelése"
 
 #: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
 msgid "Evaluate Cell(s)"
-msgstr ""
+msgstr "C&ellák újraszámolása"
 
 #: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
 msgid "Evaluate Cells Above"
-msgstr ""
+msgstr "Az aktuális hely feletti cellák újraszámolása"
 
 #: ../../src/wxMaximaFrame.cpp:866
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
-msgstr ""
+msgstr "Az aktuális hely feletti cellák újraszámolása\tCtrl+Shift+P"
 
 #: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
 #: ../../src/wxMaximaFrame.cpp:876
 msgid "Evaluate Cells Below"
-msgstr ""
+msgstr "Az aktuális hely alatti cellák újraszámolása"
 
 #: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
 #: ../../src/Worksheet.cpp:1890
 msgid "Evaluate Heading 5\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "5. cím kiértékelése \tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1457 ../../src/Worksheet.cpp:1761
 #: ../../src/Worksheet.cpp:1901
 msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "6. cím kiértékelése \tShift+Ctrl+Enter"
 
 #: ../../src/wxMaxima.cpp:8626
 msgid "Evaluate Nouns"
-msgstr ""
+msgstr "Formák kiértékelése"
 
 #: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
 msgid "Evaluate Part\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Rész kiértékelése\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1431 ../../src/Worksheet.cpp:1741
 msgid "Evaluate Section\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Fejezet kiértékelése\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1445 ../../src/Worksheet.cpp:1751
 #: ../../src/Worksheet.cpp:1879
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Al-alfejezet kiértékelése\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1438 ../../src/Worksheet.cpp:1746
 #: ../../src/Worksheet.cpp:1868
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Alfejezet kiértékelése\tShift+Ctrl+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:845
 msgid "Evaluate active or selected cell(s)"
-msgstr ""
+msgstr "Kijelölt cellák újraszámolása"
 
 #: ../../src/ToolBar.cpp:251
 msgid "Evaluate all"
-msgstr ""
+msgstr "Mindent kiértékel"
 
 #: ../../src/wxMaximaFrame.cpp:857
 msgid "Evaluate all cells in the document"
-msgstr ""
+msgstr "A dokumentum összes cellájának újraszámolása"
 
 #: ../../src/wxMaximaFrame.cpp:1653
 msgid "Evaluate all noun forms in expression"
-msgstr ""
+msgstr "Nem kiértékelésre szánt formákat is kiértékel"
 
 #: ../../src/wxMaximaFrame.cpp:852
 msgid "Evaluate all visible cells in the document"
-msgstr ""
+msgstr "A dokumentum összes látható cellájának újraszámolása"
 
 #: ../../src/ToolBar.cpp:248
 msgid "Evaluate current cell"
-msgstr ""
+msgstr "Aktuális cella kiértékelése"
 
 #: ../../src/wxMaxima.cpp:7395
 msgid "Evaluate string"
-msgstr ""
+msgstr "Karakterlánc kiértékelése"
 
 #: ../../src/wxMaximaFrame.cpp:1151
 msgid "Evaluate string..."
-msgstr ""
+msgstr "Karakterlánc kiértékelése..."
 
 #: ../../src/ToolBar.cpp:256
 msgid "Evaluate the file from its beginning to the cell above the cursor"
-msgstr ""
+msgstr "Fájl kiértékelése annak kezdetétől a kurzor feletti celláig"
 
 #: ../../src/ToolBar.cpp:259
 msgid "Evaluate the file from the cursor to its end"
-msgstr ""
+msgstr "Fájl kiértékelése a kurzortól annak végéig"
 
 #: ../../src/ToolBar.cpp:258
 msgid "Evaluate the rest"
-msgstr ""
+msgstr "A többi kiértékelése"
 
 #: ../../src/ToolBar.cpp:255
 msgid "Evaluate to point"
-msgstr ""
+msgstr "Kiértékelés eddig"
 
 #: ../../src/wxMaxima.cpp:10518
 msgid "Evaluation ended, since evaluation queue is empty."
-msgstr ""
+msgstr "Evaluation ended, since evaluation queue is empty."
 
 #: ../../src/Worksheet.cpp:1957
 msgid "Even number"
-msgstr ""
+msgstr "Páros szám"
 
 #: ../../src/wxMaximaFrame.cpp:1703
 msgid "Execute a command for each element of the list"
-msgstr ""
+msgstr "Végrehajt egy parancsot a lista egyes elemeihez"
 
 #: ../../src/main.cpp:438
 msgid "Exit"
-msgstr ""
+msgstr "Kilépés"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "Exit wxMaxima"
-msgstr ""
+msgstr "Kilépés a wxMaximából"
 
 #: ../../src/Worksheet.cpp:1583
 msgid "Expand Expression"
-msgstr ""
+msgstr "Kifejezés felbontása"
 
 #: ../../src/wxMaximaFrame.cpp:1525
 msgid "Expand an expression"
-msgstr ""
+msgstr "Egy kifejezés felbontása"
 
 #: ../../src/wxMaximaFrame.cpp:1531
 msgid "Expand for given variables"
-msgstr ""
+msgstr "Bontsa ki a megadott változókra"
 
 #: ../../src/wxMaxima.cpp:8781
 msgid "Expand for variable(s) including denominator:"
-msgstr ""
+msgstr "Kibontás a változó(k)ra, beleértve a nevezőt:"
 
 #: ../../src/wxMaxima.cpp:8716
 msgid "Expand for variable(s):"
-msgstr ""
+msgstr "Változó(k) kibontása:"
 
 #: ../../src/wxMaximaFrame.cpp:1545
 msgid "Expand log in previous expression"
-msgstr ""
+msgstr "Bontsa ki a naplót az előző kifejezésben"
 
 #: ../../src/wxMaximaFrame.cpp:1598
 msgid "Expand trigonometric expression"
-msgstr ""
+msgstr "Trigonometrikus kifejezés felbontása"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Expect numbers harder to be complex"
-msgstr ""
+msgstr "Számítson arra, hogy a számok bonyolultabbak legyenek"
 
 #: ../../src/wxMaximaFrame.cpp:1789
 msgid "Expect variables to contain complex numbers"
-msgstr ""
+msgstr "Várható, hogy a változók komplex számokat tartalmaznak"
 
 #: ../../src/wxMaxima.cpp:6121
 msgid "Export"
-msgstr ""
+msgstr "Exportálás"
 
 #: ../../src/wxMaximaFrame.cpp:1705
 msgid "Export List to csv file..."
-msgstr ""
+msgstr "Lista exportálása csv fájlba..."
 
 #: ../../src/wxMaximaFrame.cpp:1706
 msgid "Export a list to a csv file"
-msgstr ""
+msgstr "Lista exportálása csv fájlba"
 
 #: ../../src/wxMaximaFrame.cpp:1332
 msgid "Export a matrix to a csv file"
-msgstr ""
+msgstr "Mátrix exportálása csv fájlba"
 
 #: ../../src/wxMaximaFrame.cpp:619
 msgid "Export document to a HTML or LaTeX file"
-msgstr ""
+msgstr "Dokumentum exportálása HTML vagy LaTeX formátumba"
 
 #: ../../src/wxMaximaFrame.cpp:579
 msgid "Export failed."
-msgstr ""
+msgstr "Az exportálás meghiúsult."
 
 #: ../../src/wxMaximaFrame.cpp:567
 msgid "Export successful."
-msgstr ""
+msgstr "Sikeres export."
 
 #: ../../src/wxMaxima.cpp:6187
 msgid "Exporting to HTML failed!"
-msgstr ""
+msgstr "A HTML-be való exportálás meghiúsult!"
 
 #: ../../src/wxMaxima.cpp:6164
 msgid "Exporting to TeX failed!"
-msgstr ""
+msgstr "A TeX-be való exportálás meghiúsult!"
 
 #: ../../src/wxMaxima.cpp:6175
 msgid "Exporting to maxima batch file failed!"
-msgstr ""
+msgstr "Maxima batch fájlba való exportálás meghiúsult!"
 
 #: ../../src/wxMaximaFrame.cpp:561
 msgid "Exporting..."
-msgstr ""
+msgstr "Exportálás..."
 
 #: ../../src/wxMaxima.cpp:6510 ../../src/wxMaxima.cpp:6516
 #: ../../src/wxMaxima.cpp:8218 ../../src/wxMaxima.cpp:8633
 #: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
 #: ../../src/wxMaxima.cpp:10065
 msgid "Expression"
-msgstr ""
+msgstr "Kifejezés"
 
 #: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
 msgid "Expression or a list of comma-separated expressions"
-msgstr ""
+msgstr "Kifejezés vagy vesszővel elválasztott kifejezések listája"
 
 #: ../../src/wxMaximaFrame.cpp:1088
 msgid "Expression to string..."
-msgstr ""
+msgstr "Kifejezés karaterláncba..."
 
 #: ../../src/wxMaxima.cpp:7113
 msgid "Expression whose output is to be used as maxima's input."
-msgstr ""
+msgstr "Kifejezés, amelynek kimenetét a maximum bemeneteként kell használni."
 
 #: ../../src/wxMaxima.cpp:7214
 msgid "Expression(s):"
-msgstr ""
+msgstr "Függvény(ek):"
 
 #: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
 #: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
@@ -2725,385 +2824,387 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
 #: ../../src/wxMaxima.cpp:10056
 msgid "Expression:"
-msgstr ""
+msgstr "Kifejezés:"
 
 #: ../../src/wxMaximaFrame.cpp:1423
 msgid "Extract Column..."
-msgstr ""
+msgstr "Oszlop kibontása..."
 
 #: ../../src/wxMaximaFrame.cpp:1726
 msgid "Extract Elements"
-msgstr ""
+msgstr "Elemek kibontása"
 
 #: ../../src/wxMaximaFrame.cpp:1421
 msgid "Extract Row..."
-msgstr ""
+msgstr "Sor kibontása..."
 
 #: ../../src/wxMaximaFrame.cpp:1424
 msgid "Extract a column from the matrix"
-msgstr ""
+msgstr "Egy oszlop kibontása a mátrixból"
 
 #: ../../src/wxMaximaFrame.cpp:1435
 msgid "Extract a column from the matrix and convert it to a list"
-msgstr ""
+msgstr "Egy oszlop kibontása a mátrixból, és átalakítása listává"
 
 #: ../../src/wxMaxima.cpp:7960
 msgid "Extract a matrix column"
-msgstr ""
+msgstr "Egy oszlop kibontása a mátrixból"
 
 #: ../../src/wxMaxima.cpp:7970
 msgid "Extract a matrix column as a list"
-msgstr ""
+msgstr "Egy oszlop kibontása a mátrixból, és átalakítása listává"
 
 #: ../../src/wxMaximaFrame.cpp:1313
 msgid "Extract a matrix from a 2-dimensional array"
-msgstr ""
+msgstr "Mátrix generálása kétdimenziós sorozatból"
 
 #: ../../src/wxMaxima.cpp:7955
 msgid "Extract a matrix row"
-msgstr ""
+msgstr "Egy mátrix sor kibontása"
 
 #: ../../src/wxMaxima.cpp:7965
 msgid "Extract a matrix row as a list"
-msgstr ""
+msgstr "Egy sor kibontása a mátrixból, és átalakítása listává"
 
 #: ../../src/wxMaximaFrame.cpp:1422
 msgid "Extract a row from the matrix"
-msgstr ""
+msgstr "Sor kibontása a mátrixból"
 
 #: ../../src/wxMaximaFrame.cpp:1431
 msgid "Extract a row from the matrix and convert it to a list"
-msgstr ""
+msgstr "Egy sor kibontása a mátrixból, és átalakítása listává"
 
 #: ../../src/wxMaxima.cpp:8564
 msgid "Extract a variable's value from a list of variable values"
-msgstr ""
+msgstr "Egy változó értékének kibontása a változóértékek listájáról"
 
 #: ../../src/wxMaximaFrame.cpp:1723
 msgid "Extract an actual value for a variable"
-msgstr ""
+msgstr "Egy változó aktuális értékének kibontása"
 
 #: ../../src/wxMaximaFrame.cpp:1163
 msgid "Extract char..."
-msgstr ""
+msgstr "Karakter kibontása..."
 
 #: ../../src/wxMaximaFrame.cpp:1207
 msgid "Extract dir from path..."
-msgstr ""
+msgstr "A könyvtárnév kibontása az elérési útból..."
 
 #: ../../src/wxMaxima.cpp:7605
 msgid "Extract directory part"
-msgstr ""
+msgstr "Könyvtárrész kibontása"
 
 #: ../../src/wxMaxima.cpp:7617
 msgid "Extract file type extension"
-msgstr ""
+msgstr "Fájltípus kiterjesztésének kibontása"
 
 #: ../../src/wxMaximaFrame.cpp:1209
 msgid "Extract filename from path..."
-msgstr ""
+msgstr "A fájlnév kibontása az elérési útból..."
 
 #: ../../src/wxMaxima.cpp:7611
 msgid "Extract filename part"
-msgstr ""
+msgstr "Fájlnév rész kibontása"
 
 #: ../../src/wxMaximaFrame.cpp:1211
 msgid "Extract filetype from path..."
-msgstr ""
+msgstr "Fájltípus kibontása az elérési útból..."
 
 #: ../../src/wxMaxima.cpp:8445
 msgid "Extract function arguments"
-msgstr ""
+msgstr "Függvényargumentumok kibontása"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "Extract list Elements"
-msgstr ""
+msgstr "Listaelemek kibontása"
 
 #: ../../src/wxMaxima.cpp:8187
 msgid "Extract matrix from 2D array"
-msgstr ""
+msgstr "Egy mátrix kibontása 2D tömbből"
 
 #: ../../src/wxMaximaFrame.cpp:1686
 msgid "Extract the argument list from a function call"
-msgstr ""
+msgstr "Argumentumlista kibontása egy függvényhívásból"
 
 #: ../../src/wxMaxima.cpp:8538
 msgid "Extract the last n elements from a list"
-msgstr ""
+msgstr "Kibontja az utolsó n-edik elemet egy listából"
 
 #: ../../src/wxMaxima.cpp:7376
 msgid "Extract the nth char of a string"
-msgstr ""
+msgstr "Karakterlánc n-edik karakterének kibontása"
 
 #: ../../src/wxMaxima.cpp:8544
 msgid "Extract the nth list elements"
-msgstr ""
+msgstr "Az n-edik listaelem kibontása"
 
 #: ../../src/wxMaximaFrame.cpp:1724
 msgid "Extract the value for one variable assigned in a list"
-msgstr ""
+msgstr "Egy listán szereplő változó kibontása"
 
 #: ../../src/wxMaximaFrame.cpp:1439
 msgid "Extract, append or delete rows or columns"
-msgstr ""
+msgstr "Sorok vagy oszlopok kibontása, hozzáfűzése vagy törlése"
 
 #: ../../src/wxMaxima.cpp:8188
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
-msgstr ""
+msgstr "Kibont egy téglalapot egy 2D tömbből és mátrixszá alakítja"
 
 #: ../../src/wxMaximaFrame.cpp:1521
 msgid "Factor Complex"
-msgstr ""
+msgstr "K&omplex faktorizáció"
 
 #: ../../src/Worksheet.cpp:1581
 msgid "Factor Expression"
-msgstr ""
+msgstr "Kifejezés faktorizálása"
 
 #: ../../src/wxMaximaFrame.cpp:1519
 msgid "Factor Expression including subexpressions"
-msgstr ""
+msgstr "Tényezőkifejezés, beleértve a részkifejezéseket"
 
 #: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
 msgid "Factor an expression"
-msgstr ""
+msgstr "Egy kifejezés faktorizálása"
 
 #: ../../src/wxMaximaFrame.cpp:1522
 msgid "Factor an expression in Gaussian numbers"
-msgstr ""
+msgstr "Kifejezés faktorizálása Gauss-egészekre"
 
 #: ../../src/wxMaximaFrame.cpp:1587
 msgid "Factorials and &Gamma"
-msgstr ""
+msgstr "&Faktoriális- és gamma-függvény"
 
 #: ../../src/Image.cpp:137
 #, c-format
 msgid "Failed to delete gnuplot data file %s"
-msgstr ""
+msgstr "Nem sikerült törölni a %s gnuplot adatfájlt"
 
 #: ../../src/Image.cpp:121 ../../src/Image.cpp:128
 #, c-format
 msgid "Failed to delete gnuplot file %s"
-msgstr ""
+msgstr "Nem sikerült törölni a gnuplot fájlt: %s"
 
 #: ../../src/wxMaxima.cpp:2667
 msgid "Failed to start Maxima"
-msgstr ""
+msgstr "Nem sikerült elindítani a Maximát"
 
 #: ../../src/wxMaximaFrame.cpp:1418
 msgid "Fast fortran routines that perform numerical tasks"
-msgstr ""
+msgstr "Gyors fortran rutinok, amelyek numerikus feladatokat hajtanak végre"
 
 #: ../../src/wxMaximaFrame.cpp:1922
 msgid "Fast list access"
-msgstr ""
+msgstr "Gyors lista elérés"
 
 #: ../../src/wxMaxima.cpp:2553
 msgid "Fatal error"
-msgstr ""
+msgstr "Végzetes hiba"
 
 #: ../../src/wxMaxima.cpp:7191
 msgid "Field contents:"
-msgstr ""
+msgstr "Mező tartalmak :"
 
 #: ../../src/wxMaxima.cpp:7198
 msgid "Field name:"
-msgstr ""
+msgstr "Mezőnév:"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "Fields:"
-msgstr ""
+msgstr "Mezők:"
 
 #: ../../src/main.cpp:439
 msgid "File"
-msgstr ""
+msgstr "Fájl"
 
 #: ../../src/wxMaximaFrame.cpp:1333
 msgid "File I/O"
-msgstr ""
+msgstr "Fájl I/O"
 
 #: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
 #: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
 #: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
 #: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
 msgid "File could not be opened"
-msgstr ""
+msgstr "A fájlt nem lehetett megnyitni"
 
 #: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
 #: ../../src/wxMaxima.cpp:7251
 msgid "File name:"
-msgstr ""
+msgstr "Fájlnév:"
 
 #: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
 msgid "File not found"
-msgstr ""
+msgstr "A fájl nem található"
 
 #: ../../src/wxMaxima.cpp:5631
 msgid "File opened"
-msgstr ""
+msgstr "Fájl megnyitva"
 
 #: ../../src/wxMaximaFrame.cpp:1217
 msgid "File operations"
-msgstr ""
+msgstr "Fájlműveletek"
 
 #: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
 msgid "File you tried to open does not exist."
-msgstr ""
+msgstr "A megnyitni próbált fájl nem található."
 
 #: ../../src/wxMaximaFrame.cpp:1221
 msgid "File/directory functions"
-msgstr ""
+msgstr "Fájl- és könyvtárműveletek"
 
 #: ../../src/wxMaxima.cpp:7027
 msgid "Filename or a list of comma-separated file names"
-msgstr ""
+msgstr "Fájlnév vagy vesszővel elválasztott fájlnevek listája"
 
 #: ../../src/ToolBar.cpp:222
 msgid "Find"
-msgstr ""
+msgstr "Keresés"
 
 #: ../../src/wxMaximaFrame.cpp:670
 msgid "Find\tCtrl+F"
-msgstr ""
+msgstr "Ke&resés...\tCtrl+F"
 
 #: ../../src/wxMaximaFrame.cpp:1468
 msgid "Find &Limit..."
-msgstr ""
+msgstr "&Határérték számolása..."
 
 #: ../../src/wxMaximaFrame.cpp:1470
 msgid "Find Minimum..."
-msgstr ""
+msgstr "&Minimum keresése..."
 
 #: ../../src/Worksheet.cpp:1576
 msgid "Find Root..."
-msgstr ""
+msgstr "Megoldás numerikusan..."
 
 #: ../../src/wxMaximaFrame.cpp:1471
 msgid "Find a (unconstrained) minimum of an expression"
-msgstr ""
+msgstr "Kifejezés minimumának meghatározása"
 
 #: ../../src/wxMaximaFrame.cpp:1804
 msgid "Find a fraction that represents this float exactly"
-msgstr ""
+msgstr "Keress egy törtet, amely pontosan reprezentálja ezt az úszót"
 
 #: ../../src/wxMaximaFrame.cpp:1469
 msgid "Find a limit of an expression"
-msgstr ""
+msgstr "Kifejezés határértékének számolása"
 
 #: ../../src/wxMaximaFrame.cpp:1807
 msgid "Find a nice fraction that is similar to this float"
-msgstr ""
+msgstr "Keress egy szép törtet, amely hasonló ehhez az úszóhoz"
 
 #: ../../src/wxMaximaFrame.cpp:1283
 msgid "Find a numerical solution for a first degree ODE"
 msgstr ""
+"Keressen numerikus megoldást egy elsőrendű közönséges differenciálegyenletre"
 
 #: ../../src/wxMaximaFrame.cpp:1252
 msgid "Find a root of an equation on an interval"
-msgstr ""
+msgstr "Egyenlet adott intervallumba eső gyökének meghatározása"
 
 #: ../../src/wxMaximaFrame.cpp:1259
 msgid "Find all roots of a polynomial"
-msgstr ""
+msgstr "Polinom összes gyökének meghatározása"
 
 #: ../../src/wxMaximaFrame.cpp:1262
 msgid "Find all roots of a polynomial (bfloat)"
-msgstr ""
+msgstr "Polinom összes gyökének meghatározása (bfloat)"
 
 #: ../../src/wxMaxima.cpp:6589
 msgid "Find and Replace"
-msgstr ""
+msgstr "Keresés és csere"
 
 #: ../../src/ToolBar.cpp:222 ../../src/wxMaximaFrame.cpp:670
 msgid "Find and replace"
-msgstr ""
+msgstr "Keresés és csere"
 
 #: ../../src/wxMaxima.cpp:7434
 msgid "Find char in string"
-msgstr ""
+msgstr "Keresse meg a karaktert a karakterláncban"
 
 #: ../../src/wxMaximaFrame.cpp:1172
 msgid "Find char in string..."
-msgstr ""
+msgstr "Karakter keresése a karakterláncban..."
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Find common denominator"
-msgstr ""
+msgstr "Találja meg a közös nevezőt"
 
 #: ../../src/wxMaximaFrame.cpp:1366
 msgid "Find eigenvalues of a matrix"
-msgstr ""
+msgstr "Mátrix sajátértékeinek kiszámolása"
 
 #: ../../src/wxMaximaFrame.cpp:1369
 msgid "Find eigenvectors of a matrix"
-msgstr ""
+msgstr "Mátrix sajátvektorainak kiszámolása"
 
 #: ../../src/wxMaxima.cpp:7424
 msgid "Find first difference"
-msgstr ""
+msgstr "Találja meg az első különbséget"
 
 #: ../../src/wxMaximaFrame.cpp:1170
 msgid "Find first difference..."
-msgstr ""
+msgstr "Találd meg az első különbséget..."
 
 #: ../../src/wxMaximaFrame.cpp:1256
 msgid "Find fractions that real roots of a polynomial and "
 msgstr ""
+"Keresse meg azokat a törteket, amelyek valódi gyökerei egy polinomnak és "
 
 #: ../../src/wxMaxima.cpp:9039
 msgid "Find minimum"
-msgstr ""
+msgstr "Minimum keresése"
 
 #: ../../src/wxMaximaFrame.cpp:1251
 msgid "Find numerical solution..."
-msgstr ""
+msgstr "Numerikus megoldás keresése..."
 
 #: ../../src/wxMaxima.cpp:10035
 msgid "Find root (solve numerically)"
-msgstr ""
+msgstr "Gyökér keresése (numerikus megoldás)"
 
 #: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
 msgid "Find the maximum absolute value of a matrix entry"
-msgstr ""
+msgstr "Meghatározza egy mátrix elemei abszolút értékeinek maximális értékét"
 
 #: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
 msgid "Find the maximum sum of the absolute values of a matrix column"
-msgstr ""
+msgstr "Keresse meg egy mátrixoszlop abszolút értékeinek maximális összegét"
 
 #: ../../src/wxMaxima.cpp:8073 ../../src/wxMaxima.cpp:8094
 msgid "Find the maximum sum of the absolute values of a matrix row"
-msgstr ""
+msgstr "Határozzuk meg egy mátrixsor abszolút értékeinek maximális összegét"
 
 #: ../../src/wxMaximaFrame.cpp:1832
 msgid "Fine-tune the display of engineering-format numbers"
-msgstr ""
+msgstr "A mérnöki formátumú számok megjelenítésének finomítása"
 
 #: ../../src/wxMaximaFrame.cpp:1712
 msgid "First"
-msgstr ""
+msgstr "Első"
 
 #: ../../src/wxMaximaFrame.cpp:1918
 msgid "Fitting curves to measurement data"
-msgstr ""
+msgstr "Görbék illesztése a mérési adatokhoz"
 
 #: ../../src/wxMaxima.cpp:7227
 msgid "Flush stream"
-msgstr ""
+msgstr "Öblítési folyam"
 
 #: ../../src/wxMaximaFrame.cpp:1103
 msgid "Flush..."
-msgstr ""
+msgstr "Öblítés..."
 
 #: ../../src/wxMaximaFrame.cpp:922
 msgid "Fold All\tCtrl+Alt+["
-msgstr ""
+msgstr "&Minden kiválasztása\tCtrl+Alt+["
 
 #: ../../src/wxMaximaFrame.cpp:923
 msgid "Fold all sections"
-msgstr ""
+msgstr "Minden fejezet elrejtése"
 
 #: ../../src/ToolBar.cpp:240
 msgid "Follow"
-msgstr ""
+msgstr "Követés"
 
 #: ../../src/ToolBar.cpp:285
 msgid ""
@@ -3118,123 +3219,135 @@ msgid ""
 "   Ctrl+6: Heading5 cell\n"
 "   Ctrl+7: Heading6 cell\n"
 msgstr ""
+"Cellák gyorsabb létrehozásához az alábbi billentyűkombinációk léteznek:\n"
+"\n"
+"   Ctrl+0: Matematika cella\n"
+"   Ctrl+1: Szövegcella\n"
+"   Ctrl+2: Címcella\n"
+"   Ctrl+3: Fejezet cella\n"
+"   Ctrl+4: Alfejezet cella\n"
+"   Ctrl+5: Al-alfejezet cella\n"
+"   Ctrl+6: 5.címcella\n"
+"   Ctrl+7: 6.címcella\n"
 
 #: ../../src/wxMaxima.cpp:7038
 msgid "For loop"
-msgstr ""
+msgstr "A hurokhoz"
 
 #: ../../src/wxMaximaFrame.cpp:1062
 msgid "For loop..."
-msgstr ""
+msgstr "A hurokhoz..."
 
 #: ../../src/Worksheet.cpp:237 ../../src/wxMaxima.cpp:11217
 msgid "Forwarding the keyboard focus to a text control"
-msgstr ""
+msgstr "A billentyűzet fókuszának továbbítása egy szöveges vezérlőre"
 
 #: ../../src/wxMaxima.cpp:11220
 msgid "Forwarding the keyboard focus to the worksheet"
-msgstr ""
+msgstr "A billentyűzet fókuszának továbbítása a munkalapra"
 
 #: ../../src/MaximaManual.cpp:452
 #, c-format
 msgid ""
 "Found %li anchors, URLs (individual files): %li, URLs (singlepage): %li"
-msgstr ""
+msgstr "%li horgony, URL-cím (egyedi fájlok): %li, URL-ek (egyoldalas): %li"
 
 #: ../../src/MaximaManual.cpp:313
 #, c-format
 msgid "Found only %li keywords in maxima's manual. Not caching them to disc."
 msgstr ""
+"Csak %li kulcsszót található a maxima kézikönyvében. Nem tárolja őket "
+"lemezre."
 
 #: ../../src/MaximaManual.cpp:513
 #, c-format
 msgid "Found the maxima HTML manual in the folder %s."
-msgstr ""
+msgstr "A maxima HTML kézikönyvet megtaláltam a %s mappában."
 
 #: ../../src/wxMaxima.cpp:8948
 msgid "Fourier coefficients"
-msgstr ""
+msgstr "Fourier-együtthatók"
 
 #: ../../src/wxMaximaFrame.cpp:1476
 msgid "Fourier coefficients..."
-msgstr ""
+msgstr "Fourier együtthatók..."
 
 #: ../../src/ToolBar.cpp:137
 #, c-format
 msgid "Frame %li of %li"
-msgstr ""
+msgstr "Képkocka: %li / %li"
 
 #: ../../src/wxMaxima.cpp:9097
 msgid "Frame rate"
-msgstr ""
+msgstr "Frameráta"
 
 #: ../../src/wxMaximaFrame.cpp:1005 ../../src/wxMaximaFrame.cpp:1009
 msgid "Free all unused items now"
-msgstr ""
+msgstr "Free all unused items now"
 
 #: ../../src/wxMaximaFrame.cpp:1413
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
-msgstr ""
+msgstr "Frobenius Norm sqrt(sum((A(i,j))^2)) (komplex)"
 
 #: ../../src/wxMaximaFrame.cpp:1411
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (real)"
-msgstr ""
+msgstr "Frobenius Norm sqrt(sum((A(i,j))^2)) (valós)"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "From:"
-msgstr ""
+msgstr "Mettől:"
 
 #: ../../src/wxMaximaFrame.cpp:827
 msgid "Full Screen\tAlt+Enter"
-msgstr ""
+msgstr "Teljes képernyő\tAlt+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:824
 msgid "Full Screen\tF11"
-msgstr ""
+msgstr "&Teljes képernyő\tF11"
 
 #: ../../src/wxMaxima.cpp:7140
 msgid "Function contents:"
-msgstr ""
+msgstr "Függvény tartalma:"
 
 #: ../../src/wxMaxima.cpp:7908
 msgid "Function f(x):"
-msgstr ""
+msgstr "Függvény f(x):"
 
 #: ../../src/wxMaxima.cpp:8572
 msgid "Function name"
-msgstr ""
+msgstr "Függvénynév"
 
 #: ../../src/wxMaxima.cpp:7167
 msgid "Function name(s):"
-msgstr ""
+msgstr "Függvényneve(k):"
 
 #: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
 msgid "Function name:"
-msgstr ""
+msgstr "Függvénynév:"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Function:"
-msgstr ""
+msgstr "Függvény:"
 
 #: ../../src/wxMaximaFrame.cpp:1630
 msgid "Functions for complex simplification"
-msgstr ""
+msgstr "Eljárások komplex átalakításokra"
 
 #: ../../src/wxMaximaFrame.cpp:1588
 msgid "Functions for simplifying factorials and gamma function"
-msgstr ""
+msgstr "Eljárások faktoriális- és gamma-függvény átalakításokra"
 
 #: ../../src/wxMaximaFrame.cpp:1606
 msgid "Functions for simplifying trigonometric expressions"
-msgstr ""
+msgstr "Eljárások trigonometrikus átalakításokra"
 
 #: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
 msgid "GCD"
-msgstr ""
+msgstr "Legnagyobb közös osztó"
 
 #: ../../src/wxMaxima.cpp:10186
 msgid "GIF image (*.gif)|*.gif"
-msgstr ""
+msgstr "GIF képfájl (*.gif)|*.gif"
 
 #: ../../src/Worksheet.cpp:103
 msgid ""
@@ -3242,169 +3355,180 @@ msgid ""
 " hotkeys to be broken, see for example "
 "https://trac.wxwidgets.org/ticket/18462."
 msgstr ""
+"A GTK_IM_MODULE \"xim\" értékre van állítva, és a GTK3 használatban van. Ha "
+"a program rettenetesen villog és a gyorsbillentyűk sem működnek, nézze meg "
+"ezt: https://trac.wxwidgets.org/ticket/18462."
 
 #: ../../src/wxMaximaFrame.cpp:295
 msgid "General Math"
-msgstr ""
+msgstr "Általános matematika"
 
 #: ../../src/wxMaximaFrame.cpp:699
 msgid "General Math\tAlt+Shift+M"
-msgstr ""
+msgstr "Általános matematika\tAlt+Shift+M"
 
 #: ../../src/wxMaximaFrame.cpp:1316
 msgid "Generate Matrix from Expression..."
-msgstr ""
+msgstr "Mátrix &generálása kifejezésből..."
 
 #: ../../src/wxMaximaFrame.cpp:1317
 msgid "Generate a matrix from a lambda expression"
-msgstr ""
+msgstr "Mátrix generálása kétdimenziós kifejezésből"
 
 #: ../../src/wxMaximaFrame.cpp:1675
 msgid "Generate a new list using a lists' elements"
-msgstr ""
+msgstr "Létrehoz egy új listát listaelemek használatával"
 
 #: ../../src/wxMaximaFrame.cpp:1681
 msgid ""
 "Generate a storage for variable values that can be introduced into equations"
 " at any time"
 msgstr ""
+"Tároló generálása olyan változóértékekhez, amelyeket bármikor beilleszthet "
+"az egyenletekbe"
 
 #: ../../src/wxMaximaFrame.cpp:1672
 msgid "Generate list elements using a rule"
-msgstr ""
+msgstr "Listaelemeket generál egy szabály használatával"
 
 #: ../../src/wxMaxima.cpp:8196
 msgid "Generate matrix from a rule"
-msgstr ""
+msgstr "Mátrix generálása kifejezésből"
 
 #: ../../src/wxMaximaFrame.cpp:1094
 msgid "Generate unused symbol name"
-msgstr ""
+msgstr "Nem használt szimbólumnév generálása"
 
 #: ../../src/WXMXformat.cpp:231
 msgid "Generated the XML representation of the document"
-msgstr ""
+msgstr "Létrehozta a dokumentum XML-reprezentációját"
 
 #: ../../src/wxMaxima.cpp:8197
 msgid ""
 "Generates a matrix and fills each element with the result of the expression "
 "\"Rule\"."
 msgstr ""
+"Mátrixot hoz létre, és minden elemét a \"Rule\" kifejezés értékével tölti "
+"ki."
 
 #: ../../src/wxMaximaFrame.cpp:1619
 msgid "Get &Imaginary Part"
-msgstr ""
+msgstr "&Képzetes rész"
 
 #: ../../src/wxMaximaFrame.cpp:1485
 msgid "Get Laplace transformation of an expression"
-msgstr ""
+msgstr "Kifejezés Laplace-transzformáltja"
 
 #: ../../src/wxMaximaFrame.cpp:1615
 msgid "Get Real P&art"
-msgstr ""
+msgstr "&Valós rész"
 
 #: ../../src/wxMaximaFrame.cpp:1201
 msgid "Get current directory"
-msgstr ""
+msgstr "Az aktuális könyvtár lekérése"
 
 #: ../../src/wxMaximaFrame.cpp:1489
 msgid "Get inverse Laplace transformation of an expression"
-msgstr ""
+msgstr "Kifejezés inverz Laplace-transzformáltja"
 
 #: ../../src/wxMaxima.cpp:7223
 msgid "Get position in stream"
-msgstr ""
+msgstr "Szerezzen pozíciót az adatfolyamban"
 
 #: ../../src/wxMaximaFrame.cpp:1102
 msgid "Get position..."
-msgstr ""
+msgstr "Helyezd el..."
 
 #: ../../src/wxMaximaFrame.cpp:1620
 msgid "Get the imaginary part of complex expression"
-msgstr ""
+msgstr "Komplex kifejezés képzetes része"
 
 #: ../../src/wxMaximaFrame.cpp:1616
 msgid "Get the real part of complex expression"
-msgstr ""
+msgstr "Komplex kifejezés valós része"
 
 #: ../../src/wxMaxima.cpp:3609
 #, c-format
 msgid "Gnuplot (command line) found at: %s"
-msgstr ""
+msgstr "A gnuplot (parancssor) itt található: %s"
 
 #: ../../src/wxMaxima.cpp:3607
 #, c-format
 msgid "Gnuplot found at: %s"
-msgstr ""
+msgstr "A Gnuplot a következő helyen található: %s"
 
 #: ../../src/wxMaxima.cpp:2974
 msgid "Gnuplot has closed."
-msgstr ""
+msgstr "A gnuplot leállt."
 
 #: ../../src/wxMaxima.cpp:3598 ../../src/wxMaxima.cpp:3603
 #, c-format
 msgid "Gnuplot not found, using the default: %s"
-msgstr ""
+msgstr "A Gnuplot nem található, az alapértelmezett: %s"
 
 #: ../../src/wxMaxima.cpp:9428 ../../src/wxMaximaFrame.cpp:1887
 msgid "Go to URL"
-msgstr ""
+msgstr "Ugrás az URL-re"
 
 #: ../../src/wxMaxima.cpp:3989
 msgid "Got a new input prompt!"
-msgstr ""
+msgstr "Új bemeneti prompt érkezett!"
 
 #: ../../src/Worksheet.cpp:6354
 msgid ""
 "Got a request to undo an action that involves a delete which isn't possible "
 "at this moment."
 msgstr ""
+"Kérés egy olyan esemény-visszavonásra, amely egy végrehajthatatlan törlést "
+"tartalmaz."
 
 #: ../../src/wxMaximaFrame.cpp:1031
 msgid "Gradefs"
-msgstr ""
+msgstr "Osztályok"
 
 #: ../../src/Worksheet.cpp:1967
 msgid "Greater or less than a value"
-msgstr ""
+msgstr "Nagyobb vagy egyenlő, mint az érték"
 
 #: ../../src/wxMaximaFrame.cpp:1130
 msgid "Greater, ignoring case?..."
-msgstr ""
+msgstr "Nagyobb, figyelmen kívül hagyva az esetet?..."
 
 #: ../../src/wxMaximaFrame.cpp:260
 msgid "Greek Letters"
-msgstr ""
+msgstr "Görög betűk"
 
 #: ../../src/wxMaximaFrame.cpp:703
 msgid "Greek Letters\tAlt+Shift+G"
-msgstr ""
+msgstr "Görög betűk\tAlt+Shift+G"
 
 #: ../../src/wxMaximaFrame.cpp:1815
 msgid "Guess an exact number that could be meant by this float"
-msgstr ""
+msgstr "Találj ki egy pontos számot, amit ez az úszó jelenthet"
 
 #: ../../src/wxMaxima.cpp:6123
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file "
 "(*.tex)|*.tex"
 msgstr ""
+"HTML fájl (*.html)|*.html|Maxima batch fájl (*.mac)|*.mac|LaTeX fájl "
+"(*.tex)|*.tex"
 
 #: ../../src/wxMaximaFrame.cpp:1341
 msgid "Hadamard (element-by-element) product..."
-msgstr ""
+msgstr "Hadamard (elemenkénti) szorzat..."
 
 #: ../../src/wxMaxima.cpp:8004
 msgid "Hadamard Product"
-msgstr ""
+msgstr "Hadamard szorzat"
 
 #: ../../src/wxMaxima.cpp:8011
 msgid "Hadamard exponent"
-msgstr ""
+msgstr "Hadamard kitevő"
 
 #: ../../src/wxMaximaFrame.cpp:1345
 msgid "Hadamard exponent..."
-msgstr ""
+msgstr "Hadamard kitevő..."
 
 #: ../../src/MaximaManual.cpp:260
 #, c-format
@@ -3412,119 +3536,121 @@ msgid ""
 "Have only %li keyword anchors at the end of parsing the maxima manual => Not"
 " caching the result of using the built-in keyword list"
 msgstr ""
+"Csak %li kulcsszó horgony legyen a maxima kézikönyv elemzésének végén => A "
+"beépített kulcsszólista használatának eredményének gyorsítótárazása"
 
 #: ../../src/Configuration.cpp:88 ../../src/ToolBar.cpp:276
 msgid "Heading 5"
-msgstr ""
+msgstr "5. cím"
 
 #: ../../src/Configuration.cpp:87 ../../src/ToolBar.cpp:277
 msgid "Heading 6"
-msgstr ""
+msgstr "6. cím"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
 msgid "Help"
-msgstr ""
+msgstr "Súgó"
 
 #: ../../src/ToolBar.cpp:635
 msgid "Help button"
-msgstr ""
+msgstr "Súgó gomb"
 
 #: ../../src/Worksheet.cpp:1340 ../../src/Worksheet.cpp:1778
 #, c-format
 msgid "Help on \"%s\""
-msgstr ""
+msgstr "Segítség itt: \"%s\""
 
 #: ../../src/wxMaximaFrame.cpp:729
 msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr ""
+msgstr "Összes eszköztár elrejtése\tAlt+Shift+-"
 
 #: ../../src/ToolBar.cpp:264
 msgid "Hide Code"
-msgstr ""
+msgstr "Kód elrejtése"
 
 #: ../../src/wxMaximaFrame.cpp:727
 msgid "Hide Code Cells\tAlt+Ctrl+H"
-msgstr ""
+msgstr "Kód cellák elrejtése\tAlt+Ctrl+H"
 
 #: ../../src/Worksheet.cpp:1896
 msgid "Hide Heading 5"
-msgstr ""
+msgstr "5. cím elrejtése"
 
 #: ../../src/Worksheet.cpp:1907
 msgid "Hide Heading 6"
-msgstr ""
+msgstr "6. cím elrejtése"
 
 #: ../../src/Worksheet.cpp:1855
 msgid "Hide Part"
-msgstr ""
+msgstr "Rész elrejtése"
 
 #: ../../src/Worksheet.cpp:1863
 msgid "Hide Section"
-msgstr ""
+msgstr "Fejezet elrejtése"
 
 #: ../../src/Worksheet.cpp:1874
 msgid "Hide Subsection"
-msgstr ""
+msgstr "Alfejezet elrejtése"
 
 #: ../../src/Worksheet.cpp:1885
 msgid "Hide Subsubsection"
-msgstr ""
+msgstr "Al-alfejezet elrejtése"
 
 #: ../../src/wxMaximaFrame.cpp:730
 msgid "Hide all panes"
-msgstr ""
+msgstr "Összes panel elrejtése"
 
 #: ../../src/Worksheet.cpp:1491
 msgid "Hide cell brackets"
-msgstr ""
+msgstr "Cellazárójelek elrejtése"
 
 #: ../../src/Worksheet.cpp:1915
 msgid "Hide contents"
-msgstr ""
+msgstr "Tartalmak elrejtése"
 
 #: ../../src/Worksheet.cpp:1552
 msgid "Hide multiplication dots"
-msgstr ""
+msgstr "Szorzásjelek elrejtése"
 
 #: ../../src/Worksheet.cpp:1930 ../../src/Worksheet.cpp:2063
 msgid "Hide yellow tooltip marker for this cell"
-msgstr ""
+msgstr "Elrejti a sárga eszköztipp-jelölőt ezen cella esetén"
 
 #: ../../src/Worksheet.cpp:1937 ../../src/Worksheet.cpp:2069
 msgid "Hide yellow tooltip marker for this message type"
-msgstr ""
+msgstr "Sárga eszköztipp-jelölő elrejtése ezen üzenettípus esetén"
 
 #: ../../src/Configuration.cpp:82
 msgid "Highlight (box)"
-msgstr ""
+msgstr "Kiemelés (doboz)"
 
 #: ../../src/wxMaxima.cpp:9528
 msgid "Histogram"
-msgstr ""
+msgstr "Hisztogram"
 
 #: ../../src/wxMaximaFrame.cpp:232
 msgid "History"
-msgstr ""
+msgstr "Előzmények"
 
 #: ../../src/wxMaximaFrame.cpp:709
 msgid "History\tAlt+Shift+I"
-msgstr ""
+msgstr "Előzmények\tAlt+Shift+I"
 
 #: ../../src/wxMaximaFrame.cpp:1526
 msgid "Horner's rule"
-msgstr ""
+msgstr "Horner szabálya"
 
 #: ../../src/wxMaxima.cpp:9207
 msgid "How many digits to show:"
-msgstr ""
+msgstr "Hány számjegyet kell megjeleníteni:"
 
 #: ../../src/wxMaximaFrame.cpp:759
 msgid "How to display new equations"
-msgstr ""
+msgstr "Új egyenletek hogyan legyenek megjelenítve"
 
 #: ../../src/wxMaximaFrame.cpp:1113
 msgid "I/O"
-msgstr ""
+msgstr "I/O"
 
 #: ../../src/wxMaxima.cpp:7062
 msgid ""
@@ -3532,6 +3658,9 @@ msgid ""
 "between parenthesis. The result of the last operation is the return value of"
 " the program."
 msgstr ""
+"Ha egy programnak nincs szüksége helyi változókra, a maxima lehetővé teszi a"
+" parancsok zárójelek közé helyezését. Az utolsó művelet eredménye a program "
+"visszatérési értéke."
 
 #: ../../src/wxMaxima.cpp:7172
 msgid ""
@@ -3540,511 +3669,533 @@ msgid ""
 "\n"
 "array, boolean, integer, fixnum (machine-length integer), float (machine-size floating-point numbers), real or any (which is useful for declaring arrays of any)"
 msgstr ""
+"Ha egy függvényparaméter típusa ismert a függvény összeállításakor, a kód nagymértékben optimalizálható.\n"
+"Ismert típusok:\n"
+"\n"
+"tömb, logikai érték, egész szám, fixnum (géphosszúságú egész szám), lebegőpontos (gépméretű lebegőpontos számok), valós vagy bármilyen (ami bármely tömb deklarálásához hasznos)"
 
 #: ../../src/MathParser.cpp:890
 msgid ""
 "If this isn't a function returning a lambda() expression a multiplication "
 "sign (*) between closing and opening parenthesis is missing here."
 msgstr ""
+"If this isn't a function returning a lambda() expression a multiplication "
 
 #: ../../src/MaximaManual.cpp:403
 msgid "Ignoring the cache version for the manual anchors."
-msgstr ""
+msgstr "A kézi horgonyok gyorsítótár verziójának figyelmen kívül hagyása."
 
 #: ../../src/Image.cpp:79
 msgid "Image data had zero length!"
-msgstr ""
+msgstr "Image data had zero length!"
 
 #: ../../src/wxMaxima.cpp:10147 ../../src/wxMaxima.cpp:10855
 msgid ""
 "Image files (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, "
 "*.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
 msgstr ""
+"Képfájlok ( *.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, *.svgz) | *.png; *. "
+"Jpg; *. Bmp; *. Xpm; *. gif;*. svg;*. svgz"
 
 #: ../../src/Worksheet.cpp:5509
 msgid "ImageCell without image."
-msgstr ""
+msgstr "ImageCell without image."
 
 #: ../../src/MathParser.cpp:347
 msgid "Importing compressed gnuplot sources for an animation"
-msgstr ""
+msgstr "Tömörített gnuplot források importálása animációhoz"
 
 #: ../../src/MathParser.cpp:334
 msgid "Importing uncompressed gnuplot sources for an animation"
-msgstr ""
+msgstr "Tömörítetlen gnuplot források importálása animációhoz"
 
 #: ../../src/wxMaxima.cpp:7993
 msgid ""
 "In order to save memory the \":\" operator does clone the matrix, not copy it:\n"
 "If you change an element of one matrix the same element will change in all of its clones. copymatrix() instead generates a copy of a matrix: A new matrix that, if changed in any way, won't change the original."
 msgstr ""
+"A memória megtakarítása érdekében a \":\" operátor klónozza a mátrixot, nem másolja:\n"
+"Ha megváltoztatja egy mátrix elemét, akkor ugyanaz az elem minden klónjában megváltozik. A copymatrix() ehelyett egy mátrix másolatát állítja elő: Egy új mátrix, amely bármilyen módon módosítva nem változtatja meg az eredetit."
 
 #: ../../src/wxMaxima.cpp:7404
 msgid ""
 "In order to save memory the : operator doesn't create an individual copy of "
 "the string, but a clone that changes when the original string changes."
 msgstr ""
+"A memória megtakarítása érdekében a : operátor nem egyedi másolatot hoz "
+"létre a karakterláncról, hanem egy klónt, amely az eredeti karakterlánc "
+"megváltozásakor változik."
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Include columns:"
-msgstr ""
+msgstr "Tartalmazott oszlopok:"
 
 #: ../../src/Worksheet.cpp:2008
 msgid "Increasing function f(x)>x"
-msgstr ""
+msgstr "Növelő f(x)>x függvény"
 
 #: ../../src/wxMaxima.cpp:8470
 msgid "Index End:"
-msgstr ""
+msgstr "Index vége:"
 
 #: ../../src/wxMaxima.cpp:8470
 msgid "Index Start:"
-msgstr ""
+msgstr "Index kezdete:"
 
 #: ../../src/wxMaxima.cpp:8471
 msgid "Index Step:"
-msgstr ""
+msgstr "Index lépés:"
 
 #: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
 msgid "Index variable:"
-msgstr ""
+msgstr "Index változó:"
 
 #: ../../src/wxMaximaFrame.cpp:1949
 msgid "Info about Maxima build"
-msgstr ""
+msgstr "Információ a Maxima fordításáról"
 
 #: ../../src/Worksheet.cpp:2046
 msgid "Inform maxima about facts you know for this symbol"
 msgstr ""
+"Tájékoztassa a maximumot azokról a tényekről, amelyeket erről a szimbólumról"
+" tud"
 
 #: ../../src/Worksheet.cpp:1988
 msgid ""
 "Inform maxima about the value of the function at a specific point, e.G. for "
 "declaring initial conditions"
 msgstr ""
+"Tájékoztassa a maximumokat a függvény értékéről egy adott pontban, pl. "
+"kezdeti feltételek bejelentésére"
 
 #: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
 msgid "Initial Condition"
-msgstr ""
+msgstr "Kezdeti Feltétel"
 
 #: ../../src/wxMaximaFrame.cpp:1270
 msgid "Initial Value Problem (&1)..."
-msgstr ""
+msgstr "Kezdetiérték-probléma (&1)..."
 
 #: ../../src/wxMaximaFrame.cpp:1274
 msgid "Initial Value Problem (&2)..."
-msgstr ""
+msgstr "Kezdetiérték-probléma (&2)..."
 
 #: ../../src/wxMaxima.cpp:9044
 msgid "Initial estimates:"
-msgstr ""
+msgstr "Kezdeti becslések:"
 
 #: ../../src/wxMaxima.cpp:7840
 msgid "Initial x:"
-msgstr ""
+msgstr "Kezdeti x:"
 
 #: ../../src/Configuration.cpp:78
 msgid "Input labels"
-msgstr ""
+msgstr "Bemeneti címkék"
 
 #: ../../src/wxMaximaFrame.cpp:314
 msgid "Insert"
-msgstr ""
+msgstr "Beszúrás"
 
 #: ../../src/wxMaximaFrame.cpp:905
 msgid "Insert &Section Cell\tCtrl+3"
-msgstr ""
+msgstr "&Fejezetcella beszúrása\tCtrl+3"
 
 #: ../../src/wxMaximaFrame.cpp:901
 msgid "Insert &Text Cell\tCtrl+1"
-msgstr ""
+msgstr "&Szövegcella beszúrása\tCtrl+1"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Insert Cell\tAlt+Shift+C"
-msgstr ""
+msgstr "Cella beillesztése\tAlt+Shift+C"
 
 #: ../../src/Worksheet.cpp:1669
 msgid "Insert Heading5 Cell"
-msgstr ""
+msgstr "5. cím beszúrása"
 
 #: ../../src/Worksheet.cpp:1671
 msgid "Insert Heading6 Cell"
-msgstr ""
+msgstr "6. cím beszúrása"
 
 #: ../../src/wxMaxima.cpp:10854
 msgid "Insert Image"
-msgstr ""
+msgstr "Kép beszúrása"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert Image..."
-msgstr ""
+msgstr "Kép beszú&rása..."
 
 #: ../../src/wxMaximaFrame.cpp:899
 msgid "Insert Input &Cell\tCtrl+0"
-msgstr ""
+msgstr "&Bemeneti cella beszúrása\tCtrl+0"
 
 #: ../../src/wxMaximaFrame.cpp:919
 msgid "Insert Page Break"
-msgstr ""
+msgstr "La&ptörés beszúrása"
 
 #: ../../src/wxMaximaFrame.cpp:907
 msgid "Insert S&ubsection Cell\tCtrl+4"
-msgstr ""
+msgstr "&Alfejezetcella beszúrása\tCtrl+4"
 
 #: ../../src/wxMaximaFrame.cpp:910
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
-msgstr ""
+msgstr "&Al-alfejezetcella beszúrása\tCtrl+5"
 
 #: ../../src/Worksheet.cpp:1662
 msgid "Insert Section Cell"
-msgstr ""
+msgstr "&Fejezetcella beszúrása"
 
 #: ../../src/Worksheet.cpp:1664
 msgid "Insert Subsection Cell"
-msgstr ""
+msgstr "&Alfejezetcella beszúrása"
 
 #: ../../src/Worksheet.cpp:1667
 msgid "Insert Subsubsection Cell"
-msgstr ""
+msgstr "&Al-alfejezetcella beszúrása"
 
 #: ../../src/wxMaximaFrame.cpp:903
 msgid "Insert T&itle Cell\tCtrl+2"
-msgstr ""
+msgstr "&Címcella beszúrása\tCtrl+2"
 
 #: ../../src/Worksheet.cpp:1658
 msgid "Insert Text Cell"
-msgstr ""
+msgstr "&Szövegcella beszúrása"
 
 #: ../../src/Worksheet.cpp:1660
 msgid "Insert Title Cell"
-msgstr ""
+msgstr "&Címcella beszúrása"
 
 #: ../../src/wxMaximaFrame.cpp:913
 msgid "Insert a new heading5 cell"
-msgstr ""
+msgstr "Egy új 5. címcella beszúrása"
 
 #: ../../src/wxMaximaFrame.cpp:915
 msgid "Insert a new heading6 cell"
-msgstr ""
+msgstr "Egy új címsor cella beszúrása"
 
 #: ../../src/wxMaximaFrame.cpp:900
 msgid "Insert a new input cell"
-msgstr ""
+msgstr "Új bemeneti cella beszúrása"
 
 #: ../../src/wxMaximaFrame.cpp:906
 msgid "Insert a new section cell"
-msgstr ""
+msgstr "Új fejezetcella beszúrása"
 
 #: ../../src/wxMaximaFrame.cpp:908
 msgid "Insert a new subsection cell"
-msgstr ""
+msgstr "Új alfejezetcella beszúrása"
 
 #: ../../src/wxMaximaFrame.cpp:911
 msgid "Insert a new subsubsection cell"
-msgstr ""
+msgstr "Új al-alfejezetcella beszúrása"
 
 #: ../../src/wxMaximaFrame.cpp:902
 msgid "Insert a new text cell"
-msgstr ""
+msgstr "Új szövegcella beszúrása"
 
 #: ../../src/wxMaximaFrame.cpp:904
 msgid "Insert a new title cell"
-msgstr ""
+msgstr "Új címcella beszúrása"
 
 #: ../../src/wxMaximaFrame.cpp:920
 msgid "Insert a page break"
-msgstr ""
+msgstr "Laptörés beszúrása"
 
 #: ../../src/wxMaximaFrame.cpp:1164
 msgid "Insert char..."
-msgstr ""
+msgstr "Karakter beszúrása..."
 
 #: ../../src/wxMaximaFrame.cpp:912
 msgid "Insert heading5 Cell\tCtrl+6"
-msgstr ""
+msgstr "5. címcella beszúrása\tCtrl+6"
 
 #: ../../src/wxMaximaFrame.cpp:914
 msgid "Insert heading6 Cell\tCtrl+7"
-msgstr ""
+msgstr "6. címcella beszúrása\tCtrl+7"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert image"
-msgstr ""
+msgstr "Kép beszúrása"
 
 #: ../../src/wxMaximaFrame.cpp:916
 msgid "Insert textbased cell"
-msgstr ""
+msgstr "Szövegcella beszúrása"
 
 #: ../../src/wxMaxima.cpp:3566
 msgid "Instructed to prefer gnuplot over wgnuplot"
-msgstr ""
+msgstr "Instructed to prefer gnuplot over wgnuplot"
 
 #: ../../src/wxMaxima.cpp:3554
 msgid "Instructed to prefer wgnuplot over gnuplot"
-msgstr ""
+msgstr "Instructed to prefer wgnuplot over gnuplot"
 
 #: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
 msgid "Integral/Sum:"
-msgstr ""
+msgstr "Integrál/összeg:"
 
 #: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
 msgid "Integrate"
-msgstr ""
+msgstr "Integrál"
 
 #: ../../src/wxMaxima.cpp:8980
 msgid "Integrate (risch)"
-msgstr ""
+msgstr "Integrál (Risch)"
 
 #: ../../src/wxMaximaFrame.cpp:1454
 msgid "Integrate expression"
-msgstr ""
+msgstr "Függvény integrálása"
 
 #: ../../src/wxMaximaFrame.cpp:1456
 msgid "Integrate expression with Risch algorithm"
-msgstr ""
+msgstr "Függvény integrálása Risch-algoritmussal"
 
 #: ../../src/wxMaximaFrame.cpp:1869
 msgid "Integrate numerically"
-msgstr ""
+msgstr "Numerikus Integrálás"
 
 #: ../../src/Worksheet.cpp:1588
 msgid "Integrate..."
-msgstr ""
+msgstr "Integrál..."
 
 #: ../../src/wxMaximaFrame.cpp:1737
 msgid "Interleave"
-msgstr ""
+msgstr "Beillesztés"
 
 #: ../../src/wxMaximaFrame.cpp:1738
 msgid "Interleave the values of two lists"
-msgstr ""
+msgstr "Két lista értékeinek beillesztése"
 
 #: ../../src/wxMaxima.cpp:8612
 msgid "Interleave two lists"
-msgstr ""
+msgstr "Két lista beillesztése"
 
 #: ../../src/wxMaximaFrame.cpp:1087
 msgid "Interpret like input..."
-msgstr ""
+msgstr "Értelmezze úgy, mint a bemenet..."
 
 #: ../../src/wxMaxima.cpp:7104
 msgid "Interpret maxima's output as input"
-msgstr ""
+msgstr "A maxima kimenetét értelmezi bemenetként"
 
 #: ../../src/wxMaxima.cpp:7502
 msgid "Interpret string as maxima code"
-msgstr ""
+msgstr "A karakterláncot maxima kódként értelmezi"
 
 #: ../../src/wxMaximaFrame.cpp:1089
 msgid "Interpret string..."
-msgstr ""
+msgstr "Karakterlánc értelmezése..."
 
 #: ../../src/ToolBar.cpp:231
 msgid "Interrupt"
-msgstr ""
+msgstr "Megszakítás"
 
 #: ../../src/wxMaximaFrame.cpp:965
 msgid "Interrupt current computation"
-msgstr ""
+msgstr "Jelenlegi számítás megszakítása"
 
 #: ../../src/ToolBar.cpp:232
 msgid ""
 "Interrupt current computation. To completely restart maxima press the button"
 " left to this one."
 msgstr ""
+"Az aktuális művelet megszakadt. A Maxima teljes újraindításához nyomja meg "
+"az alábbi gombot."
 
 #: ../../src/wxMaxima.cpp:2766
 #, c-format
 msgid "Interrupting maxima: %s"
-msgstr ""
+msgstr "Maxima megszakítása: %s"
 
 #: ../../src/wxMaxima.cpp:8557
 msgid "Introduce a list of actual values into an equation"
-msgstr ""
+msgstr "Aktuális értékek listájának megadása egy egyenletbe"
 
 #: ../../src/wxMaximaFrame.cpp:1697
 msgid "Introduce the actual values for variables stored in the list"
-msgstr ""
+msgstr "Változók aktuális értékeinek tárolása listába"
 
 #: ../../src/wxMaxima.cpp:10062
 msgid "Introduces one or more assignments into an expression"
-msgstr ""
+msgstr "Egy vagy több hozzárendelést visz be egy kifejezésbe"
 
 #: ../../src/wxMaxima.cpp:9003
 msgid "Inverse Laplace"
-msgstr ""
+msgstr "Inverz Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1488
 msgid "Inverse Laplace T&ransform..."
-msgstr ""
+msgstr "I&nverz Laplace-transzformáció..."
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Invert worksheet brightness"
-msgstr ""
+msgstr "A munkalap fényerejének invertálása"
 
 #: ../../src/wxMaxima.cpp:7338
 msgid "Is Char 1 greater than Char2, if case is ignored?"
 msgstr ""
+"A Char 1 nagyobb, mint a Char2, ha figyelmen kívül hagyja a kis- és "
+"nagybetűket?"
 
 #: ../../src/wxMaxima.cpp:7333
 msgid "Is Char 1 greater than Char2?"
-msgstr ""
+msgstr "A Char 1 nagyobb, mint a Char2?"
 
 #: ../../src/wxMaxima.cpp:7327
 msgid "Is Char 1 less than Char2, if case is ignored?"
 msgstr ""
+"Az 1. karakter kisebb, mint a Char2, ha figyelmen kívül hagyja a kis- és "
+"nagybetűket?"
 
 #: ../../src/wxMaxima.cpp:7322
 msgid "Is Char 1 less than Char2?"
-msgstr ""
+msgstr "Az Char1  kisebb, mint a Char2?"
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Is a char?"
-msgstr ""
+msgstr "Egy char?"
 
 #: ../../src/wxMaximaFrame.cpp:1115
 msgid "Is a char?..."
-msgstr ""
+msgstr "Egy karakter?..."
 
 #: ../../src/Worksheet.cpp:1952
 msgid "Is a complex variable"
-msgstr ""
+msgstr "Komplex változó"
 
 #: ../../src/wxMaxima.cpp:7292
 msgid "Is a digit?"
-msgstr ""
+msgstr "Számjegy?"
 
 #: ../../src/wxMaximaFrame.cpp:1118
 msgid "Is a digit?..."
-msgstr ""
+msgstr "Egy számjegy?..."
 
 #: ../../src/wxMaxima.cpp:7304
 msgid "Is a lowercase char?"
-msgstr ""
+msgstr "Kisbetűs karakter?"
 
 #: ../../src/wxMaxima.cpp:7296
 msgid "Is a printable char?"
-msgstr ""
+msgstr "Nyomtatható karakter?"
 
 #: ../../src/Worksheet.cpp:1949
 msgid "Is a real variable"
-msgstr ""
+msgstr "Valós változó"
 
 #: ../../src/wxMaxima.cpp:7300
 msgid "Is a uppercase char?"
-msgstr ""
+msgstr "Nagybetűs karakter?"
 
 #: ../../src/wxMaximaFrame.cpp:1116
 msgid "Is alphabetic?..."
-msgstr ""
+msgstr "ABC?..."
 
 #: ../../src/wxMaximaFrame.cpp:1117
 msgid "Is alphanumeric?..."
-msgstr ""
+msgstr "Alfanumerikus?..."
 
 #: ../../src/wxMaxima.cpp:7284
 msgid "Is an alphabetic char?"
-msgstr ""
+msgstr "Egy alfabetikus karakter?"
 
 #: ../../src/wxMaxima.cpp:7288
 msgid "Is an alphanumeric char?"
-msgstr ""
+msgstr "Alfanumerikus karakter?"
 
 #: ../../src/Worksheet.cpp:1991
 msgid "Is an even function"
-msgstr ""
+msgstr "Páros függvény"
 
 #: ../../src/Worksheet.cpp:1955
 msgid "Is an imaginary variable"
-msgstr ""
+msgstr "Képzetes változó"
 
 #: ../../src/Worksheet.cpp:1960
 msgid "Is an integer variable"
-msgstr ""
+msgstr "Egész változó"
 
 #: ../../src/Worksheet.cpp:1993
 msgid "Is an odd function"
-msgstr ""
+msgstr "Páratlan függvény"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Is equal?..."
-msgstr ""
+msgstr "Egyenlő?..."
 
 #: ../../src/wxMaximaFrame.cpp:1128
 msgid "Is greater?..."
-msgstr ""
+msgstr "Nagyobb?..."
 
 #: ../../src/wxMaximaFrame.cpp:1125
 msgid "Is lower?..."
-msgstr ""
+msgstr "Alacsonyabb?..."
 
 #: ../../src/wxMaximaFrame.cpp:1121
 msgid "Is lowercase?..."
-msgstr ""
+msgstr "Kisbetűk?..."
 
 #: ../../src/Worksheet.cpp:1962
 msgid "Is no integer variable"
-msgstr ""
+msgstr "Nem egész szám változó"
 
 #: ../../src/wxMaximaFrame.cpp:1119
 msgid "Is printable?..."
-msgstr ""
+msgstr "Nyomtatható?..."
 
 #: ../../src/wxMaximaFrame.cpp:1120
 msgid "Is uppercase?..."
-msgstr ""
+msgstr "Nagybetűk?..."
 
 #: ../../src/Worksheet.cpp:6256
 msgid "Issuing the active cell's undo function"
-msgstr ""
+msgstr "Issuing the active cella's undo function"
 
 #: ../../src/Worksheet.cpp:6261
 msgid "Issuing the worksheet's undo function"
-msgstr ""
+msgstr "Issuing the worksheet's undo function"
 
 #: ../../src/wxMaxima.cpp:8598 ../../src/wxMaxima.cpp:8604
 msgid "Item"
-msgstr ""
+msgstr "Elem"
 
 #: ../../src/wxMaxima.cpp:8581
 msgid "Iterator name:"
-msgstr ""
+msgstr "Az iterátor neve:"
 
 #: ../../src/wxMaximaFrame.cpp:1048
 msgid "Jump to first error"
-msgstr ""
+msgstr "Ugrás az első hibára"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Jump to the first cell Maxima has reported an error in."
-msgstr ""
+msgstr "Ugrás az első cellába, amelyben a maxima hibát jelentett."
 
 #: ../../src/wxMaxima.cpp:8960
 msgid "LCM"
-msgstr ""
+msgstr "Legkisebb közös többszörös"
 
 #: ../../src/wxMaximaFrame.cpp:1407
 msgid "L[1] Norm (complex)"
-msgstr ""
+msgstr "L[1] Norm (komplex)"
 
 #: ../../src/wxMaximaFrame.cpp:1406
 msgid "L[1] Norm (real)"
-msgstr ""
+msgstr "L[1] Norm (valós)"
 
 #: ../../src/wxMaximaFrame.cpp:1409
 msgid "L[inf] Norm (complex)"
-msgstr ""
+msgstr "L[inf] Norm (komplex)"
 
 #: ../../src/wxMaximaFrame.cpp:1408
 msgid "L[inf] Norm (real)"
-msgstr ""
+msgstr "L[inf] Norm (valódi)"
 
 #: ../../src/wxMaximaFrame.cpp:1025
 msgid "Labels"
-msgstr ""
+msgstr "Címkék"
 
 #: ../../src/wxMaxima.cpp:7090
 msgid "Lambda"
-msgstr ""
+msgstr "Lambda"
 
 #: ../../src/wxMaxima.cpp:7091
 msgid ""
@@ -4052,275 +4203,283 @@ msgid ""
 "This is useful if you want to use a function only once, perhaps as a parameter to another function and don't need it to be named.\n"
 "Also you can fill a variable with a lambda() construct, effectively generating a function pointer: A variable that can be used as a function, and filled with a different function, if needed."
 msgstr ""
+"A lambda létrehoz egy függvényt, de nem ad neki nevet.\\n Ez akkor hasznos, "
+"ha egy függvényt csak egyszer akarsz használni, esetleg egy másik függvény "
+"paramétereként, és nincs szükséged arra, hogy nevet kapjon.\\n Egy változót "
+"is kitölthetsz egy lambda() konstrukcióval, így gyakorlatilag egy "
+"függvénymutatót generálsz: Egy változó, amely függvényként használható, és "
+"szükség esetén egy másik függvénnyel tölthető fel."
 
 #: ../../src/wxMaxima.cpp:8997
 msgid "Laplace"
-msgstr ""
+msgstr "Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1484
 msgid "Laplace &Transform..."
-msgstr ""
+msgstr "L&aplace-transzformáció..."
 
 #: ../../src/wxMaximaFrame.cpp:1718
 msgid "Last"
-msgstr ""
+msgstr "Utolsó"
 
 #: ../../src/wxMaxima.cpp:3006
 #, c-format
 msgid "Last message from maxima's stderr: %s"
-msgstr ""
+msgstr "Maxima stderrjének utolsó üzenete: %s"
 
 #: ../../src/wxMaxima.cpp:2993
 #, c-format
 msgid "Last message from maxima's stdout: %s"
-msgstr ""
+msgstr "A maxima stdout utolsó üzenete: %s"
 
 #: ../../src/wxMaximaFrame.cpp:1720
 msgid "Last n"
-msgstr ""
+msgstr "Utolsó n"
 
 #: ../../src/wxMaxima.cpp:10400
 msgid "Last non-whitespace is a question mark"
-msgstr ""
+msgstr "Az utolsó nem szóköz kérdőjel"
 
 #: ../../src/wxMaxima.cpp:4899
 #, c-format
 msgid "Launching the system's default help browser as %s."
-msgstr ""
+msgstr "A rendszer alapértelmezett súgóböngészőjének elindítása %s néven."
 
 #: ../../src/wxMaxima.cpp:4909
 msgid "Launching the system's default help browser failed."
-msgstr ""
+msgstr "A rendszer alapértelmezett súgóböngészőjének elindítása nem sikerült."
 
 #: ../../src/wxMaximaFrame.cpp:1493
 msgid "Least Common Multiple..."
-msgstr ""
+msgstr "L&egkisebb közös többszörös..."
 
 #: ../../src/wxMaxima.cpp:9587
 msgid "Least Squares Fit"
-msgstr ""
+msgstr "Legkisebb négyzetes közelítés"
 
 #: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
 #: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
 msgid "Left Matrix:"
-msgstr ""
+msgstr "Bal mátrix:"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Left end"
-msgstr ""
+msgstr "Bal vége"
 
 #: ../../src/wxMaximaFrame.cpp:1297
 msgid "Left side to the \"=\""
-msgstr ""
+msgstr "A \"=\" bal oldala"
 
 #: ../../src/wxMaximaFrame.cpp:1741
 msgid "Length"
-msgstr ""
+msgstr "Hossz"
 
 #: ../../src/wxMaximaFrame.cpp:1104 ../../src/wxMaximaFrame.cpp:1167
 msgid "Length..."
-msgstr ""
+msgstr "Hossz..."
 
 #: ../../src/wxMaxima.cpp:7421
 msgid "Length:"
-msgstr ""
+msgstr "Hossz:"
 
 #: ../../src/wxMaximaFrame.cpp:1032
 msgid "Letrules"
-msgstr ""
+msgstr "Letrules"
 
 #: ../../src/Worksheet.cpp:1976
 msgid "Likely to be the main variable"
-msgstr ""
+msgstr "Valószínűleg ez a fő változó"
 
 #: ../../src/wxMaxima.cpp:9028
 msgid "Limit"
-msgstr ""
+msgstr "Határérték"
 
 #: ../../src/wxMaxima.cpp:7256
 msgid "Lisp format string:"
-msgstr ""
+msgstr "Lisp formátumú karakterlánc:"
 
 #: ../../src/wxMaxima.cpp:7258
 msgid "Lisp format strings are more powerful than c++ format strings"
 msgstr ""
+"A Lisp formátumú karakterláncok erősebbek, mint a c formátumú karakterláncok"
 
 #: ../../src/wxMaxima.cpp:5066
 msgid "Lisp mode."
-msgstr ""
+msgstr "Lisp mód."
 
 #: ../../src/wxMaximaFrame.cpp:1010 ../../src/wxMaximaFrame.cpp:1012
 msgid "Lisp normally frees memory only when it has time or runs out of space"
-msgstr ""
+msgstr "Lisp normally frees memory only when it has time or runs out of space"
 
 #: ../../src/wxMaxima.cpp:3691
 #, c-format
 msgid "Lisp version: %s"
-msgstr ""
+msgstr "Lisp verzió: %s"
 
 #: ../../src/wxMaxima.cpp:8435 ../../src/wxMaxima.cpp:8539
 #: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
 #: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
 #: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
 msgid "List"
-msgstr ""
+msgstr "Lista"
 
 #: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
 msgid "List #1"
-msgstr ""
+msgstr "1. lista"
 
 #: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
 msgid "List #2"
-msgstr ""
+msgstr "2. lista"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "List directory"
-msgstr ""
+msgstr "Lista könyvtár"
 
 #: ../../src/wxMaximaFrame.cpp:1205
 msgid "List directory..."
-msgstr ""
+msgstr "Lista könyvtár..."
 
 #: ../../src/wxMaxima.cpp:7385 ../../src/wxMaxima.cpp:7389
 msgid "List of char to String"
-msgstr ""
+msgstr "Karakterek listája karakterláncba"
 
 #: ../../src/wxMaximaFrame.cpp:1150
 msgid "List of chars to string..."
-msgstr ""
+msgstr "Karakterek listája karakterláncba..."
 
 #: ../../src/wxMaxima.cpp:7386
 msgid "List of chars:"
-msgstr ""
+msgstr "Karakterek listája:"
 
 #: ../../src/wxMaxima.cpp:8559
 msgid "List with values"
-msgstr ""
+msgstr "Lista értékekkel"
 
 #: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
 msgid "List:"
-msgstr ""
+msgstr "Erre a listára:"
 
 #: ../../src/wxMaxima.cpp:6200
 msgid "Load Package"
-msgstr ""
+msgstr "Csomag betöltése"
 
 #: ../../src/wxMaximaFrame.cpp:613
 msgid "Load Recent Package"
-msgstr ""
+msgstr "Aktuális csomag betöltése"
 
 #: ../../src/wxMaximaFrame.cpp:616
 msgid "Load a Maxima file using the batch command"
-msgstr ""
+msgstr "Batch parancsokat használó Maxima fájl betöltése"
 
 #: ../../src/wxMaximaFrame.cpp:611
 msgid "Load a Maxima package file"
-msgstr ""
+msgstr "Maxima csomagfájl betöltése"
 
 #: ../../src/wxMaximaFrame.cpp:1678
 msgid "Load a list from a csv file"
-msgstr ""
+msgstr "Lista betöltése csv fájlból"
 
 #: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
 msgid "Load a matrix from a csv file"
-msgstr ""
+msgstr "Mátrix betöltése csv fájlból"
 
 #: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
 msgid "Load lapack"
-msgstr ""
+msgstr "Lapack betöltése"
 
 #: ../../src/wxMaxima.cpp:7208
 msgid "Load lisp code"
-msgstr ""
+msgstr "Lisp kód betöltése"
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "Load lisp..."
-msgstr ""
+msgstr "Lisp betöltése..."
 
 #: ../../src/wxMaximaFrame.cpp:1198
 msgid "Load the file/dir operations (operatingsystem)"
-msgstr ""
+msgstr "Fájl- és könyvtárműveletek betöltése (operatingsystem)"
 
 #: ../../src/wxMaximaFrame.cpp:1187
 msgid "Load the regular expression package (sregex)"
-msgstr ""
+msgstr "A reguláris kifejezések csomag betöltése (sregex)"
 
 #: ../../src/wxMaximaFrame.cpp:1224
 msgid "Load the translation generator (gentran)"
-msgstr ""
+msgstr "A fordításgenerátor betöltése (gentran)"
 
 #: ../../src/wxMaxima.cpp:8219
 msgid "Loop variable"
-msgstr ""
+msgstr "Hurok változó"
 
 #: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
 msgid "Lower bound:"
-msgstr ""
+msgstr "Alsó végpont:"
 
 #: ../../src/wxMaximaFrame.cpp:1127
 msgid "Lower, ignoring case?..."
-msgstr ""
+msgstr "Lejjebb, figyelmen kívül hagyja a kis- és nagybetűket?..."
 
 #: ../../src/wxMaximaFrame.cpp:1448
 msgid "M&atrix"
-msgstr ""
+msgstr "M&átrix"
 
 #: ../../src/wxMaxima.cpp:7153
 msgid "Macro contents:"
-msgstr ""
+msgstr "Makró tartalmak:"
 
 #: ../../src/wxMaxima.cpp:7148
 msgid "Macro name:"
-msgstr ""
+msgstr "Makró név:"
 
 #: ../../src/wxMaximaFrame.cpp:1024
 msgid "Macros"
-msgstr ""
+msgstr "Makrók"
 
 #: ../../src/wxMaximaFrame.cpp:697
 msgid "Main Toolbar\tAlt+Shift+B"
-msgstr ""
+msgstr "Fő eszköztár\tAlt+Shift+B"
 
 #: ../../src/wxMaxima.cpp:7906
 msgid "Make a function value at a specific point known"
-msgstr ""
+msgstr "Tegyen ismertté egy függvényértéket egy adott pontban"
 
 #: ../../src/Worksheet.cpp:2028
 msgid "Make an eventual ev() evaluate this"
-msgstr ""
+msgstr "Egy esetleges ev() kiértékeli ezt"
 
 #: ../../src/wxMaximaFrame.cpp:1070
 msgid "Make function local..."
-msgstr ""
+msgstr "Lokális függvény létrehozása..."
 
 #: ../../src/wxMaxima.cpp:8207
 msgid "Map"
-msgstr ""
+msgstr "Leképezés"
 
 #: ../../src/wxMaxima.cpp:8215
 msgid "Map an expression"
-msgstr ""
+msgstr "Térképezzen fel egy kifejezést"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "Map function to a matrix"
-msgstr ""
+msgstr "Mátrix leképezése mátrixba"
 
 #: ../../src/wxMaximaFrame.cpp:1446
 msgid "Map function to a matrix, affecting all of its clones"
 msgstr ""
+"Függvény leképezése egy mátrixba, amely hatással van annak összes klónjára"
 
 #: ../../src/Configuration.cpp:109
 msgid "Math Default"
-msgstr ""
+msgstr "Alapértelmezett matematika"
 
 #: ../../src/wxMaximaFrame.cpp:286
 msgid "Mathematical Symbols"
-msgstr ""
+msgstr "Matematikai szimbólumok"
 
 #: ../../src/ToolBar.cpp:270
 msgid "Maths"
-msgstr ""
+msgstr "Matematika"
 
 #: ../../src/wxMaxima.cpp:7945 ../../src/wxMaxima.cpp:8022
 #: ../../src/wxMaxima.cpp:8027 ../../src/wxMaxima.cpp:8032
@@ -4332,54 +4491,54 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
 #: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
 msgid "Matrix"
-msgstr ""
+msgstr "Mátrix"
 
 #: ../../src/wxMaxima.cpp:7986
 msgid "Matrix Exponent"
-msgstr ""
+msgstr "Mátrix hatványa"
 
 #: ../../src/wxMaximaFrame.cpp:1339
 msgid "Matrix exponent..."
-msgstr ""
+msgstr "Mátrix hatványa..."
 
 #: ../../src/wxMaximaFrame.cpp:1329
 msgid "Matrix from csv file"
-msgstr ""
+msgstr "Mátrix csv fájlból"
 
 #: ../../src/wxMaximaFrame.cpp:1323
 msgid "Matrix from csv file..."
-msgstr ""
+msgstr "Mátrix csv fájlból..."
 
 #: ../../src/wxMaxima.cpp:8137
 msgid "Matrix map"
-msgstr ""
+msgstr "Mátrix leképezés"
 
 #: ../../src/wxMaxima.cpp:9630
 msgid "Matrix name:"
-msgstr ""
+msgstr "Mátrix neve:"
 
 #: ../../src/wxMaximaFrame.cpp:798
 msgid "Matrix parenthesis"
-msgstr ""
+msgstr "Mátrixzárójelek"
 
 #: ../../src/wxMaximaFrame.cpp:1331
 msgid "Matrix to csv file"
-msgstr ""
+msgstr "Mátrix csv fájlba"
 
 #: ../../src/wxMaximaFrame.cpp:1334
 msgid "Matrix to file or Matrix from file"
-msgstr ""
+msgstr "Mátrix fájlba vagy Mátrix fájlból"
 
 #: ../../src/wxMaximaFrame.cpp:1761
 msgid "Matrix to nested List"
-msgstr ""
+msgstr "Mátrix beágyazott listába"
 
 #: ../../src/wxMaxima.cpp:7956 ../../src/wxMaxima.cpp:7961
 #: ../../src/wxMaxima.cpp:7966 ../../src/wxMaxima.cpp:7971
 #: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
 #: ../../src/wxMaxima.cpp:8136
 msgid "Matrix:"
-msgstr ""
+msgstr "Mátrix:"
 
 #: ../../src/wxMaxima.cpp:8627
 msgid ""
@@ -4388,189 +4547,198 @@ msgid ""
 "\n"
 "This command tells maxima that the nouns in this expression shall now be evaluated, too."
 msgstr ""
+"Maxima lehetővé teszi, hogy a függvényeket \"főnévvé\" tegye, ami azt jelenti, hogy nem kerülnek automatikusan kiértékelésre, amint maxima találkozik velük.\n"
+" Egy függvényt főnévvé lehet tenni, ha főnévvé nyilvánítjuk, ha egy '-vel előzzük meg, vagy ha a '() zárójelek közé tesszük.\n"
+"\n"
+" Ez a parancs azt mondja maximának, hogy a kifejezésben lévő főneveket is ki kell értékelni."
 
 #: ../../src/wxMaxima.cpp:3473
 #, c-format
 msgid "Maxima architecture: %s"
-msgstr ""
+msgstr "Maxima architektúra: %s"
 
 #: ../../src/StatusBar.cpp:252
 msgid "Maxima asks a question"
-msgstr ""
+msgstr "A Maxima kérdez"
 
 #: ../../src/wxMaxima.cpp:4066
 msgid "Maxima asks a question!"
-msgstr ""
+msgstr "A Maxima kérdez!"
 
 #: ../../src/wxMaxima.cpp:7118
 msgid ""
 "Maxima automatically simplifies expressions it gets as input and then tries to evaluate their value. The ' operator tells maxima that we want a command to be in noun form, which means: stand here as is, and unevaluated.\n"
 "The ' operator can be undone by using the '' operator."
 msgstr ""
+"A Maxima automatikusan egyszerűsíti a bemenetként kapott kifejezéseket, majd"
+" megpróbálja kiértékelni az értéküket. A ' operátor azt üzeni a maximának, "
+"hogy egy parancsot főnévi alakban szeretnénk, ami azt jelenti: álljon itt "
+"úgy, ahogy van, és kiértékelés nélkül.\\n A ' operátor a '' operátorral "
+"visszavonható."
 
 #: ../../src/wxMaxima.cpp:3304
 msgid "Maxima didn't attempt to authenticate!"
-msgstr ""
+msgstr "Maxima nem kísérelte meg a hitelesítést!"
 
 #: ../../src/Configuration.cpp:84
 msgid "Maxima errors"
-msgstr ""
+msgstr "Maxima hibák"
 
 #: ../../src/wxMaxima.cpp:3289
 msgid "Maxima has authenticated!"
-msgstr ""
+msgstr "A Maxima hitelesített!"
 
 #: ../../src/wxMaxima.cpp:10533
 msgid "Maxima has finished calculating."
-msgstr ""
+msgstr "A Maxima befejezte a számolást."
 
 #: ../../src/wxMaxima.cpp:5832
 msgid "Maxima has issued an error!"
-msgstr ""
+msgstr "A Maxima hibajelzést küldött!"
 
 #: ../../src/wxMaxima.cpp:3696
 #, c-format
 msgid "Maxima has loaded the file %s."
-msgstr ""
+msgstr "A Maxima betöltötte a(z) %s fájlt."
 
 #: ../../src/wxMaxima.cpp:3382
 msgid "Maxima has sent a new variable value."
-msgstr ""
+msgstr "A Maxima új változó értéket küldött."
 
 #: ../../src/MaximaManual.cpp:552
 msgid "Maxima help file not found!"
-msgstr ""
+msgstr "Maxima súgófájl nem található!"
 
 #: ../../src/wxMaximaFrame.cpp:1043
 msgid "Maxima input"
-msgstr ""
+msgstr "Maxima bemenet"
 
 #: ../../src/StatusBar.cpp:236
 msgid "Maxima is calculating"
-msgstr ""
+msgstr "A Maxima számol"
 
 #: ../../src/wxMaxima.cpp:5068
 msgid "Maxima is ready for input."
-msgstr ""
+msgstr "A Maxima használatra kész."
 
 #: ../../src/Dirstructure.cpp:144
 #, c-format
 msgid "Maxima not found as %s"
-msgstr ""
+msgstr "A Maxima nem találta %s -ként"
 
 #: ../../src/wxMaxima.cpp:6211
 msgid "Maxima package (*.mac)|*.mac"
-msgstr ""
+msgstr "Maxima csomag (*.mac)|*.mac|"
 
 #: ../../src/wxMaxima.cpp:6202
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
-msgstr ""
+msgstr "Maxima csomag (*.mac)|*.mac|Lisp csomag (*.lisp)|*.lisp|Minden fájl|*"
 
 #: ../../src/wxMaxima.cpp:3012
 msgid "Maxima process terminated unexpectedly."
-msgstr ""
+msgstr "A maxima eljárásának futása váratlanul megszakadt."
 
 #: ../../src/Configuration.cpp:79
 msgid "Maxima question labels"
-msgstr ""
+msgstr "Maxima kérdés címkék"
 
 #: ../../src/wxMaxima.cpp:3380
 msgid "Maxima sends a new set of auto-completable symbols."
-msgstr ""
+msgstr "A Maxima új, automatikusan kiegészülő szimbólumokat küld."
 
 #: ../../src/wxMaxima.cpp:3908
 msgid "Maxima sends us a new set of variables for the watch list."
-msgstr ""
+msgstr "A Maxima új változót küld nekünk a figyelők listájához."
 
 #: ../../src/wxMaximaFrame.cpp:1944
 msgid "Maxima shows help in a browser"
-msgstr ""
+msgstr "A Maxima súgót jelenít meg a böngészőben"
 
 #: ../../src/wxMaximaFrame.cpp:1940
 msgid "Maxima shows help in a sidebar"
-msgstr ""
+msgstr "A Maxima súgót jelenít meg az oldalsávon"
 
 #: ../../src/wxMaximaFrame.cpp:1935
 msgid "Maxima shows help in the console"
-msgstr ""
+msgstr "A Maxima segítséget mutat a konzolon"
 
 #: ../../src/StatusBar.cpp:232
 msgid "Maxima started. Waiting for authentication..."
-msgstr ""
+msgstr "A Maxima elindult. Várakozás a hitelesítésre..."
 
 #: ../../src/StatusBar.cpp:212
 msgid "Maxima started. Waiting for connection..."
-msgstr ""
+msgstr "A Maxima elindult és vár a kapcsolatra..."
 
 #: ../../src/StatusBar.cpp:228
 msgid "Maxima started. Waiting for initial prompt..."
-msgstr ""
+msgstr "A Maxima elindult és vár az induló promptra..."
 
 #: ../../src/wxMaximaFrame.cpp:1231
 msgid "Maxima to other language"
-msgstr ""
+msgstr "Maxima → más nyelv"
 
 #: ../../src/wxMaxima.cpp:7213
 msgid "Maxima to string"
-msgstr ""
+msgstr "Maxima karakterláncba"
 
 #: ../../src/wxMaxima.cpp:3397
 #, c-format
 msgid "Maxima user configuration is located in directory %s"
-msgstr ""
+msgstr "A Maxima felhasználói konfigurációja a(z) %s könyvtárban található"
 
 #: ../../src/wxMaxima.cpp:3443
 #, c-format
 msgid "Maxima uses temp directory %s"
-msgstr ""
+msgstr "A maxima a(z) %s ideiglenes könyvtárat használja"
 
 #: ../../src/wxMaxima.cpp:3469
 #, c-format
 msgid "Maxima version: %s"
-msgstr ""
+msgstr "Maxima verzió: %s"
 
 #: ../../src/MaximaManual.cpp:390
 #, c-format
 msgid "Maxima version: %s, Anchors cache version"
-msgstr ""
+msgstr "Maxima verzió: %s, Anchors cache verzió"
 
 #: ../../src/wxMaximaFrame.cpp:1925
 msgid "Maxima vs. Programming languages"
-msgstr ""
+msgstr "Maxima vs. Programozási nyelvek"
 
 #: ../../src/Configuration.cpp:83
 msgid "Maxima warnings"
-msgstr ""
+msgstr "Maxima figyelmeztetések"
 
 #: ../../src/wxMaxima.cpp:3687
 #, c-format
 msgid "Maxima was compiled using %s"
-msgstr ""
+msgstr "A Maxima a(z) %s használatával lett fordítva"
 
 #: ../../src/wxMaxima.cpp:3487
 #, c-format
 msgid "Maxima's HTML manuals are in directory %s"
-msgstr ""
+msgstr "A maxima HTML kézikönyvei a(z) %s könyvtárban találhatók"
 
 #: ../../src/wxMaxima.cpp:3099
 #, c-format
 msgid "Maxima's PID is %li"
-msgstr ""
+msgstr "A Maxima PID-je a(z) %li"
 
 #: ../../src/wxMaxima.cpp:3681
 #, c-format
 msgid "Maxima's demo files are located in directory %s"
-msgstr ""
+msgstr "A Maxima bemutatófájljai a(z) %s könyvtárban találhatók"
 
 #: ../../src/wxMaxima.cpp:3478
 #, c-format
 msgid "Maxima's manual is located in directory %s"
-msgstr ""
+msgstr "A Maxima kézikönyve a(z) %s könyvtárban található"
 
 #: ../../src/wxMaxima.cpp:3670
 #, c-format
 msgid "Maxima's share files are located in directory %s"
-msgstr ""
+msgstr "A Maxima share fájljai a(z) %s könyvtárban találhatók"
 
 #: ../../src/StatusBar.cpp:66
 msgid ""
@@ -4582,6 +4750,13 @@ msgid ""
 "not only intercepts connections from the outside, but also to intercept "
 "connections between two programs that run on the same computer."
 msgstr ""
+"A Maxima, a program, amely valójában a matematikai műveleteket végzi és a "
+"wxMaxima, ami megjeleníti a munkalapot, külön eljárásként fut. Ez azt "
+"jelenti, hogy  ha a Maxima futása megszakad, a wxMaxima (és így a munkalap) "
+"ép marad. A két program egy helyi hálózati socketen keresztül kommunikál. "
+"Ezúttal ez a socket nem jött létre, amit okozhatott egy tűzfal, mely nem "
+"csak a külső, hanem az egyazon a számítógépen futó programok közti "
+"kapcsolatokat is korlátozza."
 
 #: ../../src/StatusBar.cpp:75
 msgid ""
@@ -4596,480 +4771,496 @@ msgid ""
 "might be that maxima cannot be found (see wxMaxima's Configuration dialogue "
 "for a way to specify maxima's location) or isn't in a working order."
 msgstr ""
+"A Maxima, a program, amely valójában a matematikai műveleteket végzi és a "
+"wxMaxima, ami megjeleníti a munkalapot, külön eljárásként fut. Ez azt "
+"jelenti, hogy ha a Maxima futása megszakad, a wxMaxima (és így a munkalap) "
+"ép marad. Jelenleg a két program nincs kapcsolatban egymással, ami lehet "
+"amiatt, hogy a Maxima még csak most indul, vagy nem tudott elindulni. Az is "
+"előfordulhat, hogy a problémát egy tűzfal okozza, mely nem csak a külső, "
+"hanem az egyazon a számítógépen futó programok közti kapcsolatokat is "
+"korlátozza. A Maxima nem indulásának másik oka az lehet, hogy a Maxima nem "
+"található (lásd a wxMaxima beállításait a Maxima helyének meghatározására), "
+"vagy nincs futtatható állapotban."
 
 #: ../../src/StatusBar.cpp:61
 msgid ""
 "Maxima, the program that does the actual mathematics is started as a separate process. This has the advantage that an eventual crash of maxima cannot harm wxMaxima, which displays the worksheet.\n"
 "This icon indicates if data is transferred between maxima and wxMaxima."
 msgstr ""
+"A Maxima, a program, amely valójában a matematikai műveleteket végzi, külön eljárásként fut. Ennek az az előnye, hogy ha a Maxima futása megszakad, az nincs hatással a wxMaximára, mely a munkalapot megjeleníti.\n"
+"Ez az ikon jelzi az adatforgalmat a Maxima és a wxMaxima között."
 
 #: ../../src/wxMaxima.cpp:9228
 msgid "Maximum absolute value printed without exponent"
-msgstr ""
+msgstr "Maximális abszolút érték kitevő nélkül nyomtatva"
 
 #: ../../src/wxMaxima.cpp:9230
 msgid "Maximum number of digits to be displayed:"
-msgstr ""
+msgstr "Maximálisan megjelenített számjegyek száma:"
 
 #: ../../src/wxMaxima.cpp:9568
 msgid "Mean:"
-msgstr ""
+msgstr "Átlag:"
 
 #: ../../src/wxMaximaFrame.cpp:1924
 msgid "Memoizing"
-msgstr ""
+msgstr "Emlékezés"
 
 #: ../../src/wxMaximaFrame.cpp:1013
 msgid "Memory"
-msgstr ""
+msgstr "Memória"
 
 #: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
 msgid "Merge Cells"
-msgstr ""
+msgstr "Cellák egyesítése"
 
 #: ../../src/wxMaxima.cpp:5780
 msgid "Message from the stdout of Maxima: "
-msgstr ""
+msgstr "Üzenet a Maxima kimenetéről: "
 
 #: ../../src/wxMaximaFrame.cpp:1326
 msgid "Methods of generating a matrix"
-msgstr ""
+msgstr "Mátrix létrehozásának módszerei"
 
 #: ../../src/Worksheet.cpp:6866
 #, c-format
 msgid "Middle-click clipboard data: %s"
-msgstr ""
+msgstr "Középső kattintással a vágólap adatai: %s"
 
 #: ../../src/wxMaxima.cpp:9226
 msgid "Minimum absolute value printed without exponent:"
-msgstr ""
+msgstr "Minimális abszolút érték kitevő nélkül nyomtatva:"
 
 #: ../../src/wxMaxima.cpp:10449 ../../src/wxMaxima.cpp:10451
 msgid "Mismatched parenthesis"
-msgstr ""
+msgstr "Hiányzó zárójel"
 
 #: ../../src/wxMaximaFrame.cpp:1352
 msgid "Multiplication, exponent and similar"
-msgstr ""
+msgstr "Szorzás, kitevő és hasonlók"
 
 #: ../../src/Worksheet.cpp:1998
 msgid "Multiplicative function: f(a*b)=f(a)*f(b)"
-msgstr ""
+msgstr "Szorzófüggvény: f(a*b)=f(a)*f(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1338
 msgid "Multiply matrices..."
-msgstr ""
+msgstr "Mátrixok szorzása..."
 
 #: ../../src/wxMaxima.cpp:7981
 msgid "Multiply two matrices"
-msgstr ""
+msgstr "Két mátrix szorzása"
 
 #: ../../src/wxMaxima.cpp:9581
 msgid "Multivariate linear regression"
-msgstr ""
+msgstr "Többváltozós lineáris regresszió"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Name of t:"
-msgstr ""
+msgstr "t neve:"
 
 #: ../../src/wxMaxima.cpp:7838
 msgid "Name of x:"
-msgstr ""
+msgstr "x neve:"
 
 #: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
 msgid "Nested list to Matrix"
-msgstr ""
+msgstr "Beágyazott lista mátrixba"
 
 #: ../../src/wxMaximaFrame.cpp:769 ../../src/wxMaximaFrame.cpp:1053
 msgid "Never"
-msgstr ""
+msgstr "Soha"
 
 #: ../../src/wxMaxima.cpp:6534
 msgid "Never autosubscript this variable"
-msgstr ""
+msgstr "Ez a változó soha ne kapjon automatikus feliratot"
 
 #: ../../src/wxMaximaFrame.cpp:776
 msgid "Never display this variable with subscript"
-msgstr ""
+msgstr "Soha ne jelenítse meg ezt a változót alsó indexszel"
 
 #: ../../src/Worksheet.cpp:1469 ../../src/Worksheet.cpp:1843
 msgid "Never offer known answers"
-msgstr ""
+msgstr "Ne ajánljon ismert válaszokat"
 
 #: ../../src/ToolBar.cpp:174
 msgid "New"
-msgstr ""
+msgstr "Új"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "New\tCtrl+N"
-msgstr ""
+msgstr "Ú&j\tCtrl+N"
 
 #: ../../src/ToolBar.cpp:611
 msgid "New button"
-msgstr ""
+msgstr "Új gomb"
 
 #: ../../src/wxMaxima.cpp:2483
 msgid "New connection attempt whilst already connected."
-msgstr ""
+msgstr "Új csatlakozási kísérlet már csatlakoztatva."
 
 #: ../../src/wxMaxima.cpp:2491
 msgid ""
 "New connection attempt, but no currently no socket maxima could connect to."
 msgstr ""
+"Új kapcsolódási kísérlet, de jelenleg nincs olyan socket, amelyhez a Maxima "
+"csatlakozni tudna."
 
 #: ../../src/wxMaxima.cpp:2487
 msgid "New connection attempt, but no currently running maxima process."
-msgstr ""
+msgstr "Új csatlakozási kísérlet, de jelenleg nem fut maxima folyamat."
 
 #: ../../src/ToolBar.cpp:174
 msgid "New document"
-msgstr ""
+msgstr "Új dokumentum"
 
 #: ../../src/wxMaxima.cpp:3899
 #, c-format
 msgid "New maxima Operators detected: %s"
-msgstr ""
+msgstr "Új maxima operátorok: %s"
 
 #: ../../src/wxMaxima.cpp:7390
 msgid "New part:"
-msgstr ""
+msgstr "Új rész:"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
 #: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
 msgid "New variable:"
-msgstr ""
+msgstr "Új változó:"
 
 #: ../../src/wxMaximaFrame.cpp:929
 msgid "Next Command\tAlt+Down"
-msgstr ""
+msgstr "Kö&vetkező parancs\tAlt+Down"
 
 #: ../../src/wxMaximaFrame.cpp:748
 msgid "Nice Graphical Equations"
-msgstr ""
+msgstr "Szép grafikus egyenletek"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "No"
-msgstr ""
+msgstr "Nincs"
 
 #: ../../src/Worksheet.cpp:1972
 msgid "No Array"
-msgstr ""
+msgstr "Nem sorozat"
 
 #: ../../src/Worksheet.cpp:1974
 msgid "No Scalar"
-msgstr ""
+msgstr "Nincs skalár"
 
 #: ../../src/wxMaxima.cpp:10482
 msgid "No dollar ($) or semicolon (;) at the end of command"
-msgstr ""
+msgstr "Nincs dollár ($) vagy pontosvessző (;) a parancsok végén"
 
 #: ../../src/MaximaManual.cpp:406
 msgid "No entries in the caches for the subjects the manual contains."
-msgstr ""
+msgstr "A kézikönyvben szereplő tárgyakra a gyorsítótárban nincs bejegyzés."
 
 #: ../../src/MaximaManual.cpp:101
 msgid ""
 "No file with the subjects the manual contained in the last wxMaxima run."
 msgstr ""
+"Nincs bejegyzés az utolsó wxMaxima futtatásban szereplő kézikönyvben "
+"előforduló tárgyakkal."
 
 #: ../../src/Image.cpp:495
 msgid "No gnuplot data!"
-msgstr ""
+msgstr "Nincsenek gnuplot adatok!"
 
 #: ../../src/Image.cpp:530
 msgid "No gnuplot source!"
-msgstr ""
+msgstr "Nincs gnuplot forrás!"
 
 #: ../../src/wxMaxima.cpp:6662 ../../src/wxMaxima.cpp:6668
 #: ../../src/wxMaxima.cpp:6687 ../../src/wxMaxima.cpp:6697
 msgid "No matches found!"
-msgstr ""
+msgstr "A kifejezés nem található!"
 
 #: ../../src/wxMaxima.cpp:3240
 msgid "No topics found in topic flag"
-msgstr ""
+msgstr "Nem található téma a témajelzőben"
 
 #: ../../src/wxMaxima.cpp:3227
 msgid "No topics found in topic tag"
-msgstr ""
+msgstr "Nem található téma a témacímkében"
 
 #: ../../src/wxMaximaFrame.cpp:797
 msgid "None"
-msgstr ""
+msgstr "Egyik sem"
 
 #: ../../src/wxMaxima.cpp:8163
 msgid "Not a valid matrix dimension!"
-msgstr ""
+msgstr "Hibás mátrixdimenzió!"
 
 #: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
 msgid "Not a valid number of equations!"
-msgstr ""
+msgstr "Az egyenletek száma hibás!"
 
 #: ../../src/StatusBar.cpp:256
 msgid "Not connected to Maxima"
-msgstr ""
+msgstr "Nem csatlakozott a Maximához"
 
 #: ../../src/wxMaxima.cpp:10496
 msgid "Not triggering evaluation as maxima is still busy!"
-msgstr ""
+msgstr "Not triggering evaluation as maxima is still busy!"
 
 #: ../../src/wxMaxima.cpp:10503
 msgid "Not triggering evaluation as maxima still asks a question!"
-msgstr ""
+msgstr "Not triggering evaluation as maxima still asks a question!"
 
 #: ../../src/wxMaxima.cpp:10511
 msgid "Not triggering evaluation as there is no working maxima process"
-msgstr ""
+msgstr "Not triggering evaluation as there is no working maxima process"
 
 #: ../../src/wxMaxima.cpp:8926
 msgid "Num. deg:"
-msgstr ""
+msgstr "Számláló foka:"
 
 #: ../../src/wxMaxima.cpp:8540
 msgid "Number of elements"
-msgstr ""
+msgstr "Elemek száma"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
 msgid "Number of equations:"
-msgstr ""
+msgstr "Egyenletek száma:"
 
 #: ../../src/wxMaxima.cpp:7481
 msgid "Number to octets"
-msgstr ""
+msgstr "Szám oktettbe"
 
 #: ../../src/wxMaximaFrame.cpp:1154
 msgid "Number to octets..."
-msgstr ""
+msgstr "Szám oktettek..."
 
 #: ../../src/wxMaximaFrame.cpp:1906
 msgid "Number types"
-msgstr ""
+msgstr "Számtípusok"
 
 #: ../../src/wxMaxima.cpp:7482
 msgid "Number:"
-msgstr ""
+msgstr "Szám:"
 
 #: ../../src/wxMaximaFrame.cpp:1786
 msgid "Numeric output"
-msgstr ""
+msgstr "Numerikus kimenet"
 
 #: ../../src/wxMaxima.cpp:8040
 msgid "Numerical QR decomposition of a matrix"
-msgstr ""
+msgstr "Egy mátrix numerikus QR-felbontása"
 
 #: ../../src/wxMaximaFrame.cpp:1417
 msgid "Numerical operations (lapack)"
-msgstr ""
+msgstr "Numerikus műveletek (lapack)"
 
 #: ../../src/wxMaxima.cpp:7831
 msgid "Numerical solution for 1st degree ODE"
-msgstr ""
+msgstr "Elsőrendű közönséges differenciálegyenlet numerikus megoldása"
 
 #: ../../src/wxMaximaFrame.cpp:1282
 msgid "Numerical solution..."
-msgstr ""
+msgstr "Numerikus megoldás..."
 
 #: ../../src/wxMaximaFrame.cpp:1261
 msgid "Numerical solutions of polynomial (bfloat)..."
-msgstr ""
+msgstr "Polinom numerikus megoldásai (bfloat)..."
 
 #: ../../src/wxMaximaFrame.cpp:1258
 msgid "Numerical solutions of polynomial..."
-msgstr ""
+msgstr "Polinom numerikus megoldásai..."
 
 #: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: ../../src/wxMaximaFrame.cpp:122
 #, c-format
 msgid "OS: %s Version %li.%li"
-msgstr ""
+msgstr "OS: %s verzió %li.%li"
 
 #: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
 msgid "Object composed of elements"
-msgstr ""
+msgstr "Elemekből álló objektum"
 
 #: ../../src/wxMaxima.cpp:7680
 msgid "Object name:"
-msgstr ""
+msgstr "Objektum név:"
 
 #: ../../src/wxMaxima.cpp:7281
 msgid "Object:"
-msgstr ""
+msgstr "Objektum:"
 
 #: ../../src/wxMaxima.cpp:7486
 msgid "Octets to Number"
-msgstr ""
+msgstr "Oktettek számmá"
 
 #: ../../src/wxMaxima.cpp:7491
 msgid "Octets to String"
-msgstr ""
+msgstr "Octetts to String"
 
 #: ../../src/wxMaximaFrame.cpp:1156
 msgid "Octets to number..."
-msgstr ""
+msgstr "Oktett a számhoz..."
 
 #: ../../src/wxMaximaFrame.cpp:1158
 msgid "Octets to string..."
-msgstr ""
+msgstr "Oktettek karakterláncba..."
 
 #: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
 msgid "Octets:"
-msgstr ""
+msgstr "Oktettek:"
 
 #: ../../src/Worksheet.cpp:1958
 msgid "Odd number"
-msgstr ""
+msgstr "Páratlan szám"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
 #: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
 msgid "Old variable:"
-msgstr ""
+msgstr "Régi változó:"
 
 #: ../../src/wxMaximaFrame.cpp:1055
 msgid "On all errors"
-msgstr ""
+msgstr "Minden hibán"
 
 #: ../../src/wxMaximaFrame.cpp:1054
 msgid "On lisp errors"
-msgstr ""
+msgstr "A lisp hibákról"
 
 #: ../../src/wxMaxima.cpp:9566
 msgid "One sample t-test"
-msgstr ""
+msgstr "Egymintás t-próba"
 
 #: ../../src/wxMaximaFrame.cpp:1927
 msgid "Online tutorials"
-msgstr ""
+msgstr "Online ismertetők"
 
 #: ../../src/wxMaximaFrame.cpp:766
 msgid "Only Integers and single letters"
-msgstr ""
+msgstr "Csak egészek és egyedi betűk"
 
 #: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593
 #: ../../src/wxMaxima.cpp:6074
 msgid "Open"
-msgstr ""
+msgstr "Megnyitás"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "Open a document"
-msgstr ""
+msgstr "Dokumentum megnyitása"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "Open a new window"
-msgstr ""
+msgstr "Új ablak"
 
 #: ../../src/ToolBar.cpp:617
 msgid "Open and save button"
-msgstr ""
+msgstr "Megnyitás és Mentés gomb"
 
 #: ../../src/ToolBar.cpp:176
 msgid "Open document"
-msgstr ""
+msgstr "Dokumentum megnyitása"
 
 #: ../../src/wxMaxima.cpp:7239
 msgid "Open for appending"
-msgstr ""
+msgstr "Nyitva csatolásra"
 
 #: ../../src/wxMaximaFrame.cpp:1099
 msgid "Open for appending..."
-msgstr ""
+msgstr "Nyitva csatolásra..."
 
 #: ../../src/wxMaxima.cpp:7244
 msgid "Open for reading"
-msgstr ""
+msgstr "Olvasásra nyitva"
 
 #: ../../src/wxMaximaFrame.cpp:1098
 msgid "Open for reading..."
-msgstr ""
+msgstr "Olvasásra nyitva..."
 
 #: ../../src/wxMaxima.cpp:7249
 msgid "Open for writing"
-msgstr ""
+msgstr "Nyitott írásra"
 
 #: ../../src/wxMaximaFrame.cpp:1100
 msgid "Open for writing..."
-msgstr ""
+msgstr "Nyitva írásra..."
 
 #: ../../src/wxMaxima.cpp:9598
 msgid "Open matrix"
-msgstr ""
+msgstr "Mátrix megnyitása"
 
 #: ../../src/wxMaximaFrame.cpp:600
 msgid "Open recent"
-msgstr ""
+msgstr "Legutóbbi megnyitása"
 
 #: ../../src/wxMaxima.cpp:4309
 msgid "Opening a wxmx file"
-msgstr ""
+msgstr "Egy wxmx fájl megnyitása"
 
 #: ../../src/wxMaxima.cpp:4153 ../../src/wxMaxima.cpp:4214
 #: ../../src/wxMaxima.cpp:4313 ../../src/wxMaxima.cpp:4622
 msgid "Opening file"
-msgstr ""
+msgstr "Fájl megnyitása"
 
 #: ../../src/wxMaxima.cpp:5030
 #, c-format
 msgid "Opening help file %s"
-msgstr ""
+msgstr "%s súgófájl megnyitása"
 
 #: ../../src/wxMaximaFrame.cpp:1530
 msgid "Optimize for CPU time"
-msgstr ""
+msgstr "Optimalizálja a CPU-időt"
 
 #: ../../src/wxMaximaFrame.cpp:1529
 msgid "Optimize for memory"
-msgstr ""
+msgstr "Optimalizálja a memóriát"
 
 #: ../../src/ToolBar.cpp:199
 msgid "Options"
-msgstr ""
+msgstr "Beállítások"
 
 #: ../../src/wxMaximaFrame.cpp:1225
 msgid "Output C"
-msgstr ""
+msgstr "C kimenet"
 
 #: ../../src/wxMaximaFrame.cpp:1226
 msgid "Output Fortran"
-msgstr ""
+msgstr "Fortran kimenet"
 
 #: ../../src/wxMaximaFrame.cpp:1228
 msgid "Output Rational Fortran"
-msgstr ""
+msgstr "Kimenet Racionális Fortran"
 
 #: ../../src/Configuration.cpp:80
 msgid "Output labels"
-msgstr ""
+msgstr "Kimeneti címkék"
 
 #: ../../src/Configuration.cpp:73
 msgid "Output: Function names"
-msgstr ""
+msgstr "Kimenet: Függvénynevek"
 
 #: ../../src/Configuration.cpp:75
 msgid "Output: Latin names as greek symbols"
-msgstr ""
+msgstr "Kimenet: latin nevek görög szimbólumokként"
 
 #: ../../src/Configuration.cpp:72
 msgid "Output: Numbers and Digits"
-msgstr ""
+msgstr "Kimenet: Számok és számjegyek"
 
 #: ../../src/Configuration.cpp:71
 msgid "Output: Operators"
-msgstr ""
+msgstr "Kimenet: Műveletek"
 
 #: ../../src/Configuration.cpp:74
 #, c-format
 msgid "Output: Special constants (%e,%i)"
-msgstr ""
+msgstr "Kimenet: Speciális állandók (%e,%i)"
 
 #: ../../src/Configuration.cpp:76
 msgid "Output: Strings"
-msgstr ""
+msgstr "Kimenet: Karakterláncok"
 
 #: ../../src/Configuration.cpp:70
 msgid "Output: Variable names"
-msgstr ""
+msgstr "Kimenet: Változónevek"
 
 #: ../../src/wxMaxima.cpp:6442
 msgid ""
@@ -5078,6 +5269,10 @@ msgid ""
 "(*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format "
 "(*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"PNG kép (*.png) |*.png | JPEG kép (*.jpg) |*.jpg | GIF kép (*.gif) |*.gif | "
+"Méretezhető vektorgrafika (*.svg) |*.svg | Windows bitkép (*.bmp) |*.bmp | "
+"Hordozható anymap (*.pnm) |*.pnm | Címkézett képfájl formátum (*.tif) |*.tif"
+" | X pixmap (*.xpm) |*.xpm"
 
 #: ../../src/wxMaxima.cpp:10117
 msgid ""
@@ -5085,860 +5280,877 @@ msgid ""
 "(*.bmp)|*.bmp|GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged "
 "image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"PNG kép (*.png) |*.png | JPEG kép (*.jpg) |*.jpg | Windows bittérkép (*.bmp)"
+" |*.bmp | GIF kép (*.gif) |*.gif | Hordozható bármilyen térkép (*.pnm) "
+"|*.pnm | Címkézett képfájl formátum (*.tif) |*.tif | X pixmap (*.xpm) |*.xpm"
 
 #: ../../src/wxMaxima.cpp:8924
 msgid "Pade approximation"
-msgstr ""
+msgstr "Padé-approximáció"
 
 #: ../../src/wxMaximaFrame.cpp:1478
 msgid "Pade approximation of a Taylor series"
-msgstr ""
+msgstr "Taylor-sor Padé-approximációja"
 
 #: ../../src/wxMaximaFrame.cpp:1637
 msgid "Parallel Substitute..."
-msgstr ""
+msgstr "Párhuzamos helyettesítés..."
 
 #: ../../src/wxMaxima.cpp:8738
 msgid "Parallel substitution"
-msgstr ""
+msgstr "Párhuzamos behelyettesítés"
 
 #: ../../src/wxMaxima.cpp:7179
 msgid "Parameter name:"
-msgstr ""
+msgstr "A paraméter neve:"
 
 #: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
 msgid "Parameter(s):"
-msgstr ""
+msgstr "Paraméter(ek):"
 
 #: ../../src/wxMaxima.cpp:7399
 msgid "Parse string"
-msgstr ""
+msgstr "Karakterlánc elemzése"
 
 #: ../../src/wxMaximaFrame.cpp:1152
 msgid "Parse string only..."
-msgstr ""
+msgstr "Csak karakterlánc elemzése..."
 
 #: ../../src/StatusBar.cpp:240
 msgid "Parsing output"
-msgstr ""
+msgstr "Kimenet elemzése"
 
 #: ../../src/wxMaxima.cpp:7464
 msgid "Part:"
-msgstr ""
+msgstr "Rész:"
 
 #: ../../src/wxMaximaFrame.cpp:1499 ../../src/wxMaximaFrame.cpp:1535
 msgid "Partial &Fractions..."
-msgstr ""
+msgstr "&Parciális törtek..."
 
 #: ../../src/wxMaxima.cpp:8975
 msgid "Partial Fractions"
-msgstr ""
+msgstr "Parciális törtek"
 
 #: ../../src/wxMaxima.cpp:4702
 msgid "Parts of the document will not be loaded correctly!"
-msgstr ""
+msgstr "A dokumentum egyes részei nem töltődtek be!"
 
 #: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
 #: ../../src/Worksheet.cpp:1685
 msgid "Paste"
-msgstr ""
+msgstr "Beillesztés"
 
 #: ../../src/wxMaximaFrame.cpp:667
 msgid "Paste\tCtrl+V"
-msgstr ""
+msgstr "&Beillesztés\tCtrl+V"
 
 #: ../../src/ToolBar.cpp:211
 msgid "Paste from clipboard"
-msgstr ""
+msgstr "Szöveg beillesztése vágólapról"
 
 #: ../../src/wxMaximaFrame.cpp:668
 msgid "Paste text from clipboard"
-msgstr ""
+msgstr "Szöveg beillesztése vágólapról"
 
 #: ../../src/wxMaxima.cpp:4841
 msgid "Please configure wxMaxima with 'Edit->Configure'."
-msgstr ""
+msgstr "Kérem állítsa be a wxMaximát a 'Szerkesztés->Beállítás' menüpontban."
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot &2d..."
-msgstr ""
+msgstr "&2d-s ábrázolás..."
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot &3d..."
-msgstr ""
+msgstr "&3d-s ábrázolás..."
 
 #: ../../src/wxMaximaFrame.cpp:1772
 msgid "Plot &Format..."
-msgstr ""
+msgstr "Á&brázolási mód..."
 
 #: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
 msgid "Plot 2D"
-msgstr ""
+msgstr "Kétdimenziós ábrázolás"
 
 #: ../../src/Worksheet.cpp:1593
 msgid "Plot 2D..."
-msgstr ""
+msgstr "2D..."
 
 #: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
 msgid "Plot 3D"
-msgstr ""
+msgstr "Háromdimenziós ábrázolás"
 
 #: ../../src/Worksheet.cpp:1595
 msgid "Plot 3D..."
-msgstr ""
+msgstr "3D..."
 
 #: ../../src/wxMaxima.cpp:9538
 msgid "Plot as bars"
-msgstr ""
+msgstr "Telek mint bár"
 
 #: ../../src/wxMaxima.cpp:9542
 msgid "Plot as error bars"
-msgstr ""
+msgstr "Plot mint hibasávok"
 
 #: ../../src/wxMaxima.cpp:9546
 msgid "Plot as pie chart"
-msgstr ""
+msgstr "Ábrázolás kördiagramként"
 
 #: ../../src/wxMaxima.cpp:9112
 msgid "Plot format"
-msgstr ""
+msgstr "Ábrázolási mód"
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot in 2 dimensions"
-msgstr ""
+msgstr "Ábrázolás két dimenzióban"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot in 3 dimensions"
-msgstr ""
+msgstr "Ábrázolás három dimenzióban"
 
 #: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
 msgid "Plot using Draw"
-msgstr ""
+msgstr "Ábrázolás rajzolással"
 
 #: ../../src/wxMaxima.cpp:7824
 msgid "Point #1 with known value:"
-msgstr ""
+msgstr "1. pont ismert értékkel:"
 
 #: ../../src/wxMaxima.cpp:7826
 msgid "Point #2 with known value:"
-msgstr ""
+msgstr "2. pont ismert értékkel:"
 
 #: ../../src/wxMaxima.cpp:7800 ../../src/wxMaxima.cpp:7811
 msgid "Point the value is known at:"
-msgstr ""
+msgstr "Pont az érték ismert:"
 
 #: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
 msgid "Point:"
-msgstr ""
+msgstr "Hely:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 1:"
-msgstr ""
+msgstr "1. polinom:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 2:"
-msgstr ""
+msgstr "2. polinom:"
 
 #: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
 #: ../../src/wxMaxima.cpp:7739
 msgid "Polynomial:"
-msgstr ""
+msgstr "Polinom:"
 
 #: ../../src/wxMaximaFrame.cpp:1754
 msgid "Pop"
-msgstr ""
+msgstr "Pop"
 
 #: ../../src/Worksheet.cpp:1331 ../../src/Worksheet.cpp:1485
 msgid "Popout interactively"
-msgstr ""
+msgstr "Popout interaktív módon"
 
 #: ../../src/wxMaximaFrame.cpp:1189
 msgid "Position of a match"
-msgstr ""
+msgstr "Egy meccs helyzete"
 
 #: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
 msgid "Position:"
-msgstr ""
+msgstr "Pozíció:"
 
 #: ../../src/wxMaxima.cpp:8939
 msgid "Power series"
-msgstr ""
+msgstr "Hatványsor"
 
 #: ../../src/wxMaximaFrame.cpp:1475
 msgid "Power series..."
-msgstr ""
+msgstr "Hatványsor..."
 
 #: ../../src/wxMaxima.cpp:9202
 msgid "Precision"
-msgstr ""
+msgstr "Pontosság"
 
 #: ../../src/Worksheet.cpp:1616
 msgid "Prefer user labels"
-msgstr ""
+msgstr "Felhasználó által definiált címkék előnyben részesítése"
 
 #: ../../src/main.cpp:437
 msgid "Preferences"
-msgstr ""
+msgstr "Beállítások"
 
 #: ../../src/ToolBar.cpp:626
 msgid "Preferences button"
-msgstr ""
+msgstr "Beállítások gomb"
 
 #: ../../src/wxMaximaFrame.cpp:685
 msgid "Preferences...\tCtrl+,"
-msgstr ""
+msgstr "Beállítások...\tCtrl+,"
 
 #: ../../src/wxMaximaFrame.cpp:1733
 msgid "Prepend an element"
-msgstr ""
+msgstr "Egy elemet felvétele"
 
 #: ../../src/wxMaximaFrame.cpp:927
 msgid "Previous Command\tAlt+Up"
-msgstr ""
+msgstr "Előző parancs\tAlt+Up"
 
 #: ../../src/ToolBar.cpp:184
 msgid "Print"
-msgstr ""
+msgstr "Nyomtatás"
 
 #: ../../src/ToolBar.cpp:620
 msgid "Print button"
-msgstr ""
+msgstr "Nyomtatás gomb"
 
 #: ../../src/Worksheet.cpp:1493
 msgid "Print cell brackets"
-msgstr ""
+msgstr "Cellazárójelek nyomtatása"
 
 #: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
 msgid "Print document"
-msgstr ""
+msgstr "Dokumentum nyomtatása"
 
 #: ../../src/wxMaximaFrame.cpp:1829
 msgid "Print floating-point numbers with exponents dividable by 3"
-msgstr ""
+msgstr "3-mal osztható kitevőjű lebegőpontos számok kiírása"
 
 #: ../../src/WXMXformat.cpp:255
 msgid ""
 "Produced invalid XML. The erroneous XML data has therefore not been saved "
 "but has been put on the clipboard in order to allow to debug it."
 msgstr ""
+"Érvénytelen XML. Ezért a hibás XML adatokat ezért nem lettek lementve, hanem"
+" vágólapra kerültek, hogy lehetővé váljon a hibakeresés."
 
 #: ../../src/wxMaxima.cpp:9061
 msgid "Product"
-msgstr ""
+msgstr "Szorzat"
 
 #: ../../src/wxMaximaFrame.cpp:1095
 msgid "Program"
-msgstr ""
+msgstr "Program"
 
 #: ../../src/wxMaxima.cpp:7061
 msgid "Program (no local variables)"
-msgstr ""
+msgstr "Program (nincs lokális változó)"
 
 #: ../../src/wxMaxima.cpp:7052
 msgid "Program block"
-msgstr ""
+msgstr "Programblokk"
 
 #: ../../src/wxMaximaFrame.cpp:1066
 msgid "Program block with local variables..."
-msgstr ""
+msgstr "Programblokk helyi változókkal..."
 
 #: ../../src/wxMaximaFrame.cpp:1068
 msgid "Program block, no local variables..."
-msgstr ""
+msgstr "Programblokk, nincsenek helyi változók..."
 
 #: ../../src/wxMaximaFrame.cpp:1751
 msgid "Push"
-msgstr ""
+msgstr "Push"
 
 #: ../../src/wxMaxima.cpp:8508
 msgid "Push an element to a list"
-msgstr ""
+msgstr "Elem berakása egy listába"
 
 #: ../../src/wxMaximaFrame.cpp:1395
 msgid "QR decomposition"
-msgstr ""
+msgstr "QR-felbontás"
 
 #: ../../src/wxMaxima.cpp:3621
 msgid "Querying gnuplot which graphics drivers it supports."
 msgstr ""
+"A gnuplot lekérdezése, hogy mely grafikus illesztőprogramokat támogatja."
 
 #: ../../src/wxMaxima.cpp:8953
 msgid "Range radius:"
-msgstr ""
+msgstr "Tartomány sugár:"
 
 #: ../../src/wxMaximaFrame.cpp:1374
 msgid "Rank"
-msgstr ""
+msgstr "Rang"
 
 #: ../../src/wxMaximaFrame.cpp:246 ../../src/wxMaximaFrame.cpp:722
 msgid "Raw XML monitor"
-msgstr ""
+msgstr "Nyers XML monitor"
 
 #: ../../src/wxMaximaFrame.cpp:2117
 #, c-format
 msgid "Re-Reading the config from %s."
-msgstr ""
+msgstr "A konfiguráció újraolvasása %s helyről."
 
 #: ../../src/wxMaximaFrame.cpp:2114
 msgid "Re-Reading the config from the default location."
-msgstr ""
+msgstr "A konfiguráció újraolvasása annak alapértelmezett helyéről."
 
 #: ../../src/wxMaximaFrame.cpp:867
 msgid "Re-evaluate all cells above the one the cursor is in"
-msgstr ""
+msgstr "A kurzor feletti cellák újraszámolása"
 
 #: ../../src/wxMaximaFrame.cpp:877
 msgid "Re-evaluate all cells below the one the cursor is in"
-msgstr ""
+msgstr "Az olyan cella újraértékelése, amely alatt a kurzor be van kapcsolva"
 
 #: ../../src/main.cpp:366
 msgid "Re-opening STDERR failed."
-msgstr ""
+msgstr "Re-opening STDERR failed."
 
 #: ../../src/main.cpp:367
 msgid "Re-opening STDIN failed."
-msgstr ""
+msgstr "A STDIN újbóli megnyitása sikertelen."
 
 #: ../../src/main.cpp:365
 msgid "Re-opening STDOUT failed."
-msgstr ""
+msgstr "Re-opening STDOUT failed."
 
 #: ../../src/wxMaxima.cpp:7512
 msgid ""
 "Re-using a compiled regex is faster that using the same regex string "
 "multiple times."
 msgstr ""
+"Egy lefordított regex újrafelhasználása gyorsabb, mintha ugyanazt a regex "
+"karakterláncot többször használnánk."
 
 #: ../../src/Worksheet.cpp:6668
 msgid "Read .wxm data from clipboard"
-msgstr ""
+msgstr ".wxm adatok olvasása a vágólapról"
 
 #: ../../src/wxMaxima.cpp:7599
 msgid "Read Directory"
-msgstr ""
+msgstr "Olvassa el a címtárat"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Read List from csv file..."
-msgstr ""
+msgstr "Lista olvasása csv fájlból..."
 
 #: ../../src/wxMaxima.cpp:7196
 msgid "Read a structure field"
-msgstr ""
+msgstr "Olvass be egy szerkezeti mezőt"
 
 #: ../../src/wxMaxima.cpp:7270 ../../src/wxMaxima.cpp:7274
 msgid "Read byte"
-msgstr ""
+msgstr "Olvasási bájt"
 
 #: ../../src/wxMaxima.cpp:7266
 msgid "Read char"
-msgstr ""
+msgstr "Karakter beolvasása"
 
 #: ../../src/wxMaxima.cpp:7593
 msgid "Read environment variable"
-msgstr ""
+msgstr "Környezeti változók olvasása"
 
 #: ../../src/wxMaximaFrame.cpp:1219
 msgid "Read environment variable..."
-msgstr ""
+msgstr "Környezeti változó olvasása..."
 
 #: ../../src/wxMaxima.cpp:7262
 msgid "Read line"
-msgstr ""
+msgstr "Olvassa el a sort"
 
 #: ../../src/MaximaManual.cpp:113
 #, c-format
 msgid "Read the entries the maxima manual offers from %s"
 msgstr ""
+"Olvassa el a bejegyzést, amelyet a maxima kézikönyv kínál a következőtől: %s"
 
 #: ../../src/StatusBar.cpp:245
 msgid "Reading Maxima output"
-msgstr ""
+msgstr "Maxima kimenetelének olvasása"
 
 #: ../../src/StatusBar.cpp:247
 #, c-format
 msgid "Reading Maxima output: %li bytes"
-msgstr ""
+msgstr "Maxima kimenet olvasása: %li bájt"
 
 #: ../../src/wxMathml.cpp:55
 #, c-format
 msgid "Reading the Lisp part of wxMaxima from the file %s"
-msgstr ""
+msgstr "A wxMaxima Lisp részének beolvasása a %s fájlból"
 
 #: ../../src/wxMathml.cpp:43
 msgid "Reading the Lisp part of wxMaxima from the included header file."
-msgstr ""
+msgstr "A wxMaxima Lisp részének beolvasása a mellékelt fejlécfájlból."
 
 #: ../../src/wxMaximaFrame.cpp:148
 #, c-format
 msgid "Reading the config from %s."
-msgstr ""
+msgstr "A konfiguráció beolvasása %s helyről."
 
 #: ../../src/wxMaximaFrame.cpp:151
 msgid "Reading the config from the default location."
-msgstr ""
+msgstr "A konfiguráció beolvasása annak alapértelmezett helyéről."
 
 #: ../../src/StatusBar.cpp:224
 msgid "Ready for user input"
-msgstr ""
+msgstr "Bemeneti adatok fogadása"
 
 #: ../../src/Worksheet.cpp:960
 msgid "Recalculated the whole worksheet at once => Updating its size"
-msgstr ""
+msgstr "Recalculated the whole worksheet at once => Updating its size"
 
 #: ../../src/Worksheet.cpp:946
 msgid "Recalculation hit the end of the worksheet => Updating its size"
-msgstr ""
+msgstr "Recalculation hit the end of the worksheet => Updating its size"
 
 #: ../../src/wxMaximaFrame.cpp:930
 msgid "Recall next command from history"
-msgstr ""
+msgstr "A következő parancs előhozása az előzmények közül"
 
 #: ../../src/wxMaximaFrame.cpp:928
 msgid "Recall previous command from history"
-msgstr ""
+msgstr "Az előző parancs előhozása az előzmények közül"
 
 #: ../../src/wxMaxima.cpp:3235
 #, c-format
 msgid "Received manual topic request: %s"
-msgstr ""
+msgstr "Kézi témakérés érkezett: %s"
 
 #: ../../src/wxMaxima.cpp:3097
 #, c-format
 msgid "Received maxima's first prompt: %s"
-msgstr ""
+msgstr "A Maxima első promptja : %s"
 
 #: ../../src/wxMaximaFrame.cpp:603
 msgid "Recover unsaved"
-msgstr ""
+msgstr "Mentetlen visszaállítása"
 
 #: ../../src/wxMaximaFrame.cpp:1640
 msgid "Recursive Substitute..."
-msgstr ""
+msgstr "Rekurzív helyettesítés..."
 
 #: ../../src/wxMaxima.cpp:8746
 msgid "Recursive substitution"
-msgstr ""
+msgstr "Rekurzív helyettesítés"
 
 #: ../../src/ToolBar.cpp:192
 msgid "Redo"
-msgstr ""
+msgstr "Újra"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo\tCtrl+Y"
-msgstr ""
+msgstr "Ismételt végrehajtás\tCtrl+Y"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo last change"
-msgstr ""
+msgstr "Utolsó változtatás visszavonása"
 
 #: ../../src/wxMaximaFrame.cpp:1595
 msgid "Reduce trigonometric expression"
-msgstr ""
+msgstr "Trigonometrikus kifejezés redukált alakra hozása"
 
 #: ../../src/wxMaxima.cpp:2366 ../../src/wxMaxima.cpp:10630
 msgid "Refusing to send cell to maxima: "
-msgstr ""
+msgstr "A cella Maximához küldésének megtagadása: "
 
 #: ../../src/wxMaxima.cpp:7523
 msgid "Regex match"
-msgstr ""
+msgstr "Regex egyezés"
 
 #: ../../src/wxMaxima.cpp:7518
 msgid "Regex match position"
-msgstr ""
+msgstr "Regex egyezés pozíció"
 
 #: ../../src/wxMaximaFrame.cpp:1195
 msgid "Regular expression that matches a string"
-msgstr ""
+msgstr "Reguláris kifejezés, amely illeszkedik egy karakterláncra"
 
 #: ../../src/wxMaximaFrame.cpp:1196
 msgid "Regular expressions"
-msgstr ""
+msgstr "Reguláris kifejezések"
 
 #: ../../src/Worksheet.cpp:1314
 msgid "Reload Image"
-msgstr ""
+msgstr "Kép újratöltése"
 
 #: ../../src/Worksheet.cpp:1320
 #, c-format
 msgid "Reload Image \"%s\""
-msgstr ""
+msgstr "\"%s\" kép újratöltése"
 
 #: ../../src/wxMaxima.cpp:9809
 #, c-format
 msgid "Reloading image file %s."
-msgstr ""
+msgstr "%s képfájl újratöltése."
 
 #: ../../src/wxMaximaFrame.cpp:883
 msgid "Remove All Output"
-msgstr ""
+msgstr "A&z összes kimenet eltávolítása"
 
 #: ../../src/wxMaximaFrame.cpp:1426
 msgid "Remove Rows or Columns..."
-msgstr ""
+msgstr "Sorok vagy oszlopok eltávolítása..."
 
 #: ../../src/wxMaximaFrame.cpp:1748
 msgid ""
 "Remove all list elements that appear twice in a row. Normally used in "
 "conjunction with sort."
 msgstr ""
+"Minden olyan listaelem eltávolítása, amely kétszer jelenik meg egy sorban. "
+"Általában a rendezéssel együtt használják."
 
 #: ../../src/wxMaximaFrame.cpp:1174
 msgid "Remove all occurrences of a word..."
-msgstr ""
+msgstr "Távolítsa el a szó összes előfordulását..."
 
 #: ../../src/wxMaxima.cpp:7439
 msgid "Remove all occurrences of part"
-msgstr ""
+msgstr "Távolítsa el az alkatrész összes előfordulását"
 
 #: ../../src/wxMaxima.cpp:8592
 msgid "Remove an element from a list"
-msgstr ""
+msgstr "Eltávolít egy elemet egy listából"
 
 #: ../../src/wxMaxima.cpp:7566
 msgid "Remove directory"
-msgstr ""
+msgstr "Könyvtár eltávolítása"
 
 #: ../../src/wxMaximaFrame.cpp:1204
 msgid "Remove directory..."
-msgstr ""
+msgstr "Könyvtár eltávolítása..."
 
 #: ../../src/wxMaximaFrame.cpp:1747
 msgid "Remove duplicates"
-msgstr ""
+msgstr "Ismétlések eltávolítása"
 
 #: ../../src/wxMaximaFrame.cpp:1176
 msgid "Remove first occurrence of a word..."
-msgstr ""
+msgstr "A szó első előfordulásának eltávolítása..."
 
 #: ../../src/wxMaxima.cpp:7444
 msgid "Remove first occurrence of part"
-msgstr ""
+msgstr "Az alkatrész első előfordulásának eltávolítása"
 
 #: ../../src/wxMaximaFrame.cpp:884
 msgid "Remove output from input cells"
-msgstr ""
+msgstr "A kimenet eltávolítása a bemeneti cellákból"
 
 #: ../../src/wxMaxima.cpp:7975
 msgid "Remove rows and/or columns"
-msgstr ""
+msgstr "Sorok és/vagy oszlopok eltávolítása"
 
 #: ../../src/wxMaximaFrame.cpp:1427
 msgid "Remove rows and/or columns from the matrix"
-msgstr ""
+msgstr "Sorokat és/vagy oszlopok eltávolítása a mátrixból"
 
 #: ../../src/wxMaxima.cpp:7582
 msgid "Rename file"
-msgstr ""
+msgstr "Fájl átnevezése"
 
 #: ../../src/wxMaximaFrame.cpp:1215
 msgid "Rename file..."
-msgstr ""
+msgstr "Fájl átnevezése..."
 
 #: ../../src/wxMaximaFrame.cpp:1527
 msgid "Reorganize an expression using horner's rule"
-msgstr ""
+msgstr "Kifejezés átalakítása Horner-szabály segítségével"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "Repetitive element-by-element multiplication"
-msgstr ""
+msgstr "Ismétlődő elemenkénti szorzás"
 
 #: ../../src/wxMaxima.cpp:7538
 msgid "Replace all regex matches"
-msgstr ""
+msgstr "Cserélje ki az összes reguláris kifejezést"
 
 #: ../../src/wxMaxima.cpp:7533
 msgid "Replace first regex match"
-msgstr ""
+msgstr "Cserélje ki az első szabályos kifejezést"
 
 #: ../../src/wxMaxima.cpp:7463
 msgid "Replace the first occurrence of Part"
-msgstr ""
+msgstr "Cserélje ki a rész első előfordulását"
 
 #: ../../src/wxMaximaFrame.cpp:1180
 msgid "Replace..."
-msgstr ""
+msgstr "Csere..."
 
 #: ../../src/wxMaxima.cpp:6719
 #, c-format
 msgid "Replaced %li occurrences."
-msgstr ""
+msgstr "%li előfordulás lecserélve."
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "Report bug"
-msgstr ""
+msgstr "Hibajelentés"
 
 #: ../../src/wxMaximaFrame.cpp:996
 msgid "Reset option variables"
-msgstr ""
+msgstr "Beállításváltozók alaphelyzetbe állítása"
 
 #: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
 msgid "Restart Maxima"
-msgstr ""
+msgstr "A Maxima újraindítása"
 
 #: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
 msgid "Restrict Maximum size"
-msgstr ""
+msgstr "A maximum méret megszorítása"
 
 #: ../../src/wxMaxima.cpp:10031
 msgid "Result variables:"
-msgstr ""
+msgstr "Eredmény változók:"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Resulting Matrix name (may be empty):"
-msgstr ""
+msgstr "A keletkező mátrix neve (lehet üres):"
 
 #: ../../src/wxMaximaFrame.cpp:1190
 msgid "Return a match"
-msgstr ""
+msgstr "Adjon vissza egy gyufát"
 
 #: ../../src/wxMaxima.cpp:7077
 msgid "Return from a block or loop"
-msgstr ""
+msgstr "Visszatérés egy blokkból vagy hurokból"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "Return from current block/loop..."
-msgstr ""
+msgstr "Visszatérés az aktuális blokkból/hurokból..."
 
 #: ../../src/wxMaximaFrame.cpp:1755
 msgid ""
 "Return the first item of the list and remove it from the list. Useful for "
 "creating stacks."
 msgstr ""
+"Visszatér a lista első eleméhez, és eltávolítja a listából. Hasznos a "
+"kötegek létrehozásánál."
 
 #: ../../src/wxMaxima.cpp:8526
 msgid "Return the list without its first n elements"
-msgstr ""
+msgstr "Visszaadja a listát az első n elem nélkül"
 
 #: ../../src/wxMaxima.cpp:8532
 msgid "Return the list without its last n elements"
-msgstr ""
+msgstr "Visszaadja a listát az utolsó n elem nélkül"
 
 #: ../../src/ToolBar.cpp:241
 msgid "Return to the cell that is currently being evaluated"
-msgstr ""
+msgstr "Visszatérés a most kiértékelt cellára"
 
 #: ../../src/wxMaximaFrame.cpp:1711
 msgid "Returns an arbitrary list item"
-msgstr ""
+msgstr "Visszaad egy véletlen listaelemet"
 
 #: ../../src/wxMaximaFrame.cpp:1713
 msgid "Returns the first item of the list"
-msgstr ""
+msgstr "Visszaadja a lista első elemét"
 
 #: ../../src/wxMaximaFrame.cpp:1719
 msgid "Returns the last item of the list"
-msgstr ""
+msgstr "Visszaadja a lista utolsó elemét"
 
 #: ../../src/wxMaximaFrame.cpp:1721
 msgid "Returns the last n items of the list"
-msgstr ""
+msgstr "Visszaadja a lista utolsó n elemét"
 
 #: ../../src/wxMaximaFrame.cpp:1742
 msgid "Returns the length of the list"
-msgstr ""
+msgstr "Visszaadja a lista hosszát"
 
 #: ../../src/wxMaximaFrame.cpp:1715
 msgid "Returns the list without its first n elements"
-msgstr ""
+msgstr "Visszaadja a listát az első n elem nélkül"
 
 #: ../../src/wxMaximaFrame.cpp:1717
 msgid "Returns the list without its last n elements"
-msgstr ""
+msgstr "Visszaadja a listát az utolsó n elem nélkül"
 
 #: ../../src/wxMaximaFrame.cpp:1743
 msgid "Reverse"
-msgstr ""
+msgstr "Fordított"
 
 #: ../../src/wxMaximaFrame.cpp:1744
 msgid "Reverse the order of the list items"
-msgstr ""
+msgstr "Megfordítja a lista elemeinek sorrendjét"
 
 #: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
 #: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
 msgid "Right Matrix:"
-msgstr ""
+msgstr "Jobb mátrix:"
 
 #: ../../src/wxMaxima.cpp:8190
 msgid "Right end"
-msgstr ""
+msgstr "Jobb vége"
 
 #: ../../src/wxMaximaFrame.cpp:1301
 msgid "Right side to the \"=\""
-msgstr ""
+msgstr "A \"=\" jobb oldala"
 
 #: ../../src/wxMaximaFrame.cpp:1455
 msgid "Risch Integration..."
-msgstr ""
+msgstr "&Risch-integrálás..."
 
 #: ../../src/wxMaximaFrame.cpp:785
 msgid "Rounded"
-msgstr ""
+msgstr "Kerek"
 
 #: ../../src/wxMaximaFrame.cpp:1437
 msgid "Row and column operations"
-msgstr ""
+msgstr "Sor- és oszlopműveletek"
 
 #: ../../src/wxMaxima.cpp:7957 ../../src/wxMaxima.cpp:7967
 #: ../../src/wxMaxima.cpp:7972
 msgid "Row number:"
-msgstr ""
+msgstr "Sor száma:"
 
 #: ../../src/wxMaxima.cpp:7977
 msgid "Row numbers:"
-msgstr ""
+msgstr "Sor száma:"
 
 #: ../../src/wxMaxima.cpp:8203
 msgid "Rows"
-msgstr ""
+msgstr "Sorok"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Rule"
-msgstr ""
+msgstr "Szabály"
 
 #: ../../src/wxMaxima.cpp:8464 ../../src/wxMaxima.cpp:8477
 msgid "Rule:"
-msgstr ""
+msgstr "Szabály:"
 
 #: ../../src/wxMaximaFrame.cpp:1027
 msgid "Rules"
-msgstr ""
+msgstr "Szabályok"
 
 #: ../../src/wxMaximaFrame.cpp:1693
 msgid "Run each element through an expression"
-msgstr ""
+msgstr "Minden egyes elemet egy kifejezésen keresztül futtat"
 
 #: ../../src/wxMaxima.cpp:6355
 #, c-format
 msgid "Running %s on the file %s: "
-msgstr ""
+msgstr "%s futtatása a %s fájlon: "
 
 #: ../../src/wxMaxima.cpp:2633
 #, c-format
 msgid "Running maxima as: %s"
-msgstr ""
+msgstr "Maxima futtatása %s-ként"
 
 #: ../../src/wxMaximaFrame.cpp:130
 msgid "Running on DirectFB"
-msgstr ""
+msgstr "Futtatás DirectFB- rendszeren"
 
 #: ../../src/wxMaximaFrame.cpp:114
 msgid "Running on MS Windows"
-msgstr ""
+msgstr "Futtatás MS Windows rendszeren"
 
 #: ../../src/wxMaximaFrame.cpp:116
 msgid "Running on MS Windows using DirectDraw"
-msgstr ""
+msgstr "Futtatás MS Windows rendszeren a DirectDraw használatával"
 
 #: ../../src/wxMaximaFrame.cpp:136
 msgid "Running on Mac OS"
-msgstr ""
+msgstr "Futtatás Mac OS rendszeren"
 
 #: ../../src/wxMaximaFrame.cpp:127
 msgid "Running on Motif"
-msgstr ""
+msgstr "Futtatás Motif rendszeren"
 
 #: ../../src/wxMaximaFrame.cpp:133
 msgid "Running on the universal wxWidgets port"
-msgstr ""
+msgstr "Futtatás universal wxWidgets porton"
 
 #: ../../src/wxMaxima.cpp:8208
 msgid ""
 "Runs each element of an object (list, matrix, equation,...) through a "
 "function individually"
 msgstr ""
+"Egy objektum minden elemét (lista, mátrix, egyenlet,...) egyenként futtatja "
+"végig egy függvényen"
 
 #: ../../src/wxMaxima.cpp:8216
 msgid ""
 "Runs each element of an object (list, matrix, equation,...) through an "
 "expression individually"
 msgstr ""
+"Egy objektum minden elemét (lista, mátrix, egyenlet,...) egyenként futtatja "
+"végig egy kifejezésen"
 
 #: ../../src/wxMaximaFrame.cpp:1691
 msgid "Runs each element through a function"
-msgstr ""
+msgstr "Minden egyes elemet egy függvény segítségével futtat"
 
 #: ../../src/wxMaximaFrame.cpp:1694
 msgid "Runs each element through an expression"
-msgstr ""
+msgstr "Minden egyes elemet egy kifejezésen keresztül futtat"
 
 #: ../../src/wxMaxima.cpp:9572
 msgid "Sample 1:"
-msgstr ""
+msgstr "1. minta:"
 
 #: ../../src/wxMaxima.cpp:9573
 msgid "Sample 2:"
-msgstr ""
+msgstr "2. minta:"
 
 #: ../../src/wxMaxima.cpp:9567
 msgid "Sample:"
-msgstr ""
+msgstr "Minta:"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
 msgid "Save"
-msgstr ""
+msgstr "Mentés"
 
 #: ../../src/Worksheet.cpp:1294
 msgid "Save Animation..."
-msgstr ""
+msgstr "Animáció mentése..."
 
 #: ../../src/wxMaxima.cpp:5672
 msgid "Save As"
-msgstr ""
+msgstr "Mentés másként"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save As...\tShift+Ctrl+S"
-msgstr ""
+msgstr "Men&tés másként...\tShift+Ctrl+S"
 
 #: ../../src/Worksheet.cpp:1291
 msgid "Save Image..."
-msgstr ""
+msgstr "Kép mentése..."
 
 #: ../../src/wxMaxima.cpp:6440
 msgid "Save Selection to Image"
-msgstr ""
+msgstr "Kijelölés mentése képbe"
 
 #: ../../src/wxMaximaFrame.cpp:675
 msgid "Save Selection to Image..."
-msgstr ""
+msgstr "Ki&jelölés mentése képbe..."
 
 #: ../../src/wxMaxima.cpp:10184
 msgid "Save animation to file"
-msgstr ""
+msgstr "Animáció mentése fájlba"
 
 #: ../../src/wxMaxima.cpp:7203
 msgid "Save as lisp code"
-msgstr ""
+msgstr "Mentés lisp kódként"
 
 #: ../../src/wxMaximaFrame.cpp:1091
 msgid "Save as lisp..."
-msgstr ""
+msgstr "Mentés lisp kódként..."
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
 msgid "Save document"
-msgstr ""
+msgstr "Dokumentum mentése"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save document as"
-msgstr ""
+msgstr "Mentés másként"
 
 #: ../../src/wxMaximaFrame.cpp:676
 msgid "Save selection from document to an image file"
-msgstr ""
+msgstr "Kijelölt rész fájlba másolása a dokumentumból"
 
 #: ../../src/wxMaxima.cpp:10125
 msgid "Save selection to file"
-msgstr ""
+msgstr "Kijelölt rész mentése fájlba"
 
 #: ../../src/wxMaximaFrame.cpp:573
 msgid "Saving failed."
-msgstr ""
+msgstr "A mentés meghiúsult."
 
 #: ../../src/WXMXformat.cpp:310
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
-msgstr ""
+msgstr "A mentés sikerült, de a kapott fájlok eltűntek ?!?."
 
 #: ../../src/wxMaxima.cpp:10107
 msgid ""
@@ -5947,716 +6159,745 @@ msgid ""
 "(*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|Portable anymap "
 "(*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"Skálázható vektoros kép (*.svg) |*.svg | Tömörített skálázható vektoros kép "
+"(*.svgz) |*.svgz | PNG -kép (*.png) |*.png | JPEG -kép (*.jpg) |*.jpg | GIF "
+"kép (*.gif) |*.gif | Windows bittérkép (*.bmp) |*.bmp | Hordozható anymap "
+"(*.pnm) |*.pnm | Címkézett képfájl formátum (*.tif) |*.tif | X pixmap "
+"(*.xpm) |*.xpm"
 
 #: ../../src/wxMaxima.cpp:9533
 msgid "Scatterplot"
-msgstr ""
+msgstr "Szóródási pont"
 
 #: ../../src/Autocomplete.cpp:125
 msgid ""
 "Scheduling a background task that compiles a new list of autocompletable "
 "maxima commands."
 msgstr ""
+"Háttérfeladat ütemezése, amely összeállítja az automatikusan kiegészíthető "
+"maximális parancsok listáját."
 
 #: ../../src/Autocomplete.cpp:458
 msgid ""
 "Scheduling a background task that scans for autocompletable file names."
 msgstr ""
+"Olyan háttérfeladat ütemezése, amely automatikusan kiegészíthető fájlneveket"
+" keres"
 
 #: ../../src/ToolBar.cpp:632
 msgid "Search button"
-msgstr ""
+msgstr "Keresés gomb"
 
 #: ../../src/wxMaxima.cpp:7454
 msgid "Search first occurrence of part"
-msgstr ""
+msgstr "Az alkatrész első előfordulásának keresése"
 
 #: ../../src/wxMaximaFrame.cpp:1178
 msgid "Search..."
-msgstr ""
+msgstr "Keresés..."
 
 #: ../../src/ToolBar.cpp:273
 msgid "Section"
-msgstr ""
+msgstr "Fejezet"
 
 #: ../../src/Configuration.cpp:91
 msgid "Section cell (Heading 2)"
-msgstr ""
+msgstr "Szakasz cella (2. címsor)"
 
 #: ../../src/wxMaxima.cpp:7218
 msgid "Seek to position"
-msgstr ""
+msgstr "Pozíció keresése"
 
 #: ../../src/BTextCtrl.cpp:45
 msgid "Seems like something is broken with a font."
-msgstr ""
+msgstr "Úgy tűnik, valami gond van a betűtípusokkal."
 
 #: ../../src/Autocomplete.cpp:350
 msgid "Seems like the package with the maxima share files isn't installed."
 msgstr ""
+"Úgy tűnik, hogy a maxima megosztott fájljait tartalmazó csomag nincs "
+"telepítve."
 
 #: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
 msgid "Select All"
-msgstr ""
+msgstr "Cellatartalom kijelölése"
 
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select All\tCtrl+A"
-msgstr ""
+msgstr "&Minden kiválasztása\tCtrl+A"
 
 #: ../../src/ToolBar.cpp:629
 msgid "Select All button"
-msgstr ""
+msgstr "Minden kiválasztása"
 
 #: ../../src/wxMaxima.cpp:9631
 msgid "Select Subsample"
-msgstr ""
+msgstr "Részminta kiválasztása"
 
 #: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select all"
-msgstr ""
+msgstr "Minden kiválasztása"
 
 #: ../../src/wxMaxima.cpp:6971
 msgid "Select math display algorithm"
-msgstr ""
+msgstr "Matematikai megjelenítés algoritmusának kiválasztása"
 
 #: ../../src/Configuration.cpp:98
 msgid "Selection color"
-msgstr ""
+msgstr "Kijelölés színe"
 
 #: ../../src/ToolBar.cpp:252
 msgid "Send all cells to maxima"
-msgstr ""
+msgstr "Minden cella Maximához küldése"
 
 #: ../../src/ToolBar.cpp:249
 msgid "Send the current cell to maxima"
-msgstr ""
+msgstr "Az aktuális cella Maximához küldése"
 
 #: ../../src/wxMaxima.cpp:2810
 msgid "Sending Maxima a SIGINT signal."
-msgstr ""
+msgstr "SIGINT szignál küldése a Maximának."
 
 #: ../../src/StatusBar.cpp:220
 msgid "Sending a command to Maxima"
-msgstr ""
+msgstr "Parancs küldése a maximának"
 
 #: ../../src/wxMaxima.cpp:10598
 msgid "Sending a new command to Maxima."
-msgstr ""
+msgstr "Új parancs küldése a Maximának."
 
 #: ../../src/wxMaxima.cpp:2792
 msgid "Sending an interrupt signal to Maxima."
-msgstr ""
+msgstr "Megszakítási jel küldése a Maximának."
 
 #: ../../src/wxMaxima.cpp:169
 msgid "Sending configuration data to maxima."
-msgstr ""
+msgstr "Beállító adat küldése a maximának."
 
 #: ../../src/wxMaxima.cpp:4718
 msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
+"Információ küldése a Maximának, hogy hogyan fejezzük ki a 2d matematikát "
+"XML-ként"
 
 #: ../../src/wxMaximaFrame.cpp:1533
 msgid "Sequential Comparative Simplification"
-msgstr ""
+msgstr "Szekvenciális összehasonlító egyszerűsítés"
 
 #: ../../src/wxMaxima.cpp:9016
 msgid "Series"
-msgstr ""
+msgstr "Taylor- és hatványsor"
 
 #: ../../src/wxMaximaFrame.cpp:1479
 msgid "Series approximation"
-msgstr ""
+msgstr "Sorozat közelítés"
 
 #: ../../src/wxMaxima.cpp:2561
 msgid "Server started"
-msgstr ""
+msgstr "A kiszolgáló elindult"
 
 #: ../../src/wxMaximaFrame.cpp:1824
 msgid "Set &displayed Precision..."
-msgstr ""
+msgstr "Pontosság állítása és &megjelenítése..."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Set Maxima option variable logexpand:all"
-msgstr ""
+msgstr "Maxima beállítási változó logexpand:all beállítása"
 
 #: ../../src/wxMaximaFrame.cpp:1567
 msgid "Set Maxima option variable logexpand:super"
-msgstr ""
+msgstr "Állítsa be a Maxima opció logexpand:super változóját"
 
 #: ../../src/wxMaximaFrame.cpp:1560
 msgid "Set Maxima option variable logexpand:true"
-msgstr ""
+msgstr "Állítsa be a Maxima opció logexpand:true változóját"
 
 #: ../../src/wxMaximaFrame.cpp:822
 msgid "Set Zoom"
-msgstr ""
+msgstr "Nagyítás beállítása"
 
 #: ../../src/wxMaximaFrame.cpp:1819
 msgid "Set bigfloat &Precision..."
-msgstr ""
+msgstr "Hosszú lebegőpontos műveletek &pontosságának állítása..."
 
 #: ../../src/Worksheet.cpp:1306 ../../src/Worksheet.cpp:1479
 msgid "Set image resolution"
-msgstr ""
+msgstr "Állítsa be a képfelbontást"
 
 #: ../../src/wxMaximaFrame.cpp:1510
 msgid "Set main variable..."
-msgstr ""
+msgstr "Fő változó megadása..."
 
 #: ../../src/wxMaximaFrame.cpp:1773
 msgid "Set plot format"
-msgstr ""
+msgstr "Ábrázolás módjának állítása"
 
 #: ../../src/wxMaximaFrame.cpp:1101
 msgid "Set position..."
-msgstr ""
+msgstr "Pozíció beállítása..."
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Set the \"algebraic\" flag"
-msgstr ""
+msgstr "Az 'algebrai' kapcsoló állítása"
 
 #: ../../src/wxMaxima.cpp:8314
 msgid "Set the diagram title"
-msgstr ""
+msgstr "A rács sűrűségének beállítása"
 
 #: ../../src/wxMaximaFrame.cpp:1779
 msgid "Set the frame rate for animations."
-msgstr ""
+msgstr "Animáció framerátájának beállítása."
 
 #: ../../src/wxMaxima.cpp:8377
 msgid "Set the grid density."
-msgstr ""
+msgstr "A rács sűrűségének beállítása."
 
 #: ../../src/wxMaxima.cpp:8327
 msgid "Set the next plot's title. Empty = no title."
-msgstr ""
+msgstr "A következő ábra címének beállítása. Üres = nincs cím."
 
 #: ../../src/wxMaximaFrame.cpp:1820
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can"
 " be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
+"A bigfloat eljárással definiált számok pontosságának állítása. Ilyen "
+"számokat például 1.5b12 vagy bfloat(1.234) beírásával generálhatunk."
 
 #: ../../src/wxMaximaFrame.cpp:811
 msgid "Set zoom to 100%"
-msgstr ""
+msgstr "Nagyítás beállítása 100%-ra"
 
 #: ../../src/wxMaximaFrame.cpp:813
 msgid "Set zoom to 120%"
-msgstr ""
+msgstr "Nagyítás beállítása 120%-ra"
 
 #: ../../src/wxMaximaFrame.cpp:815
 msgid "Set zoom to 150%"
-msgstr ""
+msgstr "Nagyítás beállítása 150%-ra"
 
 #: ../../src/wxMaximaFrame.cpp:817
 msgid "Set zoom to 200%"
-msgstr ""
+msgstr "Nagyítás beállítása 200%-ra"
 
 #: ../../src/wxMaximaFrame.cpp:819
 msgid "Set zoom to 300%"
-msgstr ""
+msgstr "Nagyítás beállítása 300%-ra"
 
 #: ../../src/wxMaximaFrame.cpp:809
 msgid "Set zoom to 80%"
-msgstr ""
+msgstr "Nagyítás beállítása 80%-ra"
 
 #: ../../src/wxMaxima.cpp:4731
 #, c-format
 msgid "Setting gnuplot_binary to %s"
-msgstr ""
+msgstr "A gnuplot_binary beállítása %s"
 
 #: ../../src/wxMaxima.cpp:4804
 msgid "Setting prompt and help format"
-msgstr ""
+msgstr "A prompt és a súgó formátumának beállítása"
 
 #: ../../src/wxMaximaFrame.cpp:1292
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
+"Laplace-transzformációval megoldani próbált kezdetiérték-probléma kezdeti "
+"helyének és értékének beállítása"
 
 #: ../../src/wxMaximaFrame.cpp:1661
 msgid "Setup modulus computation"
-msgstr ""
+msgstr "Modulus értékének beállítása"
 
 #: ../../src/wxMaxima.cpp:9220
 msgid "Setup the engineering format"
-msgstr ""
+msgstr "Mérnöki formátum beállítása"
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "Setup the engineering format..."
-msgstr ""
+msgstr "Mérnöki formátum beállítása..."
 
 #: ../../src/wxMaxima.cpp:9576
 msgid "Shapiro-Wilk test for normality"
-msgstr ""
+msgstr "Shapiro-Wilk teszt a normalitásért"
 
 #: ../../src/Worksheet.cpp:1543
 msgid "Show \"%\" in special constants"
-msgstr ""
+msgstr "\"%\" megjelenítése különleges állandókban"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show &Tips..."
-msgstr ""
+msgstr "&Tippek..."
 
 #: ../../src/Worksheet.cpp:1556
 msgid "Show * as multiplication dot"
-msgstr ""
+msgstr "* megjelenítése szorzásjelként"
 
 #: ../../src/wxMaximaFrame.cpp:895
 msgid "Show Template\tCtrl+Shift+Space"
-msgstr ""
+msgstr "Sablon mutatása\tCtrl+Shift+Space"
 
 #: ../../src/wxMaximaFrame.cpp:753
 msgid "Show XML representation"
-msgstr ""
+msgstr "XML-reprezentáció megjelenítése"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show a tip"
-msgstr ""
+msgstr "Tippet mutat"
 
 #: ../../src/Worksheet.cpp:1607
 msgid "Show all + allow linebreaks in long numbers"
-msgstr ""
+msgstr "Az összes megjelenítése + sortörések engedélyezése hosszú számokban"
 
 #: ../../src/wxMaxima.cpp:9475
 msgid "Show all commands similar to:"
-msgstr ""
+msgstr "Megmutat minden parancsot, ami hasonlít erre:"
 
 #: ../../src/wxMaxima.cpp:9468
 msgid "Show an example for the command:"
-msgstr ""
+msgstr "Példa az alábbi parancsra:"
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "Show an example of usage"
-msgstr ""
+msgstr "Példa a parancs használatára"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "Show commands similar to"
-msgstr ""
+msgstr "Megmutat minden parancsot, ami hasonlít erre"
 
 #: ../../src/wxMaximaFrame.cpp:1020
 msgid "Show defined functions"
-msgstr ""
+msgstr "Megmutatja a definiált függvényeket"
 
 #: ../../src/wxMaximaFrame.cpp:1022
 msgid "Show defined variables"
-msgstr ""
+msgstr "Megmutatja a definiált változókat"
 
 #: ../../src/wxMaximaFrame.cpp:1074
 msgid "Show definition of a function"
-msgstr ""
+msgstr "Megmutatja a függvény definícióját"
 
 #: ../../src/wxMaximaFrame.cpp:740
 msgid "Show equations in their linear form"
-msgstr ""
+msgstr "Mutassa az egyenleteket lineáris alakjukban"
 
 #: ../../src/wxMaximaFrame.cpp:1073
 msgid "Show function &Definition..."
-msgstr ""
+msgstr "Megmutatja a &függvény definícióját..."
 
 #: ../../src/wxMaximaFrame.cpp:896
 msgid "Show function template"
-msgstr ""
+msgstr "Függvény automatikus kiegészítése sablonnal"
 
 #: ../../src/Worksheet.cpp:1614
 msgid "Show input labels"
-msgstr ""
+msgstr "Bemeneti címkék megjelenítése"
 
 #: ../../src/wxMaximaFrame.cpp:750
 msgid "Show lisp representation"
-msgstr ""
+msgstr "Lisp-reprezentáció megjelenítése"
 
 #: ../../src/Worksheet.cpp:1604
 msgid "Show max. 100 digits"
-msgstr ""
+msgstr "Legfeljebb 100 számjegyet mutat"
 
 #: ../../src/Worksheet.cpp:1602
 msgid "Show max. 20 digits"
-msgstr ""
+msgstr "Legfeljebb 20 számjegyet mutat"
 
 #: ../../src/Worksheet.cpp:1603
 msgid "Show max. 50 digits"
-msgstr ""
+msgstr "Legfeljebb 50 számjegyet mutat"
 
 #: ../../src/wxMaximaFrame.cpp:835
 msgid "Show or hide the wxMaxima logging window"
-msgstr ""
+msgstr "megjelenítés or elrejtés the wxMaxima logging window"
 
 #: ../../src/ToolBar.cpp:612
 msgid "Show the \"New\" button?"
-msgstr ""
+msgstr "Mutassa az Új gombot?"
 
 #: ../../src/ToolBar.cpp:636
 msgid "Show the \"help\" button?"
-msgstr ""
+msgstr "Mutassa a Súgó gombot?"
 
 #: ../../src/ToolBar.cpp:633
 msgid "Show the \"search\" button?"
-msgstr ""
+msgstr "Mutassa a Keresés gombot?"
 
 #: ../../src/ToolBar.cpp:630
 msgid "Show the \"select all\" button?"
-msgstr ""
+msgstr "Mutassa a \"Minden kiválasztása\" gombot?"
 
 #: ../../src/ToolBar.cpp:624
 msgid "Show the Copy, Cut and the Paste button?"
-msgstr ""
+msgstr "Mutassa a Másolás, Kivágás és Beillesztés gombokat?"
 
 #: ../../src/wxMaxima.cpp:7033
 msgid "Show the function's definition"
-msgstr ""
+msgstr "Megmutatja a függvény definícióját"
 
 #: ../../src/ToolBar.cpp:618
 msgid "Show the open and the save button?"
-msgstr ""
+msgstr "Mutassa a Megnyitás és Mentés gombokat?"
 
 #: ../../src/ToolBar.cpp:627
 msgid "Show the preferences button?"
-msgstr ""
+msgstr "Mutassa a Beállítások gombot?"
 
 #: ../../src/ToolBar.cpp:621
 msgid "Show the print button?"
-msgstr ""
+msgstr "Mutassa a Nyomtatás gombot?"
 
 #: ../../src/ToolBar.cpp:615
 msgid "Show the undo and redo button?"
-msgstr ""
+msgstr "Mutassa a visszavonás és ismétlés gombot?"
 
 #: ../../src/wxMaximaFrame.cpp:1006 ../../src/wxMaximaFrame.cpp:1011
 msgid "Show used + to-be-freed memory"
-msgstr ""
+msgstr "megjelenítés used + to-be-freed memory"
 
 #: ../../src/wxMaximaFrame.cpp:1033
 msgid "Show user definitions"
-msgstr ""
+msgstr "Megmutatja a felhasználó által megadott definíciókat"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Show wxMaxima help"
-msgstr ""
+msgstr "Maxima súgó"
 
 #: ../../src/wxMaximaFrame.cpp:1825
 msgid "Shows how many digits of a numbers are displayed"
-msgstr ""
+msgstr "Megmutatja, hogy a számok hány jegyét jeleníti meg"
 
 #: ../../src/wxMaximaFrame.cpp:732
 msgid "Sidebars"
-msgstr ""
+msgstr "Oldalsávok"
 
 #: ../../src/wxMaximaFrame.cpp:1513
 msgid "Simplify &Radicals..."
-msgstr ""
+msgstr "&Gyökös egyszerűsítés..."
 
 #: ../../src/Worksheet.cpp:1579
 msgid "Simplify Expression"
-msgstr ""
+msgstr "Kifejezés egyszerűsítése"
 
 #: ../../src/wxMaximaFrame.cpp:1568
 msgid "Simplify Logarithms"
-msgstr ""
+msgstr "Logaritmikus egyszerűsítés"
 
 #: ../../src/wxMaximaFrame.cpp:1582
 msgid "Simplify an expression containing factorials"
-msgstr ""
+msgstr "Faktoriálisokat tartalmazó kifejezések egyszerűsítése"
 
 #: ../../src/wxMaximaFrame.cpp:1539
 msgid "Simplify equations"
-msgstr ""
+msgstr "Egyenletek egyszerűsítése"
 
 #: ../../src/wxMaximaFrame.cpp:1514
 msgid "Simplify expression containing radicals"
-msgstr ""
+msgstr "Gyököket tartalmazó kifejezések egyszerűsítése"
 
 #: ../../src/wxMaxima.cpp:8649
 msgid "Simplify radicals"
-msgstr ""
+msgstr "Gyökös egyszerűsítés"
 
 #: ../../src/wxMaximaFrame.cpp:1512
 msgid "Simplify rational expression"
-msgstr ""
+msgstr "Racionális kifejezések egyszerűsítése"
 
 #: ../../src/wxMaximaFrame.cpp:1538
 msgid "Simplify sum() commands..."
-msgstr ""
+msgstr "Az összeg() parancsok egyszerűsítése..."
 
 #: ../../src/wxMaxima.cpp:8636
 msgid "Simplify sums"
-msgstr ""
+msgstr "Összeg egyszerűsítése"
 
 #: ../../src/wxMaximaFrame.cpp:1592
 msgid "Simplify trigonometric expression"
-msgstr ""
+msgstr "Trigonometrikus kifejezést egyszerűbb alakra hoz"
 
 #: ../../src/wxMaximaFrame.cpp:1399
 msgid "Singular Values"
-msgstr ""
+msgstr "Egyedi értékek"
 
 #: ../../src/wxMaximaFrame.cpp:1400 ../../src/wxMaximaFrame.cpp:1403
 msgid "Singular values using dgesvd"
-msgstr ""
+msgstr "Egyedi értékek a dgesvd használatával"
 
 #: ../../src/wxMaximaFrame.cpp:1402
 msgid "Singular values, left + right vectors"
-msgstr ""
+msgstr "Szinguláris értékek, bal jobb oldali vektorok"
 
 #: ../../src/wxMaximaFrame.cpp:1635
 msgid "Smart Substitute..."
-msgstr ""
+msgstr "Intelligens helyettesítés..."
 
 #: ../../src/wxMaxima.cpp:8730
 msgid "Smart substitution"
-msgstr ""
+msgstr "Intelligens helyettesítés"
 
 #: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
 #: ../../src/wxMaxima.cpp:7823
 msgid "Solution of the ODE:"
-msgstr ""
+msgstr "Az ODE megoldása:"
 
 #: ../../src/wxMaxima.cpp:10017
 msgid "Solve"
-msgstr ""
+msgstr "Megoldás"
 
 #: ../../src/wxMaximaFrame.cpp:1244
 msgid "Solve &Algebraic System..."
-msgstr ""
+msgstr "&Algebrai egyenletrendszer megoldása..."
 
 #: ../../src/wxMaximaFrame.cpp:1242
 msgid "Solve &Linear System..."
-msgstr ""
+msgstr "&Lineáris egyenletrendszer megoldása..."
 
 #: ../../src/wxMaximaFrame.cpp:1266
 msgid "Solve &ODE..."
-msgstr ""
+msgstr "&Differenciálegyenlet megoldása..."
 
 #: ../../src/wxMaximaFrame.cpp:1240
 msgid "Solve (to_poly)..."
-msgstr ""
+msgstr "Me&goldás (to_poly)..."
 
 #: ../../src/wxMaxima.cpp:8045
 msgid "Solve A*x=b numerically"
-msgstr ""
+msgstr "Az A*x=b numerikus megoldása"
 
 #: ../../src/wxMaximaFrame.cpp:1397
 msgid "Solve Ax=b"
-msgstr ""
+msgstr "Ax=b megoldása"
 
 #: ../../src/wxMaxima.cpp:7783
 msgid "Solve ODE"
-msgstr ""
+msgstr "Differenciálegyenlet megoldása"
 
 #: ../../src/wxMaximaFrame.cpp:1287
 msgid "Solve ODE with Lapla&ce..."
-msgstr ""
+msgstr "D&ifferenciálegyenlet megoldása (Laplace)..."
 
 #: ../../src/wxMaximaFrame.cpp:1398
 msgid "Solve a linear equation system using dgesv"
-msgstr ""
+msgstr "Lineáris egyenletrendszer megoldása dgesv segítségével"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
 msgid "Solve algebraic system"
-msgstr ""
+msgstr "Algebrai egyenletrendszer"
 
 #: ../../src/wxMaximaFrame.cpp:1245
 msgid "Solve algebraic system of equations"
-msgstr ""
+msgstr "Algebrai egyenletrendszer megoldása"
 
 #: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve boundary value problem for second degree ODE"
 msgstr ""
+"Peremérték probléma megoldása másodrendű közönséges differenciálegyenlet "
+"esetén"
 
 #: ../../src/wxMaxima.cpp:7895
 msgid "Solve differential equations using laplace()"
-msgstr ""
+msgstr "Differenciálegyenlet megoldása Laplace-transzformáció segítségével"
 
 #: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
 msgid "Solve equation(s)"
-msgstr ""
+msgstr "Egyenletet(rendszer) megoldása"
 
 #: ../../src/wxMaximaFrame.cpp:1241
 msgid "Solve equation(s) with to_poly_solve"
-msgstr ""
+msgstr "Egyenletet(rendszer)ek megoldása a to_poly_solve eljárással"
 
 #: ../../src/wxMaxima.cpp:7773
 msgid "Solve equations numerically"
-msgstr ""
+msgstr "Egyenletek numerikus megoldása"
 
 #: ../../src/wxMaxima.cpp:7757
 msgid "Solve equations to polynom"
-msgstr ""
+msgstr "Egyenletetek megoldása polinommal"
 
 #: ../../src/wxMaximaFrame.cpp:1271
 msgid "Solve initial value problem for first degree ODE"
 msgstr ""
+"Kezdetiérték-probléma megoldása elsőrendű közönséges differenciálegyenlet "
+"esetén"
 
 #: ../../src/wxMaximaFrame.cpp:1275
 msgid "Solve initial value problem for second degree ODE"
 msgstr ""
+"Kezdetiérték-probléma megoldása másodrendű közönséges differenciálegyenlet "
+"esetén"
 
 #: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
 msgid "Solve linear system"
-msgstr ""
+msgstr "Lineáris egyenletrendszer"
 
 #: ../../src/wxMaximaFrame.cpp:1243
 msgid "Solve linear system of equations"
-msgstr ""
+msgstr "Lineáris egyenletrendszer megoldása"
 
 #: ../../src/wxMaximaFrame.cpp:1263
 msgid "Solve numerical, 1 Variable"
-msgstr ""
+msgstr "Numerikus megoldás, 1 Változó"
 
 #: ../../src/wxMaximaFrame.cpp:1267
 msgid "Solve ordinary differential equation of maximum degree 2"
-msgstr ""
+msgstr "Legfeljebb másodrendű közönséges differenciálegyenlet megoldása"
 
 #: ../../src/wxMaximaFrame.cpp:1288
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
+"Közönséges differenciálegyenlet megoldása Laplace-transzformáció "
+"segítségével"
 
 #: ../../src/wxMaxima.cpp:7708
 msgid "Solve polynomials numerically"
-msgstr ""
+msgstr "Polinomok numerikus megoldása"
 
 #: ../../src/wxMaxima.cpp:7718
 msgid "Solve polynomials numerically (bfloats)"
-msgstr ""
+msgstr "Polinomok numerikus megoldása (bfloats)"
 
 #: ../../src/wxMaxima.cpp:7729
 msgid "Solve polynomials numerically (real roots)"
-msgstr ""
+msgstr "Egyenletet(rendszer) megoldása (valós gyökök)"
 
 #: ../../src/wxMaximaFrame.cpp:1249
 msgid "Solve symbolically"
-msgstr ""
+msgstr "Szimbolikus megoldás"
 
 #: ../../src/Worksheet.cpp:1574
 msgid "Solve..."
-msgstr ""
+msgstr "Megold..."
 
 #: ../../src/wxMaximaFrame.cpp:1916
 msgid "Solving differential equations"
-msgstr ""
+msgstr "Differenciálegyenletek megoldása"
 
 #: ../../src/wxMaximaFrame.cpp:1904
 msgid "Solving equations with Maxima"
-msgstr ""
+msgstr "Egyenletek megoldása maximával"
 
 #: ../../src/wxMaxima.cpp:7105
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Sometimes one wants maxima to loose the information that a function name was used with the ' operator in order to make maxima not evaluate it. In other places one wants % to mean \"the last expression at the time this function was created\", not \"the last expression now\".\n"
 "In both cases the '' operator will do what is requested."
 msgstr ""
+"Előfordul, hogy azt szeretnénk, ha a Maxima „elfelejtené”, hogy egy függvénynévhez az ' operátort használtuk, hogy a Maxima ne értékelje ki azt. Más esetekben azt szeretnénk, hogy a % jelentése „a függvény létrehozásának időpontjában utolsó kifejezés” legyen, ne pedig „a mostani utolsó kifejezés”.\n"
+"Mindkét esetben a '' operátor azt teszi, amit várunk."
 
 #: ../../src/wxMaximaFrame.cpp:1746
 msgid "Sort"
-msgstr ""
+msgstr "Rendezés"
 
 #: ../../src/wxMaxima.cpp:8496
 msgid "Sort a list"
-msgstr ""
+msgstr "Lista rendezése"
 
 #: ../../src/wxMaxima.cpp:7459
 msgid "Sort all characters in string"
-msgstr ""
+msgstr "Az összes karakter rendezése karakterláncban"
 
 #: ../../src/wxMaximaFrame.cpp:1179
 msgid "Sort the characters..."
-msgstr ""
+msgstr "Karakterek rendezése..."
 
 #: ../../src/wxMaxima.cpp:8482
 msgid "Source list:"
-msgstr ""
+msgstr "Forrás lista:"
 
 #: ../../src/wxMaxima.cpp:7429
 msgid "Split"
-msgstr ""
+msgstr "Osztva"
 
 #: ../../src/wxMaximaFrame.cpp:1191
 msgid "Split on match"
-msgstr ""
+msgstr "Megoszlik a mérkőzésen"
 
 #: ../../src/wxMaxima.cpp:7528
 msgid "Split on regex match"
-msgstr ""
+msgstr "Megosztás a reguláris kifejezésre"
 
 #: ../../src/wxMaxima.cpp:7449
 msgid "Split string into tokens"
-msgstr ""
+msgstr "Vágd fel a karakterláncot tokenekre"
 
 #: ../../src/wxMaximaFrame.cpp:1171
 msgid "Split..."
-msgstr ""
+msgstr "Felosztás..."
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Square"
-msgstr ""
+msgstr "Szögletes"
 
 #: ../../src/Configuration.cpp:86
 msgid "Standard Text"
-msgstr ""
+msgstr "Alapértelmezett Szöveg"
 
 #: ../../src/Worksheet.cpp:1298
 msgid "Start Animation"
-msgstr ""
+msgstr "Animáció indítása"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Start of t:"
-msgstr ""
+msgstr "t kezdete"
 
 #: ../../src/ToolBar.cpp:305
 msgid "Start or Stop animation"
-msgstr ""
+msgstr "Animáció indítása vagy leállítása"
 
 #: ../../src/ToolBar.cpp:306
 msgid ""
 "Start or stop the currently selected animation that has been created with "
 "the with_slider class of commands"
 msgstr ""
+"A kiválasztott, with_slider paranccsal létrehozott animáció indítása vagy "
+"megállítása"
 
 #: ../../src/wxMaxima.cpp:386
 msgid "Starting Maxima process failed"
-msgstr ""
+msgstr "A Maxima folyamat leállt"
 
 #: ../../src/main.cpp:667
 msgid "Starting a new wxMaxima process for a new window"
-msgstr ""
+msgstr "Új wxMaxima-folyamat indítása új ablakhoz"
 
 #: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:5633
 msgid "Starting evaluation of the document"
-msgstr ""
+msgstr "A dokumentum kiértékelése"
 
 #: ../../src/wxMaxima.cpp:2544
 msgid "Starting server failed"
-msgstr ""
+msgstr "A szerver leállt"
 
 #: ../../src/WXMXformat.cpp:64
 msgid "Starting to save the worksheet as .wxmx"
-msgstr ""
+msgstr "Munkalap mentése .wxmx formátumban"
 
 #: ../../src/wxMaximaFrame.cpp:252
 msgid "Statistics"
-msgstr ""
+msgstr "Statisztika"
 
 #: ../../src/wxMaximaFrame.cpp:701
 msgid "Statistics\tAlt+Shift+S"
-msgstr ""
+msgstr "Statisztika\tAlt+Shift+S"
 
 #: ../../src/wxMaxima.cpp:7844
 msgid "Step width:"
-msgstr ""
+msgstr "Lépésszélesség:"
 
 #: ../../src/wxMaximaFrame.cpp:794
 msgid "Straight lines"
-msgstr ""
+msgstr "Egyenes vonalak"
 
 #: ../../src/wxMaximaFrame.cpp:1106
 msgid "Stream"
-msgstr ""
+msgstr "Adatfolyam"
 
 #: ../../src/wxMaxima.cpp:7231
 msgid "Stream length"
-msgstr ""
+msgstr "Az adatfolyam hossza"
 
 #: ../../src/wxMaxima.cpp:7219 ../../src/wxMaxima.cpp:7224
 #: ../../src/wxMaxima.cpp:7228 ../../src/wxMaxima.cpp:7232
@@ -6666,45 +6907,45 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7267 ../../src/wxMaxima.cpp:7271
 #: ../../src/wxMaxima.cpp:7276
 msgid "Stream:"
-msgstr ""
+msgstr "Adatfolyam:"
 
 #: ../../src/wxMaximaFrame.cpp:1185
 msgid "String"
-msgstr ""
+msgstr "Karakterlánc"
 
 #: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
 #: ../../src/wxMaxima.cpp:7425
 msgid "String #1:"
-msgstr ""
+msgstr "Karakterlánc %1:"
 
 #: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
 #: ../../src/wxMaxima.cpp:7426
 msgid "String #2:"
-msgstr ""
+msgstr "Karakterlánc %2:"
 
 #: ../../src/wxMaximaFrame.cpp:1136
 msgid "String Tests"
-msgstr ""
+msgstr "Karakterlánc tesztek"
 
 #: ../../src/wxMaxima.cpp:7415
 msgid "String length"
-msgstr ""
+msgstr "Karakterlánc hossza"
 
 #: ../../src/wxMaxima.cpp:7381
 msgid "String to list of char"
-msgstr ""
+msgstr "Karakterlánc a karakterek listájához"
 
 #: ../../src/wxMaximaFrame.cpp:1148
 msgid "String to list of chars..."
-msgstr ""
+msgstr "Karakterlánc a karakterlistához..."
 
 #: ../../src/wxMaxima.cpp:7496
 msgid "String to octets"
-msgstr ""
+msgstr "Karakterlánc oktettbe"
 
 #: ../../src/wxMaximaFrame.cpp:1160
 msgid "String to octets..."
-msgstr ""
+msgstr "Húr oktettre..."
 
 #: ../../src/wxMaxima.cpp:7377 ../../src/wxMaxima.cpp:7382
 #: ../../src/wxMaxima.cpp:7391 ../../src/wxMaxima.cpp:7396
@@ -6718,74 +6959,76 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
 #: ../../src/wxMaxima.cpp:7497
 msgid "String:"
-msgstr ""
+msgstr "Karakterlánc:"
 
 #: ../../src/wxMaxima.cpp:7197
 msgid "Struct :"
-msgstr ""
+msgstr "Struktúra:"
 
 #: ../../src/wxMaxima.cpp:7184 ../../src/wxMaxima.cpp:7190
 msgid "Struct type name:"
-msgstr ""
+msgstr "Struktúratípus neve:"
 
 #: ../../src/wxMaximaFrame.cpp:1029
 msgid "Structs"
-msgstr ""
+msgstr "Struktúrák"
 
 #: ../../src/ToolBar.cpp:274
 msgid "Subsection"
-msgstr ""
+msgstr "Alfejezet"
 
 #: ../../src/Configuration.cpp:90
 msgid "Subsection cell (Heading 3)"
-msgstr ""
+msgstr "Alfejezetcella (3. fejléc)"
 
 #: ../../src/wxMaximaFrame.cpp:1643
 msgid "Subst constant t into eq with diff(x,t)..."
-msgstr ""
+msgstr "t konstans beillesztése egyenletbe diff(x,t)-vel..."
 
 #: ../../src/wxMaxima.cpp:8724
 msgid "Subst is a better string-search-and-replace for expressions."
-msgstr ""
+msgstr "A Subst egy jobb string-keresés-helyettesítés a kifejezésekhez."
 
 #: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
 #: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
 msgid "Substitute"
-msgstr ""
+msgstr "Behelyettesítés"
 
 #: ../../src/wxMaximaFrame.cpp:1193
 msgid "Substitute all matches"
-msgstr ""
+msgstr "Cserélje ki az összes egyezést"
 
 #: ../../src/wxMaximaFrame.cpp:1192
 msgid "Substitute first match"
-msgstr ""
+msgstr "Csere első mérkőzés"
 
 #: ../../src/wxMaximaFrame.cpp:1646
 msgid "Substitute only in parts..."
-msgstr ""
+msgstr "Csak meghatározott részekben helyettesít..."
 
 #: ../../src/wxMaxima.cpp:8763
 msgid "Substitute only in specific parts"
-msgstr ""
+msgstr "Csak meghatározott részekben helyettesíthető"
 
 #: ../../src/wxMaximaFrame.cpp:1647
 msgid "Substitute only in the elements n_1, n_2,..."
-msgstr ""
+msgstr "Csak az n_1, n_2,... elemekben helyettesíthető"
 
 #: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
 msgid "Substitute..."
-msgstr ""
+msgstr "&Behelyettesítés..."
 
 #: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
 msgid "Substitutes until the equation no more changes"
-msgstr ""
+msgstr "Helyettesít, amíg az egyenlet már nem változik"
 
 #: ../../src/wxMaxima.cpp:8747
 msgid ""
 "Substitutes up to lrats_max_iter times, or until the expression stops "
 "changing when substituting."
 msgstr ""
+"Legfeljebb lrats_max_iter alkalommal helyettesíti, vagy addig, amíg a "
+"kifejezés nem változik a helyettesítés során."
 
 #: ../../src/wxMaxima.cpp:8756
 #, c-format
@@ -6793,259 +7036,283 @@ msgid ""
 "Substitutes, but makes sure that if substituting t=0 in diff(x,t) the result"
 " isn't 0 (as t no more changes), but %at(diff(x,t),t=0)."
 msgstr ""
+"Helyettesíti, de ügyel arra, hogy ha a diff(x,t)-be t=0-t helyettesít, az "
+"eredmény ne 0 legyen (mivel t már nem változik), hanem %at(diff(x,t),t=0)."
 
 #: ../../src/wxMaxima.cpp:8739
 msgid ""
 "Substitutes, but makes sure that nothing is substituted into the other "
 "substituents."
 msgstr ""
+"Helyettesíti, de ügyel arra, hogy a többi szubsztituensbe semmi ne kerüljön."
 
 #: ../../src/wxMaximaFrame.cpp:1638
 msgid "Substitutes, but not in the other substituents"
-msgstr ""
+msgstr "Helyettesítők, de a többi szubsztituensben nem"
 
 #: ../../src/wxMaxima.cpp:8764
 msgid ""
 "Substitutes, but only in the n_1th, n_2th and so on term of the equation."
-msgstr ""
+msgstr "Helyettesíti, de csak az egyenlet n_1., n_2. stb. tagjában."
 
 #: ../../src/ToolBar.cpp:275
 msgid "Subsubsection"
-msgstr ""
+msgstr "Al-alfejezet"
 
 #: ../../src/Configuration.cpp:89
 msgid "Subsubsection cell (Heading 4)"
-msgstr ""
+msgstr "Al-alfejezetcella (4. fejléc)"
 
 #: ../../src/Worksheet.cpp:1831
 msgid "Suggestion: "
-msgstr ""
+msgstr "Javaslat: "
 
 #: ../../src/Worksheet.cpp:2030
 msgid "Suitable as flag for ev()"
-msgstr ""
+msgstr "Alkalmas zászlóként az ev()"
 
 #: ../../src/wxMaxima.cpp:9049
 msgid "Sum"
-msgstr ""
+msgstr "Összeg"
 
 #: ../../src/wxMaximaFrame.cpp:1551
+#, fuzzy
 msgid ""
 "Switch off simplifications of log(). Set Maxima option variable "
 "logexpand:false"
 msgstr ""
+"A log() egyszerűsítések kikapcsolása. Maxima opció változó logexpand:false "
+"beállítása"
 
 #: ../../src/wxMaxima.cpp:4090
 msgid "Switched to lisp mode after receiving a lisp debug prompt!"
-msgstr ""
+msgstr "Lisp módra váltott, miután megkapta a lisp hibakeresési üzenetet!"
 
 #: ../../src/wxMaxima.cpp:4092
 msgid "Switched to lisp mode after receiving a lisp prompt!"
-msgstr ""
+msgstr "Lisp módba váltott, miután a Lisp promptot megkapta!"
 
 #: ../../src/Worksheet.cpp:1971
 msgid "Symbolic Constant"
-msgstr ""
+msgstr "Szimbolikus állandó"
 
 #: ../../src/wxMaximaFrame.cpp:705
 msgid "Symbols\tAlt+Shift+Y"
-msgstr ""
+msgstr "Szimbólumok\tAlt+Shift+Y"
 
 #: ../../src/Worksheet.cpp:2006
 msgid "Symmetric function: f(x)=f(-x)"
-msgstr ""
+msgstr "Szimmetrikus függvény: f(x)=f(-x)"
 
 #: ../../src/wxMaximaFrame.cpp:238
 msgid "Table of Contents"
-msgstr ""
+msgstr "Tartalomjegyzék"
 
 #: ../../src/wxMaximaFrame.cpp:711
 msgid "Table of Contents\tAlt+Shift+T"
-msgstr ""
+msgstr "Tartalomjegyzék\tAlt+Shift+T"
 
 #: ../../src/wxMaxima.cpp:8930
 msgid "Taylor series"
-msgstr ""
+msgstr "Taylor-sor"
 
 #: ../../src/wxMaximaFrame.cpp:1474
 msgid "Taylor series..."
-msgstr ""
+msgstr "Taylor-sor..."
 
 #: ../../src/wxMaxima.cpp:8925
 msgid "Taylor series:"
-msgstr ""
+msgstr "Taylor-sor:"
 
 #: ../../src/wxMaxima.cpp:4132
 msgid "Telling maxima about the new working directory."
-msgstr ""
+msgstr "A Maxima tájékoztatása az új munkakönyvtárról."
 
 #: ../../src/wxMaxima.cpp:7907
 msgid "Tells maxima for an f(x), that f(x=t)=a"
-msgstr ""
+msgstr "Az f(x) maximumát mondja meg, hogy f(x=t)=a"
 
 #: ../../src/wxMaximaFrame.cpp:1945
 msgid ""
 "Tells maxima to show the help for ?, ?? and describe() in a separate browser"
 " window"
 msgstr ""
+"Megadja a maxima számára, hogy a ?, ?? és describe() súgóját egy külön "
+"böngészőablakban jelenítse meg"
 
 #: ../../src/wxMaximaFrame.cpp:1941
 msgid ""
 "Tells maxima to show the help for ?, ?? and describe() in a wxMaxima sidebar"
 msgstr ""
+"Megmondja a maxima-nak, hogy a ?, ?? és describe() súgóját egy wxMaxima "
+"oldalsávban jelenítse meg"
 
 #: ../../src/wxMaximaFrame.cpp:1936
 msgid "Tells maxima to show the help for ?, ?? and describe() on the console"
 msgstr ""
+"Megmondja a maximának, hogy mutassa meg súgót a ?, ?? és a description() "
+"részére a konzolon"
 
 #: ../../src/ToolBar.cpp:271
 msgid "Text"
-msgstr ""
+msgstr "Szöveg"
 
 #: ../../src/Configuration.cpp:93
 msgid "Text cell background"
-msgstr ""
+msgstr "Szöveg háttere"
 
 #: ../../src/wxMaxima.cpp:6541
 msgid "Text snippet"
-msgstr ""
+msgstr "Szövegrészlet"
 
 #: ../../src/wxMaxima.cpp:4632
 msgid ""
 "The .xml file doesn't seem to be valid xml or isn't a content.xml extracted "
 "from a .wxmx zip archive"
 msgstr ""
+"Az xml fájl nem tűnik szabványos xml-nek, esetleg a content.xml nem egy . "
+"wxmx tömörített archívumból származik"
 
 #: ../../src/wxMaxima.cpp:2734
 msgid ""
 "The Maxima process doesn't offer a shared memory segment we can send an "
 "interrupt signal to."
 msgstr ""
+"A Maxima folyamat nem kínál megosztott memória szegmenst, így küldhetünk "
+"megszakítási jelet."
 
 #: ../../src/MaximaManual.cpp:107
 msgid "The cache for the subjects the manual contains cannot be read."
-msgstr ""
+msgstr "A kézikönyvben szereplő tárgyak gyorsítótára nem olvasható."
 
 #: ../../src/MaximaManual.cpp:378
 msgid "The cache for the subjects the manual contains has no head node."
-msgstr ""
+msgstr "A kézikönyvben szereplő tárgyak gyorsítótárának nincs \"head node\"-ja."
 
 #: ../../src/MaximaManual.cpp:396
 msgid ""
 "The cache for the subjects the manual contains is from a different Maxima "
 "version."
 msgstr ""
+"A kézikönyvben szereplő tárgyak gyorsítótára egy másik maxima verzióból "
+"származik."
 
 #: ../../src/wxMaximaFrame.cpp:1379
 msgid "The classic operations one typically uses matrices for"
-msgstr ""
+msgstr "A klasszikus műveletek, amelyekhez általában mátrixokat használunk"
 
 #: ../../src/wxMaxima.cpp:7193
 msgid "The comma-separated contents of the struct fields"
-msgstr ""
+msgstr "A struct mezők vesszővel elválasztott tartalma"
 
 #: ../../src/wxMaxima.cpp:7186
 msgid "The comma-separated names of the struct fields"
-msgstr ""
+msgstr "A szerkezet mezők vesszővel elválasztott nevei"
 
 #: ../../src/wxMaxima.cpp:7070
 msgid ""
 "The command local() allows to tell maxima which functions to make local to "
 "the current program when defined."
 msgstr ""
+"A local() paranccsal megmondhatjuk a maxima-nak, hogy mely függvények "
+"legyenek lokálisak az aktuális programban, amikor definiáljuk őket."
 
 #: ../../src/wxMaximaFrame.cpp:303
 msgid "The current Wizard"
-msgstr ""
+msgstr "A jelenlegi varázsló"
 
 #: ../../src/wxMaxima.cpp:9592
 msgid "The equation to fit the data to"
-msgstr ""
+msgstr "Az egyenlet, amelyre az adatokat illesztjük"
 
 #: ../../src/wxMaxima.cpp:8447
 msgid "The function call whose arguments to extract"
-msgstr ""
+msgstr "Függvényhívás, mely argumentumait ki kell csomagolni"
 
 #: ../../src/wxMaximaFrame.cpp:1298
 msgid "The half of the equation that is to the left of the \"=\""
-msgstr ""
+msgstr "Az egyenlőség \"=\"-től balra eső fele"
 
 #: ../../src/wxMaximaFrame.cpp:1302
 msgid "The half of the equation that is to the right of the \"=\""
-msgstr ""
+msgstr "Az egyenlőség \"=\"-től jobbra eső fele"
 
 #: ../../src/MaximaManual.cpp:399
 msgid "The help dir from the cache differs from the current one."
-msgstr ""
+msgstr "A gyorsítótárból származó súgókönyvtár eltér a jelenlegitől."
 
 #: ../../src/Image.cpp:985
 msgid ""
 "The image could not be displayed. It may be broken, in a wrong format or be the result of gnuplot not being able to write the image or not being able to understand what maxima wanted to plot.\n"
 "One example of the latter would be: Gnuplot refuses to plot entirely empty images"
 msgstr ""
+"The image could not be displayed. It may be broken, in a wrong format or be "
 
 #: ../../src/wxMaxima.cpp:9799 ../../src/wxMaxima.cpp:10158
 #, c-format
 msgid "The image file \"%s\" cannot be found."
-msgstr ""
+msgstr "A \"%s\" képfájl nem található."
 
 #: ../../src/wxMaximaFrame.cpp:718
 msgid "The integrated help browser"
-msgstr ""
+msgstr "Az integrált súgóböngésző"
 
 #: ../../src/wxMaxima.cpp:9591
 msgid "The list of variables contained in each matrix row"
-msgstr ""
+msgstr "Az egyes mátrixsorokban található változók listája"
 
 #: ../../src/wxMaximaFrame.cpp:214
 msgid "The main toolbar"
-msgstr ""
+msgstr "A fő eszköztár"
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "The manual of Maxima"
-msgstr ""
+msgstr "A maxima kézikönyve"
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "The manual of wxMaxima"
-msgstr ""
+msgstr "A maxima kézikönyve"
 
 #: ../../src/wxMaxima.cpp:7125
 msgid "The name of a function we don't want to be evaluated here"
-msgstr ""
+msgstr "Annak a függvénynek a neve, amelyet itt nem szeretnénk kiértékelni"
 
 #: ../../src/wxMaxima.cpp:7131
 msgid "The name of an expression that we don't want to be evaluated."
-msgstr ""
+msgstr "Annak a kifejezésnek a neve, amelyet nem szeretnénk kiértékelni."
 
 #: ../../src/wxMaxima.cpp:7199
 msgid "The name of the field to read"
-msgstr ""
+msgstr "Az olvasandó mező neve"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "The name of the new struct type"
-msgstr ""
+msgstr "Az új struktúratípus neve"
 
 #: ../../src/wxMaxima.cpp:7198
 msgid "The name of the struct"
-msgstr ""
+msgstr "A szerkezet neve"
 
 #: ../../src/wxMaxima.cpp:7191
 msgid "The name of the struct type"
-msgstr ""
+msgstr "A struktúra típusának neve"
 
 #: ../../src/wxMaxima.cpp:8220
 msgid "The name of the variable that shall contain the current element"
-msgstr ""
+msgstr "Az aktuális elemet tartalmazó változó neve"
 
 #: ../../src/wxMaxima.cpp:8468
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
-msgstr ""
+msgstr "Az \"Index kezdete\"-ről az \"Index vége\"-ig tett lépések száma."
 
 #: ../../src/wxMaxima.cpp:8465 ../../src/wxMaxima.cpp:8478
+#, fuzzy
 msgid ""
 "The rule that explains how to generate the value of a list item.\n"
 "Might be something like \"i\", \"i^2\" or \"sin(i)\""
 msgstr ""
+"A szabály, amely meghatározza, hogyan generálja a listaelem értékét. Lehet, "
+"hogy olyasmi, mint \"i\", \"i^2\" vagy \"sin(i)\""
 
 #: ../../src/wxMaxima.cpp:7785
 msgid ""
@@ -7053,18 +7320,25 @@ msgid ""
 "The actual height of that curve is defined by the initial condition or "
 "boundary values, later on."
 msgstr ""
+"Egy ODE megoldása a kapott görbe általános alakját írja le. Ennek a görbének"
+" a tényleges magasságát a kezdeti feltétel vagy a peremértékek határozzák "
+"meg a későbbiekben."
 
 #: ../../src/wxMaxima.cpp:7818
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's result is known at two points this function fills in the correct values for the  constants"
 msgstr ""
+"Egy ODE megoldása megadja a megoldás alakját, de nem a magasságát.\n"
+" Ha az ODE eredménye két ponton ismert, akkor ez a függvény kitölti a konstansok helyes értékeit."
 
 #: ../../src/wxMaxima.cpp:7794 ../../src/wxMaxima.cpp:7805
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's state is known at a point this function fills in the correct values for the constants"
 msgstr ""
+"Egy ODE megoldása megadja a megoldás alakját, de nem a megoldás magasságát.\n"
+" Ha az ODE állapota ismert egy pontban, akkor ez a függvény kitölti a konstansok helyes értékeit."
 
 #: ../../src/wxMaxima.cpp:7896
 msgid ""
@@ -7072,64 +7346,81 @@ msgid ""
 "   U(t)=1/2*U(t)+3*diff(U(t),t)\n"
 "for this to work; Initial conditions can be specified using atvalue()."
 msgstr ""
+"A megoldásváltozónak a \n"
+" U(t)=1/2*U(t)+3*diff(U(t),t)\n"
+" formában kell lennie, hogy ez működjön; A kezdeti feltételeket az atvalue() segítségével adhatjuk meg."
 
 #: ../../src/wxMaxima.cpp:8481 ../../src/wxMaxima.cpp:8582
 msgid "The variable the value of the current source item is stored in."
-msgstr ""
+msgstr "A változó az aktuális forráselem értékét tárolja."
 
 #: ../../src/wxMaxima.cpp:9594
 msgid "The variables to search the optimum solution for"
-msgstr ""
+msgstr "Azok a változók, amelyekre az optimális megoldást kell keresni"
 
 #: ../../src/wxMaximaFrame.cpp:193
 msgid "The worksheet"
-msgstr ""
+msgstr "Munkalap"
 
 #: ../../src/Worksheet.cpp:8122
 msgid "The worksheet containing maxima's input and output"
-msgstr ""
+msgstr "A munkalap a Maxima bemenetét és kimenetét tartalmazza"
 
 #: ../../src/MathParser.cpp:629
 msgid ""
 "The xml data from maxima or from the .wxmx file was missing data here.\n"
 "If you find a way how to reproduce this problem please file a bug report against wxMaxima."
 msgstr ""
+"A maxima vagy a .wxmx fájl xml adataiból hiányoztak adatok.\n"
+"Ha talál módot a probléma reprodukálására, kérjük, küldjön hibajelentés."
 
 #: ../../src/wxMaxima.cpp:2143
 msgid ""
 "There was an error in the XML maxima has generated.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Hiba van a maxima által generélt XML-ben.\n"
+"Kérjük, jelentse a wxMaxima projektnek."
 
 #: ../../src/wxMaxima.cpp:3911
 msgid ""
 "There was an error in the XML that should contain a list of watch variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Hiba volt az XML-ben, amelynek tartalmaznia kellene a watch változók "
+"listáját.\\n Kérjük, ezt hibaként jelentse a wxMaxima projektnek."
 
 #: ../../src/wxMaxima.cpp:3869
 msgid ""
 "There was an error in the XML that should contain the list of operators.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Hiba volt az XML-ben, amelynek tartalmaznia kell az operátorok listáját.\\n "
+"Kérjük, ezt hibaként jelentse a wxMaxima projektnek."
 
 #: ../../src/wxMaxima.cpp:3321
 msgid ""
 "There was an error in the XML that should describe the contents of some variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Hiba volt az XML-ben, amelynek néhány változó tartalmát kellene leírnia.\\n "
+"Kérjük, ezt hibaként jelentse a wxMaxima projektnek."
 
 #: ../../src/wxMaxima.cpp:3257
 msgid ""
 "There was an error in the XML that should describe the manual topics.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Hiba történt az XML-ben, amely leírja a kézikönyv témaköreit.\n"
+"Kérjük, jelentse ezt a wxMaxima projektnek."
 
 #: ../../src/wxMaxima.cpp:3202
 msgid ""
 "There was an error in the XML that should describe the status bar message.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Hiba volt az XML-ben, amelynek az állapotsor üzenetét kellene leírnia.\\n "
+"Kérjük, ezt hibaként jelentse a wxMaxima projektnek."
 
 #: ../../src/MaximaManual.cpp:363
 msgid ""
@@ -7137,110 +7428,117 @@ msgid ""
 "It caches the list of subjects maxima's manual offers and is automatically\n"
 "overwritten if maxima's version changes or the file cannot be read"
 msgstr ""
+"Ezt a fájlt a wxMaxima állítja elő\n"
+"Gyorsítótárba helyezi a maxima kézikönyvének ajánlatait, és automatikusan \n"
+"felülírja, ha a maxima verziója megváltozik, vagy a fájl nem olvasható\n"
+"\n"
+"„Közösség által ellenőrizve” ikon"
 
 #: ../../src/Worksheet.cpp:1992
 msgid "This function will return even integers"
-msgstr ""
+msgstr "Ez a függvény páros egész számokat ad vissza"
 
 #: ../../src/Worksheet.cpp:1994
 msgid "This function will return odd integers"
-msgstr ""
+msgstr "Ez a függvény páratlan egész számokat ad vissza"
 
 #: ../../src/Worksheet.cpp:1950
 msgid "This symbol has no imaginary part"
-msgstr ""
+msgstr "Ennek a szimbólumnak nincs képzeletbeli része"
 
 #: ../../src/Worksheet.cpp:1956
 msgid "This symbol has no real part"
-msgstr ""
+msgstr "Ennek a szimbólumnak nincs valódi része"
 
 #: ../../src/Worksheet.cpp:1953
 msgid "This symbol might have both real and imaginary part"
-msgstr ""
+msgstr "Ennek a szimbólumnak lehet valós és képzeletbeli része is"
 
 #: ../../src/Worksheet.cpp:1980
 msgid "Throw an error if this symbol is used before assigning it any contents"
 msgstr ""
+"Ha ezt a szimbólumot használja, adjon meg egy hibát, mielőtt bármilyen "
+"tartalmat hozzárendelne"
 
 #: ../../src/wxMaxima.cpp:9013 ../../src/wxMaxima.cpp:10058
 msgid "Times:"
-msgstr ""
+msgstr "Ennyiszer:"
 
 #: ../../src/ToolBar.cpp:272
 msgid "Title"
-msgstr ""
+msgstr "Cím"
 
 #: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
-msgstr ""
+msgstr "Cím (alsó és felső indexek, mint x_{10} vagy x^{10})"
 
 #: ../../src/Configuration.cpp:92
 msgid "Title cell (Heading 1)"
-msgstr ""
+msgstr "Címcella (1. fejléc)"
 
 #: ../../src/wxMaximaFrame.cpp:1794
 msgid "To &Bigfloat"
-msgstr ""
+msgstr "&Hosszú tizedestört"
 
 #: ../../src/wxMaximaFrame.cpp:1791
 msgid "To &Float"
-msgstr ""
+msgstr "&Tizedestört"
 
 #: ../../src/Worksheet.cpp:1571
 msgid "To Float"
-msgstr ""
+msgstr "Tizedestört"
 
 #: ../../src/wxMaximaFrame.cpp:1797
 msgid "To Numeri&c\tCtrl+Shift+N"
-msgstr ""
+msgstr "Numeri&kus\tCtrl+Shift+N"
 
 #: ../../src/wxMaximaFrame.cpp:1803
 msgid "To exact fraction"
-msgstr ""
+msgstr "Pontos tört"
 
 #: ../../src/wxMaximaFrame.cpp:1814
 msgid "To exact number"
-msgstr ""
+msgstr "Pontos számra"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "To:"
-msgstr ""
+msgstr "Meddig:"
 
 #: ../../src/wxMaximaFrame.cpp:825 ../../src/wxMaximaFrame.cpp:828
 msgid "Toggle full screen editing"
-msgstr ""
+msgstr "Teljes képernyős üzemmód"
 
 #: ../../src/ToolBar.cpp:265
 msgid "Toggle the visibility of code cells"
-msgstr ""
+msgstr "Kódcellák láthatóságának állítása"
 
 #: ../../src/wxMaximaFrame.cpp:1177
 msgid "Tokenize..."
-msgstr ""
+msgstr "Tokenize..."
 
 #: ../../src/wxMaximaFrame.cpp:1909
 msgid "Tolerance calculations with Maxima"
-msgstr ""
+msgstr "Toleranciaszámítások maximával"
 
 #: ../../src/wxMaxima.cpp:8192
 msgid "Top end"
-msgstr ""
+msgstr "Felső vége"
 
 #: ../../src/wxMaximaFrame.cpp:1078
 msgid "Trace a function..."
-msgstr ""
+msgstr "Függvény nyomon követése..."
 
 #: ../../src/wxMaxima.cpp:7084
 msgid "Trace function(s)"
-msgstr ""
+msgstr "Függvény(ek) nyomon követése..."
 
 #: ../../src/wxMaximaFrame.cpp:1184
 msgid "Transformations"
-msgstr ""
+msgstr "Átalakítások"
 
 #: ../../src/wxMaximaFrame.cpp:1376
 msgid "Transpose a matrix"
-msgstr ""
+msgstr "Mátrix transzponálás"
 
 #: ../../src/wxMaxima.cpp:7832
 msgid ""
@@ -7248,17 +7546,23 @@ msgid ""
 " equation of the format depends(x,t);diff(x,t)=(something containing x and "
 "t)"
 msgstr ""
+"Megpróbál numerikus megoldást találni egy elsőrendű ODE-re (vagy más szóval:"
+" egy olyan egyenletre, amely a következő formátumú: "
+"depends(x,t);diff(x,t)=(valami, ami tartalmazza x-et és t-t)."
 
 #: ../../src/wxMaxima.cpp:10036
 msgid ""
 "Tries to find a solution of the equation that lies between the two bounds."
 msgstr ""
+"Megpróbál megoldást találni a két korlát között elhelyezkedő egyenletre."
 
 #: ../../src/wxMaxima.cpp:7774
 msgid ""
 "Tries to find a value of the variable that solves the equation between the "
 "two bonds"
 msgstr ""
+"Megpróbál olyan változóértéket találni, amely megoldja a két oldal közötti "
+"egyenletet."
 
 #: ../../src/wxMaxima.cpp:7719
 msgid ""
@@ -7267,6 +7571,10 @@ msgid ""
 "\n"
 "    bfallroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
+"Megpróbálja megtalálni egy polinom összes megoldását numerikusan, bfloats "
+"segítségével.\\n Lehet, hogy nem polinomok megoldásait is képes lesz "
+"felismerni, ha a kifejezést előzetesen egy polinommal közelíti:\\n\\n "
+"bfallroots(ratdisrep(taylor(expression,0,30)));"
 
 #: ../../src/wxMaxima.cpp:7709
 msgid ""
@@ -7275,6 +7583,9 @@ msgid ""
 "\n"
 "    allroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
+"Megpróbálja numerikusan megtalálni egy polinom összes megoldását.\\n Lehet, "
+"hogy nem polinomok megoldásait is felismeri, ha a kifejezést előzetesen egy "
+"polinommal közelíti:\\n\\n allroots(ratdisrep(taylor(expression,0,30)));"
 
 #: ../../src/wxMaxima.cpp:7730
 #, c-format
@@ -7287,78 +7598,88 @@ msgid ""
 "\n"
 "See also guess_exact_value()"
 msgstr ""
+"Megpróbál olyan pontos törteket találni, amelyek megfelelnek egy polinom numerikus megoldásainak.\n"
+"Nem képes kezelni a képzetes résszel rendelkező megoldásokat. Az olyan numerikus konstansokat, mint a %pi%n, a float() vagy hasonló segítségével ki kell küszöbölni\n"
+"Lehet, hogy nem csak polinomok megoldásait is képes felismerni, ha a kifejezést előzetesen egy polinommal közelítjük:\n"
+"\n"
+"   realroots(ratdisrep(taylor(expression,0,30)));\n"
+"\n"
+"Lásd még guess_exact_value()"
 
 #: ../../src/wxMaximaFrame.cpp:1181
 msgid "Trim both ends..."
-msgstr ""
+msgstr "Vágja le mindkét végét..."
 
 #: ../../src/wxMaximaFrame.cpp:1182
 msgid "Trim left..."
-msgstr ""
+msgstr "Balra igazít..."
 
 #: ../../src/wxMaximaFrame.cpp:1183
 msgid "Trim right..."
-msgstr ""
+msgstr "Jobbra igazít..."
 
 #: ../../src/wxMaxima.cpp:7473
 msgid "Trim string left"
-msgstr ""
+msgstr "Vágja le a karakterláncot balra"
 
 #: ../../src/wxMaxima.cpp:7469
 msgid "Trim string on both ends"
-msgstr ""
+msgstr "Vágja le a zsinórt mindkét végén"
 
 #: ../../src/wxMaxima.cpp:7477
 msgid "Trim string right"
-msgstr ""
+msgstr "Vágja le a karakterláncot jobbra"
 
 #: ../../src/wxMaximaFrame.cpp:1511
 msgid "Try to guess which form is &simple"
-msgstr ""
+msgstr "Próbáld kitalálni, melyik forma"
 
 #: ../../src/wxMaxima.cpp:8637
 msgid "Try to simplify sums that result from sum() commands."
 msgstr ""
+"Próbálja meg egyszerűsíteni a sum() parancsok által kapott összegeket."
 
 #: ../../src/MaximaManual.cpp:369
 #, c-format
 msgid ""
 "Trying to cache the list of subjects the manual contains in the file %s."
 msgstr ""
+"Próbálja gyorsítótárazni a kézikönyvben található tárgyak listáját a(z) %s "
+"fájlban."
 
 #: ../../src/wxMaxima.cpp:4423
 msgid "Trying to discard all output."
-msgstr ""
+msgstr "Megpróbálja elvetni az összes kimenetet."
 
 #: ../../src/wxMaxima.cpp:4380
 msgid "Trying to extract content.xml out of a broken .zip file."
-msgstr ""
+msgstr "Kísérlet a content.xml kinyerésére egy sérült .zip fájlból."
 
 #: ../../src/wxMaxima.cpp:5519
 msgid "Trying to open a file with an empty name!"
-msgstr ""
+msgstr "Neve megadása nélkül próbált fájlt megnyitni!"
 
 #: ../../src/wxMaxima.cpp:5523
 #, c-format
 msgid "Trying to open the non-existing file %s"
-msgstr ""
+msgstr "Megpróbál megnyitni a nem létező %s fájlt"
 
 #: ../../src/wxMaxima.cpp:4457
 msgid "Trying to reconstruct the xml closing markers."
-msgstr ""
+msgstr "Az xml záró jelek rekonstruálása."
 
 #: ../../src/wxMaxima.cpp:4376
 msgid "Trying to recover a broken .wxmx file."
-msgstr ""
+msgstr "Megpróbál eltávolítani egy törött .wxmx fájlt."
 
 #: ../../src/wxMaxima.cpp:6026
 #, c-format
 msgid "Trying to remove the old temp file %s"
-msgstr ""
+msgstr "Próbálja eltávolítani a(z) %s régi ideiglenes fájlt"
 
 #: ../../src/wxMaxima.cpp:2507
 msgid "Trying to restart maxima."
-msgstr ""
+msgstr "A maxima újraindítása."
 
 #: ../../src/wxMaxima.cpp:2523
 #, c-format
@@ -7366,282 +7687,293 @@ msgid ""
 "Trying to start the socket a Maxima on the local machine can connect to on "
 "port %i"
 msgstr ""
+"Kísérlet a socket elindítására, amelyhez a helyi gépen futó Maxima a(z) %i "
+"porton csatlakozhat."
 
 #: ../../src/wxMaximaFrame.cpp:1928
 msgid "Tutorials"
-msgstr ""
+msgstr "&Ismertetők"
 
 #: ../../src/wxMaxima.cpp:9571
 msgid "Two sample t-test"
-msgstr ""
+msgstr "Kétmintás t-próba"
 
 #: ../../src/Worksheet.cpp:8013
 msgid "Type"
-msgstr ""
+msgstr "Típus"
 
 #: ../../src/wxMaxima.cpp:7180
 msgid "Type:"
-msgstr ""
+msgstr "Típus:"
 
 #: ../../src/wxMaxima.cpp:9429
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 #: ../../src/wxMaximaFrame.cpp:1146
 msgid "UTF8 to Unicode code point..."
-msgstr ""
+msgstr "UTF8 to Unicode kódpont..."
 
 #: ../../src/wxMaxima.cpp:10479
 msgid "Un-closed parenthesis"
-msgstr ""
+msgstr "Bezáratlan zárójel"
 
 #: ../../src/wxMaxima.cpp:10467
 msgid "Un-closed parenthesis on encountering ; or $"
-msgstr ""
+msgstr "Bezáratlan zárójel"
 
 #: ../../src/wxMaxima.cpp:11160
 msgid ""
 "Unable to interpret the version info I got from http://wxMaxima-"
 "developers.github.io/wxmaxima/version.txt: "
 msgstr ""
+"Nem tudtam értelmezni a http://wxMaxima-"
+"developers.github.io/~wxmaxima/version.txt címről kapott verzióinformációt: "
 
 #: ../../src/wxMaximaFrame.cpp:1007
 msgid "Undefine"
-msgstr ""
+msgstr "Definíció megszüntetése"
 
 #: ../../src/ToolBar.cpp:191
 msgid "Undo"
-msgstr ""
+msgstr "Undo"
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo\tCtrl+Z"
-msgstr ""
+msgstr "&Visszavonás\tCtrl+Z"
 
 #: ../../src/ToolBar.cpp:614
 msgid "Undo and redo button"
-msgstr ""
+msgstr "Visszavonás és ismétlés gomb"
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo last change"
-msgstr ""
+msgstr "Utolsó változtatás visszavonása"
 
 #: ../../src/wxMaximaFrame.cpp:924
 msgid "Unfold All\tCtrl+Alt+]"
-msgstr ""
+msgstr "&Minden megjelenítése\tCtrl+Alt+]"
 
 #: ../../src/wxMaximaFrame.cpp:925
 msgid "Unfold all folded sections"
-msgstr ""
+msgstr "Minden fejezet megjelenítése"
 
 #: ../../src/Worksheet.cpp:1893
 msgid "Unhide Heading 5"
-msgstr ""
+msgstr "5. cím megjelenítése"
 
 #: ../../src/Worksheet.cpp:1904
 msgid "Unhide Heading 6"
-msgstr ""
+msgstr "6. cím megjelenítése"
 
 #: ../../src/Worksheet.cpp:1852
 msgid "Unhide Part"
-msgstr ""
+msgstr "Rész megjelenítése"
 
 #: ../../src/Worksheet.cpp:1860
 msgid "Unhide Section"
-msgstr ""
+msgstr "Fejezet megjelenítése"
 
 #: ../../src/Worksheet.cpp:1871
 msgid "Unhide Subsection"
-msgstr ""
+msgstr "Alfejezet megjelenítése"
 
 #: ../../src/Worksheet.cpp:1882
 msgid "Unhide Subsubsection"
-msgstr ""
+msgstr "Al-alfejezet megjelenítése"
 
 #: ../../src/Worksheet.cpp:1912
 msgid "Unhide contents"
-msgstr ""
+msgstr "Tartalmak megjelenítése"
 
 #: ../../src/wxMaximaFrame.cpp:266
 msgid "Unicode characters"
-msgstr ""
+msgstr "Unicode karakterek"
 
 #: ../../src/wxMaximaFrame.cpp:707
 msgid "Unicode chars\tAlt+Shift+U"
-msgstr ""
+msgstr "Unicode karakterek \tAlt+Shift+U"
 
 #: ../../src/wxMaximaFrame.cpp:1144
 msgid "Unicode code point to UTF8..."
-msgstr ""
+msgstr "Unicode kódpont UTF8-ra..."
 
 #: ../../src/wxMaxima.cpp:7366
 msgid "Unicode code point to char"
-msgstr ""
+msgstr "Unicode kódpontból char"
 
 #: ../../src/wxMaximaFrame.cpp:1142
 msgid "Unicode code point to char..."
-msgstr ""
+msgstr "Unicode kódpont a karakterhez..."
 
 #: ../../src/wxMaxima.cpp:7371
 msgid "Unicode code point to utf8 numbers"
-msgstr ""
+msgstr "Unicode kódpont utf8 számokra"
 
 #: ../../src/wxMaxima.cpp:7078
 msgid ""
 "Unlike in other programming language return() only exits from the current "
 "loop or block(), not from the whole function."
 msgstr ""
+"Más programozási nyelvekkel ellentétben a return() csak az aktuális "
+"ciklusból vagy blokkból() lép ki, nem az egész függvényből."
 
 #: ../../src/wxMaxima.cpp:10418
 msgid "Unterminated comment."
-msgstr ""
+msgstr "Befejezetlen megjegyzés."
 
 #: ../../src/wxMaxima.cpp:10461
 msgid "Unterminated string."
-msgstr ""
+msgstr "Befejezetlen szöveg."
 
 #: ../../src/wxMaxima.cpp:4786
 msgid "Updating maxima's configuration"
-msgstr ""
+msgstr "A Maxima beállításának frissítése"
 
 #: ../../src/wxMaxima.cpp:11150 ../../src/wxMaxima.cpp:11157
 #: ../../src/wxMaxima.cpp:11163
 msgid "Upgrade"
-msgstr ""
+msgstr "Frissítés"
 
 #: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
 msgid "Upper bound:"
-msgstr ""
+msgstr "Felső végpont:"
 
 #: ../../src/wxMaximaFrame.cpp:792
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
-msgstr ""
+msgstr "\"<\" és \">\" jelek használata mátrixoknál"
 
 #: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
 msgid "Use a list"
-msgstr ""
+msgstr "Lista használata"
 
 #: ../../src/wxMaxima.cpp:8571
 msgid "Use a list as parameter list for a function"
-msgstr ""
+msgstr "Lista használata egy függvény paraméterlistájaként"
 
 #: ../../src/wxMaximaFrame.cpp:1708
 msgid "Use list"
-msgstr ""
+msgstr "Lista használata"
 
 #: ../../src/wxMaximaFrame.cpp:1701
 msgid "Use list as the arguments of a function"
-msgstr ""
+msgstr "Lista használata egy függvény argomentumaiként"
 
 #: ../../src/wxMaximaFrame.cpp:786
 msgid "Use rounded parenthesis for matrices"
-msgstr ""
+msgstr "Lekerekített zárójel használata mátrixoknál"
 
 #: ../../src/wxMaximaFrame.cpp:789
 msgid "Use square parenthesis for matrices"
-msgstr ""
+msgstr "Szögletes zárójel használata mátrixoknál"
 
 #: ../../src/wxMaximaFrame.cpp:1083
 msgid "Use struct field..."
-msgstr ""
+msgstr "Struktúra mező használata..."
 
 #: ../../src/wxMaximaFrame.cpp:795
 msgid "Use vertical lines instead of parenthesis for matrices"
-msgstr ""
+msgstr "Függőleges vonalak használata mátrixoknál"
 
 #: ../../src/Worksheet.cpp:1619
 msgid "User labels only"
-msgstr ""
+msgstr "Csak a felhasználó által definiált címkék"
 
 #: ../../src/Configuration.cpp:81
 msgid "User-defined labels"
-msgstr ""
+msgstr "Felhasználó által definiált címkék"
 
 #: ../../src/MaximaManual.cpp:483
 msgid ""
 "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
 msgstr ""
+"Maxima súgófájl használata a wxMaxima konfigurációs fájlból (helpFile=...))"
 
 #: ../../src/wxMaxima.cpp:4825
 msgid "Using Maxima path from command line."
-msgstr ""
+msgstr "Using Maxima path from command line."
 
 #: ../../src/wxMaxima.cpp:4822
 msgid "Using configured Maxima path."
-msgstr ""
+msgstr "A beállított Maxima-útvonal használata."
 
 #: ../../src/wxMaxima.cpp:2961
 msgid ""
 "Using gnuplot's antialiassing-less png driver for embedded plots as pngcairo"
 " could not be found"
 msgstr ""
+"A gnuplot élsimítás nélküli png illesztőprogramjának használata a beágyazott"
+" ábrákhoz, mivel a pngcairo nem található"
 
 #: ../../src/wxMaxima.cpp:2956
 msgid "Using gnuplot's pngcairo driver for embedded plots"
 msgstr ""
+"A gnuplot pngcairo illesztőprogramjának használata a beágyazott ábrákhoz"
 
 #: ../../src/MaximaManual.cpp:88
 msgid "Using the built-in list of manual anchors."
-msgstr ""
+msgstr "A kézi horgonyok beépített listájának használata."
 
 #: ../../src/WXMXformat.cpp:266
 msgid ""
 "Validated that the XML representation of the document actually is valid XML"
 msgstr ""
+"Ellenőrzi, hogy a dokumentum XML-reprezentációja valóban érvényes XML-e."
 
 #: ../../src/wxMaxima.cpp:8755
 msgid "Value at a given point"
-msgstr ""
+msgstr "Érték egy adott helyen"
 
 #: ../../src/Worksheet.cpp:1987
 msgid "Value at a specific point"
-msgstr ""
+msgstr "Érték egy adott ponton"
 
 #: ../../src/wxMaxima.cpp:7801
 msgid "Value at that point:"
-msgstr ""
+msgstr "Érték azon a helyen:"
 
 #: ../../src/wxMaxima.cpp:7812 ../../src/wxMaxima.cpp:7825
 #: ../../src/wxMaxima.cpp:7827
 msgid "Value y at that point:"
-msgstr ""
+msgstr "y érték azon a helyen:"
 
 #: ../../src/wxMaxima.cpp:7910
 msgid "Value:"
-msgstr ""
+msgstr "Érték:"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Var #1"
-msgstr ""
+msgstr "Var #1"
 
 #: ../../src/wxMaxima.cpp:8202
 msgid "Var #2"
-msgstr ""
+msgstr "Var #2"
 
 #: ../../src/wxMaxima.cpp:6852 ../../src/wxMaxima.cpp:8183
 msgid "Variable"
-msgstr ""
+msgstr "Változó"
 
 #: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
 #: ../../src/wxMaxima.cpp:8568
 msgid "Variable name"
-msgstr ""
+msgstr "Változónév"
 
 #: ../../src/wxMaximaFrame.cpp:1085
 msgid "Variable name, not contents..."
-msgstr ""
+msgstr "Változónév, nem tartalmak..."
 
 #: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
 msgid "Variable name:"
-msgstr ""
+msgstr "Változónév:"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 msgid "Variable(s)"
-msgstr ""
+msgstr "Változó(k)"
 
 #: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
 #: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
 msgid "Variable(s):"
-msgstr ""
+msgstr "Változó(k):"
 
 #: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
 #: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
@@ -7649,49 +7981,51 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
 #: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
 msgid "Variable:"
-msgstr ""
+msgstr "Változó:"
 
 #: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
 msgid "Variables"
-msgstr ""
+msgstr "Változók"
 
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
 msgid "Variables:"
-msgstr ""
+msgstr "Változók:"
 
 #: ../../src/WXMXformat.cpp:337
 msgid "Verified that we are able to read the whole .zip archive we produced."
 msgstr ""
+"Ellenőriztük, hogy képesek vagyunk-e beolvasni az általunk készített teljes "
+"zip archívumot."
 
 #: ../../src/wxMaximaFrame.cpp:836
 msgid "View"
-msgstr ""
+msgstr "Nézet"
 
 #: ../../src/Autocomplete.cpp:235
 msgid "Waiting for m_addFiles_backgroundThread to finish"
-msgstr ""
+msgstr "Waiting for m_addFiles_backgroundThread to finish"
 
 #: ../../src/Autocomplete.cpp:122 ../../src/Autocomplete.cpp:240
 msgid "Waiting for m_addSymbols_backgroundThread to finish"
-msgstr ""
+msgstr "Waiting for m_addSymbols_backgroundThread to finish"
 
 #: ../../src/MaximaManual.cpp:533
 msgid "Waiting for the Manual anchors background task."
-msgstr ""
+msgstr "Waiting for the Manual anchors background task."
 
 #: ../../src/MaximaManual.cpp:562
 msgid "Waiting for the thread that parses the maxima manual to finish"
-msgstr ""
+msgstr "Várakozás a maxima kézikönyvet elemző szál befejezésére"
 
 #: ../../src/MathParser.cpp:1229 ../../src/wxMaxima.cpp:3296
 #: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
 #: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
 msgid "Warning"
-msgstr ""
+msgstr "Figyelmeztetés"
 
 #: ../../src/wxMaximaFrame.cpp:1556
 msgid "Warning:"
-msgstr ""
+msgstr "Figyelmeztetés:"
 
 #: ../../src/Dirstructure.cpp:72
 #, c-format
@@ -7699,245 +8033,254 @@ msgid ""
 "Warning: Cannot create %s, the directory maxima keeps configuration, user packages and caches in.\n"
 "Make sure that your system's home directory is set up correctly"
 msgstr ""
+"Figyelmeztetés: A(z) %s nem hozható létre, a könyvtár maxima megőrzi a konfigurációt, a felhasználói csomagokat és a gyorsítótárakat. \n"
+"Győződjön meg arról, hogy a rendszer saját könyvtára megfelelően van beállítva"
 
 #: ../../src/wxMaximaFrame.cpp:1546
 msgid ""
 "Warning: No test if the argument of the log is complex, positive or negative"
 msgstr ""
+"Figyelmeztetés: Nincs teszt, ha a napló argumentuma összetett, pozitív vagy "
+"negatív"
 
 #: ../../src/wxMaxima.cpp:5063
 msgid "Welcome to wxMaxima"
-msgstr ""
+msgstr "A wxMaxima üdvözli Önt"
 
 #: ../../src/wxMaxima.cpp:8583
 msgid "What to do:"
-msgstr ""
+msgstr "Mit kell tenni:"
 
 #: ../../src/wxMaximaFrame.cpp:1058
 msgid "When to invoke the lisp compiler's debugger"
-msgstr ""
+msgstr "Mikor kell meghívni a lisp fordító hibakeresőjét"
 
 #: ../../src/wxMaxima.cpp:7046
 msgid "While loop"
-msgstr ""
+msgstr "While ciklus"
 
 #: ../../src/wxMaximaFrame.cpp:1063
 msgid "While loop..."
-msgstr ""
+msgstr "Míg a hurok..."
 
 #: ../../src/wxMaxima.cpp:5673
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38)"
 " (*.wxm)|*.wxm|All Files (*.*)|*"
 msgstr ""
+"Egész dokumentum: (*.wxmx)|*.wxmx|Bemenet, olvasható a load()-al (Maxima > "
+"5.38):(*.wxm)|*.wxm|Minden Fájl (*.*)|*"
 
 #: ../../src/wxMaxima.cpp:210
 msgid "Will try to generate a stack backtrace, if the program ever crashes"
-msgstr ""
+msgstr "Will try to generate a stack backtrace, if the program ever crashes"
 
 #: ../../src/Worksheet.cpp:6920
 msgid "Worksheet got activated"
-msgstr ""
+msgstr "A munkalap aktiválódott"
 
 #: ../../src/Worksheet.cpp:6840
 msgid "Worksheet got the mouse focus"
-msgstr ""
+msgstr "A munkalap az egér fókuszát kapta"
 
 #: ../../src/Worksheet.cpp:7191 ../../src/Worksheet.cpp:7279
 msgid "Wrapped search"
-msgstr ""
+msgstr "Csomagolt keresés"
 
 #: ../../src/WXMXformat.cpp:282
 msgid "Wrote all image and gnuplot files to the zip archive"
-msgstr ""
+msgstr "Az összes kép- és gnuplot-fájlt beírta a zip-archívumba"
 
 #: ../../src/WXMXformat.cpp:272
 msgid "Wrote the XML representation of the document to the zip archive"
-msgstr ""
+msgstr "Beírta a dokumentum XML-reprezentációját a zip archívumba"
 
 #: ../../src/WXMXformat.cpp:116
 msgid "Wrote the mimetype info"
-msgstr ""
+msgstr "Megírta a MIME-típus adatait"
 
 #: ../../src/wxMaxima.cpp:11147
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have version %s. The newest version source code is available for is %s.\n"
 "\n"
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
+"A telepített verzió: %s. A legújabb verzió forráskódja itt érhető el: %s.\n"
+"\n"
+" Az OK gombbal megnyithatod a wxMaxima weboldalát."
 
 #: ../../src/wxMaxima.cpp:11202
 msgid "Your changes will be lost if you don't save them."
-msgstr ""
+msgstr "Ha nem ment, változásai elvesznek."
 
 #: ../../src/wxMaxima.cpp:11156
 msgid "Your version of wxMaxima is up to date."
-msgstr ""
+msgstr "A wxMaxima verzió a lehető legfrissebb."
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom &In\tCtrl++"
-msgstr ""
+msgstr "&Nagyítás\tCtrl++"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom Ou&t\tCtrl+-"
-msgstr ""
+msgstr "K&icsinyítés\tCtrl+-"
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom in 10%"
-msgstr ""
+msgstr "Nagyítás 10%-kal"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom out 10%"
-msgstr ""
+msgstr "Kicsinyítés 10%-kal"
 
 #: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
 msgid "[ unsaved ]"
-msgstr ""
+msgstr "[ mentetlen ]"
 
 #: ../../src/wxMaxima.cpp:10920
 msgid "[ unsaved* ]"
-msgstr ""
+msgstr "[ mentetlen* ]"
 
 #: ../../src/Worksheet.cpp:5278
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" loading=\"lazy\" style=\"max-width:90%%;\">\n"
-msgstr ""
+msgstr "_%d.gif\"  alt=\"Animated Diagram\" loading=\"lazy\" style=\"max-width:90%%;\">\n"
 
 #: ../../src/Worksheet.cpp:5484
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"lazy\">"
-msgstr ""
+msgstr "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"lazy\">"
 
 #: ../../src/wxMaximaFrame.cpp:1690
 msgid "apply function to each element"
-msgstr ""
+msgstr "függvény alkalmazása az összes elemre"
 
 #: ../../src/wxMaximaFrame.cpp:739
 msgid "as 1D ASCII"
-msgstr ""
+msgstr "1D-s ASCII-ként"
 
 #: ../../src/wxMaximaFrame.cpp:742
 msgid "as ASCII Art"
-msgstr ""
+msgstr "ASCII Art-ként"
 
 #: ../../src/wxMaximaFrame.cpp:745
 msgid "as ASCII+Unicode Art"
-msgstr ""
+msgstr "ASCII+Unicode ábraként"
 
 #: ../../src/wxMaximaFrame.cpp:1680
 msgid "as storage for actual values for variables"
-msgstr ""
+msgstr "a változók tényleges értékeinek tárolása"
 
 #: ../../src/wxMaximaFrame.cpp:1139
 msgid "char to Ascii code..."
-msgstr ""
+msgstr "char - Ascii kód..."
 
 #: ../../src/wxMaxima.cpp:7836
 msgid "diff(x,t)="
-msgstr ""
+msgstr "diff(x,t)="
 
 #: ../../src/wxMaximaFrame.cpp:1064 ../../src/wxMaximaFrame.cpp:1702
 msgid "do for each element"
-msgstr ""
+msgstr "végrehajt egy parancsot a lista egyes elemeihez"
 
 #: ../../src/Worksheet.cpp:2027
 msgid "ev() shall evaluate this automatically"
-msgstr ""
+msgstr "Az ev() ezt automatikusan kiértékeli"
 
 #: ../../src/wxMaxima.cpp:7130
 msgid "expression:"
-msgstr ""
+msgstr "kifejezés:"
 
 #: ../../src/Worksheet.cpp:2025
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
-msgstr ""
+msgstr "f(x) akkor is f(x) marad, ha az f(x) értéke kiszámítható"
 
 #: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
 msgid "filename:"
-msgstr ""
+msgstr "fájlnév:"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "from a list"
-msgstr ""
+msgstr "listából"
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "from a rule"
-msgstr ""
+msgstr "egy szabályból"
 
 #: ../../src/wxMaximaFrame.cpp:1685
 msgid "from function arguments"
-msgstr ""
+msgstr "függvény argumentumaiból"
 
 #: ../../src/wxMaximaFrame.cpp:1669
 msgid "from individual elements"
-msgstr ""
+msgstr "különböző elemekből"
 
 #: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
 msgid "function"
-msgstr ""
+msgstr "függvény"
 
 #: ../../src/wxMaximaFrame.cpp:747
 msgid "in 2D"
-msgstr ""
+msgstr "2D-sen"
 
 #: ../../src/wxMaxima.cpp:8554
 msgid "list"
-msgstr ""
+msgstr "lista"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "max(abs(A(i,j))) (complex)"
-msgstr ""
+msgstr "max(abs(A(i,j))) (komplex)"
 
 #: ../../src/wxMaximaFrame.cpp:1404
 msgid "max(abs(A(i,j))) (real)"
-msgstr ""
+msgstr "max(abs(A(i,j))) (valós)"
 
 #: ../../src/wxMaxima.cpp:8046
 msgid "m×n Matrix A:"
-msgstr ""
+msgstr "m×n-es A mátrix:"
 
 #: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533
 msgid "n:"
-msgstr ""
+msgstr "n:"
 
 #: ../../src/Worksheet.cpp:2000
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
-msgstr ""
+msgstr "nary: f(x, f(y,z)) = foo(x,y,z)"
 
 #: ../../src/Worksheet.cpp:2024
 msgid "noun: Not evaluated by default"
-msgstr ""
+msgstr "főnév: Alapértelmezés szerint nincs kiértékelve"
 
 #: ../../src/wxMaximaFrame.cpp:1710
 msgid "nth"
-msgstr ""
+msgstr "n-edik"
 
 #: ../../src/Worksheet.cpp:2021
 msgid "outative: f(2*x) = 2*f(x)"
-msgstr ""
+msgstr "outatív: f(2*x) = 2*f(x)"
 
 #: ../../src/wxMaxima.cpp:7440 ../../src/wxMaxima.cpp:7445
 #: ../../src/wxMaxima.cpp:7455
 msgid "part:"
-msgstr ""
+msgstr "rész:"
 
 #: ../../src/wxMaxima.cpp:8942
 msgid "point:"
-msgstr ""
+msgstr "hely:"
 
 #: ../../src/wxMaxima.cpp:7740
 msgid "precision:"
-msgstr ""
+msgstr "pontosság:"
 
 #: ../../src/wxMaxima.cpp:7255
 msgid "printf"
-msgstr ""
+msgstr "printf"
 
 #: ../../src/wxMaximaFrame.cpp:1108
 msgid "printf..."
-msgstr ""
+msgstr "printf..."
 
 #: ../../src/wxMaxima.cpp:8650
 msgid ""
@@ -7947,22 +8290,29 @@ msgid ""
 " makes sense for the problem that resulted in the Expression that is to be "
 "simplified."
 msgstr ""
+"A radcan() egy hatékony eszköz a trigonometrikus függvények "
+"egyszerűsítésére, de óvatosan kell bánni vele: Ha egy függvénynek több "
+"elágazása van, a radcan azt használja, amelyik a legjobban illeszkedik, nem "
+"feltétlenül azt, amelyik az egyszerűsítendő kifejezést eredményező probléma "
+"szempontjából értelmes."
 
 #: ../../src/wxMaxima.cpp:8731
 msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
+"A ratsubst úgy működik, mint a subst, de szükség esetén ismer néhány "
+"alapvető matematikai azonosságot."
 
 #: ../../src/wxMaximaFrame.cpp:1111
 msgid "readbyte..."
-msgstr ""
+msgstr "readbyte..."
 
 #: ../../src/wxMaximaFrame.cpp:1110
 msgid "readchar..."
-msgstr ""
+msgstr "readchar..."
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "readline..."
-msgstr ""
+msgstr "readline..."
 
 #: ../../src/wxMaxima.cpp:10018
 msgid ""
@@ -7970,67 +8320,75 @@ msgid ""
 "If only one result variable is of interest the other result variables can be used to to tell solve() which variables to eliminate from the solution\n"
 "solve() searches for a global solution. If a problem has different solutions depending on the range its variables are in one way to successfully use solve() is to use solve() to eliminate variables one by one and to manually choose which of the solutions solve() found matches the current problem."
 msgstr ""
+"A solve() csak akkor oldja meg az egyenletrendszert, ha n független egyenlethez n változó tartozik.\n"
+"Ha csak egy változó értéke érdekli, a többi változó segítségével megmondhatja a solve()-nak, hogy mely változókat távolítsa el a megoldásból\n"
+"A solve() globális megoldást keres. Ha egy problémának a tartománytól függően különböző megoldásai vannak, akkor a változók egyik módja a solve() sikeres használatának, ha a változókat egyenkénti eltávolítjuk, és manuálisan kiválasztjuk, hogy a megoldások közül melyik felel meg az aktuális problémának."
 
 #: ../../src/wxMaxima.cpp:7745
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables solve needs to do its work can be used to tell solve() which variables to eliminate in the solution for the interesting variable."
 msgstr ""
+"A solve() csak akkor oldja meg az egyenletrendszert, ha n független egyenletet n változóra akarunk megoldani.\n"
+"If only one result variable is of interest the other result variables solve needs to do its work can be used to tell solve() which variables to eliminate in the solution for the interesting variable."
 
 #: ../../src/wxMaxima.cpp:7784
+#, fuzzy
 msgid ""
 "solves an equation of the form\n"
 "    'diff(y,t) = -y;"
 msgstr ""
+"megoldja a \n"
+" 'diff(y,t) = -y' formájú egyenletet;"
 
 #: ../../src/wxMaxima.cpp:7789
 msgid "t:"
-msgstr ""
+msgstr "t:"
 
 #: ../../src/wxMaximaFrame.cpp:1075
 msgid "unnamed function (lambda)..."
-msgstr ""
+msgstr "névtelen függvény (lambda)..."
 
 #: ../../src/wxMaxima.cpp:11190
 msgid "unsaved"
-msgstr ""
+msgstr "mentetlen"
 
 #: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
 #: ../../src/wxMaximaFrame.cpp:189
 msgid "untitled"
-msgstr ""
+msgstr "névtelen"
 
 #: ../../src/wxMaximaFrame.cpp:1700
 msgid "use as function arguments"
-msgstr ""
+msgstr "függvény-argumentumokként használva"
 
 #: ../../src/wxMaximaFrame.cpp:1696
 msgid "use the actual values stored"
-msgstr ""
+msgstr "a tárolt aktuális értékek használata"
 
 #: ../../src/wxMaximaFrame.cpp:1112
 msgid "writebyte..."
-msgstr ""
+msgstr "writebyte..."
 
 #: ../../src/main.cpp:509
 msgid "wxMaxima"
-msgstr ""
+msgstr "wxMaxima"
 
 #: ../../src/main.cpp:516
 #, c-format
 msgid "wxMaxima %ld"
-msgstr ""
+msgstr "wxMaxima %ld"
 
 #: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
 #: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
 #: ../../src/wxMaximaFrame.cpp:185
 #, c-format
 msgid "wxMaxima %s (%s) "
-msgstr ""
+msgstr "wxMaxima %s (%s) "
 
 #: ../../src/wxMaxima.cpp:4490
 msgid "wxMaxima cannot read the xml contents of "
-msgstr ""
+msgstr "A wxMaxima nem képes az xml tartalom olvasására itt: "
 
 #: ../../src/wxMaxima.cpp:2546
 msgid ""
@@ -8039,60 +8397,68 @@ msgid ""
 "Please check you have network support\n"
 "enabled, that no internet safety appliance is configured to intercept creation of servers even if said server only accepts connections from local application (maxima insists on the graphical frontend acting as a server it can connect on over a local socket) and try again!"
 msgstr ""
+"A wxMaxima nem tudott elindítani egy szervert.\n"
+"\n"
+"Kérjük, ellenőrizze, hogy engedélyezve van-e a hálózati támogatás,\n"
+"és hogy nincs-e beállítva internetbiztonsági eszköz a szerverek létrehozásának elfogására, még akkor sem, ha az adott szerver csak helyi alkalmazásoktól fogad kapcsolatokat (a maxima ragaszkodik ahhoz, hogy a grafikus kezelőfelület szerverként működjön, amelyhez helyi socketen keresztül csatlakozhat), majd próbálja újra!"
 
 #: ../../src/wxMaxima.cpp:5285
 msgid "wxMaxima document"
-msgstr ""
+msgstr "wxMaxima dokumentum"
 
 #: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
 #: ../../src/wxMaxima.cpp:4230
 msgid "wxMaxima encountered an error loading "
-msgstr ""
+msgstr "A wxMaxima nem tudta betölteni a következő fájlt"
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "wxMaxima help"
-msgstr ""
+msgstr "wxMaxima Súgó"
 
 #: ../../src/Worksheet.cpp:1465 ../../src/Worksheet.cpp:1839
 msgid ""
 "wxMaxima remembers answers from the last run and is able to automatically "
 "send them to maxima, if requested"
 msgstr ""
+"A wxMaxima megjegyzi az utolsó futtatásnál adott válaszokat, és kérésre "
+"automatikusan el tudja küldeni azokat a maximának"
 
 #: ../../src/Worksheet.cpp:1470 ../../src/Worksheet.cpp:1844
 msgid ""
 "wxMaxima remembers answers from the last run and is able to offer them as "
 "the default answer"
 msgstr ""
+"A wxMaxima megjegyzi az utolsó futtatásnál adott válaszokat, és "
+"automatikusan el tudja küldeni azokat"
 
 #: ../../src/wxMaximaFrame.cpp:1896
 msgid "wxMaxima shows help in a browser"
-msgstr ""
+msgstr "A wxMaxima böngészőben jeleníti meg a súgót"
 
 #: ../../src/wxMaximaFrame.cpp:1894
 msgid "wxMaxima shows help in the sidebar"
-msgstr ""
+msgstr "A wxMaxima az oldalsávban jeleníti meg a súgót"
 
 #: ../../src/wxMaximaFrame.cpp:111
 #, c-format
 msgid "wxMaxima version %s"
-msgstr ""
+msgstr "wxMaxima verzió %s"
 
 #: ../../src/wxMaximaFrame.cpp:1954
 msgid "wxMaxima's ChangeLog"
-msgstr ""
+msgstr "A wxMaxima változásnaplója"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "wxMaxima's license"
-msgstr ""
+msgstr "A wxMaxima licence"
 
 #: ../../src/wxMaximaFrame.cpp:144
 msgid "wxWidgets is using GTK 2"
-msgstr ""
+msgstr "A wxWidgets GTK 2-t használ"
 
 #: ../../src/wxMaximaFrame.cpp:142
 msgid "wxWidgets is using GTK 3"
-msgstr ""
+msgstr "A wxWidgets GTK 3-at használ"
 
 #: ../../src/WXMXformat.cpp:367
 msgid "wxmx file saved"
@@ -8144,8 +8510,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:10
+#, fuzzy
 msgid "# Introduction to wxMaxima"
-msgstr ""
+msgstr "A wxMaxima üdvözli Önt"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:12
@@ -8184,8 +8551,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:18
+#, fuzzy
 msgid "### _Maxima_"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:20
@@ -8220,8 +8588,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:26
+#, fuzzy
 msgid "### WxMaxima"
-msgstr ""
+msgstr "wxMaxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:28
@@ -8344,8 +8713,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:54
+#, fuzzy
 msgid "### Cells"
-msgstr ""
+msgstr "Cellák egyesítése"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:56
@@ -8366,8 +8736,9 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Image cells."
-msgstr ""
+msgstr "Cellák egyesítése"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
@@ -8383,8 +8754,9 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Page breaks."
-msgstr ""
+msgstr "La&ptörés beszúrása"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:65
@@ -8412,8 +8784,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:71
+#, fuzzy
 msgid "### Horizontal and vertical cursors"
-msgstr ""
+msgstr "A vízszintes és függőleges kurzor is legyen aktív egyidőben"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:73
@@ -8491,8 +8864,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:90
+#, fuzzy
 msgid "### Sending cells to Maxima"
-msgstr ""
+msgstr "Minden cella Maximához küldése"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:92
@@ -8538,8 +8912,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:102
+#, fuzzy
 msgid "#### Greek characters"
-msgstr ""
+msgstr "Unicode karakterek"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:104
@@ -8954,8 +9329,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:282
+#, fuzzy
 msgid "## File Formats"
-msgstr ""
+msgstr "Fájlműveletek"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:284
@@ -9249,8 +9625,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:384
+#, fuzzy
 msgid "### Default animation framerate"
-msgstr ""
+msgstr "Az animáció framerátája..."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:386
@@ -9392,8 +9769,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:432
+#, fuzzy
 msgid "## Subscripted variables"
-msgstr ""
+msgstr "Automatikus feliratkozás erre a változóra"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:434
@@ -10041,8 +10419,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:704
+#, fuzzy
 msgid "#### Expression"
-msgstr ""
+msgstr "Kifejezés"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:706
@@ -10096,8 +10475,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:720
+#, fuzzy
 msgid "#### Diagram title"
-msgstr ""
+msgstr "A rács sűrűségének beállítása"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:722
@@ -10308,8 +10688,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:794
+#, fuzzy
 msgid "## Special variables wx..."
-msgstr ""
+msgstr "Fő változó megadása..."
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:805
@@ -10481,8 +10862,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:837
+#, fuzzy
 msgid "Example:"
-msgstr ""
+msgstr "Minta:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:842
@@ -10496,8 +10878,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:844
+#, fuzzy
 msgid "## Bug reporting"
-msgstr ""
+msgstr "&Hibajelentés"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:846
@@ -10533,8 +10916,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:856
+#, fuzzy
 msgid "## Output rendering."
-msgstr ""
+msgstr "Kimenet: Karakterláncok"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:858
@@ -10612,8 +10996,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:885
+#, fuzzy
 msgid "## Cannot connect to _Maxima_"
-msgstr ""
+msgstr "Nem csatlakozott a Maximához"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:887
@@ -10642,8 +11027,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:891
+#, fuzzy
 msgid "## How to save data from a broken .wxmx file"
-msgstr ""
+msgstr "Megpróbál eltávolítani egy törött .wxmx fájlt."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:893
@@ -10960,8 +11346,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:988
+#, fuzzy
 msgid "E.g. start wxMaxima with:"
-msgstr ""
+msgstr "A Maxima újraindítása"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:990
@@ -11321,8 +11708,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1140
+#, fuzzy
 msgid "# Command-line arguments"
-msgstr ""
+msgstr "Vesszővel elválasztott argomentumok"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1142

--- a/locales/wxMaxima/it.po
+++ b/locales/wxMaxima/it.po
@@ -29,12 +29,17 @@ msgid ""
 "\n"
 "Maxima is currently using %3.3f%% of all available CPUs."
 msgstr ""
+"\n"
+"\n"
+"Maxima sta usando attualmente il %3.3f%% di tutte le CPU disponibili."
 
 #: ../../src/Image.cpp:690
 msgid ""
 "\n"
 "Image was loaded from a .wxmx file"
 msgstr ""
+"\n"
+"Immagine caricata da un file .wxmx"
 
 #: ../../src/wxMaxima.cpp:5153
 msgid ""
@@ -48,257 +53,259 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1559
 msgid " Wrong, if a is complex"
-msgstr ""
+msgstr "Sbagliato, se a è complessa"
 
 #: ../../src/wxMaxima.cpp:7601
 msgid ""
 "\".\" = \"The current directory\"\n"
 "\"..\" = \"One directory up\""
 msgstr ""
+"\".\" = \"La cartella corrente\"\n"
+"\"..\" = \"Una cartella su\""
 
 #: ../../src/wxMaxima.cpp:7557 ../../src/wxMaxima.cpp:7563
 #: ../../src/wxMaxima.cpp:7568
 msgid "\"..\" means \"one directory up\"."
-msgstr ""
+msgstr "\"..\" significa \"una cartella su\"."
 
 #: ../../src/wxMaxima.cpp:5053
-#, c-format
+#, fuzzy, c-format
 msgid "%i cells in evaluation queue"
-msgstr ""
+msgstr "%i celle in coda di elaborazione"
 
 #: ../../src/Worksheet.cpp:330
 #, c-format
 msgid "%s image, %li×%li, %li ppi"
-msgstr ""
+msgstr "%s imamgine, %li×%li, %li ppi"
 
 #: ../../src/Autocomplete.cpp:319
 #, c-format
 msgid "%s: Can't interpret line: %s"
-msgstr ""
+msgstr "%s: Impossibile interpretare la riga: %s"
 
 #: ../../src/wxMaximaFrame.cpp:1655
 msgid "&Algebraic Mode"
-msgstr ""
+msgstr "Modalità &algebrica"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "&Apropos..."
-msgstr ""
+msgstr "&A proposito di..."
 
 #: ../../src/wxMaximaFrame.cpp:615
 msgid "&Batch File...\tCtrl+B"
-msgstr ""
+msgstr "File &batch...\tCtrl+B"
 
 #: ../../src/wxMaximaFrame.cpp:1278
 msgid "&Boundary Value Problem..."
-msgstr ""
+msgstr "Pro&blema del valore al contorno ..."
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "&Bug Report"
-msgstr ""
+msgstr "Rapporto &bug"
 
 #: ../../src/wxMaximaFrame.cpp:1505
 msgid "&Calculus"
-msgstr ""
+msgstr "&Calcolo"
 
 #: ../../src/wxMaximaFrame.cpp:1601
 msgid "&Canonical Form"
-msgstr ""
+msgstr "Forma &canonica"
 
 #: ../../src/wxMaximaFrame.cpp:1358
 msgid "&Characteristic Polynomial..."
-msgstr ""
+msgstr "Polinomiale &caratteristico ..."
 
 #: ../../src/wxMaximaFrame.cpp:990
 msgid "&Clear Memory"
-msgstr ""
+msgstr "&Cancella la memoria"
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "&Combine Factorials"
-msgstr ""
+msgstr "&Combina i fattoriali"
 
 #: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Complex Simplification"
-msgstr ""
+msgstr "Semplificazione &Complessa"
 
 #: ../../src/wxMaximaFrame.cpp:1502
 msgid "&Continued Fraction"
-msgstr ""
+msgstr "Frazione &continua"
 
 #: ../../src/wxMaximaFrame.cpp:638
 msgid "&Copy\tCtrl+C"
-msgstr ""
+msgstr "&Copia\tCtrl+C"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "&Demoivre"
-msgstr ""
+msgstr "&Demoivre"
 
 #: ../../src/wxMaximaFrame.cpp:1362
 msgid "&Determinant"
-msgstr ""
+msgstr "&Determinante"
 
 #: ../../src/wxMaximaFrame.cpp:1466
 msgid "&Differentiate..."
-msgstr ""
+msgstr "&Differenzia..."
 
 #: ../../src/wxMaximaFrame.cpp:689
 msgid "&Edit"
-msgstr ""
+msgstr "&Modifica"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "&Eliminate Variable..."
-msgstr ""
+msgstr "&Elimina la variabile..."
 
 #: ../../src/wxMaximaFrame.cpp:1318
 msgid "&Enter Matrix..."
-msgstr ""
+msgstr "Ins&erire la matrice..."
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "&Example..."
-msgstr ""
+msgstr "&Esempio..."
 
 #: ../../src/wxMaximaFrame.cpp:1524
 msgid "&Expand Expression"
-msgstr ""
+msgstr "&Espandi l'espressione"
 
 #: ../../src/wxMaximaFrame.cpp:1597
 msgid "&Expand Trigonometric"
-msgstr ""
+msgstr "&Espandi trigonometrica"
 
 #: ../../src/wxMaximaFrame.cpp:1626
 msgid "&Exponentialize"
-msgstr ""
+msgstr "&Esponenzializza"
 
 #: ../../src/wxMaximaFrame.cpp:618
 msgid "&Export..."
-msgstr ""
+msgstr "&Esporta..."
 
 #: ../../src/wxMaximaFrame.cpp:1516
 msgid "&Factor Expression"
-msgstr ""
+msgstr "Scomponi in &fattori"
 
 #: ../../src/wxMaximaFrame.cpp:626
 msgid "&File"
-msgstr ""
+msgstr "&File"
 
 #: ../../src/wxMaximaFrame.cpp:1019
 msgid "&Functions"
-msgstr ""
+msgstr "&Funzioni"
 
 #: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Greatest Common Divisor..."
-msgstr ""
+msgstr "&Massimo comun denominatore..."
 
 #: ../../src/wxMaximaFrame.cpp:1968
 msgid "&Help"
-msgstr ""
+msgstr "&Aiuto"
 
 #: ../../src/wxMaximaFrame.cpp:1453
 msgid "&Integrate..."
-msgstr ""
+msgstr "&Integra..."
 
 #: ../../src/wxMaximaFrame.cpp:964
 msgid "&Interrupt\tCtrl+G"
-msgstr ""
+msgstr "&Interrompi\tCtrl+G"
 
 #: ../../src/wxMaximaFrame.cpp:1355
 msgid "&Invert Matrix"
-msgstr ""
+msgstr "&Inverti la matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "&License"
-msgstr ""
+msgstr "&Licenza"
 
 #: ../../src/wxMaximaFrame.cpp:1763
 msgid "&List"
-msgstr ""
+msgstr "&Lista"
 
 #: ../../src/wxMaximaFrame.cpp:610
 msgid "&Load Package...\tCtrl+L"
-msgstr ""
+msgstr "Carica i&l pacchetto\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "&Maxima"
-msgstr ""
+msgstr "&Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "&Maxima help"
-msgstr ""
+msgstr "Aiuto di &Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1660
 msgid "&Modulus Computation..."
-msgstr ""
+msgstr "Calcolo &modulo..."
 
 #: ../../src/main.cpp:435
 msgid "&New\tCtrl+N"
-msgstr ""
+msgstr "&Nuovo\tCtrl+N"
 
 #: ../../src/wxMaximaFrame.cpp:1870
 msgid "&Numeric"
-msgstr ""
+msgstr "&Numerico"
 
 #: ../../src/wxMaximaFrame.cpp:1785
 msgid "&Numeric Output"
-msgstr ""
+msgstr "Risultati &numerici"
 
 #: ../../src/main.cpp:436
 msgid "&Open\tCtrl+O"
-msgstr ""
+msgstr "&Apri\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "&Open...\tCtrl+O"
-msgstr ""
+msgstr "&Apri...\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "&Plot"
-msgstr ""
+msgstr "&Disegno"
 
 #: ../../src/wxMaximaFrame.cpp:622
 msgid "&Print...\tCtrl+P"
-msgstr ""
+msgstr "Stam&pa...\tCtrl+P"
 
 #: ../../src/wxMaximaFrame.cpp:1594
 msgid "&Reduce Trigonometric"
-msgstr ""
+msgstr "&Riduci trigonometrica"
 
 #: ../../src/wxMaximaFrame.cpp:974
 msgid "&Restart Maxima\tCtrl+Alt+R"
-msgstr ""
+msgstr "&Riavvia Maxima\tCtrl+Alt+R"
 
 #: ../../src/wxMaximaFrame.cpp:608
 msgid "&Save\tCtrl+S"
-msgstr ""
+msgstr "&Salva\tCtrl+S"
 
 #: ../../src/wxMaximaFrame.cpp:1662
 msgid "&Simplify"
-msgstr ""
+msgstr "&Semplifica"
 
 #: ../../src/wxMaximaFrame.cpp:1581
 msgid "&Simplify Factorials"
-msgstr ""
+msgstr "&Semplifica fattoriali"
 
 #: ../../src/wxMaximaFrame.cpp:1591
 msgid "&Simplify Trigonometric"
-msgstr ""
+msgstr "&Semplifica trigonometrica"
 
 #: ../../src/wxMaximaFrame.cpp:1238
 msgid "&Solve..."
-msgstr ""
+msgstr "Ris&olvi..."
 
 #: ../../src/wxMaximaFrame.cpp:1035
 msgid "&Time Display"
-msgstr ""
+msgstr "Mostra &tempo"
 
 #: ../../src/wxMaximaFrame.cpp:1375
 msgid "&Transpose Matrix"
-msgstr ""
+msgstr "&Trasponi la matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1605
 msgid "&Trigonometric Simplification"
-msgstr ""
+msgstr "Semplificazione &trigonometrica"
 
 #: ../../src/wxMaximaFrame.cpp:1021
 msgid "&Variables"
-msgstr ""
+msgstr "&Variabili"
 
 #: ../../src/wxMaxima.cpp:2443
 msgid "(Config tells to suppress the output of long cells)"
@@ -314,209 +321,212 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9248
 msgid "(f(x),x,a,b)), Epsilon algorithm"
-msgstr ""
+msgstr "(f(x),x,a,b)), algoritmo epsilon"
 
 #: ../../src/wxMaxima.cpp:9235
 msgid "(f(x),x,a,b)), Strategy of Aind"
-msgstr ""
+msgstr "(f(x),x,a,b)), strategia di Aind"
 
 #: ../../src/wxMaxima.cpp:9258
 msgid "(f(x),x,a,b), (semi-) infinite interval"
-msgstr ""
+msgstr "(f(x),x,a,b), intervalli (semi-)infiniti"
 
 #: ../../src/wxMaximaFrame.cpp:1841
 msgid "(f(x),x,a,b), Epsilon algorithm"
-msgstr ""
+msgstr "(f(x),x,a,b), algoritmo epsilon"
 
 #: ../../src/wxMaximaFrame.cpp:1843
 msgid "(f(x),x,a,b), infinite interval"
-msgstr ""
+msgstr "(f(x),x,a,b), intervallo infinito"
 
 #: ../../src/wxMaximaFrame.cpp:1839
 msgid "(f(x),x,a,b), strategy of Aind"
-msgstr ""
+msgstr "(f(x),x,a,b), strategia di Aind"
 
 #: ../../src/wxMaxima.cpp:9361 ../../src/wxMaximaFrame.cpp:1867
 msgid "(f(x),x,y) with singularities+discontinuities"
-msgstr ""
+msgstr "(f(x),x,y) con singolarità+discontinuità"
 
 #: ../../src/wxMaxima.cpp:2065
 msgid ""
 "... [suppressed additional lines as the output is longer than allowed in the"
 " wxMaxima configuration] "
 msgstr ""
+"... [soppresse righe aggiuntive dato che il risultato è più lungo da quanto "
+"permesso dalla configurazione di wxMaxima] "
 
 #: ../../src/Worksheet.cpp:6666
 msgid ".wxm clipboard data with unusual header"
-msgstr ""
+msgstr ".wxm dati appunti con insolita intestazione"
 
 #: ../../src/wxMaxima.cpp:8047
 msgid "1×n Matrix b:"
-msgstr ""
+msgstr "1×n Matrice b:"
 
 #: ../../src/wxMaximaFrame.cpp:1312
 msgid "2D Array to Matrix..."
-msgstr ""
+msgstr "Array 2D a Matrice..."
 
 #: ../../src/wxMaximaFrame.cpp:743
 msgid "2D equations using ASCII Art"
-msgstr ""
+msgstr "Equazioni 2D usando ASCII Art"
 
 #: ../../src/wxMaximaFrame.cpp:746
 msgid "2D equations using ASCII Art with unicode characters, if available"
-msgstr ""
+msgstr "equazioni 2D usando ASCII Art con caratteri unicode, se disponibili"
 
 #: ../../src/wxMaxima.cpp:5057
-#, c-format
+#, fuzzy, c-format
 msgid "; %i commands left in the current cell"
-msgstr ""
+msgstr "; %li comandi lasciati nella cella corrente"
 
 #: ../../src/wxMaxima.cpp:10617
 msgid "A \":lisp\" as the first command might fail to send a \"finished\" signal."
-msgstr ""
+msgstr "Un \":lisp\" come primo comando può impedire l'invio del segnale \"finito\"."
 
 #: ../../src/wxMaxima.cpp:6585
 msgid "A Ctrl-F event"
-msgstr ""
+msgstr "Un evento Ctrl-F"
 
 #: ../../src/Worksheet.cpp:1973
 msgid "A Scalar"
-msgstr ""
+msgstr "Uno scalare"
 
 #: ../../src/wxMaxima.cpp:6653
 #, c-format
 msgid "A find event, %s"
-msgstr ""
+msgstr "Un evento trova, %s"
 
 #: ../../src/Worksheet.cpp:2012
 msgid "A function returning integers"
-msgstr ""
+msgstr "Una funzione che restituisce interi"
 
 #: ../../src/Worksheet.cpp:2014
 msgid "A function returning positive numbers"
-msgstr ""
+msgstr "Una funzione che restituisce numeri positivi"
 
 #: ../../src/Worksheet.cpp:1965
 msgid "A irrational variable"
-msgstr ""
+msgstr "Una variabile irrazionale"
 
 #: ../../src/Worksheet.cpp:2016
 msgid "A left-associative function"
-msgstr ""
+msgstr "Una funzione associativa a sinistra"
 
 #: ../../src/Worksheet.cpp:2019
 msgid "A linear function"
-msgstr ""
+msgstr "Una funzione lineare"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "A matrix in which each row is a set of variables"
-msgstr ""
+msgstr "Una matrice nella quale ogni riga è un insieme di variabili"
 
 #: ../../src/Worksheet.cpp:1963
 msgid "A rational variable"
-msgstr ""
+msgstr "Una variabile razionale"
 
 #: ../../src/Worksheet.cpp:2018
 msgid "A right-associative function"
-msgstr ""
+msgstr "Una funzione associativa a destra"
 
 #: ../../src/wxMaximaFrame.cpp:1634
 msgid "A search-and-replace for equations"
-msgstr ""
+msgstr "Ricerca e sostituzione per equazioni"
 
 #: ../../src/wxMaximaFrame.cpp:1636
 msgid "A subst with basic maths knowledge"
-msgstr ""
+msgstr "Una subst con conoscenze di matematica di base"
 
 #: ../../src/BTextCtrl.cpp:64
 msgid "A text control got the mouse focus"
-msgstr ""
+msgstr "Un elemento di testo ha ottenuto il focus del mouse"
 
 #: ../../src/wxMaximaFrame.cpp:1442
 msgid "A&pply function to each Matrix element..."
-msgstr ""
+msgstr "A&pplica funzione ad ogni elemento della matrice..."
 
 #: ../../src/wxMaximaFrame.cpp:1291
 msgid "A&t Value..."
-msgstr ""
+msgstr "A&l valore..."
 
 #: ../../src/Configuration.cpp:85
 msgid "ASCII maths"
-msgstr ""
+msgstr "Matem. ASCII"
 
 #: ../../src/wxMaximaFrame.cpp:1963
 msgid "About"
-msgstr ""
+msgstr "Informazioni"
 
 #: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
 msgid "About wxMaxima"
-msgstr ""
+msgstr "Informazioni su wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7837
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
-msgstr ""
+msgstr "Accetta ona espressione o una lista nel formato [ode1,ode2,...]"
 
 #: ../../src/wxMaxima.cpp:7841
 msgid "Accepts one variable or a list in the format [1,4,...]"
-msgstr ""
+msgstr "Accetta una variabile o una lista nel formato [1,4,...]"
 
 #: ../../src/wxMaxima.cpp:7839
 msgid "Accepts one variable or a list in the format [var1,var2,...]"
-msgstr ""
+msgstr "Accetta una variabile o una lista nel formato [var1,var2,...]"
 
 #: ../../src/wxMaximaFrame.cpp:1371
 msgid "Ad&joint Matrix"
-msgstr ""
+msgstr "Matrice ag&giunta"
 
 #: ../../src/wxMaximaFrame.cpp:1657
 msgid "Add Algebraic E&quality..."
-msgstr ""
+msgstr "Aggiungi &uguaglianza algebrica..."
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add a directory to search path"
-msgstr ""
+msgstr "Aggiungi una directory al percorso di ricerca"
 
 #: ../../src/wxMaximaFrame.cpp:1752
 msgid ""
 "Add a new item to the beginning of the list. Useful for creating stacks."
 msgstr ""
+"Aggiungi un nuovo elemento all'inizio della lista. Utile per creare pile."
 
 #: ../../src/wxMaxima.cpp:8602
 msgid "Add an element to the end of a list"
-msgstr ""
+msgstr "Aggiungi un elemento alla fine di una lista"
 
 #: ../../src/wxMaxima.cpp:8597
 msgid "Add an element to the start of a list"
-msgstr ""
+msgstr "Aggiungi un elemento all'inizio di una lista"
 
 #: ../../src/wxMaxima.cpp:7625
 msgid "Add dir to path:"
-msgstr ""
+msgstr "Aggiungi una directory al percorso:"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "Add equality to the rational simplifier"
-msgstr ""
+msgstr "Aggiungi uguaglianza al semplificatore razionale"
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add to &Path..."
-msgstr ""
+msgstr "Aggiungi al &percorso..."
 
 #: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
 #: ../../src/Worksheet.cpp:1704
 msgid "Add to watchlist"
-msgstr ""
+msgstr "Aggiungi alla alla watchlist"
 
 #: ../../src/wxMaximaFrame.cpp:1562
 msgid "Additionally: log(a*b)=log(a)+log(b)"
-msgstr ""
+msgstr "Inoltre: log(a*b)=log(a)+log(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1566
 msgid "Additionally: log(a/b)=log(a)-log(b), a and b positive integers"
-msgstr ""
+msgstr "Inoltre: log(a/b)=log(a)-log(b), a e b interi positivi"
 
 #: ../../src/Worksheet.cpp:1996
 msgid "Additive function: f(a+b)=f(a)+f(b)"
-msgstr ""
+msgstr "Funzione additiva: f(a+b)=f(a)+f(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1911
 msgid "Advanced 2d plotting"
@@ -524,29 +534,31 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1809
 msgid "Advanced guess (PSLQ algorithm)"
-msgstr ""
+msgstr "Ipotesi avanzata (algoritmo PSLQ)"
 
 #: ../../src/wxMaximaFrame.cpp:1920
 msgid "Advanced variable names"
-msgstr ""
+msgstr "Nomi variabili avanzati"
 
 #: ../../src/ToolBar.cpp:321 ../../src/ToolBar.cpp:589
 msgid ""
 "After clicking on animations created with with_slider_draw() or similar this"
 " slider allows to change the current frame."
 msgstr ""
+"Dopo aver fatto clic sulle animazioni create con with_slider_draw() o simili"
+" questo cursore permette di cambiare il quadro corrente."
 
 #: ../../src/wxMaximaFrame.cpp:1028
 msgid "Aliases"
-msgstr ""
+msgstr "Alias"
 
 #: ../../src/wxMaximaFrame.cpp:1714
 msgid "All but the 1st n elements"
-msgstr ""
+msgstr "Tutti a parte i primi n elementi"
 
 #: ../../src/wxMaximaFrame.cpp:1716
 msgid "All but the last n elements"
-msgstr ""
+msgstr "Tutti a parte gli ultimi n elementi"
 
 #: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
 msgid ""
@@ -555,93 +567,101 @@ msgid ""
 "*.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session "
 "(*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr ""
+"Tutti i tipi apribili (*.wxm, *.wxmx, *.mac, *.out, "
+"*.xml)|*.wxm;*.wxmx;*.mac;*.out;*.xml|Documenti di wxMaxima (*.wxm, "
+"*.wxmx)|*.wxm;*.wxmx|Sessioni Maxima (*.mac)|*.mac|Sessioni Xmaxima "
+"(*.out)|*.out|xml da spezzoni di .wxmx (*.xml)|*.xml"
 
 #: ../../src/wxMaximaFrame.cpp:733
 msgid "All visible sidebars"
-msgstr ""
+msgstr "Tutte le barre laterali visibili"
 
 #: ../../src/wxMaximaFrame.cpp:1650
 msgid "Allow to substitute operators"
-msgstr ""
+msgstr "Permetti di sostituire gli operatori"
 
 #: ../../src/wxMaxima.cpp:9040
 msgid ""
 "Allows to vary the parameters of a function until it fits experimental data."
 msgstr ""
+"Permette di variare i parametri di una funzione per farla corrispondere ai "
+"dati sperimentali."
 
 #: ../../src/wxMaximaFrame.cpp:763
 msgid "Always after underscores"
-msgstr ""
+msgstr "Sempre dopo un carattere di sottolineato"
 
 #: ../../src/wxMaximaFrame.cpp:764
 msgid "Always autosubscript after an underscore"
-msgstr ""
+msgstr "Passa sempre al pedice dopo un carattere di sottolineato"
 
 #: ../../src/wxMaximaFrame.cpp:774
 msgid "Always display this variable with subscript"
-msgstr ""
+msgstr "Mostra sempre questa variabile col pedice"
 
 #: ../../src/Worksheet.cpp:1605
 msgid "Always show all digits"
-msgstr ""
+msgstr "Mostra sempre tutte le cifre"
 
 #: ../../src/wxMaxima.cpp:9241
 msgid ""
 "An integer between 1..6; Higher numbers work better for oscillating "
 "integrands"
 msgstr ""
+"Un intero tra 1..6; Numeri più alti funzionano meglio per integrandi "
+"oscillanti"
 
 #: ../../src/MaximaManual.cpp:385
 msgid "Anchors file has no top node."
-msgstr ""
+msgstr "Il file ancore non ha un nodo cima."
 
 #: ../../src/wxMaximaFrame.cpp:791
 msgid "Angles"
-msgstr ""
+msgstr "Angoli"
 
 #: ../../src/wxMaximaFrame.cpp:1775
 msgid "Animation autoplay"
-msgstr ""
+msgstr "Autoesecuzione animazioni"
 
 #: ../../src/wxMaximaFrame.cpp:1778
 msgid "Animation framerate..."
-msgstr ""
+msgstr "Frequenza di quadro animazioni..."
 
 #: ../../src/Worksheet.cpp:2002
 msgid "Antisymmetric function: f(x)=-f(-x)"
-msgstr ""
+msgstr "Funzione antisimmetrica: f(x)=-f(-x)"
 
 #: ../../src/wxMaximaFrame.cpp:1739
 msgid "Append"
-msgstr ""
+msgstr "Accoda"
 
 #: ../../src/wxMaximaFrame.cpp:1735
 msgid "Append a list"
-msgstr ""
+msgstr "Accoda una lista"
 
 #: ../../src/wxMaximaFrame.cpp:1736
 msgid "Append a list to an existing list"
-msgstr ""
+msgstr "Accoda una lista ad una lista esistente"
 
 #: ../../src/wxMaxima.cpp:8607
 msgid "Append a list to another list"
-msgstr ""
+msgstr "Accoda una lista ad un'altra lista"
 
 #: ../../src/wxMaximaFrame.cpp:1729
 msgid "Append an element"
-msgstr ""
+msgstr "Accoda un elemento"
 
 #: ../../src/wxMaximaFrame.cpp:1734
 msgid "Append an element to the beginning an existing list"
-msgstr ""
+msgstr "Accoda un elemento all'inizio di una lista esistente"
 
 #: ../../src/wxMaximaFrame.cpp:1730
 msgid "Append an element to the end of an existing list"
-msgstr ""
+msgstr "Accoda un elemento alla fine di ad una lista esistente"
 
 #: ../../src/wxMaxima.cpp:8552
 msgid "Apply a function to each list element"
-msgstr ""
+msgstr "Applica una funzione ad ogni elemento lista"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 #, c-format
@@ -649,32 +669,36 @@ msgid ""
 "Approximate by a fraction using log(), sqrt() and %pi, when needed. Only "
 "available in maxima > 5.46.0"
 msgstr ""
+"Approssima per frazione usando log(), sqrt() e %pi, quando necessario. "
+"Disponibile solo in maxima > 5.46.0"
 
 #: ../../src/wxMaximaFrame.cpp:1806
 msgid "Approximate by nice fraction"
-msgstr ""
+msgstr "Approssima tramite una bella frazione"
 
 #: ../../src/wxMaxima.cpp:8931
 msgid ""
 "Approximates a expression around a point as a polynom\n"
 "The trailing \"...\" can be removed by using ratdisrep()"
 msgstr ""
+"Approssima un'espressione attorno a un punto come polinomio\n"
+"Il \"...\" finale può essere rimosso utilizzando ratdisrep()"
 
 #: ../../src/wxMaxima.cpp:8939
 msgid "Approximates a expression as a polynom"
-msgstr ""
+msgstr "Approssima una espressione come polinomio"
 
 #: ../../src/wxMaxima.cpp:9474
 msgid "Apropos"
-msgstr ""
+msgstr "Aproposito"
 
 #: ../../src/wxMaxima.cpp:7317
 msgid "Are the chars equal, if case is ignored?"
-msgstr ""
+msgstr "I caratteri sono uguali se si trascurano le maiuscole?"
 
 #: ../../src/wxMaxima.cpp:7312
 msgid "Are the chars equal?"
-msgstr ""
+msgstr "I caratteri sono uguali?"
 
 #: ../../src/wxMaxima.cpp:7349
 msgid "Are these strings equal if case is ignored?"
@@ -682,39 +706,39 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7344
 msgid "Are these strings equal?"
-msgstr ""
+msgstr "Queste stringhe sono uguali?"
 
 #: ../../src/wxMaxima.cpp:7259
 msgid "Arguments:"
-msgstr ""
+msgstr "Argomenti:"
 
 #: ../../src/wxMaxima.cpp:8189
 msgid "Array"
-msgstr ""
+msgstr "Array"
 
 #: ../../src/wxMaximaFrame.cpp:1023
 msgid "Arrays"
-msgstr ""
+msgstr "Array"
 
 #: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
 msgid "Ascii code to char"
-msgstr ""
+msgstr "Codice ascii a char"
 
 #: ../../src/wxMaximaFrame.cpp:1138
 msgid "Ascii code to char..."
-msgstr ""
+msgstr "Codice ascii a char..."
 
 #: ../../src/wxMaxima.cpp:10063
 msgid "Assignment(s):"
-msgstr ""
+msgstr "Assegnamenti:"
 
 #: ../../src/wxMaxima.cpp:10064
 msgid "Assignments of the format a=10,b=20"
-msgstr ""
+msgstr "Assegnamenti del formato a=10,b=20"
 
 #: ../../src/wxMaxima.cpp:6851
 msgid "Assume a value range for a variable"
-msgstr ""
+msgstr "Assumi un campo di valori per una variabile"
 
 #: ../../src/wxMaxima.cpp:8545
 msgid ""
@@ -724,45 +748,47 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1618
 msgid "Automatic labels"
-msgstr ""
+msgstr "Etichette automatiche"
 
 #: ../../src/wxMaximaFrame.cpp:952
 msgid "Automatically answer questions"
-msgstr ""
+msgstr "Rispondi alle domande automaticamente"
 
 #: ../../src/wxMaximaFrame.cpp:953
 msgid "Automatically fill in answers known from the last run"
 msgstr ""
+"Rispondi automaticamente alle domande conosciute dall'ultima esecuzione"
 
 #: ../../src/Worksheet.cpp:1464 ../../src/Worksheet.cpp:1838
 msgid "Automatically send known answers"
-msgstr ""
+msgstr "Invia automaticamente domande conosciute"
 
 #: ../../src/wxMaxima.cpp:6021
 #, c-format
 msgid "Autosaving as temp file %s"
-msgstr ""
+msgstr "Autosalvataggio come file temporaneo %s"
 
 #: ../../src/wxMaxima.cpp:6033
 #, c-format
 msgid "Autosaving the .wxmx file as %s"
-msgstr ""
+msgstr "Autosalvataggio del file .wxmx come %s"
 
 #: ../../src/wxMaximaFrame.cpp:781
 msgid "Autosubscript"
-msgstr ""
+msgstr "Autopedice"
 
 #: ../../src/wxMaximaFrame.cpp:782
 msgid "Autosubscript chars after an underscore"
-msgstr ""
+msgstr "Passa automaticamente al pedice dopo un carattere di sottolineato"
 
 #: ../../src/wxMaximaFrame.cpp:767
 msgid "Autosubscript numbers and text following single letters"
 msgstr ""
+"Passa automaticamente al pedice i numeri e il testo seguenti singole lettere"
 
 #: ../../src/wxMaxima.cpp:6529
 msgid "Autosubscript this variable"
-msgstr ""
+msgstr "Auto-pedice questa variabile"
 
 #: ../../src/MaximaManual.cpp:536
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -770,15 +796,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1350
 msgid "Basic matrix operations"
-msgstr ""
+msgstr "Operazioni matriciali di base"
 
 #: ../../src/wxMaxima.cpp:6210
 msgid "Batch File"
-msgstr ""
+msgstr "File batch"
 
 #: ../../src/wxMaxima.cpp:5318
 msgid "Both horizontal and vertical cursor active at the same time"
-msgstr ""
+msgstr "Entrambi i cursori orizzontale e verticale attivi allo stesso tempo"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Bottom end"
@@ -786,24 +812,25 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7817
 msgid "Boundary value problem"
-msgstr ""
+msgstr "Problema del valore al contorno"
 
 #: ../../src/wxMathml.cpp:101
 msgid ""
 "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
 msgstr ""
+"Bug: dopo la rimozione dello spazio wxMathml.lisp è più corto del previsto!"
 
 #: ../../src/Autocomplete.cpp:509
 msgid "Bug: Autocompletion requested for unknown type of item."
-msgstr ""
+msgstr "Bug: autocompletamento richiesto per tipo sconosciuto di elemento."
 
 #: ../../src/Worksheet.cpp:2992
 msgid "Bug: Cell left but not entered."
-msgstr ""
+msgstr "Bug: cella lasciata ma non immessa."
 
 #: ../../src/Worksheet.cpp:6203
 msgid "Bug: Cell with negative y position!"
-msgstr ""
+msgstr "Bug: cella con posizione y negativa!"
 
 #: ../../src/Worksheet.cpp:7723
 msgid ""
@@ -817,36 +844,42 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:3112
 msgid "Bug: Got a question but no cell to answer it in"
-msgstr ""
+msgstr "Bug: trovata domanda ma nessuna cella per rispondere"
 
 #: ../../src/Worksheet.cpp:6378
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of"
 " the worksheet."
 msgstr ""
+"Bug: trovata una richiesta di cambio dei contenuti della cella sopra "
+"l'inizio del foglio di lavoro."
 
 #: ../../src/Worksheet.cpp:6346
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
+"Bug: trovata richiesta di cancellazione della cella sopra l'inizio del "
+"foglio di lavoro."
 
 #: ../../src/Worksheet.cpp:6415
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
 msgstr ""
+"Bug:  trovata richiesta cambiamento dei contenuti di una cella seguita da "
+"una richiesta di annullamento della sua cancellazione."
 
 #: ../../src/Worksheet.cpp:5578
 msgid "Bug: HTML output is no valid XML"
-msgstr ""
+msgstr "Bug: il risultato HTML non è XML valido"
 
 #: ../../src/Configuration.h:615
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
-msgstr ""
+msgstr "Bug: il numero massimo di cifre da visualizzare è troppo basso!"
 
 #: ../../src/MathParser.cpp:523
 msgid "Bug: Missing contents"
-msgstr ""
+msgstr "Bug: contenuti mancanti"
 
 #: ../../src/Worksheet.cpp:2597 ../../src/Worksheet.cpp:2711
 #: ../../src/Worksheet.cpp:2753 ../../src/Worksheet.cpp:2787
@@ -854,7 +887,7 @@ msgstr ""
 #: ../../src/Worksheet.cpp:4442 ../../src/Worksheet.cpp:6650
 #: ../../src/Worksheet.cpp:6863
 msgid "Bug: The clipboard is already opened"
-msgstr ""
+msgstr "Bug: gli appunti sono già aperti"
 
 #: ../../src/Worksheet.cpp:7763
 msgid "Bug: Trying to move a title out by one sectioning unit"
@@ -865,38 +898,44 @@ msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
+"Bug: tentativo di spostare il cursore disegnato orizzontalmente all'interno "
+"di una Cella di gruppo."
 
 #: ../../src/Worksheet.h:247 ../../src/Worksheet.h:252
 msgid "Bug: Trying to record a cell contents change for undo without a cell."
 msgstr ""
+"Bug: tentativo di registrare i contenuti dei cambiamenti di una cella per "
+"l'annullamento senza una cella."
 
 #: ../../src/Worksheet.cpp:6417
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
+"Bug: azione di annullamento con sia cambiamento contenuti cella che aggiunta"
+" cella."
 
 #: ../../src/Worksheet.cpp:6383
 msgid "Bug: Undo request for cell outside worksheet."
-msgstr ""
+msgstr "Bug: richiesta annullamento per celle fuori dal foglio di lavoro."
 
 #: ../../src/wxMaximaFrame.cpp:1948
 msgid "Build &Info"
-msgstr ""
+msgstr "&Informazioni sulla compilazione"
 
 #: ../../src/wxMaxima.cpp:7275
 msgid "Byte:"
-msgstr ""
+msgstr "Byte:"
 
 #: ../../src/wxMaximaFrame.cpp:1458
 msgid "C&hange Variable in Integrate..."
-msgstr ""
+msgstr "Cambia la &variabile nell'integrale..."
 
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "C&onfigure"
-msgstr ""
+msgstr "C&onfigura"
 
 #: ../../src/wxMaximaFrame.cpp:1482
 msgid "Calculate &Product..."
-msgstr ""
+msgstr "Calcola il &prodotto..."
 
 #: ../../src/wxMaxima.cpp:8057
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
@@ -910,35 +949,35 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate Su&m..."
-msgstr ""
+msgstr "Calcola la so&mma..."
 
 #: ../../src/wxMaximaFrame.cpp:1795
 msgid "Calculate bigfloat value of the last result"
-msgstr ""
+msgstr "Calcola il valore dell'ultimo risultato in virgola mobile precisa"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Calculate float value of the last result"
-msgstr ""
+msgstr "Calcola il valore dell'ultimo risultato in virgola mobile"
 
 #: ../../src/wxMaxima.cpp:9550
 msgid "Calculate mean value"
-msgstr ""
+msgstr "Calcola valore medio"
 
 #: ../../src/wxMaxima.cpp:9554
 msgid "Calculate median value"
-msgstr ""
+msgstr "Calcola valore mediano"
 
 #: ../../src/wxMaxima.cpp:8871
 msgid "Calculate modulus:"
-msgstr ""
+msgstr "Calcola il modulo:"
 
 #: ../../src/wxMaximaFrame.cpp:1798
 msgid "Calculate numeric value of the last result"
-msgstr ""
+msgstr "Calcola il valore numeric dell'ultimo risultato"
 
 #: ../../src/wxMaximaFrame.cpp:1483
 msgid "Calculate products"
-msgstr ""
+msgstr "Calcola i prodotti"
 
 #: ../../src/wxMaxima.cpp:9562
 msgid "Calculate standard deviation"
@@ -946,31 +985,32 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate sums"
-msgstr ""
+msgstr "Calcola le somme"
 
 #: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
 msgid "Calculate the eigenvalues and eigenvectors numerically"
-msgstr ""
+msgstr "Calcola numericamente gli autovalori e gli autovettori"
 
 #: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
 msgid "Calculate the eigenvalues of a matrix numerically"
-msgstr ""
+msgstr "Calcola numericamente gli autovalori di una matrice"
 
 #: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
 msgid "Calculate the root of the sum of squares of matrix entries"
 msgstr ""
+"Calcola la radice della somma dei quadrati degli elementi della matrice"
 
 #: ../../src/wxMaxima.cpp:9558
 msgid "Calculate variation"
-msgstr ""
+msgstr "Calcola variante"
 
 #: ../../src/wxMaxima.cpp:8949
 msgid "Calculates the fourier coefficients for the expression from -p to p"
-msgstr ""
+msgstr "Calcola i coefficienti di fourier per l'espressione da -p a p"
 
 #: ../../src/Worksheet.cpp:1968
 msgid "Calls assume() in order to tell maxima about the variable's range"
-msgstr ""
+msgstr "Chiama assume() in modo da dire a maxima il campo della variabile"
 
 #: ../../src/Worksheet.cpp:2031
 msgid "Can be specified as flag in ev(exp, flag)"
@@ -978,11 +1018,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11125
 msgid "Can not connect to the web server."
-msgstr ""
+msgstr "Impossibile connettersi al server web."
 
 #: ../../src/wxMaxima.cpp:11166
 msgid "Can not download version info."
-msgstr ""
+msgstr "Impossibile scaricare le informazioni di versione."
 
 #: ../../src/wxMaxima.cpp:3016 ../../src/wxMaxima.cpp:4836
 msgid ""
@@ -990,141 +1030,148 @@ msgid ""
 " (it can be downloaded from https://maxima.sourceforge.io) or in wxMaxima's "
 "config dialogue the setting for Maxima's location is wrong."
 msgstr ""
+"Impossibile avviare Maxima. La causa più probabile è che Maxima non sia "
+"installato (si può scaricare da https://maxima.sourceforge.io) o che le "
+"impostazioni della pozione di Maxima nella finestra di configurazione di "
+"wxMaxima siano errate."
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Cancel"
-msgstr ""
+msgstr "Annulla"
 
 #: ../../src/wxMaxima.cpp:3292
 msgid "Cannot authenticate Maxima!"
-msgstr ""
+msgstr "Impossibile autenticare Maxima!"
 
 #: ../../src/wxMaxima.cpp:2677
 msgid ""
 "Cannot find a maxima binary and no binary chosen in the config dialogue."
 msgstr ""
+"Impossibile trovare un eseguibile maxima e non è stato scelto un eseguibile "
+"nella finestra di dialogo di configurazione."
 
 #: ../../src/Autocomplete.cpp:583
 #, c-format
 msgid "Cannot interpret template %s"
-msgstr ""
+msgstr "Impossibile interpretare il modello %s"
 
 #: ../../src/wxMaxima.cpp:3082
 #, c-format
 msgid "Cannot interpret the numeric value of pid %s"
-msgstr ""
+msgstr "Impossibile interpretare il valore numerico del pid %s"
 
 #: ../../src/wxMaxima.cpp:11066 ../../src/wxMaxima.cpp:11073
 #: ../../src/wxMaxima.cpp:11080
 #, c-format
 msgid "Cannot interpret version number component %s"
-msgstr ""
+msgstr "Impossibile interpretare il componente numero di versione %s"
 
 #: ../../src/wxMaxima.cpp:2530
 msgid "Cannot set the communication address to localhost."
-msgstr ""
+msgstr "Impossibile impostare l'indirizzo di comunicazione a localhost."
 
 #: ../../src/wxMaxima.cpp:2532
-#, c-format
+#, fuzzy, c-format
 msgid "Cannot set the communication port to %i."
-msgstr ""
+msgstr "Impossibile impostare la porta di comunicazione a %li."
 
 #: ../../src/wxMaxima.cpp:3656 ../../src/wxMaxima.cpp:6359
 msgid "Cannot start gnuplot"
-msgstr ""
+msgstr "Impossibile avviare gnuplot"
 
 #: ../../src/StatusBar.cpp:216 ../../src/wxMaxima.cpp:2662
 msgid "Cannot start the maxima binary"
-msgstr ""
+msgstr "Impossibile avviare maxima"
 
 #: ../../src/wxMaxima.cpp:9268
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
-msgstr ""
+msgstr "Valore principale di Cauchy di f(x)/(x-c), intervallo finito"
 
 #: ../../src/wxMaximaFrame.cpp:1845
 msgid "Cauchy principal value, finite interval"
-msgstr ""
+msgstr "Valore principale di Cauchy, intervallo finito"
 
 #: ../../src/wxMaximaFrame.cpp:955
 msgid "Ce&ll"
-msgstr ""
+msgstr "Ce&lla"
 
 #: ../../src/Configuration.cpp:96
 msgid "Cell bracket fill, Active"
-msgstr ""
+msgstr "Riempimento parentesi cella, attivo"
 
 #: ../../src/Configuration.cpp:95
 msgid "Cell bracket fill, Inactive"
-msgstr ""
+msgstr "Riempimento parentesi cella, inattivo"
 
 #: ../../src/wxMaxima.cpp:10395
 msgid "Cell ends in a backslash"
-msgstr ""
+msgstr "La cella finisce con un backslash"
 
 #: ../../src/wxMaximaFrame.cpp:1038
 msgid "Change &2d Display"
-msgstr ""
+msgstr "Cambia la finestra &2d"
 
 #: ../../src/wxMaxima.cpp:10146
 msgid "Change Image"
-msgstr ""
+msgstr "Cambia immagine"
 
 #: ../../src/Worksheet.cpp:1324
 msgid "Change Image..."
-msgstr ""
+msgstr "Cambia immagine..."
 
 #: ../../src/wxMaximaFrame.cpp:1954
 msgid "Change Log"
-msgstr ""
+msgstr "Cambia log"
 
 #: ../../src/wxMaxima.cpp:7555
 msgid "Change directory"
-msgstr ""
+msgstr "Cambia cartella"
 
 #: ../../src/wxMaximaFrame.cpp:1202
 msgid "Change directory..."
-msgstr ""
+msgstr "Cambia cartella..."
 
 #: ../../src/wxMaximaFrame.cpp:1039
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
+"Cambia l'algoritmo della finestra 2d usato per visualizzare il risultato."
 
 #: ../../src/wxMaxima.cpp:8885
 msgid "Change variable"
-msgstr ""
+msgstr "Cambia la variabile"
 
 #: ../../src/wxMaxima.cpp:8905
 msgid "Change variable and evaluate"
-msgstr ""
+msgstr "Cambia variabile ed elabora"
 
 #: ../../src/wxMaximaFrame.cpp:1459
 msgid "Change variable in integral or sum"
-msgstr ""
+msgstr "Cambia variabile nell'integrale o nella somma"
 
 #: ../../src/wxMaximaFrame.cpp:1463
 msgid "Change variable in integral or sum and evaluate the result"
-msgstr ""
+msgstr "Cambia variabile nell'integrale o nella somma ed elabora il risultato"
 
 #: ../../src/wxMaximaFrame.cpp:1026
 msgid "Changed option variables"
-msgstr ""
+msgstr "Cambiate le variabili opzionali"
 
 #: ../../src/wxMaxima.cpp:10170
 #, c-format
 msgid "Changing image originally loaded from file %s to %s."
-msgstr ""
+msgstr "Cambio immagine originariamente caricata da file %s a %s."
 
 #: ../../src/wxMaxima.cpp:7313 ../../src/wxMaxima.cpp:7318
 #: ../../src/wxMaxima.cpp:7323 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7334 ../../src/wxMaxima.cpp:7340
 msgid "Char #1:"
-msgstr ""
+msgstr "Car #1:"
 
 #: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
 #: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
 msgid "Char #2:"
-msgstr ""
+msgstr "Car #2:"
 
 #: ../../src/wxMaximaFrame.cpp:1140
 msgid "Char to Unicode code point..."
@@ -1144,31 +1191,31 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1131
 msgid "Character Tests"
-msgstr ""
+msgstr "Carattere testi"
 
 #: ../../src/wxMaxima.cpp:8181
 msgid "Characteristic polynom"
-msgstr ""
+msgstr "Polinomiale caratteristico"
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Chars are strings that are one character long"
-msgstr ""
+msgstr "I caratteri sono stringhe lunghe un carattere"
 
 #: ../../src/wxMaximaFrame.cpp:1957
 msgid "Check for Updates"
-msgstr ""
+msgstr "Controlla gli aggiornamenti"
 
 #: ../../src/wxMaximaFrame.cpp:1958
 msgid "Check if a newer version of wxMaxima is available."
-msgstr ""
+msgstr "Controlla se esiste una versione più recente di wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Choose the parenthesis type for Matrices"
-msgstr ""
+msgstr "Scegliere il tipo di parentesi per le matrici"
 
 #: ../../src/wxMaxima.cpp:9530 ../../src/wxMaxima.cpp:9535
 msgid "Classes:"
-msgstr ""
+msgstr "Classi:"
 
 #: ../../src/wxMaximaFrame.cpp:1378
 msgid "Classic matrix operations"
@@ -1176,288 +1223,298 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:998
 msgid "Clear all aliases"
-msgstr ""
+msgstr "Cancella tutti gli alias"
 
 #: ../../src/wxMaximaFrame.cpp:995
 msgid "Clear all arrays"
-msgstr ""
+msgstr "Cancella tutti gli array"
 
 #: ../../src/wxMaximaFrame.cpp:992
 msgid "Clear all dependencies"
-msgstr ""
+msgstr "Cancella tutte le dipendenze"
 
 #: ../../src/wxMaximaFrame.cpp:994
 msgid "Clear all functions"
-msgstr ""
+msgstr "Cancella tutte le funzioni"
 
 #: ../../src/wxMaximaFrame.cpp:1001
 msgid "Clear all gradefs"
-msgstr ""
+msgstr "Cancella tutte le grafdefs"
 
 #: ../../src/wxMaximaFrame.cpp:1000
 msgid "Clear all labels"
-msgstr ""
+msgstr "Cancella tutte le etichette"
 
 #: ../../src/wxMaximaFrame.cpp:1004
+#, fuzzy
 msgid "Clear all let rule packages"
-msgstr ""
+msgstr "Cancella tutti i pacchetti di regole di permessi"
 
 #: ../../src/wxMaximaFrame.cpp:1003
 msgid "Clear all macros"
-msgstr ""
+msgstr "Cancella tutte le macro"
 
 #: ../../src/wxMaximaFrame.cpp:1002
 msgid "Clear all props"
-msgstr ""
+msgstr "Cancella tutte le prop"
 
 #: ../../src/wxMaximaFrame.cpp:997
 msgid "Clear all rules"
-msgstr ""
+msgstr "Cancella tutte le regole"
 
 #: ../../src/wxMaximaFrame.cpp:999
 msgid "Clear all structures"
-msgstr ""
+msgstr "Cancella tutte le strutture"
 
 #: ../../src/wxMaximaFrame.cpp:993
 msgid "Clear all variables"
-msgstr ""
+msgstr "Cancella tutte le variabili"
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close\tCtrl+W"
-msgstr ""
+msgstr "Chiudi\tCtrl+W"
 
 #: ../../src/wxMaxima.cpp:7235
 msgid "Close Stream"
-msgstr ""
+msgstr "Chiudi lo stream"
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close window"
-msgstr ""
+msgstr "Chiudi la finestra"
 
 #: ../../src/wxMaximaFrame.cpp:1105
 msgid "Close..."
-msgstr ""
+msgstr "Chiudi..."
 
 #: ../../src/WXMXformat.cpp:301
 msgid "Closed the zip archive"
-msgstr ""
+msgstr "Archivio zip chiuso"
 
 #: ../../src/Configuration.cpp:77
 msgid "Code Default (Maxima input)"
-msgstr ""
+msgstr "Codice predefinito (ingresso di Maxima)"
 
 #: ../../src/Configuration.cpp:103
 msgid "Code highlighting: Comments"
-msgstr ""
+msgstr "Evidenziazione codice: commenti"
 
 #: ../../src/Configuration.cpp:108
 msgid "Code highlighting: End of line markers"
-msgstr ""
+msgstr "Evidenziazione codice: marcatori fine riga"
 
 #: ../../src/Configuration.cpp:102
 msgid "Code highlighting: Functions"
-msgstr ""
+msgstr "Evidenziazione codice: funzioni"
 
 #: ../../src/Configuration.cpp:107
 msgid "Code highlighting: Lisp"
-msgstr ""
+msgstr "Evidenziazione codice: Lisp"
 
 #: ../../src/Configuration.cpp:104
 msgid "Code highlighting: Numbers"
-msgstr ""
+msgstr "Evidenziazione codice: numeri"
 
 #: ../../src/Configuration.cpp:106
 msgid "Code highlighting: Operators"
-msgstr ""
+msgstr "Evidenziazione codice: operatori"
 
 #: ../../src/Configuration.cpp:105
 msgid "Code highlighting: Strings"
-msgstr ""
+msgstr "Evidenziazione codice: stringhe"
 
 #: ../../src/Configuration.cpp:101
 msgid "Code highlighting: Variables"
-msgstr ""
+msgstr "Evidenziazione codice: variabili"
 
 #: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
 msgid "Code number:"
-msgstr ""
+msgstr "Numero codice:"
 
 #: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
 msgid "Codepoint number:"
-msgstr ""
+msgstr "Numero puntocodice:"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "Col. names:"
-msgstr ""
+msgstr "Nomi colonne:"
 
 #: ../../src/Configuration.cpp:100
 msgid "Color of Outdated cells"
-msgstr ""
+msgstr "Colore delle celle non aggiornate"
 
 #: ../../src/Configuration.cpp:99
 msgid "Color of text equal to selection"
-msgstr ""
+msgstr "Colore del testo uguale alla selezione"
 
 #: ../../src/wxMaxima.cpp:7962
 msgid "Column number:"
-msgstr ""
+msgstr "Numero colonna:"
 
 #: ../../src/wxMaxima.cpp:7978
 msgid "Column numbers:"
-msgstr ""
+msgstr "Numeri colonne:"
 
 #: ../../src/wxMaxima.cpp:8202
+#, fuzzy
 msgid "Columns"
-msgstr ""
+msgstr "Numeri colonne:"
 
 #: ../../src/wxMaximaFrame.cpp:1584
 msgid "Combine factorials in an expression"
-msgstr ""
+msgstr "Combina i fattoriali in un'espressione"
 
 #: ../../src/wxMaxima.cpp:10454
 msgid "Comma directly followed by a closing parenthesis"
-msgstr ""
+msgstr "Virgola direttamente seguita da una parentesi chiusa"
 
 #: ../../src/wxMaxima.cpp:7259
 msgid "Comma-separated arguments"
-msgstr ""
+msgstr "Argomenti separati da virgole"
 
 #: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
 msgid "Comma-separated commands"
-msgstr ""
+msgstr "Comandi separati da virgole"
 
 #: ../../src/wxMaxima.cpp:8458
 msgid "Comma-separated elements"
-msgstr ""
+msgstr "Elementi separati da virgole"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 #: ../../src/wxMaxima.cpp:10031
 msgid "Comma-separated equations"
-msgstr ""
+msgstr "Equazioni separate da virgole"
 
 #: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
 #: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
 #: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
 msgid "Comma-separated expressions"
-msgstr ""
+msgstr "Espressioni separate da virgole"
 
 #: ../../src/wxMaxima.cpp:7215
 msgid "Comma-separated expressions that shall be converted to a string"
 msgstr ""
+"Espressioni separate da virgole che devono essere convertite in una stringa"
 
 #: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
 msgid "Comma-separated expressions."
-msgstr ""
+msgstr "Espressioni separate da virgole"
 
 #: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
 msgid "Comma-separated function names"
-msgstr ""
+msgstr "Nomi di funzioni separate da virgole"
 
 #: ../../src/wxMaxima.cpp:7086
 msgid "Comma-separated function names."
-msgstr ""
+msgstr "Nomi di funzioni separate da virgole."
 
 #: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
 #: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
 msgid "Comma-separated list entry in the format val1=1,val2=2"
-msgstr ""
+msgstr "Voce di lista separata da virgole nel formato val1=1,val2=2"
 
 #: ../../src/wxMaxima.cpp:7205
 msgid "Comma-separated names of the elements that shall be written"
-msgstr ""
+msgstr "Nomi separati da virgole degli elementi che devono essere scritti"
 
 #: ../../src/wxMaxima.cpp:7099
 msgid "Comma-separated names the parameters will be referenced by later."
 msgstr ""
+"Nomi separati da virgole dei parametri a cui dopo si farà riferimento."
 
 #: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
 msgid "Comma-separated numbers from 0 to 255"
-msgstr ""
+msgstr "Numeri di riga separati da virgole da 0 a 255"
 
 #: ../../src/wxMaxima.cpp:8770
 msgid "Comma-separated numbers of the terms to substitute in"
-msgstr ""
+msgstr "Numeri separati da virgole dei termini da sostituire"
 
 #: ../../src/wxMaxima.cpp:7137 ../../src/wxMaxima.cpp:7150
 msgid ""
 "Comma-separated parameter names. A parameter in square brackets [] will be "
 "filled with the list of any additional arguments the function gets."
 msgstr ""
+"Nomi dei parametri separati da virgole. Un parametro tra parentesi quadre []"
+" verrà riempito con l'elenco di eventuali argomenti aggiuntivi ottenuti "
+"dalla funzione."
 
 #: ../../src/wxMaxima.cpp:7054
 msgid "Comma-separated variable names, can be initialized by the \":\" operator."
 msgstr ""
+"Nomi di variabili separati da virgole, possono essere inizializzati "
+"dall'operatore \":\"."
 
 #: ../../src/wxMaxima.cpp:7753 ../../src/wxMaxima.cpp:7767
 #: ../../src/wxMaxima.cpp:8719 ../../src/wxMaxima.cpp:8785
 #: ../../src/wxMaxima.cpp:10032
 msgid "Comma-separated variables"
-msgstr ""
+msgstr "Variabili separate da virgole"
 
 #: ../../src/wxMaxima.cpp:9469
 msgid "Command:"
-msgstr ""
+msgstr "Comando:"
 
 #: ../../src/Worksheet.cpp:1692
 msgid "Comment Selection"
-msgstr ""
+msgstr "Commenta la selezione"
 
 #: ../../src/wxMaximaFrame.cpp:681
 msgid "Comment out the currently selected text"
-msgstr ""
+msgstr "Commento fuori dal testo attualmente selezionato"
 
 #: ../../src/wxMaximaFrame.cpp:680
 msgid "Comment selection\tCtrl+/"
-msgstr ""
+msgstr "Commenta la selezione\tCtrl+/"
 
 #: ../../src/Worksheet.cpp:2004
 msgid "Commutative function"
-msgstr ""
+msgstr "Funzione commutativa"
 
 #: ../../src/wxMaximaFrame.cpp:1396
 msgid "Compile a QR decomposition using dgeqrf"
-msgstr ""
+msgstr "Compila una scomposizione QR usando dgeqrf"
 
 #: ../../src/wxMaxima.cpp:7162
 msgid "Compile a function"
-msgstr ""
+msgstr "Compila una funzione"
 
 #: ../../src/wxMaximaFrame.cpp:1188
+#, fuzzy
 msgid "Compile a regular expression"
-msgstr ""
+msgstr "Compila una regex"
 
 #: ../../src/wxMaximaFrame.cpp:1385
 msgid "Compile eigenvalues using dgeev"
-msgstr ""
+msgstr "Compila gli autovalori usando dgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1388
 msgid "Compile eigenvalues using zgeev"
-msgstr ""
+msgstr "Compila gli autovalori usando zgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1391
 msgid "Compile eigenvalues+eigenvectors using dgeev"
-msgstr ""
+msgstr "Compila autovalori+autovettori usando dgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1394
 msgid "Compile eigenvalues+eigenvectors using zgeev"
-msgstr ""
+msgstr "Compila autovalori+autovettori usando zgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1076
 msgid "Compile function..."
-msgstr ""
+msgstr "Compila funzione..."
 
 #: ../../src/wxMaxima.cpp:7511
 msgid "Compile regex"
-msgstr ""
+msgstr "Compila regex"
 
 #: ../../src/wxMathml.cpp:53
 msgid "Compiler-Bug? wxMathml.lisp is shorter than expected!"
-msgstr ""
+msgstr "Bug compilatore? wxMathml.lisp è più corto del previsto!"
 
 #: ../../src/wxMaxima.cpp:2234
 #, c-format
 msgid "Compiling %s"
-msgstr ""
+msgstr "Compilazione di %s"
 
 #: ../../src/wxMaxima.cpp:7163
 msgid ""
@@ -1465,408 +1522,427 @@ msgid ""
 " the function parameters are made known to the function before it is "
 "compiled. Else the generated code has to be hideously generic."
 msgstr ""
+"La compilazione di una funzione può generare un notevole aumento di velocità"
+" se i tipi dei parametri della funzione vengono resi noti alla funzione "
+"prima della compilazione. Altrimenti il codice generato deve essere "
+"orribilmente generico."
 
 #: ../../src/wxMaximaFrame.cpp:892
 msgid "Complete Word\tCtrl+Space"
-msgstr ""
+msgstr "Completa parola\tCtrl+Space"
 
 #: ../../src/wxMaximaFrame.cpp:893
 msgid "Complete word"
-msgstr ""
+msgstr "Completa parola"
 
 #: ../../src/ToolBar.cpp:230
 msgid "Completely stop maxima and restart it"
-msgstr ""
+msgstr "Ferma completamente maxima e riavvialo"
 
 #: ../../src/wxMaximaFrame.cpp:1503
 msgid "Compute continued fraction of a value"
-msgstr ""
+msgstr "Calcola la frazione continua di un valore"
 
 #: ../../src/wxMaximaFrame.cpp:1372
 msgid "Compute the adjoint matrix"
-msgstr ""
+msgstr "Calcola la matrice aggiunta"
 
 #: ../../src/wxMaximaFrame.cpp:1359
 msgid "Compute the characteristic polynomial of a matrix"
-msgstr ""
+msgstr "Calcola la polinomiale caratteristica di una matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1363
 msgid "Compute the determinant of a matrix"
-msgstr ""
+msgstr "Calcola il determinante di una matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1491
 msgid "Compute the greatest common divisor"
-msgstr ""
+msgstr "Calcola il massimo comun denominatore"
 
 #: ../../src/wxMaximaFrame.cpp:1356
 msgid "Compute the inverse of a matrix"
-msgstr ""
+msgstr "Calcola l'inversa di una matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1494
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
+"Calcola il minimo comune multiplo (esegui load(functs) prima di usarlo)"
 
 #: ../../src/wxMaximaFrame.cpp:1374
 msgid "Compute the rank of a matrix"
-msgstr ""
+msgstr "Calcola il rango di una matrice"
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Condition:"
-msgstr ""
+msgstr "Condizione:"
 
 #: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "Configure wxMaxima"
-msgstr ""
+msgstr "Configura wxMaxima"
 
 #: ../../src/wxMaxima.cpp:2504
 msgid "Connection attempt, but connection failed."
-msgstr ""
+msgstr "Tentativo di connessione, ma la connessione è fallita."
 
 #: ../../src/wxMaxima.cpp:2459
 msgid "Connection to Maxima lost."
-msgstr ""
+msgstr "Connessione a Maxima persa."
 
 #: ../../src/wxMaxima.cpp:7921
 msgid "Construct a fraction"
-msgstr ""
+msgstr "Costruisci una frazione"
 
 #: ../../src/wxMaximaFrame.cpp:1305
 msgid "Construct fraction..."
-msgstr ""
+msgstr "Costruisci frazione..."
 
 #: ../../src/wxMaxima.cpp:7158
 msgid "Contents:"
-msgstr ""
+msgstr "Contenuti:"
 
 #: ../../src/wxMaximaFrame.cpp:1877
 msgid "Context-sensitive &Help\tCtrl+?"
-msgstr ""
+msgstr "Aiuto sensibile al contesto(&h)\tCtrl+?"
 
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Context-sensitive &Help\tF1"
-msgstr ""
+msgstr "Aiuto sensibile al contesto (&h)\tF1"
 
 #: ../../src/wxMaximaFrame.cpp:1542
 msgid "Contract Logarithms"
-msgstr ""
+msgstr "Contrai i logaritmi"
 
 #: ../../src/wxMaximaFrame.cpp:1161
 msgid "Conversions"
-msgstr ""
+msgstr "Conversioni"
 
 #: ../../src/wxMaximaFrame.cpp:1229
 msgid "Convert"
-msgstr ""
+msgstr "Converti"
 
 #: ../../src/wxMaximaFrame.cpp:1230
 msgid "Convert + Write to file"
-msgstr ""
+msgstr "Converti + scrivi su file"
 
 #: ../../src/wxMaximaFrame.cpp:1434
 msgid "Convert Column to list..."
-msgstr ""
+msgstr "Converti colonna in lista..."
 
 #: ../../src/wxMaximaFrame.cpp:1430
 msgid "Convert Row to list..."
-msgstr ""
+msgstr "Converti riga in lista..."
 
 #: ../../src/wxMaximaFrame.cpp:1044
 msgid "Convert a command to maxima code"
-msgstr ""
+msgstr "Converti un comando in codice maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1321
 msgid "Convert a list of lists to a matrix"
-msgstr ""
+msgstr "Converti una lista di liste in una matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1574
 msgid "Convert binomials, beta and gamma function to factorials"
-msgstr ""
+msgstr "Converti binomiali, funzioni beta e gamma in fattoriali"
 
 #: ../../src/wxMaximaFrame.cpp:1578
 msgid "Convert binomials, factorials and beta function to gamma function"
-msgstr ""
+msgstr "Converti binomiali, fattoriali e funzione beta in funzione gamma"
 
 #: ../../src/wxMaximaFrame.cpp:1613
 msgid "Convert complex expression to polar form"
-msgstr ""
+msgstr "Converti l'espressione complessa nella forma polare"
 
 #: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert complex expression to rect form"
-msgstr ""
+msgstr "Converti l'espressione complessa nella forma normale"
 
 #: ../../src/wxMaximaFrame.cpp:1622
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
+"Converti la funzione esponenziale dell'argomento immaginario nella forma "
+"trigonometrica"
 
 #: ../../src/wxMaxima.cpp:7411
 msgid "Convert string to lowercase"
-msgstr ""
+msgstr "Converti stringa in minuscole"
 
 #: ../../src/wxMaxima.cpp:7543
 msgid "Convert string to matching regex"
-msgstr ""
+msgstr "Rivela stringa in una regex corrispondente"
 
 #: ../../src/wxMaximaFrame.cpp:1543
 msgid "Convert sum of logarithms to logarithm of product"
-msgstr ""
+msgstr "Converti la somma dei logaritmi in logaritmo del prodotto"
 
 #: ../../src/wxMaximaFrame.cpp:1573
 msgid "Convert to &Factorials"
-msgstr ""
+msgstr "Converti in &fattoriali"
 
 #: ../../src/wxMaximaFrame.cpp:1577
 msgid "Convert to &Gamma"
-msgstr ""
+msgstr "Converti in &gamma"
 
 #: ../../src/wxMaximaFrame.cpp:1612
 msgid "Convert to &Polarform"
-msgstr ""
+msgstr "Converti in forma &polare"
 
 #: ../../src/wxMaximaFrame.cpp:1609
 msgid "Convert to &Rectform"
-msgstr ""
+msgstr "Converti in forma no&rmale"
 
 #: ../../src/wxMaximaFrame.cpp:1166
 msgid "Convert to downcase..."
-msgstr ""
+msgstr "Converti a minuscole"
 
 #: ../../src/wxMaxima.cpp:7016
 msgid "Convert to programming language"
-msgstr ""
+msgstr "Converti a linguaggio di programmazione"
 
 #: ../../src/wxMaxima.cpp:7022
 msgid "Convert to programming language file"
-msgstr ""
+msgstr "Converti a file di linguaggio di programmazione"
 
 #: ../../src/wxMaximaFrame.cpp:1602
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr ""
+"Converti l'espressione trigonometrica nella forma canonica quasilineare"
 
 #: ../../src/wxMaximaFrame.cpp:1627
 msgid "Convert trigonometric functions to exponential form"
-msgstr ""
+msgstr "Converti le funzioni trigonometriche nella forma esponenziale"
 
 #: ../../src/wxMaximaFrame.cpp:1762
 msgid "Converts a matrix to a list of lists"
-msgstr ""
+msgstr "Converte una matrice in una lista di liste"
 
 #: ../../src/wxMaximaFrame.cpp:1760
 msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
-msgstr ""
+msgstr "Converte una lista annidata come [[1,2],[3,4]] in una matrice"
 
 #: ../../src/ToolBar.cpp:209 ../../src/Worksheet.cpp:1290
 #: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
 #: ../../src/Worksheet.cpp:1684
 msgid "Copy"
-msgstr ""
+msgstr "Copia"
 
 #: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
 #: ../../src/Worksheet.cpp:1514
 msgid "Copy Animation"
-msgstr ""
+msgstr "Copia animazione"
 
 #: ../../src/wxMaximaFrame.cpp:887
 msgid "Copy Previous Input\tCtrl+I"
-msgstr ""
+msgstr "Copia l'inserimento precedente\tCtrl+I"
 
 #: ../../src/wxMaximaFrame.cpp:890
 msgid "Copy Previous Output\tCtrl+U"
-msgstr ""
+msgstr "Copia il risultato precedente\tCtrl+U"
 
 #: ../../src/wxMaxima.cpp:7992
 msgid "Copy a matrix"
-msgstr ""
+msgstr "Copia una matrice"
 
 #: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
 #: ../../src/wxMaximaFrame.cpp:663
 msgid "Copy as EMF"
-msgstr ""
+msgstr "Copia come EMF"
 
 #: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Copy as Image"
-msgstr ""
+msgstr "Copia come immagine"
 
 #: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
 #: ../../src/wxMaximaFrame.cpp:645
 msgid "Copy as LaTeX"
-msgstr ""
+msgstr "Copia come LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:648
 msgid "Copy as MathML"
-msgstr ""
+msgstr "Copia come MathML"
 
 #: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
 msgid "Copy as MathML (e.g. to word processor)"
-msgstr ""
+msgstr "Copia come MathML (per es. per un programma di videoscrittura)"
 
 #: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
 #: ../../src/wxMaximaFrame.cpp:658
 msgid "Copy as RTF"
-msgstr ""
+msgstr "Copia come RTF"
 
 #: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "Copy as SVG"
-msgstr ""
+msgstr "Copia come SVG"
 
 #: ../../src/wxMaximaFrame.cpp:640
 msgid "Copy as Text\tCtrl+Shift+C"
-msgstr ""
+msgstr "Copia come testo\tCtrl+Shift+C"
 
 #: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
 msgid "Copy as plain text"
-msgstr ""
+msgstr "Copia come immagine"
 
 #: ../../src/wxMaxima.cpp:7576
 msgid "Copy file"
-msgstr ""
+msgstr "Copia file"
 
 #: ../../src/wxMaximaFrame.cpp:1214
 msgid "Copy file..."
-msgstr ""
+msgstr "Copia file..."
 
 #: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
 #: ../../src/wxMaximaFrame.cpp:643
 msgid "Copy for Octave/Matlab"
-msgstr ""
+msgstr "Copia da Octave/Matlab"
 
 #: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
 msgid "Copy selection"
-msgstr ""
+msgstr "Copia la selezione"
 
 #: ../../src/wxMaximaFrame.cpp:664
 msgid "Copy selection from document as an Enhanced Metafile"
-msgstr ""
+msgstr "Copia la selezione dal documento come Metafile Avanzato"
 
 #: ../../src/wxMaximaFrame.cpp:656
 msgid "Copy selection from document as an SVG image"
-msgstr ""
+msgstr "Copia la selezione dal documento come immagine SVG"
 
 #: ../../src/wxMaximaFrame.cpp:653
 msgid "Copy selection from document as an image"
-msgstr ""
+msgstr "Copia la selezione dal documento come immagine"
 
 #: ../../src/wxMaximaFrame.cpp:659
 msgid ""
 "Copy selection from document as rtf that a word processor might understand"
 msgstr ""
+"Copia la selezione dal documento in rtf, un formato che molti programmi di "
+"videoscrittura possono comprendere"
 
 #: ../../src/wxMaximaFrame.cpp:641
 msgid "Copy selection from document as text"
-msgstr ""
+msgstr "Copia la selezione dal documento come testo"
 
 #: ../../src/wxMaximaFrame.cpp:646
 msgid "Copy selection from document in LaTeX format"
-msgstr ""
+msgstr "Copia la selezione dal documento in formato LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:644
 msgid "Copy selection from document in Matlab format"
-msgstr ""
+msgstr "Copia la selezione dal documento in formato Matlab"
 
 #: ../../src/wxMaximaFrame.cpp:649
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
+"Copia la selezione dal documento in formato MathML che molti programmi di "
+"videoscrittura possono mostrare come equazioni in forma grafica 2d"
 
 #: ../../src/wxMaxima.cpp:7403
 msgid "Copy string"
-msgstr ""
+msgstr "Copia stringa"
 
 #: ../../src/wxMaximaFrame.cpp:1165
 msgid "Copy string..."
-msgstr ""
+msgstr "Copia stringa..."
 
 #: ../../src/ToolBar.cpp:623
 msgid "Copy, Cut and Paste button"
-msgstr ""
+msgstr "Pulsante copia, taglia e incolla"
 
 #: ../../src/WXMXformat.cpp:295
 msgid "Could not create the backup file during saving => aborting."
 msgstr ""
+"Impossibile creare il file di backup durante il salvataggio => interruzione."
 
 #: ../../src/wxMaxima.cpp:3294 ../../src/wxMaxima.cpp:3306
 msgid ""
 "Could not make sure that we talk to the maxima we started => discarding all "
 "data it sends."
 msgstr ""
+"Impossibile assicurarsi di comunicare con il maxima avviato => vengono "
+"scartati tutti i dati inviati."
 
 #: ../../src/wxMaxima.cpp:2783
 msgid ""
 "Could not map view of the file needed in order to send an interrupt signal "
 "to maxima."
 msgstr ""
+"Impossibile mappare la vista del file necessaria per spedire un segnale di "
+"interruzione a maxima."
 
 #: ../../src/wxMaxima.cpp:2763 ../../src/wxMaxima.cpp:2805
 msgid "Could not send an interrupt signal to maxima."
-msgstr ""
+msgstr "Impossibile inviare un segnale di interruzione a maxima."
 
 #: ../../src/WXMXformat.cpp:287
 msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
+"Impossibile scrivere il contenuto del file durante il salvataggio => "
+"interruzione."
 
 #: ../../src/wxMaximaFrame.cpp:1325
 msgid "Create Matrix"
-msgstr ""
+msgstr "Crea matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1688
 msgid "Create a list"
-msgstr ""
+msgstr "Crea una lista"
 
 #: ../../src/wxMaxima.cpp:8487
 msgid "Create a list as a storage for the values of variables"
-msgstr ""
+msgstr "Crea una lista come contenitore per i valori di variabili"
 
 #: ../../src/wxMaxima.cpp:8463 ../../src/wxMaxima.cpp:8476
 msgid "Create a list from a rule"
-msgstr ""
+msgstr "Crea una lista da una regola"
 
 #: ../../src/wxMaximaFrame.cpp:1670
 msgid "Create a list from comma-separated elements"
-msgstr ""
+msgstr "Crea una lista da elementi separati da virgole"
 
 #: ../../src/wxMaximaFrame.cpp:888
 msgid "Create a new cell with previous input"
-msgstr ""
+msgstr "Crea una nuova cella con i dati inseriti precedentemente"
 
 #: ../../src/wxMaximaFrame.cpp:891
 msgid "Create a new cell with previous output"
-msgstr ""
+msgstr "Crea una nuova cella con il risultato precedente"
 
 #: ../../src/wxMaximaFrame.cpp:1348
 msgid "Create copy, not clone..."
-msgstr ""
+msgstr "Crea copia, non clone..."
 
 #: ../../src/wxMaxima.cpp:7561
 msgid "Create directory"
-msgstr ""
+msgstr "Crea cartella"
 
 #: ../../src/wxMaximaFrame.cpp:1203
 msgid "Create directory..."
-msgstr ""
+msgstr "Crea cartella..."
 
 #: ../../src/wxMaxima.cpp:7419
 msgid "Create empty string"
-msgstr ""
+msgstr "Crea stringa vuota"
 
 #: ../../src/wxMaximaFrame.cpp:1168
 msgid "Create empty string..."
-msgstr ""
+msgstr "Crea stringa vuota..."
 
 #: ../../src/wxMaximaFrame.cpp:1687
 msgid "Create list"
-msgstr ""
+msgstr "Crea lista"
 
 #: ../../src/wxMaxima.cpp:8457
 msgid "Create list from comma-separated elements"
-msgstr ""
+msgstr "Crea una lista da elementi separati da virgole"
 
 #: ../../src/wxMaximaFrame.cpp:1082
 msgid "Create struct..."
-msgstr ""
+msgstr "Crea struttura..."
 
 #: ../../src/WXMXformat.cpp:80
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
@@ -1874,31 +1950,31 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1349
 msgid "Creates an independent matrix with the same contents"
-msgstr ""
+msgstr "Crea una matrice indipendente con gli stessi contenuti"
 
 #: ../../src/Configuration.cpp:97
 msgid "Cursor color"
-msgstr ""
+msgstr "Colore cursore"
 
 #: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
 msgid "Cut"
-msgstr ""
+msgstr "Taglia"
 
 #: ../../src/wxMaximaFrame.cpp:636
 msgid "Cut\tCtrl+X"
-msgstr ""
+msgstr "Taglia\tCtrl+X"
 
 #: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
 msgid "Cut selection"
-msgstr ""
+msgstr "Taglia la selezione"
 
 #: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
 msgid "Data Matrix:"
-msgstr ""
+msgstr "Matrice dati:"
 
 #: ../../src/wxMaxima.cpp:9599
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
-msgstr ""
+msgstr "File dati (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wxMaxima.cpp:9529 ../../src/wxMaxima.cpp:9534
 #: ../../src/wxMaxima.cpp:9539 ../../src/wxMaxima.cpp:9543
@@ -1907,15 +1983,15 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9563 ../../src/wxMaxima.cpp:9577
 #: ../../src/wxMaxima.cpp:9582 ../../src/wxMaxima.cpp:10030
 msgid "Data:"
-msgstr ""
+msgstr "Dati:"
 
 #: ../../src/wxMaximaFrame.cpp:1057
 msgid "Debugger trigger"
-msgstr ""
+msgstr "Innesco debugger"
 
 #: ../../src/wxMaximaFrame.cpp:779
 msgid "Declare Text to always be displayed as subscript"
-msgstr ""
+msgstr "Dichiara che il testo sia sempre mostrato come pedice"
 
 #: ../../src/wxMaxima.cpp:7069
 msgid "Declare a function local to a Program"
@@ -1923,77 +1999,79 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6539
 msgid "Declare a text snippet to always be displayed as subscript"
-msgstr ""
+msgstr "Dichiara che il ritaglio di testo sia sempre mostrato come pedice"
 
 #: ../../src/Worksheet.cpp:2044
 #, c-format
 msgid "Declare facts about %s"
-msgstr ""
+msgstr "Dichiara fatti su %s"
 
 #: ../../src/wxMaxima.cpp:8800
 msgid "Declare main variable:"
-msgstr ""
+msgstr "Dichiara variabile principale:"
 
 #: ../../src/wxMaxima.cpp:7171
 msgid "Declare the type of a function parameter"
-msgstr ""
+msgstr "Dichiara il tipo di un parametro funzione"
 
 #: ../../src/Worksheet.cpp:2038
 msgid "Declare these chars as ordinary letters"
-msgstr ""
+msgstr "Dichiara questi caratteri come lettere normali"
 
 #: ../../src/wxMaximaFrame.cpp:1500 ../../src/wxMaximaFrame.cpp:1536
 msgid "Decompose rational function to partial fractions"
-msgstr ""
+msgstr "Decomponi la funzione razionale in frazioni parziali"
 
 #: ../../src/Worksheet.cpp:2010
 msgid "Decreasing function f(x)<x"
-msgstr ""
+msgstr "Funzione decremento f(x)<x"
 
 #: ../../src/wxMaxima.cpp:7134
 msgid "Define a function"
-msgstr ""
+msgstr "Definisci una funzione"
 
 #: ../../src/wxMaxima.cpp:7147
 msgid "Define a macro"
-msgstr ""
+msgstr "Definisci una macro"
 
 #: ../../src/wxMaxima.cpp:7189
 msgid "Define a structure"
-msgstr ""
+msgstr "Definisci una struttura"
 
 #: ../../src/wxMaxima.cpp:7183
 msgid "Define a structure type"
-msgstr ""
+msgstr "Definisci un tipo di struttura"
 
 #: ../../src/wxMaxima.cpp:7156
 msgid "Define a variable"
-msgstr ""
+msgstr "Definisci una variabile"
 
 #: ../../src/wxMaximaFrame.cpp:1072
 msgid "Define function..."
-msgstr ""
+msgstr "Definisci una funzione..."
 
 #: ../../src/wxMaximaFrame.cpp:1079
 msgid "Define macro..."
-msgstr ""
+msgstr "Definisci macro..."
 
 #: ../../src/wxMaximaFrame.cpp:1077
 msgid "Define parameter type..."
-msgstr ""
+msgstr "Definisci tipo di parametro..."
 
 #: ../../src/wxMaximaFrame.cpp:1081
 msgid "Define struct..."
-msgstr ""
+msgstr "Definisci struttura..."
 
 #: ../../src/wxMaximaFrame.cpp:1080
 msgid "Define variable..."
-msgstr ""
+msgstr "Definisci variabile..."
 
 #: ../../src/wxMaximaFrame.cpp:1776
 msgid ""
 "Defines if an animation is automatically started or only by clicking on it."
 msgstr ""
+"Definisce se un'animazione parte automaticamente o solo se si fa clic su di "
+"essa."
 
 #: ../../src/wxMaxima.cpp:8935
 msgid "Degree:"
@@ -2001,23 +2079,23 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:985
 msgid "Delete F&unction..."
-msgstr ""
+msgstr "Elimina una f&unzione..."
 
 #: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
 msgid "Delete Selection"
-msgstr ""
+msgstr "Elimina la selezione"
 
 #: ../../src/wxMaximaFrame.cpp:987
 msgid "Delete V&ariable..."
-msgstr ""
+msgstr "Elimina la v&ariabile..."
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Delete a function"
-msgstr ""
+msgstr "Elimina una funzione"
 
 #: ../../src/wxMaximaFrame.cpp:988
 msgid "Delete a variable"
-msgstr ""
+msgstr "Elimina una variabile"
 
 #: ../../src/wxMaximaFrame.cpp:982
 msgid "Delete all objects with a given name"
@@ -2025,68 +2103,68 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:991
 msgid "Delete all values from memory"
-msgstr ""
+msgstr "Cancella tutti i valori dalla memoria"
 
 #: ../../src/wxMaxima.cpp:7588
 msgid "Delete file"
-msgstr ""
+msgstr "Elimina file"
 
 #: ../../src/wxMaximaFrame.cpp:1216
 msgid "Delete file..."
-msgstr ""
+msgstr "Elimina file..."
 
 #: ../../src/wxMaxima.cpp:7683
 msgid "Delete function(s)"
-msgstr ""
+msgstr "Elimina le funzioni"
 
 #: ../../src/wxMaxima.cpp:7679
 msgid "Delete named object(s)"
-msgstr ""
+msgstr "Elimina oggetti con nome"
 
 #: ../../src/wxMaximaFrame.cpp:981
 msgid "Delete named object..."
-msgstr ""
+msgstr "Elimina oggetto con nome..."
 
 #: ../../src/wxMaxima.cpp:7674
 msgid "Delete variable(s)"
-msgstr ""
+msgstr "Elimina variabili"
 
 #: ../../src/wxMaxima.cpp:7430
 msgid "Delimiter:"
-msgstr ""
+msgstr "Delimitatore:"
 
 #: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
 #, c-format
 msgid "Demo for \"%s\""
-msgstr ""
+msgstr "Demo per \"%s\""
 
 #: ../../src/wxMaximaFrame.cpp:1930
 msgid "Demos"
-msgstr ""
+msgstr "Demo"
 
 #: ../../src/wxMaxima.cpp:8927
 msgid "Denom. deg:"
-msgstr ""
+msgstr "Denom. deg:"
 
 #: ../../src/wxMaxima.cpp:7923
 msgid "Denominator:"
-msgstr ""
+msgstr "Denominatore:"
 
 #: ../../src/wxMaximaFrame.cpp:1030
 msgid "Dependencies"
-msgstr ""
+msgstr "Dipendenze"
 
 #: ../../src/wxMaxima.cpp:7813
 msgid "Derivate of y at that point:"
-msgstr ""
+msgstr "Derivata per y in quel punto:"
 
 #: ../../src/wxMaximaFrame.cpp:1497
 msgid "Di&vide Polynomials..."
-msgstr ""
+msgstr "Di&vidi le polinomiali..."
 
 #: ../../src/MaximaManual.cpp:517
 msgid "Didn't find the maxima HTML manual."
-msgstr ""
+msgstr "Non ho trovato il manuale maxima HTML."
 
 #: ../../src/wxMaxima.cpp:4907
 msgid ""
@@ -2096,35 +2174,35 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
 msgid "Differentiate"
-msgstr ""
+msgstr "Differenzia"
 
 #: ../../src/wxMaximaFrame.cpp:1467
 msgid "Differentiate expression"
-msgstr ""
+msgstr "Differenzia l'espressione"
 
 #: ../../src/Worksheet.cpp:1590
 msgid "Differentiate..."
-msgstr ""
+msgstr "Deriva..."
 
 #: ../../src/wxMaxima.cpp:9010
 msgid "Differentiates an expression n times"
-msgstr ""
+msgstr "Deriva un'espressione n volte"
 
 #: ../../src/wxMaxima.cpp:10055
 msgid "Differentiates the expression n times"
-msgstr ""
+msgstr "Deriva l'espressione n volte"
 
 #: ../../src/wxMaximaFrame.cpp:1212
 msgid "Directory operations"
-msgstr ""
+msgstr "Operazioni sulle cartelle"
 
 #: ../../src/wxMaximaFrame.cpp:1041
 msgid "Display Te&X Form"
-msgstr ""
+msgstr "Mostra in Te&X"
 
 #: ../../src/wxMaxima.cpp:6972
 msgid "Display algorithm"
-msgstr ""
+msgstr "Mostra l'algoritmo"
 
 #: ../../src/wxMaximaFrame.cpp:751
 msgid "Display an expression as maxima's internal lisp representation"
@@ -2136,7 +2214,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:758
 msgid "Display equations"
-msgstr ""
+msgstr "Mostra le equazioni"
 
 #: ../../src/wxMaxima.cpp:6508
 msgid "Display expression in maxima's internal representation"
@@ -2148,113 +2226,118 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1042
 msgid "Display last result in TeX form"
-msgstr ""
+msgstr "Mostra l'espressione precedente in TeX"
 
 #: ../../src/ToolBar.cpp:360
 #, c-format
 msgid "Display resolution according to wxWidgets: %li x %li ppi"
-msgstr ""
+msgstr "Risoluzione display secondo gli wxWidget: %li x %li ppi"
 
 #: ../../src/wxMaximaFrame.cpp:802
 msgid "Display string quotation marks"
-msgstr ""
+msgstr "Mostra virgolette delle stringhe"
 
 #: ../../src/wxMaximaFrame.cpp:1036
 msgid "Display time used for evaluation"
-msgstr ""
+msgstr "Mostra il tempo impiegato per l'esecuzione"
 
 #: ../../src/wxMaxima.cpp:9206
 msgid "Displayed Precision"
-msgstr ""
+msgstr "Precisione visualizzata"
 
 #: ../../src/wxMaximaFrame.cpp:1913
 msgid "Displaying 3d curves"
-msgstr ""
+msgstr "Visualizzazione curve 3d"
 
 #: ../../src/wxMaximaFrame.cpp:1462
 msgid "Dito, and evaluate the result..."
-msgstr ""
+msgstr "Dito, ed elabora il risultato..."
 
 #: ../../src/wxMaximaFrame.cpp:1445
 msgid "Dito, but affect all clones of the Matrix..."
-msgstr ""
+msgstr "Dito, ma influenza tutti i cloni della matrice..."
 
 #: ../../src/wxMaximaFrame.cpp:1255
 msgid "Dito, but as fraction (real only)..."
-msgstr ""
+msgstr "Dito, ma come frazione (solo reale)..."
 
 #: ../../src/wxMaximaFrame.cpp:1532
 msgid "Dito, including denominator"
-msgstr ""
+msgstr "Dito, includendo il denominatore"
 
 #: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
 msgid "Divide Cell"
-msgstr ""
+msgstr "Dividi cella"
 
 #: ../../src/wxMaximaFrame.cpp:1498
 msgid "Divide numbers or polynomials"
-msgstr ""
+msgstr "Dividi i numeri o i polinomiali"
 
 #: ../../src/wxMaxima.cpp:8578
 msgid "Do for each list element"
-msgstr ""
+msgstr "Fa per ogni elemento della lista"
 
 #: ../../src/wxMaxima.cpp:11197
 #, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
-msgstr ""
+msgstr "Salvare i cambiamenti effettuati nel documento \"%s\"?\""
 
 #: ../../src/wxMaximaFrame.cpp:724
 msgid "Dock all Sidebars"
-msgstr ""
+msgstr "Aggancia tutte le barre laterali"
 
 #: ../../src/Configuration.cpp:94
 msgid "Document background"
-msgstr ""
+msgstr "Sfondo del documento"
 
 #: ../../src/wxMaxima.cpp:4611
 msgid ""
 "Document was saved using a newer version of wxMaxima so it may not load "
 "correctly. Please update your wxMaxima."
 msgstr ""
+"Il documento è stato salvato usando una versione più recente di wxMaxima "
+"perciò potrebbe non caricarsi correttamente. Si consiglia di aggiornare "
+"wxMaxima."
 
 #: ../../src/wxMaxima.cpp:4603
 msgid ""
 "Document was saved using a newer version of wxMaxima. Please update your "
 "wxMaxima."
 msgstr ""
+"Il documento è stato salvato usando una versione più recente di wxMaxima. Si"
+" consiglia di aggiornare wxMaxima."
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "Don't autosubscript after an underscore"
-msgstr ""
+msgstr "Non passare al pedice dopo un carattere di sottolineato"
 
 #: ../../src/wxMaximaFrame.cpp:1086
 msgid "Don't evaluate Expression..."
-msgstr ""
+msgstr "Non elaborare l'espressione..."
 
 #: ../../src/wxMaxima.cpp:7117
 msgid "Don't evaluate one command"
-msgstr ""
+msgstr "Non elaborare un comando"
 
 #: ../../src/wxMaxima.cpp:7129
 msgid "Don't evaluate one whole expression"
-msgstr ""
+msgstr "Non elaborare l'intera espressione"
 
 #: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
 msgid "Don't mark cells that contain tooltips in yellow"
-msgstr ""
+msgstr "Non marcare le celle che contengono suggerimenti in giallo"
 
 #: ../../src/Worksheet.cpp:1938 ../../src/Worksheet.cpp:2070
 msgid "Don't mark this message text in yellow"
-msgstr ""
+msgstr "Non marcare il testo di questo messaggio in giallo"
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Don't save"
-msgstr ""
+msgstr "Non salvare"
 
 #: ../../src/Worksheet.cpp:1620
 msgid "Don't show labels"
-msgstr ""
+msgstr "Non mostrare etichette"
 
 #: ../../src/Worksheet.cpp:1979
 msgid "Don't use if unassigned"
@@ -2262,47 +2345,47 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:797
 msgid "Don't use parenthesis for matrices"
-msgstr ""
+msgstr "Non usare le parentesi per le matrici"
 
 #: ../../src/wxMaxima.cpp:8525
 msgid "Drop the first n list elements"
-msgstr ""
+msgstr "Elimina i primi n elementi della lista"
 
 #: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
 msgid "Drop the last n list elements"
-msgstr ""
+msgstr "Elimina gli ultimi n elementi della lista"
 
 #: ../../src/wxMaximaFrame.cpp:1306
 msgid "E&quations"
-msgstr ""
+msgstr "E&quazioni"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "E&xit\tCtrl+Q"
-msgstr ""
+msgstr "&Esci\tCtrl+Q"
 
 #: ../../src/wxMaximaFrame.cpp:1368
 msgid "Eige&nvectors"
-msgstr ""
+msgstr "&Autovettori"
 
 #: ../../src/wxMaximaFrame.cpp:1365
 msgid "Eigen&values"
-msgstr ""
+msgstr "Auto&valori"
 
 #: ../../src/wxMaximaFrame.cpp:1387
 msgid "Eigenvalues (complex)"
-msgstr ""
+msgstr "Autovalori (complessi)"
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Eigenvalues (real)"
-msgstr ""
+msgstr "Autovalori (reali)"
 
 #: ../../src/wxMaximaFrame.cpp:1393
 msgid "Eigenvalues, left+right eigenvectors (complex)"
-msgstr ""
+msgstr "Autovalori, autovalori sinistro+destro (complessi)"
 
 #: ../../src/wxMaximaFrame.cpp:1390
 msgid "Eigenvalues, left+right eigenvectors (real)"
-msgstr ""
+msgstr "<Autovalori, autovalori sinistro+destro (reali)"
 
 #: ../../src/wxMaxima.cpp:8584
 msgid ""
@@ -2310,43 +2393,48 @@ msgid ""
 "parenthesis. In the latter case the result of the last expression in the "
 "parenthesis is used."
 msgstr ""
+"Una singola espressione o una lista separata da virgole di espressioni tra "
+"parentesi. Nel secondo caso viene usato il risultato dell'ultima espressione"
+" tra parentesi."
 
 #: ../../src/wxMaxima.cpp:8593
 msgid "Element"
-msgstr ""
+msgstr "Elemento"
 
 #: ../../src/wxMaxima.cpp:8549
 msgid "Element number"
-msgstr ""
+msgstr "Numero elemento"
 
 #: ../../src/wxMaxima.cpp:8005
 msgid ""
 "Element-by-element Product of matrices of the same size (Hadamard product)"
 msgstr ""
+"Prodotto di matrici elemento-per-elemento della stessa dimensione (prodotto "
+"Hadamard)"
 
 #: ../../src/wxMaxima.cpp:8012
 msgid "Element-by-element exponentiation of two matrices"
-msgstr ""
+msgstr "Esponenziazione elemento-per-elemento di due matrici"
 
 #: ../../src/wxMaximaFrame.cpp:1342
 msgid "Element-by-element multiplication"
-msgstr ""
+msgstr "Moltiplicazione elemento-per-elemento"
 
 #: ../../src/wxMaxima.cpp:8510
 msgid "Element:"
-msgstr ""
+msgstr "Elemento:"
 
 #: ../../src/wxMaxima.cpp:7204
 msgid "Elements:"
-msgstr ""
+msgstr "Elementi:"
 
 #: ../../src/wxMaxima.cpp:7847
 msgid "Eliminate a variable"
-msgstr ""
+msgstr "Elimina una variabile"
 
 #: ../../src/wxMaximaFrame.cpp:1247
 msgid "Eliminate a variable from a system of equations"
-msgstr ""
+msgstr "Elimina una variabile da un sistema di equazioni"
 
 #: ../../src/wxMaxima.cpp:10651
 msgid "Empty command => re-triggering evaluation"
@@ -2354,86 +2442,86 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9225
 msgid "Enable:"
-msgstr ""
+msgstr "Abilita:"
 
 #: ../../src/MathParser.cpp:99
 #, c-format
 msgid "Encountered an unknown XML tag: <%s>"
-msgstr ""
+msgstr "Incontrato un marcatore XML sconosciuto: <%s>"
 
 #: ../../src/wxMaxima.cpp:2476
 msgid "Encountered an unknown socket event."
-msgstr ""
+msgstr "Incontrato un evento socket sconosciuto."
 
 #: ../../src/wxMaxima.cpp:7843
 msgid "End of t:"
-msgstr ""
+msgstr "Fine di t:"
 
 #: ../../src/wxMaxima.cpp:4097
 msgid "Ended lisp mode after receiving a maxima prompt!"
-msgstr ""
+msgstr "Finita modalità lisp dopo la ricezione di un prompt maxima!"
 
 #: ../../src/wxMaximaFrame.cpp:1828
 msgid "Engineering format (12.1e6 etc.)"
-msgstr ""
+msgstr "Formato ingegneristico (12.1e6 ecc.)"
 
 #: ../../src/wxMaximaFrame.cpp:1319
 msgid "Enter a matrix"
-msgstr ""
+msgstr "Inserisci una matrice"
 
 #: ../../src/wxMaxima.cpp:8866
 msgid "Enter an equation for rational simplification:"
-msgstr ""
+msgstr "Inserire un'equazione per la semplificazione razionale:"
 
 #: ../../src/wxMaxima.cpp:8169
 msgid "Enter matrix"
-msgstr ""
+msgstr "Inserire la matrice"
 
 #: ../../src/wxMaxima.cpp:9095
 msgid "Enter new animation frame rate [Hz, integer]:"
-msgstr ""
+msgstr "Inserire la nuova frequenza di quadro animazioni [Hz, intero]:"
 
 #: ../../src/wxMaxima.cpp:9201
 msgid "Enter new precision for bigfloats:"
-msgstr ""
+msgstr "Inserire la nuova precisione per i bigfloat:"
 
 #: ../../src/wxMaxima.cpp:7922
 msgid "Enumerator:"
-msgstr ""
+msgstr "Enumeratore:"
 
 #: ../../src/wxMaximaFrame.cpp:1220
 msgid "Environment variables"
-msgstr ""
+msgstr "Variabili ambiente"
 
 #: ../../src/wxMaxima.cpp:9045
 msgid "Epsilon:"
-msgstr ""
+msgstr "Epsilon:"
 
 #: ../../src/wxMaximaFrame.cpp:1124 ../../src/wxMaximaFrame.cpp:1135
 msgid "Equal, ignoring case?..."
-msgstr ""
+msgstr "Uguale, ignorare maiuscole?..."
 
 #: ../../src/wxMaximaFrame.cpp:1133
 msgid "Equal?..."
-msgstr ""
+msgstr "Uguale?..."
 
 #: ../../src/wxMaxima.cpp:8561
 msgid "Equation"
-msgstr ""
+msgstr "Equazione"
 
 #: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
 msgid "Equation(s)"
-msgstr ""
+msgstr "Equazione(i)"
 
 #: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
 msgid "Equation(s):"
-msgstr ""
+msgstr "Equazione(i):"
 
 #: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
 #: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
 #: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
 msgid "Equation:"
-msgstr ""
+msgstr "Equazione:"
 
 #: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
 #: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
@@ -2445,22 +2533,22 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
 #: ../../src/wxMaxima.cpp:11166
 msgid "Error"
-msgstr ""
+msgstr "Errore"
 
 #: ../../src/wxMaxima.cpp:2456
 msgid "Error writing to Maxima"
-msgstr ""
+msgstr "Errore durante la scrittura a Maxima"
 
 #: ../../src/wxMaxima.cpp:6164 ../../src/wxMaxima.cpp:6176
 #: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
 #: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
 msgid "Error!"
-msgstr ""
+msgstr "Errore!"
 
 #: ../../src/Image.cpp:696
 #, c-format
 msgid "Error: Cannot render %s."
-msgstr ""
+msgstr "Errore: impossibile renderizzare %s."
 
 #: ../../src/Image.cpp:699
 #, c-format
@@ -2468,10 +2556,12 @@ msgid ""
 "Error: Cannot render %s:\n"
 "%s"
 msgstr ""
+"Errore: impossibile renderizzare %s:\n"
+"%s"
 
 #: ../../src/Image.cpp:704
 msgid "Error: Cannot render the image."
-msgstr ""
+msgstr "Errore: impossibile renderizzare l'immagine."
 
 #: ../../src/Image.cpp:706
 #, c-format
@@ -2479,125 +2569,131 @@ msgid ""
 "Error: Cannot render the image:\n"
 "%s"
 msgstr ""
+"Errore: impossibile renderizzare l'immagine:\n"
+"%s"
 
 #: ../../src/wxMaxima.cpp:7544
 msgid ""
 "Escapes all special characters in a string. The result is a regex that "
 "matches this string exactly."
 msgstr ""
+"Escapes all special characters in a string. The result is a regex that matches this string exactly.<\n"
+"\n"
+"Esegue l'escape su tutti i caratteri speciali in una stringa. Il risultato è una regex che corrisponde esattamente la stringa."
 
 #: ../../src/wxMaximaFrame.cpp:1652
 msgid "Evaluate &Noun Forms..."
-msgstr ""
+msgstr "Elabora le forme &nominali..."
 
 #: ../../src/wxMaximaFrame.cpp:856
 msgid "Evaluate All Cells\tCtrl+Shift+R"
-msgstr ""
+msgstr "Elabora tutte le celle\tCtrl+Shift-R"
 
 #: ../../src/wxMaximaFrame.cpp:851
 msgid "Evaluate All Visible Cells\tCtrl+R"
-msgstr ""
+msgstr "Elabora tutte le celle visibili\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1395
+#, fuzzy
 msgid "Evaluate Cell"
-msgstr ""
+msgstr "Elabora le celle"
 
 #: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
 msgid "Evaluate Cell(s)"
-msgstr ""
+msgstr "Elabora le celle"
 
 #: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
 msgid "Evaluate Cells Above"
-msgstr ""
+msgstr "Elabora le celle sopra"
 
 #: ../../src/wxMaximaFrame.cpp:866
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
-msgstr ""
+msgstr "Elabora le celle sopra\tCtrl+Shift+P"
 
 #: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
 #: ../../src/wxMaximaFrame.cpp:876
 msgid "Evaluate Cells Below"
-msgstr ""
+msgstr "Elabora le celle sotto"
 
 #: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
 #: ../../src/Worksheet.cpp:1890
 msgid "Evaluate Heading 5\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Elabora intestazione 5\tMaiusc+Ctrl+Invio"
 
 #: ../../src/Worksheet.cpp:1457 ../../src/Worksheet.cpp:1761
 #: ../../src/Worksheet.cpp:1901
 msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Elabora intestazione 6\tMaiusc+Ctrl+Invio"
 
 #: ../../src/wxMaxima.cpp:8626
 msgid "Evaluate Nouns"
-msgstr ""
+msgstr "Elabora le forme nominali"
 
 #: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
 msgid "Evaluate Part\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Elabora parte\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1431 ../../src/Worksheet.cpp:1741
 msgid "Evaluate Section\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Elabora sezione\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1445 ../../src/Worksheet.cpp:1751
 #: ../../src/Worksheet.cpp:1879
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Elabora sub-subsezione\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1438 ../../src/Worksheet.cpp:1746
 #: ../../src/Worksheet.cpp:1868
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Elabora subsezione\tShift+Ctrl+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:845
 msgid "Evaluate active or selected cell(s)"
-msgstr ""
+msgstr "Elabora le celle attive o selezionate"
 
 #: ../../src/ToolBar.cpp:251
 msgid "Evaluate all"
-msgstr ""
+msgstr "Elabora tutto"
 
 #: ../../src/wxMaximaFrame.cpp:857
 msgid "Evaluate all cells in the document"
-msgstr ""
+msgstr "Elabora tutte le celle nel documento"
 
 #: ../../src/wxMaximaFrame.cpp:1653
 msgid "Evaluate all noun forms in expression"
-msgstr ""
+msgstr "Elabora tutte le forme nominali nell'espressione"
 
 #: ../../src/wxMaximaFrame.cpp:852
 msgid "Evaluate all visible cells in the document"
-msgstr ""
+msgstr "Elabora tutte le celle visibili nel documento"
 
 #: ../../src/ToolBar.cpp:248
 msgid "Evaluate current cell"
-msgstr ""
+msgstr "Elabora la cella corrente"
 
 #: ../../src/wxMaxima.cpp:7395
 msgid "Evaluate string"
-msgstr ""
+msgstr "Elabora la stringa"
 
 #: ../../src/wxMaximaFrame.cpp:1151
 msgid "Evaluate string..."
-msgstr ""
+msgstr "Elabora la stringa..."
 
 #: ../../src/ToolBar.cpp:256
 msgid "Evaluate the file from its beginning to the cell above the cursor"
-msgstr ""
+msgstr "Elabora il file dal suo inizio fino alla cella sopra il cursore"
 
 #: ../../src/ToolBar.cpp:259
 msgid "Evaluate the file from the cursor to its end"
-msgstr ""
+msgstr "Elabora il file dal cursore fino alla fine"
 
 #: ../../src/ToolBar.cpp:258
 msgid "Evaluate the rest"
-msgstr ""
+msgstr "Elabora il resto"
 
 #: ../../src/ToolBar.cpp:255
 msgid "Evaluate to point"
-msgstr ""
+msgstr "Elabora fino al punto"
 
 #: ../../src/wxMaxima.cpp:10518
 msgid "Evaluation ended, since evaluation queue is empty."
@@ -2605,122 +2701,122 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1957
 msgid "Even number"
-msgstr ""
+msgstr "Numero pari"
 
 #: ../../src/wxMaximaFrame.cpp:1703
 msgid "Execute a command for each element of the list"
-msgstr ""
+msgstr "Esegue un comando per ogni elemento della lista"
 
 #: ../../src/main.cpp:438
 msgid "Exit"
-msgstr ""
+msgstr "Uscita"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "Exit wxMaxima"
-msgstr ""
+msgstr "Esci da wxMaxima"
 
 #: ../../src/Worksheet.cpp:1583
 msgid "Expand Expression"
-msgstr ""
+msgstr "Espandi l'espressione"
 
 #: ../../src/wxMaximaFrame.cpp:1525
 msgid "Expand an expression"
-msgstr ""
+msgstr "Espandi un'espressione"
 
 #: ../../src/wxMaximaFrame.cpp:1531
 msgid "Expand for given variables"
-msgstr ""
+msgstr "Espandi per le date variabili"
 
 #: ../../src/wxMaxima.cpp:8781
 msgid "Expand for variable(s) including denominator:"
-msgstr ""
+msgstr "Espandi per variabili includendo il denominatore:"
 
 #: ../../src/wxMaxima.cpp:8716
 msgid "Expand for variable(s):"
-msgstr ""
+msgstr "Espandi per variabile(i):"
 
 #: ../../src/wxMaximaFrame.cpp:1545
 msgid "Expand log in previous expression"
-msgstr ""
+msgstr "Espandi log in espressione precedente"
 
 #: ../../src/wxMaximaFrame.cpp:1598
 msgid "Expand trigonometric expression"
-msgstr ""
+msgstr "Espandi espressione trigonometrica"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Expect numbers harder to be complex"
-msgstr ""
+msgstr "Aspettarsi che i numeri più difficili siano complessi"
 
 #: ../../src/wxMaximaFrame.cpp:1789
 msgid "Expect variables to contain complex numbers"
-msgstr ""
+msgstr "Aspettarsi che le variabili contengano numeri complessi"
 
 #: ../../src/wxMaxima.cpp:6121
 msgid "Export"
-msgstr ""
+msgstr "Esporta"
 
 #: ../../src/wxMaximaFrame.cpp:1705
 msgid "Export List to csv file..."
-msgstr ""
+msgstr "Esporta lista in file csv..."
 
 #: ../../src/wxMaximaFrame.cpp:1706
 msgid "Export a list to a csv file"
-msgstr ""
+msgstr "Esporta una lista in un file csv"
 
 #: ../../src/wxMaximaFrame.cpp:1332
 msgid "Export a matrix to a csv file"
-msgstr ""
+msgstr "Esporta una matrice in un file csv"
 
 #: ../../src/wxMaximaFrame.cpp:619
 msgid "Export document to a HTML or LaTeX file"
-msgstr ""
+msgstr "Esporta il documento in un file HTML o LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:579
 msgid "Export failed."
-msgstr ""
+msgstr "Esportazione fallita."
 
 #: ../../src/wxMaximaFrame.cpp:567
 msgid "Export successful."
-msgstr ""
+msgstr "Esportazione effettuata."
 
 #: ../../src/wxMaxima.cpp:6187
 msgid "Exporting to HTML failed!"
-msgstr ""
+msgstr "Esportazione su HTML fallita!"
 
 #: ../../src/wxMaxima.cpp:6164
 msgid "Exporting to TeX failed!"
-msgstr ""
+msgstr "Esportazione in TeX fallita!"
 
 #: ../../src/wxMaxima.cpp:6175
 msgid "Exporting to maxima batch file failed!"
-msgstr ""
+msgstr "Esportazione su file batch maxima fallita!"
 
 #: ../../src/wxMaximaFrame.cpp:561
 msgid "Exporting..."
-msgstr ""
+msgstr "Esportazione..."
 
 #: ../../src/wxMaxima.cpp:6510 ../../src/wxMaxima.cpp:6516
 #: ../../src/wxMaxima.cpp:8218 ../../src/wxMaxima.cpp:8633
 #: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
 #: ../../src/wxMaxima.cpp:10065
 msgid "Expression"
-msgstr ""
+msgstr "Espressione"
 
 #: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
 msgid "Expression or a list of comma-separated expressions"
-msgstr ""
+msgstr "Espressione o lista di elementi separati da virgole"
 
 #: ../../src/wxMaximaFrame.cpp:1088
 msgid "Expression to string..."
-msgstr ""
+msgstr "Espressione a stringa..."
 
 #: ../../src/wxMaxima.cpp:7113
 msgid "Expression whose output is to be used as maxima's input."
-msgstr ""
+msgstr "Espressione il cui risultato viene usato come ingresso di maxima."
 
 #: ../../src/wxMaxima.cpp:7214
 msgid "Expression(s):"
-msgstr ""
+msgstr "Espressione(i):"
 
 #: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
 #: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
@@ -2729,261 +2825,263 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
 #: ../../src/wxMaxima.cpp:10056
 msgid "Expression:"
-msgstr ""
+msgstr "Espressione:"
 
 #: ../../src/wxMaximaFrame.cpp:1423
 msgid "Extract Column..."
-msgstr ""
+msgstr "Estrai colonna..."
 
 #: ../../src/wxMaximaFrame.cpp:1726
 msgid "Extract Elements"
-msgstr ""
+msgstr "Estrai elementi"
 
 #: ../../src/wxMaximaFrame.cpp:1421
 msgid "Extract Row..."
-msgstr ""
+msgstr "Estrai riga..."
 
 #: ../../src/wxMaximaFrame.cpp:1424
 msgid "Extract a column from the matrix"
-msgstr ""
+msgstr "Estrai una colonna dalla matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1435
 msgid "Extract a column from the matrix and convert it to a list"
-msgstr ""
+msgstr "Estrai una colonna dalla matrice e convertila in una lista"
 
 #: ../../src/wxMaxima.cpp:7960
 msgid "Extract a matrix column"
-msgstr ""
+msgstr "Estrai una colonna di matrice"
 
 #: ../../src/wxMaxima.cpp:7970
 msgid "Extract a matrix column as a list"
-msgstr ""
+msgstr "Estrai una colonna di matrice come lista"
 
 #: ../../src/wxMaximaFrame.cpp:1313
 msgid "Extract a matrix from a 2-dimensional array"
-msgstr ""
+msgstr "Estrai una matrice da un array bidimensionale"
 
 #: ../../src/wxMaxima.cpp:7955
 msgid "Extract a matrix row"
-msgstr ""
+msgstr "Estrai una riga di matrice"
 
 #: ../../src/wxMaxima.cpp:7965
 msgid "Extract a matrix row as a list"
-msgstr ""
+msgstr "Estrai una riga di matrice come lista"
 
 #: ../../src/wxMaximaFrame.cpp:1422
 msgid "Extract a row from the matrix"
-msgstr ""
+msgstr "Estrai una riga dalla matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1431
 msgid "Extract a row from the matrix and convert it to a list"
-msgstr ""
+msgstr "Estrai una riga dalla matrice e convertila in una lista"
 
 #: ../../src/wxMaxima.cpp:8564
 msgid "Extract a variable's value from a list of variable values"
-msgstr ""
+msgstr "Estrai il valore di una variabile da una lista di valori di variabili"
 
 #: ../../src/wxMaximaFrame.cpp:1723
 msgid "Extract an actual value for a variable"
-msgstr ""
+msgstr "Estrai il valore corrente di una variabile"
 
 #: ../../src/wxMaximaFrame.cpp:1163
 msgid "Extract char..."
-msgstr ""
+msgstr "Estrai carattere..."
 
 #: ../../src/wxMaximaFrame.cpp:1207
 msgid "Extract dir from path..."
-msgstr ""
+msgstr "Estrai cartella da un percorso..."
 
 #: ../../src/wxMaxima.cpp:7605
 msgid "Extract directory part"
-msgstr ""
+msgstr "Estrai la parte cartella"
 
 #: ../../src/wxMaxima.cpp:7617
 msgid "Extract file type extension"
-msgstr ""
+msgstr "Estrai estensione tipo file"
 
 #: ../../src/wxMaximaFrame.cpp:1209
 msgid "Extract filename from path..."
-msgstr ""
+msgstr "Estrai nomefile da percorso..."
 
 #: ../../src/wxMaxima.cpp:7611
 msgid "Extract filename part"
-msgstr ""
+msgstr "Estrai la parte nomefile"
 
 #: ../../src/wxMaximaFrame.cpp:1211
 msgid "Extract filetype from path..."
-msgstr ""
+msgstr "Estrai tipofile da percorso..."
 
 #: ../../src/wxMaxima.cpp:8445
 msgid "Extract function arguments"
-msgstr ""
+msgstr "Estrai gli argomenti funzione"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "Extract list Elements"
-msgstr ""
+msgstr "Estrai elementi lista"
 
 #: ../../src/wxMaxima.cpp:8187
 msgid "Extract matrix from 2D array"
-msgstr ""
+msgstr "Estrai matrice da array 2D"
 
 #: ../../src/wxMaximaFrame.cpp:1686
 msgid "Extract the argument list from a function call"
-msgstr ""
+msgstr "Estrai la lista degli argomenti da una chiamata a funzione"
 
 #: ../../src/wxMaxima.cpp:8538
 msgid "Extract the last n elements from a list"
-msgstr ""
+msgstr "Estrai gli ultimi n elementi da una lista"
 
 #: ../../src/wxMaxima.cpp:7376
 msgid "Extract the nth char of a string"
-msgstr ""
+msgstr "Estrai l'n-esimo carattere di una stringa"
 
 #: ../../src/wxMaxima.cpp:8544
 msgid "Extract the nth list elements"
-msgstr ""
+msgstr "Estrai gli n-esimi elementi di una lista"
 
 #: ../../src/wxMaximaFrame.cpp:1724
 msgid "Extract the value for one variable assigned in a list"
-msgstr ""
+msgstr "Estrai il valore di una variabile assegnata in una lista"
 
 #: ../../src/wxMaximaFrame.cpp:1439
 msgid "Extract, append or delete rows or columns"
-msgstr ""
+msgstr "Estrai, accoda o elimina righe o colonne"
 
 #: ../../src/wxMaxima.cpp:8188
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
-msgstr ""
+msgstr "Estrai un rettangolo da un array 2D e convertilo in una matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1521
 msgid "Factor Complex"
-msgstr ""
+msgstr "Fattorizza in numeri complessi"
 
 #: ../../src/Worksheet.cpp:1581
 msgid "Factor Expression"
-msgstr ""
+msgstr "Fattorizza l'espressione"
 
 #: ../../src/wxMaximaFrame.cpp:1519
 msgid "Factor Expression including subexpressions"
-msgstr ""
+msgstr "Fattorizza un'espressione includendo le sottoespressioni"
 
 #: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
 msgid "Factor an expression"
-msgstr ""
+msgstr "Fattorizza un'espressione"
 
 #: ../../src/wxMaximaFrame.cpp:1522
 msgid "Factor an expression in Gaussian numbers"
-msgstr ""
+msgstr "Fattorizza un'espressione di numeri Gaussiani"
 
 #: ../../src/wxMaximaFrame.cpp:1587
 msgid "Factorials and &Gamma"
-msgstr ""
+msgstr "Fattoriali e &gamma"
 
 #: ../../src/Image.cpp:137
 #, c-format
 msgid "Failed to delete gnuplot data file %s"
-msgstr ""
+msgstr "Fallito il tentativo di cancellare il file dati gnuplot %s"
 
 #: ../../src/Image.cpp:121 ../../src/Image.cpp:128
 #, c-format
 msgid "Failed to delete gnuplot file %s"
-msgstr ""
+msgstr "Fallito il tentativo di cancellare il file gnuplot %s"
 
 #: ../../src/wxMaxima.cpp:2667
+#, fuzzy
 msgid "Failed to start Maxima"
-msgstr ""
+msgstr "Riavvia maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1418
 msgid "Fast fortran routines that perform numerical tasks"
-msgstr ""
+msgstr "Routine veloci fortran che eseguono i compiti numerici"
 
 #: ../../src/wxMaximaFrame.cpp:1922
 msgid "Fast list access"
-msgstr ""
+msgstr "Accesso veloce lista"
 
 #: ../../src/wxMaxima.cpp:2553
 msgid "Fatal error"
-msgstr ""
+msgstr "Errore fatale"
 
 #: ../../src/wxMaxima.cpp:7191
 msgid "Field contents:"
-msgstr ""
+msgstr "Contenuti campo:"
 
 #: ../../src/wxMaxima.cpp:7198
 msgid "Field name:"
-msgstr ""
+msgstr "Nome campo:"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "Fields:"
-msgstr ""
+msgstr "Campi:"
 
 #: ../../src/main.cpp:439
 msgid "File"
-msgstr ""
+msgstr "File"
 
 #: ../../src/wxMaximaFrame.cpp:1333
 msgid "File I/O"
-msgstr ""
+msgstr "I/O File"
 
 #: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
 #: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
 #: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
 #: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
 msgid "File could not be opened"
-msgstr ""
+msgstr "File non può essere aperto"
 
 #: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
 #: ../../src/wxMaxima.cpp:7251
 msgid "File name:"
-msgstr ""
+msgstr "Nome file:"
 
 #: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
 msgid "File not found"
-msgstr ""
+msgstr "File non trovato"
 
 #: ../../src/wxMaxima.cpp:5631
 msgid "File opened"
-msgstr ""
+msgstr "File aperto"
 
 #: ../../src/wxMaximaFrame.cpp:1217
 msgid "File operations"
-msgstr ""
+msgstr "Operazioni sui file"
 
 #: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
 msgid "File you tried to open does not exist."
-msgstr ""
+msgstr "Il file che si sta provando ad aprire non esiste."
 
 #: ../../src/wxMaximaFrame.cpp:1221
+#, fuzzy
 msgid "File/directory functions"
-msgstr ""
+msgstr "Operazioni sulle cartelle"
 
 #: ../../src/wxMaxima.cpp:7027
 msgid "Filename or a list of comma-separated file names"
-msgstr ""
+msgstr "Nomefile o una lista di nomi di file separati da virgole"
 
 #: ../../src/ToolBar.cpp:222
 msgid "Find"
-msgstr ""
+msgstr "Trova"
 
 #: ../../src/wxMaximaFrame.cpp:670
 msgid "Find\tCtrl+F"
-msgstr ""
+msgstr "Trova\tCtrl+F"
 
 #: ../../src/wxMaximaFrame.cpp:1468
 msgid "Find &Limit..."
-msgstr ""
+msgstr "Trova il &limite..."
 
 #: ../../src/wxMaximaFrame.cpp:1470
 msgid "Find Minimum..."
-msgstr ""
+msgstr "Trova il minimo..."
 
 #: ../../src/Worksheet.cpp:1576
 msgid "Find Root..."
-msgstr ""
+msgstr "Trova la radice..."
 
 #: ../../src/wxMaximaFrame.cpp:1471
 msgid "Find a (unconstrained) minimum of an expression"
-msgstr ""
+msgstr "Trova un minimo (libero) di un'espressione"
 
 #: ../../src/wxMaximaFrame.cpp:1804
 msgid "Find a fraction that represents this float exactly"
@@ -2991,103 +3089,104 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1469
 msgid "Find a limit of an expression"
-msgstr ""
+msgstr "Trova il limite di un'espressione"
 
 #: ../../src/wxMaximaFrame.cpp:1807
 msgid "Find a nice fraction that is similar to this float"
-msgstr ""
+msgstr "Trova frazione simile a questo numero in virgola mobile"
 
 #: ../../src/wxMaximaFrame.cpp:1283
 msgid "Find a numerical solution for a first degree ODE"
-msgstr ""
+msgstr "Trova soluzione numerica per un'ODE di primo grado"
 
 #: ../../src/wxMaximaFrame.cpp:1252
 msgid "Find a root of an equation on an interval"
-msgstr ""
+msgstr "Trova la radice di un'equazione in un intervallo"
 
 #: ../../src/wxMaximaFrame.cpp:1259
 msgid "Find all roots of a polynomial"
-msgstr ""
+msgstr "Trova tutte le radici di una polinomiale"
 
 #: ../../src/wxMaximaFrame.cpp:1262
 msgid "Find all roots of a polynomial (bfloat)"
-msgstr ""
+msgstr "Trova tutte le radici di una polinomiale (alta precisione)"
 
 #: ../../src/wxMaxima.cpp:6589
 msgid "Find and Replace"
-msgstr ""
+msgstr "Cerca e sostituisci"
 
 #: ../../src/ToolBar.cpp:222 ../../src/wxMaximaFrame.cpp:670
 msgid "Find and replace"
-msgstr ""
+msgstr "Cerca e sostituisci"
 
 #: ../../src/wxMaxima.cpp:7434
 msgid "Find char in string"
-msgstr ""
+msgstr "Trova un carattere in una stringa"
 
 #: ../../src/wxMaximaFrame.cpp:1172
 msgid "Find char in string..."
-msgstr ""
+msgstr "Trova un carattere in una stringa..."
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Find common denominator"
-msgstr ""
+msgstr "Trova comune denominatore"
 
 #: ../../src/wxMaximaFrame.cpp:1366
 msgid "Find eigenvalues of a matrix"
-msgstr ""
+msgstr "Trova gli autovalori di una matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1369
 msgid "Find eigenvectors of a matrix"
-msgstr ""
+msgstr "Trova gli autovettori di una matrice"
 
 #: ../../src/wxMaxima.cpp:7424
 msgid "Find first difference"
-msgstr ""
+msgstr "Trova la prima differenza"
 
 #: ../../src/wxMaximaFrame.cpp:1170
 msgid "Find first difference..."
-msgstr ""
+msgstr "Trova la prima differenza..."
 
 #: ../../src/wxMaximaFrame.cpp:1256
 msgid "Find fractions that real roots of a polynomial and "
-msgstr ""
+msgstr "Trova frazioni che siano radici reali di una polinomiale e"
 
 #: ../../src/wxMaxima.cpp:9039
 msgid "Find minimum"
-msgstr ""
+msgstr "Trova il minimo"
 
 #: ../../src/wxMaximaFrame.cpp:1251
 msgid "Find numerical solution..."
-msgstr ""
+msgstr "Trova soluzione numerica..."
 
 #: ../../src/wxMaxima.cpp:10035
 msgid "Find root (solve numerically)"
-msgstr ""
+msgstr "Trova radice (risolvi numericamente)"
 
 #: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
 msgid "Find the maximum absolute value of a matrix entry"
-msgstr ""
+msgstr "Trova il massimo valore assoluto di un elemento di matrice"
 
 #: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
 msgid "Find the maximum sum of the absolute values of a matrix column"
-msgstr ""
+msgstr "Trova la somma massima dei valori assoluti di una colonna di matrice"
 
 #: ../../src/wxMaxima.cpp:8073 ../../src/wxMaxima.cpp:8094
 msgid "Find the maximum sum of the absolute values of a matrix row"
-msgstr ""
+msgstr "Trova la somma massima dei valori assoluti di una riga di matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1832
 msgid "Fine-tune the display of engineering-format numbers"
 msgstr ""
+"Regola finemente la visualizzazione dei numeri in formato ingegneristico"
 
 #: ../../src/wxMaximaFrame.cpp:1712
 msgid "First"
-msgstr ""
+msgstr "Primo"
 
 #: ../../src/wxMaximaFrame.cpp:1918
 msgid "Fitting curves to measurement data"
-msgstr ""
+msgstr "Fit delle curve dei dati di misura"
 
 #: ../../src/wxMaxima.cpp:7227
 msgid "Flush stream"
@@ -3099,15 +3198,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:922
 msgid "Fold All\tCtrl+Alt+["
-msgstr ""
+msgstr "Ripiega tutto\tCtrl+["
 
 #: ../../src/wxMaximaFrame.cpp:923
 msgid "Fold all sections"
-msgstr ""
+msgstr "Ripiega tutte le sezioni"
 
 #: ../../src/ToolBar.cpp:240
 msgid "Follow"
-msgstr ""
+msgstr "Segui"
 
 #: ../../src/ToolBar.cpp:285
 msgid ""
@@ -3122,6 +3221,16 @@ msgid ""
 "   Ctrl+6: Heading5 cell\n"
 "   Ctrl+7: Heading6 cell\n"
 msgstr ""
+"Per la creazione rapida di celle esistono le seguenti scorciatoie:\n"
+"\n"
+"   Ctrl+0: Cella formula\n"
+"   Ctrl+1: Cella testo\n"
+"   Ctrl+2: Cella titolo\n"
+"   Ctrl+3: Cella sezione\n"
+"   Ctrl+4: Cella subsezione\n"
+"   Ctrl+5: Cella sub-subsezione\n"
+"   Ctrl+6: Cella Intestazione5\n"
+"   Ctrl+7: Cella Intestazione6\n"
 
 #: ../../src/wxMaxima.cpp:7038
 msgid "For loop"
@@ -3143,34 +3252,36 @@ msgstr ""
 #, c-format
 msgid ""
 "Found %li anchors, URLs (individual files): %li, URLs (singlepage): %li"
-msgstr ""
+msgstr "Trovate %li ancore, URL (file singoli): %li, URL (paginasingola): %li"
 
 #: ../../src/MaximaManual.cpp:313
 #, c-format
 msgid "Found only %li keywords in maxima's manual. Not caching them to disc."
 msgstr ""
+"Trovate solo %li parole chiave nel manuale di maxima. Non memorizzate "
+"temporaneamente su disco."
 
 #: ../../src/MaximaManual.cpp:513
 #, c-format
 msgid "Found the maxima HTML manual in the folder %s."
-msgstr ""
+msgstr "Trovato il manuale HTML di maxima nella cartella %s."
 
 #: ../../src/wxMaxima.cpp:8948
 msgid "Fourier coefficients"
-msgstr ""
+msgstr "Coefficienti di Fourier"
 
 #: ../../src/wxMaximaFrame.cpp:1476
 msgid "Fourier coefficients..."
-msgstr ""
+msgstr "Coefficienti di Fourier..."
 
 #: ../../src/ToolBar.cpp:137
 #, c-format
 msgid "Frame %li of %li"
-msgstr ""
+msgstr "Quadro %li di %li"
 
 #: ../../src/wxMaxima.cpp:9097
 msgid "Frame rate"
-msgstr ""
+msgstr "Frequenza di quadro"
 
 #: ../../src/wxMaximaFrame.cpp:1005 ../../src/wxMaximaFrame.cpp:1009
 msgid "Free all unused items now"
@@ -3186,59 +3297,60 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "From:"
-msgstr ""
+msgstr "Da:"
 
 #: ../../src/wxMaximaFrame.cpp:827
+#, fuzzy
 msgid "Full Screen\tAlt+Enter"
-msgstr ""
+msgstr "Pieno schermo\tAlt-Enter"
 
 #: ../../src/wxMaximaFrame.cpp:824
 msgid "Full Screen\tF11"
-msgstr ""
+msgstr "Pieno schermo\tF11"
 
 #: ../../src/wxMaxima.cpp:7140
 msgid "Function contents:"
-msgstr ""
+msgstr "Contenuti funzione:"
 
 #: ../../src/wxMaxima.cpp:7908
 msgid "Function f(x):"
-msgstr ""
+msgstr "Funzione f(x):"
 
 #: ../../src/wxMaxima.cpp:8572
 msgid "Function name"
-msgstr ""
+msgstr "Nome funzione"
 
 #: ../../src/wxMaxima.cpp:7167
 msgid "Function name(s):"
-msgstr ""
+msgstr "Nomi funzione:"
 
 #: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
 msgid "Function name:"
-msgstr ""
+msgstr "Nome funzione:"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Function:"
-msgstr ""
+msgstr "Funzione:"
 
 #: ../../src/wxMaximaFrame.cpp:1630
 msgid "Functions for complex simplification"
-msgstr ""
+msgstr "Funzioni per la semplificazione complessa"
 
 #: ../../src/wxMaximaFrame.cpp:1588
 msgid "Functions for simplifying factorials and gamma function"
-msgstr ""
+msgstr "Funzioni per semplificare fattoriali e funzione gamma"
 
 #: ../../src/wxMaximaFrame.cpp:1606
 msgid "Functions for simplifying trigonometric expressions"
-msgstr ""
+msgstr "Funzioni per semplificare le espressioni trigonometriche"
 
 #: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
 msgid "GCD"
-msgstr ""
+msgstr "MCD"
 
 #: ../../src/wxMaxima.cpp:10186
 msgid "GIF image (*.gif)|*.gif"
-msgstr ""
+msgstr "Immagine GIF (*.gif)|*.gif"
 
 #: ../../src/Worksheet.cpp:103
 msgid ""
@@ -3246,143 +3358,153 @@ msgid ""
 " hotkeys to be broken, see for example "
 "https://trac.wxwidgets.org/ticket/18462."
 msgstr ""
+"GTK_IM_MODULE è impostato a \"xim\". Aspettarsi che il programma emetta un "
+"flickering odioso e che i tasti acceleratori non funzionino, vedere per "
+"esempio https://trac.wxwidgets.org/ticket/18462."
 
 #: ../../src/wxMaximaFrame.cpp:295
 msgid "General Math"
-msgstr ""
+msgstr "Matematica generale"
 
 #: ../../src/wxMaximaFrame.cpp:699
 msgid "General Math\tAlt+Shift+M"
-msgstr ""
+msgstr "Matematica generale\tAlt+Shift+M"
 
 #: ../../src/wxMaximaFrame.cpp:1316
 msgid "Generate Matrix from Expression..."
-msgstr ""
+msgstr "Genera una matrice dall'espressione..."
 
 #: ../../src/wxMaximaFrame.cpp:1317
 msgid "Generate a matrix from a lambda expression"
-msgstr ""
+msgstr "Genera una matrice da una espressione lambda"
 
 #: ../../src/wxMaximaFrame.cpp:1675
 msgid "Generate a new list using a lists' elements"
-msgstr ""
+msgstr "Genera una nuova lista usando gli elementi di una lista"
 
 #: ../../src/wxMaximaFrame.cpp:1681
 msgid ""
 "Generate a storage for variable values that can be introduced into equations"
 " at any time"
 msgstr ""
+"Crea un contenitore per i valori delle variabili che possono essere inseriti"
+" in equazioni in qualsiasi momento."
 
 #: ../../src/wxMaximaFrame.cpp:1672
 msgid "Generate list elements using a rule"
-msgstr ""
+msgstr "Genera gli elementi di una lista usando una regola"
 
 #: ../../src/wxMaxima.cpp:8196
 msgid "Generate matrix from a rule"
-msgstr ""
+msgstr "Genera matrice da una regola"
 
 #: ../../src/wxMaximaFrame.cpp:1094
 msgid "Generate unused symbol name"
-msgstr ""
+msgstr "Genera nome simbolo non usato"
 
 #: ../../src/WXMXformat.cpp:231
 msgid "Generated the XML representation of the document"
-msgstr ""
+msgstr "Genera la rappresentazione XML del documento"
 
 #: ../../src/wxMaxima.cpp:8197
+#, fuzzy
 msgid ""
 "Generates a matrix and fills each element with the result of the expression "
 "\"Rule\"."
 msgstr ""
+"Genera una matrice rettangolare e riempie ogni elemento con il risultato "
+"dell'espressione \"Regola\"."
 
 #: ../../src/wxMaximaFrame.cpp:1619
 msgid "Get &Imaginary Part"
-msgstr ""
+msgstr "Ricava la parte &immaginaria"
 
 #: ../../src/wxMaximaFrame.cpp:1485
 msgid "Get Laplace transformation of an expression"
-msgstr ""
+msgstr "Calcola la trasformata di Laplace di un'espressione"
 
 #: ../../src/wxMaximaFrame.cpp:1615
 msgid "Get Real P&art"
-msgstr ""
+msgstr "Ricava la p&arte reale"
 
 #: ../../src/wxMaximaFrame.cpp:1201
 msgid "Get current directory"
-msgstr ""
+msgstr "Ricava la cartella corrente"
 
 #: ../../src/wxMaximaFrame.cpp:1489
 msgid "Get inverse Laplace transformation of an expression"
-msgstr ""
+msgstr "Calcola la trasformata inversa di Laplace di un'espressione"
 
 #: ../../src/wxMaxima.cpp:7223
 msgid "Get position in stream"
-msgstr ""
+msgstr "Ricava la posizione in uno stream"
 
 #: ../../src/wxMaximaFrame.cpp:1102
 msgid "Get position..."
-msgstr ""
+msgstr "Ricava posizione..."
 
 #: ../../src/wxMaximaFrame.cpp:1620
 msgid "Get the imaginary part of complex expression"
-msgstr ""
+msgstr "Ricava la parte immaginaria da un'espressione complessa"
 
 #: ../../src/wxMaximaFrame.cpp:1616
 msgid "Get the real part of complex expression"
-msgstr ""
+msgstr "Ricava la parte reale da un'espressione complessa"
 
 #: ../../src/wxMaxima.cpp:3609
-#, c-format
+#, fuzzy, c-format
 msgid "Gnuplot (command line) found at: %s"
-msgstr ""
+msgstr "Gnuplot trovato a: %s"
 
 #: ../../src/wxMaxima.cpp:3607
 #, c-format
 msgid "Gnuplot found at: %s"
-msgstr ""
+msgstr "Gnuplot trovato a: %s"
 
 #: ../../src/wxMaxima.cpp:2974
 msgid "Gnuplot has closed."
-msgstr ""
+msgstr "Gnuplot è chiuso."
 
 #: ../../src/wxMaxima.cpp:3598 ../../src/wxMaxima.cpp:3603
 #, c-format
 msgid "Gnuplot not found, using the default: %s"
-msgstr ""
+msgstr "Gnuplot non trovato, uso del predefinito: %s"
 
 #: ../../src/wxMaxima.cpp:9428 ../../src/wxMaximaFrame.cpp:1887
 msgid "Go to URL"
-msgstr ""
+msgstr "Vai alla URL"
 
 #: ../../src/wxMaxima.cpp:3989
 msgid "Got a new input prompt!"
-msgstr ""
+msgstr "Nuova richiesta inserimento dati!"
 
 #: ../../src/Worksheet.cpp:6354
 msgid ""
 "Got a request to undo an action that involves a delete which isn't possible "
 "at this moment."
 msgstr ""
+"Richiesta di annullamento azione che implica una cancellazione che è "
+"impossibile in questo momento."
 
 #: ../../src/wxMaximaFrame.cpp:1031
 msgid "Gradefs"
-msgstr ""
+msgstr "Gradefs"
 
 #: ../../src/Worksheet.cpp:1967
 msgid "Greater or less than a value"
-msgstr ""
+msgstr "Maggiore o uguale ad un valore"
 
 #: ../../src/wxMaximaFrame.cpp:1130
 msgid "Greater, ignoring case?..."
-msgstr ""
+msgstr "Maggiore, ignorare le maiuscole?..."
 
 #: ../../src/wxMaximaFrame.cpp:260
 msgid "Greek Letters"
-msgstr ""
+msgstr "Lettere greche"
 
 #: ../../src/wxMaximaFrame.cpp:703
 msgid "Greek Letters\tAlt+Shift+G"
-msgstr ""
+msgstr "Lettere greche\tAlt+Shift+G"
 
 #: ../../src/wxMaximaFrame.cpp:1815
 msgid "Guess an exact number that could be meant by this float"
@@ -3393,22 +3515,24 @@ msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file "
 "(*.tex)|*.tex"
 msgstr ""
+"File HTML (*.html)|*.html|File batch maxima (*.mac)|*.mac|File LaTeX "
+"(*.tex)|*.tex"
 
 #: ../../src/wxMaximaFrame.cpp:1341
 msgid "Hadamard (element-by-element) product..."
-msgstr ""
+msgstr "Prodotto Hadamard (elemento-per-elemento)..."
 
 #: ../../src/wxMaxima.cpp:8004
 msgid "Hadamard Product"
-msgstr ""
+msgstr "Prodotto Hadamard"
 
 #: ../../src/wxMaxima.cpp:8011
 msgid "Hadamard exponent"
-msgstr ""
+msgstr "Esponente Hadamard"
 
 #: ../../src/wxMaximaFrame.cpp:1345
 msgid "Hadamard exponent..."
-msgstr ""
+msgstr "Esponente Hadamard..."
 
 #: ../../src/MaximaManual.cpp:260
 #, c-format
@@ -3416,119 +3540,122 @@ msgid ""
 "Have only %li keyword anchors at the end of parsing the maxima manual => Not"
 " caching the result of using the built-in keyword list"
 msgstr ""
+"Ha solo %li ancore di parole chiave alla fine dell'analisi del manuale di "
+"maxima => Non memorizzato nella cache il risultato dell'utilizzo dell'elenco"
+" di parole chiave integrato"
 
 #: ../../src/Configuration.cpp:88 ../../src/ToolBar.cpp:276
 msgid "Heading 5"
-msgstr ""
+msgstr "Intestazione 5"
 
 #: ../../src/Configuration.cpp:87 ../../src/ToolBar.cpp:277
 msgid "Heading 6"
-msgstr ""
+msgstr "Intestazione 6"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
 msgid "Help"
-msgstr ""
+msgstr "Aiuto"
 
 #: ../../src/ToolBar.cpp:635
 msgid "Help button"
-msgstr ""
+msgstr "Pulsante di aiuto"
 
 #: ../../src/Worksheet.cpp:1340 ../../src/Worksheet.cpp:1778
 #, c-format
 msgid "Help on \"%s\""
-msgstr ""
+msgstr "Aiuto su \"%s\""
 
 #: ../../src/wxMaximaFrame.cpp:729
 msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr ""
+msgstr "Nascondi tutte le barre\tAlt+Shift+-"
 
 #: ../../src/ToolBar.cpp:264
 msgid "Hide Code"
-msgstr ""
+msgstr "Nascondi codice"
 
 #: ../../src/wxMaximaFrame.cpp:727
 msgid "Hide Code Cells\tAlt+Ctrl+H"
-msgstr ""
+msgstr "Nascondi le celle di codice\tAlt+Ctrl+H"
 
 #: ../../src/Worksheet.cpp:1896
 msgid "Hide Heading 5"
-msgstr ""
+msgstr "Nascondi intestazione 5"
 
 #: ../../src/Worksheet.cpp:1907
 msgid "Hide Heading 6"
-msgstr ""
+msgstr "Nascondi intestazione 6"
 
 #: ../../src/Worksheet.cpp:1855
 msgid "Hide Part"
-msgstr ""
+msgstr "Nascondi parte"
 
 #: ../../src/Worksheet.cpp:1863
 msgid "Hide Section"
-msgstr ""
+msgstr "Nascondo sezione"
 
 #: ../../src/Worksheet.cpp:1874
 msgid "Hide Subsection"
-msgstr ""
+msgstr "Nascondi subsezione"
 
 #: ../../src/Worksheet.cpp:1885
 msgid "Hide Subsubsection"
-msgstr ""
+msgstr "Nascondi subsubsezione"
 
 #: ../../src/wxMaximaFrame.cpp:730
 msgid "Hide all panes"
-msgstr ""
+msgstr "Nascondi tutti i pannelli"
 
 #: ../../src/Worksheet.cpp:1491
 msgid "Hide cell brackets"
-msgstr ""
+msgstr "Nascondi parentesi cella"
 
 #: ../../src/Worksheet.cpp:1915
 msgid "Hide contents"
-msgstr ""
+msgstr "Nascondi i contenuti"
 
 #: ../../src/Worksheet.cpp:1552
 msgid "Hide multiplication dots"
-msgstr ""
+msgstr "Nascondi punti moltiplicazioni"
 
 #: ../../src/Worksheet.cpp:1930 ../../src/Worksheet.cpp:2063
 msgid "Hide yellow tooltip marker for this cell"
-msgstr ""
+msgstr "Nascondi marcatore giallo suggerimenti per questa cella"
 
 #: ../../src/Worksheet.cpp:1937 ../../src/Worksheet.cpp:2069
 msgid "Hide yellow tooltip marker for this message type"
-msgstr ""
+msgstr "Nascondi marcatore giallo suggerimenti per questo tipo di messaggi"
 
 #: ../../src/Configuration.cpp:82
 msgid "Highlight (box)"
-msgstr ""
+msgstr "Evidenzia (riquadro)"
 
 #: ../../src/wxMaxima.cpp:9528
 msgid "Histogram"
-msgstr ""
+msgstr "Istogramma"
 
 #: ../../src/wxMaximaFrame.cpp:232
 msgid "History"
-msgstr ""
+msgstr "Cronologia"
 
 #: ../../src/wxMaximaFrame.cpp:709
 msgid "History\tAlt+Shift+I"
-msgstr ""
+msgstr "Cronologia\tAlt+Shift+I"
 
 #: ../../src/wxMaximaFrame.cpp:1526
 msgid "Horner's rule"
-msgstr ""
+msgstr "Regola di Horner"
 
 #: ../../src/wxMaxima.cpp:9207
 msgid "How many digits to show:"
-msgstr ""
+msgstr "Quante cifre mostrare:"
 
 #: ../../src/wxMaximaFrame.cpp:759
 msgid "How to display new equations"
-msgstr ""
+msgstr "Come mostrare le nuove equazioni"
 
 #: ../../src/wxMaximaFrame.cpp:1113
 msgid "I/O"
-msgstr ""
+msgstr "I/O"
 
 #: ../../src/wxMaxima.cpp:7062
 msgid ""
@@ -3536,6 +3663,9 @@ msgid ""
 "between parenthesis. The result of the last operation is the return value of"
 " the program."
 msgstr ""
+"Se un programma non necessita di variabili locali, maxima permette di "
+"mettere i comandi tra parentesi. Il risultato dell'ultima operazione è il "
+"valore restituito dal programma."
 
 #: ../../src/wxMaxima.cpp:7172
 msgid ""
@@ -3553,21 +3683,23 @@ msgstr ""
 
 #: ../../src/MaximaManual.cpp:403
 msgid "Ignoring the cache version for the manual anchors."
-msgstr ""
+msgstr "Ignorata la versione in cache delle ancore del manuale."
 
 #: ../../src/Image.cpp:79
 msgid "Image data had zero length!"
-msgstr ""
+msgstr "I dati immagine avevano lunghezza zero!"
 
 #: ../../src/wxMaxima.cpp:10147 ../../src/wxMaxima.cpp:10855
 msgid ""
 "Image files (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, "
 "*.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
 msgstr ""
+"File immagine (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, "
+"*.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
 
 #: ../../src/Worksheet.cpp:5509
 msgid "ImageCell without image."
-msgstr ""
+msgstr "ImageCell senza immagine."
 
 #: ../../src/MathParser.cpp:347
 msgid "Importing compressed gnuplot sources for an animation"
@@ -3591,7 +3723,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Include columns:"
-msgstr ""
+msgstr "Includi colonne:"
 
 #: ../../src/Worksheet.cpp:2008
 msgid "Increasing function f(x)>x"
@@ -3599,23 +3731,23 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8470
 msgid "Index End:"
-msgstr ""
+msgstr "Fine indice:"
 
 #: ../../src/wxMaxima.cpp:8470
 msgid "Index Start:"
-msgstr ""
+msgstr "Inizio indice:"
 
 #: ../../src/wxMaxima.cpp:8471
 msgid "Index Step:"
-msgstr ""
+msgstr "Passo indice:"
 
 #: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
 msgid "Index variable:"
-msgstr ""
+msgstr "Variabile indice:"
 
 #: ../../src/wxMaximaFrame.cpp:1949
 msgid "Info about Maxima build"
-msgstr ""
+msgstr "Informazioni sulla compilazione di Maxima"
 
 #: ../../src/Worksheet.cpp:2046
 msgid "Inform maxima about facts you know for this symbol"
@@ -3629,155 +3761,155 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
 msgid "Initial Condition"
-msgstr ""
+msgstr "Condizione iniziale"
 
 #: ../../src/wxMaximaFrame.cpp:1270
 msgid "Initial Value Problem (&1)..."
-msgstr ""
+msgstr "Problema ai valori iniziali (&1)..."
 
 #: ../../src/wxMaximaFrame.cpp:1274
 msgid "Initial Value Problem (&2)..."
-msgstr ""
+msgstr "Problema ai valori iniziali (&2)..."
 
 #: ../../src/wxMaxima.cpp:9044
 msgid "Initial estimates:"
-msgstr ""
+msgstr "Stime iniziali:"
 
 #: ../../src/wxMaxima.cpp:7840
 msgid "Initial x:"
-msgstr ""
+msgstr "X iniziale:"
 
 #: ../../src/Configuration.cpp:78
 msgid "Input labels"
-msgstr ""
+msgstr "Etichette d'ingresso"
 
 #: ../../src/wxMaximaFrame.cpp:314
 msgid "Insert"
-msgstr ""
+msgstr "Inserisci"
 
 #: ../../src/wxMaximaFrame.cpp:905
 msgid "Insert &Section Cell\tCtrl+3"
-msgstr ""
+msgstr "Inserisci cella &sezione\tCtrl+3"
 
 #: ../../src/wxMaximaFrame.cpp:901
 msgid "Insert &Text Cell\tCtrl+1"
-msgstr ""
+msgstr "Inserisci cella &testo\tCtrl+1"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Insert Cell\tAlt+Shift+C"
-msgstr ""
+msgstr "Inserisci cella\tAlt+Shift+C"
 
 #: ../../src/Worksheet.cpp:1669
 msgid "Insert Heading5 Cell"
-msgstr ""
+msgstr "Inserisci cella intestazione5"
 
 #: ../../src/Worksheet.cpp:1671
 msgid "Insert Heading6 Cell"
-msgstr ""
+msgstr "Inserisci cella intestazione6"
 
 #: ../../src/wxMaxima.cpp:10854
 msgid "Insert Image"
-msgstr ""
+msgstr "Inserisci immagine"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert Image..."
-msgstr ""
+msgstr "Inserisci immagine..."
 
 #: ../../src/wxMaximaFrame.cpp:899
 msgid "Insert Input &Cell\tCtrl+0"
-msgstr ""
+msgstr "Inserisci &cella d'ingresso\tCtrl+0"
 
 #: ../../src/wxMaximaFrame.cpp:919
 msgid "Insert Page Break"
-msgstr ""
+msgstr "Inserisci interruzione di pagina"
 
 #: ../../src/wxMaximaFrame.cpp:907
 msgid "Insert S&ubsection Cell\tCtrl+4"
-msgstr ""
+msgstr "Inserisci cella s&ottosezione\tCtrl+4"
 
 #: ../../src/wxMaximaFrame.cpp:910
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
-msgstr ""
+msgstr "Inserisci cella s&ubsubsezione\tCtrl+5"
 
 #: ../../src/Worksheet.cpp:1662
 msgid "Insert Section Cell"
-msgstr ""
+msgstr "Inserisci cella sezione"
 
 #: ../../src/Worksheet.cpp:1664
 msgid "Insert Subsection Cell"
-msgstr ""
+msgstr "Inserisci cella subsezione"
 
 #: ../../src/Worksheet.cpp:1667
 msgid "Insert Subsubsection Cell"
-msgstr ""
+msgstr "Inserisci cella subsubsezione"
 
 #: ../../src/wxMaximaFrame.cpp:903
 msgid "Insert T&itle Cell\tCtrl+2"
-msgstr ""
+msgstr "Inserisci cella t&itolo\tCtrl+2"
 
 #: ../../src/Worksheet.cpp:1658
 msgid "Insert Text Cell"
-msgstr ""
+msgstr "Inserisci cella testo"
 
 #: ../../src/Worksheet.cpp:1660
 msgid "Insert Title Cell"
-msgstr ""
+msgstr "Inserisci cella titolo"
 
 #: ../../src/wxMaximaFrame.cpp:913
 msgid "Insert a new heading5 cell"
-msgstr ""
+msgstr "Inserisci una nuova cella intestazione5"
 
 #: ../../src/wxMaximaFrame.cpp:915
 msgid "Insert a new heading6 cell"
-msgstr ""
+msgstr "Inserisci una nuova cella intestazione6"
 
 #: ../../src/wxMaximaFrame.cpp:900
 msgid "Insert a new input cell"
-msgstr ""
+msgstr "Inserisci nuova cella di ingresso"
 
 #: ../../src/wxMaximaFrame.cpp:906
 msgid "Insert a new section cell"
-msgstr ""
+msgstr "Inserisci nuova cella sezione"
 
 #: ../../src/wxMaximaFrame.cpp:908
 msgid "Insert a new subsection cell"
-msgstr ""
+msgstr "Inserisci nuova cella subsezione"
 
 #: ../../src/wxMaximaFrame.cpp:911
 msgid "Insert a new subsubsection cell"
-msgstr ""
+msgstr "Inserisci nuova cella subsubsezione"
 
 #: ../../src/wxMaximaFrame.cpp:902
 msgid "Insert a new text cell"
-msgstr ""
+msgstr "Inserisci nuova cella testo"
 
 #: ../../src/wxMaximaFrame.cpp:904
 msgid "Insert a new title cell"
-msgstr ""
+msgstr "Inserisci nuova cella titolo"
 
 #: ../../src/wxMaximaFrame.cpp:920
 msgid "Insert a page break"
-msgstr ""
+msgstr "Inserisci un'interruzione di pagina"
 
 #: ../../src/wxMaximaFrame.cpp:1164
 msgid "Insert char..."
-msgstr ""
+msgstr "Inserisci carattere..."
 
 #: ../../src/wxMaximaFrame.cpp:912
 msgid "Insert heading5 Cell\tCtrl+6"
-msgstr ""
+msgstr "Inserisci cella intestazione5\tCtrl+6"
 
 #: ../../src/wxMaximaFrame.cpp:914
 msgid "Insert heading6 Cell\tCtrl+7"
-msgstr ""
+msgstr "Inserisci cella intestazione6\tCtrl+7"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert image"
-msgstr ""
+msgstr "Inserisci immagine"
 
 #: ../../src/wxMaximaFrame.cpp:916
 msgid "Insert textbased cell"
-msgstr ""
+msgstr "Inserisci cella di testo"
 
 #: ../../src/wxMaxima.cpp:3566
 msgid "Instructed to prefer gnuplot over wgnuplot"
@@ -3789,86 +3921,88 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
 msgid "Integral/Sum:"
-msgstr ""
+msgstr "Integrale/somma:"
 
 #: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
 msgid "Integrate"
-msgstr ""
+msgstr "Integra"
 
 #: ../../src/wxMaxima.cpp:8980
 msgid "Integrate (risch)"
-msgstr ""
+msgstr "Integra (Risch)"
 
 #: ../../src/wxMaximaFrame.cpp:1454
 msgid "Integrate expression"
-msgstr ""
+msgstr "Integra l'espressione"
 
 #: ../../src/wxMaximaFrame.cpp:1456
 msgid "Integrate expression with Risch algorithm"
-msgstr ""
+msgstr "Integra l'espressione con l'algoritmo di Risch"
 
 #: ../../src/wxMaximaFrame.cpp:1869
 msgid "Integrate numerically"
-msgstr ""
+msgstr "Integra numericamente"
 
 #: ../../src/Worksheet.cpp:1588
 msgid "Integrate..."
-msgstr ""
+msgstr "Integra..."
 
 #: ../../src/wxMaximaFrame.cpp:1737
 msgid "Interleave"
-msgstr ""
+msgstr "Alterna"
 
 #: ../../src/wxMaximaFrame.cpp:1738
 msgid "Interleave the values of two lists"
-msgstr ""
+msgstr "Alterna i valori di due liste"
 
 #: ../../src/wxMaxima.cpp:8612
 msgid "Interleave two lists"
-msgstr ""
+msgstr "Alterna due liste"
 
 #: ../../src/wxMaximaFrame.cpp:1087
 msgid "Interpret like input..."
-msgstr ""
+msgstr "Interpreta come ingresso..."
 
 #: ../../src/wxMaxima.cpp:7104
 msgid "Interpret maxima's output as input"
-msgstr ""
+msgstr "Interpreta l'uscita di maxima come ingresso"
 
 #: ../../src/wxMaxima.cpp:7502
 msgid "Interpret string as maxima code"
-msgstr ""
+msgstr "Interpreta la stringa come codice maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1089
 msgid "Interpret string..."
-msgstr ""
+msgstr "Interpreta la stringa..."
 
 #: ../../src/ToolBar.cpp:231
 msgid "Interrupt"
-msgstr ""
+msgstr "Interruzione"
 
 #: ../../src/wxMaximaFrame.cpp:965
 msgid "Interrupt current computation"
-msgstr ""
+msgstr "Interruzione del calcolo corrente"
 
 #: ../../src/ToolBar.cpp:232
 msgid ""
 "Interrupt current computation. To completely restart maxima press the button"
 " left to this one."
 msgstr ""
+"Interrompe l'elaborazione corrente. Per riavviare completamente maxima "
+"premere il pulsante alla sua sinistra."
 
 #: ../../src/wxMaxima.cpp:2766
 #, c-format
 msgid "Interrupting maxima: %s"
-msgstr ""
+msgstr "Interruzione di maxima: %s"
 
 #: ../../src/wxMaxima.cpp:8557
 msgid "Introduce a list of actual values into an equation"
-msgstr ""
+msgstr "Inserisce una lista di valori correnti in una equazione"
 
 #: ../../src/wxMaximaFrame.cpp:1697
 msgid "Introduce the actual values for variables stored in the list"
-msgstr ""
+msgstr "Inserisce i valori correnti delle variabili memorizzate nella lista"
 
 #: ../../src/wxMaxima.cpp:10062
 msgid "Introduces one or more assignments into an expression"
@@ -3876,15 +4010,15 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9003
 msgid "Inverse Laplace"
-msgstr ""
+msgstr "Inversa di Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1488
 msgid "Inverse Laplace T&ransform..."
-msgstr ""
+msgstr "T&rasformata inversa di Laplace..."
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Invert worksheet brightness"
-msgstr ""
+msgstr "Inverti la luminosità del foglio di lavoro"
 
 #: ../../src/wxMaxima.cpp:7338
 msgid "Is Char 1 greater than Char2, if case is ignored?"
@@ -3892,111 +4026,111 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7333
 msgid "Is Char 1 greater than Char2?"
-msgstr ""
+msgstr "Il car 1 è maggiore del car 2?"
 
 #: ../../src/wxMaxima.cpp:7327
 msgid "Is Char 1 less than Char2, if case is ignored?"
-msgstr ""
+msgstr "Il car 1 è minore del car 2, se le maiuscole sono state ignorate?"
 
 #: ../../src/wxMaxima.cpp:7322
 msgid "Is Char 1 less than Char2?"
-msgstr ""
+msgstr "Il car 1 è minore del car 2?"
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Is a char?"
-msgstr ""
+msgstr "È un carattere?"
 
 #: ../../src/wxMaximaFrame.cpp:1115
 msgid "Is a char?..."
-msgstr ""
+msgstr "È un carattere?..."
 
 #: ../../src/Worksheet.cpp:1952
 msgid "Is a complex variable"
-msgstr ""
+msgstr "È una variabile complessa"
 
 #: ../../src/wxMaxima.cpp:7292
 msgid "Is a digit?"
-msgstr ""
+msgstr "È una cifra?"
 
 #: ../../src/wxMaximaFrame.cpp:1118
 msgid "Is a digit?..."
-msgstr ""
+msgstr "È una cifra?..."
 
 #: ../../src/wxMaxima.cpp:7304
 msgid "Is a lowercase char?"
-msgstr ""
+msgstr "È un carattere minuscolo?"
 
 #: ../../src/wxMaxima.cpp:7296
 msgid "Is a printable char?"
-msgstr ""
+msgstr "È un carattere stampabile?"
 
 #: ../../src/Worksheet.cpp:1949
 msgid "Is a real variable"
-msgstr ""
+msgstr "È una variabile reale"
 
 #: ../../src/wxMaxima.cpp:7300
 msgid "Is a uppercase char?"
-msgstr ""
+msgstr "È un carattere maiuscolo?"
 
 #: ../../src/wxMaximaFrame.cpp:1116
 msgid "Is alphabetic?..."
-msgstr ""
+msgstr "È alfabetico?..."
 
 #: ../../src/wxMaximaFrame.cpp:1117
 msgid "Is alphanumeric?..."
-msgstr ""
+msgstr "È alfanumerico?..."
 
 #: ../../src/wxMaxima.cpp:7284
 msgid "Is an alphabetic char?"
-msgstr ""
+msgstr "È un carattere alfabetico?"
 
 #: ../../src/wxMaxima.cpp:7288
 msgid "Is an alphanumeric char?"
-msgstr ""
+msgstr "È un carattere alfanumerico?"
 
 #: ../../src/Worksheet.cpp:1991
 msgid "Is an even function"
-msgstr ""
+msgstr "È una funzione pari"
 
 #: ../../src/Worksheet.cpp:1955
 msgid "Is an imaginary variable"
-msgstr ""
+msgstr "È una variabile immaginaria"
 
 #: ../../src/Worksheet.cpp:1960
 msgid "Is an integer variable"
-msgstr ""
+msgstr "È una variabile intera"
 
 #: ../../src/Worksheet.cpp:1993
 msgid "Is an odd function"
-msgstr ""
+msgstr "È una funzione dispari"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Is equal?..."
-msgstr ""
+msgstr "È uguale?..."
 
 #: ../../src/wxMaximaFrame.cpp:1128
 msgid "Is greater?..."
-msgstr ""
+msgstr "È maggiore?..."
 
 #: ../../src/wxMaximaFrame.cpp:1125
 msgid "Is lower?..."
-msgstr ""
+msgstr "È minore?..."
 
 #: ../../src/wxMaximaFrame.cpp:1121
 msgid "Is lowercase?..."
-msgstr ""
+msgstr "È minuscolo?..."
 
 #: ../../src/Worksheet.cpp:1962
 msgid "Is no integer variable"
-msgstr ""
+msgstr "Non è una variabile intera"
 
 #: ../../src/wxMaximaFrame.cpp:1119
 msgid "Is printable?..."
-msgstr ""
+msgstr "È stampabile?..."
 
 #: ../../src/wxMaximaFrame.cpp:1120
 msgid "Is uppercase?..."
-msgstr ""
+msgstr "È maiuscolo?..."
 
 #: ../../src/Worksheet.cpp:6256
 msgid "Issuing the active cell's undo function"
@@ -4008,23 +4142,23 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8598 ../../src/wxMaxima.cpp:8604
 msgid "Item"
-msgstr ""
+msgstr "Elemento"
 
 #: ../../src/wxMaxima.cpp:8581
 msgid "Iterator name:"
-msgstr ""
+msgstr "Nome iteratore:"
 
 #: ../../src/wxMaximaFrame.cpp:1048
 msgid "Jump to first error"
-msgstr ""
+msgstr "Salta al primo errore"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Jump to the first cell Maxima has reported an error in."
-msgstr ""
+msgstr "Salta alla prima cella nella quale Maxima ha segnalato un errore."
 
 #: ../../src/wxMaxima.cpp:8960
 msgid "LCM"
-msgstr ""
+msgstr "mcm"
 
 #: ../../src/wxMaximaFrame.cpp:1407
 msgid "L[1] Norm (complex)"
@@ -4044,11 +4178,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1025
 msgid "Labels"
-msgstr ""
+msgstr "Etichette"
 
 #: ../../src/wxMaxima.cpp:7090
 msgid "Lambda"
-msgstr ""
+msgstr "Lambda"
 
 #: ../../src/wxMaxima.cpp:7091
 msgid ""
@@ -4059,29 +4193,29 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8997
 msgid "Laplace"
-msgstr ""
+msgstr "Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1484
 msgid "Laplace &Transform..."
-msgstr ""
+msgstr "&Trasformata di Laplace..."
 
 #: ../../src/wxMaximaFrame.cpp:1718
 msgid "Last"
-msgstr ""
+msgstr "Ultimo"
 
 #: ../../src/wxMaxima.cpp:3006
 #, c-format
 msgid "Last message from maxima's stderr: %s"
-msgstr ""
+msgstr "L'ultimo messaggio dallo stderr di maxima: %s"
 
 #: ../../src/wxMaxima.cpp:2993
 #, c-format
 msgid "Last message from maxima's stdout: %s"
-msgstr ""
+msgstr "L'ultimo messaggio dallo stdout di maxima: %s"
 
 #: ../../src/wxMaximaFrame.cpp:1720
 msgid "Last n"
-msgstr ""
+msgstr "Ultimi n"
 
 #: ../../src/wxMaxima.cpp:10400
 msgid "Last non-whitespace is a question mark"
@@ -4090,44 +4224,44 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4899
 #, c-format
 msgid "Launching the system's default help browser as %s."
-msgstr ""
+msgstr "Avvio del browser dell'aiuto di sistema predefinito come %s."
 
 #: ../../src/wxMaxima.cpp:4909
 msgid "Launching the system's default help browser failed."
-msgstr ""
+msgstr "Avvio del browser dell'aiuto di sistema predefinito fallito."
 
 #: ../../src/wxMaximaFrame.cpp:1493
 msgid "Least Common Multiple..."
-msgstr ""
+msgstr "Minimo comune multiplo..."
 
 #: ../../src/wxMaxima.cpp:9587
 msgid "Least Squares Fit"
-msgstr ""
+msgstr "Metodo dei minimi quadrati"
 
 #: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
 #: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
 msgid "Left Matrix:"
-msgstr ""
+msgstr "Matrice sinistra:"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Left end"
-msgstr ""
+msgstr "Capo sinistro"
 
 #: ../../src/wxMaximaFrame.cpp:1297
 msgid "Left side to the \"=\""
-msgstr ""
+msgstr "Lato sinistro del \"=\""
 
 #: ../../src/wxMaximaFrame.cpp:1741
 msgid "Length"
-msgstr ""
+msgstr "Lunghezza"
 
 #: ../../src/wxMaximaFrame.cpp:1104 ../../src/wxMaximaFrame.cpp:1167
 msgid "Length..."
-msgstr ""
+msgstr "Lunghezza..."
 
 #: ../../src/wxMaxima.cpp:7421
 msgid "Length:"
-msgstr ""
+msgstr "Lunghezza:"
 
 #: ../../src/wxMaximaFrame.cpp:1032
 msgid "Letrules"
@@ -4135,23 +4269,24 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1976
 msgid "Likely to be the main variable"
-msgstr ""
+msgstr "Probabilmente la variabile principale"
 
 #: ../../src/wxMaxima.cpp:9028
 msgid "Limit"
-msgstr ""
+msgstr "Limite"
 
 #: ../../src/wxMaxima.cpp:7256
 msgid "Lisp format string:"
-msgstr ""
+msgstr "Stringa di formato lisp:"
 
 #: ../../src/wxMaxima.cpp:7258
 msgid "Lisp format strings are more powerful than c++ format strings"
 msgstr ""
+"Le stringhe in formato Lisp sono più potenti delle stringhe in formato C++"
 
 #: ../../src/wxMaxima.cpp:5066
 msgid "Lisp mode."
-msgstr ""
+msgstr "Modalità lisp."
 
 #: ../../src/wxMaximaFrame.cpp:1010 ../../src/wxMaximaFrame.cpp:1012
 msgid "Lisp normally frees memory only when it has time or runs out of space"
@@ -4160,87 +4295,87 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:3691
 #, c-format
 msgid "Lisp version: %s"
-msgstr ""
+msgstr "Versione Lisp: %s"
 
 #: ../../src/wxMaxima.cpp:8435 ../../src/wxMaxima.cpp:8539
 #: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
 #: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
 #: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
 msgid "List"
-msgstr ""
+msgstr "Lista"
 
 #: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
 msgid "List #1"
-msgstr ""
+msgstr "Lista #1"
 
 #: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
 msgid "List #2"
-msgstr ""
+msgstr "Lista #2"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "List directory"
-msgstr ""
+msgstr "Lista cartelle"
 
 #: ../../src/wxMaximaFrame.cpp:1205
 msgid "List directory..."
-msgstr ""
+msgstr "Lista cartelle..."
 
 #: ../../src/wxMaxima.cpp:7385 ../../src/wxMaxima.cpp:7389
 msgid "List of char to String"
-msgstr ""
+msgstr "Elenco di carattere a stringa"
 
 #: ../../src/wxMaximaFrame.cpp:1150
 msgid "List of chars to string..."
-msgstr ""
+msgstr "Elenco di carattere a stringa..."
 
 #: ../../src/wxMaxima.cpp:7386
 msgid "List of chars:"
-msgstr ""
+msgstr "Lista di caratteri:"
 
 #: ../../src/wxMaxima.cpp:8559
 msgid "List with values"
-msgstr ""
+msgstr "Lista con valori"
 
 #: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
 msgid "List:"
-msgstr ""
+msgstr "Lista:"
 
 #: ../../src/wxMaxima.cpp:6200
 msgid "Load Package"
-msgstr ""
+msgstr "Carica il pacchetto"
 
 #: ../../src/wxMaximaFrame.cpp:613
 msgid "Load Recent Package"
-msgstr ""
+msgstr "Carica il pacchetto recente"
 
 #: ../../src/wxMaximaFrame.cpp:616
 msgid "Load a Maxima file using the batch command"
-msgstr ""
+msgstr "Carica un file Maxima usando un comando batch"
 
 #: ../../src/wxMaximaFrame.cpp:611
 msgid "Load a Maxima package file"
-msgstr ""
+msgstr "Carica un file pacchetto Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1678
 msgid "Load a list from a csv file"
-msgstr ""
+msgstr "Carica una lista da un file csv"
 
 #: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
 msgid "Load a matrix from a csv file"
-msgstr ""
+msgstr "Carica una matrice da un file csv"
 
 #: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
 msgid "Load lapack"
-msgstr ""
+msgstr "Carica lapack"
 
 #: ../../src/wxMaxima.cpp:7208
 msgid "Load lisp code"
-msgstr ""
+msgstr "Carica codice lisp"
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "Load lisp..."
-msgstr ""
+msgstr "Carica lisp..."
 
 #: ../../src/wxMaximaFrame.cpp:1198
 msgid "Load the file/dir operations (operatingsystem)"
@@ -4256,11 +4391,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8219
 msgid "Loop variable"
-msgstr ""
+msgstr "Variabile di ciclo"
 
 #: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
 msgid "Lower bound:"
-msgstr ""
+msgstr "Intorno basso:"
 
 #: ../../src/wxMaximaFrame.cpp:1127
 msgid "Lower, ignoring case?..."
@@ -4268,23 +4403,23 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1448
 msgid "M&atrix"
-msgstr ""
+msgstr "M&atrice"
 
 #: ../../src/wxMaxima.cpp:7153
 msgid "Macro contents:"
-msgstr ""
+msgstr "Contenuti macro:"
 
 #: ../../src/wxMaxima.cpp:7148
 msgid "Macro name:"
-msgstr ""
+msgstr "Nome macro:"
 
 #: ../../src/wxMaximaFrame.cpp:1024
 msgid "Macros"
-msgstr ""
+msgstr "Macro"
 
 #: ../../src/wxMaximaFrame.cpp:697
 msgid "Main Toolbar\tAlt+Shift+B"
-msgstr ""
+msgstr "Barra strumenti principale\tAlt+Shift+B"
 
 #: ../../src/wxMaxima.cpp:7906
 msgid "Make a function value at a specific point known"
@@ -4296,35 +4431,35 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1070
 msgid "Make function local..."
-msgstr ""
+msgstr "Rendi la funzione locale..."
 
 #: ../../src/wxMaxima.cpp:8207
 msgid "Map"
-msgstr ""
+msgstr "Mappa"
 
 #: ../../src/wxMaxima.cpp:8215
 msgid "Map an expression"
-msgstr ""
+msgstr "Mappa un'espressione"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "Map function to a matrix"
-msgstr ""
+msgstr "Mappa la funzione su di una matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1446
 msgid "Map function to a matrix, affecting all of its clones"
-msgstr ""
+msgstr "Mappa la funzione su di una matrice, influenza tutti i suoi cloni"
 
 #: ../../src/Configuration.cpp:109
 msgid "Math Default"
-msgstr ""
+msgstr "Matem. predefinita"
 
 #: ../../src/wxMaximaFrame.cpp:286
 msgid "Mathematical Symbols"
-msgstr ""
+msgstr "Simboli matematici"
 
 #: ../../src/ToolBar.cpp:270
 msgid "Maths"
-msgstr ""
+msgstr "Matematici"
 
 #: ../../src/wxMaxima.cpp:7945 ../../src/wxMaxima.cpp:8022
 #: ../../src/wxMaxima.cpp:8027 ../../src/wxMaxima.cpp:8032
@@ -4336,39 +4471,39 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
 #: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
 msgid "Matrix"
-msgstr ""
+msgstr "Matrice"
 
 #: ../../src/wxMaxima.cpp:7986
 msgid "Matrix Exponent"
-msgstr ""
+msgstr "Esponente matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1339
 msgid "Matrix exponent..."
-msgstr ""
+msgstr "Esponente matrice..."
 
 #: ../../src/wxMaximaFrame.cpp:1329
 msgid "Matrix from csv file"
-msgstr ""
+msgstr "Matrice da file csv"
 
 #: ../../src/wxMaximaFrame.cpp:1323
 msgid "Matrix from csv file..."
-msgstr ""
+msgstr "Matrice da file csv..."
 
 #: ../../src/wxMaxima.cpp:8137
 msgid "Matrix map"
-msgstr ""
+msgstr "Mappa matrice"
 
 #: ../../src/wxMaxima.cpp:9630
 msgid "Matrix name:"
-msgstr ""
+msgstr "Nome matrice:"
 
 #: ../../src/wxMaximaFrame.cpp:798
 msgid "Matrix parenthesis"
-msgstr ""
+msgstr "Parentesi di matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1331
 msgid "Matrix to csv file"
-msgstr ""
+msgstr "Matrice verso file csv"
 
 #: ../../src/wxMaximaFrame.cpp:1334
 msgid "Matrix to file or Matrix from file"
@@ -4376,14 +4511,14 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1761
 msgid "Matrix to nested List"
-msgstr ""
+msgstr "Matrice a lista nidificata"
 
 #: ../../src/wxMaxima.cpp:7956 ../../src/wxMaxima.cpp:7961
 #: ../../src/wxMaxima.cpp:7966 ../../src/wxMaxima.cpp:7971
 #: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
 #: ../../src/wxMaxima.cpp:8136
 msgid "Matrix:"
-msgstr ""
+msgstr "Matrice:"
 
 #: ../../src/wxMaxima.cpp:8627
 msgid ""
@@ -4396,15 +4531,15 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:3473
 #, c-format
 msgid "Maxima architecture: %s"
-msgstr ""
+msgstr "Architettura di Maxima: %s"
 
 #: ../../src/StatusBar.cpp:252
 msgid "Maxima asks a question"
-msgstr ""
+msgstr "Maxima ha una domanda"
 
 #: ../../src/wxMaxima.cpp:4066
 msgid "Maxima asks a question!"
-msgstr ""
+msgstr "Maxima ha una domanda!"
 
 #: ../../src/wxMaxima.cpp:7118
 msgid ""
@@ -4418,163 +4553,164 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:84
 msgid "Maxima errors"
-msgstr ""
+msgstr "Errori maxima"
 
 #: ../../src/wxMaxima.cpp:3289
 msgid "Maxima has authenticated!"
-msgstr ""
+msgstr "Maxima si è autenticato!"
 
 #: ../../src/wxMaxima.cpp:10533
 msgid "Maxima has finished calculating."
-msgstr ""
+msgstr "Maxima ha finito di calcolare."
 
 #: ../../src/wxMaxima.cpp:5832
 msgid "Maxima has issued an error!"
-msgstr ""
+msgstr "Maxima ha prodotto un errore!"
 
 #: ../../src/wxMaxima.cpp:3696
 #, c-format
 msgid "Maxima has loaded the file %s."
-msgstr ""
+msgstr "Maxima ha caricato il file %s."
 
 #: ../../src/wxMaxima.cpp:3382
 msgid "Maxima has sent a new variable value."
-msgstr ""
+msgstr "Maxima ha inviato un nuovo valore variabile."
 
 #: ../../src/MaximaManual.cpp:552
 msgid "Maxima help file not found!"
-msgstr ""
+msgstr "File di aiuto maxima non trovato!"
 
 #: ../../src/wxMaximaFrame.cpp:1043
 msgid "Maxima input"
-msgstr ""
+msgstr "Ingresso di Maxima"
 
 #: ../../src/StatusBar.cpp:236
 msgid "Maxima is calculating"
-msgstr ""
+msgstr "Maxima sta calcolando"
 
 #: ../../src/wxMaxima.cpp:5068
 msgid "Maxima is ready for input."
-msgstr ""
+msgstr "Maxima è pronto per l'inserimento"
 
 #: ../../src/Dirstructure.cpp:144
 #, c-format
 msgid "Maxima not found as %s"
-msgstr ""
+msgstr "Maxima non trovato come %s"
 
 #: ../../src/wxMaxima.cpp:6211
 msgid "Maxima package (*.mac)|*.mac"
-msgstr ""
+msgstr "Pacchetto Maxima (*.mac)|*.mac"
 
 #: ../../src/wxMaxima.cpp:6202
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
-msgstr ""
+msgstr "Pacchetto Maxima (*.mac)|*.mac|Pacchetto Lisp (*.lisp)|*.lisp|Tutti|*"
 
 #: ../../src/wxMaxima.cpp:3012
 msgid "Maxima process terminated unexpectedly."
-msgstr ""
+msgstr "Il processo Maxima è terminato inaspettatamente."
 
 #: ../../src/Configuration.cpp:79
 msgid "Maxima question labels"
-msgstr ""
+msgstr "Etichette domanda di Maxima"
 
 #: ../../src/wxMaxima.cpp:3380
 msgid "Maxima sends a new set of auto-completable symbols."
-msgstr ""
+msgstr "Maxima invia un nuovo insieme di simboli auto completabili."
 
 #: ../../src/wxMaxima.cpp:3908
 msgid "Maxima sends us a new set of variables for the watch list."
-msgstr ""
+msgstr "Maxima ci spedisce un nuovo insieme di variabili per la watch list."
 
 #: ../../src/wxMaximaFrame.cpp:1944
 msgid "Maxima shows help in a browser"
-msgstr ""
+msgstr "Maxima mostra l'aiuto in un browser"
 
 #: ../../src/wxMaximaFrame.cpp:1940
 msgid "Maxima shows help in a sidebar"
-msgstr ""
+msgstr "Maxima mostra l'aiuto in una barra laterale"
 
 #: ../../src/wxMaximaFrame.cpp:1935
 msgid "Maxima shows help in the console"
-msgstr ""
+msgstr "Maxima mostra l'aiuto nella console"
 
 #: ../../src/StatusBar.cpp:232
 msgid "Maxima started. Waiting for authentication..."
-msgstr ""
+msgstr "Maxima avviato. In attesa di autenticazione..."
 
 #: ../../src/StatusBar.cpp:212
 msgid "Maxima started. Waiting for connection..."
-msgstr ""
+msgstr "Maxima avviato. In attesa di connessione..."
 
 #: ../../src/StatusBar.cpp:228
 msgid "Maxima started. Waiting for initial prompt..."
-msgstr ""
+msgstr "Maxima avviato. In attesa del prompt iniziale..."
 
 #: ../../src/wxMaximaFrame.cpp:1231
+#, fuzzy
 msgid "Maxima to other language"
-msgstr ""
+msgstr "maxima a altri linguaggi"
 
 #: ../../src/wxMaxima.cpp:7213
 msgid "Maxima to string"
-msgstr ""
+msgstr "Maxima a stringa"
 
 #: ../../src/wxMaxima.cpp:3397
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima user configuration is located in directory %s"
-msgstr ""
+msgstr "La configurazione utente Maxima sta nella cartella %s"
 
 #: ../../src/wxMaxima.cpp:3443
 #, c-format
 msgid "Maxima uses temp directory %s"
-msgstr ""
+msgstr "Maxima usa la cartella temporanea %s"
 
 #: ../../src/wxMaxima.cpp:3469
 #, c-format
 msgid "Maxima version: %s"
-msgstr ""
+msgstr "Versione Maxima: %s"
 
 #: ../../src/MaximaManual.cpp:390
 #, c-format
 msgid "Maxima version: %s, Anchors cache version"
-msgstr ""
+msgstr "Versione Maxima: %s, versione cache ancore"
 
 #: ../../src/wxMaximaFrame.cpp:1925
 msgid "Maxima vs. Programming languages"
-msgstr ""
+msgstr "Maxima vs linguaggi di programmazione"
 
 #: ../../src/Configuration.cpp:83
 msgid "Maxima warnings"
-msgstr ""
+msgstr "Avvertimenti di Maxima"
 
 #: ../../src/wxMaxima.cpp:3687
 #, c-format
 msgid "Maxima was compiled using %s"
-msgstr ""
+msgstr "Maxima è stato compilato usando %s"
 
 #: ../../src/wxMaxima.cpp:3487
 #, c-format
 msgid "Maxima's HTML manuals are in directory %s"
-msgstr ""
+msgstr "I manuali HTML di Maxima stanno nella cartella %s"
 
 #: ../../src/wxMaxima.cpp:3099
 #, c-format
 msgid "Maxima's PID is %li"
-msgstr ""
+msgstr "Il PID di maxima è %li"
 
 #: ../../src/wxMaxima.cpp:3681
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's demo files are located in directory %s"
-msgstr ""
+msgstr "I file condivisi di Maxima stanno nella cartella %s"
 
 #: ../../src/wxMaxima.cpp:3478
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's manual is located in directory %s"
-msgstr ""
+msgstr "Il manuale di Maxima sta nella cartella %s"
 
 #: ../../src/wxMaxima.cpp:3670
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's share files are located in directory %s"
-msgstr ""
+msgstr "I file condivisi di Maxima stanno nella cartella %s"
 
 #: ../../src/StatusBar.cpp:66
 msgid ""
@@ -4586,6 +4722,15 @@ msgid ""
 "not only intercepts connections from the outside, but also to intercept "
 "connections between two programs that run on the same computer."
 msgstr ""
+"Maxima, il programma che esegue effettivamente i calcoli matematici e "
+"wxMaxima, che mostra il foglio di lavoro sono mantenuti in processi "
+"separati. Ciò significa che anche se maxima dovesse andare in crash, "
+"wxMaxima (e perciò il foglio di lavoro) rimane intatto. Entrambi i programmi"
+" comunicano tramite un socket di rete locale. Questa non è stato possibile "
+"creare volta questo socket; il motivo potrebbe essere imputabile ad un "
+"firewall impostato non solo per intercettare le connessioni provenienti "
+"dall'esterno, ma anche quelle tra due programmi in esecuzione sullo stesso "
+"computer."
 
 #: ../../src/StatusBar.cpp:75
 msgid ""
@@ -4600,24 +4745,39 @@ msgid ""
 "might be that maxima cannot be found (see wxMaxima's Configuration dialogue "
 "for a way to specify maxima's location) or isn't in a working order."
 msgstr ""
+"Maxima, il programma che esegue effettivamente i calcoli matematici e "
+"wxMaxima, che mostra il foglio di lavoro sono mantenuti in processi "
+"separati. Ciò significa che anche se maxima dovesse andare in crash, "
+"wxMaxima (e perciò il foglio di lavoro) rimane intatto. Attualmente i due "
+"programmi non sono connessi tra di loro e ciò potrebbe significare che "
+"maxima sta ancora avviandosi o non riesce a partire. Oppure questo problema "
+"potrebbe essere causato da un firewall impostato non solo per intercettare "
+"le connessioni provenienti dall'esterno, ma anche quelle tra due programmi "
+"in esecuzione sullo stesso computer. Un altro fattore che potrebbe impedire "
+"l'avvio di maxima è che wxMaxima riesca a trovare la posizione esatta "
+"dell'eseguibile maxima su disco (controllare la finestra di configurazione "
+"di wxMaxima per indicare la posizione corretta di maxima) o che maxima abbia"
+" qualche problema in sè."
 
 #: ../../src/StatusBar.cpp:61
 msgid ""
 "Maxima, the program that does the actual mathematics is started as a separate process. This has the advantage that an eventual crash of maxima cannot harm wxMaxima, which displays the worksheet.\n"
 "This icon indicates if data is transferred between maxima and wxMaxima."
 msgstr ""
+"Maxima, il programma che esegue effettivamente i calcoli matematici, viene avviato come processo separato. Il vantaggio di ciò è che un eventuale crash di maxima non influirà su wxMaxima, che continuerà a mostrare il foglio di lavoro indisturbato.\n"
+"Questa icona indica se i dati sono stati trasferiti tra maxima e wxMaxima."
 
 #: ../../src/wxMaxima.cpp:9228
 msgid "Maximum absolute value printed without exponent"
-msgstr ""
+msgstr "Valore assoluto massimo stampato senza esponente"
 
 #: ../../src/wxMaxima.cpp:9230
 msgid "Maximum number of digits to be displayed:"
-msgstr ""
+msgstr "Numero massimo di cifre da visualizzare:"
 
 #: ../../src/wxMaxima.cpp:9568
 msgid "Mean:"
-msgstr ""
+msgstr "Media:"
 
 #: ../../src/wxMaximaFrame.cpp:1924
 msgid "Memoizing"
@@ -4625,19 +4785,19 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1013
 msgid "Memory"
-msgstr ""
+msgstr "Memoria"
 
 #: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
 msgid "Merge Cells"
-msgstr ""
+msgstr "Fondi celle"
 
 #: ../../src/wxMaxima.cpp:5780
 msgid "Message from the stdout of Maxima: "
-msgstr ""
+msgstr "Messaggio dallo stdout di Maxima: "
 
 #: ../../src/wxMaximaFrame.cpp:1326
 msgid "Methods of generating a matrix"
-msgstr ""
+msgstr "Metodi per generare una matrice"
 
 #: ../../src/Worksheet.cpp:6866
 #, c-format
@@ -4646,11 +4806,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9226
 msgid "Minimum absolute value printed without exponent:"
-msgstr ""
+msgstr "Valore assoluto minimo stampato senza esponente:"
 
 #: ../../src/wxMaxima.cpp:10449 ../../src/wxMaxima.cpp:10451
 msgid "Mismatched parenthesis"
-msgstr ""
+msgstr "Parentesi sbilanciate"
 
 #: ../../src/wxMaximaFrame.cpp:1352
 msgid "Multiplication, exponent and similar"
@@ -4662,132 +4822,138 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1338
 msgid "Multiply matrices..."
-msgstr ""
+msgstr "Moltiplica matrici..."
 
 #: ../../src/wxMaxima.cpp:7981
 msgid "Multiply two matrices"
-msgstr ""
+msgstr "Moltiplica due matrici"
 
 #: ../../src/wxMaxima.cpp:9581
 msgid "Multivariate linear regression"
-msgstr ""
+msgstr "Regressione lineare multivariata"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Name of t:"
-msgstr ""
+msgstr "Nome di t:"
 
 #: ../../src/wxMaxima.cpp:7838
 msgid "Name of x:"
-msgstr ""
+msgstr "Nome di x:"
 
 #: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
 msgid "Nested list to Matrix"
-msgstr ""
+msgstr "Lista annidata a matrice"
 
 #: ../../src/wxMaximaFrame.cpp:769 ../../src/wxMaximaFrame.cpp:1053
 msgid "Never"
-msgstr ""
+msgstr "Mai"
 
 #: ../../src/wxMaxima.cpp:6534
 msgid "Never autosubscript this variable"
-msgstr ""
+msgstr "Mai pedice questa variabile"
 
 #: ../../src/wxMaximaFrame.cpp:776
 msgid "Never display this variable with subscript"
-msgstr ""
+msgstr "Mai mostrare in pedice questa variabile"
 
 #: ../../src/Worksheet.cpp:1469 ../../src/Worksheet.cpp:1843
 msgid "Never offer known answers"
-msgstr ""
+msgstr "Non offrire mai risposte conosciute"
 
 #: ../../src/ToolBar.cpp:174
 msgid "New"
-msgstr ""
+msgstr "Nuovo"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "New\tCtrl+N"
-msgstr ""
+msgstr "Nuovo\tCtrl+N"
 
 #: ../../src/ToolBar.cpp:611
 msgid "New button"
-msgstr ""
+msgstr "Nuovo pulsante"
 
 #: ../../src/wxMaxima.cpp:2483
 msgid "New connection attempt whilst already connected."
-msgstr ""
+msgstr "Nuovo tentativo di connessione mentre si è già connessi."
 
 #: ../../src/wxMaxima.cpp:2491
 msgid ""
 "New connection attempt, but no currently no socket maxima could connect to."
 msgstr ""
+"Nuovo tentativo di connessione, ma senza un socket al quale maxima possa "
+"collegarsi."
 
 #: ../../src/wxMaxima.cpp:2487
 msgid "New connection attempt, but no currently running maxima process."
 msgstr ""
+"Nuovo tentativo di connessione, ma senza processo maxima attualmente in "
+"esecuzione."
 
 #: ../../src/ToolBar.cpp:174
 msgid "New document"
-msgstr ""
+msgstr "Nuovo documento"
 
 #: ../../src/wxMaxima.cpp:3899
 #, c-format
 msgid "New maxima Operators detected: %s"
-msgstr ""
+msgstr "Rilevato nuovo operatore maxima: %s"
 
 #: ../../src/wxMaxima.cpp:7390
 msgid "New part:"
-msgstr ""
+msgstr "Nuova parte:"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
 #: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
 msgid "New variable:"
-msgstr ""
+msgstr "Nuova variabile:"
 
 #: ../../src/wxMaximaFrame.cpp:929
 msgid "Next Command\tAlt+Down"
-msgstr ""
+msgstr "Comando successivo\tAlt+Down"
 
 #: ../../src/wxMaximaFrame.cpp:748
 msgid "Nice Graphical Equations"
-msgstr ""
+msgstr "Belle equazioni grafiche"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "No"
-msgstr ""
+msgstr "No"
 
 #: ../../src/Worksheet.cpp:1972
 msgid "No Array"
-msgstr ""
+msgstr "No array"
 
 #: ../../src/Worksheet.cpp:1974
 msgid "No Scalar"
-msgstr ""
+msgstr "No scalare"
 
 #: ../../src/wxMaxima.cpp:10482
 msgid "No dollar ($) or semicolon (;) at the end of command"
-msgstr ""
+msgstr "Dollaro ($) o punto e virgola (;) alla fine del comando"
 
 #: ../../src/MaximaManual.cpp:406
 msgid "No entries in the caches for the subjects the manual contains."
-msgstr ""
+msgstr "Nessuna voce nella cache per gli argomenti che il manuale contiene."
 
 #: ../../src/MaximaManual.cpp:101
 msgid ""
 "No file with the subjects the manual contained in the last wxMaxima run."
 msgstr ""
+"Nessun file con gli argomenti contenuti nel manuale nell'ultima esecuzione "
+"di wxMaxima."
 
 #: ../../src/Image.cpp:495
 msgid "No gnuplot data!"
-msgstr ""
+msgstr "Nessuno dato gnuplot!"
 
 #: ../../src/Image.cpp:530
 msgid "No gnuplot source!"
-msgstr ""
+msgstr "Nessuna sorgente gnuplot!"
 
 #: ../../src/wxMaxima.cpp:6662 ../../src/wxMaxima.cpp:6668
 #: ../../src/wxMaxima.cpp:6687 ../../src/wxMaxima.cpp:6697
 msgid "No matches found!"
-msgstr ""
+msgstr "Nessuna corrispondenza trovata!"
 
 #: ../../src/wxMaxima.cpp:3240
 msgid "No topics found in topic flag"
@@ -4799,19 +4965,19 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:797
 msgid "None"
-msgstr ""
+msgstr "Nulla"
 
 #: ../../src/wxMaxima.cpp:8163
 msgid "Not a valid matrix dimension!"
-msgstr ""
+msgstr "Dimensione matrice non valida!"
 
 #: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
 msgid "Not a valid number of equations!"
-msgstr ""
+msgstr "Numero di equazioni non valido!"
 
 #: ../../src/StatusBar.cpp:256
 msgid "Not connected to Maxima"
-msgstr ""
+msgstr "Non connesso a Maxima"
 
 #: ../../src/wxMaxima.cpp:10496
 msgid "Not triggering evaluation as maxima is still busy!"
@@ -4827,88 +4993,89 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8926
 msgid "Num. deg:"
-msgstr ""
+msgstr "Num. deg:"
 
 #: ../../src/wxMaxima.cpp:8540
 msgid "Number of elements"
-msgstr ""
+msgstr "Numero di elementi"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
 msgid "Number of equations:"
-msgstr ""
+msgstr "Numero di equazioni:"
 
 #: ../../src/wxMaxima.cpp:7481
 msgid "Number to octets"
-msgstr ""
+msgstr "Numero di otteti"
 
 #: ../../src/wxMaximaFrame.cpp:1154
 msgid "Number to octets..."
-msgstr ""
+msgstr "Numero di otteti..."
 
 #: ../../src/wxMaximaFrame.cpp:1906
 msgid "Number types"
-msgstr ""
+msgstr "Tipi di numeri"
 
 #: ../../src/wxMaxima.cpp:7482
 msgid "Number:"
-msgstr ""
+msgstr "Numero:"
 
 #: ../../src/wxMaximaFrame.cpp:1786
 msgid "Numeric output"
-msgstr ""
+msgstr "Risultati numerici"
 
 #: ../../src/wxMaxima.cpp:8040
 msgid "Numerical QR decomposition of a matrix"
-msgstr ""
+msgstr "Decomposizione QR numerica di una matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1417
 msgid "Numerical operations (lapack)"
-msgstr ""
+msgstr "Operazioni numeriche (lapack)"
 
 #: ../../src/wxMaxima.cpp:7831
 msgid "Numerical solution for 1st degree ODE"
-msgstr ""
+msgstr "Soluzione numerica per un'ODE di primo grado"
 
 #: ../../src/wxMaximaFrame.cpp:1282
 msgid "Numerical solution..."
-msgstr ""
+msgstr "Soluzione numerica..."
 
 #: ../../src/wxMaximaFrame.cpp:1261
+#, fuzzy
 msgid "Numerical solutions of polynomial (bfloat)..."
-msgstr ""
+msgstr "Soluzioni numeriche di una polinomiale..."
 
 #: ../../src/wxMaximaFrame.cpp:1258
 msgid "Numerical solutions of polynomial..."
-msgstr ""
+msgstr "Soluzioni numeriche di una polinomiale..."
 
 #: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: ../../src/wxMaximaFrame.cpp:122
 #, c-format
 msgid "OS: %s Version %li.%li"
-msgstr ""
+msgstr "OS: %s Versione %li.%li"
 
 #: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
 msgid "Object composed of elements"
-msgstr ""
+msgstr "Oggetto composto da elementi"
 
 #: ../../src/wxMaxima.cpp:7680
 msgid "Object name:"
-msgstr ""
+msgstr "Nome oggetto:"
 
 #: ../../src/wxMaxima.cpp:7281
 msgid "Object:"
-msgstr ""
+msgstr "Oggetto:"
 
 #: ../../src/wxMaxima.cpp:7486
 msgid "Octets to Number"
-msgstr ""
+msgstr "Otteti a numero"
 
 #: ../../src/wxMaxima.cpp:7491
 msgid "Octets to String"
-msgstr ""
+msgstr "Otteti a stringa"
 
 #: ../../src/wxMaximaFrame.cpp:1156
 msgid "Octets to number..."
@@ -4916,61 +5083,61 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1158
 msgid "Octets to string..."
-msgstr ""
+msgstr "Otteti a stringa..."
 
 #: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
 msgid "Octets:"
-msgstr ""
+msgstr "Otteti:"
 
 #: ../../src/Worksheet.cpp:1958
 msgid "Odd number"
-msgstr ""
+msgstr "Numero dispari"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
 #: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
 msgid "Old variable:"
-msgstr ""
+msgstr "Vecchia variabile:"
 
 #: ../../src/wxMaximaFrame.cpp:1055
 msgid "On all errors"
-msgstr ""
+msgstr "Con tutti gli errori"
 
 #: ../../src/wxMaximaFrame.cpp:1054
 msgid "On lisp errors"
-msgstr ""
+msgstr "Con errori lisp"
 
 #: ../../src/wxMaxima.cpp:9566
 msgid "One sample t-test"
-msgstr ""
+msgstr "Test t a un campione"
 
 #: ../../src/wxMaximaFrame.cpp:1927
 msgid "Online tutorials"
-msgstr ""
+msgstr "Guide online"
 
 #: ../../src/wxMaximaFrame.cpp:766
 msgid "Only Integers and single letters"
-msgstr ""
+msgstr "Solo interi e lettere singole"
 
 #: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593
 #: ../../src/wxMaxima.cpp:6074
 msgid "Open"
-msgstr ""
+msgstr "Apri"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "Open a document"
-msgstr ""
+msgstr "Apri un documento"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "Open a new window"
-msgstr ""
+msgstr "Apri una nuova finestra"
 
 #: ../../src/ToolBar.cpp:617
 msgid "Open and save button"
-msgstr ""
+msgstr "Pulsante apri e salva"
 
 #: ../../src/ToolBar.cpp:176
 msgid "Open document"
-msgstr ""
+msgstr "Apri documento"
 
 #: ../../src/wxMaxima.cpp:7239
 msgid "Open for appending"
@@ -4986,94 +5153,94 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1098
 msgid "Open for reading..."
-msgstr ""
+msgstr "Aperto per la lettura..."
 
 #: ../../src/wxMaxima.cpp:7249
 msgid "Open for writing"
-msgstr ""
+msgstr "Aperto per la scrittura"
 
 #: ../../src/wxMaximaFrame.cpp:1100
 msgid "Open for writing..."
-msgstr ""
+msgstr "Aperto per la scrittura..."
 
 #: ../../src/wxMaxima.cpp:9598
 msgid "Open matrix"
-msgstr ""
+msgstr "Apri matrice"
 
 #: ../../src/wxMaximaFrame.cpp:600
 msgid "Open recent"
-msgstr ""
+msgstr "Apri recenti"
 
 #: ../../src/wxMaxima.cpp:4309
 msgid "Opening a wxmx file"
-msgstr ""
+msgstr "Apertura di un file wxmx"
 
 #: ../../src/wxMaxima.cpp:4153 ../../src/wxMaxima.cpp:4214
 #: ../../src/wxMaxima.cpp:4313 ../../src/wxMaxima.cpp:4622
 msgid "Opening file"
-msgstr ""
+msgstr "Apertura file"
 
 #: ../../src/wxMaxima.cpp:5030
 #, c-format
 msgid "Opening help file %s"
-msgstr ""
+msgstr "Apertura file di aiuto %s"
 
 #: ../../src/wxMaximaFrame.cpp:1530
 msgid "Optimize for CPU time"
-msgstr ""
+msgstr "Ottimizza per il tempo CPU"
 
 #: ../../src/wxMaximaFrame.cpp:1529
 msgid "Optimize for memory"
-msgstr ""
+msgstr "Ottimizza per la memoria"
 
 #: ../../src/ToolBar.cpp:199
 msgid "Options"
-msgstr ""
+msgstr "Opzioni"
 
 #: ../../src/wxMaximaFrame.cpp:1225
 msgid "Output C"
-msgstr ""
+msgstr "Uscita C"
 
 #: ../../src/wxMaximaFrame.cpp:1226
 msgid "Output Fortran"
-msgstr ""
+msgstr "Uscita Fortran"
 
 #: ../../src/wxMaximaFrame.cpp:1228
 msgid "Output Rational Fortran"
-msgstr ""
+msgstr "Uscita Fortran razionale"
 
 #: ../../src/Configuration.cpp:80
 msgid "Output labels"
-msgstr ""
+msgstr "Uscita etichette"
 
 #: ../../src/Configuration.cpp:73
 msgid "Output: Function names"
-msgstr ""
+msgstr "Uscita: nomi funzione"
 
 #: ../../src/Configuration.cpp:75
 msgid "Output: Latin names as greek symbols"
-msgstr ""
+msgstr "Uscita: nomi latini come simboli greci"
 
 #: ../../src/Configuration.cpp:72
 msgid "Output: Numbers and Digits"
-msgstr ""
+msgstr "Uscita: numeri e cifre"
 
 #: ../../src/Configuration.cpp:71
 msgid "Output: Operators"
-msgstr ""
+msgstr "Uscita: operatori"
 
 #: ../../src/Configuration.cpp:74
 #, c-format
 msgid "Output: Special constants (%e,%i)"
-msgstr ""
+msgstr "Uscita: costanti speciali (%e,%i)"
 
 #: ../../src/Configuration.cpp:76
 msgid "Output: Strings"
-msgstr ""
+msgstr "Uscita: stringhe"
 
 #: ../../src/Configuration.cpp:70
 msgid "Output: Variable names"
-msgstr ""
+msgstr "Uscita: nomi variabili"
 
 #: ../../src/wxMaxima.cpp:6442
 msgid ""
@@ -5082,6 +5249,9 @@ msgid ""
 "(*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format "
 "(*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"Immagine PNG (*.png)|*.png|Immagine JPEG (*.jpg)|*.jpg|Immagine GIF "
+"(*.gif)|*.gif|Immagine SVG (*.svg)|*.svg|Immagine BMP (*.bmp)|*.bmp|Immagine"
+" PNM (*.pnm)|*.pnm|Immagine TIFF (*.tif)|*.tif|Immagine XPM (*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:10117
 msgid ""
@@ -5089,107 +5259,110 @@ msgid ""
 "(*.bmp)|*.bmp|GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged "
 "image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"Immagine PNG (*.png)|*.png|Immagine JPEG (*.jpg)|*.jpg|Immagine BMP "
+"(*.bmp)|*.bmp|Immagine GIF (*.gif)|*.gif|Immagine PNM (*.pnm)|*.pnm|Immagine"
+" TIFF (*.tif)|*.tif|Immagine XPM (*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:8924
 msgid "Pade approximation"
-msgstr ""
+msgstr "Approssimazione di Pade"
 
 #: ../../src/wxMaximaFrame.cpp:1478
 msgid "Pade approximation of a Taylor series"
-msgstr ""
+msgstr "Approssimazione Pade di una serie di Taylor"
 
 #: ../../src/wxMaximaFrame.cpp:1637
 msgid "Parallel Substitute..."
-msgstr ""
+msgstr "Sostituzione parallela..."
 
 #: ../../src/wxMaxima.cpp:8738
 msgid "Parallel substitution"
-msgstr ""
+msgstr "Sosituzione parallela"
 
 #: ../../src/wxMaxima.cpp:7179
 msgid "Parameter name:"
-msgstr ""
+msgstr "Nome parametro:"
 
 #: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
 msgid "Parameter(s):"
-msgstr ""
+msgstr "Parametro(i):"
 
 #: ../../src/wxMaxima.cpp:7399
 msgid "Parse string"
-msgstr ""
+msgstr "Analizza stringhe"
 
 #: ../../src/wxMaximaFrame.cpp:1152
 msgid "Parse string only..."
-msgstr ""
+msgstr "Analizza solo stringhe..."
 
 #: ../../src/StatusBar.cpp:240
 msgid "Parsing output"
-msgstr ""
+msgstr "Elaborazione uscita"
 
 #: ../../src/wxMaxima.cpp:7464
 msgid "Part:"
-msgstr ""
+msgstr "Parte:"
 
 #: ../../src/wxMaximaFrame.cpp:1499 ../../src/wxMaximaFrame.cpp:1535
 msgid "Partial &Fractions..."
-msgstr ""
+msgstr "&Frazioni parziali..."
 
 #: ../../src/wxMaxima.cpp:8975
 msgid "Partial Fractions"
-msgstr ""
+msgstr "Frazioni parziali"
 
 #: ../../src/wxMaxima.cpp:4702
 msgid "Parts of the document will not be loaded correctly!"
-msgstr ""
+msgstr "Parti del documento non saranno caricate correttamente!"
 
 #: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
 #: ../../src/Worksheet.cpp:1685
 msgid "Paste"
-msgstr ""
+msgstr "Incolla"
 
 #: ../../src/wxMaximaFrame.cpp:667
 msgid "Paste\tCtrl+V"
-msgstr ""
+msgstr "Incolla\tCtrl+V"
 
 #: ../../src/ToolBar.cpp:211
 msgid "Paste from clipboard"
-msgstr ""
+msgstr "Incolla dagli appunti"
 
 #: ../../src/wxMaximaFrame.cpp:668
 msgid "Paste text from clipboard"
-msgstr ""
+msgstr "Incolla testo dagli appunti"
 
 #: ../../src/wxMaxima.cpp:4841
 msgid "Please configure wxMaxima with 'Edit->Configure'."
-msgstr ""
+msgstr "Configurare wxMaxima con \"Modifica->Configura\"."
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot &2d..."
-msgstr ""
+msgstr "Grafico &2d..."
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot &3d..."
-msgstr ""
+msgstr "Grafico &3d..."
 
 #: ../../src/wxMaximaFrame.cpp:1772
 msgid "Plot &Format..."
-msgstr ""
+msgstr "&Formato grafico..."
 
 #: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
 msgid "Plot 2D"
-msgstr ""
+msgstr "Grafico 2D"
 
 #: ../../src/Worksheet.cpp:1593
 msgid "Plot 2D..."
-msgstr ""
+msgstr "Grafico 2D..."
 
 #: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
 msgid "Plot 3D"
-msgstr ""
+msgstr "Grafico 3D"
 
 #: ../../src/Worksheet.cpp:1595
 msgid "Plot 3D..."
-msgstr ""
+msgstr "Grafico 3D..."
 
 #: ../../src/wxMaxima.cpp:9538
 msgid "Plot as bars"
@@ -5205,58 +5378,58 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9112
 msgid "Plot format"
-msgstr ""
+msgstr "Formato grafico"
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot in 2 dimensions"
-msgstr ""
+msgstr "Grafico in 2 dimensioni"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot in 3 dimensions"
-msgstr ""
+msgstr "Grafico in 3 dimensioni"
 
 #: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
 msgid "Plot using Draw"
-msgstr ""
+msgstr "Grafico usando Draw"
 
 #: ../../src/wxMaxima.cpp:7824
 msgid "Point #1 with known value:"
-msgstr ""
+msgstr "Punto #1 con valore noto:"
 
 #: ../../src/wxMaxima.cpp:7826
 msgid "Point #2 with known value:"
-msgstr ""
+msgstr "Punto #2 con valore noto:"
 
 #: ../../src/wxMaxima.cpp:7800 ../../src/wxMaxima.cpp:7811
 msgid "Point the value is known at:"
-msgstr ""
+msgstr "Punto in cui è noto il valore:"
 
 #: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
 msgid "Point:"
-msgstr ""
+msgstr "Punto:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 1:"
-msgstr ""
+msgstr "Polinomiale 1:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 2:"
-msgstr ""
+msgstr "Polinomiale 2:"
 
 #: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
 #: ../../src/wxMaxima.cpp:7739
 msgid "Polynomial:"
-msgstr ""
+msgstr "Polinomiale:"
 
 #: ../../src/wxMaximaFrame.cpp:1754
 msgid "Pop"
-msgstr ""
+msgstr "Pop"
 
 #: ../../src/Worksheet.cpp:1331 ../../src/Worksheet.cpp:1485
 msgid "Popout interactively"
-msgstr ""
+msgstr "Popout interattivamente"
 
 #: ../../src/wxMaximaFrame.cpp:1189
 msgid "Position of a match"
@@ -5264,146 +5437,149 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
 msgid "Position:"
-msgstr ""
+msgstr "Posizione:"
 
 #: ../../src/wxMaxima.cpp:8939
 msgid "Power series"
-msgstr ""
+msgstr "Serie di potenze"
 
 #: ../../src/wxMaximaFrame.cpp:1475
 msgid "Power series..."
-msgstr ""
+msgstr "Serie di potenze..."
 
 #: ../../src/wxMaxima.cpp:9202
 msgid "Precision"
-msgstr ""
+msgstr "Precisione"
 
 #: ../../src/Worksheet.cpp:1616
 msgid "Prefer user labels"
-msgstr ""
+msgstr "Preferisci le etichette utente"
 
 #: ../../src/main.cpp:437
 msgid "Preferences"
-msgstr ""
+msgstr "Preferenze"
 
 #: ../../src/ToolBar.cpp:626
 msgid "Preferences button"
-msgstr ""
+msgstr "Punsante delle preferenze"
 
 #: ../../src/wxMaximaFrame.cpp:685
 msgid "Preferences...\tCtrl+,"
-msgstr ""
+msgstr "Preferenze...\tCtrl+,"
 
 #: ../../src/wxMaximaFrame.cpp:1733
 msgid "Prepend an element"
-msgstr ""
+msgstr "Metti in cima un elemento"
 
 #: ../../src/wxMaximaFrame.cpp:927
 msgid "Previous Command\tAlt+Up"
-msgstr ""
+msgstr "Comando precedente\tAlt+Up"
 
 #: ../../src/ToolBar.cpp:184
 msgid "Print"
-msgstr ""
+msgstr "Stampa"
 
 #: ../../src/ToolBar.cpp:620
 msgid "Print button"
-msgstr ""
+msgstr "Pulsante di stampa"
 
 #: ../../src/Worksheet.cpp:1493
 msgid "Print cell brackets"
-msgstr ""
+msgstr "Stampa parentesi cella"
 
 #: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
 msgid "Print document"
-msgstr ""
+msgstr "Stampa documento"
 
 #: ../../src/wxMaximaFrame.cpp:1829
 msgid "Print floating-point numbers with exponents dividable by 3"
-msgstr ""
+msgstr "Stampa i numeri in virgola mobile con esponenti divisibili per 3"
 
 #: ../../src/WXMXformat.cpp:255
 msgid ""
 "Produced invalid XML. The erroneous XML data has therefore not been saved "
 "but has been put on the clipboard in order to allow to debug it."
 msgstr ""
+"Prodotto un XML non valido. I dati XML errati non sono perciò stati salvati "
+"ma sono stati inseriti negli appunti in modo da consentirne la correzione."
 
 #: ../../src/wxMaxima.cpp:9061
 msgid "Product"
-msgstr ""
+msgstr "Prodotto"
 
 #: ../../src/wxMaximaFrame.cpp:1095
 msgid "Program"
-msgstr ""
+msgstr "Programma"
 
 #: ../../src/wxMaxima.cpp:7061
 msgid "Program (no local variables)"
-msgstr ""
+msgstr "Programma (no variabili locali)"
 
 #: ../../src/wxMaxima.cpp:7052
 msgid "Program block"
-msgstr ""
+msgstr "Blocco programma"
 
 #: ../../src/wxMaximaFrame.cpp:1066
 msgid "Program block with local variables..."
-msgstr ""
+msgstr "Blocco programma con variabili locali..."
 
 #: ../../src/wxMaximaFrame.cpp:1068
 msgid "Program block, no local variables..."
-msgstr ""
+msgstr "Blocco programma, senza variabili locali..."
 
 #: ../../src/wxMaximaFrame.cpp:1751
 msgid "Push"
-msgstr ""
+msgstr "Push"
 
 #: ../../src/wxMaxima.cpp:8508
 msgid "Push an element to a list"
-msgstr ""
+msgstr "Inserisci un elemento in una lista"
 
 #: ../../src/wxMaximaFrame.cpp:1395
 msgid "QR decomposition"
-msgstr ""
+msgstr "Decomposizione QR"
 
 #: ../../src/wxMaxima.cpp:3621
 msgid "Querying gnuplot which graphics drivers it supports."
-msgstr ""
+msgstr "Interrogazione di gnuplot sui driver grafici supportati."
 
 #: ../../src/wxMaxima.cpp:8953
 msgid "Range radius:"
-msgstr ""
+msgstr "Campo raggio:"
 
 #: ../../src/wxMaximaFrame.cpp:1374
 msgid "Rank"
-msgstr ""
+msgstr "Rango"
 
 #: ../../src/wxMaximaFrame.cpp:246 ../../src/wxMaximaFrame.cpp:722
 msgid "Raw XML monitor"
-msgstr ""
+msgstr "Monitor XML grezzo"
 
 #: ../../src/wxMaximaFrame.cpp:2117
 #, c-format
 msgid "Re-Reading the config from %s."
-msgstr ""
+msgstr "Rileggi la configurazione da %s."
 
 #: ../../src/wxMaximaFrame.cpp:2114
 msgid "Re-Reading the config from the default location."
-msgstr ""
+msgstr "Rileggi la configurazione dalla posizione predefinita."
 
 #: ../../src/wxMaximaFrame.cpp:867
 msgid "Re-evaluate all cells above the one the cursor is in"
-msgstr ""
+msgstr "Ri-elabora tutte le celle sopra quella dove si trova il cursore"
 
 #: ../../src/wxMaximaFrame.cpp:877
 msgid "Re-evaluate all cells below the one the cursor is in"
-msgstr ""
+msgstr "Ri-elabora tutte le celle sopra quella dove si trova il cursore"
 
 #: ../../src/main.cpp:366
 msgid "Re-opening STDERR failed."
 msgstr ""
 
 #: ../../src/main.cpp:367
+#, fuzzy
 msgid "Re-opening STDIN failed."
-msgstr ""
+msgstr "Apertura file"
 
 #: ../../src/main.cpp:365
 msgid "Re-opening STDOUT failed."
@@ -5417,53 +5593,53 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:6668
 msgid "Read .wxm data from clipboard"
-msgstr ""
+msgstr "Leggi dati .wxm dagli appunti"
 
 #: ../../src/wxMaxima.cpp:7599
 msgid "Read Directory"
-msgstr ""
+msgstr "Leggi cartella"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Read List from csv file..."
-msgstr ""
+msgstr "Leggi lista da file csv..."
 
 #: ../../src/wxMaxima.cpp:7196
 msgid "Read a structure field"
-msgstr ""
+msgstr "Leggi un campo struttura"
 
 #: ../../src/wxMaxima.cpp:7270 ../../src/wxMaxima.cpp:7274
 msgid "Read byte"
-msgstr ""
+msgstr "Leggi byte"
 
 #: ../../src/wxMaxima.cpp:7266
 msgid "Read char"
-msgstr ""
+msgstr "Leggi carattere"
 
 #: ../../src/wxMaxima.cpp:7593
 msgid "Read environment variable"
-msgstr ""
+msgstr "Leggi variabile ambiente"
 
 #: ../../src/wxMaximaFrame.cpp:1219
 msgid "Read environment variable..."
-msgstr ""
+msgstr "Leggi variabile ambiente..."
 
 #: ../../src/wxMaxima.cpp:7262
 msgid "Read line"
-msgstr ""
+msgstr "Leggi linea"
 
 #: ../../src/MaximaManual.cpp:113
 #, c-format
 msgid "Read the entries the maxima manual offers from %s"
-msgstr ""
+msgstr "Leggi le voci che il manuale di maxima offre da %s"
 
 #: ../../src/StatusBar.cpp:245
 msgid "Reading Maxima output"
-msgstr ""
+msgstr "Lettura risultati maxima"
 
 #: ../../src/StatusBar.cpp:247
 #, c-format
 msgid "Reading Maxima output: %li bytes"
-msgstr ""
+msgstr "Lettura uscita Maxima: %li byte"
 
 #: ../../src/wxMathml.cpp:55
 #, c-format
@@ -5477,15 +5653,15 @@ msgstr ""
 #: ../../src/wxMaximaFrame.cpp:148
 #, c-format
 msgid "Reading the config from %s."
-msgstr ""
+msgstr "Lettura della configurazione da %s."
 
 #: ../../src/wxMaximaFrame.cpp:151
 msgid "Reading the config from the default location."
-msgstr ""
+msgstr "Lettura della configurazione dalla posizione predefinita."
 
 #: ../../src/StatusBar.cpp:224
 msgid "Ready for user input"
-msgstr ""
+msgstr "In attesa di dati dall'utente"
 
 #: ../../src/Worksheet.cpp:960
 msgid "Recalculated the whole worksheet at once => Updating its size"
@@ -5497,97 +5673,101 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:930
 msgid "Recall next command from history"
-msgstr ""
+msgstr "Richiama il comando successivo dalla cronologia"
 
 #: ../../src/wxMaximaFrame.cpp:928
 msgid "Recall previous command from history"
-msgstr ""
+msgstr "Richiama il comando precedente dalla cronologia"
 
 #: ../../src/wxMaxima.cpp:3235
 #, c-format
 msgid "Received manual topic request: %s"
-msgstr ""
+msgstr "Ricevuta richiesta argomento manuale: %s"
 
 #: ../../src/wxMaxima.cpp:3097
 #, c-format
 msgid "Received maxima's first prompt: %s"
-msgstr ""
+msgstr "Ricevuto il primo prompt di maxima: %s"
 
 #: ../../src/wxMaximaFrame.cpp:603
 msgid "Recover unsaved"
-msgstr ""
+msgstr "Recupero non salvato"
 
 #: ../../src/wxMaximaFrame.cpp:1640
 msgid "Recursive Substitute..."
-msgstr ""
+msgstr "Sostituisci ricorsivo..."
 
 #: ../../src/wxMaxima.cpp:8746
 msgid "Recursive substitution"
-msgstr ""
+msgstr "Sostituzione ricorsiva"
 
 #: ../../src/ToolBar.cpp:192
 msgid "Redo"
-msgstr ""
+msgstr "Rifai"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo\tCtrl+Y"
-msgstr ""
+msgstr "Ripeti\tCtrl+Y"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo last change"
-msgstr ""
+msgstr "Ripeti l'ultima modifica"
 
 #: ../../src/wxMaximaFrame.cpp:1595
 msgid "Reduce trigonometric expression"
-msgstr ""
+msgstr "Riduci l'espressione trigonometrica"
 
 #: ../../src/wxMaxima.cpp:2366 ../../src/wxMaxima.cpp:10630
 msgid "Refusing to send cell to maxima: "
-msgstr ""
+msgstr "Rifiuto di spedire la cella a maxima:"
 
 #: ../../src/wxMaxima.cpp:7523
 msgid "Regex match"
-msgstr ""
+msgstr "Riscontro regex"
 
 #: ../../src/wxMaxima.cpp:7518
 msgid "Regex match position"
-msgstr ""
+msgstr "Posizione riscontro regex"
 
 #: ../../src/wxMaximaFrame.cpp:1195
+#, fuzzy
 msgid "Regular expression that matches a string"
-msgstr ""
+msgstr "Regex che corrisponde ad una stringa"
 
 #: ../../src/wxMaximaFrame.cpp:1196
+#, fuzzy
 msgid "Regular expressions"
-msgstr ""
+msgstr "Integra l'espressione"
 
 #: ../../src/Worksheet.cpp:1314
 msgid "Reload Image"
-msgstr ""
+msgstr "Ricarica immagine"
 
 #: ../../src/Worksheet.cpp:1320
 #, c-format
 msgid "Reload Image \"%s\""
-msgstr ""
+msgstr "Ricarica immagine \"%s\""
 
 #: ../../src/wxMaxima.cpp:9809
 #, c-format
 msgid "Reloading image file %s."
-msgstr ""
+msgstr "Ricaricamento file immagine %s."
 
 #: ../../src/wxMaximaFrame.cpp:883
 msgid "Remove All Output"
-msgstr ""
+msgstr "Elimina tutti i risultati"
 
 #: ../../src/wxMaximaFrame.cpp:1426
 msgid "Remove Rows or Columns..."
-msgstr ""
+msgstr "Rimuovi righe o colonne..."
 
 #: ../../src/wxMaximaFrame.cpp:1748
 msgid ""
 "Remove all list elements that appear twice in a row. Normally used in "
 "conjunction with sort."
 msgstr ""
+"Rimuove tutti gli elementi doppi in una riga della lista. Usata normalmente "
+"assieme a ordina."
 
 #: ../../src/wxMaximaFrame.cpp:1174
 msgid "Remove all occurrences of a word..."
@@ -5599,19 +5779,19 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8592
 msgid "Remove an element from a list"
-msgstr ""
+msgstr "Rimuovi un elemento da una lista"
 
 #: ../../src/wxMaxima.cpp:7566
 msgid "Remove directory"
-msgstr ""
+msgstr "Rimuovi cartella"
 
 #: ../../src/wxMaximaFrame.cpp:1204
 msgid "Remove directory..."
-msgstr ""
+msgstr "Rimuovi cartella..."
 
 #: ../../src/wxMaximaFrame.cpp:1747
 msgid "Remove duplicates"
-msgstr ""
+msgstr "Rimuovi duplicati"
 
 #: ../../src/wxMaximaFrame.cpp:1176
 msgid "Remove first occurrence of a word..."
@@ -5623,163 +5803,165 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:884
 msgid "Remove output from input cells"
-msgstr ""
+msgstr "Elimina tutti i risultati dalla celle d'ingresso"
 
 #: ../../src/wxMaxima.cpp:7975
 msgid "Remove rows and/or columns"
-msgstr ""
+msgstr "Rimuovi righe e/o colonne"
 
 #: ../../src/wxMaximaFrame.cpp:1427
 msgid "Remove rows and/or columns from the matrix"
-msgstr ""
+msgstr "Rimuovi righe e/o colonne dalla matrice"
 
 #: ../../src/wxMaxima.cpp:7582
 msgid "Rename file"
-msgstr ""
+msgstr "Rinomina file"
 
 #: ../../src/wxMaximaFrame.cpp:1215
 msgid "Rename file..."
-msgstr ""
+msgstr "Rinomina file..."
 
 #: ../../src/wxMaximaFrame.cpp:1527
 msgid "Reorganize an expression using horner's rule"
-msgstr ""
+msgstr "Riordina un'espressione usando la regola di Horner"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "Repetitive element-by-element multiplication"
-msgstr ""
+msgstr "Moltiplicazione ripetitiva elemento-per-elemento"
 
 #: ../../src/wxMaxima.cpp:7538
 msgid "Replace all regex matches"
-msgstr ""
+msgstr "Rimpiazza tutti i riscontri da regex"
 
 #: ../../src/wxMaxima.cpp:7533
 msgid "Replace first regex match"
-msgstr ""
+msgstr "Rimpiazza il primo riscontro regex"
 
 #: ../../src/wxMaxima.cpp:7463
 msgid "Replace the first occurrence of Part"
-msgstr ""
+msgstr "Rimpiazza la prima occorrenza della parte"
 
 #: ../../src/wxMaximaFrame.cpp:1180
 msgid "Replace..."
-msgstr ""
+msgstr "Rimpiazza..."
 
 #: ../../src/wxMaxima.cpp:6719
 #, c-format
 msgid "Replaced %li occurrences."
-msgstr ""
+msgstr "Rimpiazzate %li occorrenze."
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "Report bug"
-msgstr ""
+msgstr "Riporta un bug"
 
 #: ../../src/wxMaximaFrame.cpp:996
 msgid "Reset option variables"
-msgstr ""
+msgstr "Reimposta variabili opzionali"
 
 #: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
 msgid "Restart Maxima"
-msgstr ""
+msgstr "Riavvia maxima"
 
 #: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
 msgid "Restrict Maximum size"
-msgstr ""
+msgstr "Limita la dimensione massima"
 
 #: ../../src/wxMaxima.cpp:10031
 msgid "Result variables:"
-msgstr ""
+msgstr "Variabili risultato:"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Resulting Matrix name (may be empty):"
-msgstr ""
+msgstr "Nome matrice risultante (può essere vuoto):"
 
 #: ../../src/wxMaximaFrame.cpp:1190
 msgid "Return a match"
-msgstr ""
+msgstr "Ritorna da un riscontro"
 
 #: ../../src/wxMaxima.cpp:7077
 msgid "Return from a block or loop"
-msgstr ""
+msgstr "Ritorna da un blocco o da un ciclo"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "Return from current block/loop..."
-msgstr ""
+msgstr "Ritorna dal blocco/ciclo corrente..."
 
 #: ../../src/wxMaximaFrame.cpp:1755
 msgid ""
 "Return the first item of the list and remove it from the list. Useful for "
 "creating stacks."
 msgstr ""
+"Restituisce il primo elemento della lista e lo rimuove dalla lista. Utile "
+"per creare pile."
 
 #: ../../src/wxMaxima.cpp:8526
 msgid "Return the list without its first n elements"
-msgstr ""
+msgstr "Restituisce la lista senza i primi n elementi"
 
 #: ../../src/wxMaxima.cpp:8532
 msgid "Return the list without its last n elements"
-msgstr ""
+msgstr "Restituisce la lista senza gli ultimi n elementi"
 
 #: ../../src/ToolBar.cpp:241
 msgid "Return to the cell that is currently being evaluated"
-msgstr ""
+msgstr "Ritorna alla cella correntemente in elaborazione"
 
 #: ../../src/wxMaximaFrame.cpp:1711
 msgid "Returns an arbitrary list item"
-msgstr ""
+msgstr "Restituisce un elemento arbitrario della lista"
 
 #: ../../src/wxMaximaFrame.cpp:1713
 msgid "Returns the first item of the list"
-msgstr ""
+msgstr "Restituisce il primo elemento della lista"
 
 #: ../../src/wxMaximaFrame.cpp:1719
 msgid "Returns the last item of the list"
-msgstr ""
+msgstr "Restituisce l'ultimo elemento della lista"
 
 #: ../../src/wxMaximaFrame.cpp:1721
 msgid "Returns the last n items of the list"
-msgstr ""
+msgstr "Restituisce gli ultimi n elementi della lista"
 
 #: ../../src/wxMaximaFrame.cpp:1742
 msgid "Returns the length of the list"
-msgstr ""
+msgstr "Restituisce la lunghezza della lista"
 
 #: ../../src/wxMaximaFrame.cpp:1715
 msgid "Returns the list without its first n elements"
-msgstr ""
+msgstr "Restituisce la lista senza i primi n elementi"
 
 #: ../../src/wxMaximaFrame.cpp:1717
 msgid "Returns the list without its last n elements"
-msgstr ""
+msgstr "Restituisce la lista senza gli ultimi n elementi"
 
 #: ../../src/wxMaximaFrame.cpp:1743
 msgid "Reverse"
-msgstr ""
+msgstr "Inverti"
 
 #: ../../src/wxMaximaFrame.cpp:1744
 msgid "Reverse the order of the list items"
-msgstr ""
+msgstr "Inverti l'ordine degli elementi della lista"
 
 #: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
 #: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
 msgid "Right Matrix:"
-msgstr ""
+msgstr "Matrice destra:"
 
 #: ../../src/wxMaxima.cpp:8190
 msgid "Right end"
-msgstr ""
+msgstr "Capo destro"
 
 #: ../../src/wxMaximaFrame.cpp:1301
 msgid "Right side to the \"=\""
-msgstr ""
+msgstr "Lato destro del \"=\""
 
 #: ../../src/wxMaximaFrame.cpp:1455
 msgid "Risch Integration..."
-msgstr ""
+msgstr "Integrazione di Risch..."
 
 #: ../../src/wxMaximaFrame.cpp:785
 msgid "Rounded"
-msgstr ""
+msgstr "Arrotondato"
 
 #: ../../src/wxMaximaFrame.cpp:1437
 msgid "Row and column operations"
@@ -5788,11 +5970,11 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7957 ../../src/wxMaxima.cpp:7967
 #: ../../src/wxMaxima.cpp:7972
 msgid "Row number:"
-msgstr ""
+msgstr "Numero riga:"
 
 #: ../../src/wxMaxima.cpp:7977
 msgid "Row numbers:"
-msgstr ""
+msgstr "Numeri di riga:"
 
 #: ../../src/wxMaxima.cpp:8203
 msgid "Rows"
@@ -5800,117 +5982,121 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Rule"
-msgstr ""
+msgstr "Regola"
 
 #: ../../src/wxMaxima.cpp:8464 ../../src/wxMaxima.cpp:8477
 msgid "Rule:"
-msgstr ""
+msgstr "Regola:"
 
 #: ../../src/wxMaximaFrame.cpp:1027
 msgid "Rules"
-msgstr ""
+msgstr "Regole"
 
 #: ../../src/wxMaximaFrame.cpp:1693
 msgid "Run each element through an expression"
-msgstr ""
+msgstr "Passa ogni elemento attraverso una espressione"
 
 #: ../../src/wxMaxima.cpp:6355
 #, c-format
 msgid "Running %s on the file %s: "
-msgstr ""
+msgstr "Esecuzione di %s sul file %s:"
 
 #: ../../src/wxMaxima.cpp:2633
 #, c-format
 msgid "Running maxima as: %s"
-msgstr ""
+msgstr "Esecuzione di maxima come: %s"
 
 #: ../../src/wxMaximaFrame.cpp:130
 msgid "Running on DirectFB"
-msgstr ""
+msgstr "In esecuzione su DirectFB"
 
 #: ../../src/wxMaximaFrame.cpp:114
 msgid "Running on MS Windows"
-msgstr ""
+msgstr "In esecuzione su MS Windows"
 
 #: ../../src/wxMaximaFrame.cpp:116
 msgid "Running on MS Windows using DirectDraw"
-msgstr ""
+msgstr "In esecuzione su MS Windows usando DirectDraw"
 
 #: ../../src/wxMaximaFrame.cpp:136
 msgid "Running on Mac OS"
-msgstr ""
+msgstr "In esecuzione su Mac OS"
 
 #: ../../src/wxMaximaFrame.cpp:127
 msgid "Running on Motif"
-msgstr ""
+msgstr "In esecuzione su Motif"
 
 #: ../../src/wxMaximaFrame.cpp:133
 msgid "Running on the universal wxWidgets port"
-msgstr ""
+msgstr "In esecuzione sul port wxWidget universale"
 
 #: ../../src/wxMaxima.cpp:8208
 msgid ""
 "Runs each element of an object (list, matrix, equation,...) through a "
 "function individually"
 msgstr ""
+"Passa individualmente ogni elemento di un oggetto (lista, matrice, "
+"equazione,...) attraverso una funzione"
 
 #: ../../src/wxMaxima.cpp:8216
 msgid ""
 "Runs each element of an object (list, matrix, equation,...) through an "
 "expression individually"
 msgstr ""
+"Passa individualmente ogni elemento di un oggetto (lista, matrice, "
+"equazione,...) attraverso una espressione"
 
 #: ../../src/wxMaximaFrame.cpp:1691
 msgid "Runs each element through a function"
-msgstr ""
+msgstr "Esegue ogni elemento attraverso una funzione"
 
 #: ../../src/wxMaximaFrame.cpp:1694
 msgid "Runs each element through an expression"
-msgstr ""
+msgstr "Passa ogni elemento attraverso una espressione"
 
 #: ../../src/wxMaxima.cpp:9572
 msgid "Sample 1:"
-msgstr ""
+msgstr "Esempio 1:"
 
 #: ../../src/wxMaxima.cpp:9573
 msgid "Sample 2:"
-msgstr ""
+msgstr "Esempio 2:"
 
 #: ../../src/wxMaxima.cpp:9567
 msgid "Sample:"
-msgstr ""
+msgstr "Esempio:"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
 msgid "Save"
-msgstr ""
+msgstr "Salva"
 
 #: ../../src/Worksheet.cpp:1294
 msgid "Save Animation..."
-msgstr ""
+msgstr "Salva animazione..."
 
 #: ../../src/wxMaxima.cpp:5672
 msgid "Save As"
-msgstr ""
+msgstr "Salva come"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save As...\tShift+Ctrl+S"
-msgstr ""
+msgstr "Salva come...\tShift+Ctrl+S"
 
 #: ../../src/Worksheet.cpp:1291
 msgid "Save Image..."
-msgstr ""
+msgstr "Salva immagine..."
 
 #: ../../src/wxMaxima.cpp:6440
 msgid "Save Selection to Image"
-msgstr ""
+msgstr "Salva la selezione su immagine"
 
 #: ../../src/wxMaximaFrame.cpp:675
 msgid "Save Selection to Image..."
-msgstr ""
+msgstr "Salva la selezione su immagine..."
 
 #: ../../src/wxMaxima.cpp:10184
 msgid "Save animation to file"
-msgstr ""
+msgstr "Salva l'animazione su file"
 
 #: ../../src/wxMaxima.cpp:7203
 msgid "Save as lisp code"
@@ -5918,27 +6104,27 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1091
 msgid "Save as lisp..."
-msgstr ""
+msgstr "Salva come lisp..."
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
 msgid "Save document"
-msgstr ""
+msgstr "Salva documento"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save document as"
-msgstr ""
+msgstr "Salva documento come"
 
 #: ../../src/wxMaximaFrame.cpp:676
 msgid "Save selection from document to an image file"
-msgstr ""
+msgstr "Salva la selezione del documento su di un file immagine"
 
 #: ../../src/wxMaxima.cpp:10125
 msgid "Save selection to file"
-msgstr ""
+msgstr "Salva la selezione su file"
 
 #: ../../src/wxMaximaFrame.cpp:573
 msgid "Saving failed."
-msgstr ""
+msgstr "Salvataggio fallito."
 
 #: ../../src/WXMXformat.cpp:310
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
@@ -5951,134 +6137,144 @@ msgid ""
 "(*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|Portable anymap "
 "(*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"Immagine SVG (*.svg)|*.svg|Immagine SVG compressa (*.svgz)|*.svgz|Immagine "
+"PNG (*.png)|*.png|Immagine JPEG (*.jpg)|*.jpg|Immagine GIF "
+"(*.gif)|*.gif|Immagine BMP (*.bmp)|*.bmp|Immagine PNM (*.pnm)|*.pnm|Immagine"
+" TIFF (*.tif)|*.tif|Immagine XPM (*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:9533
 msgid "Scatterplot"
-msgstr ""
+msgstr "Grafico a dispersione"
 
 #: ../../src/Autocomplete.cpp:125
 msgid ""
 "Scheduling a background task that compiles a new list of autocompletable "
 "maxima commands."
 msgstr ""
+"Programmazione attività in background che compila una nuova lista di comandi"
+" maxima autocompletabili."
 
 #: ../../src/Autocomplete.cpp:458
 msgid ""
 "Scheduling a background task that scans for autocompletable file names."
 msgstr ""
+"Programmazione attività in background che esegue la scansione dei nomi di "
+"file autocompletabili."
 
 #: ../../src/ToolBar.cpp:632
 msgid "Search button"
-msgstr ""
+msgstr "Pulsante di ricerca"
 
 #: ../../src/wxMaxima.cpp:7454
 msgid "Search first occurrence of part"
-msgstr ""
+msgstr "Cerca la prima occorrenza di parte"
 
 #: ../../src/wxMaximaFrame.cpp:1178
 msgid "Search..."
-msgstr ""
+msgstr "Cerca..."
 
 #: ../../src/ToolBar.cpp:273
 msgid "Section"
-msgstr ""
+msgstr "Sezione"
 
 #: ../../src/Configuration.cpp:91
 msgid "Section cell (Heading 2)"
-msgstr ""
+msgstr "Cella sezione (Intestazione 2)"
 
 #: ../../src/wxMaxima.cpp:7218
 msgid "Seek to position"
-msgstr ""
+msgstr "Salta alla posizione"
 
 #: ../../src/BTextCtrl.cpp:45
 msgid "Seems like something is broken with a font."
-msgstr ""
+msgstr "Sembra che ci sia un problema con un font."
 
 #: ../../src/Autocomplete.cpp:350
 msgid "Seems like the package with the maxima share files isn't installed."
 msgstr ""
+"Sembra che il pacchetto con i file condivisi di maxima non sia installato."
 
 #: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
 msgid "Select All"
-msgstr ""
+msgstr "Seleziona tutto"
 
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select All\tCtrl+A"
-msgstr ""
+msgstr "Seleziona tutto\tCtrl+A"
 
 #: ../../src/ToolBar.cpp:629
 msgid "Select All button"
-msgstr ""
+msgstr "Pulsante seleziona tutto"
 
 #: ../../src/wxMaxima.cpp:9631
 msgid "Select Subsample"
-msgstr ""
+msgstr "Seleziona il sottocampione"
 
 #: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select all"
-msgstr ""
+msgstr "Seleziona tutto"
 
 #: ../../src/wxMaxima.cpp:6971
 msgid "Select math display algorithm"
-msgstr ""
+msgstr "Seleziona l'algoritmo di visualizzazione matematica"
 
 #: ../../src/Configuration.cpp:98
 msgid "Selection color"
-msgstr ""
+msgstr "Colore selezione"
 
 #: ../../src/ToolBar.cpp:252
 msgid "Send all cells to maxima"
-msgstr ""
+msgstr "Invia tutte le celle a maxima"
 
 #: ../../src/ToolBar.cpp:249
 msgid "Send the current cell to maxima"
-msgstr ""
+msgstr "Invia la cella corrente a maxima"
 
 #: ../../src/wxMaxima.cpp:2810
 msgid "Sending Maxima a SIGINT signal."
-msgstr ""
+msgstr "Invio a maxima di un segnale SIGINT."
 
 #: ../../src/StatusBar.cpp:220
 msgid "Sending a command to Maxima"
-msgstr ""
+msgstr "Invio di un comando a Maxima"
 
 #: ../../src/wxMaxima.cpp:10598
 msgid "Sending a new command to Maxima."
-msgstr ""
+msgstr "Invio di un nuovo comanda a Maxima."
 
 #: ../../src/wxMaxima.cpp:2792
 msgid "Sending an interrupt signal to Maxima."
-msgstr ""
+msgstr "Invio di segnale di interruzione a Maxima."
 
 #: ../../src/wxMaxima.cpp:169
 msgid "Sending configuration data to maxima."
-msgstr ""
+msgstr "Invio dei dati di configurazione a maxima."
 
 #: ../../src/wxMaxima.cpp:4718
 msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
+"Invio a maxima delle informazioni su come esprimere in calcoli 2d come XML"
 
 #: ../../src/wxMaximaFrame.cpp:1533
 msgid "Sequential Comparative Simplification"
-msgstr ""
+msgstr "Semplificazione comparativa sequenziale"
 
 #: ../../src/wxMaxima.cpp:9016
 msgid "Series"
-msgstr ""
+msgstr "Serie"
 
 #: ../../src/wxMaximaFrame.cpp:1479
 msgid "Series approximation"
-msgstr ""
+msgstr "Approssimazione di serie"
 
 #: ../../src/wxMaxima.cpp:2561
 msgid "Server started"
-msgstr ""
+msgstr "Server avviato"
 
 #: ../../src/wxMaximaFrame.cpp:1824
 msgid "Set &displayed Precision..."
-msgstr ""
+msgstr "Imposta la precisione &mostrata..."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Set Maxima option variable logexpand:all"
@@ -6094,11 +6290,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:822
 msgid "Set Zoom"
-msgstr ""
+msgstr "Imposta lo zoom"
 
 #: ../../src/wxMaximaFrame.cpp:1819
 msgid "Set bigfloat &Precision..."
-msgstr ""
+msgstr "Imposta la &precisione bigfloat..."
 
 #: ../../src/Worksheet.cpp:1306 ../../src/Worksheet.cpp:1479
 msgid "Set image resolution"
@@ -6106,182 +6302,185 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1510
 msgid "Set main variable..."
-msgstr ""
+msgstr "Imposta variabile principale..."
 
 #: ../../src/wxMaximaFrame.cpp:1773
 msgid "Set plot format"
-msgstr ""
+msgstr "Imposta il formato del grafico"
 
 #: ../../src/wxMaximaFrame.cpp:1101
 msgid "Set position..."
-msgstr ""
+msgstr "Imposta posizione..."
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Set the \"algebraic\" flag"
-msgstr ""
+msgstr "Imposta flag \"algebrico\""
 
 #: ../../src/wxMaxima.cpp:8314
 msgid "Set the diagram title"
-msgstr ""
+msgstr "Imposta il titolo del diagramma"
 
 #: ../../src/wxMaximaFrame.cpp:1779
 msgid "Set the frame rate for animations."
-msgstr ""
+msgstr "Imposta la frequenza di quadro per le animazioni."
 
 #: ../../src/wxMaxima.cpp:8377
 msgid "Set the grid density."
-msgstr ""
+msgstr "Imposta la densità della griglia."
 
 #: ../../src/wxMaxima.cpp:8327
 msgid "Set the next plot's title. Empty = no title."
-msgstr ""
+msgstr "Imposta il titolo del prossimo grafico. Vuoto = nessun titolo."
 
 #: ../../src/wxMaximaFrame.cpp:1820
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can"
 " be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
+"Imposta la precisione per i numeri definiti come bigfloat. Tali numeri "
+"possono essere generati inserendo 1.5b12 o come bfloat(1.234)"
 
 #: ../../src/wxMaximaFrame.cpp:811
 msgid "Set zoom to 100%"
-msgstr ""
+msgstr "Imposta lo zoom al 100%"
 
 #: ../../src/wxMaximaFrame.cpp:813
 msgid "Set zoom to 120%"
-msgstr ""
+msgstr "Imposta lo zoom al 120%"
 
 #: ../../src/wxMaximaFrame.cpp:815
 msgid "Set zoom to 150%"
-msgstr ""
+msgstr "Imposta lo zoom al 150%"
 
 #: ../../src/wxMaximaFrame.cpp:817
 msgid "Set zoom to 200%"
-msgstr ""
+msgstr "Imposta lo zoom al 200%"
 
 #: ../../src/wxMaximaFrame.cpp:819
 msgid "Set zoom to 300%"
-msgstr ""
+msgstr "Imposta lo zoom al 300%"
 
 #: ../../src/wxMaximaFrame.cpp:809
 msgid "Set zoom to 80%"
-msgstr ""
+msgstr "Imposta lo zoom al 80%"
 
 #: ../../src/wxMaxima.cpp:4731
 #, c-format
 msgid "Setting gnuplot_binary to %s"
-msgstr ""
+msgstr "Impostazione gnuplot_binary a %s"
 
 #: ../../src/wxMaxima.cpp:4804
 msgid "Setting prompt and help format"
-msgstr ""
+msgstr "Impostazione formati di prompt e aiuto"
 
 #: ../../src/wxMaximaFrame.cpp:1292
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
+"Imposta i valori puntuali per risolvere l'ODE con la trasformata di Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1661
 msgid "Setup modulus computation"
-msgstr ""
+msgstr "Imposta il calcolo del modulo"
 
 #: ../../src/wxMaxima.cpp:9220
 msgid "Setup the engineering format"
-msgstr ""
+msgstr "Imposta formato ingegneristico"
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "Setup the engineering format..."
-msgstr ""
+msgstr "Imposta formato ingegneristico..."
 
 #: ../../src/wxMaxima.cpp:9576
 msgid "Shapiro-Wilk test for normality"
-msgstr ""
+msgstr "Test di normalità Shapiro-Wilk"
 
 #: ../../src/Worksheet.cpp:1543
 msgid "Show \"%\" in special constants"
-msgstr ""
+msgstr "Mostra \"%\" nelle costanti speciali"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show &Tips..."
-msgstr ""
+msgstr "Mostra i suggerimen&ti..."
 
 #: ../../src/Worksheet.cpp:1556
 msgid "Show * as multiplication dot"
-msgstr ""
+msgstr "Mostra * come punto moltiplicativo"
 
 #: ../../src/wxMaximaFrame.cpp:895
 msgid "Show Template\tCtrl+Shift+Space"
-msgstr ""
+msgstr "Mostra modello\tCtrl+Shift+Space"
 
 #: ../../src/wxMaximaFrame.cpp:753
 msgid "Show XML representation"
-msgstr ""
+msgstr "Mostra rappresentazione XML"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show a tip"
-msgstr ""
+msgstr "Mostra un suggerimento"
 
 #: ../../src/Worksheet.cpp:1607
 msgid "Show all + allow linebreaks in long numbers"
-msgstr ""
+msgstr "Mostra tutto + permette i ritorni a capo nei numeri lunghi"
 
 #: ../../src/wxMaxima.cpp:9475
 msgid "Show all commands similar to:"
-msgstr ""
+msgstr "Mostra tutti i comandi simili a:"
 
 #: ../../src/wxMaxima.cpp:9468
 msgid "Show an example for the command:"
-msgstr ""
+msgstr "Mostra un esempio per il comando:"
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "Show an example of usage"
-msgstr ""
+msgstr "Mostra un esempio di uso"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "Show commands similar to"
-msgstr ""
+msgstr "Mostra comandi simili a"
 
 #: ../../src/wxMaximaFrame.cpp:1020
 msgid "Show defined functions"
-msgstr ""
+msgstr "Mostra le funzioni definite"
 
 #: ../../src/wxMaximaFrame.cpp:1022
 msgid "Show defined variables"
-msgstr ""
+msgstr "Mostra le variabili definite"
 
 #: ../../src/wxMaximaFrame.cpp:1074
 msgid "Show definition of a function"
-msgstr ""
+msgstr "Mostra la definizione di una funzione"
 
 #: ../../src/wxMaximaFrame.cpp:740
 msgid "Show equations in their linear form"
-msgstr ""
+msgstr "Mostra le equazioni nella loro forma lineare"
 
 #: ../../src/wxMaximaFrame.cpp:1073
 msgid "Show function &Definition..."
-msgstr ""
+msgstr "Mostra la &definizione della funzione..."
 
 #: ../../src/wxMaximaFrame.cpp:896
 msgid "Show function template"
-msgstr ""
+msgstr "Mostra un modello di funzione"
 
 #: ../../src/Worksheet.cpp:1614
 msgid "Show input labels"
-msgstr ""
+msgstr "Mostra etichette d'ingresso"
 
 #: ../../src/wxMaximaFrame.cpp:750
 msgid "Show lisp representation"
-msgstr ""
+msgstr "Mostra rappresentazione lisp"
 
 #: ../../src/Worksheet.cpp:1604
 msgid "Show max. 100 digits"
-msgstr ""
+msgstr "Mostra max 100 cifre"
 
 #: ../../src/Worksheet.cpp:1602
 msgid "Show max. 20 digits"
-msgstr ""
+msgstr "Mostra max 20 cifre"
 
 #: ../../src/Worksheet.cpp:1603
 msgid "Show max. 50 digits"
-msgstr ""
+msgstr "Mostra max 50 cifre"
 
 #: ../../src/wxMaximaFrame.cpp:835
 msgid "Show or hide the wxMaxima logging window"
@@ -6289,43 +6488,43 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:612
 msgid "Show the \"New\" button?"
-msgstr ""
+msgstr "Mostrare il pulsante \"Nuovo\"?"
 
 #: ../../src/ToolBar.cpp:636
 msgid "Show the \"help\" button?"
-msgstr ""
+msgstr "Mostrare il pulsante \"Aiuto\"?"
 
 #: ../../src/ToolBar.cpp:633
 msgid "Show the \"search\" button?"
-msgstr ""
+msgstr "Mostrare il pulsante \"Cerca\"?"
 
 #: ../../src/ToolBar.cpp:630
 msgid "Show the \"select all\" button?"
-msgstr ""
+msgstr "Mostrare il pulsante \"Seleziona tutto\"?"
 
 #: ../../src/ToolBar.cpp:624
 msgid "Show the Copy, Cut and the Paste button?"
-msgstr ""
+msgstr "Mostrare i pulsanti Copia, Taglia e Incolla?"
 
 #: ../../src/wxMaxima.cpp:7033
 msgid "Show the function's definition"
-msgstr ""
+msgstr "Mostra la definizione della funzione"
 
 #: ../../src/ToolBar.cpp:618
 msgid "Show the open and the save button?"
-msgstr ""
+msgstr "Mostrare i pulsanti Apri e Salva?"
 
 #: ../../src/ToolBar.cpp:627
 msgid "Show the preferences button?"
-msgstr ""
+msgstr "Mostrare il pulsante delle Preferenze?"
 
 #: ../../src/ToolBar.cpp:621
 msgid "Show the print button?"
-msgstr ""
+msgstr "Mostrare il pulsante della Stampa?"
 
 #: ../../src/ToolBar.cpp:615
 msgid "Show the undo and redo button?"
-msgstr ""
+msgstr "Mostrare i pulsanti Annulla e Rifai?"
 
 #: ../../src/wxMaximaFrame.cpp:1006 ../../src/wxMaximaFrame.cpp:1011
 msgid "Show used + to-be-freed memory"
@@ -6333,64 +6532,64 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1033
 msgid "Show user definitions"
-msgstr ""
+msgstr "Mostra le definizione dell'utente"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Show wxMaxima help"
-msgstr ""
+msgstr "Mostra l'aiuto di maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1825
 msgid "Shows how many digits of a numbers are displayed"
-msgstr ""
+msgstr "Mostra quante cifre numeriche vengono visualizzate"
 
 #: ../../src/wxMaximaFrame.cpp:732
 msgid "Sidebars"
-msgstr ""
+msgstr "Barre laterali"
 
 #: ../../src/wxMaximaFrame.cpp:1513
 msgid "Simplify &Radicals..."
-msgstr ""
+msgstr "Semplifica i &radicali..."
 
 #: ../../src/Worksheet.cpp:1579
 msgid "Simplify Expression"
-msgstr ""
+msgstr "Semplifica l'espressione"
 
 #: ../../src/wxMaximaFrame.cpp:1568
 msgid "Simplify Logarithms"
-msgstr ""
+msgstr "Semplifica i logaritmi"
 
 #: ../../src/wxMaximaFrame.cpp:1582
 msgid "Simplify an expression containing factorials"
-msgstr ""
+msgstr "Semplifica un'espressione contenente dei fattoriali"
 
 #: ../../src/wxMaximaFrame.cpp:1539
 msgid "Simplify equations"
-msgstr ""
+msgstr "Semplifica le equazioni"
 
 #: ../../src/wxMaximaFrame.cpp:1514
 msgid "Simplify expression containing radicals"
-msgstr ""
+msgstr "Semplifica un'espressione contenente dei radicali"
 
 #: ../../src/wxMaxima.cpp:8649
 msgid "Simplify radicals"
-msgstr ""
+msgstr "Semplifica i radicali"
 
 #: ../../src/wxMaximaFrame.cpp:1512
 msgid "Simplify rational expression"
-msgstr ""
+msgstr "Semplifica espressione razionale"
 
 #: ../../src/wxMaximaFrame.cpp:1538
 msgid "Simplify sum() commands..."
-msgstr ""
+msgstr "Semplifica i comandi sum()..."
 
 #: ../../src/wxMaxima.cpp:8636
 msgid "Simplify sums"
-msgstr ""
+msgstr "Semplifica le somme"
 
 #: ../../src/wxMaximaFrame.cpp:1592
 msgid "Simplify trigonometric expression"
-msgstr ""
+msgstr "Semplifica espressione trigonometrica"
 
 #: ../../src/wxMaximaFrame.cpp:1399
 msgid "Singular Values"
@@ -6406,261 +6605,268 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1635
 msgid "Smart Substitute..."
-msgstr ""
+msgstr "Sostituisci intelligente..."
 
 #: ../../src/wxMaxima.cpp:8730
 msgid "Smart substitution"
-msgstr ""
+msgstr "Sostituzione intelligente"
 
 #: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
 #: ../../src/wxMaxima.cpp:7823
 msgid "Solution of the ODE:"
-msgstr ""
+msgstr "Soluzione dell'ODE:"
 
 #: ../../src/wxMaxima.cpp:10017
 msgid "Solve"
-msgstr ""
+msgstr "Risolvi"
 
 #: ../../src/wxMaximaFrame.cpp:1244
 msgid "Solve &Algebraic System..."
-msgstr ""
+msgstr "Risolvi il sistema &algebrico..."
 
 #: ../../src/wxMaximaFrame.cpp:1242
 msgid "Solve &Linear System..."
-msgstr ""
+msgstr "Risolvi il sistema &lineare..."
 
 #: ../../src/wxMaximaFrame.cpp:1266
 msgid "Solve &ODE..."
-msgstr ""
+msgstr "Risolvi &ODE..."
 
 #: ../../src/wxMaximaFrame.cpp:1240
 msgid "Solve (to_poly)..."
-msgstr ""
+msgstr "Risolvi (to_poly)..."
 
 #: ../../src/wxMaxima.cpp:8045
 msgid "Solve A*x=b numerically"
-msgstr ""
+msgstr "Risolvi A*x=b numericamente"
 
 #: ../../src/wxMaximaFrame.cpp:1397
 msgid "Solve Ax=b"
-msgstr ""
+msgstr "Risolvi Ax=b"
 
 #: ../../src/wxMaxima.cpp:7783
 msgid "Solve ODE"
-msgstr ""
+msgstr "Risolvi ODE"
 
 #: ../../src/wxMaximaFrame.cpp:1287
 msgid "Solve ODE with Lapla&ce..."
-msgstr ""
+msgstr "Risolvi ODE con Lapla&ce..."
 
 #: ../../src/wxMaximaFrame.cpp:1398
 msgid "Solve a linear equation system using dgesv"
-msgstr ""
+msgstr "Risolvi sistema lineare di equazioni usando dgesv"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
 msgid "Solve algebraic system"
-msgstr ""
+msgstr "Risolvi il sistema algebrico"
 
 #: ../../src/wxMaximaFrame.cpp:1245
 msgid "Solve algebraic system of equations"
-msgstr ""
+msgstr "Risolvi il sistema algebrico di equazioni"
 
 #: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve boundary value problem for second degree ODE"
 msgstr ""
+"Risolvi il problema del valore al contorno per un'ODE di secondo grado"
 
 #: ../../src/wxMaxima.cpp:7895
 msgid "Solve differential equations using laplace()"
-msgstr ""
+msgstr "Risolve equazioni differenziali usando laplace()"
 
 #: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
 msgid "Solve equation(s)"
-msgstr ""
+msgstr "Risolvi le equazioni"
 
 #: ../../src/wxMaximaFrame.cpp:1241
 msgid "Solve equation(s) with to_poly_solve"
-msgstr ""
+msgstr "Risolvi le equazioni con to_poly_solve"
 
 #: ../../src/wxMaxima.cpp:7773
+#, fuzzy
 msgid "Solve equations numerically"
-msgstr ""
+msgstr "Risolvi le polinomiali numericamente"
 
 #: ../../src/wxMaxima.cpp:7757
 msgid "Solve equations to polynom"
-msgstr ""
+msgstr "Risolvi le equazioni in polinomi"
 
 #: ../../src/wxMaximaFrame.cpp:1271
 msgid "Solve initial value problem for first degree ODE"
-msgstr ""
+msgstr "Risolvi problema del valore iniziale per un'ODE di primo grado"
 
 #: ../../src/wxMaximaFrame.cpp:1275
 msgid "Solve initial value problem for second degree ODE"
-msgstr ""
+msgstr "Risolvi problema del valore iniziale per un'ODE di secondo grado"
 
 #: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
 msgid "Solve linear system"
-msgstr ""
+msgstr "Risolvi sistema lineare"
 
 #: ../../src/wxMaximaFrame.cpp:1243
 msgid "Solve linear system of equations"
-msgstr ""
+msgstr "Risolvi sistema lineare di equazioni"
 
 #: ../../src/wxMaximaFrame.cpp:1263
 msgid "Solve numerical, 1 Variable"
-msgstr ""
+msgstr "Risolvi numericamente, 1 variabile"
 
 #: ../../src/wxMaximaFrame.cpp:1267
 msgid "Solve ordinary differential equation of maximum degree 2"
-msgstr ""
+msgstr "Risolvi l'equazione differenziale ordinaria per un grado massimo di 2"
 
 #: ../../src/wxMaximaFrame.cpp:1288
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
+"Risolvi l'equazione differenziale ordinaria con la trasformata di Laplace"
 
 #: ../../src/wxMaxima.cpp:7708
 msgid "Solve polynomials numerically"
-msgstr ""
+msgstr "Risolvi le polinomiali numericamente"
 
 #: ../../src/wxMaxima.cpp:7718
 msgid "Solve polynomials numerically (bfloats)"
-msgstr ""
+msgstr "Risolvi le polinomiali numericamente (bfloats)"
 
 #: ../../src/wxMaxima.cpp:7729
 msgid "Solve polynomials numerically (real roots)"
-msgstr ""
+msgstr "Risolvi le polinomiali numericamente (radici reali)"
 
 #: ../../src/wxMaximaFrame.cpp:1249
 msgid "Solve symbolically"
-msgstr ""
+msgstr "Risolvi simbolicamente"
 
 #: ../../src/Worksheet.cpp:1574
 msgid "Solve..."
-msgstr ""
+msgstr "Risolvi..."
 
 #: ../../src/wxMaximaFrame.cpp:1916
 msgid "Solving differential equations"
-msgstr ""
+msgstr "Risoluzione equazioni differenziali"
 
 #: ../../src/wxMaximaFrame.cpp:1904
 msgid "Solving equations with Maxima"
-msgstr ""
+msgstr "Risoluzione equazioni con Maxima"
 
 #: ../../src/wxMaxima.cpp:7105
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Sometimes one wants maxima to loose the information that a function name was used with the ' operator in order to make maxima not evaluate it. In other places one wants % to mean \"the last expression at the time this function was created\", not \"the last expression now\".\n"
 "In both cases the '' operator will do what is requested."
 msgstr ""
+"A volte si vuole che maxima perda l'informazione che un nome di funzione sia stato usato con l'operatore ' per fare in modo che maxima non lo valuti. Da altre parti si vuole che % significhi \"l'ultima espressione al momento in cui questa funzione è stata creata\", non \"l'ultima espressione ora\".\n"
+"In entrambi i casi l'operatore '' farà quanto richiesto."
 
 #: ../../src/wxMaximaFrame.cpp:1746
 msgid "Sort"
-msgstr ""
+msgstr "Ordina"
 
 #: ../../src/wxMaxima.cpp:8496
 msgid "Sort a list"
-msgstr ""
+msgstr "Ordina una lista"
 
 #: ../../src/wxMaxima.cpp:7459
 msgid "Sort all characters in string"
-msgstr ""
+msgstr "Ordina tutti i caratteri in una stringa"
 
 #: ../../src/wxMaximaFrame.cpp:1179
 msgid "Sort the characters..."
-msgstr ""
+msgstr "Ordina tutti i caratteri..."
 
 #: ../../src/wxMaxima.cpp:8482
 msgid "Source list:"
-msgstr ""
+msgstr "Lista sorgente:"
 
 #: ../../src/wxMaxima.cpp:7429
 msgid "Split"
-msgstr ""
+msgstr "Dividi"
 
 #: ../../src/wxMaximaFrame.cpp:1191
 msgid "Split on match"
-msgstr ""
+msgstr "Dividi alla ricorrenza"
 
 #: ../../src/wxMaxima.cpp:7528
 msgid "Split on regex match"
-msgstr ""
+msgstr "Dividi alla ricorrenza regex"
 
 #: ../../src/wxMaxima.cpp:7449
 msgid "Split string into tokens"
-msgstr ""
+msgstr "Dividi la stringa in token"
 
 #: ../../src/wxMaximaFrame.cpp:1171
 msgid "Split..."
-msgstr ""
+msgstr "Dividi..."
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Square"
-msgstr ""
+msgstr "Quadrato"
 
 #: ../../src/Configuration.cpp:86
 msgid "Standard Text"
-msgstr ""
+msgstr "Testo standard"
 
 #: ../../src/Worksheet.cpp:1298
 msgid "Start Animation"
-msgstr ""
+msgstr "Avvia animazione"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Start of t:"
-msgstr ""
+msgstr "Inizio di t:"
 
 #: ../../src/ToolBar.cpp:305
 msgid "Start or Stop animation"
-msgstr ""
+msgstr "Avvia o blocca l'animazione"
 
 #: ../../src/ToolBar.cpp:306
 msgid ""
 "Start or stop the currently selected animation that has been created with "
 "the with_slider class of commands"
 msgstr ""
+"Avvia o blocca l'animazione attualmente selezionata creata con la classe di "
+"comandi with_slider."
 
 #: ../../src/wxMaxima.cpp:386
 msgid "Starting Maxima process failed"
-msgstr ""
+msgstr "Avvio del processo Maxima fallito"
 
 #: ../../src/main.cpp:667
 msgid "Starting a new wxMaxima process for a new window"
-msgstr ""
+msgstr "Avvio di un nuovo processo wxMaxima per una nuova finestra"
 
 #: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:5633
 msgid "Starting evaluation of the document"
-msgstr ""
+msgstr "Inizio elaborazione del documento"
 
 #: ../../src/wxMaxima.cpp:2544
 msgid "Starting server failed"
-msgstr ""
+msgstr "Avvio del server fallito"
 
 #: ../../src/WXMXformat.cpp:64
 msgid "Starting to save the worksheet as .wxmx"
-msgstr ""
+msgstr "Inizio salvataggio del foglio di lavoro come .wxmx"
 
 #: ../../src/wxMaximaFrame.cpp:252
 msgid "Statistics"
-msgstr ""
+msgstr "Statistiche"
 
 #: ../../src/wxMaximaFrame.cpp:701
 msgid "Statistics\tAlt+Shift+S"
-msgstr ""
+msgstr "Statistiche\tAlt+Shift+S"
 
 #: ../../src/wxMaxima.cpp:7844
 msgid "Step width:"
-msgstr ""
+msgstr "Larghezza passo:"
 
 #: ../../src/wxMaximaFrame.cpp:794
 msgid "Straight lines"
-msgstr ""
+msgstr "Righe diritte"
 
 #: ../../src/wxMaximaFrame.cpp:1106
 msgid "Stream"
-msgstr ""
+msgstr "Flusso"
 
 #: ../../src/wxMaxima.cpp:7231
 msgid "Stream length"
-msgstr ""
+msgstr "Lunghezza flusso"
 
 #: ../../src/wxMaxima.cpp:7219 ../../src/wxMaxima.cpp:7224
 #: ../../src/wxMaxima.cpp:7228 ../../src/wxMaxima.cpp:7232
@@ -6670,45 +6876,45 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7267 ../../src/wxMaxima.cpp:7271
 #: ../../src/wxMaxima.cpp:7276
 msgid "Stream:"
-msgstr ""
+msgstr "Flusso:"
 
 #: ../../src/wxMaximaFrame.cpp:1185
 msgid "String"
-msgstr ""
+msgstr "Stringa"
 
 #: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
 #: ../../src/wxMaxima.cpp:7425
 msgid "String #1:"
-msgstr ""
+msgstr "Stringa #1:"
 
 #: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
 #: ../../src/wxMaxima.cpp:7426
 msgid "String #2:"
-msgstr ""
+msgstr "Stringa #2:"
 
 #: ../../src/wxMaximaFrame.cpp:1136
 msgid "String Tests"
-msgstr ""
+msgstr "Test stringhe"
 
 #: ../../src/wxMaxima.cpp:7415
 msgid "String length"
-msgstr ""
+msgstr "Lunghezza stringa"
 
 #: ../../src/wxMaxima.cpp:7381
 msgid "String to list of char"
-msgstr ""
+msgstr "Stringa a lista di caratteri"
 
 #: ../../src/wxMaximaFrame.cpp:1148
 msgid "String to list of chars..."
-msgstr ""
+msgstr "Stringa a lista di caratteri..."
 
 #: ../../src/wxMaxima.cpp:7496
 msgid "String to octets"
-msgstr ""
+msgstr "Stringa a ottetti"
 
 #: ../../src/wxMaximaFrame.cpp:1160
 msgid "String to octets..."
-msgstr ""
+msgstr "Stringa a ottetti..."
 
 #: ../../src/wxMaxima.cpp:7377 ../../src/wxMaxima.cpp:7382
 #: ../../src/wxMaxima.cpp:7391 ../../src/wxMaxima.cpp:7396
@@ -6722,27 +6928,27 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
 #: ../../src/wxMaxima.cpp:7497
 msgid "String:"
-msgstr ""
+msgstr "Stringa:"
 
 #: ../../src/wxMaxima.cpp:7197
 msgid "Struct :"
-msgstr ""
+msgstr "Struttura:"
 
 #: ../../src/wxMaxima.cpp:7184 ../../src/wxMaxima.cpp:7190
 msgid "Struct type name:"
-msgstr ""
+msgstr "Nome tipo struttura:"
 
 #: ../../src/wxMaximaFrame.cpp:1029
 msgid "Structs"
-msgstr ""
+msgstr "Strutture"
 
 #: ../../src/ToolBar.cpp:274
 msgid "Subsection"
-msgstr ""
+msgstr "Subsezione"
 
 #: ../../src/Configuration.cpp:90
 msgid "Subsection cell (Heading 3)"
-msgstr ""
+msgstr "Cella subsezione (Intestazione 3)"
 
 #: ../../src/wxMaximaFrame.cpp:1643
 msgid "Subst constant t into eq with diff(x,t)..."
@@ -6750,40 +6956,40 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8724
 msgid "Subst is a better string-search-and-replace for expressions."
-msgstr ""
+msgstr "Subst è un buon sistema di ricerca e sostituzione per le espressioni."
 
 #: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
 #: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
 msgid "Substitute"
-msgstr ""
+msgstr "Sostituisci"
 
 #: ../../src/wxMaximaFrame.cpp:1193
 msgid "Substitute all matches"
-msgstr ""
+msgstr "Sostituisci tutte le ricorrenze"
 
 #: ../../src/wxMaximaFrame.cpp:1192
 msgid "Substitute first match"
-msgstr ""
+msgstr "Sostituisci prima ricorrenza"
 
 #: ../../src/wxMaximaFrame.cpp:1646
 msgid "Substitute only in parts..."
-msgstr ""
+msgstr "Sostituisci solo in parti..."
 
 #: ../../src/wxMaxima.cpp:8763
 msgid "Substitute only in specific parts"
-msgstr ""
+msgstr "Sostituisci solo parti specifiche"
 
 #: ../../src/wxMaximaFrame.cpp:1647
 msgid "Substitute only in the elements n_1, n_2,..."
-msgstr ""
+msgstr "Sostituisci solo gli elementi n_1, n_2,..."
 
 #: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
 msgid "Substitute..."
-msgstr ""
+msgstr "Sostituisci..."
 
 #: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
 msgid "Substitutes until the equation no more changes"
-msgstr ""
+msgstr "Sostituisci finché l'equazione non cambia più"
 
 #: ../../src/wxMaxima.cpp:8747
 msgid ""
@@ -6815,15 +7021,16 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:275
 msgid "Subsubsection"
-msgstr ""
+msgstr "Subsubsezione"
 
 #: ../../src/Configuration.cpp:89
 msgid "Subsubsection cell (Heading 4)"
-msgstr ""
+msgstr "Cella subsubsezione (Intestazione 4)"
 
 #: ../../src/Worksheet.cpp:1831
+#, fuzzy
 msgid "Suggestion: "
-msgstr ""
+msgstr "Subsezione"
 
 #: ../../src/Worksheet.cpp:2030
 msgid "Suitable as flag for ev()"
@@ -6831,29 +7038,32 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9049
 msgid "Sum"
-msgstr ""
+msgstr "Somma"
 
 #: ../../src/wxMaximaFrame.cpp:1551
 msgid ""
 "Switch off simplifications of log(). Set Maxima option variable "
 "logexpand:false"
 msgstr ""
+"Spegni semplificazione di log(). Imposta la variabile opzione "
+"logexpand:false"
 
 #: ../../src/wxMaxima.cpp:4090
 msgid "Switched to lisp mode after receiving a lisp debug prompt!"
 msgstr ""
+"Commutato su modalità lisp dopo la ricezione di un prompt di debug lisp!"
 
 #: ../../src/wxMaxima.cpp:4092
 msgid "Switched to lisp mode after receiving a lisp prompt!"
-msgstr ""
+msgstr "Commutato su modalità lisp dopo la ricezione di un prompt lisp!"
 
 #: ../../src/Worksheet.cpp:1971
 msgid "Symbolic Constant"
-msgstr ""
+msgstr "Costante simbolica"
 
 #: ../../src/wxMaximaFrame.cpp:705
 msgid "Symbols\tAlt+Shift+Y"
-msgstr ""
+msgstr "Simboli\tAlt+Shift+Y"
 
 #: ../../src/Worksheet.cpp:2006
 msgid "Symmetric function: f(x)=f(-x)"
@@ -6861,27 +7071,27 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:238
 msgid "Table of Contents"
-msgstr ""
+msgstr "Sommario"
 
 #: ../../src/wxMaximaFrame.cpp:711
 msgid "Table of Contents\tAlt+Shift+T"
-msgstr ""
+msgstr "Sommario\tAlt+Shift+T"
 
 #: ../../src/wxMaxima.cpp:8930
 msgid "Taylor series"
-msgstr ""
+msgstr "Serie di Taylor"
 
 #: ../../src/wxMaximaFrame.cpp:1474
 msgid "Taylor series..."
-msgstr ""
+msgstr "Serie di Taylor..."
 
 #: ../../src/wxMaxima.cpp:8925
 msgid "Taylor series:"
-msgstr ""
+msgstr "Serie di Taylor:"
 
 #: ../../src/wxMaxima.cpp:4132
 msgid "Telling maxima about the new working directory."
-msgstr ""
+msgstr "Indicazione a maxima della nuova cartella di lavoro."
 
 #: ../../src/wxMaxima.cpp:7907
 msgid "Tells maxima for an f(x), that f(x=t)=a"
@@ -6904,41 +7114,50 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:271
 msgid "Text"
-msgstr ""
+msgstr "Testo"
 
 #: ../../src/Configuration.cpp:93
 msgid "Text cell background"
-msgstr ""
+msgstr "Sfondo della cella di testo"
 
 #: ../../src/wxMaxima.cpp:6541
 msgid "Text snippet"
-msgstr ""
+msgstr "Ritaglio di testo"
 
 #: ../../src/wxMaxima.cpp:4632
 msgid ""
 "The .xml file doesn't seem to be valid xml or isn't a content.xml extracted "
 "from a .wxmx zip archive"
 msgstr ""
+"Il file .xml non sembra essere xml valido o non è un content.xml estratto da"
+" un archivio zip .wxmx ."
 
 #: ../../src/wxMaxima.cpp:2734
 msgid ""
 "The Maxima process doesn't offer a shared memory segment we can send an "
 "interrupt signal to."
 msgstr ""
+"Il processo Maxima non offre un segmento di memoria condivisa a cui possa "
+"essere inviato un segnale di interruzione."
 
 #: ../../src/MaximaManual.cpp:107
 msgid "The cache for the subjects the manual contains cannot be read."
 msgstr ""
+"La cache degli argomenti dei contenuti del manuale non puà essere letta."
 
 #: ../../src/MaximaManual.cpp:378
 msgid "The cache for the subjects the manual contains has no head node."
 msgstr ""
+"La cache degli argomenti dei contenuti del manuale non ha il nodo "
+"principale."
 
 #: ../../src/MaximaManual.cpp:396
 msgid ""
 "The cache for the subjects the manual contains is from a different Maxima "
 "version."
 msgstr ""
+"La cache degli argomenti dei contenuti del manuale proviene da una versione "
+"di Maxima diversa."
 
 #: ../../src/wxMaximaFrame.cpp:1379
 msgid "The classic operations one typically uses matrices for"
@@ -6964,19 +7183,19 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9592
 msgid "The equation to fit the data to"
-msgstr ""
+msgstr "L'equazione da far corrispondere ai dati"
 
 #: ../../src/wxMaxima.cpp:8447
 msgid "The function call whose arguments to extract"
-msgstr ""
+msgstr "La chiamata a funzione i cui argomenti sono da estrarre"
 
 #: ../../src/wxMaximaFrame.cpp:1298
 msgid "The half of the equation that is to the left of the \"=\""
-msgstr ""
+msgstr "La metà dell'equazione a sinistra del \"=\""
 
 #: ../../src/wxMaximaFrame.cpp:1302
 msgid "The half of the equation that is to the right of the \"=\""
-msgstr ""
+msgstr "La metà dell'equazione a destra del \"=\""
 
 #: ../../src/MaximaManual.cpp:399
 msgid "The help dir from the cache differs from the current one."
@@ -6991,15 +7210,15 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9799 ../../src/wxMaxima.cpp:10158
 #, c-format
 msgid "The image file \"%s\" cannot be found."
-msgstr ""
+msgstr "Fili immagine \"%s\" non trovato."
 
 #: ../../src/wxMaximaFrame.cpp:718
 msgid "The integrated help browser"
-msgstr ""
+msgstr "Lettore del manuale integrato"
 
 #: ../../src/wxMaxima.cpp:9591
 msgid "The list of variables contained in each matrix row"
-msgstr ""
+msgstr "La lista delle variabili contenute in ogni riga della matrice"
 
 #: ../../src/wxMaximaFrame.cpp:214
 msgid "The main toolbar"
@@ -7007,11 +7226,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "The manual of Maxima"
-msgstr ""
+msgstr "Il manuale di Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "The manual of wxMaxima"
-msgstr ""
+msgstr "Il manuale di wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7125
 msgid "The name of a function we don't want to be evaluated here"
@@ -7023,33 +7242,35 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7199
 msgid "The name of the field to read"
-msgstr ""
+msgstr "Il nome del campo da leggere"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "The name of the new struct type"
-msgstr ""
+msgstr "Il nome del nuovo tipo di struttura"
 
 #: ../../src/wxMaxima.cpp:7198
 msgid "The name of the struct"
-msgstr ""
+msgstr "Il nome della struttura"
 
 #: ../../src/wxMaxima.cpp:7191
 msgid "The name of the struct type"
-msgstr ""
+msgstr "Il nome del tipo di struttura"
 
 #: ../../src/wxMaxima.cpp:8220
 msgid "The name of the variable that shall contain the current element"
-msgstr ""
+msgstr "Il nome della variabile che conterrà l'elemento corrente"
 
 #: ../../src/wxMaxima.cpp:8468
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
-msgstr ""
+msgstr "Il numero dell'elemento al passo da \"Inizio indice\" a \"Fine indice\"."
 
 #: ../../src/wxMaxima.cpp:8465 ../../src/wxMaxima.cpp:8478
 msgid ""
 "The rule that explains how to generate the value of a list item.\n"
 "Might be something like \"i\", \"i^2\" or \"sin(i)\""
 msgstr ""
+"La regola che spiega come generare il valore di un elemento della lista.\n"
+"Può essere qualcosa come \"i\", \"i^2\" o \"sin(i)\""
 
 #: ../../src/wxMaxima.cpp:7785
 msgid ""
@@ -7080,6 +7301,8 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8481 ../../src/wxMaxima.cpp:8582
 msgid "The variable the value of the current source item is stored in."
 msgstr ""
+"La variabile in cui il valore dell'elemento sorgente corrente viene "
+"memorizzato."
 
 #: ../../src/wxMaxima.cpp:9594
 msgid "The variables to search the optimum solution for"
@@ -7087,11 +7310,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:193
 msgid "The worksheet"
-msgstr ""
+msgstr "Il foglio di lavoro"
 
 #: ../../src/Worksheet.cpp:8122
 msgid "The worksheet containing maxima's input and output"
-msgstr ""
+msgstr "Il foglio di lavoro contenente l'ingresso e l'uscita di maxima"
 
 #: ../../src/MathParser.cpp:629
 msgid ""
@@ -7104,36 +7327,48 @@ msgid ""
 "There was an error in the XML maxima has generated.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"C'è stato un'errore nell'XML generato da maxima.\n"
+"Fate un rapporto di questo bug al progetto wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3911
 msgid ""
 "There was an error in the XML that should contain a list of watch variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"C'è stato un errore nell'XML che doveva contenere un elenco di variabili di controllo.\n"
+"Per favore fare rapporto di questo difetto al progetto wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3869
 msgid ""
 "There was an error in the XML that should contain the list of operators.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"C'è stato un errore nell'XML che doveva contenere l'elenco degli operatori.\n"
+"Per favore fare rapporto di questo difetto al progetto wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3321
 msgid ""
 "There was an error in the XML that should describe the contents of some variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"C'è stato un errore nell'XML che doveva descrivere il contenuto di alcune variabili.\n"
+"Per favore fare rapporto di questo difetto al progetto wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3257
 msgid ""
 "There was an error in the XML that should describe the manual topics.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"C'è stato un'errore nell'XML che doveva descrivere l'argomento del manuale.\n"
+"Per favore fare rapporto di questo difetto al progetto wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3202
 msgid ""
 "There was an error in the XML that should describe the status bar message.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"C'è stato un errore nell'XML che doveva descrivere il messaggio della barra di stato\n"
+"Per favore fare rapporto di questo difetto al progetto wxMaxima."
 
 #: ../../src/MaximaManual.cpp:363
 msgid ""
@@ -7141,26 +7376,29 @@ msgid ""
 "It caches the list of subjects maxima's manual offers and is automatically\n"
 "overwritten if maxima's version changes or the file cannot be read"
 msgstr ""
+"Questo file è stato generato da wxMaxima\n"
+"Contiene l'elenco degli argomenti del manuale di maxima e viene automaticamente\n"
+"sovrascritto se la versione di maxima cambia o se il file non può essere letto"
 
 #: ../../src/Worksheet.cpp:1992
 msgid "This function will return even integers"
-msgstr ""
+msgstr "Questa funzione restituirà interi pari"
 
 #: ../../src/Worksheet.cpp:1994
 msgid "This function will return odd integers"
-msgstr ""
+msgstr "Questa funzione restituirà interi dispari"
 
 #: ../../src/Worksheet.cpp:1950
 msgid "This symbol has no imaginary part"
-msgstr ""
+msgstr "Questo simbolo non ha la parte immaginaria"
 
 #: ../../src/Worksheet.cpp:1956
 msgid "This symbol has no real part"
-msgstr ""
+msgstr "Questo simbolo non ha la parte reale"
 
 #: ../../src/Worksheet.cpp:1953
 msgid "This symbol might have both real and imaginary part"
-msgstr ""
+msgstr "Questo simbolo potrebbe avere sia parte reale che immaginaria"
 
 #: ../../src/Worksheet.cpp:1980
 msgid "Throw an error if this symbol is used before assigning it any contents"
@@ -7168,63 +7406,63 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9013 ../../src/wxMaxima.cpp:10058
 msgid "Times:"
-msgstr ""
+msgstr "Volte:"
 
 #: ../../src/ToolBar.cpp:272
 msgid "Title"
-msgstr ""
+msgstr "Titolo"
 
 #: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
-msgstr ""
+msgstr "Titolo (pedici e apici come x_{10} o x^{10})"
 
 #: ../../src/Configuration.cpp:92
 msgid "Title cell (Heading 1)"
-msgstr ""
+msgstr "Cella titolo (Intestazione 1)"
 
 #: ../../src/wxMaximaFrame.cpp:1794
 msgid "To &Bigfloat"
-msgstr ""
+msgstr "In virgola mobile &precisa"
 
 #: ../../src/wxMaximaFrame.cpp:1791
 msgid "To &Float"
-msgstr ""
+msgstr "In &virgola mobile"
 
 #: ../../src/Worksheet.cpp:1571
 msgid "To Float"
-msgstr ""
+msgstr "In virgola mobile"
 
 #: ../../src/wxMaximaFrame.cpp:1797
 msgid "To Numeri&c\tCtrl+Shift+N"
-msgstr ""
+msgstr "In forma numeri&ca\tCtrl+Shift+N"
 
 #: ../../src/wxMaximaFrame.cpp:1803
 msgid "To exact fraction"
-msgstr ""
+msgstr "In frazione esatta"
 
 #: ../../src/wxMaximaFrame.cpp:1814
 msgid "To exact number"
-msgstr ""
+msgstr "In numero esatto"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "To:"
-msgstr ""
+msgstr "A:"
 
 #: ../../src/wxMaximaFrame.cpp:825 ../../src/wxMaximaFrame.cpp:828
 msgid "Toggle full screen editing"
-msgstr ""
+msgstr "Mostra/nascondi schermo pieno"
 
 #: ../../src/ToolBar.cpp:265
 msgid "Toggle the visibility of code cells"
-msgstr ""
+msgstr "Commuta la visibilità delle celle di codice"
 
 #: ../../src/wxMaximaFrame.cpp:1177
 msgid "Tokenize..."
-msgstr ""
+msgstr "Tokenizza..."
 
 #: ../../src/wxMaximaFrame.cpp:1909
 msgid "Tolerance calculations with Maxima"
-msgstr ""
+msgstr "Calcoli delle tolleranze con Maxima"
 
 #: ../../src/wxMaxima.cpp:8192
 msgid "Top end"
@@ -7232,19 +7470,19 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1078
 msgid "Trace a function..."
-msgstr ""
+msgstr "Traccia una funzione..."
 
 #: ../../src/wxMaxima.cpp:7084
 msgid "Trace function(s)"
-msgstr ""
+msgstr "Traccia funzioni"
 
 #: ../../src/wxMaximaFrame.cpp:1184
 msgid "Transformations"
-msgstr ""
+msgstr "Trasformazioni"
 
 #: ../../src/wxMaximaFrame.cpp:1376
 msgid "Transpose a matrix"
-msgstr ""
+msgstr "Trasponi una matrice"
 
 #: ../../src/wxMaxima.cpp:7832
 msgid ""
@@ -7257,12 +7495,15 @@ msgstr ""
 msgid ""
 "Tries to find a solution of the equation that lies between the two bounds."
 msgstr ""
+"Cerca di trovare una soluzione all'equazione che giace tra i dui limiti."
 
 #: ../../src/wxMaxima.cpp:7774
+#, fuzzy
 msgid ""
 "Tries to find a value of the variable that solves the equation between the "
 "two bonds"
 msgstr ""
+"Cerca di trovare una soluzione all'equazione che giace tra i dui limiti."
 
 #: ../../src/wxMaxima.cpp:7719
 msgid ""
@@ -7294,102 +7535,106 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1181
 msgid "Trim both ends..."
-msgstr ""
+msgstr "Taglia entrambi i lati..."
 
 #: ../../src/wxMaximaFrame.cpp:1182
 msgid "Trim left..."
-msgstr ""
+msgstr "Taglia sinistra..."
 
 #: ../../src/wxMaximaFrame.cpp:1183
 msgid "Trim right..."
-msgstr ""
+msgstr "Taglia destra..."
 
 #: ../../src/wxMaxima.cpp:7473
 msgid "Trim string left"
-msgstr ""
+msgstr "Taglia la stringa a sinistra"
 
 #: ../../src/wxMaxima.cpp:7469
 msgid "Trim string on both ends"
-msgstr ""
+msgstr "Taglia la stringa in entrambi i lati"
 
 #: ../../src/wxMaxima.cpp:7477
 msgid "Trim string right"
-msgstr ""
+msgstr "Taglia la stringa a destra"
 
 #: ../../src/wxMaximaFrame.cpp:1511
 msgid "Try to guess which form is &simple"
-msgstr ""
+msgstr "Prova ad indovinare quale forma è &semplice"
 
 #: ../../src/wxMaxima.cpp:8637
 msgid "Try to simplify sums that result from sum() commands."
-msgstr ""
+msgstr "Prova a semplificare le somme che risultano dai comandi sum()."
 
 #: ../../src/MaximaManual.cpp:369
 #, c-format
 msgid ""
 "Trying to cache the list of subjects the manual contains in the file %s."
 msgstr ""
+"Tentativo di memorizzare in cache l'elenco degli argomenti che il manuale "
+"contiene nel file %s."
 
 #: ../../src/wxMaxima.cpp:4423
 msgid "Trying to discard all output."
-msgstr ""
+msgstr "Tentativo di scartare tutto l'output."
 
 #: ../../src/wxMaxima.cpp:4380
 msgid "Trying to extract content.xml out of a broken .zip file."
-msgstr ""
+msgstr "Tentativo di estrarre content.xml da un file .zip danneggiato."
 
 #: ../../src/wxMaxima.cpp:5519
 msgid "Trying to open a file with an empty name!"
-msgstr ""
+msgstr "Tentativo di aprire un file con nome vuoto!"
 
 #: ../../src/wxMaxima.cpp:5523
 #, c-format
 msgid "Trying to open the non-existing file %s"
-msgstr ""
+msgstr "Tentativo di aprire il file inesistente %s"
 
 #: ../../src/wxMaxima.cpp:4457
 msgid "Trying to reconstruct the xml closing markers."
-msgstr ""
+msgstr "Tentativo di ricostruire il file xml chiudendo i marcatori."
 
 #: ../../src/wxMaxima.cpp:4376
 msgid "Trying to recover a broken .wxmx file."
-msgstr ""
+msgstr "Tentativo di recuperare un file .wxmx danneggiato."
 
 #: ../../src/wxMaxima.cpp:6026
 #, c-format
 msgid "Trying to remove the old temp file %s"
-msgstr ""
+msgstr "Tentativo di rimuovere il vecchio file temporaneo %s"
 
 #: ../../src/wxMaxima.cpp:2507
 msgid "Trying to restart maxima."
-msgstr ""
+msgstr "Tentativo di riavviare maxima."
 
 #: ../../src/wxMaxima.cpp:2523
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Trying to start the socket a Maxima on the local machine can connect to on "
 "port %i"
 msgstr ""
+"Tentativo di far partire il socket su cui maxima può collegarsi sulla "
+"macchina locale alla porta %li"
 
 #: ../../src/wxMaximaFrame.cpp:1928
 msgid "Tutorials"
-msgstr ""
+msgstr "Guide"
 
 #: ../../src/wxMaxima.cpp:9571
 msgid "Two sample t-test"
-msgstr ""
+msgstr "Test t a due campioni"
 
 #: ../../src/Worksheet.cpp:8013
 msgid "Type"
-msgstr ""
+msgstr "Tipo"
 
 #: ../../src/wxMaxima.cpp:7180
 msgid "Type:"
-msgstr ""
+msgstr "Tipo:"
 
 #: ../../src/wxMaxima.cpp:9429
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 #: ../../src/wxMaximaFrame.cpp:1146
 msgid "UTF8 to Unicode code point..."
@@ -7397,81 +7642,83 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10479
 msgid "Un-closed parenthesis"
-msgstr ""
+msgstr "Parentesi non chiusa"
 
 #: ../../src/wxMaxima.cpp:10467
 msgid "Un-closed parenthesis on encountering ; or $"
-msgstr ""
+msgstr "Parentesi non chiusa in corrispondenza di un ; o un $"
 
 #: ../../src/wxMaxima.cpp:11160
 msgid ""
 "Unable to interpret the version info I got from http://wxMaxima-"
 "developers.github.io/wxmaxima/version.txt: "
 msgstr ""
+"Impossibile interpretare le informazioni di versione che ottengo da "
+"http://wxMaxima-developers.github.io/wxmaxima/version.txt: "
 
 #: ../../src/wxMaximaFrame.cpp:1007
 msgid "Undefine"
-msgstr ""
+msgstr "Indefinito"
 
 #: ../../src/ToolBar.cpp:191
 msgid "Undo"
-msgstr ""
+msgstr "Annulla"
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo\tCtrl+Z"
-msgstr ""
+msgstr "Annulla\tCtrl+Z"
 
 #: ../../src/ToolBar.cpp:614
 msgid "Undo and redo button"
-msgstr ""
+msgstr "Pulsante annulla e rifai"
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo last change"
-msgstr ""
+msgstr "Annulla l'ultima modifica"
 
 #: ../../src/wxMaximaFrame.cpp:924
 msgid "Unfold All\tCtrl+Alt+]"
-msgstr ""
+msgstr "Spiega tutto\tCtrl+Alt+]"
 
 #: ../../src/wxMaximaFrame.cpp:925
 msgid "Unfold all folded sections"
-msgstr ""
+msgstr "Spiega tutte le sezioni ripiegate"
 
 #: ../../src/Worksheet.cpp:1893
 msgid "Unhide Heading 5"
-msgstr ""
+msgstr "Rivela intestazione 5"
 
 #: ../../src/Worksheet.cpp:1904
 msgid "Unhide Heading 6"
-msgstr ""
+msgstr "Rivela intestazione 6"
 
 #: ../../src/Worksheet.cpp:1852
 msgid "Unhide Part"
-msgstr ""
+msgstr "Rivela parte"
 
 #: ../../src/Worksheet.cpp:1860
 msgid "Unhide Section"
-msgstr ""
+msgstr "Rivela sezione"
 
 #: ../../src/Worksheet.cpp:1871
 msgid "Unhide Subsection"
-msgstr ""
+msgstr "Rivela subsezione"
 
 #: ../../src/Worksheet.cpp:1882
 msgid "Unhide Subsubsection"
-msgstr ""
+msgstr "Rivela subsubsezione"
 
 #: ../../src/Worksheet.cpp:1912
 msgid "Unhide contents"
-msgstr ""
+msgstr "Rivela i contenuti"
 
 #: ../../src/wxMaximaFrame.cpp:266
 msgid "Unicode characters"
-msgstr ""
+msgstr "Caratteri unicode"
 
 #: ../../src/wxMaximaFrame.cpp:707
 msgid "Unicode chars\tAlt+Shift+U"
-msgstr ""
+msgstr "Caratt. Unicode\tAlt+Shift+U"
 
 #: ../../src/wxMaximaFrame.cpp:1144
 msgid "Unicode code point to UTF8..."
@@ -7497,68 +7744,68 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10418
 msgid "Unterminated comment."
-msgstr ""
+msgstr "Commento non terminato."
 
 #: ../../src/wxMaxima.cpp:10461
 msgid "Unterminated string."
-msgstr ""
+msgstr "Stringa non terminata."
 
 #: ../../src/wxMaxima.cpp:4786
 msgid "Updating maxima's configuration"
-msgstr ""
+msgstr "Aggiornamento della configurazione di maxima"
 
 #: ../../src/wxMaxima.cpp:11150 ../../src/wxMaxima.cpp:11157
 #: ../../src/wxMaxima.cpp:11163
 msgid "Upgrade"
-msgstr ""
+msgstr "Aggiorna"
 
 #: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
 msgid "Upper bound:"
-msgstr ""
+msgstr "Intorno alto:"
 
 #: ../../src/wxMaximaFrame.cpp:792
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
-msgstr ""
+msgstr "Usa \"<\" e \">\" come parentesi per le matrici"
 
 #: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
 msgid "Use a list"
-msgstr ""
+msgstr "Usa una lista"
 
 #: ../../src/wxMaxima.cpp:8571
 msgid "Use a list as parameter list for a function"
-msgstr ""
+msgstr "Usa una lista come lista parametri per una funzione"
 
 #: ../../src/wxMaximaFrame.cpp:1708
 msgid "Use list"
-msgstr ""
+msgstr "Usa una lista"
 
 #: ../../src/wxMaximaFrame.cpp:1701
 msgid "Use list as the arguments of a function"
-msgstr ""
+msgstr "Usa una lista per gli argomenti di una funzione"
 
 #: ../../src/wxMaximaFrame.cpp:786
 msgid "Use rounded parenthesis for matrices"
-msgstr ""
+msgstr "Usa le parentesi tonde per le matrici"
 
 #: ../../src/wxMaximaFrame.cpp:789
 msgid "Use square parenthesis for matrices"
-msgstr ""
+msgstr "Usa le parentesi quadre per le matrici"
 
 #: ../../src/wxMaximaFrame.cpp:1083
 msgid "Use struct field..."
-msgstr ""
+msgstr "Usa campo struct..."
 
 #: ../../src/wxMaximaFrame.cpp:795
 msgid "Use vertical lines instead of parenthesis for matrices"
-msgstr ""
+msgstr "Usa le linee verticali invece delle parentesi per le matrici"
 
 #: ../../src/Worksheet.cpp:1619
 msgid "User labels only"
-msgstr ""
+msgstr "Solo etichette utente"
 
 #: ../../src/Configuration.cpp:81
 msgid "User-defined labels"
-msgstr ""
+msgstr "Etichette definite dall'utente"
 
 #: ../../src/MaximaManual.cpp:483
 msgid ""
@@ -7571,21 +7818,23 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:4822
 msgid "Using configured Maxima path."
-msgstr ""
+msgstr "Uso il percorso Maxima configurato."
 
 #: ../../src/wxMaxima.cpp:2961
 msgid ""
 "Using gnuplot's antialiassing-less png driver for embedded plots as pngcairo"
 " could not be found"
 msgstr ""
+"Uso del driver png senza antialias di gnuplot per i grafici incorporati dato"
+" che non si riesce a trovare pngcairo"
 
 #: ../../src/wxMaxima.cpp:2956
 msgid "Using gnuplot's pngcairo driver for embedded plots"
-msgstr ""
+msgstr "Uso del driver di gnuplot pngcairo per i grafici incorportati"
 
 #: ../../src/MaximaManual.cpp:88
 msgid "Using the built-in list of manual anchors."
-msgstr ""
+msgstr "Uso della lista incorporata di àncore manuali."
 
 #: ../../src/WXMXformat.cpp:266
 msgid ""
@@ -7594,24 +7843,24 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8755
 msgid "Value at a given point"
-msgstr ""
+msgstr "Valore in un dato punto"
 
 #: ../../src/Worksheet.cpp:1987
 msgid "Value at a specific point"
-msgstr ""
+msgstr "Valore in uno specifico punto"
 
 #: ../../src/wxMaxima.cpp:7801
 msgid "Value at that point:"
-msgstr ""
+msgstr "Valore in quel punto:"
 
 #: ../../src/wxMaxima.cpp:7812 ../../src/wxMaxima.cpp:7825
 #: ../../src/wxMaxima.cpp:7827
 msgid "Value y at that point:"
-msgstr ""
+msgstr "Valore y in quel punto:"
 
 #: ../../src/wxMaxima.cpp:7910
 msgid "Value:"
-msgstr ""
+msgstr "Valore:"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Var #1"
@@ -7623,29 +7872,29 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6852 ../../src/wxMaxima.cpp:8183
 msgid "Variable"
-msgstr ""
+msgstr "Variabile"
 
 #: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
 #: ../../src/wxMaxima.cpp:8568
 msgid "Variable name"
-msgstr ""
+msgstr "Nome variabile"
 
 #: ../../src/wxMaximaFrame.cpp:1085
 msgid "Variable name, not contents..."
-msgstr ""
+msgstr "Nome variabile, non contenuti..."
 
 #: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
 msgid "Variable name:"
-msgstr ""
+msgstr "Nome variabile:"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 msgid "Variable(s)"
-msgstr ""
+msgstr "Variabile(i)"
 
 #: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
 #: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
 msgid "Variable(s):"
-msgstr ""
+msgstr "Variabile(i):"
 
 #: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
 #: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
@@ -7653,15 +7902,15 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
 #: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
 msgid "Variable:"
-msgstr ""
+msgstr "Variabile:"
 
 #: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
 msgid "Variables"
-msgstr ""
+msgstr "Variabili"
 
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
 msgid "Variables:"
-msgstr ""
+msgstr "Variabili:"
 
 #: ../../src/WXMXformat.cpp:337
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -7669,7 +7918,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:836
 msgid "View"
-msgstr ""
+msgstr "Vista"
 
 #: ../../src/Autocomplete.cpp:235
 msgid "Waiting for m_addFiles_backgroundThread to finish"
@@ -7685,17 +7934,17 @@ msgstr ""
 
 #: ../../src/MaximaManual.cpp:562
 msgid "Waiting for the thread that parses the maxima manual to finish"
-msgstr ""
+msgstr "In attesa che il thread che analizza il manuale di maxima finisca"
 
 #: ../../src/MathParser.cpp:1229 ../../src/wxMaxima.cpp:3296
 #: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
 #: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
 msgid "Warning"
-msgstr ""
+msgstr "Attenzione"
 
 #: ../../src/wxMaximaFrame.cpp:1556
 msgid "Warning:"
-msgstr ""
+msgstr "Attenzione:"
 
 #: ../../src/Dirstructure.cpp:72
 #, c-format
@@ -7703,6 +7952,8 @@ msgid ""
 "Warning: Cannot create %s, the directory maxima keeps configuration, user packages and caches in.\n"
 "Make sure that your system's home directory is set up correctly"
 msgstr ""
+"Attenzione: impossibile creare %s, la cartella nella quale maxima tiene la configurazione, i pacchetti utenti e le memorie di lavoro.\n"
+"Assicurarsi che la cartella utente del sistema operativo sia configurata correttamente"
 
 #: ../../src/wxMaximaFrame.cpp:1546
 msgid ""
@@ -7711,15 +7962,15 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5063
 msgid "Welcome to wxMaxima"
-msgstr ""
+msgstr "Benvenuti in wxMaxima"
 
 #: ../../src/wxMaxima.cpp:8583
 msgid "What to do:"
-msgstr ""
+msgstr "Cosa fare:"
 
 #: ../../src/wxMaximaFrame.cpp:1058
 msgid "When to invoke the lisp compiler's debugger"
-msgstr ""
+msgstr "Quando invocare il debugger del compilatore lisp"
 
 #: ../../src/wxMaxima.cpp:7046
 msgid "While loop"
@@ -7734,6 +7985,8 @@ msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38)"
 " (*.wxm)|*.wxm|All Files (*.*)|*"
 msgstr ""
+"Intero documento (*.wxmx)|*.wxmx|L'ingresso, leggibile da load() (maxima > "
+"5.38) (*.wxm)|*.wxm|Tutti i file (*.*)|*"
 
 #: ../../src/wxMaxima.cpp:210
 msgid "Will try to generate a stack backtrace, if the program ever crashes"
@@ -7741,117 +7994,120 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:6920
 msgid "Worksheet got activated"
-msgstr ""
+msgstr "Il foglio di lavoro è stato attivato"
 
 #: ../../src/Worksheet.cpp:6840
 msgid "Worksheet got the mouse focus"
-msgstr ""
+msgstr "Il foglio di lavoro ha catturato il focus del mouse"
 
 #: ../../src/Worksheet.cpp:7191 ../../src/Worksheet.cpp:7279
 msgid "Wrapped search"
-msgstr ""
+msgstr "Ricerca in tutto il documento"
 
 #: ../../src/WXMXformat.cpp:282
 msgid "Wrote all image and gnuplot files to the zip archive"
-msgstr ""
+msgstr "Scritti tutti i file immagine e gnuplot nell'archivio zip"
 
 #: ../../src/WXMXformat.cpp:272
 msgid "Wrote the XML representation of the document to the zip archive"
-msgstr ""
+msgstr "Scritta la rappresentazione XML del documento nell'archivio zip"
 
 #: ../../src/WXMXformat.cpp:116
 msgid "Wrote the mimetype info"
-msgstr ""
+msgstr "Scritte le informazioni sul tipo mime"
 
 #: ../../src/wxMaxima.cpp:11147
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have version %s. The newest version source code is available for is %s.\n"
 "\n"
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
+"La versione installata è %s. L'ultima versione disponibile è %s.\n"
+"\n"
+"Selezionare OK per visitare il sito web di wxMaxima."
 
 #: ../../src/wxMaxima.cpp:11202
 msgid "Your changes will be lost if you don't save them."
-msgstr ""
+msgstr "I cambiamenti andranno persi se non vengono salvati."
 
 #: ../../src/wxMaxima.cpp:11156
 msgid "Your version of wxMaxima is up to date."
-msgstr ""
+msgstr "L'attuale versione di wxMaxima è aggiornata."
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom &In\tCtrl++"
-msgstr ""
+msgstr "&Ingrandisci\tCtrl++"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom Ou&t\tCtrl+-"
-msgstr ""
+msgstr "Rimpicci&olisci\tCtrl+-"
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom in 10%"
-msgstr ""
+msgstr "Ingrandisci del 10%"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom out 10%"
-msgstr ""
+msgstr "Rimpicciolisci del 10%"
 
 #: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
 msgid "[ unsaved ]"
-msgstr ""
+msgstr "[ non salvato ]"
 
 #: ../../src/wxMaxima.cpp:10920
 msgid "[ unsaved* ]"
-msgstr ""
+msgstr "[ non salvato* ]"
 
 #: ../../src/Worksheet.cpp:5278
-#, c-format
+#, fuzzy, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" loading=\"lazy\" style=\"max-width:90%%;\">\n"
-msgstr ""
+msgstr "_%d.gif\"  alt=\"Diagramma animato\" loading=\"lazy\" style=\"max-width:90%%;\" />\n"
 
 #: ../../src/Worksheet.cpp:5484
-#, c-format
+#, fuzzy, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"lazy\">"
-msgstr ""
+msgstr "_%d.gif\" alt=\"Diagramma animato\" style=\"max-width:90%%;\" loading=\"lazy\" />"
 
 #: ../../src/wxMaximaFrame.cpp:1690
 msgid "apply function to each element"
-msgstr ""
+msgstr "applica funzione ad ogni elemento"
 
 #: ../../src/wxMaximaFrame.cpp:739
 msgid "as 1D ASCII"
-msgstr ""
+msgstr "come 1D ASCII"
 
 #: ../../src/wxMaximaFrame.cpp:742
 msgid "as ASCII Art"
-msgstr ""
+msgstr "come ASCII Art"
 
 #: ../../src/wxMaximaFrame.cpp:745
 msgid "as ASCII+Unicode Art"
-msgstr ""
+msgstr "come Arte ASCII+Unicode"
 
 #: ../../src/wxMaximaFrame.cpp:1680
 msgid "as storage for actual values for variables"
-msgstr ""
+msgstr "come contenitore dei valori correnti delle variabili"
 
 #: ../../src/wxMaximaFrame.cpp:1139
 msgid "char to Ascii code..."
-msgstr ""
+msgstr "da carattere a codice ASCII.."
 
 #: ../../src/wxMaxima.cpp:7836
 msgid "diff(x,t)="
-msgstr ""
+msgstr "diff(x,t)="
 
 #: ../../src/wxMaximaFrame.cpp:1064 ../../src/wxMaximaFrame.cpp:1702
 msgid "do for each element"
-msgstr ""
+msgstr "fai per ogni elemento"
 
 #: ../../src/Worksheet.cpp:2027
 msgid "ev() shall evaluate this automatically"
-msgstr ""
+msgstr "ev() lo valuterà automaticamente"
 
 #: ../../src/wxMaxima.cpp:7130
 msgid "expression:"
-msgstr ""
+msgstr "espressione:"
 
 #: ../../src/Worksheet.cpp:2025
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
@@ -7859,35 +8115,35 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
 msgid "filename:"
-msgstr ""
+msgstr "nomefile:"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "from a list"
-msgstr ""
+msgstr "da una lista"
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "from a rule"
-msgstr ""
+msgstr "da una regola"
 
 #: ../../src/wxMaximaFrame.cpp:1685
 msgid "from function arguments"
-msgstr ""
+msgstr "dagli argomenti funzione"
 
 #: ../../src/wxMaximaFrame.cpp:1669
 msgid "from individual elements"
-msgstr ""
+msgstr "dagli elementi individuali"
 
 #: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
 msgid "function"
-msgstr ""
+msgstr "funzione"
 
 #: ../../src/wxMaximaFrame.cpp:747
 msgid "in 2D"
-msgstr ""
+msgstr "in 2D"
 
 #: ../../src/wxMaxima.cpp:8554
 msgid "list"
-msgstr ""
+msgstr "lista"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "max(abs(A(i,j))) (complex)"
@@ -7899,12 +8155,12 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8046
 msgid "m×n Matrix A:"
-msgstr ""
+msgstr "m×n Matrix A:"
 
 #: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533
 msgid "n:"
-msgstr ""
+msgstr "n:"
 
 #: ../../src/Worksheet.cpp:2000
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -7916,7 +8172,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1710
 msgid "nth"
-msgstr ""
+msgstr "n-esimo"
 
 #: ../../src/Worksheet.cpp:2021
 msgid "outative: f(2*x) = 2*f(x)"
@@ -7929,19 +8185,19 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8942
 msgid "point:"
-msgstr ""
+msgstr "punto:"
 
 #: ../../src/wxMaxima.cpp:7740
 msgid "precision:"
-msgstr ""
+msgstr "precisione:"
 
 #: ../../src/wxMaxima.cpp:7255
 msgid "printf"
-msgstr ""
+msgstr "printf"
 
 #: ../../src/wxMaximaFrame.cpp:1108
 msgid "printf..."
-msgstr ""
+msgstr "printf..."
 
 #: ../../src/wxMaxima.cpp:8650
 msgid ""
@@ -7955,18 +8211,20 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8731
 msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
+"ratsubst funziona come subst, ma conosce alcuni calcoli di base, se "
+"necessario."
 
 #: ../../src/wxMaximaFrame.cpp:1111
 msgid "readbyte..."
-msgstr ""
+msgstr "readbyte..."
 
 #: ../../src/wxMaximaFrame.cpp:1110
 msgid "readchar..."
-msgstr ""
+msgstr "readchar..."
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "readline..."
-msgstr ""
+msgstr "readline..."
 
 #: ../../src/wxMaxima.cpp:10018
 msgid ""
@@ -7974,12 +8232,17 @@ msgid ""
 "If only one result variable is of interest the other result variables can be used to to tell solve() which variables to eliminate from the solution\n"
 "solve() searches for a global solution. If a problem has different solutions depending on the range its variables are in one way to successfully use solve() is to use solve() to eliminate variables one by one and to manually choose which of the solutions solve() found matches the current problem."
 msgstr ""
+"solve() risolverà un elenco di equazioni solo se per n equazioni indipendenti ci sono n variabili da risolvere.\n"
+"Se interessa solo una variabile di risultato, le altre variabili di risultato possono essere utilizzate per indicare a solve() quali variabili eliminare dalla soluzione\n"
+"solve() cerca una soluzione globale. Se un problema ha soluzioni diverse a seconda dell'intervallo delle sue variabili, un modo per utilizzare correttamente solve() consiste nell'usare solve() per eliminare le variabili una per una e scegliere manualmente quale delle soluzioni solve() trovate corrisponde al problema corrente ."
 
 #: ../../src/wxMaxima.cpp:7745
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables solve needs to do its work can be used to tell solve() which variables to eliminate in the solution for the interesting variable."
 msgstr ""
+"solve() risolverà un elenco di equazioni solo se per n equazioni indipendenti ci sono n variabili da risolvere.\n"
+"Se è interessante solo il risultato di una variabile, e le altre variabili servono solo per trovare il risultato, si può dire a solve() quali variabili eliminare dalla soluzione per ottenere solo le variabili interessanti."
 
 #: ../../src/wxMaxima.cpp:7784
 msgid ""
@@ -7997,20 +8260,20 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11190
 msgid "unsaved"
-msgstr ""
+msgstr "non salvato"
 
 #: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
 #: ../../src/wxMaximaFrame.cpp:189
 msgid "untitled"
-msgstr ""
+msgstr "senzanome"
 
 #: ../../src/wxMaximaFrame.cpp:1700
 msgid "use as function arguments"
-msgstr ""
+msgstr "usa come argomenti funzione"
 
 #: ../../src/wxMaximaFrame.cpp:1696
 msgid "use the actual values stored"
-msgstr ""
+msgstr "usa i valori correnti memorizzati"
 
 #: ../../src/wxMaximaFrame.cpp:1112
 msgid "writebyte..."
@@ -8018,23 +8281,23 @@ msgstr ""
 
 #: ../../src/main.cpp:509
 msgid "wxMaxima"
-msgstr ""
+msgstr "wxMaxima"
 
 #: ../../src/main.cpp:516
 #, c-format
 msgid "wxMaxima %ld"
-msgstr ""
+msgstr "wxMaxima %ld"
 
 #: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
 #: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
 #: ../../src/wxMaximaFrame.cpp:185
 #, c-format
 msgid "wxMaxima %s (%s) "
-msgstr ""
+msgstr "wxMaxima %s (%s) "
 
 #: ../../src/wxMaxima.cpp:4490
 msgid "wxMaxima cannot read the xml contents of "
-msgstr ""
+msgstr "wxMaxima non può leggere il contenuto xml di "
 
 #: ../../src/wxMaxima.cpp:2546
 msgid ""
@@ -8046,77 +8309,83 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5285
 msgid "wxMaxima document"
-msgstr ""
+msgstr "Documento wxMaxima"
 
 #: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
 #: ../../src/wxMaxima.cpp:4230
 msgid "wxMaxima encountered an error loading "
-msgstr ""
+msgstr "wxMaxima ha riscontrato un errore durante il caricamento "
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "wxMaxima help"
-msgstr ""
+msgstr "Aiuto di wxMaxima"
 
 #: ../../src/Worksheet.cpp:1465 ../../src/Worksheet.cpp:1839
 msgid ""
 "wxMaxima remembers answers from the last run and is able to automatically "
 "send them to maxima, if requested"
 msgstr ""
+"wxMaxima ricorda le risposte dall'ultima esecuzione ed è in grado di inviare"
+" automaticamente a maxima, se richiesto"
 
 #: ../../src/Worksheet.cpp:1470 ../../src/Worksheet.cpp:1844
 msgid ""
 "wxMaxima remembers answers from the last run and is able to offer them as "
 "the default answer"
 msgstr ""
+"wxMaxima ricorda le risposte dall'ultima esecuzione ed è in grado di "
+"offrirle come risposte predefinite"
 
 #: ../../src/wxMaximaFrame.cpp:1896
 msgid "wxMaxima shows help in a browser"
-msgstr ""
+msgstr "wxMaxima mostra la guida in un browser"
 
 #: ../../src/wxMaximaFrame.cpp:1894
 msgid "wxMaxima shows help in the sidebar"
-msgstr ""
+msgstr "wxMaxima mostra la guida nella barra laterale"
 
 #: ../../src/wxMaximaFrame.cpp:111
 #, c-format
 msgid "wxMaxima version %s"
-msgstr ""
+msgstr "wxMaxima versione %s"
 
 #: ../../src/wxMaximaFrame.cpp:1954
 msgid "wxMaxima's ChangeLog"
-msgstr ""
+msgstr "Changelog di wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "wxMaxima's license"
-msgstr ""
+msgstr "Licenza di wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:144
 msgid "wxWidgets is using GTK 2"
-msgstr ""
+msgstr "wxWidgets sta usando GTK 2"
 
 #: ../../src/wxMaximaFrame.cpp:142
 msgid "wxWidgets is using GTK 3"
-msgstr ""
+msgstr "wxWidgets sta usando GTK 3"
 
 #: ../../src/WXMXformat.cpp:367
 msgid "wxmx file saved"
-msgstr ""
+msgstr "file wxmx salvato"
 
 #: ../../src/wxMaxima.cpp:8375
 msgid "x direction [in multiples of the tick frequency]"
-msgstr ""
+msgstr "direzione x [in multipli della frequenza delle tacche]"
 
 #: ../../src/wxMaxima.cpp:4500 ../../src/wxMaxima.cpp:4643
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
+"l'xml contenuto nel file dichiara di non essere un foglio di lavoro "
+"wxMaxima. "
 
 #: ../../src/wxMaxima.cpp:8376
 msgid "y direction [in multiples of the tick frequency]"
-msgstr ""
+msgstr "direzione y [in multipli della frequenza delle tacche]"
 
 #: ../../src/wxMaxima.cpp:7789
 msgid "y:"
-msgstr ""
+msgstr "y:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:2
@@ -10872,8 +11141,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:704
+#, fuzzy
 msgid "#### Expression"
-msgstr ""
+msgstr "Espressione"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:706
@@ -10927,8 +11197,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:720
+#, fuzzy
 msgid "#### Diagram title"
-msgstr ""
+msgstr "Imposta il titolo del diagramma"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:722
@@ -11139,8 +11410,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:794
+#, fuzzy
 msgid "## Special variables wx..."
-msgstr ""
+msgstr "Imposta variabile principale..."
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:805
@@ -11312,8 +11584,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:837
+#, fuzzy
 msgid "Example:"
-msgstr ""
+msgstr "Esempio:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:842
@@ -11327,8 +11600,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:844
+#, fuzzy
 msgid "## Bug reporting"
-msgstr ""
+msgstr "Rapporto &bug"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:846
@@ -11364,8 +11638,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:856
+#, fuzzy
 msgid "## Output rendering."
-msgstr ""
+msgstr "Uscita: stringhe"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:858
@@ -11473,8 +11748,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:891
+#, fuzzy
 msgid "## How to save data from a broken .wxmx file"
-msgstr ""
+msgstr "Tentativo di recuperare un file .wxmx danneggiato."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:893
@@ -11808,8 +12084,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:988
+#, fuzzy
 msgid "E.g. start wxMaxima with:"
-msgstr ""
+msgstr "Riavvia maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:990

--- a/locales/wxMaxima/ja.po
+++ b/locales/wxMaxima/ja.po
@@ -73,20 +73,21 @@ msgid "%s: Can't interpret line: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1655
+#, fuzzy
 msgid "&Algebraic Mode"
-msgstr ""
+msgstr "代数(&A)"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "&Apropos..."
-msgstr ""
+msgstr "コマンドを探す(&A)..."
 
 #: ../../src/wxMaximaFrame.cpp:615
 msgid "&Batch File...\tCtrl+B"
-msgstr ""
+msgstr "バッチファイル(&B)...\tCtrl+B"
 
 #: ../../src/wxMaximaFrame.cpp:1278
 msgid "&Boundary Value Problem..."
-msgstr ""
+msgstr "境界条件から特殊解を求める(&B)..."
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "&Bug Report"
@@ -94,207 +95,215 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1505
 msgid "&Calculus"
-msgstr ""
+msgstr "微積分(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:1601
 msgid "&Canonical Form"
-msgstr ""
+msgstr "三角関数式の整理(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:1358
 msgid "&Characteristic Polynomial..."
-msgstr ""
+msgstr "固有多項式(&C)..."
 
 #: ../../src/wxMaximaFrame.cpp:990
 msgid "&Clear Memory"
-msgstr ""
+msgstr "メモリをクリア(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "&Combine Factorials"
-msgstr ""
+msgstr "係数の結合(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Complex Simplification"
-msgstr ""
+msgstr "複素関数への操作(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:1502
 msgid "&Continued Fraction"
-msgstr ""
+msgstr "連分数で表示(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:638
 msgid "&Copy\tCtrl+C"
-msgstr ""
+msgstr "コピー(&C)\tCtrl+C"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "&Demoivre"
-msgstr ""
+msgstr "指数関数の変換(&D)"
 
 #: ../../src/wxMaximaFrame.cpp:1362
 msgid "&Determinant"
-msgstr ""
+msgstr "行列式の計算(&D)"
 
 #: ../../src/wxMaximaFrame.cpp:1466
 msgid "&Differentiate..."
-msgstr ""
+msgstr "微分(&D)..."
 
 #: ../../src/wxMaximaFrame.cpp:689
 msgid "&Edit"
-msgstr ""
+msgstr "編集(&E)"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "&Eliminate Variable..."
-msgstr ""
+msgstr "方程式の数を減らす(&E)..."
 
 #: ../../src/wxMaximaFrame.cpp:1318
 msgid "&Enter Matrix..."
-msgstr ""
+msgstr "手入力による行列生成(&E)..."
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "&Example..."
-msgstr ""
+msgstr "コマンドの使用例(&E)..."
 
 #: ../../src/wxMaximaFrame.cpp:1524
 msgid "&Expand Expression"
-msgstr ""
+msgstr "展開(&E)"
 
 #: ../../src/wxMaximaFrame.cpp:1597
 msgid "&Expand Trigonometric"
-msgstr ""
+msgstr "三角関数の展開(&E)"
 
 #: ../../src/wxMaximaFrame.cpp:1626
 msgid "&Exponentialize"
-msgstr ""
+msgstr "三角関数の変換(&E)"
 
 #: ../../src/wxMaximaFrame.cpp:618
 msgid "&Export..."
-msgstr ""
+msgstr "エクスポート(&E)..."
 
 #: ../../src/wxMaximaFrame.cpp:1516
 msgid "&Factor Expression"
-msgstr ""
+msgstr "因数分解(&F)"
 
 #: ../../src/wxMaximaFrame.cpp:626
 msgid "&File"
-msgstr ""
+msgstr "ファイル(&F)"
 
 #: ../../src/wxMaximaFrame.cpp:1019
+#, fuzzy
 msgid "&Functions"
-msgstr ""
+msgstr "関数："
 
 #: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Greatest Common Divisor..."
-msgstr ""
+msgstr "最大公約数(&G)..."
 
 #: ../../src/wxMaximaFrame.cpp:1968
 msgid "&Help"
-msgstr ""
+msgstr "ヘルプ(&H)"
 
 #: ../../src/wxMaximaFrame.cpp:1453
 msgid "&Integrate..."
-msgstr ""
+msgstr "積分(&I)..."
 
 #: ../../src/wxMaximaFrame.cpp:964
 msgid "&Interrupt\tCtrl+G"
-msgstr ""
+msgstr "処理を強制終了(&I)\tCtrl+G"
 
 #: ../../src/wxMaximaFrame.cpp:1355
 msgid "&Invert Matrix"
-msgstr ""
+msgstr "逆行列(&I)"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "&License"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1763
+#, fuzzy
 msgid "&List"
-msgstr ""
+msgstr "リスト："
 
 #: ../../src/wxMaximaFrame.cpp:610
 msgid "&Load Package...\tCtrl+L"
-msgstr ""
+msgstr "パッケージ読込み(&L)...\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "&Maxima"
-msgstr ""
+msgstr "&Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "&Maxima help"
-msgstr ""
+msgstr "Maximaのヘルプ(&M)"
 
 #: ../../src/wxMaximaFrame.cpp:1660
 msgid "&Modulus Computation..."
-msgstr ""
+msgstr "法を設定する(&M)..."
 
 #: ../../src/main.cpp:435
+#, fuzzy
 msgid "&New\tCtrl+N"
-msgstr ""
+msgstr "新規作成\tCtrl+N"
 
 #: ../../src/wxMaximaFrame.cpp:1870
 msgid "&Numeric"
-msgstr ""
+msgstr "数値処理(&N)"
 
 #: ../../src/wxMaximaFrame.cpp:1785
+#, fuzzy
 msgid "&Numeric Output"
-msgstr ""
+msgstr "自動的に数値で出力(&N)"
 
 #: ../../src/main.cpp:436
+#, fuzzy
 msgid "&Open\tCtrl+O"
-msgstr ""
+msgstr "開く(&O)\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "&Open...\tCtrl+O"
-msgstr ""
+msgstr "開く(&O)...\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "&Plot"
-msgstr ""
+msgstr "プロット(&P)"
 
 #: ../../src/wxMaximaFrame.cpp:622
 msgid "&Print...\tCtrl+P"
-msgstr ""
+msgstr "印刷(&P)...\tCtrl+P"
 
 #: ../../src/wxMaximaFrame.cpp:1594
 msgid "&Reduce Trigonometric"
-msgstr ""
+msgstr "三角関数の結合(&R)"
 
 #: ../../src/wxMaximaFrame.cpp:974
+#, fuzzy
 msgid "&Restart Maxima\tCtrl+Alt+R"
-msgstr ""
+msgstr "ラベル番号をリセット(&R)"
 
 #: ../../src/wxMaximaFrame.cpp:608
 msgid "&Save\tCtrl+S"
-msgstr ""
+msgstr "上書き保存(&S)\tCtrl+S"
 
 #: ../../src/wxMaximaFrame.cpp:1662
 msgid "&Simplify"
-msgstr ""
+msgstr "式の変形(&S)"
 
 #: ../../src/wxMaximaFrame.cpp:1581
 msgid "&Simplify Factorials"
-msgstr ""
+msgstr "階乗式の整理(&S)"
 
 #: ../../src/wxMaximaFrame.cpp:1591
 msgid "&Simplify Trigonometric"
-msgstr ""
+msgstr "三角関数の変形(&S)"
 
 #: ../../src/wxMaximaFrame.cpp:1238
 msgid "&Solve..."
-msgstr ""
+msgstr "方程式を解く(&S)..."
 
 #: ../../src/wxMaximaFrame.cpp:1035
+#, fuzzy
 msgid "&Time Display"
-msgstr ""
+msgstr "計算に要した時間を表示(&T)"
 
 #: ../../src/wxMaximaFrame.cpp:1375
 msgid "&Transpose Matrix"
-msgstr ""
+msgstr "転置行列(&T)"
 
 #: ../../src/wxMaximaFrame.cpp:1605
 msgid "&Trigonometric Simplification"
-msgstr ""
+msgstr "三角関数への操作(&T)"
 
 #: ../../src/wxMaximaFrame.cpp:1021
+#, fuzzy
 msgid "&Variables"
-msgstr ""
+msgstr "変数"
 
 #: ../../src/wxMaxima.cpp:2443
 msgid "(Config tells to suppress the output of long cells)"
@@ -347,12 +356,14 @@ msgid ".wxm clipboard data with unusual header"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8047
+#, fuzzy
 msgid "1×n Matrix b:"
-msgstr ""
+msgstr "行列："
 
 #: ../../src/wxMaximaFrame.cpp:1312
+#, fuzzy
 msgid "2D Array to Matrix..."
-msgstr ""
+msgstr "行列に関数を適用(&P)..."
 
 #: ../../src/wxMaximaFrame.cpp:743
 msgid "2D equations using ASCII Art"
@@ -393,24 +404,27 @@ msgid "A function returning positive numbers"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1965
+#, fuzzy
 msgid "A irrational variable"
-msgstr ""
+msgstr "変数の置換"
 
 #: ../../src/Worksheet.cpp:2016
 msgid "A left-associative function"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:2019
+#, fuzzy
 msgid "A linear function"
-msgstr ""
+msgstr "ユーザー定義関数を削除"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "A matrix in which each row is a set of variables"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1963
+#, fuzzy
 msgid "A rational variable"
-msgstr ""
+msgstr "変数の置換"
 
 #: ../../src/Worksheet.cpp:2018
 msgid "A right-associative function"
@@ -429,12 +443,13 @@ msgid "A text control got the mouse focus"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1442
+#, fuzzy
 msgid "A&pply function to each Matrix element..."
-msgstr ""
+msgstr "リストにコマンドを適用（ダイアログの\"関数\"は\"コマンド\"のことです）"
 
 #: ../../src/wxMaximaFrame.cpp:1291
 msgid "A&t Value..."
-msgstr ""
+msgstr "初期条件の設定(&T)..."
 
 #: ../../src/Configuration.cpp:85
 msgid "ASCII maths"
@@ -442,11 +457,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1963
 msgid "About"
-msgstr ""
+msgstr "wxMaximaについて"
 
 #: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
 msgid "About wxMaxima"
-msgstr ""
+msgstr "wxMaximaについて"
 
 #: ../../src/wxMaxima.cpp:7837
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
@@ -462,15 +477,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1371
 msgid "Ad&joint Matrix"
-msgstr ""
+msgstr "余因子行列(&J)"
 
 #: ../../src/wxMaximaFrame.cpp:1657
 msgid "Add Algebraic E&quality..."
-msgstr ""
+msgstr "整数環に多項式の解を追加(&Q)..."
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add a directory to search path"
-msgstr ""
+msgstr "Maximaパッケージを検索するディレクトリの追加"
 
 #: ../../src/wxMaximaFrame.cpp:1752
 msgid ""
@@ -478,24 +493,26 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8602
+#, fuzzy
 msgid "Add an element to the end of a list"
-msgstr ""
+msgstr "ドキュメントを開く"
 
 #: ../../src/wxMaxima.cpp:8597
+#, fuzzy
 msgid "Add an element to the start of a list"
-msgstr ""
+msgstr "ドキュメントを開く"
 
 #: ../../src/wxMaxima.cpp:7625
 msgid "Add dir to path:"
-msgstr ""
+msgstr "検索するディレクトリの選択："
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "Add equality to the rational simplifier"
-msgstr ""
+msgstr "代数的整数環に整数係数の多項式の解を追加"
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add to &Path..."
-msgstr ""
+msgstr "検索するディレクトリを追加(&P)..."
 
 #: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
 #: ../../src/Worksheet.cpp:1704
@@ -537,12 +554,14 @@ msgid "Aliases"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1714
+#, fuzzy
 msgid "All but the 1st n elements"
-msgstr ""
+msgstr "リストにコマンドを適用（ダイアログの\"関数\"は\"コマンド\"のことです）"
 
 #: ../../src/wxMaximaFrame.cpp:1716
+#, fuzzy
 msgid "All but the last n elements"
-msgstr ""
+msgstr "リストにコマンドを適用（ダイアログの\"関数\"は\"コマンド\"のことです）"
 
 #: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
 msgid ""
@@ -553,8 +572,9 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:733
+#, fuzzy
 msgid "All visible sidebars"
-msgstr ""
+msgstr "全ての変数名"
 
 #: ../../src/wxMaximaFrame.cpp:1650
 msgid "Allow to substitute operators"
@@ -596,12 +616,14 @@ msgid "Angles"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1775
+#, fuzzy
 msgid "Animation autoplay"
-msgstr ""
+msgstr "アニメーションの開始"
 
 #: ../../src/wxMaximaFrame.cpp:1778
+#, fuzzy
 msgid "Animation framerate..."
-msgstr ""
+msgstr "既定のアニメーションフレームレート:"
 
 #: ../../src/Worksheet.cpp:2002
 msgid "Antisymmetric function: f(x)=-f(-x)"
@@ -616,28 +638,34 @@ msgid "Append a list"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1736
+#, fuzzy
 msgid "Append a list to an existing list"
-msgstr ""
+msgstr "極限値を求める"
 
 #: ../../src/wxMaxima.cpp:8607
+#, fuzzy
 msgid "Append a list to another list"
-msgstr ""
+msgstr "極限値を求める"
 
 #: ../../src/wxMaximaFrame.cpp:1729
+#, fuzzy
 msgid "Append an element"
-msgstr ""
+msgstr "ドキュメントを開く"
 
 #: ../../src/wxMaximaFrame.cpp:1734
+#, fuzzy
 msgid "Append an element to the beginning an existing list"
-msgstr ""
+msgstr "極限値を求める"
 
 #: ../../src/wxMaximaFrame.cpp:1730
+#, fuzzy
 msgid "Append an element to the end of an existing list"
-msgstr ""
+msgstr "極限値を求める"
 
 #: ../../src/wxMaxima.cpp:8552
+#, fuzzy
 msgid "Apply a function to each list element"
-msgstr ""
+msgstr "リストにコマンドを適用（ダイアログの\"関数\"は\"コマンド\"のことです）"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 #, c-format
@@ -662,15 +690,16 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9474
 msgid "Apropos"
-msgstr ""
+msgstr "コマンド検索"
 
 #: ../../src/wxMaxima.cpp:7317
 msgid "Are the chars equal, if case is ignored?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7312
+#, fuzzy
 msgid "Are the chars equal?"
-msgstr ""
+msgstr "以上"
 
 #: ../../src/wxMaxima.cpp:7349
 msgid "Are these strings equal if case is ignored?"
@@ -685,12 +714,14 @@ msgid "Arguments:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8189
+#, fuzzy
 msgid "Array"
-msgstr ""
+msgstr "文字："
 
 #: ../../src/wxMaximaFrame.cpp:1023
+#, fuzzy
 msgid "Arrays"
-msgstr ""
+msgstr "文字："
 
 #: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
 msgid "Ascii code to char"
@@ -770,7 +801,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6210
 msgid "Batch File"
-msgstr ""
+msgstr "バッチファイル"
 
 #: ../../src/wxMaxima.cpp:5318
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -781,8 +812,9 @@ msgid "Bottom end"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7817
+#, fuzzy
 msgid "Boundary value problem"
-msgstr ""
+msgstr "境界条件から特殊解を求める(&B)..."
 
 #: ../../src/wxMathml.cpp:101
 msgid ""
@@ -876,23 +908,24 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1948
 msgid "Build &Info"
-msgstr ""
+msgstr "ビルド情報(&I)"
 
 #: ../../src/wxMaxima.cpp:7275
 msgid "Byte:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1458
+#, fuzzy
 msgid "C&hange Variable in Integrate..."
-msgstr ""
+msgstr "変数の置換(&H)..."
 
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "C&onfigure"
-msgstr ""
+msgstr "設定(&O)"
 
 #: ../../src/wxMaximaFrame.cpp:1482
 msgid "Calculate &Product..."
-msgstr ""
+msgstr "数列の総乗(&P)..."
 
 #: ../../src/wxMaxima.cpp:8057
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
@@ -906,35 +939,37 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate Su&m..."
-msgstr ""
+msgstr "数列の総和(&M)..."
 
 #: ../../src/wxMaximaFrame.cpp:1795
 msgid "Calculate bigfloat value of the last result"
-msgstr ""
+msgstr "直前の計算結果を多倍長浮動小数点(bigfloat)に変換します"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Calculate float value of the last result"
-msgstr ""
+msgstr "直前の計算結果を浮動小数点数に変換します"
 
 #: ../../src/wxMaxima.cpp:9550
+#, fuzzy
 msgid "Calculate mean value"
-msgstr ""
+msgstr "モジュラス（法）の設定:"
 
 #: ../../src/wxMaxima.cpp:9554
+#, fuzzy
 msgid "Calculate median value"
-msgstr ""
+msgstr "モジュラス（法）の設定:"
 
 #: ../../src/wxMaxima.cpp:8871
 msgid "Calculate modulus:"
-msgstr ""
+msgstr "モジュラス（法）の設定:"
 
 #: ../../src/wxMaximaFrame.cpp:1798
 msgid "Calculate numeric value of the last result"
-msgstr ""
+msgstr "直前の計算結果を数値に変換します"
 
 #: ../../src/wxMaximaFrame.cpp:1483
 msgid "Calculate products"
-msgstr ""
+msgstr "総乗を計算"
 
 #: ../../src/wxMaxima.cpp:9562
 msgid "Calculate standard deviation"
@@ -942,23 +977,25 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate sums"
-msgstr ""
+msgstr "総和を計算"
 
 #: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
 msgid "Calculate the eigenvalues and eigenvectors numerically"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
+#, fuzzy
 msgid "Calculate the eigenvalues of a matrix numerically"
-msgstr ""
+msgstr "逆行列を求める"
 
 #: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
 msgid "Calculate the root of the sum of squares of matrix entries"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9558
+#, fuzzy
 msgid "Calculate variation"
-msgstr ""
+msgstr "総乗を計算"
 
 #: ../../src/wxMaxima.cpp:8949
 msgid "Calculates the fourier coefficients for the expression from -p to p"
@@ -974,11 +1011,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11125
 msgid "Can not connect to the web server."
-msgstr ""
+msgstr "Webサーバーに接続できません"
 
 #: ../../src/wxMaxima.cpp:11166
 msgid "Can not download version info."
-msgstr ""
+msgstr "バージョン情報をダウンロードできません"
 
 #: ../../src/wxMaxima.cpp:3016 ../../src/wxMaxima.cpp:4836
 msgid ""
@@ -989,7 +1026,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Cancel"
-msgstr ""
+msgstr "キャンセル"
 
 #: ../../src/wxMaxima.cpp:3292
 msgid "Cannot authenticate Maxima!"
@@ -1026,8 +1063,9 @@ msgid "Cannot set the communication port to %i."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3656 ../../src/wxMaxima.cpp:6359
+#, fuzzy
 msgid "Cannot start gnuplot"
-msgstr ""
+msgstr "媒介変数プロット"
 
 #: ../../src/StatusBar.cpp:216 ../../src/wxMaxima.cpp:2662
 msgid "Cannot start the maxima binary"
@@ -1043,15 +1081,17 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:955
 msgid "Ce&ll"
-msgstr ""
+msgstr "セル(L)"
 
 #: ../../src/Configuration.cpp:96
+#, fuzzy
 msgid "Cell bracket fill, Active"
-msgstr ""
+msgstr "セル"
 
 #: ../../src/Configuration.cpp:95
+#, fuzzy
 msgid "Cell bracket fill, Inactive"
-msgstr ""
+msgstr "セル"
 
 #: ../../src/wxMaxima.cpp:10395
 msgid "Cell ends in a backslash"
@@ -1059,51 +1099,58 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1038
 msgid "Change &2d Display"
-msgstr ""
+msgstr "出力の表示形式を変更(&2)"
 
 #: ../../src/wxMaxima.cpp:10146
+#, fuzzy
 msgid "Change Image"
-msgstr ""
+msgstr "変数の置換"
 
 #: ../../src/Worksheet.cpp:1324
+#, fuzzy
 msgid "Change Image..."
-msgstr ""
+msgstr "画像として保存..."
 
 #: ../../src/wxMaximaFrame.cpp:1954
+#, fuzzy
 msgid "Change Log"
-msgstr ""
+msgstr "変数の置換"
 
 #: ../../src/wxMaxima.cpp:7555
 msgid "Change directory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1202
+#, fuzzy
 msgid "Change directory..."
-msgstr ""
+msgstr "画像として保存..."
 
 #: ../../src/wxMaximaFrame.cpp:1039
 msgid "Change the 2d display algorithm used to display math output"
-msgstr ""
+msgstr "数式の出力形式を変更"
 
 #: ../../src/wxMaxima.cpp:8885
 msgid "Change variable"
-msgstr ""
+msgstr "変数の置換"
 
 #: ../../src/wxMaxima.cpp:8905
+#, fuzzy
 msgid "Change variable and evaluate"
-msgstr ""
+msgstr "未評価の積分，総和，総乗の変数を置換"
 
 #: ../../src/wxMaximaFrame.cpp:1459
 msgid "Change variable in integral or sum"
-msgstr ""
+msgstr "未評価の積分，総和，総乗の変数を置換"
 
 #: ../../src/wxMaximaFrame.cpp:1463
+#, fuzzy
 msgid "Change variable in integral or sum and evaluate the result"
-msgstr ""
+msgstr "未評価の積分，総和，総乗の変数を置換"
 
 #: ../../src/wxMaximaFrame.cpp:1026
+#, fuzzy
 msgid "Changed option variables"
-msgstr ""
+msgstr "変数の置換"
 
 #: ../../src/wxMaxima.cpp:10170
 #, c-format
@@ -1119,8 +1166,9 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
 #: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
+#, fuzzy
 msgid "Char #2:"
-msgstr ""
+msgstr "行列："
 
 #: ../../src/wxMaximaFrame.cpp:1140
 msgid "Char to Unicode code point..."
@@ -1143,8 +1191,9 @@ msgid "Character Tests"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8181
+#, fuzzy
 msgid "Characteristic polynom"
-msgstr ""
+msgstr "固有多項式(&C)..."
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Chars are strings that are one character long"
@@ -1152,11 +1201,12 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1957
 msgid "Check for Updates"
-msgstr ""
+msgstr "更新の確認"
 
 #: ../../src/wxMaximaFrame.cpp:1958
+#, fuzzy
 msgid "Check if a newer version of wxMaxima is available."
-msgstr ""
+msgstr "wxMaxima/Maxima の最新版がないか確認"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Choose the parenthesis type for Matrices"
@@ -1164,63 +1214,74 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9530 ../../src/wxMaxima.cpp:9535
 msgid "Classes:"
-msgstr ""
+msgstr "区間の数："
 
 #: ../../src/wxMaximaFrame.cpp:1378
 msgid "Classic matrix operations"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:998
+#, fuzzy
 msgid "Clear all aliases"
-msgstr ""
+msgstr "メモリをクリア(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:995
+#, fuzzy
 msgid "Clear all arrays"
-msgstr ""
+msgstr "メモリをクリア(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:992
+#, fuzzy
 msgid "Clear all dependencies"
-msgstr ""
+msgstr "メモリをクリア(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:994
+#, fuzzy
 msgid "Clear all functions"
-msgstr ""
+msgstr "ユーザー定義関数を削除"
 
 #: ../../src/wxMaximaFrame.cpp:1001
+#, fuzzy
 msgid "Clear all gradefs"
-msgstr ""
+msgstr "メモリをクリア(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:1000
+#, fuzzy
 msgid "Clear all labels"
-msgstr ""
+msgstr "メモリをクリア(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:1004
 msgid "Clear all let rule packages"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1003
+#, fuzzy
 msgid "Clear all macros"
-msgstr ""
+msgstr "メモリをクリア(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:1002
+#, fuzzy
 msgid "Clear all props"
-msgstr ""
+msgstr "メモリをクリア(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:997
+#, fuzzy
 msgid "Clear all rules"
-msgstr ""
+msgstr "メモリをクリア(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:999
+#, fuzzy
 msgid "Clear all structures"
-msgstr ""
+msgstr "メモリをクリア(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:993
+#, fuzzy
 msgid "Clear all variables"
-msgstr ""
+msgstr "ユーザー定義変数を削除"
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close\tCtrl+W"
-msgstr ""
+msgstr "閉じる\tCtrl+W"
 
 #: ../../src/wxMaxima.cpp:7235
 msgid "Close Stream"
@@ -1228,19 +1289,21 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close window"
-msgstr ""
+msgstr "ウィンドウを閉じる"
 
 #: ../../src/wxMaximaFrame.cpp:1105
+#, fuzzy
 msgid "Close..."
-msgstr ""
+msgstr "方程式を解く..."
 
 #: ../../src/WXMXformat.cpp:301
 msgid "Closed the zip archive"
 msgstr ""
 
 #: ../../src/Configuration.cpp:77
+#, fuzzy
 msgid "Code Default (Maxima input)"
-msgstr ""
+msgstr "入力文字列"
 
 #: ../../src/Configuration.cpp:103
 msgid "Code highlighting: Comments"
@@ -1275,83 +1338,99 @@ msgid "Code highlighting: Variables"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
+#, fuzzy
 msgid "Code number:"
-msgstr ""
+msgstr "列数："
 
 #: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
+#, fuzzy
 msgid "Codepoint number:"
-msgstr ""
+msgstr "列数："
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "Col. names:"
-msgstr ""
+msgstr "文字変数："
 
 #: ../../src/Configuration.cpp:100
+#, fuzzy
 msgid "Color of Outdated cells"
-msgstr ""
+msgstr "再入力する前の出力"
 
 #: ../../src/Configuration.cpp:99
+#, fuzzy
 msgid "Color of text equal to selection"
-msgstr ""
+msgstr "選択部分と一致する文字列"
 
 #: ../../src/wxMaxima.cpp:7962
+#, fuzzy
 msgid "Column number:"
-msgstr ""
+msgstr "列数："
 
 #: ../../src/wxMaxima.cpp:7978
+#, fuzzy
 msgid "Column numbers:"
-msgstr ""
+msgstr "列数："
 
 #: ../../src/wxMaxima.cpp:8202
+#, fuzzy
 msgid "Columns"
-msgstr ""
+msgstr "列数："
 
 #: ../../src/wxMaximaFrame.cpp:1584
 msgid "Combine factorials in an expression"
-msgstr ""
+msgstr "与えられた階乗とその係数を結合して一つの階乗に変換"
 
 #: ../../src/wxMaxima.cpp:10454
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7259
+#, fuzzy
 msgid "Comma-separated arguments"
-msgstr ""
+msgstr "各x座標はカンマで区切ってください"
 
 #: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
+#, fuzzy
 msgid "Comma-separated commands"
-msgstr ""
+msgstr "各x座標はカンマで区切ってください"
 
 #: ../../src/wxMaxima.cpp:8458
+#, fuzzy
 msgid "Comma-separated elements"
-msgstr ""
+msgstr "各x座標はカンマで区切ってください"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 #: ../../src/wxMaxima.cpp:10031
+#, fuzzy
 msgid "Comma-separated equations"
-msgstr ""
+msgstr "各x座標はカンマで区切ってください"
 
 #: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
 #: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
 #: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
+#, fuzzy
 msgid "Comma-separated expressions"
-msgstr ""
+msgstr "各x座標はカンマで区切ってください"
 
 #: ../../src/wxMaxima.cpp:7215
+#, fuzzy
 msgid "Comma-separated expressions that shall be converted to a string"
-msgstr ""
+msgstr "各x座標はカンマで区切ってください"
 
 #: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
+#, fuzzy
 msgid "Comma-separated expressions."
-msgstr ""
+msgstr "各x座標はカンマで区切ってください"
 
 #: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
+#, fuzzy
 msgid "Comma-separated function names"
-msgstr ""
+msgstr "各x座標はカンマで区切ってください"
 
 #: ../../src/wxMaxima.cpp:7086
+#, fuzzy
 msgid "Comma-separated function names."
-msgstr ""
+msgstr "各x座標はカンマで区切ってください"
 
 #: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
 #: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
@@ -1367,8 +1446,9 @@ msgid "Comma-separated names the parameters will be referenced by later."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
+#, fuzzy
 msgid "Comma-separated numbers from 0 to 255"
-msgstr ""
+msgstr "各x座標はカンマで区切ってください"
 
 #: ../../src/wxMaxima.cpp:8770
 msgid "Comma-separated numbers of the terms to substitute in"
@@ -1396,7 +1476,7 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1692
 msgid "Comment Selection"
-msgstr ""
+msgstr "選択をコメント化"
 
 #: ../../src/wxMaximaFrame.cpp:681
 msgid "Comment out the currently selected text"
@@ -1404,7 +1484,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:680
 msgid "Comment selection\tCtrl+/"
-msgstr ""
+msgstr "選択をコメント化\tCtrl+/"
 
 #: ../../src/Worksheet.cpp:2004
 msgid "Commutative function"
@@ -1415,12 +1495,14 @@ msgid "Compile a QR decomposition using dgeqrf"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7162
+#, fuzzy
 msgid "Compile a function"
-msgstr ""
+msgstr "ユーザー定義関数を削除"
 
 #: ../../src/wxMaximaFrame.cpp:1188
+#, fuzzy
 msgid "Compile a regular expression"
-msgstr ""
+msgstr "ユーザー定義関数を削除"
 
 #: ../../src/wxMaximaFrame.cpp:1385
 msgid "Compile eigenvalues using dgeev"
@@ -1439,12 +1521,14 @@ msgid "Compile eigenvalues+eigenvectors using zgeev"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1076
+#, fuzzy
 msgid "Compile function..."
-msgstr ""
+msgstr "ユーザー定義関数を削除(&U)..."
 
 #: ../../src/wxMaxima.cpp:7511
+#, fuzzy
 msgid "Compile regex"
-msgstr ""
+msgstr "単語補完"
 
 #: ../../src/wxMathml.cpp:53
 msgid "Compiler-Bug? wxMathml.lisp is shorter than expected!"
@@ -1463,12 +1547,13 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:892
+#, fuzzy
 msgid "Complete Word\tCtrl+Space"
-msgstr ""
+msgstr "単語補完\tCtrl+K"
 
 #: ../../src/wxMaximaFrame.cpp:893
 msgid "Complete word"
-msgstr ""
+msgstr "単語補完"
 
 #: ../../src/ToolBar.cpp:230
 msgid "Completely stop maxima and restart it"
@@ -1476,44 +1561,48 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1503
 msgid "Compute continued fraction of a value"
-msgstr ""
+msgstr "連分数を求める（連分数の段数はコマンド \"cflength:＜段数＞\"で変更可能）"
 
 #: ../../src/wxMaximaFrame.cpp:1372
 msgid "Compute the adjoint matrix"
-msgstr ""
+msgstr "余因子行列を求める"
 
 #: ../../src/wxMaximaFrame.cpp:1359
 msgid "Compute the characteristic polynomial of a matrix"
-msgstr ""
+msgstr "固有多項式を求めます"
 
 #: ../../src/wxMaximaFrame.cpp:1363
 msgid "Compute the determinant of a matrix"
-msgstr ""
+msgstr "行列式の計算"
 
 #: ../../src/wxMaximaFrame.cpp:1491
 msgid "Compute the greatest common divisor"
-msgstr ""
+msgstr "最大公約数を求める"
 
 #: ../../src/wxMaximaFrame.cpp:1356
 msgid "Compute the inverse of a matrix"
-msgstr ""
+msgstr "逆行列を求める"
 
 #: ../../src/wxMaximaFrame.cpp:1494
 msgid "Compute the least common multiple (do load(functs) before using)"
-msgstr ""
+msgstr "最小公倍数を求める"
 
 #: ../../src/wxMaximaFrame.cpp:1374
+#, fuzzy
 msgid "Compute the rank of a matrix"
-msgstr ""
+msgstr "行列式の計算"
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Condition:"
 msgstr ""
+"抽出条件（複数指定可）：\n"
+"（col[i]#Xでi列のXを除外）\n"
+"（col[i]=Xでi列のXのみ抽出）"
 
 #: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "Configure wxMaxima"
-msgstr ""
+msgstr "設定"
 
 #: ../../src/wxMaxima.cpp:2504
 msgid "Connection attempt, but connection failed."
@@ -1524,16 +1613,19 @@ msgid "Connection to Maxima lost."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7921
+#, fuzzy
 msgid "Construct a fraction"
-msgstr ""
+msgstr "連分数で表示(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:1305
+#, fuzzy
 msgid "Construct fraction..."
-msgstr ""
+msgstr "連分数で表示(&C)"
 
 #: ../../src/wxMaxima.cpp:7158
+#, fuzzy
 msgid "Contents:"
-msgstr ""
+msgstr "ギリシャ文字"
 
 #: ../../src/wxMaximaFrame.cpp:1877
 msgid "Context-sensitive &Help\tCtrl+?"
@@ -1545,27 +1637,32 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1542
 msgid "Contract Logarithms"
-msgstr ""
+msgstr "対数の結合"
 
 #: ../../src/wxMaximaFrame.cpp:1161
+#, fuzzy
 msgid "Conversions"
-msgstr ""
+msgstr "複素関数の展開(&R)"
 
 #: ../../src/wxMaximaFrame.cpp:1229
+#, fuzzy
 msgid "Convert"
-msgstr ""
+msgstr "複素関数の展開(&R)"
 
 #: ../../src/wxMaximaFrame.cpp:1230
+#, fuzzy
 msgid "Convert + Write to file"
-msgstr ""
+msgstr "階乗に変換(&F)"
 
 #: ../../src/wxMaximaFrame.cpp:1434
+#, fuzzy
 msgid "Convert Column to list..."
-msgstr ""
+msgstr "階乗に変換(&F)"
 
 #: ../../src/wxMaximaFrame.cpp:1430
+#, fuzzy
 msgid "Convert Row to list..."
-msgstr ""
+msgstr "階乗に変換(&F)"
 
 #: ../../src/wxMaximaFrame.cpp:1044
 msgid "Convert a command to maxima code"
@@ -1577,60 +1674,64 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1574
 msgid "Convert binomials, beta and gamma function to factorials"
-msgstr ""
+msgstr "2項係数，ベータ関数およびガンマ関数を階乗に変換"
 
 #: ../../src/wxMaximaFrame.cpp:1578
 msgid "Convert binomials, factorials and beta function to gamma function"
-msgstr ""
+msgstr "2項係数，ベータ関数および階乗をガンマ関数に変換"
 
 #: ../../src/wxMaximaFrame.cpp:1613
 msgid "Convert complex expression to polar form"
-msgstr ""
+msgstr "複素関数またはその展開形を極形式に変換（指数関数として出力されます）"
 
 #: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert complex expression to rect form"
-msgstr ""
+msgstr "複素関数を実変数の関数と虚数iの積の形に変換"
 
 #: ../../src/wxMaximaFrame.cpp:1622
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
-msgstr ""
+msgstr "引数が複素数の指数関数を三角関数に変換"
 
 #: ../../src/wxMaxima.cpp:7411
+#, fuzzy
 msgid "Convert string to lowercase"
-msgstr ""
+msgstr "階乗に変換(&F)"
 
 #: ../../src/wxMaxima.cpp:7543
+#, fuzzy
 msgid "Convert string to matching regex"
-msgstr ""
+msgstr "ガンマ関数に変換(&G)"
 
 #: ../../src/wxMaximaFrame.cpp:1543
 msgid "Convert sum of logarithms to logarithm of product"
-msgstr ""
+msgstr "展開された状態の対数をまとめる"
 
 #: ../../src/wxMaximaFrame.cpp:1573
 msgid "Convert to &Factorials"
-msgstr ""
+msgstr "階乗に変換(&F)"
 
 #: ../../src/wxMaximaFrame.cpp:1577
 msgid "Convert to &Gamma"
-msgstr ""
+msgstr "ガンマ関数に変換(&G)"
 
 #: ../../src/wxMaximaFrame.cpp:1612
 msgid "Convert to &Polarform"
-msgstr ""
+msgstr "複素関数の変換(&P)"
 
 #: ../../src/wxMaximaFrame.cpp:1609
 msgid "Convert to &Rectform"
-msgstr ""
+msgstr "複素関数の展開(&R)"
 
 #: ../../src/wxMaximaFrame.cpp:1166
+#, fuzzy
 msgid "Convert to downcase..."
-msgstr ""
+msgstr "階乗に変換(&F)"
 
 #: ../../src/wxMaxima.cpp:7016
+#, fuzzy
 msgid "Convert to programming language"
-msgstr ""
+msgstr "ガンマ関数に変換(&G)"
 
 #: ../../src/wxMaxima.cpp:7022
 msgid "Convert to programming language file"
@@ -1638,11 +1739,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1602
 msgid "Convert trigonometric expression to canonical quasilinear form"
-msgstr ""
+msgstr "三角関数を含む有理式を整理（引数にｙπが含まれると余計に複雑になる事があります）"
 
 #: ../../src/wxMaximaFrame.cpp:1627
 msgid "Convert trigonometric functions to exponential form"
-msgstr ""
+msgstr "三角関数および双曲線関数を指数関数に変換"
 
 #: ../../src/wxMaximaFrame.cpp:1762
 msgid "Converts a matrix to a list of lists"
@@ -1656,24 +1757,26 @@ msgstr ""
 #: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
 #: ../../src/Worksheet.cpp:1684
 msgid "Copy"
-msgstr ""
+msgstr "コピー"
 
 #: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
 #: ../../src/Worksheet.cpp:1514
+#, fuzzy
 msgid "Copy Animation"
-msgstr ""
+msgstr "アニメーションの停止"
 
 #: ../../src/wxMaximaFrame.cpp:887
 msgid "Copy Previous Input\tCtrl+I"
-msgstr ""
+msgstr "直前の入力を再入力\tCtrl+I"
 
 #: ../../src/wxMaximaFrame.cpp:890
 msgid "Copy Previous Output\tCtrl+U"
-msgstr ""
+msgstr "直前の入力を再入力\tCtrl+U"
 
 #: ../../src/wxMaxima.cpp:7992
+#, fuzzy
 msgid "Copy a matrix"
-msgstr ""
+msgstr "画像としてコピー"
 
 #: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
 #: ../../src/wxMaximaFrame.cpp:663
@@ -1683,46 +1786,50 @@ msgstr ""
 #: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Copy as Image"
-msgstr ""
+msgstr "画像としてコピー"
 
 #: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
 #: ../../src/wxMaximaFrame.cpp:645
 msgid "Copy as LaTeX"
-msgstr ""
+msgstr "LaTeXとしてコピー"
 
 #: ../../src/wxMaximaFrame.cpp:648
 msgid "Copy as MathML"
-msgstr ""
+msgstr "MathMLとしてコピー"
 
 #: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
 msgid "Copy as MathML (e.g. to word processor)"
-msgstr ""
+msgstr "MathMLとしてコピー"
 
 #: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
 #: ../../src/wxMaximaFrame.cpp:658
+#, fuzzy
 msgid "Copy as RTF"
-msgstr ""
+msgstr "LaTeXとしてコピー"
 
 #: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
 #: ../../src/wxMaximaFrame.cpp:655
+#, fuzzy
 msgid "Copy as SVG"
-msgstr ""
+msgstr "LaTeXとしてコピー"
 
 #: ../../src/wxMaximaFrame.cpp:640
 msgid "Copy as Text\tCtrl+Shift+C"
-msgstr ""
+msgstr "テキストとしてコピー\tCtrl+Shift+C"
 
 #: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
 msgid "Copy as plain text"
-msgstr ""
+msgstr "標準テキストとしてコピー"
 
 #: ../../src/wxMaxima.cpp:7576
+#, fuzzy
 msgid "Copy file"
-msgstr ""
+msgstr "コピー"
 
 #: ../../src/wxMaximaFrame.cpp:1214
+#, fuzzy
 msgid "Copy file..."
-msgstr ""
+msgstr "方程式を解く..."
 
 #: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
 #: ../../src/wxMaximaFrame.cpp:643
@@ -1731,32 +1838,34 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
 msgid "Copy selection"
-msgstr ""
+msgstr "コピー"
 
 #: ../../src/wxMaximaFrame.cpp:664
 msgid "Copy selection from document as an Enhanced Metafile"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:656
+#, fuzzy
 msgid "Copy selection from document as an SVG image"
-msgstr ""
+msgstr "選択範囲を画像としてコピー"
 
 #: ../../src/wxMaximaFrame.cpp:653
 msgid "Copy selection from document as an image"
-msgstr ""
+msgstr "選択範囲を画像としてコピー"
 
 #: ../../src/wxMaximaFrame.cpp:659
+#, fuzzy
 msgid ""
 "Copy selection from document as rtf that a word processor might understand"
-msgstr ""
+msgstr "選択範囲を画像としてコピー"
 
 #: ../../src/wxMaximaFrame.cpp:641
 msgid "Copy selection from document as text"
-msgstr ""
+msgstr "選択範囲をテキストとしてコピー"
 
 #: ../../src/wxMaximaFrame.cpp:646
 msgid "Copy selection from document in LaTeX format"
-msgstr ""
+msgstr "選択範囲をLaTeXとしてコピー"
 
 #: ../../src/wxMaximaFrame.cpp:644
 msgid "Copy selection from document in Matlab format"
@@ -1769,12 +1878,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7403
+#, fuzzy
 msgid "Copy string"
-msgstr ""
+msgstr "コピー"
 
 #: ../../src/wxMaximaFrame.cpp:1165
+#, fuzzy
 msgid "Copy string..."
-msgstr ""
+msgstr "行列を手入力..."
 
 #: ../../src/ToolBar.cpp:623
 msgid "Copy, Cut and Paste button"
@@ -1805,20 +1916,23 @@ msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1325
+#, fuzzy
 msgid "Create Matrix"
-msgstr ""
+msgstr "行列生成"
 
 #: ../../src/wxMaximaFrame.cpp:1688
+#, fuzzy
 msgid "Create a list"
-msgstr ""
+msgstr "リスト作成"
 
 #: ../../src/wxMaxima.cpp:8487
 msgid "Create a list as a storage for the values of variables"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8463 ../../src/wxMaxima.cpp:8476
+#, fuzzy
 msgid "Create a list from a rule"
-msgstr ""
+msgstr "関数からリストを作成"
 
 #: ../../src/wxMaximaFrame.cpp:1670
 msgid "Create a list from comma-separated elements"
@@ -1826,43 +1940,49 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:888
 msgid "Create a new cell with previous input"
-msgstr ""
+msgstr "新しいセルに直前の入力を再入力"
 
 #: ../../src/wxMaximaFrame.cpp:891
 msgid "Create a new cell with previous output"
-msgstr ""
+msgstr "直前の入力を再入力して新しいセルを挿入"
 
 #: ../../src/wxMaximaFrame.cpp:1348
 msgid "Create copy, not clone..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7561
+#, fuzzy
 msgid "Create directory"
-msgstr ""
+msgstr "リスト作成"
 
 #: ../../src/wxMaximaFrame.cpp:1203
+#, fuzzy
 msgid "Create directory..."
-msgstr ""
+msgstr "リスト作成"
 
 #: ../../src/wxMaxima.cpp:7419
+#, fuzzy
 msgid "Create empty string"
-msgstr ""
+msgstr "行列生成"
 
 #: ../../src/wxMaximaFrame.cpp:1168
+#, fuzzy
 msgid "Create empty string..."
-msgstr ""
+msgstr "リスト作成"
 
 #: ../../src/wxMaximaFrame.cpp:1687
+#, fuzzy
 msgid "Create list"
-msgstr ""
+msgstr "リスト作成"
 
 #: ../../src/wxMaxima.cpp:8457
 msgid "Create list from comma-separated elements"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1082
+#, fuzzy
 msgid "Create struct..."
-msgstr ""
+msgstr "リスト作成"
 
 #: ../../src/WXMXformat.cpp:80
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
@@ -1873,28 +1993,29 @@ msgid "Creates an independent matrix with the same contents"
 msgstr ""
 
 #: ../../src/Configuration.cpp:97
+#, fuzzy
 msgid "Cursor color"
-msgstr ""
+msgstr "カーソル"
 
 #: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
 msgid "Cut"
-msgstr ""
+msgstr "切り取り"
 
 #: ../../src/wxMaximaFrame.cpp:636
 msgid "Cut\tCtrl+X"
-msgstr ""
+msgstr "切り取り\tCtrl+X"
 
 #: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
 msgid "Cut selection"
-msgstr ""
+msgstr "切り取り"
 
 #: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
 msgid "Data Matrix:"
-msgstr ""
+msgstr "データ（行列）："
 
 #: ../../src/wxMaxima.cpp:9599
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
-msgstr ""
+msgstr "データファイル (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wxMaxima.cpp:9529 ../../src/wxMaxima.cpp:9534
 #: ../../src/wxMaxima.cpp:9539 ../../src/wxMaxima.cpp:9543
@@ -1903,7 +2024,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9563 ../../src/wxMaxima.cpp:9577
 #: ../../src/wxMaxima.cpp:9582 ../../src/wxMaxima.cpp:10030
 msgid "Data:"
-msgstr ""
+msgstr "リスト/ベクトル："
 
 #: ../../src/wxMaximaFrame.cpp:1057
 msgid "Debugger trigger"
@@ -1927,8 +2048,9 @@ msgid "Declare facts about %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8800
+#, fuzzy
 msgid "Declare main variable:"
-msgstr ""
+msgstr "ユーザー定義変数を削除"
 
 #: ../../src/wxMaxima.cpp:7171
 msgid "Declare the type of a function parameter"
@@ -1940,15 +2062,17 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1500 ../../src/wxMaximaFrame.cpp:1536
 msgid "Decompose rational function to partial fractions"
-msgstr ""
+msgstr "指定した変数に対して部分分数分解を実行"
 
 #: ../../src/Worksheet.cpp:2010
+#, fuzzy
 msgid "Decreasing function f(x)<x"
-msgstr ""
+msgstr "削除する関数名の入力："
 
 #: ../../src/wxMaxima.cpp:7134
+#, fuzzy
 msgid "Define a function"
-msgstr ""
+msgstr "ユーザー定義関数を削除"
 
 #: ../../src/wxMaxima.cpp:7147
 msgid "Define a macro"
@@ -1963,12 +2087,14 @@ msgid "Define a structure type"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7156
+#, fuzzy
 msgid "Define a variable"
-msgstr ""
+msgstr "ユーザー定義変数を削除"
 
 #: ../../src/wxMaximaFrame.cpp:1072
+#, fuzzy
 msgid "Define function..."
-msgstr ""
+msgstr "ユーザー定義関数を削除(&U)..."
 
 #: ../../src/wxMaximaFrame.cpp:1079
 msgid "Define macro..."
@@ -1983,8 +2109,9 @@ msgid "Define struct..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1080
+#, fuzzy
 msgid "Define variable..."
-msgstr ""
+msgstr "ユーザー定義変数を削除"
 
 #: ../../src/wxMaximaFrame.cpp:1776
 msgid ""
@@ -1997,23 +2124,23 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:985
 msgid "Delete F&unction..."
-msgstr ""
+msgstr "ユーザー定義関数を削除(&U)..."
 
 #: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
 msgid "Delete Selection"
-msgstr ""
+msgstr "選択を削除"
 
 #: ../../src/wxMaximaFrame.cpp:987
 msgid "Delete V&ariable..."
-msgstr ""
+msgstr "ユーザー定義変数を削除(&A)..."
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Delete a function"
-msgstr ""
+msgstr "ユーザー定義関数を削除"
 
 #: ../../src/wxMaximaFrame.cpp:988
 msgid "Delete a variable"
-msgstr ""
+msgstr "ユーザー定義変数を削除"
 
 #: ../../src/wxMaximaFrame.cpp:982
 msgid "Delete all objects with a given name"
@@ -2021,35 +2148,42 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:991
 msgid "Delete all values from memory"
-msgstr ""
+msgstr "セルの内容は保持してMaximaを起動した直後の状態にリセット"
 
 #: ../../src/wxMaxima.cpp:7588
+#, fuzzy
 msgid "Delete file"
-msgstr ""
+msgstr "ユーザー定義変数を削除"
 
 #: ../../src/wxMaximaFrame.cpp:1216
+#, fuzzy
 msgid "Delete file..."
-msgstr ""
+msgstr "ユーザー定義変数を削除(&A)..."
 
 #: ../../src/wxMaxima.cpp:7683
+#, fuzzy
 msgid "Delete function(s)"
-msgstr ""
+msgstr "削除する関数名の入力："
 
 #: ../../src/wxMaxima.cpp:7679
+#, fuzzy
 msgid "Delete named object(s)"
-msgstr ""
+msgstr "削除する関数名の入力："
 
 #: ../../src/wxMaximaFrame.cpp:981
+#, fuzzy
 msgid "Delete named object..."
-msgstr ""
+msgstr "ユーザー定義関数を削除(&U)..."
 
 #: ../../src/wxMaxima.cpp:7674
+#, fuzzy
 msgid "Delete variable(s)"
-msgstr ""
+msgstr "削除する変数の入力："
 
 #: ../../src/wxMaxima.cpp:7430
+#, fuzzy
 msgid "Delimiter:"
-msgstr ""
+msgstr "消去"
 
 #: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
 #, c-format
@@ -2062,7 +2196,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8927
 msgid "Denom. deg:"
-msgstr ""
+msgstr "分母の最高次数："
 
 #: ../../src/wxMaxima.cpp:7923
 msgid "Denominator:"
@@ -2078,7 +2212,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1497
 msgid "Di&vide Polynomials..."
-msgstr ""
+msgstr "多項式の除算(&V)..."
 
 #: ../../src/MaximaManual.cpp:517
 msgid "Didn't find the maxima HTML manual."
@@ -2092,35 +2226,38 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
 msgid "Differentiate"
-msgstr ""
+msgstr "微分"
 
 #: ../../src/wxMaximaFrame.cpp:1467
 msgid "Differentiate expression"
-msgstr ""
+msgstr "微分"
 
 #: ../../src/Worksheet.cpp:1590
 msgid "Differentiate..."
-msgstr ""
+msgstr "微分..."
 
 #: ../../src/wxMaxima.cpp:9010
+#, fuzzy
 msgid "Differentiates an expression n times"
-msgstr ""
+msgstr "微分"
 
 #: ../../src/wxMaxima.cpp:10055
+#, fuzzy
 msgid "Differentiates the expression n times"
-msgstr ""
+msgstr "微分"
 
 #: ../../src/wxMaximaFrame.cpp:1212
+#, fuzzy
 msgid "Directory operations"
-msgstr ""
+msgstr "近づき方："
 
 #: ../../src/wxMaximaFrame.cpp:1041
 msgid "Display Te&X Form"
-msgstr ""
+msgstr "Te&X形式で出力"
 
 #: ../../src/wxMaxima.cpp:6972
 msgid "Display algorithm"
-msgstr ""
+msgstr "表示形式"
 
 #: ../../src/wxMaximaFrame.cpp:751
 msgid "Display an expression as maxima's internal lisp representation"
@@ -2131,8 +2268,9 @@ msgid "Display an expression as wxMaxima's internal XML representation"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:758
+#, fuzzy
 msgid "Display equations"
-msgstr ""
+msgstr "解の公式から厳密解を求める"
 
 #: ../../src/wxMaxima.cpp:6508
 msgid "Display expression in maxima's internal representation"
@@ -2144,7 +2282,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1042
 msgid "Display last result in TeX form"
-msgstr ""
+msgstr "一番新しい出力をTeX形式で出力"
 
 #: ../../src/ToolBar.cpp:360
 #, c-format
@@ -2152,24 +2290,27 @@ msgid "Display resolution according to wxWidgets: %li x %li ppi"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:802
+#, fuzzy
 msgid "Display string quotation marks"
-msgstr ""
+msgstr "解の公式から厳密解を求める"
 
 #: ../../src/wxMaximaFrame.cpp:1036
 msgid "Display time used for evaluation"
-msgstr ""
+msgstr "計算に要した時間を表示"
 
 #: ../../src/wxMaxima.cpp:9206
+#, fuzzy
 msgid "Displayed Precision"
-msgstr ""
+msgstr "解の公式から厳密解を求める"
 
 #: ../../src/wxMaximaFrame.cpp:1913
 msgid "Displaying 3d curves"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1462
+#, fuzzy
 msgid "Dito, and evaluate the result..."
-msgstr ""
+msgstr "現在位置より上のセルを再評価"
 
 #: ../../src/wxMaximaFrame.cpp:1445
 msgid "Dito, but affect all clones of the Matrix..."
@@ -2185,20 +2326,21 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
 msgid "Divide Cell"
-msgstr ""
+msgstr "セルの分割"
 
 #: ../../src/wxMaximaFrame.cpp:1498
 msgid "Divide numbers or polynomials"
-msgstr ""
+msgstr "[商]および[余り]を出力"
 
 #: ../../src/wxMaxima.cpp:8578
+#, fuzzy
 msgid "Do for each list element"
-msgstr ""
+msgstr "リストにコマンドを適用（ダイアログの\"関数\"は\"コマンド\"のことです）"
 
 #: ../../src/wxMaxima.cpp:11197
 #, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
-msgstr ""
+msgstr "ドキュメント「%s」への変更を保存しますか？"
 
 #: ../../src/wxMaximaFrame.cpp:724
 msgid "Dock all Sidebars"
@@ -2206,35 +2348,42 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:94
 msgid "Document background"
-msgstr ""
+msgstr "ドキュメントの背景色"
 
 #: ../../src/wxMaxima.cpp:4611
+#, fuzzy
 msgid ""
 "Document was saved using a newer version of wxMaxima so it may not load "
 "correctly. Please update your wxMaxima."
 msgstr ""
+" はより新しいバージョンのwxMaximaを用いて保存されたものなので、正しく読み込めないかもしれません。 "
+"このwxMaximaををアップデートしてください。"
 
 #: ../../src/wxMaxima.cpp:4603
+#, fuzzy
 msgid ""
 "Document was saved using a newer version of wxMaxima. Please update your "
 "wxMaxima."
-msgstr ""
+msgstr " はより新しいバージョンのwxMaximaを用いて保存されたものです。このwxMaximaををアップデートしてください。"
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "Don't autosubscript after an underscore"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1086
+#, fuzzy
 msgid "Don't evaluate Expression..."
-msgstr ""
+msgstr "積分"
 
 #: ../../src/wxMaxima.cpp:7117
+#, fuzzy
 msgid "Don't evaluate one command"
-msgstr ""
+msgstr "使用例を見たいコマンド名："
 
 #: ../../src/wxMaxima.cpp:7129
+#, fuzzy
 msgid "Don't evaluate one whole expression"
-msgstr ""
+msgstr "複素関数から実部を取り出す"
 
 #: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
 msgid "Don't mark cells that contain tooltips in yellow"
@@ -2246,7 +2395,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Don't save"
-msgstr ""
+msgstr "保存しない"
 
 #: ../../src/Worksheet.cpp:1620
 msgid "Don't show labels"
@@ -2261,36 +2410,40 @@ msgid "Don't use parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8525
+#, fuzzy
 msgid "Drop the first n list elements"
-msgstr ""
+msgstr "リストにコマンドを適用（ダイアログの\"関数\"は\"コマンド\"のことです）"
 
 #: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
+#, fuzzy
 msgid "Drop the last n list elements"
-msgstr ""
+msgstr "リストにコマンドを適用（ダイアログの\"関数\"は\"コマンド\"のことです）"
 
 #: ../../src/wxMaximaFrame.cpp:1306
 msgid "E&quations"
-msgstr ""
+msgstr "方程式(&Q)"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "E&xit\tCtrl+Q"
-msgstr ""
+msgstr "終了(&X)\tCtrl+Q"
 
 #: ../../src/wxMaximaFrame.cpp:1368
 msgid "Eige&nvectors"
-msgstr ""
+msgstr "固有ベクトル(&N)"
 
 #: ../../src/wxMaximaFrame.cpp:1365
 msgid "Eigen&values"
-msgstr ""
+msgstr "固有値(&V)"
 
 #: ../../src/wxMaximaFrame.cpp:1387
+#, fuzzy
 msgid "Eigenvalues (complex)"
-msgstr ""
+msgstr "固有値(&V)"
 
 #: ../../src/wxMaximaFrame.cpp:1384
+#, fuzzy
 msgid "Eigenvalues (real)"
-msgstr ""
+msgstr "固有値(&V)"
 
 #: ../../src/wxMaximaFrame.cpp:1393
 msgid "Eigenvalues, left+right eigenvectors (complex)"
@@ -2308,12 +2461,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8593
+#, fuzzy
 msgid "Element"
-msgstr ""
+msgstr "置換文字列："
 
 #: ../../src/wxMaxima.cpp:8549
+#, fuzzy
 msgid "Element number"
-msgstr ""
+msgstr "置換文字列："
 
 #: ../../src/wxMaxima.cpp:8005
 msgid ""
@@ -2329,28 +2484,32 @@ msgid "Element-by-element multiplication"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8510
+#, fuzzy
 msgid "Element:"
-msgstr ""
+msgstr "置換文字列："
 
 #: ../../src/wxMaxima.cpp:7204
+#, fuzzy
 msgid "Elements:"
-msgstr ""
+msgstr "置換文字列："
 
 #: ../../src/wxMaxima.cpp:7847
+#, fuzzy
 msgid "Eliminate a variable"
-msgstr ""
+msgstr "方程式の数を減らす(&E)..."
 
 #: ../../src/wxMaximaFrame.cpp:1247
 msgid "Eliminate a variable from a system of equations"
-msgstr ""
+msgstr "連立方程式から指定した変数を消去（方程式に代入）"
 
 #: ../../src/wxMaxima.cpp:10651
 msgid "Empty command => re-triggering evaluation"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9225
+#, fuzzy
 msgid "Enable:"
-msgstr ""
+msgstr "変数："
 
 #: ../../src/MathParser.cpp:99
 #, c-format
@@ -2362,8 +2521,9 @@ msgid "Encountered an unknown socket event."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7843
+#, fuzzy
 msgid "End of t:"
-msgstr ""
+msgstr "証明終了"
 
 #: ../../src/wxMaxima.cpp:4097
 msgid "Ended lisp mode after receiving a maxima prompt!"
@@ -2375,35 +2535,37 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1319
 msgid "Enter a matrix"
-msgstr ""
+msgstr "行列の各成分に任意の値を入力"
 
 #: ../../src/wxMaxima.cpp:8866
 msgid "Enter an equation for rational simplification:"
-msgstr ""
+msgstr "整数環に解を追加するための整数係数の多項式:"
 
 #: ../../src/wxMaxima.cpp:8169
 msgid "Enter matrix"
-msgstr ""
+msgstr "行列の入力"
 
 #: ../../src/wxMaxima.cpp:9095
+#, fuzzy
 msgid "Enter new animation frame rate [Hz, integer]:"
-msgstr ""
+msgstr "既定のアニメーションフレームレート:"
 
 #: ../../src/wxMaxima.cpp:9201
 msgid "Enter new precision for bigfloats:"
-msgstr ""
+msgstr "多倍長浮動小数点数(bigfloat)の精度を入力してください："
 
 #: ../../src/wxMaxima.cpp:7922
 msgid "Enumerator:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1220
+#, fuzzy
 msgid "Environment variables"
-msgstr ""
+msgstr "追加パラメーター："
 
 #: ../../src/wxMaxima.cpp:9045
 msgid "Epsilon:"
-msgstr ""
+msgstr "許容誤差："
 
 #: ../../src/wxMaximaFrame.cpp:1124 ../../src/wxMaximaFrame.cpp:1135
 msgid "Equal, ignoring case?..."
@@ -2414,22 +2576,24 @@ msgid "Equal?..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8561
+#, fuzzy
 msgid "Equation"
-msgstr ""
+msgstr "方程式："
 
 #: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
+#, fuzzy
 msgid "Equation(s)"
-msgstr ""
+msgstr "方程式："
 
 #: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
 msgid "Equation(s):"
-msgstr ""
+msgstr "方程式："
 
 #: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
 #: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
 #: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
 msgid "Equation:"
-msgstr ""
+msgstr "方程式："
 
 #: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
 #: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
@@ -2441,7 +2605,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
 #: ../../src/wxMaxima.cpp:11166
 msgid "Error"
-msgstr ""
+msgstr "エラー"
 
 #: ../../src/wxMaxima.cpp:2456
 msgid "Error writing to Maxima"
@@ -2451,7 +2615,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
 #: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
 msgid "Error!"
-msgstr ""
+msgstr "エラー"
 
 #: ../../src/Image.cpp:696
 #, c-format
@@ -2483,37 +2647,41 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1652
+#, fuzzy
 msgid "Evaluate &Noun Forms..."
-msgstr ""
+msgstr "未評価の式を評価(&N)"
 
 #: ../../src/wxMaximaFrame.cpp:856
 msgid "Evaluate All Cells\tCtrl+Shift+R"
-msgstr ""
+msgstr "全てのセルを評価\tCtrl+Shift+R"
 
 #: ../../src/wxMaximaFrame.cpp:851
 msgid "Evaluate All Visible Cells\tCtrl+R"
-msgstr ""
+msgstr "表示されている全てのセルを評価\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1395
+#, fuzzy
 msgid "Evaluate Cell"
-msgstr ""
+msgstr "セルを評価"
 
 #: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
 msgid "Evaluate Cell(s)"
-msgstr ""
+msgstr "セルを評価"
 
 #: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
+#, fuzzy
 msgid "Evaluate Cells Above"
-msgstr ""
+msgstr "セルを評価"
 
 #: ../../src/wxMaximaFrame.cpp:866
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
-msgstr ""
+msgstr "カーソル位置より上の全てのセルを評価\tCtrl+Shift+P"
 
 #: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
 #: ../../src/wxMaximaFrame.cpp:876
+#, fuzzy
 msgid "Evaluate Cells Below"
-msgstr ""
+msgstr "セルを評価"
 
 #: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
 #: ../../src/Worksheet.cpp:1890
@@ -2526,30 +2694,31 @@ msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8626
+#, fuzzy
 msgid "Evaluate Nouns"
-msgstr ""
+msgstr "未評価の式を評価(&N)"
 
 #: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
 msgid "Evaluate Part\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "部を評価\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1431 ../../src/Worksheet.cpp:1741
 msgid "Evaluate Section\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "セクションを評価\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1445 ../../src/Worksheet.cpp:1751
 #: ../../src/Worksheet.cpp:1879
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "サブサブセクションを評価\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1438 ../../src/Worksheet.cpp:1746
 #: ../../src/Worksheet.cpp:1868
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "サブセクションを評価\tShift+Ctrl+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:845
 msgid "Evaluate active or selected cell(s)"
-msgstr ""
+msgstr "アクティブ/選択セルを評価"
 
 #: ../../src/ToolBar.cpp:251
 msgid "Evaluate all"
@@ -2557,43 +2726,47 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:857
 msgid "Evaluate all cells in the document"
-msgstr ""
+msgstr "全てのセルを評価"
 
 #: ../../src/wxMaximaFrame.cpp:1653
 msgid "Evaluate all noun forms in expression"
-msgstr ""
+msgstr "'integrateのような未評価の式を評価"
 
 #: ../../src/wxMaximaFrame.cpp:852
 msgid "Evaluate all visible cells in the document"
-msgstr ""
+msgstr "ドキュメント内の全てのセルを評価"
 
 #: ../../src/ToolBar.cpp:248
 msgid "Evaluate current cell"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7395
+#, fuzzy
 msgid "Evaluate string"
-msgstr ""
+msgstr "現在位置より上のセルを再評価"
 
 #: ../../src/wxMaximaFrame.cpp:1151
+#, fuzzy
 msgid "Evaluate string..."
-msgstr ""
+msgstr "現在位置より上のセルを再評価"
 
 #: ../../src/ToolBar.cpp:256
 msgid "Evaluate the file from its beginning to the cell above the cursor"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:259
+#, fuzzy
 msgid "Evaluate the file from the cursor to its end"
-msgstr ""
+msgstr "カーソルがあるセルより上にある全てのセルを再評価"
 
 #: ../../src/ToolBar.cpp:258
+#, fuzzy
 msgid "Evaluate the rest"
-msgstr ""
+msgstr "現在位置より上のセルを再評価"
 
 #: ../../src/ToolBar.cpp:255
 msgid "Evaluate to point"
-msgstr ""
+msgstr "現在位置より上のセルを再評価"
 
 #: ../../src/wxMaxima.cpp:10518
 msgid "Evaluation ended, since evaluation queue is empty."
@@ -2617,31 +2790,34 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1583
 msgid "Expand Expression"
-msgstr ""
+msgstr "展開"
 
 #: ../../src/wxMaximaFrame.cpp:1525
 msgid "Expand an expression"
-msgstr ""
+msgstr "展開"
 
 #: ../../src/wxMaximaFrame.cpp:1531
+#, fuzzy
 msgid "Expand for given variables"
-msgstr ""
+msgstr "変数の置換"
 
 #: ../../src/wxMaxima.cpp:8781
 msgid "Expand for variable(s) including denominator:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8716
+#, fuzzy
 msgid "Expand for variable(s):"
-msgstr ""
+msgstr "新変数："
 
 #: ../../src/wxMaximaFrame.cpp:1545
+#, fuzzy
 msgid "Expand log in previous expression"
-msgstr ""
+msgstr "展開"
 
 #: ../../src/wxMaximaFrame.cpp:1598
 msgid "Expand trigonometric expression"
-msgstr ""
+msgstr "三角関数および双曲線関数の展開"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Expect numbers harder to be complex"
@@ -2653,62 +2829,68 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6121
 msgid "Export"
-msgstr ""
+msgstr "エクスポート"
 
 #: ../../src/wxMaximaFrame.cpp:1705
+#, fuzzy
 msgid "Export List to csv file..."
-msgstr ""
+msgstr "エクスポートに失敗しました"
 
 #: ../../src/wxMaximaFrame.cpp:1706
+#, fuzzy
 msgid "Export a list to a csv file"
-msgstr ""
+msgstr "パッケージファイルの読み込み"
 
 #: ../../src/wxMaximaFrame.cpp:1332
+#, fuzzy
 msgid "Export a matrix to a csv file"
-msgstr ""
+msgstr "パッケージファイルの読み込み"
 
 #: ../../src/wxMaximaFrame.cpp:619
+#, fuzzy
 msgid "Export document to a HTML or LaTeX file"
-msgstr ""
+msgstr "HTML/TeX形式でエクスポート"
 
 #: ../../src/wxMaximaFrame.cpp:579
 msgid "Export failed."
-msgstr ""
+msgstr "エクスポートに失敗しました"
 
 #: ../../src/wxMaximaFrame.cpp:567
 msgid "Export successful."
-msgstr ""
+msgstr "エクスポートに成功しました"
 
 #: ../../src/wxMaxima.cpp:6187
 msgid "Exporting to HTML failed!"
-msgstr ""
+msgstr "エクスポートに失敗しました"
 
 #: ../../src/wxMaxima.cpp:6164
 msgid "Exporting to TeX failed!"
-msgstr ""
+msgstr "エクスポートに失敗しました"
 
 #: ../../src/wxMaxima.cpp:6175
 msgid "Exporting to maxima batch file failed!"
-msgstr ""
+msgstr "バッチファイルへのエクスポートに失敗しました"
 
 #: ../../src/wxMaximaFrame.cpp:561
 msgid "Exporting..."
-msgstr ""
+msgstr "エクスポート中..."
 
 #: ../../src/wxMaxima.cpp:6510 ../../src/wxMaxima.cpp:6516
 #: ../../src/wxMaxima.cpp:8218 ../../src/wxMaxima.cpp:8633
 #: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
 #: ../../src/wxMaxima.cpp:10065
 msgid "Expression"
-msgstr ""
+msgstr "関数"
 
 #: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
+#, fuzzy
 msgid "Expression or a list of comma-separated expressions"
-msgstr ""
+msgstr "各x座標はカンマで区切ってください"
 
 #: ../../src/wxMaximaFrame.cpp:1088
+#, fuzzy
 msgid "Expression to string..."
-msgstr ""
+msgstr "関数"
 
 #: ../../src/wxMaxima.cpp:7113
 msgid "Expression whose output is to be used as maxima's input."
@@ -2716,7 +2898,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7214
 msgid "Expression(s):"
-msgstr ""
+msgstr "関数："
 
 #: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
 #: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
@@ -2725,19 +2907,22 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
 #: ../../src/wxMaxima.cpp:10056
 msgid "Expression:"
-msgstr ""
+msgstr "関数："
 
 #: ../../src/wxMaximaFrame.cpp:1423
+#, fuzzy
 msgid "Extract Column..."
-msgstr ""
+msgstr "置換文字列："
 
 #: ../../src/wxMaximaFrame.cpp:1726
+#, fuzzy
 msgid "Extract Elements"
-msgstr ""
+msgstr "置換文字列："
 
 #: ../../src/wxMaximaFrame.cpp:1421
+#, fuzzy
 msgid "Extract Row..."
-msgstr ""
+msgstr "置換文字列："
 
 #: ../../src/wxMaximaFrame.cpp:1424
 msgid "Extract a column from the matrix"
@@ -2748,32 +2933,38 @@ msgid "Extract a column from the matrix and convert it to a list"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7960
+#, fuzzy
 msgid "Extract a matrix column"
-msgstr ""
+msgstr "行列の各成分に任意の値を入力"
 
 #: ../../src/wxMaxima.cpp:7970
+#, fuzzy
 msgid "Extract a matrix column as a list"
-msgstr ""
+msgstr "行列の各成分に任意の値を入力"
 
 #: ../../src/wxMaximaFrame.cpp:1313
+#, fuzzy
 msgid "Extract a matrix from a 2-dimensional array"
-msgstr ""
+msgstr "文字のみの行列を生成"
 
 #: ../../src/wxMaxima.cpp:7955
+#, fuzzy
 msgid "Extract a matrix row"
-msgstr ""
+msgstr "行列の各成分に任意の値を入力"
 
 #: ../../src/wxMaxima.cpp:7965
+#, fuzzy
 msgid "Extract a matrix row as a list"
-msgstr ""
+msgstr "行列の各成分に任意の値を入力"
 
 #: ../../src/wxMaximaFrame.cpp:1422
 msgid "Extract a row from the matrix"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1431
+#, fuzzy
 msgid "Extract a row from the matrix and convert it to a list"
-msgstr ""
+msgstr "関数からリストを作成"
 
 #: ../../src/wxMaxima.cpp:8564
 msgid "Extract a variable's value from a list of variable values"
@@ -2784,60 +2975,72 @@ msgid "Extract an actual value for a variable"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1163
+#, fuzzy
 msgid "Extract char..."
-msgstr ""
+msgstr "置換文字列："
 
 #: ../../src/wxMaximaFrame.cpp:1207
+#, fuzzy
 msgid "Extract dir from path..."
-msgstr ""
+msgstr "置換文字列："
 
 #: ../../src/wxMaxima.cpp:7605
+#, fuzzy
 msgid "Extract directory part"
-msgstr ""
+msgstr "ユーザー定義関数名"
 
 #: ../../src/wxMaxima.cpp:7617
+#, fuzzy
 msgid "Extract file type extension"
-msgstr ""
+msgstr "関数からリストを作成"
 
 #: ../../src/wxMaximaFrame.cpp:1209
 msgid "Extract filename from path..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7611
+#, fuzzy
 msgid "Extract filename part"
-msgstr ""
+msgstr "置換文字列："
 
 #: ../../src/wxMaximaFrame.cpp:1211
 msgid "Extract filetype from path..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8445
+#, fuzzy
 msgid "Extract function arguments"
-msgstr ""
+msgstr "ユーザー定義関数名"
 
 #: ../../src/wxMaximaFrame.cpp:1727
+#, fuzzy
 msgid "Extract list Elements"
-msgstr ""
+msgstr "関数からリストを作成"
 
 #: ../../src/wxMaxima.cpp:8187
+#, fuzzy
 msgid "Extract matrix from 2D array"
-msgstr ""
+msgstr "行列の各成分に任意の値を入力"
 
 #: ../../src/wxMaximaFrame.cpp:1686
+#, fuzzy
 msgid "Extract the argument list from a function call"
-msgstr ""
+msgstr "関数からリストを作成"
 
 #: ../../src/wxMaxima.cpp:8538
+#, fuzzy
 msgid "Extract the last n elements from a list"
-msgstr ""
+msgstr "関数からリストを作成"
 
 #: ../../src/wxMaxima.cpp:7376
+#, fuzzy
 msgid "Extract the nth char of a string"
-msgstr ""
+msgstr "関数からリストを作成"
 
 #: ../../src/wxMaxima.cpp:8544
+#, fuzzy
 msgid "Extract the nth list elements"
-msgstr ""
+msgstr "関数からリストを作成"
 
 #: ../../src/wxMaximaFrame.cpp:1724
 msgid "Extract the value for one variable assigned in a list"
@@ -2848,32 +3051,34 @@ msgid "Extract, append or delete rows or columns"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8188
+#, fuzzy
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
-msgstr ""
+msgstr "関数からリストを作成"
 
 #: ../../src/wxMaximaFrame.cpp:1521
 msgid "Factor Complex"
-msgstr ""
+msgstr "複素数の範囲で因数分解"
 
 #: ../../src/Worksheet.cpp:1581
 msgid "Factor Expression"
-msgstr ""
+msgstr "因数分解"
 
 #: ../../src/wxMaximaFrame.cpp:1519
+#, fuzzy
 msgid "Factor Expression including subexpressions"
-msgstr ""
+msgstr "複素数の範囲で因数分解"
 
 #: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
 msgid "Factor an expression"
-msgstr ""
+msgstr "因数分解（素因数分解も可能）"
 
 #: ../../src/wxMaximaFrame.cpp:1522
 msgid "Factor an expression in Gaussian numbers"
-msgstr ""
+msgstr "複素数の範囲で因数分解"
 
 #: ../../src/wxMaximaFrame.cpp:1587
 msgid "Factorials and &Gamma"
-msgstr ""
+msgstr "階乗とガンマ関数(&G)"
 
 #: ../../src/Image.cpp:137
 #, c-format
@@ -2886,8 +3091,9 @@ msgid "Failed to delete gnuplot file %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:2667
+#, fuzzy
 msgid "Failed to start Maxima"
-msgstr ""
+msgstr "ラベル番号をリセット"
 
 #: ../../src/wxMaximaFrame.cpp:1418
 msgid "Fast fortran routines that perform numerical tasks"
@@ -2899,15 +3105,17 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:2553
 msgid "Fatal error"
-msgstr ""
+msgstr "致命的なエラー"
 
 #: ../../src/wxMaxima.cpp:7191
+#, fuzzy
 msgid "Field contents:"
-msgstr ""
+msgstr "ギリシャ文字"
 
 #: ../../src/wxMaxima.cpp:7198
+#, fuzzy
 msgid "Field name:"
-msgstr ""
+msgstr "全ての変数名"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "Fields:"
@@ -2915,43 +3123,49 @@ msgstr ""
 
 #: ../../src/main.cpp:439
 msgid "File"
-msgstr ""
+msgstr "ファイル"
 
 #: ../../src/wxMaximaFrame.cpp:1333
+#, fuzzy
 msgid "File I/O"
-msgstr ""
+msgstr "ファイル"
 
 #: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
 #: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
 #: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
 #: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
 msgid "File could not be opened"
-msgstr ""
+msgstr "ファイルを開けません"
 
 #: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
 #: ../../src/wxMaxima.cpp:7251
+#, fuzzy
 msgid "File name:"
-msgstr ""
+msgstr "全ての変数名"
 
 #: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
 msgid "File not found"
-msgstr ""
+msgstr "ファイルが見つかりません"
 
 #: ../../src/wxMaxima.cpp:5631
 msgid "File opened"
-msgstr ""
+msgstr "ファイルを開きました"
 
 #: ../../src/wxMaximaFrame.cpp:1217
+#, fuzzy
 msgid "File operations"
-msgstr ""
+msgstr "ファイルを開きました"
 
 #: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
 msgid "File you tried to open does not exist."
 msgstr ""
+"開こうとしたファイルは\n"
+"存在しません"
 
 #: ../../src/wxMaximaFrame.cpp:1221
+#, fuzzy
 msgid "File/directory functions"
-msgstr ""
+msgstr "近づき方："
 
 #: ../../src/wxMaxima.cpp:7027
 msgid "Filename or a list of comma-separated file names"
@@ -2959,27 +3173,27 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:222
 msgid "Find"
-msgstr ""
+msgstr "検索"
 
 #: ../../src/wxMaximaFrame.cpp:670
 msgid "Find\tCtrl+F"
-msgstr ""
+msgstr "テキストを検索\tCtrl+F"
 
 #: ../../src/wxMaximaFrame.cpp:1468
 msgid "Find &Limit..."
-msgstr ""
+msgstr "極限値(&L)..."
 
 #: ../../src/wxMaximaFrame.cpp:1470
 msgid "Find Minimum..."
-msgstr ""
+msgstr "極小値..."
 
 #: ../../src/Worksheet.cpp:1576
 msgid "Find Root..."
-msgstr ""
+msgstr "解を1つ探す..."
 
 #: ../../src/wxMaximaFrame.cpp:1471
 msgid "Find a (unconstrained) minimum of an expression"
-msgstr ""
+msgstr "正しい極小値を得るには開始位置の値を極小値の付近に設定してください"
 
 #: ../../src/wxMaximaFrame.cpp:1804
 msgid "Find a fraction that represents this float exactly"
@@ -2987,35 +3201,36 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1469
 msgid "Find a limit of an expression"
-msgstr ""
+msgstr "極限値を求める"
 
 #: ../../src/wxMaximaFrame.cpp:1807
 msgid "Find a nice fraction that is similar to this float"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1283
+#, fuzzy
 msgid "Find a numerical solution for a first degree ODE"
-msgstr ""
+msgstr "1階微分方程式の一般解に初期条件を適用"
 
 #: ../../src/wxMaximaFrame.cpp:1252
 msgid "Find a root of an equation on an interval"
-msgstr ""
+msgstr "定義域内で解を1つ探す（定義域の両端の符号が同じ場合エラーを出します）"
 
 #: ../../src/wxMaximaFrame.cpp:1259
 msgid "Find all roots of a polynomial"
-msgstr ""
+msgstr "方程式の解を小数で求める"
 
 #: ../../src/wxMaximaFrame.cpp:1262
 msgid "Find all roots of a polynomial (bfloat)"
-msgstr ""
+msgstr "方程式の解を浮動小数点で求める"
 
 #: ../../src/wxMaxima.cpp:6589
 msgid "Find and Replace"
-msgstr ""
+msgstr "検索と置換"
 
 #: ../../src/ToolBar.cpp:222 ../../src/wxMaximaFrame.cpp:670
 msgid "Find and replace"
-msgstr ""
+msgstr "検索と置換"
 
 #: ../../src/wxMaxima.cpp:7434
 msgid "Find char in string"
@@ -3031,11 +3246,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1366
 msgid "Find eigenvalues of a matrix"
-msgstr ""
+msgstr "固有値を求める（[固有値],[各固有値の重複]の順に表示）"
 
 #: ../../src/wxMaximaFrame.cpp:1369
 msgid "Find eigenvectors of a matrix"
-msgstr ""
+msgstr "固有ベクトルを求める（[固有値],[各固有値の重複],[各固有値での固有ベクトル]の順に表示）"
 
 #: ../../src/wxMaxima.cpp:7424
 msgid "Find first difference"
@@ -3046,12 +3261,13 @@ msgid "Find first difference..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1256
+#, fuzzy
 msgid "Find fractions that real roots of a polynomial and "
-msgstr ""
+msgstr "方程式の実数解を有理数で求める"
 
 #: ../../src/wxMaxima.cpp:9039
 msgid "Find minimum"
-msgstr ""
+msgstr "極小値"
 
 #: ../../src/wxMaximaFrame.cpp:1251
 msgid "Find numerical solution..."
@@ -3062,8 +3278,9 @@ msgid "Find root (solve numerically)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
+#, fuzzy
 msgid "Find the maximum absolute value of a matrix entry"
-msgstr ""
+msgstr "固有値を求める（[固有値],[各固有値の重複]の順に表示）"
 
 #: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
 msgid "Find the maximum sum of the absolute values of a matrix column"
@@ -3095,11 +3312,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:922
 msgid "Fold All\tCtrl+Alt+["
-msgstr ""
+msgstr "全て折りたたむ\tCtrl+Alt+["
 
 #: ../../src/wxMaximaFrame.cpp:923
 msgid "Fold all sections"
-msgstr ""
+msgstr "すべてのセクションを折りたたむ"
 
 #: ../../src/ToolBar.cpp:240
 msgid "Follow"
@@ -3182,59 +3399,64 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "From:"
-msgstr ""
+msgstr "下端："
 
 #: ../../src/wxMaximaFrame.cpp:827
 msgid "Full Screen\tAlt+Enter"
-msgstr ""
+msgstr "全画面表示\tAlt+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:824
 msgid "Full Screen\tF11"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7140
+#, fuzzy
 msgid "Function contents:"
-msgstr ""
+msgstr "ユーザー定義関数名"
 
 #: ../../src/wxMaxima.cpp:7908
+#, fuzzy
 msgid "Function f(x):"
-msgstr ""
+msgstr "関数："
 
 #: ../../src/wxMaxima.cpp:8572
+#, fuzzy
 msgid "Function name"
-msgstr ""
+msgstr "ユーザー定義関数名"
 
 #: ../../src/wxMaxima.cpp:7167
+#, fuzzy
 msgid "Function name(s):"
-msgstr ""
+msgstr "ユーザー定義関数名"
 
 #: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
+#, fuzzy
 msgid "Function name:"
-msgstr ""
+msgstr "ユーザー定義関数名"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Function:"
-msgstr ""
+msgstr "関数："
 
 #: ../../src/wxMaximaFrame.cpp:1630
 msgid "Functions for complex simplification"
-msgstr ""
+msgstr "複素関数をを単純化するための機能"
 
 #: ../../src/wxMaximaFrame.cpp:1588
 msgid "Functions for simplifying factorials and gamma function"
-msgstr ""
+msgstr "階乗とガンマ関数を単純化するための機能"
 
 #: ../../src/wxMaximaFrame.cpp:1606
 msgid "Functions for simplifying trigonometric expressions"
-msgstr ""
+msgstr "三角関数をを単純化するための機能"
 
 #: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
 msgid "GCD"
-msgstr ""
+msgstr "最大公約数"
 
 #: ../../src/wxMaxima.cpp:10186
 msgid "GIF image (*.gif)|*.gif"
-msgstr ""
+msgstr "GIF ファイル (*.gif)|*.gif"
 
 #: ../../src/Worksheet.cpp:103
 msgid ""
@@ -3245,19 +3467,19 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:295
 msgid "General Math"
-msgstr ""
+msgstr "数式処理"
 
 #: ../../src/wxMaximaFrame.cpp:699
 msgid "General Math\tAlt+Shift+M"
-msgstr ""
+msgstr "数式処理\tAlt+Shift+M"
 
 #: ../../src/wxMaximaFrame.cpp:1316
 msgid "Generate Matrix from Expression..."
-msgstr ""
+msgstr "関数から行列生成..."
 
 #: ../../src/wxMaximaFrame.cpp:1317
 msgid "Generate a matrix from a lambda expression"
-msgstr ""
+msgstr "i行j列の成分に関数f(i,j)の値を代入"
 
 #: ../../src/wxMaximaFrame.cpp:1675
 msgid "Generate a new list using a lists' elements"
@@ -3274,8 +3496,9 @@ msgid "Generate list elements using a rule"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8196
+#, fuzzy
 msgid "Generate matrix from a rule"
-msgstr ""
+msgstr "関数からリストを作成"
 
 #: ../../src/wxMaximaFrame.cpp:1094
 msgid "Generate unused symbol name"
@@ -3293,15 +3516,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1619
 msgid "Get &Imaginary Part"
-msgstr ""
+msgstr "虚部を取り出す(&I)"
 
 #: ../../src/wxMaximaFrame.cpp:1485
 msgid "Get Laplace transformation of an expression"
-msgstr ""
+msgstr "ラプラス変換を求める"
 
 #: ../../src/wxMaximaFrame.cpp:1615
 msgid "Get Real P&art"
-msgstr ""
+msgstr "実部を取り出す(&A)"
 
 #: ../../src/wxMaximaFrame.cpp:1201
 msgid "Get current directory"
@@ -3309,23 +3532,24 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1489
 msgid "Get inverse Laplace transformation of an expression"
-msgstr ""
+msgstr "ラプラス逆変換を求めます（分母の多項式は各次数が定まっている必要があります）"
 
 #: ../../src/wxMaxima.cpp:7223
 msgid "Get position in stream"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1102
+#, fuzzy
 msgid "Get position..."
-msgstr ""
+msgstr "標準偏差..."
 
 #: ../../src/wxMaximaFrame.cpp:1620
 msgid "Get the imaginary part of complex expression"
-msgstr ""
+msgstr "複素関数から虚部を取り出す"
 
 #: ../../src/wxMaximaFrame.cpp:1616
 msgid "Get the real part of complex expression"
-msgstr ""
+msgstr "複素関数から実部を取り出す"
 
 #: ../../src/wxMaxima.cpp:3609
 #, c-format
@@ -3351,8 +3575,9 @@ msgid "Go to URL"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3989
+#, fuzzy
 msgid "Got a new input prompt!"
-msgstr ""
+msgstr "入力セルを挿入"
 
 #: ../../src/Worksheet.cpp:6354
 msgid ""
@@ -3365,8 +3590,9 @@ msgid "Gradefs"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1967
+#, fuzzy
 msgid "Greater or less than a value"
-msgstr ""
+msgstr "以上"
 
 #: ../../src/wxMaximaFrame.cpp:1130
 msgid "Greater, ignoring case?..."
@@ -3374,37 +3600,42 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:260
 msgid "Greek Letters"
-msgstr ""
+msgstr "ギリシャ文字"
 
 #: ../../src/wxMaximaFrame.cpp:703
 msgid "Greek Letters\tAlt+Shift+G"
-msgstr ""
+msgstr "ギリシャ文字\tAlt+Shift+G"
 
 #: ../../src/wxMaximaFrame.cpp:1815
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:6123
+#, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file "
 "(*.tex)|*.tex"
 msgstr ""
+"HTML ドキュメント (*.html)|*.html|maxima バッチファイル (*.mac)|*.mac|pdfLaTeX ファイル "
+"(*.tex)|*.tex"
 
 #: ../../src/wxMaximaFrame.cpp:1341
 msgid "Hadamard (element-by-element) product..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8004
+#, fuzzy
 msgid "Hadamard Product"
-msgstr ""
+msgstr "総乗"
 
 #: ../../src/wxMaxima.cpp:8011
 msgid "Hadamard exponent"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1345
+#, fuzzy
 msgid "Hadamard exponent..."
-msgstr ""
+msgstr "変数名："
 
 #: ../../src/MaximaManual.cpp:260
 #, c-format
@@ -3423,7 +3654,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
 msgid "Help"
-msgstr ""
+msgstr "ヘルプ"
 
 #: ../../src/ToolBar.cpp:635
 msgid "Help button"
@@ -3436,15 +3667,17 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:729
 msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr ""
+msgstr "全て隠す\tAlt+Shift+-"
 
 #: ../../src/ToolBar.cpp:264
+#, fuzzy
 msgid "Hide Code"
-msgstr ""
+msgstr "セルの分割"
 
 #: ../../src/wxMaximaFrame.cpp:727
+#, fuzzy
 msgid "Hide Code Cells\tAlt+Ctrl+H"
-msgstr ""
+msgstr "セルの挿入\tAlt+Shift+C"
 
 #: ../../src/Worksheet.cpp:1896
 msgid "Hide Heading 5"
@@ -3455,32 +3688,38 @@ msgid "Hide Heading 6"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1855
+#, fuzzy
 msgid "Hide Part"
-msgstr ""
+msgstr "セルの分割"
 
 #: ../../src/Worksheet.cpp:1863
+#, fuzzy
 msgid "Hide Section"
-msgstr ""
+msgstr "セクション"
 
 #: ../../src/Worksheet.cpp:1874
+#, fuzzy
 msgid "Hide Subsection"
-msgstr ""
+msgstr "サブセクション"
 
 #: ../../src/Worksheet.cpp:1885
+#, fuzzy
 msgid "Hide Subsubsection"
-msgstr ""
+msgstr "サブサブセクション"
 
 #: ../../src/wxMaximaFrame.cpp:730
 msgid "Hide all panes"
-msgstr ""
+msgstr "サイドバーのツールを全て隠す"
 
 #: ../../src/Worksheet.cpp:1491
+#, fuzzy
 msgid "Hide cell brackets"
-msgstr ""
+msgstr "アクティブセル"
 
 #: ../../src/Worksheet.cpp:1915
+#, fuzzy
 msgid "Hide contents"
-msgstr ""
+msgstr "ギリシャ文字"
 
 #: ../../src/Worksheet.cpp:1552
 msgid "Hide multiplication dots"
@@ -3495,20 +3734,21 @@ msgid "Hide yellow tooltip marker for this message type"
 msgstr ""
 
 #: ../../src/Configuration.cpp:82
+#, fuzzy
 msgid "Highlight (box)"
-msgstr ""
+msgstr "強調コマンド(dpartなど)の出力"
 
 #: ../../src/wxMaxima.cpp:9528
 msgid "Histogram"
-msgstr ""
+msgstr "ヒストグラム"
 
 #: ../../src/wxMaximaFrame.cpp:232
 msgid "History"
-msgstr ""
+msgstr "入力履歴"
 
 #: ../../src/wxMaximaFrame.cpp:709
 msgid "History\tAlt+Shift+I"
-msgstr ""
+msgstr "入力履歴\tAlt+Shift+I"
 
 #: ../../src/wxMaximaFrame.cpp:1526
 msgid "Horner's rule"
@@ -3587,7 +3827,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Include columns:"
-msgstr ""
+msgstr "抽出列"
 
 #: ../../src/Worksheet.cpp:2008
 msgid "Increasing function f(x)>x"
@@ -3606,12 +3846,13 @@ msgid "Index Step:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
+#, fuzzy
 msgid "Index variable:"
-msgstr ""
+msgstr "新変数："
 
 #: ../../src/wxMaximaFrame.cpp:1949
 msgid "Info about Maxima build"
-msgstr ""
+msgstr "ビルド情報の表示"
 
 #: ../../src/Worksheet.cpp:2046
 msgid "Inform maxima about facts you know for this symbol"
@@ -3624,44 +3865,50 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
+#, fuzzy
 msgid "Initial Condition"
 msgstr ""
+"抽出条件（複数指定可）：\n"
+"（col[i]#Xでi列のXを除外）\n"
+"（col[i]=Xでi列のXのみ抽出）"
 
 #: ../../src/wxMaximaFrame.cpp:1270
 msgid "Initial Value Problem (&1)..."
-msgstr ""
+msgstr "特殊解を求める（&1階微分方程式）..."
 
 #: ../../src/wxMaximaFrame.cpp:1274
 msgid "Initial Value Problem (&2)..."
-msgstr ""
+msgstr "特殊解を求める（&2階微分方程式）..."
 
 #: ../../src/wxMaxima.cpp:9044
+#, fuzzy
 msgid "Initial estimates:"
-msgstr ""
+msgstr "開始位置："
 
 #: ../../src/wxMaxima.cpp:7840
+#, fuzzy
 msgid "Initial x:"
-msgstr ""
+msgstr "開始位置："
 
 #: ../../src/Configuration.cpp:78
 msgid "Input labels"
-msgstr ""
+msgstr "入力ラベル"
 
 #: ../../src/wxMaximaFrame.cpp:314
 msgid "Insert"
-msgstr ""
+msgstr "挿入"
 
 #: ../../src/wxMaximaFrame.cpp:905
 msgid "Insert &Section Cell\tCtrl+3"
-msgstr ""
+msgstr "セクションセルの挿入(&S)\tCtrl+3"
 
 #: ../../src/wxMaximaFrame.cpp:901
 msgid "Insert &Text Cell\tCtrl+1"
-msgstr ""
+msgstr "テキストセルの挿入(&T)\tCtrl+1"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Insert Cell\tAlt+Shift+C"
-msgstr ""
+msgstr "セルの挿入\tAlt+Shift+C"
 
 #: ../../src/Worksheet.cpp:1669
 msgid "Insert Heading5 Cell"
@@ -3673,51 +3920,52 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10854
 msgid "Insert Image"
-msgstr ""
+msgstr "画像の挿入"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert Image..."
-msgstr ""
+msgstr "画像の挿入..."
 
 #: ../../src/wxMaximaFrame.cpp:899
+#, fuzzy
 msgid "Insert Input &Cell\tCtrl+0"
-msgstr ""
+msgstr "入力セルの挿入(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:919
 msgid "Insert Page Break"
-msgstr ""
+msgstr "改ページの挿入"
 
 #: ../../src/wxMaximaFrame.cpp:907
 msgid "Insert S&ubsection Cell\tCtrl+4"
-msgstr ""
+msgstr "サブセクションセルの挿入(&U)\tCtrl+4"
 
 #: ../../src/wxMaximaFrame.cpp:910
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
-msgstr ""
+msgstr "サブサブセクションセルの挿入\tCtrl+5"
 
 #: ../../src/Worksheet.cpp:1662
 msgid "Insert Section Cell"
-msgstr ""
+msgstr "セクションセルの挿入"
 
 #: ../../src/Worksheet.cpp:1664
 msgid "Insert Subsection Cell"
-msgstr ""
+msgstr "サブセクションセルの挿入"
 
 #: ../../src/Worksheet.cpp:1667
 msgid "Insert Subsubsection Cell"
-msgstr ""
+msgstr "サブサブセクションセルの挿入"
 
 #: ../../src/wxMaximaFrame.cpp:903
 msgid "Insert T&itle Cell\tCtrl+2"
-msgstr ""
+msgstr "タイトルセルの挿入(&I)\tCtrl+2"
 
 #: ../../src/Worksheet.cpp:1658
 msgid "Insert Text Cell"
-msgstr ""
+msgstr "テキストセルの挿入"
 
 #: ../../src/Worksheet.cpp:1660
 msgid "Insert Title Cell"
-msgstr ""
+msgstr "タイトルセルの挿入"
 
 #: ../../src/wxMaximaFrame.cpp:913
 msgid "Insert a new heading5 cell"
@@ -3729,35 +3977,36 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:900
 msgid "Insert a new input cell"
-msgstr ""
+msgstr "入力セルを挿入"
 
 #: ../../src/wxMaximaFrame.cpp:906
 msgid "Insert a new section cell"
-msgstr ""
+msgstr "セクションセルを挿入"
 
 #: ../../src/wxMaximaFrame.cpp:908
 msgid "Insert a new subsection cell"
-msgstr ""
+msgstr "サブセクションセルを挿入"
 
 #: ../../src/wxMaximaFrame.cpp:911
 msgid "Insert a new subsubsection cell"
-msgstr ""
+msgstr "サブサブセクションセルを挿入"
 
 #: ../../src/wxMaximaFrame.cpp:902
 msgid "Insert a new text cell"
-msgstr ""
+msgstr "テキストセルを挿入"
 
 #: ../../src/wxMaximaFrame.cpp:904
 msgid "Insert a new title cell"
-msgstr ""
+msgstr "タイトルセルを挿入"
 
 #: ../../src/wxMaximaFrame.cpp:920
 msgid "Insert a page break"
-msgstr ""
+msgstr "改ページを挿入"
 
 #: ../../src/wxMaximaFrame.cpp:1164
+#, fuzzy
 msgid "Insert char..."
-msgstr ""
+msgstr "画像の挿入..."
 
 #: ../../src/wxMaximaFrame.cpp:912
 msgid "Insert heading5 Cell\tCtrl+6"
@@ -3772,8 +4021,9 @@ msgid "Insert image"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:916
+#, fuzzy
 msgid "Insert textbased cell"
-msgstr ""
+msgstr "テキストセルの挿入"
 
 #: ../../src/wxMaxima.cpp:3566
 msgid "Instructed to prefer gnuplot over wgnuplot"
@@ -3785,43 +4035,47 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
 msgid "Integral/Sum:"
-msgstr ""
+msgstr "未評価の式："
 
 #: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
 msgid "Integrate"
-msgstr ""
+msgstr "積分"
 
 #: ../../src/wxMaxima.cpp:8980
 msgid "Integrate (risch)"
-msgstr ""
+msgstr "Risch積分"
 
 #: ../../src/wxMaximaFrame.cpp:1454
 msgid "Integrate expression"
-msgstr ""
+msgstr "積分"
 
 #: ../../src/wxMaximaFrame.cpp:1456
 msgid "Integrate expression with Risch algorithm"
-msgstr ""
+msgstr "Rishのアルゴリズムによる積分"
 
 #: ../../src/wxMaximaFrame.cpp:1869
+#, fuzzy
 msgid "Integrate numerically"
-msgstr ""
+msgstr "Risch積分"
 
 #: ../../src/Worksheet.cpp:1588
 msgid "Integrate..."
-msgstr ""
+msgstr "積分..."
 
 #: ../../src/wxMaximaFrame.cpp:1737
+#, fuzzy
 msgid "Interleave"
-msgstr ""
+msgstr "積分"
 
 #: ../../src/wxMaximaFrame.cpp:1738
+#, fuzzy
 msgid "Interleave the values of two lists"
-msgstr ""
+msgstr "積分"
 
 #: ../../src/wxMaxima.cpp:8612
+#, fuzzy
 msgid "Interleave two lists"
-msgstr ""
+msgstr "積分"
 
 #: ../../src/wxMaximaFrame.cpp:1087
 msgid "Interpret like input..."
@@ -3836,16 +4090,17 @@ msgid "Interpret string as maxima code"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1089
+#, fuzzy
 msgid "Interpret string..."
-msgstr ""
+msgstr "行列を手入力..."
 
 #: ../../src/ToolBar.cpp:231
 msgid "Interrupt"
-msgstr ""
+msgstr "強制終了"
 
 #: ../../src/wxMaximaFrame.cpp:965
 msgid "Interrupt current computation"
-msgstr ""
+msgstr "処理を強制終了"
 
 #: ../../src/ToolBar.cpp:232
 msgid ""
@@ -3872,11 +4127,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9003
 msgid "Inverse Laplace"
-msgstr ""
+msgstr "ラプラス逆変換"
 
 #: ../../src/wxMaximaFrame.cpp:1488
 msgid "Inverse Laplace T&ransform..."
-msgstr ""
+msgstr "ラプラス逆変換(&R)..."
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Invert worksheet brightness"
@@ -3887,8 +4142,9 @@ msgid "Is Char 1 greater than Char2, if case is ignored?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7333
+#, fuzzy
 msgid "Is Char 1 greater than Char2?"
-msgstr ""
+msgstr "非常に大きい"
 
 #: ../../src/wxMaxima.cpp:7327
 msgid "Is Char 1 less than Char2, if case is ignored?"
@@ -3907,12 +4163,14 @@ msgid "Is a char?..."
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1952
+#, fuzzy
 msgid "Is a complex variable"
-msgstr ""
+msgstr "新変数："
 
 #: ../../src/wxMaxima.cpp:7292
+#, fuzzy
 msgid "Is a digit?"
-msgstr ""
+msgstr "表示形式"
 
 #: ../../src/wxMaximaFrame.cpp:1118
 msgid "Is a digit?..."
@@ -3927,8 +4185,9 @@ msgid "Is a printable char?"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1949
+#, fuzzy
 msgid "Is a real variable"
-msgstr ""
+msgstr "変数の置換"
 
 #: ../../src/wxMaxima.cpp:7300
 msgid "Is a uppercase char?"
@@ -3951,28 +4210,33 @@ msgid "Is an alphanumeric char?"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1991
+#, fuzzy
 msgid "Is an even function"
-msgstr ""
+msgstr "ユーザー定義関数を削除"
 
 #: ../../src/Worksheet.cpp:1955
+#, fuzzy
 msgid "Is an imaginary variable"
-msgstr ""
+msgstr "変数の置換"
 
 #: ../../src/Worksheet.cpp:1960
+#, fuzzy
 msgid "Is an integer variable"
-msgstr ""
+msgstr "変数の置換"
 
 #: ../../src/Worksheet.cpp:1993
+#, fuzzy
 msgid "Is an odd function"
-msgstr ""
+msgstr "ユーザー定義関数を削除"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Is equal?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1128
+#, fuzzy
 msgid "Is greater?..."
-msgstr ""
+msgstr "リスト作成"
 
 #: ../../src/wxMaximaFrame.cpp:1125
 msgid "Is lower?..."
@@ -3983,8 +4247,9 @@ msgid "Is lowercase?..."
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1962
+#, fuzzy
 msgid "Is no integer variable"
-msgstr ""
+msgstr "変数の置換"
 
 #: ../../src/wxMaximaFrame.cpp:1119
 msgid "Is printable?..."
@@ -4007,8 +4272,9 @@ msgid "Item"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8581
+#, fuzzy
 msgid "Iterator name:"
-msgstr ""
+msgstr "変数名："
 
 #: ../../src/wxMaximaFrame.cpp:1048
 msgid "Jump to first error"
@@ -4020,7 +4286,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8960
 msgid "LCM"
-msgstr ""
+msgstr "最小公倍数"
 
 #: ../../src/wxMaximaFrame.cpp:1407
 msgid "L[1] Norm (complex)"
@@ -4039,8 +4305,9 @@ msgid "L[inf] Norm (real)"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1025
+#, fuzzy
 msgid "Labels"
-msgstr ""
+msgstr "入力ラベル"
 
 #: ../../src/wxMaxima.cpp:7090
 msgid "Lambda"
@@ -4055,11 +4322,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8997
 msgid "Laplace"
-msgstr ""
+msgstr "ラプラス変換"
 
 #: ../../src/wxMaximaFrame.cpp:1484
 msgid "Laplace &Transform..."
-msgstr ""
+msgstr "ラプラス変換(&T)..."
 
 #: ../../src/wxMaximaFrame.cpp:1718
 msgid "Last"
@@ -4076,8 +4343,9 @@ msgid "Last message from maxima's stdout: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1720
+#, fuzzy
 msgid "Last n"
-msgstr ""
+msgstr "リスト："
 
 #: ../../src/wxMaxima.cpp:10400
 msgid "Last non-whitespace is a question mark"
@@ -4094,16 +4362,17 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1493
 msgid "Least Common Multiple..."
-msgstr ""
+msgstr "最小公倍数..."
 
 #: ../../src/wxMaxima.cpp:9587
 msgid "Least Squares Fit"
-msgstr ""
+msgstr "最小二乗法"
 
 #: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
 #: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
+#, fuzzy
 msgid "Left Matrix:"
-msgstr ""
+msgstr "ファイルを開く"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Left end"
@@ -4130,16 +4399,18 @@ msgid "Letrules"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1976
+#, fuzzy
 msgid "Likely to be the main variable"
-msgstr ""
+msgstr "ユーザー定義変数を削除"
 
 #: ../../src/wxMaxima.cpp:9028
 msgid "Limit"
-msgstr ""
+msgstr "極限値"
 
 #: ../../src/wxMaxima.cpp:7256
+#, fuzzy
 msgid "Lisp format string:"
-msgstr ""
+msgstr "条件不足時のMaximaの質問"
 
 #: ../../src/wxMaxima.cpp:7258
 msgid "Lisp format strings are more powerful than c++ format strings"
@@ -4162,16 +4433,19 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
 #: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
 #: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
+#, fuzzy
 msgid "List"
-msgstr ""
+msgstr "リスト："
 
 #: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
+#, fuzzy
 msgid "List #1"
-msgstr ""
+msgstr "リスト："
 
 #: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
+#, fuzzy
 msgid "List #2"
-msgstr ""
+msgstr "リスト："
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "List directory"
@@ -4186,12 +4460,14 @@ msgid "List of char to String"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1150
+#, fuzzy
 msgid "List of chars to string..."
-msgstr ""
+msgstr "関数"
 
 #: ../../src/wxMaxima.cpp:7386
+#, fuzzy
 msgid "List of chars:"
-msgstr ""
+msgstr "入力ラベル"
 
 #: ../../src/wxMaxima.cpp:8559
 msgid "List with values"
@@ -4200,43 +4476,49 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
 msgid "List:"
-msgstr ""
+msgstr "リスト："
 
 #: ../../src/wxMaxima.cpp:6200
 msgid "Load Package"
-msgstr ""
+msgstr "パッケージ読み込み"
 
 #: ../../src/wxMaximaFrame.cpp:613
+#, fuzzy
 msgid "Load Recent Package"
-msgstr ""
+msgstr "パッケージ読み込み"
 
 #: ../../src/wxMaximaFrame.cpp:616
 msgid "Load a Maxima file using the batch command"
-msgstr ""
+msgstr "バッチ処理に使うファイルの読み込み"
 
 #: ../../src/wxMaximaFrame.cpp:611
 msgid "Load a Maxima package file"
-msgstr ""
+msgstr "パッケージファイルの読み込み"
 
 #: ../../src/wxMaximaFrame.cpp:1678
+#, fuzzy
 msgid "Load a list from a csv file"
-msgstr ""
+msgstr "パッケージファイルの読み込み"
 
 #: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
+#, fuzzy
 msgid "Load a matrix from a csv file"
-msgstr ""
+msgstr "パッケージファイルの読み込み"
 
 #: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
+#, fuzzy
 msgid "Load lapack"
-msgstr ""
+msgstr "パッケージ読み込み"
 
 #: ../../src/wxMaxima.cpp:7208
+#, fuzzy
 msgid "Load lisp code"
-msgstr ""
+msgstr "パッケージ読み込み"
 
 #: ../../src/wxMaximaFrame.cpp:1092
+#, fuzzy
 msgid "Load lisp..."
-msgstr ""
+msgstr "パッケージ読み込み"
 
 #: ../../src/wxMaximaFrame.cpp:1198
 msgid "Load the file/dir operations (operatingsystem)"
@@ -4251,28 +4533,32 @@ msgid "Load the translation generator (gentran)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8219
+#, fuzzy
 msgid "Loop variable"
-msgstr ""
+msgstr "新変数："
 
 #: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
 msgid "Lower bound:"
-msgstr ""
+msgstr "下限："
 
 #: ../../src/wxMaximaFrame.cpp:1127
 msgid "Lower, ignoring case?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1448
+#, fuzzy
 msgid "M&atrix"
-msgstr ""
+msgstr "行列"
 
 #: ../../src/wxMaxima.cpp:7153
+#, fuzzy
 msgid "Macro contents:"
-msgstr ""
+msgstr "ギリシャ文字"
 
 #: ../../src/wxMaxima.cpp:7148
+#, fuzzy
 msgid "Macro name:"
-msgstr ""
+msgstr "変数名："
 
 #: ../../src/wxMaximaFrame.cpp:1024
 msgid "Macros"
@@ -4280,7 +4566,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:697
 msgid "Main Toolbar\tAlt+Shift+B"
-msgstr ""
+msgstr "ツールバー\tAlt+Shift+B"
 
 #: ../../src/wxMaxima.cpp:7906
 msgid "Make a function value at a specific point known"
@@ -4291,32 +4577,36 @@ msgid "Make an eventual ev() evaluate this"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1070
+#, fuzzy
 msgid "Make function local..."
-msgstr ""
+msgstr "リストに関数を適用"
 
 #: ../../src/wxMaxima.cpp:8207
 msgid "Map"
-msgstr ""
+msgstr "リストに関数を適用"
 
 #: ../../src/wxMaxima.cpp:8215
+#, fuzzy
 msgid "Map an expression"
-msgstr ""
+msgstr "展開"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "Map function to a matrix"
-msgstr ""
+msgstr "行列に関数を適用"
 
 #: ../../src/wxMaximaFrame.cpp:1446
+#, fuzzy
 msgid "Map function to a matrix, affecting all of its clones"
-msgstr ""
+msgstr "行列に関数を適用"
 
 #: ../../src/Configuration.cpp:109
+#, fuzzy
 msgid "Math Default"
-msgstr ""
+msgstr "特別な文字列"
 
 #: ../../src/wxMaximaFrame.cpp:286
 msgid "Mathematical Symbols"
-msgstr ""
+msgstr "数学記号"
 
 #: ../../src/ToolBar.cpp:270
 msgid "Maths"
@@ -4332,39 +4622,45 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
 #: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
 msgid "Matrix"
-msgstr ""
+msgstr "行列"
 
 #: ../../src/wxMaxima.cpp:7986
+#, fuzzy
 msgid "Matrix Exponent"
-msgstr ""
+msgstr "変数名："
 
 #: ../../src/wxMaximaFrame.cpp:1339
+#, fuzzy
 msgid "Matrix exponent..."
-msgstr ""
+msgstr "変数名："
 
 #: ../../src/wxMaximaFrame.cpp:1329
+#, fuzzy
 msgid "Matrix from csv file"
-msgstr ""
+msgstr "スタイルの読み込み"
 
 #: ../../src/wxMaximaFrame.cpp:1323
+#, fuzzy
 msgid "Matrix from csv file..."
-msgstr ""
+msgstr "スタイルの読み込み"
 
 #: ../../src/wxMaxima.cpp:8137
 msgid "Matrix map"
-msgstr ""
+msgstr "行列に関数を適用"
 
 #: ../../src/wxMaxima.cpp:9630
 msgid "Matrix name:"
-msgstr ""
+msgstr "変数名："
 
 #: ../../src/wxMaximaFrame.cpp:798
+#, fuzzy
 msgid "Matrix parenthesis"
-msgstr ""
+msgstr "括弧の対応が間違っています"
 
 #: ../../src/wxMaximaFrame.cpp:1331
+#, fuzzy
 msgid "Matrix to csv file"
-msgstr ""
+msgstr "スタイルの読み込み"
 
 #: ../../src/wxMaximaFrame.cpp:1334
 msgid "Matrix to file or Matrix from file"
@@ -4379,7 +4675,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
 #: ../../src/wxMaxima.cpp:8136
 msgid "Matrix:"
-msgstr ""
+msgstr "行列："
 
 #: ../../src/wxMaxima.cpp:8627
 msgid ""
@@ -4395,12 +4691,14 @@ msgid "Maxima architecture: %s"
 msgstr ""
 
 #: ../../src/StatusBar.cpp:252
+#, fuzzy
 msgid "Maxima asks a question"
-msgstr ""
+msgstr "Maximaからの質問です"
 
 #: ../../src/wxMaxima.cpp:4066
+#, fuzzy
 msgid "Maxima asks a question!"
-msgstr ""
+msgstr "Maximaからの質問です"
 
 #: ../../src/wxMaxima.cpp:7118
 msgid ""
@@ -4417,16 +4715,19 @@ msgid "Maxima errors"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3289
+#, fuzzy
 msgid "Maxima has authenticated!"
-msgstr ""
+msgstr "Maximaの処理は終了しました"
 
 #: ../../src/wxMaxima.cpp:10533
+#, fuzzy
 msgid "Maxima has finished calculating."
-msgstr ""
+msgstr "処理中"
 
 #: ../../src/wxMaxima.cpp:5832
+#, fuzzy
 msgid "Maxima has issued an error!"
-msgstr ""
+msgstr "Maximaからの質問です"
 
 #: ../../src/wxMaxima.cpp:3696
 #, c-format
@@ -4438,20 +4739,21 @@ msgid "Maxima has sent a new variable value."
 msgstr ""
 
 #: ../../src/MaximaManual.cpp:552
+#, fuzzy
 msgid "Maxima help file not found!"
-msgstr ""
+msgstr "ファイルが見つかりません"
 
 #: ../../src/wxMaximaFrame.cpp:1043
 msgid "Maxima input"
-msgstr ""
+msgstr "入力文字列"
 
 #: ../../src/StatusBar.cpp:236
 msgid "Maxima is calculating"
-msgstr ""
+msgstr "処理中"
 
 #: ../../src/wxMaxima.cpp:5068
 msgid "Maxima is ready for input."
-msgstr ""
+msgstr "入力できます"
 
 #: ../../src/Dirstructure.cpp:144
 #, c-format
@@ -4460,19 +4762,21 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6211
 msgid "Maxima package (*.mac)|*.mac"
-msgstr ""
+msgstr "バッチファイル (*.bat, *.mac)|*.bat;*.mac"
 
 #: ../../src/wxMaxima.cpp:6202
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr ""
+"Maxima パッケージ (*.mac)|*.mac|Lisp パッケージ (*.lisp)|*.lisp|すべてのファイル (*.*)|*"
 
 #: ../../src/wxMaxima.cpp:3012
 msgid "Maxima process terminated unexpectedly."
 msgstr ""
 
 #: ../../src/Configuration.cpp:79
+#, fuzzy
 msgid "Maxima question labels"
-msgstr ""
+msgstr "条件不足時のMaximaの質問"
 
 #: ../../src/wxMaxima.cpp:3380
 msgid "Maxima sends a new set of auto-completable symbols."
@@ -4491,28 +4795,33 @@ msgid "Maxima shows help in a sidebar"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1935
+#, fuzzy
 msgid "Maxima shows help in the console"
-msgstr ""
+msgstr "ファイルが見つかりません"
 
 #: ../../src/StatusBar.cpp:232
+#, fuzzy
 msgid "Maxima started. Waiting for authentication..."
-msgstr ""
+msgstr "Maximaと接続しています"
 
 #: ../../src/StatusBar.cpp:212
 msgid "Maxima started. Waiting for connection..."
-msgstr ""
+msgstr "Maximaと接続しています"
 
 #: ../../src/StatusBar.cpp:228
+#, fuzzy
 msgid "Maxima started. Waiting for initial prompt..."
-msgstr ""
+msgstr "Maximaと接続しています"
 
 #: ../../src/wxMaximaFrame.cpp:1231
+#, fuzzy
 msgid "Maxima to other language"
-msgstr ""
+msgstr "条件不足時のMaximaの質問"
 
 #: ../../src/wxMaxima.cpp:7213
+#, fuzzy
 msgid "Maxima to string"
-msgstr ""
+msgstr "条件不足時のMaximaの質問"
 
 #: ../../src/wxMaxima.cpp:3397
 #, c-format
@@ -4535,12 +4844,14 @@ msgid "Maxima version: %s, Anchors cache version"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1925
+#, fuzzy
 msgid "Maxima vs. Programming languages"
-msgstr ""
+msgstr "ガンマ関数に変換(&G)"
 
 #: ../../src/Configuration.cpp:83
+#, fuzzy
 msgid "Maxima warnings"
-msgstr ""
+msgstr "入力文字列"
 
 #: ../../src/wxMaxima.cpp:3687
 #, c-format
@@ -4568,9 +4879,9 @@ msgid "Maxima's manual is located in directory %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3670
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's share files are located in directory %s"
-msgstr ""
+msgstr "アニメーションの開始"
 
 #: ../../src/StatusBar.cpp:66
 msgid ""
@@ -4608,24 +4919,26 @@ msgid "Maximum absolute value printed without exponent"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9230
+#, fuzzy
 msgid "Maximum number of digits to be displayed:"
-msgstr ""
+msgstr "表示する最大の桁数:"
 
 #: ../../src/wxMaxima.cpp:9568
 msgid "Mean:"
-msgstr ""
+msgstr "比較する値："
 
 #: ../../src/wxMaximaFrame.cpp:1924
 msgid "Memoizing"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1013
+#, fuzzy
 msgid "Memory"
-msgstr ""
+msgstr "メモリをクリア(&C)"
 
 #: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
 msgid "Merge Cells"
-msgstr ""
+msgstr "セルの結合"
 
 #: ../../src/wxMaxima.cpp:5780
 msgid "Message from the stdout of Maxima: "
@@ -4646,7 +4959,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10449 ../../src/wxMaxima.cpp:10451
 msgid "Mismatched parenthesis"
-msgstr ""
+msgstr "括弧の対応が間違っています"
 
 #: ../../src/wxMaximaFrame.cpp:1352
 msgid "Multiplication, exponent and similar"
@@ -4665,16 +4978,19 @@ msgid "Multiply two matrices"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9581
+#, fuzzy
 msgid "Multivariate linear regression"
-msgstr ""
+msgstr "単回帰分析..."
 
 #: ../../src/wxMaxima.cpp:7842
+#, fuzzy
 msgid "Name of t:"
-msgstr ""
+msgstr "変数名："
 
 #: ../../src/wxMaxima.cpp:7838
+#, fuzzy
 msgid "Name of x:"
-msgstr ""
+msgstr "変数名："
 
 #: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
 msgid "Nested list to Matrix"
@@ -4698,11 +5014,11 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:174
 msgid "New"
-msgstr ""
+msgstr "新規作成"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "New\tCtrl+N"
-msgstr ""
+msgstr "新規作成\tCtrl+N"
 
 #: ../../src/ToolBar.cpp:611
 msgid "New button"
@@ -4723,7 +5039,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:174
 msgid "New document"
-msgstr ""
+msgstr "新しいドキュメントの作成"
 
 #: ../../src/wxMaxima.cpp:3899
 #, c-format
@@ -4731,17 +5047,18 @@ msgid "New maxima Operators detected: %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7390
+#, fuzzy
 msgid "New part:"
-msgstr ""
+msgstr "新変数："
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
 #: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
 msgid "New variable:"
-msgstr ""
+msgstr "新変数："
 
 #: ../../src/wxMaximaFrame.cpp:929
 msgid "Next Command\tAlt+Down"
-msgstr ""
+msgstr "履歴から入力（次）\tAlt+Down"
 
 #: ../../src/wxMaximaFrame.cpp:748
 msgid "Nice Graphical Equations"
@@ -4752,8 +5069,9 @@ msgid "No"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1972
+#, fuzzy
 msgid "No Array"
-msgstr ""
+msgstr "文字："
 
 #: ../../src/Worksheet.cpp:1974
 msgid "No Scalar"
@@ -4783,7 +5101,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:6662 ../../src/wxMaxima.cpp:6668
 #: ../../src/wxMaxima.cpp:6687 ../../src/wxMaxima.cpp:6697
 msgid "No matches found!"
-msgstr ""
+msgstr "一致する文字列がありません"
 
 #: ../../src/wxMaxima.cpp:3240
 msgid "No topics found in topic flag"
@@ -4799,11 +5117,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8163
 msgid "Not a valid matrix dimension!"
-msgstr ""
+msgstr "有効な行列の次元ではありません！"
 
 #: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
 msgid "Not a valid number of equations!"
-msgstr ""
+msgstr "有効な方程式の数ではありません!"
 
 #: ../../src/StatusBar.cpp:256
 msgid "Not connected to Maxima"
@@ -4823,63 +5141,73 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8926
 msgid "Num. deg:"
-msgstr ""
+msgstr "分子の最高次数："
 
 #: ../../src/wxMaxima.cpp:8540
+#, fuzzy
 msgid "Number of elements"
-msgstr ""
+msgstr "方程式の数："
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
 msgid "Number of equations:"
-msgstr ""
+msgstr "方程式の数："
 
 #: ../../src/wxMaxima.cpp:7481
+#, fuzzy
 msgid "Number to octets"
-msgstr ""
+msgstr "方程式の数："
 
 #: ../../src/wxMaximaFrame.cpp:1154
+#, fuzzy
 msgid "Number to octets..."
-msgstr ""
+msgstr "方程式の数："
 
 #: ../../src/wxMaximaFrame.cpp:1906
 msgid "Number types"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7482
+#, fuzzy
 msgid "Number:"
-msgstr ""
+msgstr "数値"
 
 #: ../../src/wxMaximaFrame.cpp:1786
+#, fuzzy
 msgid "Numeric output"
-msgstr ""
+msgstr "平方根やπといった数を自動的に数値で出力"
 
 #: ../../src/wxMaxima.cpp:8040
 msgid "Numerical QR decomposition of a matrix"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1417
+#, fuzzy
 msgid "Numerical operations (lapack)"
-msgstr ""
+msgstr "結果を小数で出力(&N)"
 
 #: ../../src/wxMaxima.cpp:7831
+#, fuzzy
 msgid "Numerical solution for 1st degree ODE"
-msgstr ""
+msgstr "1階微分方程式の一般解に初期条件を適用"
 
 #: ../../src/wxMaximaFrame.cpp:1282
+#, fuzzy
 msgid "Numerical solution..."
-msgstr ""
+msgstr "平方根やπといった数を自動的に数値で出力"
 
 #: ../../src/wxMaximaFrame.cpp:1261
+#, fuzzy
 msgid "Numerical solutions of polynomial (bfloat)..."
-msgstr ""
+msgstr "方程式の解を小数で求める"
 
 #: ../../src/wxMaximaFrame.cpp:1258
+#, fuzzy
 msgid "Numerical solutions of polynomial..."
-msgstr ""
+msgstr "方程式の解を小数で求める"
 
 #: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: ../../src/wxMaximaFrame.cpp:122
 #, c-format
@@ -4887,16 +5215,19 @@ msgid "OS: %s Version %li.%li"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
+#, fuzzy
 msgid "Object composed of elements"
-msgstr ""
+msgstr "方程式の数："
 
 #: ../../src/wxMaxima.cpp:7680
+#, fuzzy
 msgid "Object name:"
-msgstr ""
+msgstr "リスト："
 
 #: ../../src/wxMaxima.cpp:7281
+#, fuzzy
 msgid "Object:"
-msgstr ""
+msgstr "リスト："
 
 #: ../../src/wxMaxima.cpp:7486
 msgid "Octets to Number"
@@ -4911,8 +5242,9 @@ msgid "Octets to number..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1158
+#, fuzzy
 msgid "Octets to string..."
-msgstr ""
+msgstr "関数"
 
 #: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
 msgid "Octets:"
@@ -4925,11 +5257,12 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
 #: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
 msgid "Old variable:"
-msgstr ""
+msgstr "旧変数："
 
 #: ../../src/wxMaximaFrame.cpp:1055
+#, fuzzy
 msgid "On all errors"
-msgstr ""
+msgstr "致命的なエラー"
 
 #: ../../src/wxMaximaFrame.cpp:1054
 msgid "On lisp errors"
@@ -4937,11 +5270,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9566
 msgid "One sample t-test"
-msgstr ""
+msgstr "t検定"
 
 #: ../../src/wxMaximaFrame.cpp:1927
 msgid "Online tutorials"
-msgstr ""
+msgstr "ブラウザでチュートリアルのページを開く"
 
 #: ../../src/wxMaximaFrame.cpp:766
 msgid "Only Integers and single letters"
@@ -4950,15 +5283,15 @@ msgstr ""
 #: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593
 #: ../../src/wxMaxima.cpp:6074
 msgid "Open"
-msgstr ""
+msgstr "参照"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "Open a document"
-msgstr ""
+msgstr "ドキュメントを開く"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "Open a new window"
-msgstr ""
+msgstr "新しいウィンドウを開く"
 
 #: ../../src/ToolBar.cpp:617
 msgid "Open and save button"
@@ -4966,7 +5299,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:176
 msgid "Open document"
-msgstr ""
+msgstr "開く"
 
 #: ../../src/wxMaxima.cpp:7239
 msgid "Open for appending"
@@ -4981,24 +5314,27 @@ msgid "Open for reading"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1098
+#, fuzzy
 msgid "Open for reading..."
-msgstr ""
+msgstr "関数"
 
 #: ../../src/wxMaxima.cpp:7249
 msgid "Open for writing"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1100
+#, fuzzy
 msgid "Open for writing..."
-msgstr ""
+msgstr "エクスポート中..."
 
 #: ../../src/wxMaxima.cpp:9598
 msgid "Open matrix"
-msgstr ""
+msgstr "ファイルを開く"
 
 #: ../../src/wxMaximaFrame.cpp:600
+#, fuzzy
 msgid "Open recent"
-msgstr ""
+msgstr "最近開いたファイル"
 
 #: ../../src/wxMaxima.cpp:4309
 msgid "Opening a wxmx file"
@@ -5007,7 +5343,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4153 ../../src/wxMaxima.cpp:4214
 #: ../../src/wxMaxima.cpp:4313 ../../src/wxMaxima.cpp:4622
 msgid "Opening file"
-msgstr ""
+msgstr "ファイルを開く"
 
 #: ../../src/wxMaxima.cpp:5030
 #, c-format
@@ -5024,11 +5360,12 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:199
 msgid "Options"
-msgstr ""
+msgstr "オプション"
 
 #: ../../src/wxMaximaFrame.cpp:1225
+#, fuzzy
 msgid "Output C"
-msgstr ""
+msgstr "出力ラベル"
 
 #: ../../src/wxMaximaFrame.cpp:1226
 msgid "Output Fortran"
@@ -5040,11 +5377,12 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:80
 msgid "Output labels"
-msgstr ""
+msgstr "出力ラベル"
 
 #: ../../src/Configuration.cpp:73
+#, fuzzy
 msgid "Output: Function names"
-msgstr ""
+msgstr "ユーザー定義関数名"
 
 #: ../../src/Configuration.cpp:75
 msgid "Output: Latin names as greek symbols"
@@ -5055,21 +5393,24 @@ msgid "Output: Numbers and Digits"
 msgstr ""
 
 #: ../../src/Configuration.cpp:71
+#, fuzzy
 msgid "Output: Operators"
-msgstr ""
+msgstr "出力ラベル"
 
 #: ../../src/Configuration.cpp:74
-#, c-format
+#, fuzzy, c-format
 msgid "Output: Special constants (%e,%i)"
-msgstr ""
+msgstr "数学定数（ギリシャ文字以外）"
 
 #: ../../src/Configuration.cpp:76
+#, fuzzy
 msgid "Output: Strings"
-msgstr ""
+msgstr "出力文字列"
 
 #: ../../src/Configuration.cpp:70
+#, fuzzy
 msgid "Output: Variable names"
-msgstr ""
+msgstr "全ての変数名"
 
 #: ../../src/wxMaxima.cpp:6442
 msgid ""
@@ -5088,39 +5429,44 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8924
 msgid "Pade approximation"
-msgstr ""
+msgstr "Pade近似"
 
 #: ../../src/wxMaximaFrame.cpp:1478
 msgid "Pade approximation of a Taylor series"
-msgstr ""
+msgstr "テイラー級数を有理式で近似"
 
 #: ../../src/wxMaximaFrame.cpp:1637
+#, fuzzy
 msgid "Parallel Substitute..."
-msgstr ""
+msgstr "式中の部分式を置換..."
 
 #: ../../src/wxMaxima.cpp:8738
+#, fuzzy
 msgid "Parallel substitution"
-msgstr ""
+msgstr "平行"
 
 #: ../../src/wxMaxima.cpp:7179
+#, fuzzy
 msgid "Parameter name:"
-msgstr ""
+msgstr "変数名："
 
 #: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
+#, fuzzy
 msgid "Parameter(s):"
-msgstr ""
+msgstr "変数："
 
 #: ../../src/wxMaxima.cpp:7399
 msgid "Parse string"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1152
+#, fuzzy
 msgid "Parse string only..."
-msgstr ""
+msgstr "行列を手入力..."
 
 #: ../../src/StatusBar.cpp:240
 msgid "Parsing output"
-msgstr ""
+msgstr "出力しています"
 
 #: ../../src/wxMaxima.cpp:7464
 msgid "Part:"
@@ -5128,64 +5474,65 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1499 ../../src/wxMaximaFrame.cpp:1535
 msgid "Partial &Fractions..."
-msgstr ""
+msgstr "部分分数分解(&F)..."
 
 #: ../../src/wxMaxima.cpp:8975
+#, fuzzy
 msgid "Partial Fractions"
-msgstr ""
+msgstr "部分分数分解"
 
 #: ../../src/wxMaxima.cpp:4702
 msgid "Parts of the document will not be loaded correctly!"
-msgstr ""
+msgstr "ドキュメントの一部は正確に読み込まれないでしょう！"
 
 #: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
 #: ../../src/Worksheet.cpp:1685
 msgid "Paste"
-msgstr ""
+msgstr "貼り付け"
 
 #: ../../src/wxMaximaFrame.cpp:667
 msgid "Paste\tCtrl+V"
-msgstr ""
+msgstr "貼り付け\tCtrl+V"
 
 #: ../../src/ToolBar.cpp:211
 msgid "Paste from clipboard"
-msgstr ""
+msgstr "貼り付け"
 
 #: ../../src/wxMaximaFrame.cpp:668
 msgid "Paste text from clipboard"
-msgstr ""
+msgstr "クリップボードから貼り付け"
 
 #: ../../src/wxMaxima.cpp:4841
 msgid "Please configure wxMaxima with 'Edit->Configure'."
-msgstr ""
+msgstr "メニューバーの「編集」から「設定」ダイアログを開き、wxMaximaを設定してください"
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot &2d..."
-msgstr ""
+msgstr "&2次元プロット..."
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot &3d..."
-msgstr ""
+msgstr "&3次元プロット..."
 
 #: ../../src/wxMaximaFrame.cpp:1772
 msgid "Plot &Format..."
-msgstr ""
+msgstr "プロットエンジンの変更(&F)..."
 
 #: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
 msgid "Plot 2D"
-msgstr ""
+msgstr "2次元プロット"
 
 #: ../../src/Worksheet.cpp:1593
 msgid "Plot 2D..."
-msgstr ""
+msgstr "2次元プロット..."
 
 #: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
 msgid "Plot 3D"
-msgstr ""
+msgstr "3次元プロット"
 
 #: ../../src/Worksheet.cpp:1595
 msgid "Plot 3D..."
-msgstr ""
+msgstr "3次元プロット..."
 
 #: ../../src/wxMaxima.cpp:9538
 msgid "Plot as bars"
@@ -5201,15 +5548,15 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9112
 msgid "Plot format"
-msgstr ""
+msgstr "プロットエンジン"
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot in 2 dimensions"
-msgstr ""
+msgstr "2次元プロット（同時に複数の関数を表示可能）"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot in 3 dimensions"
-msgstr ""
+msgstr "3次元プロット（同時に表示できる関数は１つまたは３つ）"
 
 #: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
 msgid "Plot using Draw"
@@ -5229,22 +5576,23 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
 msgid "Point:"
-msgstr ""
+msgstr "値の入力："
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 1:"
-msgstr ""
+msgstr "多項式 1："
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 2:"
-msgstr ""
+msgstr "多項式 2："
 
 #: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
 #: ../../src/wxMaxima.cpp:7739
+#, fuzzy
 msgid "Polynomial:"
-msgstr ""
+msgstr "多項式 1："
 
 #: ../../src/wxMaximaFrame.cpp:1754
 msgid "Pop"
@@ -5259,28 +5607,35 @@ msgid "Position of a match"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
+#, fuzzy
 msgid "Position:"
 msgstr ""
+"抽出条件（複数指定可）：\n"
+"（col[i]#Xでi列のXを除外）\n"
+"（col[i]=Xでi列のXのみ抽出）"
 
 #: ../../src/wxMaxima.cpp:8939
+#, fuzzy
 msgid "Power series"
-msgstr ""
+msgstr "ベキ級数で表示(&P)"
 
 #: ../../src/wxMaximaFrame.cpp:1475
+#, fuzzy
 msgid "Power series..."
-msgstr ""
+msgstr "ベキ級数で表示(&P)"
 
 #: ../../src/wxMaxima.cpp:9202
 msgid "Precision"
-msgstr ""
+msgstr "表示桁数"
 
 #: ../../src/Worksheet.cpp:1616
 msgid "Prefer user labels"
 msgstr ""
 
 #: ../../src/main.cpp:437
+#, fuzzy
 msgid "Preferences"
-msgstr ""
+msgstr "環境設定…\tCtrl+,"
 
 #: ../../src/ToolBar.cpp:626
 msgid "Preferences button"
@@ -5288,31 +5643,33 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:685
 msgid "Preferences...\tCtrl+,"
-msgstr ""
+msgstr "環境設定…\tCtrl+,"
 
 #: ../../src/wxMaximaFrame.cpp:1733
+#, fuzzy
 msgid "Prepend an element"
-msgstr ""
+msgstr "ドキュメントを開く"
 
 #: ../../src/wxMaximaFrame.cpp:927
 msgid "Previous Command\tAlt+Up"
-msgstr ""
+msgstr "履歴から入力（前）\tAlt+Up"
 
 #: ../../src/ToolBar.cpp:184
 msgid "Print"
-msgstr ""
+msgstr "印刷"
 
 #: ../../src/ToolBar.cpp:620
 msgid "Print button"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1493
+#, fuzzy
 msgid "Print cell brackets"
-msgstr ""
+msgstr "アクティブセル"
 
 #: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
 msgid "Print document"
-msgstr ""
+msgstr "印刷"
 
 #: ../../src/wxMaximaFrame.cpp:1829
 msgid "Print floating-point numbers with exponents dividable by 3"
@@ -5326,15 +5683,17 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9061
 msgid "Product"
-msgstr ""
+msgstr "総乗"
 
 #: ../../src/wxMaximaFrame.cpp:1095
+#, fuzzy
 msgid "Program"
-msgstr ""
+msgstr "ヒストグラム"
 
 #: ../../src/wxMaxima.cpp:7061
+#, fuzzy
 msgid "Program (no local variables)"
-msgstr ""
+msgstr "変数の置換"
 
 #: ../../src/wxMaxima.cpp:7052
 msgid "Program block"
@@ -5353,8 +5712,9 @@ msgid "Push"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8508
+#, fuzzy
 msgid "Push an element to a list"
-msgstr ""
+msgstr "関数からリストを作成"
 
 #: ../../src/wxMaximaFrame.cpp:1395
 msgid "QR decomposition"
@@ -5387,19 +5747,21 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:867
 msgid "Re-evaluate all cells above the one the cursor is in"
-msgstr ""
+msgstr "カーソルがあるセルより上にある全てのセルを再評価"
 
 #: ../../src/wxMaximaFrame.cpp:877
+#, fuzzy
 msgid "Re-evaluate all cells below the one the cursor is in"
-msgstr ""
+msgstr "カーソルがあるセルより上にある全てのセルを再評価"
 
 #: ../../src/main.cpp:366
 msgid "Re-opening STDERR failed."
 msgstr ""
 
 #: ../../src/main.cpp:367
+#, fuzzy
 msgid "Re-opening STDIN failed."
-msgstr ""
+msgstr "ファイルを開く"
 
 #: ../../src/main.cpp:365
 msgid "Re-opening STDOUT failed."
@@ -5412,16 +5774,18 @@ msgid ""
 msgstr ""
 
 #: ../../src/Worksheet.cpp:6668
+#, fuzzy
 msgid "Read .wxm data from clipboard"
-msgstr ""
+msgstr "クリップボードから貼り付け"
 
 #: ../../src/wxMaxima.cpp:7599
 msgid "Read Directory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1677
+#, fuzzy
 msgid "Read List from csv file..."
-msgstr ""
+msgstr "スタイルの読み込み"
 
 #: ../../src/wxMaxima.cpp:7196
 msgid "Read a structure field"
@@ -5432,16 +5796,19 @@ msgid "Read byte"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7266
+#, fuzzy
 msgid "Read char"
-msgstr ""
+msgstr "行列のファイル..."
 
 #: ../../src/wxMaxima.cpp:7593
+#, fuzzy
 msgid "Read environment variable"
-msgstr ""
+msgstr "追加パラメーター："
 
 #: ../../src/wxMaximaFrame.cpp:1219
+#, fuzzy
 msgid "Read environment variable..."
-msgstr ""
+msgstr "ユーザー定義変数を削除"
 
 #: ../../src/wxMaxima.cpp:7262
 msgid "Read line"
@@ -5454,7 +5821,7 @@ msgstr ""
 
 #: ../../src/StatusBar.cpp:245
 msgid "Reading Maxima output"
-msgstr ""
+msgstr "処理が終了しました"
 
 #: ../../src/StatusBar.cpp:247
 #, c-format
@@ -5481,7 +5848,7 @@ msgstr ""
 
 #: ../../src/StatusBar.cpp:224
 msgid "Ready for user input"
-msgstr ""
+msgstr "入力可能"
 
 #: ../../src/Worksheet.cpp:960
 msgid "Recalculated the whole worksheet at once => Updating its size"
@@ -5493,11 +5860,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:930
 msgid "Recall next command from history"
-msgstr ""
+msgstr "入力履歴のコマンドを古いものから順に表示します"
 
 #: ../../src/wxMaximaFrame.cpp:928
 msgid "Recall previous command from history"
-msgstr ""
+msgstr "入力履歴のコマンドを新しいものから順に表示します"
 
 #: ../../src/wxMaxima.cpp:3235
 #, c-format
@@ -5510,12 +5877,14 @@ msgid "Received maxima's first prompt: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:603
+#, fuzzy
 msgid "Recover unsaved"
-msgstr ""
+msgstr "[ 無題 ]"
 
 #: ../../src/wxMaximaFrame.cpp:1640
+#, fuzzy
 msgid "Recursive Substitute..."
-msgstr ""
+msgstr "式中の部分式を置換..."
 
 #: ../../src/wxMaxima.cpp:8746
 msgid "Recursive substitution"
@@ -5527,15 +5896,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo\tCtrl+Y"
-msgstr ""
+msgstr "やり直す\tCtrl+Y"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo last change"
-msgstr ""
+msgstr "一番新しい入力をやり直す"
 
 #: ../../src/wxMaximaFrame.cpp:1595
 msgid "Reduce trigonometric expression"
-msgstr ""
+msgstr "三角関数(sin,cos)，双曲線関数(sinh,cosh)の積を一つの関数にまとめる"
 
 #: ../../src/wxMaxima.cpp:2366 ../../src/wxMaxima.cpp:10630
 msgid "Refusing to send cell to maxima: "
@@ -5550,16 +5919,19 @@ msgid "Regex match position"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1195
+#, fuzzy
 msgid "Regular expression that matches a string"
-msgstr ""
+msgstr "各x座標はカンマで区切ってください"
 
 #: ../../src/wxMaximaFrame.cpp:1196
+#, fuzzy
 msgid "Regular expressions"
-msgstr ""
+msgstr "積分"
 
 #: ../../src/Worksheet.cpp:1314
+#, fuzzy
 msgid "Reload Image"
-msgstr ""
+msgstr "画像としてコピー"
 
 #: ../../src/Worksheet.cpp:1320
 #, c-format
@@ -5573,7 +5945,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:883
 msgid "Remove All Output"
-msgstr ""
+msgstr "全ての出力をクリア"
 
 #: ../../src/wxMaximaFrame.cpp:1426
 msgid "Remove Rows or Columns..."
@@ -5594,8 +5966,9 @@ msgid "Remove all occurrences of part"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8592
+#, fuzzy
 msgid "Remove an element from a list"
-msgstr ""
+msgstr "関数からリストを作成"
 
 #: ../../src/wxMaxima.cpp:7566
 msgid "Remove directory"
@@ -5619,7 +5992,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:884
 msgid "Remove output from input cells"
-msgstr ""
+msgstr "全ての出力をクリア"
 
 #: ../../src/wxMaxima.cpp:7975
 msgid "Remove rows and/or columns"
@@ -5630,16 +6003,19 @@ msgid "Remove rows and/or columns from the matrix"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7582
+#, fuzzy
 msgid "Rename file"
-msgstr ""
+msgstr "ファイルを開く"
 
 #: ../../src/wxMaximaFrame.cpp:1215
+#, fuzzy
 msgid "Rename file..."
-msgstr ""
+msgstr "ユーザー定義変数を削除"
 
 #: ../../src/wxMaximaFrame.cpp:1527
+#, fuzzy
 msgid "Reorganize an expression using horner's rule"
-msgstr ""
+msgstr "複素数の範囲で因数分解"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "Repetitive element-by-element multiplication"
@@ -5654,37 +6030,42 @@ msgid "Replace first regex match"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7463
+#, fuzzy
 msgid "Replace the first occurrence of Part"
-msgstr ""
+msgstr "%d箇所を置換しました"
 
 #: ../../src/wxMaximaFrame.cpp:1180
+#, fuzzy
 msgid "Replace..."
-msgstr ""
+msgstr "全て置換"
 
 #: ../../src/wxMaxima.cpp:6719
-#, c-format
+#, fuzzy, c-format
 msgid "Replaced %li occurrences."
-msgstr ""
+msgstr "%d箇所を置換しました"
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "Report bug"
-msgstr ""
+msgstr "バグの報告"
 
 #: ../../src/wxMaximaFrame.cpp:996
+#, fuzzy
 msgid "Reset option variables"
-msgstr ""
+msgstr "変数の置換"
 
 #: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
 msgid "Restart Maxima"
-msgstr ""
+msgstr "ラベル番号をリセット"
 
 #: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
+#, fuzzy
 msgid "Restrict Maximum size"
-msgstr ""
+msgstr "ラベル番号をリセット"
 
 #: ../../src/wxMaxima.cpp:10031
+#, fuzzy
 msgid "Result variables:"
-msgstr ""
+msgstr "削除する変数の入力："
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Resulting Matrix name (may be empty):"
@@ -5758,12 +6139,14 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
 #: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
+#, fuzzy
 msgid "Right Matrix:"
-msgstr ""
+msgstr "右矢印"
 
 #: ../../src/wxMaxima.cpp:8190
+#, fuzzy
 msgid "Right end"
-msgstr ""
+msgstr "右矢印"
 
 #: ../../src/wxMaximaFrame.cpp:1301
 msgid "Right side to the \"=\""
@@ -5771,7 +6154,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1455
 msgid "Risch Integration..."
-msgstr ""
+msgstr "Risch積分..."
 
 #: ../../src/wxMaximaFrame.cpp:785
 msgid "Rounded"
@@ -5787,12 +6170,14 @@ msgid "Row number:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7977
+#, fuzzy
 msgid "Row numbers:"
-msgstr ""
+msgstr "数値"
 
 #: ../../src/wxMaxima.cpp:8203
+#, fuzzy
 msgid "Rows"
-msgstr ""
+msgstr "行数："
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Rule"
@@ -5807,8 +6192,9 @@ msgid "Rules"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1693
+#, fuzzy
 msgid "Run each element through an expression"
-msgstr ""
+msgstr "極限値を求める"
 
 #: ../../src/wxMaxima.cpp:6355
 #, c-format
@@ -5861,80 +6247,82 @@ msgid "Runs each element through a function"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1694
+#, fuzzy
 msgid "Runs each element through an expression"
-msgstr ""
+msgstr "極限値を求める"
 
 #: ../../src/wxMaxima.cpp:9572
 msgid "Sample 1:"
-msgstr ""
+msgstr "標本１（リスト/行ベクトル）："
 
 #: ../../src/wxMaxima.cpp:9573
 msgid "Sample 2:"
-msgstr ""
+msgstr "標本２（リスト/行ベクトル）："
 
 #: ../../src/wxMaxima.cpp:9567
 msgid "Sample:"
-msgstr ""
+msgstr "標本（リスト/行ベクトル）："
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
 msgid "Save"
-msgstr ""
+msgstr "設定の保存"
 
 #: ../../src/Worksheet.cpp:1294
 msgid "Save Animation..."
-msgstr ""
+msgstr "アニメーションを保存する..."
 
 #: ../../src/wxMaxima.cpp:5672
 msgid "Save As"
-msgstr ""
+msgstr "名前をつけて保存"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save As...\tShift+Ctrl+S"
-msgstr ""
+msgstr "名前を付けて保存...\tShift+Ctrl+S"
 
 #: ../../src/Worksheet.cpp:1291
 msgid "Save Image..."
-msgstr ""
+msgstr "画像として保存..."
 
 #: ../../src/wxMaxima.cpp:6440
 msgid "Save Selection to Image"
-msgstr ""
+msgstr "選択範囲を画像として保存"
 
 #: ../../src/wxMaximaFrame.cpp:675
 msgid "Save Selection to Image..."
-msgstr ""
+msgstr "選択範囲を画像として保存..."
 
 #: ../../src/wxMaxima.cpp:10184
 msgid "Save animation to file"
-msgstr ""
+msgstr "アニメーションの開始"
 
 #: ../../src/wxMaxima.cpp:7203
 msgid "Save as lisp code"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1091
+#, fuzzy
 msgid "Save as lisp..."
-msgstr ""
+msgstr "パッケージ読み込み"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
 msgid "Save document"
-msgstr ""
+msgstr "上書き保存"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save document as"
-msgstr ""
+msgstr "名前を付けて保存"
 
 #: ../../src/wxMaximaFrame.cpp:676
 msgid "Save selection from document to an image file"
-msgstr ""
+msgstr "選択範囲を画像として保存"
 
 #: ../../src/wxMaxima.cpp:10125
 msgid "Save selection to file"
-msgstr ""
+msgstr "画像として保存"
 
 #: ../../src/wxMaximaFrame.cpp:573
 msgid "Saving failed."
-msgstr ""
+msgstr "保存できませんでした"
 
 #: ../../src/WXMXformat.cpp:310
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
@@ -5950,7 +6338,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9533
 msgid "Scatterplot"
-msgstr ""
+msgstr "散布図"
 
 #: ../../src/Autocomplete.cpp:125
 msgid ""
@@ -5977,15 +6365,16 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:273
 msgid "Section"
-msgstr ""
+msgstr "セクション"
 
 #: ../../src/Configuration.cpp:91
 msgid "Section cell (Heading 2)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7218
+#, fuzzy
 msgid "Seek to position"
-msgstr ""
+msgstr "Pade近似"
 
 #: ../../src/BTextCtrl.cpp:45
 msgid "Seems like something is broken with a font."
@@ -5997,11 +6386,11 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
 msgid "Select All"
-msgstr ""
+msgstr "全て選択"
 
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select All\tCtrl+A"
-msgstr ""
+msgstr "全て選択\tCtrl+A"
 
 #: ../../src/ToolBar.cpp:629
 msgid "Select All button"
@@ -6009,20 +6398,21 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9631
 msgid "Select Subsample"
-msgstr ""
+msgstr "標本抽出"
 
 #: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select all"
-msgstr ""
+msgstr "全て選択"
 
 #: ../../src/wxMaxima.cpp:6971
 msgid "Select math display algorithm"
-msgstr ""
+msgstr "数式の出力形式を選択してください"
 
 #: ../../src/Configuration.cpp:98
+#, fuzzy
 msgid "Selection color"
-msgstr ""
+msgstr "選択範囲"
 
 #: ../../src/ToolBar.cpp:252
 msgid "Send all cells to maxima"
@@ -6057,24 +6447,27 @@ msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1533
+#, fuzzy
 msgid "Sequential Comparative Simplification"
-msgstr ""
+msgstr "複素関数への操作(&C)"
 
 #: ../../src/wxMaxima.cpp:9016
 msgid "Series"
-msgstr ""
+msgstr "テイラー展開"
 
 #: ../../src/wxMaximaFrame.cpp:1479
+#, fuzzy
 msgid "Series approximation"
-msgstr ""
+msgstr "Pade近似"
 
 #: ../../src/wxMaxima.cpp:2561
 msgid "Server started"
-msgstr ""
+msgstr "サーバーが開始しました"
 
 #: ../../src/wxMaximaFrame.cpp:1824
+#, fuzzy
 msgid "Set &displayed Precision..."
-msgstr ""
+msgstr "浮動小数点の桁数設定(&P)"
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Set Maxima option variable logexpand:all"
@@ -6090,39 +6483,43 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:822
 msgid "Set Zoom"
-msgstr ""
+msgstr "指定倍率で表示"
 
 #: ../../src/wxMaximaFrame.cpp:1819
 msgid "Set bigfloat &Precision..."
-msgstr ""
+msgstr "bigfloat の精度を設定..."
 
 #: ../../src/Worksheet.cpp:1306 ../../src/Worksheet.cpp:1479
 msgid "Set image resolution"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1510
+#, fuzzy
 msgid "Set main variable..."
-msgstr ""
+msgstr "ユーザー定義変数を削除"
 
 #: ../../src/wxMaximaFrame.cpp:1773
 msgid "Set plot format"
-msgstr ""
+msgstr "プロットに使うソフトの変更"
 
 #: ../../src/wxMaximaFrame.cpp:1101
+#, fuzzy
 msgid "Set position..."
-msgstr ""
+msgstr "アニメーションを保存する..."
 
 #: ../../src/wxMaximaFrame.cpp:1656
+#, fuzzy
 msgid "Set the \"algebraic\" flag"
-msgstr ""
+msgstr "式中の平方根や虚数といった代数的整数の整理を有効にします（デフォルトは無効）"
 
 #: ../../src/wxMaxima.cpp:8314
 msgid "Set the diagram title"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1779
+#, fuzzy
 msgid "Set the frame rate for animations."
-msgstr ""
+msgstr "アニメーションの開始・停止"
 
 #: ../../src/wxMaxima.cpp:8377
 msgid "Set the grid density."
@@ -6140,27 +6537,27 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:811
 msgid "Set zoom to 100%"
-msgstr ""
+msgstr "100%の倍率で表示"
 
 #: ../../src/wxMaximaFrame.cpp:813
 msgid "Set zoom to 120%"
-msgstr ""
+msgstr "120%の倍率で表示"
 
 #: ../../src/wxMaximaFrame.cpp:815
 msgid "Set zoom to 150%"
-msgstr ""
+msgstr "150%の倍率で表示"
 
 #: ../../src/wxMaximaFrame.cpp:817
 msgid "Set zoom to 200%"
-msgstr ""
+msgstr "200%の倍率で表示"
 
 #: ../../src/wxMaximaFrame.cpp:819
 msgid "Set zoom to 300%"
-msgstr ""
+msgstr "300%の倍率で表示"
 
 #: ../../src/wxMaximaFrame.cpp:809
 msgid "Set zoom to 80%"
-msgstr ""
+msgstr "80%の倍率で表示"
 
 #: ../../src/wxMaxima.cpp:4731
 #, c-format
@@ -6168,16 +6565,17 @@ msgid "Setting gnuplot_binary to %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:4804
+#, fuzzy
 msgid "Setting prompt and help format"
-msgstr ""
+msgstr "プロットに使うソフトの変更"
 
 #: ../../src/wxMaximaFrame.cpp:1292
 msgid "Setup atvalues for solving ODE with Laplace transformation"
-msgstr ""
+msgstr "連立微分方程式の特殊解を求める際の初期条件を設定"
 
 #: ../../src/wxMaximaFrame.cpp:1661
 msgid "Setup modulus computation"
-msgstr ""
+msgstr "モジュラス（法）を設定します"
 
 #: ../../src/wxMaxima.cpp:9220
 msgid "Setup the engineering format"
@@ -6192,28 +6590,31 @@ msgid "Shapiro-Wilk test for normality"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1543
+#, fuzzy
 msgid "Show \"%\" in special constants"
-msgstr ""
+msgstr "数学定数（ギリシャ文字以外）"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show &Tips..."
-msgstr ""
+msgstr "ヒントを表示(&T)..."
 
 #: ../../src/Worksheet.cpp:1556
 msgid "Show * as multiplication dot"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:895
+#, fuzzy
 msgid "Show Template\tCtrl+Shift+Space"
-msgstr ""
+msgstr "コマンドの補完\tCtrl+Shift+K"
 
 #: ../../src/wxMaximaFrame.cpp:753
+#, fuzzy
 msgid "Show XML representation"
-msgstr ""
+msgstr "出力に時間がかかる式も表示："
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show a tip"
-msgstr ""
+msgstr "ヒントを表示"
 
 #: ../../src/Worksheet.cpp:1607
 msgid "Show all + allow linebreaks in long numbers"
@@ -6221,51 +6622,54 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9475
 msgid "Show all commands similar to:"
-msgstr ""
+msgstr "コマンド名に含まれる文字列："
 
 #: ../../src/wxMaxima.cpp:9468
 msgid "Show an example for the command:"
-msgstr ""
+msgstr "使用例を見たいコマンド名："
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "Show an example of usage"
-msgstr ""
+msgstr "コマンドの使用例を表示"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "Show commands similar to"
-msgstr ""
+msgstr "コマンドを探す"
 
 #: ../../src/wxMaximaFrame.cpp:1020
 msgid "Show defined functions"
-msgstr ""
+msgstr "ユーザー定義関数名をリスト表示"
 
 #: ../../src/wxMaximaFrame.cpp:1022
 msgid "Show defined variables"
-msgstr ""
+msgstr "ユーザー定義変数をリスト表示"
 
 #: ../../src/wxMaximaFrame.cpp:1074
 msgid "Show definition of a function"
-msgstr ""
+msgstr "関数名を指定してユーザー定義関数を表示"
 
 #: ../../src/wxMaximaFrame.cpp:740
 msgid "Show equations in their linear form"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1073
+#, fuzzy
 msgid "Show function &Definition..."
-msgstr ""
+msgstr "ユーザー定義関数を表示(&D)..."
 
 #: ../../src/wxMaximaFrame.cpp:896
 msgid "Show function template"
-msgstr ""
+msgstr "コマンドの補完"
 
 #: ../../src/Worksheet.cpp:1614
+#, fuzzy
 msgid "Show input labels"
-msgstr ""
+msgstr "入力ラベル"
 
 #: ../../src/wxMaximaFrame.cpp:750
+#, fuzzy
 msgid "Show lisp representation"
-msgstr ""
+msgstr "出力に時間がかかる式も表示："
 
 #: ../../src/Worksheet.cpp:1604
 msgid "Show max. 100 digits"
@@ -6304,8 +6708,9 @@ msgid "Show the Copy, Cut and the Paste button?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7033
+#, fuzzy
 msgid "Show the function's definition"
-msgstr ""
+msgstr "表示する関数名の入力"
 
 #: ../../src/ToolBar.cpp:618
 msgid "Show the open and the save button?"
@@ -6320,21 +6725,23 @@ msgid "Show the print button?"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:615
+#, fuzzy
 msgid "Show the undo and redo button?"
-msgstr ""
+msgstr "表示する関数名の入力"
 
 #: ../../src/wxMaximaFrame.cpp:1006 ../../src/wxMaximaFrame.cpp:1011
 msgid "Show used + to-be-freed memory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1033
+#, fuzzy
 msgid "Show user definitions"
-msgstr ""
+msgstr "表示する関数名の入力"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Show wxMaxima help"
-msgstr ""
+msgstr "wxMaximaのヘルプを表示"
 
 #: ../../src/wxMaximaFrame.cpp:1825
 msgid "Shows how many digits of a numbers are displayed"
@@ -6345,48 +6752,53 @@ msgid "Sidebars"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1513
+#, fuzzy
 msgid "Simplify &Radicals..."
-msgstr ""
+msgstr "関数の整理(&R)"
 
 #: ../../src/Worksheet.cpp:1579
 msgid "Simplify Expression"
-msgstr ""
+msgstr "式の整理"
 
 #: ../../src/wxMaximaFrame.cpp:1568
+#, fuzzy
 msgid "Simplify Logarithms"
-msgstr ""
+msgstr "数式を整理して出力"
 
 #: ../../src/wxMaximaFrame.cpp:1582
 msgid "Simplify an expression containing factorials"
-msgstr ""
+msgstr "階乗を含む有理式を整理"
 
 #: ../../src/wxMaximaFrame.cpp:1539
+#, fuzzy
 msgid "Simplify equations"
-msgstr ""
+msgstr "解の公式から厳密解を求める"
 
 #: ../../src/wxMaximaFrame.cpp:1514
 msgid "Simplify expression containing radicals"
-msgstr ""
+msgstr "式中の関数も含めて整理（三角関数は文字定数として扱われます）"
 
 #: ../../src/wxMaxima.cpp:8649
+#, fuzzy
 msgid "Simplify radicals"
-msgstr ""
+msgstr "関数の整理(&R)"
 
 #: ../../src/wxMaximaFrame.cpp:1512
 msgid "Simplify rational expression"
-msgstr ""
+msgstr "式および関数の引数を整理（式中の関数自体は文字定数として扱われます）"
 
 #: ../../src/wxMaximaFrame.cpp:1538
 msgid "Simplify sum() commands..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8636
+#, fuzzy
 msgid "Simplify sums"
-msgstr ""
+msgstr "式の整理"
 
 #: ../../src/wxMaximaFrame.cpp:1592
 msgid "Simplify trigonometric expression"
-msgstr ""
+msgstr "三角関数をsinとcosの関数，双曲線関数をsinhとcoshの関数に変形"
 
 #: ../../src/wxMaximaFrame.cpp:1399
 msgid "Singular Values"
@@ -6401,105 +6813,113 @@ msgid "Singular values, left + right vectors"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1635
+#, fuzzy
 msgid "Smart Substitute..."
-msgstr ""
+msgstr "式中の部分式を置換..."
 
 #: ../../src/wxMaxima.cpp:8730
+#, fuzzy
 msgid "Smart substitution"
-msgstr ""
+msgstr "置換"
 
 #: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
 #: ../../src/wxMaxima.cpp:7823
+#, fuzzy
 msgid "Solution of the ODE:"
-msgstr ""
+msgstr "一般解："
 
 #: ../../src/wxMaxima.cpp:10017
 msgid "Solve"
-msgstr ""
+msgstr "方程式"
 
 #: ../../src/wxMaximaFrame.cpp:1244
 msgid "Solve &Algebraic System..."
-msgstr ""
+msgstr "連立高次方程式の解を求める(&A)..."
 
 #: ../../src/wxMaximaFrame.cpp:1242
 msgid "Solve &Linear System..."
-msgstr ""
+msgstr "連立一次方程式を解く(&L)..."
 
 #: ../../src/wxMaximaFrame.cpp:1266
 msgid "Solve &ODE..."
-msgstr ""
+msgstr "微分方程式を解く(&O)..."
 
 #: ../../src/wxMaximaFrame.cpp:1240
 msgid "Solve (to_poly)..."
-msgstr ""
+msgstr "高次方程式の解を求める..."
 
 #: ../../src/wxMaxima.cpp:8045
 msgid "Solve A*x=b numerically"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1397
+#, fuzzy
 msgid "Solve Ax=b"
-msgstr ""
+msgstr "方程式"
 
 #: ../../src/wxMaxima.cpp:7783
 msgid "Solve ODE"
-msgstr ""
+msgstr "微分方程式"
 
 #: ../../src/wxMaximaFrame.cpp:1287
 msgid "Solve ODE with Lapla&ce..."
-msgstr ""
+msgstr "連立微分方程式を解く(&C)..."
 
 #: ../../src/wxMaximaFrame.cpp:1398
+#, fuzzy
 msgid "Solve a linear equation system using dgesv"
-msgstr ""
+msgstr "連立一次方程式を解く"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
 msgid "Solve algebraic system"
-msgstr ""
+msgstr "連立高次方程式"
 
 #: ../../src/wxMaximaFrame.cpp:1245
 msgid "Solve algebraic system of equations"
-msgstr ""
+msgstr "連立高次方程式の近似解（可能であれば厳密解）を求める"
 
 #: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve boundary value problem for second degree ODE"
-msgstr ""
+msgstr "2階微分方程式の一般解に境界条件を適用"
 
 #: ../../src/wxMaxima.cpp:7895
+#, fuzzy
 msgid "Solve differential equations using laplace()"
-msgstr ""
+msgstr "連立微分方程式を解く （関数は変数名を明示する必要があります 例：f(x)）"
 
 #: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
 msgid "Solve equation(s)"
-msgstr ""
+msgstr "解の公式から厳密解を求める"
 
 #: ../../src/wxMaximaFrame.cpp:1241
 msgid "Solve equation(s) with to_poly_solve"
-msgstr ""
+msgstr "高次方程式の近似解を小数で求める"
 
 #: ../../src/wxMaxima.cpp:7773
+#, fuzzy
 msgid "Solve equations numerically"
-msgstr ""
+msgstr "解の公式から厳密解を求める"
 
 #: ../../src/wxMaxima.cpp:7757
+#, fuzzy
 msgid "Solve equations to polynom"
-msgstr ""
+msgstr "高次方程式の近似解を小数で求める"
 
 #: ../../src/wxMaximaFrame.cpp:1271
 msgid "Solve initial value problem for first degree ODE"
-msgstr ""
+msgstr "1階微分方程式の一般解に初期条件を適用"
 
 #: ../../src/wxMaximaFrame.cpp:1275
 msgid "Solve initial value problem for second degree ODE"
-msgstr ""
+msgstr "2階微分方程式の一般解に初期条件を適用"
 
 #: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
 msgid "Solve linear system"
-msgstr ""
+msgstr "連立一次方程式"
 
 #: ../../src/wxMaximaFrame.cpp:1243
 msgid "Solve linear system of equations"
-msgstr ""
+msgstr "連立一次方程式を解く"
 
 #: ../../src/wxMaximaFrame.cpp:1263
 msgid "Solve numerical, 1 Variable"
@@ -6507,31 +6927,35 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1267
 msgid "Solve ordinary differential equation of maximum degree 2"
-msgstr ""
+msgstr "Maximaが対応しているのは2階常微分方程式までです"
 
 #: ../../src/wxMaximaFrame.cpp:1288
 msgid "Solve ordinary differential equations with Laplace transformation"
-msgstr ""
+msgstr "連立微分方程式を解く （関数は変数名を明示する必要があります 例：f(x)）"
 
 #: ../../src/wxMaxima.cpp:7708
+#, fuzzy
 msgid "Solve polynomials numerically"
-msgstr ""
+msgstr "解の公式から厳密解を求める"
 
 #: ../../src/wxMaxima.cpp:7718
+#, fuzzy
 msgid "Solve polynomials numerically (bfloats)"
-msgstr ""
+msgstr "解の公式から厳密解を求める"
 
 #: ../../src/wxMaxima.cpp:7729
+#, fuzzy
 msgid "Solve polynomials numerically (real roots)"
-msgstr ""
+msgstr "解の公式から厳密解を求める"
 
 #: ../../src/wxMaximaFrame.cpp:1249
+#, fuzzy
 msgid "Solve symbolically"
-msgstr ""
+msgstr "解の公式から厳密解を求める"
 
 #: ../../src/Worksheet.cpp:1574
 msgid "Solve..."
-msgstr ""
+msgstr "方程式を解く..."
 
 #: ../../src/wxMaximaFrame.cpp:1916
 msgid "Solving differential equations"
@@ -6553,20 +6977,23 @@ msgid "Sort"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8496
+#, fuzzy
 msgid "Sort a list"
-msgstr ""
+msgstr "リスト作成"
 
 #: ../../src/wxMaxima.cpp:7459
 msgid "Sort all characters in string"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1179
+#, fuzzy
 msgid "Sort the characters..."
-msgstr ""
+msgstr "ギリシャ文字"
 
 #: ../../src/wxMaxima.cpp:8482
+#, fuzzy
 msgid "Source list:"
-msgstr ""
+msgstr "リスト作成"
 
 #: ../../src/wxMaxima.cpp:7429
 msgid "Split"
@@ -6585,20 +7012,22 @@ msgid "Split string into tokens"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1171
+#, fuzzy
 msgid "Split..."
-msgstr ""
+msgstr "箱ひげ図..."
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Square"
 msgstr ""
 
 #: ../../src/Configuration.cpp:86
+#, fuzzy
 msgid "Standard Text"
-msgstr ""
+msgstr "オプション"
 
 #: ../../src/Worksheet.cpp:1298
 msgid "Start Animation"
-msgstr ""
+msgstr "アニメーションの開始"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Start of t:"
@@ -6606,7 +7035,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:305
 msgid "Start or Stop animation"
-msgstr ""
+msgstr "アニメーションの開始・停止"
 
 #: ../../src/ToolBar.cpp:306
 msgid ""
@@ -6616,11 +7045,12 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:386
 msgid "Starting Maxima process failed"
-msgstr ""
+msgstr "Maximaプロセスを開始できませんでした"
 
 #: ../../src/main.cpp:667
+#, fuzzy
 msgid "Starting a new wxMaxima process for a new window"
-msgstr ""
+msgstr "Maximaプロセスを開始できませんでした"
 
 #: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:5633
 msgid "Starting evaluation of the document"
@@ -6628,7 +7058,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:2544
 msgid "Starting server failed"
-msgstr ""
+msgstr "サーバーを開始できませんでした"
 
 #: ../../src/WXMXformat.cpp:64
 msgid "Starting to save the worksheet as .wxmx"
@@ -6636,15 +7066,16 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:252
 msgid "Statistics"
-msgstr ""
+msgstr "統計処理"
 
 #: ../../src/wxMaximaFrame.cpp:701
 msgid "Statistics\tAlt+Shift+S"
-msgstr ""
+msgstr "統計処理\tAlt+Shift+S"
 
 #: ../../src/wxMaxima.cpp:7844
+#, fuzzy
 msgid "Step width:"
-msgstr ""
+msgstr "ラベル幅"
 
 #: ../../src/wxMaximaFrame.cpp:794
 msgid "Straight lines"
@@ -6669,26 +7100,31 @@ msgid "Stream:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1185
+#, fuzzy
 msgid "String"
-msgstr ""
+msgstr "出力文字列"
 
 #: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
 #: ../../src/wxMaxima.cpp:7425
+#, fuzzy
 msgid "String #1:"
-msgstr ""
+msgstr "出力文字列"
 
 #: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
 #: ../../src/wxMaxima.cpp:7426
+#, fuzzy
 msgid "String #2:"
-msgstr ""
+msgstr "出力文字列"
 
 #: ../../src/wxMaximaFrame.cpp:1136
+#, fuzzy
 msgid "String Tests"
-msgstr ""
+msgstr "出力文字列"
 
 #: ../../src/wxMaxima.cpp:7415
+#, fuzzy
 msgid "String length"
-msgstr ""
+msgstr "出力文字列"
 
 #: ../../src/wxMaxima.cpp:7381
 msgid "String to list of char"
@@ -6699,8 +7135,9 @@ msgid "String to list of chars..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7496
+#, fuzzy
 msgid "String to octets"
-msgstr ""
+msgstr "出力文字列"
 
 #: ../../src/wxMaximaFrame.cpp:1160
 msgid "String to octets..."
@@ -6717,8 +7154,9 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7465 ../../src/wxMaxima.cpp:7470
 #: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
 #: ../../src/wxMaxima.cpp:7497
+#, fuzzy
 msgid "String:"
-msgstr ""
+msgstr "出力文字列"
 
 #: ../../src/wxMaxima.cpp:7197
 msgid "Struct :"
@@ -6734,7 +7172,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:274
 msgid "Subsection"
-msgstr ""
+msgstr "サブセクション"
 
 #: ../../src/Configuration.cpp:90
 msgid "Subsection cell (Heading 3)"
@@ -6751,19 +7189,21 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
 #: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
 msgid "Substitute"
-msgstr ""
+msgstr "置換"
 
 #: ../../src/wxMaximaFrame.cpp:1193
+#, fuzzy
 msgid "Substitute all matches"
-msgstr ""
+msgstr "式中の部分式を置換..."
 
 #: ../../src/wxMaximaFrame.cpp:1192
 msgid "Substitute first match"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1646
+#, fuzzy
 msgid "Substitute only in parts..."
-msgstr ""
+msgstr "式中の部分式を置換..."
 
 #: ../../src/wxMaxima.cpp:8763
 msgid "Substitute only in specific parts"
@@ -6775,7 +7215,7 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
 msgid "Substitute..."
-msgstr ""
+msgstr "式中の部分式を置換..."
 
 #: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
 msgid "Substitutes until the equation no more changes"
@@ -6811,15 +7251,16 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:275
 msgid "Subsubsection"
-msgstr ""
+msgstr "サブサブセクション"
 
 #: ../../src/Configuration.cpp:89
 msgid "Subsubsection cell (Heading 4)"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1831
+#, fuzzy
 msgid "Suggestion: "
-msgstr ""
+msgstr "サブセクション"
 
 #: ../../src/Worksheet.cpp:2030
 msgid "Suitable as flag for ev()"
@@ -6827,7 +7268,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9049
 msgid "Sum"
-msgstr ""
+msgstr "総和"
 
 #: ../../src/wxMaximaFrame.cpp:1551
 msgid ""
@@ -6844,12 +7285,13 @@ msgid "Switched to lisp mode after receiving a lisp prompt!"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1971
+#, fuzzy
 msgid "Symbolic Constant"
-msgstr ""
+msgstr "定数を選択してください"
 
 #: ../../src/wxMaximaFrame.cpp:705
 msgid "Symbols\tAlt+Shift+Y"
-msgstr ""
+msgstr "記号\tAlt+Shift+Y"
 
 #: ../../src/Worksheet.cpp:2006
 msgid "Symmetric function: f(x)=f(-x)"
@@ -6857,23 +7299,25 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:238
 msgid "Table of Contents"
-msgstr ""
+msgstr "目次"
 
 #: ../../src/wxMaximaFrame.cpp:711
 msgid "Table of Contents\tAlt+Shift+T"
-msgstr ""
+msgstr "目次\tAlt+Shift+T"
 
 #: ../../src/wxMaxima.cpp:8930
+#, fuzzy
 msgid "Taylor series"
-msgstr ""
+msgstr "テイラー級数："
 
 #: ../../src/wxMaximaFrame.cpp:1474
+#, fuzzy
 msgid "Taylor series..."
-msgstr ""
+msgstr "テイラー級数："
 
 #: ../../src/wxMaxima.cpp:8925
 msgid "Taylor series:"
-msgstr ""
+msgstr "テイラー級数："
 
 #: ../../src/wxMaxima.cpp:4132
 msgid "Telling maxima about the new working directory."
@@ -6900,11 +7344,11 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:271
 msgid "Text"
-msgstr ""
+msgstr "テキスト"
 
 #: ../../src/Configuration.cpp:93
 msgid "Text cell background"
-msgstr ""
+msgstr "テキストセルの背景色"
 
 #: ../../src/wxMaxima.cpp:6541
 msgid "Text snippet"
@@ -6945,8 +7389,9 @@ msgid "The comma-separated contents of the struct fields"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7186
+#, fuzzy
 msgid "The comma-separated names of the struct fields"
-msgstr ""
+msgstr "変数はカンマで区切ります（例：x,y,…）"
 
 #: ../../src/wxMaxima.cpp:7070
 msgid ""
@@ -7002,12 +7447,14 @@ msgid "The main toolbar"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1882
+#, fuzzy
 msgid "The manual of Maxima"
-msgstr ""
+msgstr "Maximaのオフラインマニュアルを開く"
 
 #: ../../src/wxMaximaFrame.cpp:1881
+#, fuzzy
 msgid "The manual of wxMaxima"
-msgstr ""
+msgstr "Maximaのオフラインマニュアルを開く"
 
 #: ../../src/wxMaxima.cpp:7125
 msgid "The name of a function we don't want to be evaluated here"
@@ -7082,8 +7529,9 @@ msgid "The variables to search the optimum solution for"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:193
+#, fuzzy
 msgid "The worksheet"
-msgstr ""
+msgstr "ワークシート"
 
 #: ../../src/Worksheet.cpp:8122
 msgid "The worksheet containing maxima's input and output"
@@ -7096,10 +7544,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:2143
+#, fuzzy
 msgid ""
 "There was an error in the XML maxima has generated.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"XMLの生成においてエラーが発生しました。\n"
+"\n"
+"この事象をバグとして報告していただければ幸いです。"
 
 #: ../../src/wxMaxima.cpp:3911
 msgid ""
@@ -7120,10 +7572,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3257
+#, fuzzy
 msgid ""
 "There was an error in the XML that should describe the manual topics.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"XMLの生成においてエラーが発生しました。\n"
+"\n"
+"この事象をバグとして報告していただければ幸いです。"
 
 #: ../../src/wxMaxima.cpp:3202
 msgid ""
@@ -7164,11 +7620,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9013 ../../src/wxMaxima.cpp:10058
 msgid "Times:"
-msgstr ""
+msgstr "微分回数："
 
 #: ../../src/ToolBar.cpp:272
 msgid "Title"
-msgstr ""
+msgstr "タイトル"
 
 #: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
@@ -7180,35 +7636,37 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1794
 msgid "To &Bigfloat"
-msgstr ""
+msgstr "多倍長浮動小数点数(&Bigfloat)へ変換"
 
 #: ../../src/wxMaximaFrame.cpp:1791
 msgid "To &Float"
-msgstr ""
+msgstr "浮動小数点数へ変換(&F)"
 
 #: ../../src/Worksheet.cpp:1571
 msgid "To Float"
-msgstr ""
+msgstr "浮動小数点数へ変換"
 
 #: ../../src/wxMaximaFrame.cpp:1797
 msgid "To Numeri&c\tCtrl+Shift+N"
-msgstr ""
+msgstr "数値へ変換(&C)\tCtrl+Shift+N"
 
 #: ../../src/wxMaximaFrame.cpp:1803
+#, fuzzy
 msgid "To exact fraction"
-msgstr ""
+msgstr "部分分数分解"
 
 #: ../../src/wxMaximaFrame.cpp:1814
+#, fuzzy
 msgid "To exact number"
-msgstr ""
+msgstr "ユーザー定義関数名をリスト表示(&F)"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "To:"
-msgstr ""
+msgstr "上端："
 
 #: ../../src/wxMaximaFrame.cpp:825 ../../src/wxMaximaFrame.cpp:828
 msgid "Toggle full screen editing"
-msgstr ""
+msgstr "全画面表示の切り替え"
 
 #: ../../src/ToolBar.cpp:265
 msgid "Toggle the visibility of code cells"
@@ -7227,20 +7685,23 @@ msgid "Top end"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1078
+#, fuzzy
 msgid "Trace a function..."
-msgstr ""
+msgstr "ユーザー定義関数を削除"
 
 #: ../../src/wxMaxima.cpp:7084
+#, fuzzy
 msgid "Trace function(s)"
-msgstr ""
+msgstr "削除する関数名の入力："
 
 #: ../../src/wxMaximaFrame.cpp:1184
+#, fuzzy
 msgid "Transformations"
-msgstr ""
+msgstr "転置行列を求める"
 
 #: ../../src/wxMaximaFrame.cpp:1376
 msgid "Transpose a matrix"
-msgstr ""
+msgstr "転置行列を求める"
 
 #: ../../src/wxMaxima.cpp:7832
 msgid ""
@@ -7293,12 +7754,14 @@ msgid "Trim both ends..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1182
+#, fuzzy
 msgid "Trim left..."
-msgstr ""
+msgstr "極限値..."
 
 #: ../../src/wxMaximaFrame.cpp:1183
+#, fuzzy
 msgid "Trim right..."
-msgstr ""
+msgstr "極限値..."
 
 #: ../../src/wxMaxima.cpp:7473
 msgid "Trim string left"
@@ -7369,19 +7832,20 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1928
 msgid "Tutorials"
-msgstr ""
+msgstr "チュートリアル"
 
 #: ../../src/wxMaxima.cpp:9571
 msgid "Two sample t-test"
-msgstr ""
+msgstr "t検定"
 
 #: ../../src/Worksheet.cpp:8013
+#, fuzzy
 msgid "Type"
-msgstr ""
+msgstr "タイプ："
 
 #: ../../src/wxMaxima.cpp:7180
 msgid "Type:"
-msgstr ""
+msgstr "タイプ："
 
 #: ../../src/wxMaxima.cpp:9429
 msgid "URL"
@@ -7406,8 +7870,9 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1007
+#, fuzzy
 msgid "Undefine"
-msgstr ""
+msgstr "下線"
 
 #: ../../src/ToolBar.cpp:191
 msgid "Undo"
@@ -7415,7 +7880,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo\tCtrl+Z"
-msgstr ""
+msgstr "元に戻す\tCtrl+Z"
 
 #: ../../src/ToolBar.cpp:614
 msgid "Undo and redo button"
@@ -7423,15 +7888,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo last change"
-msgstr ""
+msgstr "一番新しい入力をリセット"
 
 #: ../../src/wxMaximaFrame.cpp:924
 msgid "Unfold All\tCtrl+Alt+]"
-msgstr ""
+msgstr "全て展開する\tCtrl+Alt+]"
 
 #: ../../src/wxMaximaFrame.cpp:925
 msgid "Unfold all folded sections"
-msgstr ""
+msgstr "全ての折りたたまれたセクションを展開"
 
 #: ../../src/Worksheet.cpp:1893
 msgid "Unhide Heading 5"
@@ -7446,24 +7911,29 @@ msgid "Unhide Part"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1860
+#, fuzzy
 msgid "Unhide Section"
-msgstr ""
+msgstr "セクション"
 
 #: ../../src/Worksheet.cpp:1871
+#, fuzzy
 msgid "Unhide Subsection"
-msgstr ""
+msgstr "サブセクション"
 
 #: ../../src/Worksheet.cpp:1882
+#, fuzzy
 msgid "Unhide Subsubsection"
-msgstr ""
+msgstr "サブサブセクション"
 
 #: ../../src/Worksheet.cpp:1912
+#, fuzzy
 msgid "Unhide contents"
-msgstr ""
+msgstr "ギリシャ文字"
 
 #: ../../src/wxMaximaFrame.cpp:266
+#, fuzzy
 msgid "Unicode characters"
-msgstr ""
+msgstr "ギリシャ文字"
 
 #: ../../src/wxMaximaFrame.cpp:707
 msgid "Unicode chars\tAlt+Shift+U"
@@ -7506,27 +7976,29 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:11150 ../../src/wxMaxima.cpp:11157
 #: ../../src/wxMaxima.cpp:11163
 msgid "Upgrade"
-msgstr ""
+msgstr "ソフトウェアの更新"
 
 #: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
 msgid "Upper bound:"
-msgstr ""
+msgstr "上限："
 
 #: ../../src/wxMaximaFrame.cpp:792
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
+#, fuzzy
 msgid "Use a list"
-msgstr ""
+msgstr "リスト作成"
 
 #: ../../src/wxMaxima.cpp:8571
 msgid "Use a list as parameter list for a function"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1708
+#, fuzzy
 msgid "Use list"
-msgstr ""
+msgstr "リスト作成"
 
 #: ../../src/wxMaximaFrame.cpp:1701
 msgid "Use list as the arguments of a function"
@@ -7541,8 +8013,9 @@ msgid "Use square parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1083
+#, fuzzy
 msgid "Use struct field..."
-msgstr ""
+msgstr "連分数で表示(&C)"
 
 #: ../../src/wxMaximaFrame.cpp:795
 msgid "Use vertical lines instead of parenthesis for matrices"
@@ -7554,7 +8027,7 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:81
 msgid "User-defined labels"
-msgstr ""
+msgstr "ユーザー定義のラベル"
 
 #: ../../src/MaximaManual.cpp:483
 msgid ""
@@ -7566,8 +8039,9 @@ msgid "Using Maxima path from command line."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:4822
+#, fuzzy
 msgid "Using configured Maxima path."
-msgstr ""
+msgstr "設定"
 
 #: ../../src/wxMaxima.cpp:2961
 msgid ""
@@ -7589,25 +8063,28 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8755
+#, fuzzy
 msgid "Value at a given point"
-msgstr ""
+msgstr "現在位置より上のセルを再評価"
 
 #: ../../src/Worksheet.cpp:1987
 msgid "Value at a specific point"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7801
+#, fuzzy
 msgid "Value at that point:"
-msgstr ""
+msgstr "現在位置より上のセルを再評価"
 
 #: ../../src/wxMaxima.cpp:7812 ../../src/wxMaxima.cpp:7825
 #: ../../src/wxMaxima.cpp:7827
+#, fuzzy
 msgid "Value y at that point:"
-msgstr ""
+msgstr "現在位置より上のセルを再評価"
 
 #: ../../src/wxMaxima.cpp:7910
 msgid "Value:"
-msgstr ""
+msgstr "関数の値："
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Var #1"
@@ -7623,25 +8100,29 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
 #: ../../src/wxMaxima.cpp:8568
+#, fuzzy
 msgid "Variable name"
-msgstr ""
+msgstr "全ての変数名"
 
 #: ../../src/wxMaximaFrame.cpp:1085
+#, fuzzy
 msgid "Variable name, not contents..."
-msgstr ""
+msgstr "全ての変数名"
 
 #: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
+#, fuzzy
 msgid "Variable name:"
-msgstr ""
+msgstr "全ての変数名"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
+#, fuzzy
 msgid "Variable(s)"
-msgstr ""
+msgstr "変数："
 
 #: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
 #: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
 msgid "Variable(s):"
-msgstr ""
+msgstr "変数："
 
 #: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
 #: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
@@ -7649,15 +8130,15 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
 #: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
 msgid "Variable:"
-msgstr ""
+msgstr "変数："
 
 #: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
 msgid "Variables"
-msgstr ""
+msgstr "変数"
 
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
 msgid "Variables:"
-msgstr ""
+msgstr "変数："
 
 #: ../../src/WXMXformat.cpp:337
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -7665,7 +8146,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:836
 msgid "View"
-msgstr ""
+msgstr "表示"
 
 #: ../../src/Autocomplete.cpp:235
 msgid "Waiting for m_addFiles_backgroundThread to finish"
@@ -7687,11 +8168,12 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
 #: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
 msgid "Warning"
-msgstr ""
+msgstr "Warning"
 
 #: ../../src/wxMaximaFrame.cpp:1556
+#, fuzzy
 msgid "Warning:"
-msgstr ""
+msgstr "Warning"
 
 #: ../../src/Dirstructure.cpp:72
 #, c-format
@@ -7707,7 +8189,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5063
 msgid "Welcome to wxMaxima"
-msgstr ""
+msgstr "wxMaximaへようこそ"
 
 #: ../../src/wxMaxima.cpp:8583
 msgid "What to do:"
@@ -7760,44 +8242,47 @@ msgid "Wrote the mimetype info"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:11147
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have version %s. The newest version source code is available for is %s.\n"
 "\n"
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
+"このwxMaximaのバージョンは %s です。最新のバージョンは %s です。\n"
+"\n"
+"OKを選択してwxMaximaのウェブページを開いてください。"
 
 #: ../../src/wxMaxima.cpp:11202
 msgid "Your changes will be lost if you don't save them."
-msgstr ""
+msgstr "保存しなければ、変更は失われます"
 
 #: ../../src/wxMaxima.cpp:11156
 msgid "Your version of wxMaxima is up to date."
-msgstr ""
+msgstr "お使いのwxMaximaは最新版です"
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom &In\tCtrl++"
-msgstr ""
+msgstr "拡大(&I)\tCtrl++"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom Ou&t\tCtrl+-"
-msgstr ""
+msgstr "縮小(&T)\tCtrl+-"
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom in 10%"
-msgstr ""
+msgstr "拡大率10%"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom out 10%"
-msgstr ""
+msgstr "縮小率10%"
 
 #: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
 msgid "[ unsaved ]"
-msgstr ""
+msgstr "[ 無題 ]"
 
 #: ../../src/wxMaxima.cpp:10920
 msgid "[ unsaved* ]"
-msgstr ""
+msgstr "[ 無題* ]"
 
 #: ../../src/Worksheet.cpp:5278
 #, c-format
@@ -7810,8 +8295,9 @@ msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"la
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1690
+#, fuzzy
 msgid "apply function to each element"
-msgstr ""
+msgstr "リストにコマンドを適用（ダイアログの\"関数\"は\"コマンド\"のことです）"
 
 #: ../../src/wxMaximaFrame.cpp:739
 msgid "as 1D ASCII"
@@ -7846,44 +8332,50 @@ msgid "ev() shall evaluate this automatically"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7130
+#, fuzzy
 msgid "expression:"
-msgstr ""
+msgstr "関数："
 
 #: ../../src/Worksheet.cpp:2025
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
+#, fuzzy
 msgid "filename:"
-msgstr ""
+msgstr "全ての変数名"
 
 #: ../../src/wxMaximaFrame.cpp:1674
+#, fuzzy
 msgid "from a list"
-msgstr ""
+msgstr "リスト作成"
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "from a rule"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1685
+#, fuzzy
 msgid "from function arguments"
-msgstr ""
+msgstr "ユーザー定義関数名"
 
 #: ../../src/wxMaximaFrame.cpp:1669
 msgid "from individual elements"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
+#, fuzzy
 msgid "function"
-msgstr ""
+msgstr "表示"
 
 #: ../../src/wxMaximaFrame.cpp:747
 msgid "in 2D"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8554
+#, fuzzy
 msgid "list"
-msgstr ""
+msgstr "リスト作成"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "max(abs(A(i,j))) (complex)"
@@ -7894,13 +8386,15 @@ msgid "max(abs(A(i,j))) (real)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8046
+#, fuzzy
 msgid "m×n Matrix A:"
-msgstr ""
+msgstr "行列："
 
 #: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533
+#, fuzzy
 msgid "n:"
-msgstr ""
+msgstr "属する"
 
 #: ../../src/Worksheet.cpp:2000
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -7911,8 +8405,9 @@ msgid "noun: Not evaluated by default"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1710
+#, fuzzy
 msgid "nth"
-msgstr ""
+msgstr "否定"
 
 #: ../../src/Worksheet.cpp:2021
 msgid "outative: f(2*x) = 2*f(x)"
@@ -7924,20 +8419,24 @@ msgid "part:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8942
+#, fuzzy
 msgid "point:"
-msgstr ""
+msgstr "値の入力："
 
 #: ../../src/wxMaxima.cpp:7740
+#, fuzzy
 msgid "precision:"
-msgstr ""
+msgstr "表示桁数"
 
 #: ../../src/wxMaxima.cpp:7255
+#, fuzzy
 msgid "printf"
-msgstr ""
+msgstr "印刷"
 
 #: ../../src/wxMaximaFrame.cpp:1108
+#, fuzzy
 msgid "printf..."
-msgstr ""
+msgstr "微分..."
 
 #: ../../src/wxMaxima.cpp:8650
 msgid ""
@@ -7953,16 +8452,19 @@ msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1111
+#, fuzzy
 msgid "readbyte..."
-msgstr ""
+msgstr "積分..."
 
 #: ../../src/wxMaximaFrame.cpp:1110
+#, fuzzy
 msgid "readchar..."
-msgstr ""
+msgstr "円グラフ..."
 
 #: ../../src/wxMaximaFrame.cpp:1109
+#, fuzzy
 msgid "readline..."
-msgstr ""
+msgstr "標本分散..."
 
 #: ../../src/wxMaxima.cpp:10018
 msgid ""
@@ -7993,16 +8495,17 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11190
 msgid "unsaved"
-msgstr ""
+msgstr "[ 無題 ]"
 
 #: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
 #: ../../src/wxMaximaFrame.cpp:189
 msgid "untitled"
-msgstr ""
+msgstr "無題"
 
 #: ../../src/wxMaximaFrame.cpp:1700
+#, fuzzy
 msgid "use as function arguments"
-msgstr ""
+msgstr "ユーザー定義関数名"
 
 #: ../../src/wxMaximaFrame.cpp:1696
 msgid "use the actual values stored"
@@ -8017,16 +8520,16 @@ msgid "wxMaxima"
 msgstr ""
 
 #: ../../src/main.cpp:516
-#, c-format
+#, fuzzy, c-format
 msgid "wxMaxima %ld"
-msgstr ""
+msgstr "wxMaxima %s "
 
 #: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
 #: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
 #: ../../src/wxMaximaFrame.cpp:185
-#, c-format
+#, fuzzy, c-format
 msgid "wxMaxima %s (%s) "
-msgstr ""
+msgstr "wxMaxima %s "
 
 #: ../../src/wxMaxima.cpp:4490
 msgid "wxMaxima cannot read the xml contents of "
@@ -8042,12 +8545,12 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5285
 msgid "wxMaxima document"
-msgstr ""
+msgstr "wxMaxima document"
 
 #: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
 #: ../../src/wxMaxima.cpp:4230
 msgid "wxMaxima encountered an error loading "
-msgstr ""
+msgstr "以下のファイルの読込みに失敗しました　"
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "wxMaxima help"
@@ -8066,12 +8569,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1896
+#, fuzzy
 msgid "wxMaxima shows help in a browser"
-msgstr ""
+msgstr "ファイルが見つかりません"
 
 #: ../../src/wxMaximaFrame.cpp:1894
+#, fuzzy
 msgid "wxMaxima shows help in the sidebar"
-msgstr ""
+msgstr "ファイルが見つかりません"
 
 #: ../../src/wxMaximaFrame.cpp:111
 #, c-format
@@ -8079,8 +8584,9 @@ msgid "wxMaxima version %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1954
+#, fuzzy
 msgid "wxMaxima's ChangeLog"
-msgstr ""
+msgstr "wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "wxMaxima's license"
@@ -8144,8 +8650,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:10
+#, fuzzy
 msgid "# Introduction to wxMaxima"
-msgstr ""
+msgstr "wxMaximaへようこそ"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:12
@@ -8184,8 +8691,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:18
+#, fuzzy
 msgid "### _Maxima_"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:20
@@ -8220,8 +8728,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:26
+#, fuzzy
 msgid "### WxMaxima"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:28
@@ -8344,8 +8853,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:54
+#, fuzzy
 msgid "### Cells"
-msgstr ""
+msgstr "セルの結合"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:56
@@ -8366,8 +8876,9 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Image cells."
-msgstr ""
+msgstr "セルの結合"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
@@ -8383,8 +8894,9 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Page breaks."
-msgstr ""
+msgstr "改ページ"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:65
@@ -8538,8 +9050,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:102
+#, fuzzy
 msgid "#### Greek characters"
-msgstr ""
+msgstr "ギリシャ文字"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:104
@@ -8954,8 +9467,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:282
+#, fuzzy
 msgid "## File Formats"
-msgstr ""
+msgstr "ファイルを開きました"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:284
@@ -9249,8 +9763,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:384
+#, fuzzy
 msgid "### Default animation framerate"
-msgstr ""
+msgstr "既定のアニメーションフレームレート:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:386
@@ -9295,8 +9810,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:403
+#, fuzzy
 msgid "### Match parenthesis in text controls"
-msgstr ""
+msgstr "テキスト入力ボックスで固定幅フォントを使用"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:405
@@ -9392,8 +9908,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:432
+#, fuzzy
 msgid "## Subscripted variables"
-msgstr ""
+msgstr "ユーザー定義変数をリスト表示"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:434
@@ -10041,8 +10558,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:704
+#, fuzzy
 msgid "#### Expression"
-msgstr ""
+msgstr "関数"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:706
@@ -10069,8 +10587,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:712
+#, fuzzy
 msgid "#### Parametric plot"
-msgstr ""
+msgstr "媒介変数プロット"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:714
@@ -10083,8 +10602,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:716
+#, fuzzy
 msgid "#### Points"
-msgstr ""
+msgstr "値の入力："
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:718
@@ -10131,8 +10651,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:732
+#, fuzzy
 msgid "#### Plot name"
-msgstr ""
+msgstr "リスト："
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:734
@@ -10168,8 +10689,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:744
+#, fuzzy
 msgid "#### Grid"
-msgstr ""
+msgstr "グラフの滑らかさ（y）："
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:746
@@ -10308,8 +10830,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:794
+#, fuzzy
 msgid "## Special variables wx..."
-msgstr ""
+msgstr "ユーザー定義変数を削除"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:805
@@ -10360,10 +10883,11 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:805
+#, fuzzy
 msgid ""
 "`wxanimate_framerate`: The number of frames per second the following "
 "animations have to be played back with."
-msgstr ""
+msgstr "アニメーションを再生する際のデフォルトのスピード（一秒あたりのフレーム数）を定義。"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:805
@@ -10481,8 +11005,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:837
+#, fuzzy
 msgid "Example:"
-msgstr ""
+msgstr "使用例"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:842
@@ -10533,8 +11058,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:856
+#, fuzzy
 msgid "## Output rendering."
-msgstr ""
+msgstr "出力文字列"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:858
@@ -10612,8 +11138,11 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:885
+#, fuzzy
 msgid "## Cannot connect to _Maxima_"
 msgstr ""
+"\n"
+"接続していません"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:887
@@ -10960,8 +11489,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:988
+#, fuzzy
 msgid "E.g. start wxMaxima with:"
-msgstr ""
+msgstr "ラベル番号をリセット"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:990
@@ -11321,8 +11851,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1140
+#, fuzzy
 msgid "# Command-line arguments"
-msgstr ""
+msgstr "各x座標はカンマで区切ってください"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1142

--- a/locales/wxMaxima/kab.po
+++ b/locales/wxMaxima/kab.po
@@ -73,20 +73,21 @@ msgid "%s: Can't interpret line: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1655
+#, fuzzy
 msgid "&Algebraic Mode"
-msgstr ""
+msgstr "&Aljibṛ"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "&Apropos..."
-msgstr ""
+msgstr "&À propos…"
 
 #: ../../src/wxMaximaFrame.cpp:615
 msgid "&Batch File...\tCtrl+B"
-msgstr ""
+msgstr "Traiter un fichier\tCTRL-B"
 
 #: ../../src/wxMaximaFrame.cpp:1278
 msgid "&Boundary Value Problem..."
-msgstr ""
+msgstr "Pro&blème aux limites…"
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "&Bug Report"
@@ -94,207 +95,215 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1505
 msgid "&Calculus"
-msgstr ""
+msgstr "A&siḍen"
 
 #: ../../src/wxMaximaFrame.cpp:1601
 msgid "&Canonical Form"
-msgstr ""
+msgstr "Tala  &tuqnint"
 
 #: ../../src/wxMaximaFrame.cpp:1358
 msgid "&Characteristic Polynomial..."
-msgstr ""
+msgstr "Polynôme &caractéristique…"
 
 #: ../../src/wxMaximaFrame.cpp:990
 msgid "&Clear Memory"
-msgstr ""
+msgstr "Effa&cer la mémoire"
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "&Combine Factorials"
-msgstr ""
+msgstr "&Combiner les factorielles"
 
 #: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Complex Simplification"
-msgstr ""
+msgstr "Simplification &complexe"
 
 #: ../../src/wxMaximaFrame.cpp:1502
 msgid "&Continued Fraction"
-msgstr ""
+msgstr "Fraction &continue"
 
 #: ../../src/wxMaximaFrame.cpp:638
 msgid "&Copy\tCtrl+C"
-msgstr ""
+msgstr "&Copier\tCtrl+C"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "&Demoivre"
-msgstr ""
+msgstr "&Demoivre"
 
 #: ../../src/wxMaximaFrame.cpp:1362
 msgid "&Determinant"
-msgstr ""
+msgstr "Améguccal"
 
 #: ../../src/wxMaximaFrame.cpp:1466
 msgid "&Differentiate..."
-msgstr ""
+msgstr "&Zlem…"
 
 #: ../../src/wxMaximaFrame.cpp:689
 msgid "&Edit"
-msgstr ""
+msgstr "&Taẓrigt"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "&Eliminate Variable..."
-msgstr ""
+msgstr "&Éliminer une variable…"
 
 #: ../../src/wxMaximaFrame.cpp:1318
 msgid "&Enter Matrix..."
-msgstr ""
+msgstr "&Sekcem isirew..."
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "&Example..."
-msgstr ""
+msgstr "&Exemple"
 
 #: ../../src/wxMaximaFrame.cpp:1524
 msgid "&Expand Expression"
-msgstr ""
+msgstr "Dév&elopper une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1597
 msgid "&Expand Trigonometric"
-msgstr ""
+msgstr "Dév&elopper une expression trigonométrique"
 
 #: ../../src/wxMaximaFrame.cpp:1626
 msgid "&Exponentialize"
-msgstr ""
+msgstr "&Exposant"
 
 #: ../../src/wxMaximaFrame.cpp:618
 msgid "&Export..."
-msgstr ""
+msgstr "&Exporter"
 
 #: ../../src/wxMaximaFrame.cpp:1516
 msgid "&Factor Expression"
-msgstr ""
+msgstr "&Factoriser une expression"
 
 #: ../../src/wxMaximaFrame.cpp:626
 msgid "&File"
-msgstr ""
+msgstr "A&faylu"
 
 #: ../../src/wxMaximaFrame.cpp:1019
+#, fuzzy
 msgid "&Functions"
-msgstr ""
+msgstr "Tawuri"
 
 #: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Greatest Common Divisor..."
-msgstr ""
+msgstr "Plus &grand diviseur commun…"
 
 #: ../../src/wxMaximaFrame.cpp:1968
 msgid "&Help"
-msgstr ""
+msgstr "Ta&llalt"
 
 #: ../../src/wxMaximaFrame.cpp:1453
 msgid "&Integrate..."
-msgstr ""
+msgstr "&Sidef…"
 
 #: ../../src/wxMaximaFrame.cpp:964
 msgid "&Interrupt\tCtrl+G"
-msgstr ""
+msgstr "&Interrompre\tCtrl+G"
 
 #: ../../src/wxMaximaFrame.cpp:1355
 msgid "&Invert Matrix"
-msgstr ""
+msgstr "&Inverser la matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "&License"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1763
+#, fuzzy
 msgid "&List"
-msgstr ""
+msgstr "Tabdart :"
 
 #: ../../src/wxMaximaFrame.cpp:610
 msgid "&Load Package...\tCtrl+L"
-msgstr ""
+msgstr "Sali-d akemmus\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "&Maxima"
-msgstr ""
+msgstr "&Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "&Maxima help"
-msgstr ""
+msgstr "Sken tallalt n Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1660
 msgid "&Modulus Computation..."
-msgstr ""
+msgstr "Calcul &modulaire…"
 
 #: ../../src/main.cpp:435
+#, fuzzy
 msgid "&New\tCtrl+N"
-msgstr ""
+msgstr "&Rnu tiɣimit\tCtrl+N"
 
 #: ../../src/wxMaximaFrame.cpp:1870
 msgid "&Numeric"
-msgstr ""
+msgstr "&Umḍin"
 
 #: ../../src/wxMaximaFrame.cpp:1785
+#, fuzzy
 msgid "&Numeric Output"
-msgstr ""
+msgstr "Basculer l'affichage numérique"
 
 #: ../../src/main.cpp:436
+#, fuzzy
 msgid "&Open\tCtrl+O"
-msgstr ""
+msgstr "&Ldi tiɣimit\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "&Open...\tCtrl+O"
-msgstr ""
+msgstr "&Ldi tiɣimit\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "&Plot"
-msgstr ""
+msgstr "Asuneɣ n tmaknayt"
 
 #: ../../src/wxMaximaFrame.cpp:622
 msgid "&Print...\tCtrl+P"
-msgstr ""
+msgstr "Im&primer\tCtrl+P"
 
 #: ../../src/wxMaximaFrame.cpp:1594
 msgid "&Reduce Trigonometric"
-msgstr ""
+msgstr "&Réduire une expression trigonométrique"
 
 #: ../../src/wxMaximaFrame.cpp:974
+#, fuzzy
 msgid "&Restart Maxima\tCtrl+Alt+R"
-msgstr ""
+msgstr "S&enker tikelt nniḍen Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:608
 msgid "&Save\tCtrl+S"
-msgstr ""
+msgstr "&Sekles tiɣimit\tCtrl+S"
 
 #: ../../src/wxMaximaFrame.cpp:1662
 msgid "&Simplify"
-msgstr ""
+msgstr "&Sefres"
 
 #: ../../src/wxMaximaFrame.cpp:1581
 msgid "&Simplify Factorials"
-msgstr ""
+msgstr "&Simplifier des factorielles"
 
 #: ../../src/wxMaximaFrame.cpp:1591
 msgid "&Simplify Trigonometric"
-msgstr ""
+msgstr "&Simplifier une expression trigonométrique"
 
 #: ../../src/wxMaximaFrame.cpp:1238
 msgid "&Solve..."
-msgstr ""
+msgstr "&Fru…"
 
 #: ../../src/wxMaximaFrame.cpp:1035
+#, fuzzy
 msgid "&Time Display"
-msgstr ""
+msgstr "Affichage du &temps"
 
 #: ../../src/wxMaximaFrame.cpp:1375
 msgid "&Transpose Matrix"
-msgstr ""
+msgstr "&Transposer une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1605
 msgid "&Trigonometric Simplification"
-msgstr ""
+msgstr "Simplification &trigonométrique"
 
 #: ../../src/wxMaximaFrame.cpp:1021
+#, fuzzy
 msgid "&Variables"
-msgstr ""
+msgstr "Imuttiyen"
 
 #: ../../src/wxMaxima.cpp:2443
 msgid "(Config tells to suppress the output of long cells)"
@@ -347,12 +356,14 @@ msgid ".wxm clipboard data with unusual header"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8047
+#, fuzzy
 msgid "1×n Matrix b:"
-msgstr ""
+msgstr "Isirew :"
 
 #: ../../src/wxMaximaFrame.cpp:1312
+#, fuzzy
 msgid "2D Array to Matrix..."
-msgstr ""
+msgstr "A&ppliquer à une matrice…"
 
 #: ../../src/wxMaximaFrame.cpp:743
 msgid "2D equations using ASCII Art"
@@ -393,24 +404,27 @@ msgid "A function returning positive numbers"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1965
+#, fuzzy
 msgid "A irrational variable"
-msgstr ""
+msgstr "Changer la variable"
 
 #: ../../src/Worksheet.cpp:2016
 msgid "A left-associative function"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:2019
+#, fuzzy
 msgid "A linear function"
-msgstr ""
+msgstr "Kkes tawuri"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "A matrix in which each row is a set of variables"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1963
+#, fuzzy
 msgid "A rational variable"
-msgstr ""
+msgstr "Changer la variable"
 
 #: ../../src/Worksheet.cpp:2018
 msgid "A right-associative function"
@@ -429,12 +443,13 @@ msgid "A text control got the mouse focus"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1442
+#, fuzzy
 msgid "A&pply function to each Matrix element..."
-msgstr ""
+msgstr "Appliquer une fonction à une liste"
 
 #: ../../src/wxMaximaFrame.cpp:1291
 msgid "A&t Value..."
-msgstr ""
+msgstr "À la valeur…"
 
 #: ../../src/Configuration.cpp:85
 msgid "ASCII maths"
@@ -442,11 +457,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1963
 msgid "About"
-msgstr ""
+msgstr "Talɣut ɣef"
 
 #: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
 msgid "About wxMaxima"
-msgstr ""
+msgstr "À propos de wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7837
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
@@ -462,15 +477,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1371
 msgid "Ad&joint Matrix"
-msgstr ""
+msgstr "Matrice associée"
 
 #: ../../src/wxMaximaFrame.cpp:1657
 msgid "Add Algebraic E&quality..."
-msgstr ""
+msgstr "Ajouter une égalité algébri&que"
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add a directory to search path"
-msgstr ""
+msgstr "Ajouter un répertoire au chemin de recherche"
 
 #: ../../src/wxMaximaFrame.cpp:1752
 msgid ""
@@ -478,24 +493,26 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8602
+#, fuzzy
 msgid "Add an element to the end of a list"
-msgstr ""
+msgstr "Ldi isemli"
 
 #: ../../src/wxMaxima.cpp:8597
+#, fuzzy
 msgid "Add an element to the start of a list"
-msgstr ""
+msgstr "Ldi isemli"
 
 #: ../../src/wxMaxima.cpp:7625
 msgid "Add dir to path:"
-msgstr ""
+msgstr "Ajouter le répertoire au chemin:"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "Add equality to the rational simplifier"
-msgstr ""
+msgstr "Ajouter une égalité au simplificateur rationnel"
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add to &Path..."
-msgstr ""
+msgstr "Ajouter au &chemin"
 
 #: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
 #: ../../src/Worksheet.cpp:1704
@@ -537,12 +554,14 @@ msgid "Aliases"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1714
+#, fuzzy
 msgid "All but the 1st n elements"
-msgstr ""
+msgstr "Appliquer une fonction à une liste"
 
 #: ../../src/wxMaximaFrame.cpp:1716
+#, fuzzy
 msgid "All but the last n elements"
-msgstr ""
+msgstr "Appliquer une fonction à une liste"
 
 #: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
 msgid ""
@@ -553,8 +572,9 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:733
+#, fuzzy
 msgid "All visible sidebars"
-msgstr ""
+msgstr "Ancienne variable :"
 
 #: ../../src/wxMaximaFrame.cpp:1650
 msgid "Allow to substitute operators"
@@ -596,8 +616,9 @@ msgid "Angles"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1775
+#, fuzzy
 msgid "Animation autoplay"
-msgstr ""
+msgstr "Sekles amray ɣer ufaylu"
 
 #: ../../src/wxMaximaFrame.cpp:1778
 msgid "Animation framerate..."
@@ -616,28 +637,34 @@ msgid "Append a list"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1736
+#, fuzzy
 msgid "Append a list to an existing list"
-msgstr ""
+msgstr "Trouver la limite d'une expression"
 
 #: ../../src/wxMaxima.cpp:8607
+#, fuzzy
 msgid "Append a list to another list"
-msgstr ""
+msgstr "Trouver la limite d'une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1729
+#, fuzzy
 msgid "Append an element"
-msgstr ""
+msgstr "Ldi isemli"
 
 #: ../../src/wxMaximaFrame.cpp:1734
+#, fuzzy
 msgid "Append an element to the beginning an existing list"
-msgstr ""
+msgstr "Trouver la limite d'une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1730
+#, fuzzy
 msgid "Append an element to the end of an existing list"
-msgstr ""
+msgstr "Trouver la limite d'une expression"
 
 #: ../../src/wxMaxima.cpp:8552
+#, fuzzy
 msgid "Apply a function to each list element"
-msgstr ""
+msgstr "Appliquer une fonction à une liste"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 #, c-format
@@ -662,15 +689,16 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9474
 msgid "Apropos"
-msgstr ""
+msgstr "Talɣut ɣef"
 
 #: ../../src/wxMaxima.cpp:7317
 msgid "Are the chars equal, if case is ignored?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7312
+#, fuzzy
 msgid "Are the chars equal?"
-msgstr ""
+msgstr "Cellule de sous-section"
 
 #: ../../src/wxMaxima.cpp:7349
 msgid "Are these strings equal if case is ignored?"
@@ -685,12 +713,14 @@ msgid "Arguments:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8189
+#, fuzzy
 msgid "Array"
-msgstr ""
+msgstr "Tableau :"
 
 #: ../../src/wxMaximaFrame.cpp:1023
+#, fuzzy
 msgid "Arrays"
-msgstr ""
+msgstr "Tableau :"
 
 #: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
 msgid "Ascii code to char"
@@ -770,7 +800,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6210
 msgid "Batch File"
-msgstr ""
+msgstr "Fichier de commandes"
 
 #: ../../src/wxMaxima.cpp:5318
 msgid "Both horizontal and vertical cursor active at the same time"
@@ -781,8 +811,9 @@ msgid "Bottom end"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7817
+#, fuzzy
 msgid "Boundary value problem"
-msgstr ""
+msgstr "Pro&blème aux limites…"
 
 #: ../../src/wxMathml.cpp:101
 msgid ""
@@ -876,23 +907,24 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1948
 msgid "Build &Info"
-msgstr ""
+msgstr "Information &de compilation"
 
 #: ../../src/wxMaxima.cpp:7275
 msgid "Byte:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1458
+#, fuzzy
 msgid "C&hange Variable in Integrate..."
-msgstr ""
+msgstr "C&hanger de variable…"
 
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "C&onfigure"
-msgstr ""
+msgstr "C&onfigurer"
 
 #: ../../src/wxMaximaFrame.cpp:1482
 msgid "Calculate &Product..."
-msgstr ""
+msgstr "Calculer le &produit…"
 
 #: ../../src/wxMaxima.cpp:8057
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
@@ -906,35 +938,38 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate Su&m..."
-msgstr ""
+msgstr "Calculer la som&me…"
 
 #: ../../src/wxMaximaFrame.cpp:1795
 msgid "Calculate bigfloat value of the last result"
-msgstr ""
+msgstr "Valeur approchée (bigfloat) d'une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Calculate float value of the last result"
-msgstr ""
+msgstr "Calculer une valeur approchée du dernier résultat"
 
 #: ../../src/wxMaxima.cpp:9550
+#, fuzzy
 msgid "Calculate mean value"
-msgstr ""
+msgstr "Calculer le module :"
 
 #: ../../src/wxMaxima.cpp:9554
+#, fuzzy
 msgid "Calculate median value"
-msgstr ""
+msgstr "Calculer le module :"
 
 #: ../../src/wxMaxima.cpp:8871
 msgid "Calculate modulus:"
-msgstr ""
+msgstr "Calculer le module :"
 
 #: ../../src/wxMaximaFrame.cpp:1798
+#, fuzzy
 msgid "Calculate numeric value of the last result"
-msgstr ""
+msgstr "Calculer une valeur approchée du dernier résultat"
 
 #: ../../src/wxMaximaFrame.cpp:1483
 msgid "Calculate products"
-msgstr ""
+msgstr "Calculer les produits"
 
 #: ../../src/wxMaxima.cpp:9562
 msgid "Calculate standard deviation"
@@ -942,23 +977,25 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate sums"
-msgstr ""
+msgstr "Calculer les sommes"
 
 #: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
 msgid "Calculate the eigenvalues and eigenvectors numerically"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
+#, fuzzy
 msgid "Calculate the eigenvalues of a matrix numerically"
-msgstr ""
+msgstr "Calculer l'inverse d'une matrice"
 
 #: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
 msgid "Calculate the root of the sum of squares of matrix entries"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9558
+#, fuzzy
 msgid "Calculate variation"
-msgstr ""
+msgstr "Calculer les produits"
 
 #: ../../src/wxMaxima.cpp:8949
 msgid "Calculates the fourier coefficients for the expression from -p to p"
@@ -974,7 +1011,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11125
 msgid "Can not connect to the web server."
-msgstr ""
+msgstr "Ur yezmir ara ad yeqqen ɣer uqeddac Web"
 
 #: ../../src/wxMaxima.cpp:11166
 msgid "Can not download version info."
@@ -989,7 +1026,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Cancel"
-msgstr ""
+msgstr "Sefsex"
 
 #: ../../src/wxMaxima.cpp:3292
 msgid "Cannot authenticate Maxima!"
@@ -1026,8 +1063,9 @@ msgid "Cannot set the communication port to %i."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3656 ../../src/wxMaxima.cpp:6359
+#, fuzzy
 msgid "Cannot start gnuplot"
-msgstr ""
+msgstr "Courbe paramétrée"
 
 #: ../../src/StatusBar.cpp:216 ../../src/wxMaxima.cpp:2662
 msgid "Cannot start the maxima binary"
@@ -1043,15 +1081,17 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:955
 msgid "Ce&ll"
-msgstr ""
+msgstr "Tabni&qt"
 
 #: ../../src/Configuration.cpp:96
+#, fuzzy
 msgid "Cell bracket fill, Active"
-msgstr ""
+msgstr "Crochet de la cellule"
 
 #: ../../src/Configuration.cpp:95
+#, fuzzy
 msgid "Cell bracket fill, Inactive"
-msgstr ""
+msgstr "Crochet de la cellule"
 
 #: ../../src/wxMaxima.cpp:10395
 msgid "Cell ends in a backslash"
@@ -1059,51 +1099,58 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1038
 msgid "Change &2d Display"
-msgstr ""
+msgstr "Basculer en affichage &2d"
 
 #: ../../src/wxMaxima.cpp:10146
+#, fuzzy
 msgid "Change Image"
-msgstr ""
+msgstr "Changer la variable"
 
 #: ../../src/Worksheet.cpp:1324
+#, fuzzy
 msgid "Change Image..."
-msgstr ""
+msgstr "Sekles tugna…"
 
 #: ../../src/wxMaximaFrame.cpp:1954
+#, fuzzy
 msgid "Change Log"
-msgstr ""
+msgstr "Changer la variable"
 
 #: ../../src/wxMaxima.cpp:7555
 msgid "Change directory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1202
+#, fuzzy
 msgid "Change directory..."
-msgstr ""
+msgstr "Sekles tugna…"
 
 #: ../../src/wxMaximaFrame.cpp:1039
 msgid "Change the 2d display algorithm used to display math output"
-msgstr ""
+msgstr "Modifier l'algorithme d'affichage 2d utilisé pour les mathématiques"
 
 #: ../../src/wxMaxima.cpp:8885
 msgid "Change variable"
-msgstr ""
+msgstr "Changer la variable"
 
 #: ../../src/wxMaxima.cpp:8905
+#, fuzzy
 msgid "Change variable and evaluate"
-msgstr ""
+msgstr "Change la variable dans l'intégrale ou la somme"
 
 #: ../../src/wxMaximaFrame.cpp:1459
 msgid "Change variable in integral or sum"
-msgstr ""
+msgstr "Change la variable dans l'intégrale ou la somme"
 
 #: ../../src/wxMaximaFrame.cpp:1463
+#, fuzzy
 msgid "Change variable in integral or sum and evaluate the result"
-msgstr ""
+msgstr "Change la variable dans l'intégrale ou la somme"
 
 #: ../../src/wxMaximaFrame.cpp:1026
+#, fuzzy
 msgid "Changed option variables"
-msgstr ""
+msgstr "Changer la variable"
 
 #: ../../src/wxMaxima.cpp:10170
 #, c-format
@@ -1119,8 +1166,9 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
 #: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
+#, fuzzy
 msgid "Char #2:"
-msgstr ""
+msgstr "Isirew :"
 
 #: ../../src/wxMaximaFrame.cpp:1140
 msgid "Char to Unicode code point..."
@@ -1143,8 +1191,9 @@ msgid "Character Tests"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8181
+#, fuzzy
 msgid "Characteristic polynom"
-msgstr ""
+msgstr "Polynôme &caractéristique…"
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Chars are strings that are one character long"
@@ -1152,11 +1201,12 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1957
 msgid "Check for Updates"
-msgstr ""
+msgstr "Rechercher des mises à jour"
 
 #: ../../src/wxMaximaFrame.cpp:1958
+#, fuzzy
 msgid "Check if a newer version of wxMaxima is available."
-msgstr ""
+msgstr "Vérifier si une nouvelle version de wxMaxima éxiste"
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Choose the parenthesis type for Matrices"
@@ -1164,63 +1214,74 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9530 ../../src/wxMaxima.cpp:9535
 msgid "Classes:"
-msgstr ""
+msgstr "Classes :"
 
 #: ../../src/wxMaximaFrame.cpp:1378
 msgid "Classic matrix operations"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:998
+#, fuzzy
 msgid "Clear all aliases"
-msgstr ""
+msgstr "Effa&cer la mémoire"
 
 #: ../../src/wxMaximaFrame.cpp:995
+#, fuzzy
 msgid "Clear all arrays"
-msgstr ""
+msgstr "Effa&cer la mémoire"
 
 #: ../../src/wxMaximaFrame.cpp:992
+#, fuzzy
 msgid "Clear all dependencies"
-msgstr ""
+msgstr "Effa&cer la mémoire"
 
 #: ../../src/wxMaximaFrame.cpp:994
+#, fuzzy
 msgid "Clear all functions"
-msgstr ""
+msgstr "Kkes tawuri"
 
 #: ../../src/wxMaximaFrame.cpp:1001
+#, fuzzy
 msgid "Clear all gradefs"
-msgstr ""
+msgstr "Effa&cer la mémoire"
 
 #: ../../src/wxMaximaFrame.cpp:1000
+#, fuzzy
 msgid "Clear all labels"
-msgstr ""
+msgstr "Effa&cer la mémoire"
 
 #: ../../src/wxMaximaFrame.cpp:1004
 msgid "Clear all let rule packages"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1003
+#, fuzzy
 msgid "Clear all macros"
-msgstr ""
+msgstr "Effa&cer la mémoire"
 
 #: ../../src/wxMaximaFrame.cpp:1002
+#, fuzzy
 msgid "Clear all props"
-msgstr ""
+msgstr "Effa&cer la mémoire"
 
 #: ../../src/wxMaximaFrame.cpp:997
+#, fuzzy
 msgid "Clear all rules"
-msgstr ""
+msgstr "Effa&cer la mémoire"
 
 #: ../../src/wxMaximaFrame.cpp:999
+#, fuzzy
 msgid "Clear all structures"
-msgstr ""
+msgstr "Effa&cer la mémoire"
 
 #: ../../src/wxMaximaFrame.cpp:993
+#, fuzzy
 msgid "Clear all variables"
-msgstr ""
+msgstr "Kkes amutti"
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close\tCtrl+W"
-msgstr ""
+msgstr "Fermer\tCtrl+W"
 
 #: ../../src/wxMaxima.cpp:7235
 msgid "Close Stream"
@@ -1228,19 +1289,21 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close window"
-msgstr ""
+msgstr "Fermer la fenêtre"
 
 #: ../../src/wxMaximaFrame.cpp:1105
+#, fuzzy
 msgid "Close..."
-msgstr ""
+msgstr "Fru…"
 
 #: ../../src/WXMXformat.cpp:301
 msgid "Closed the zip archive"
 msgstr ""
 
 #: ../../src/Configuration.cpp:77
+#, fuzzy
 msgid "Code Default (Maxima input)"
-msgstr ""
+msgstr "Anekcam Maxima"
 
 #: ../../src/Configuration.cpp:103
 msgid "Code highlighting: Comments"
@@ -1275,83 +1338,99 @@ msgid "Code highlighting: Variables"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
+#, fuzzy
 msgid "Code number:"
-msgstr ""
+msgstr "Colonnes :"
 
 #: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
+#, fuzzy
 msgid "Codepoint number:"
-msgstr ""
+msgstr "Colonnes :"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "Col. names:"
-msgstr ""
+msgstr "Noms des colonnes :"
 
 #: ../../src/Configuration.cpp:100
+#, fuzzy
 msgid "Color of Outdated cells"
-msgstr ""
+msgstr "Cellules inactualisées"
 
 #: ../../src/Configuration.cpp:99
+#, fuzzy
 msgid "Color of text equal to selection"
-msgstr ""
+msgstr "Aḍris yegda tafrant"
 
 #: ../../src/wxMaxima.cpp:7962
+#, fuzzy
 msgid "Column number:"
-msgstr ""
+msgstr "Colonnes :"
 
 #: ../../src/wxMaxima.cpp:7978
+#, fuzzy
 msgid "Column numbers:"
-msgstr ""
+msgstr "Colonnes :"
 
 #: ../../src/wxMaxima.cpp:8202
+#, fuzzy
 msgid "Columns"
-msgstr ""
+msgstr "Colonnes :"
 
 #: ../../src/wxMaximaFrame.cpp:1584
 msgid "Combine factorials in an expression"
-msgstr ""
+msgstr "Combiner les factorielles dans une expression"
 
 #: ../../src/wxMaxima.cpp:10454
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7259
+#, fuzzy
 msgid "Comma-separated arguments"
-msgstr ""
+msgstr "Liste x séparée par des virgules"
 
 #: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
+#, fuzzy
 msgid "Comma-separated commands"
-msgstr ""
+msgstr "Liste x séparée par des virgules"
 
 #: ../../src/wxMaxima.cpp:8458
+#, fuzzy
 msgid "Comma-separated elements"
-msgstr ""
+msgstr "Liste x séparée par des virgules"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 #: ../../src/wxMaxima.cpp:10031
+#, fuzzy
 msgid "Comma-separated equations"
-msgstr ""
+msgstr "Liste x séparée par des virgules"
 
 #: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
 #: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
 #: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
+#, fuzzy
 msgid "Comma-separated expressions"
-msgstr ""
+msgstr "Liste x séparée par des virgules"
 
 #: ../../src/wxMaxima.cpp:7215
+#, fuzzy
 msgid "Comma-separated expressions that shall be converted to a string"
-msgstr ""
+msgstr "Liste x séparée par des virgules"
 
 #: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
+#, fuzzy
 msgid "Comma-separated expressions."
-msgstr ""
+msgstr "Liste x séparée par des virgules"
 
 #: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
+#, fuzzy
 msgid "Comma-separated function names"
-msgstr ""
+msgstr "Liste x séparée par des virgules"
 
 #: ../../src/wxMaxima.cpp:7086
+#, fuzzy
 msgid "Comma-separated function names."
-msgstr ""
+msgstr "Liste x séparée par des virgules"
 
 #: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
 #: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
@@ -1367,8 +1446,9 @@ msgid "Comma-separated names the parameters will be referenced by later."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
+#, fuzzy
 msgid "Comma-separated numbers from 0 to 255"
-msgstr ""
+msgstr "Liste x séparée par des virgules"
 
 #: ../../src/wxMaxima.cpp:8770
 msgid "Comma-separated numbers of the terms to substitute in"
@@ -1396,15 +1476,16 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1692
 msgid "Comment Selection"
-msgstr ""
+msgstr "Commenter la sélection"
 
 #: ../../src/wxMaximaFrame.cpp:681
 msgid "Comment out the currently selected text"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:680
+#, fuzzy
 msgid "Comment selection\tCtrl+/"
-msgstr ""
+msgstr "Commenter la sélection"
 
 #: ../../src/Worksheet.cpp:2004
 msgid "Commutative function"
@@ -1415,12 +1496,14 @@ msgid "Compile a QR decomposition using dgeqrf"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7162
+#, fuzzy
 msgid "Compile a function"
-msgstr ""
+msgstr "Kkes tawuri"
 
 #: ../../src/wxMaximaFrame.cpp:1188
+#, fuzzy
 msgid "Compile a regular expression"
-msgstr ""
+msgstr "Kkes tawuri"
 
 #: ../../src/wxMaximaFrame.cpp:1385
 msgid "Compile eigenvalues using dgeev"
@@ -1439,12 +1522,14 @@ msgid "Compile eigenvalues+eigenvectors using zgeev"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1076
+#, fuzzy
 msgid "Compile function..."
-msgstr ""
+msgstr "Kkes tawuri"
 
 #: ../../src/wxMaxima.cpp:7511
+#, fuzzy
 msgid "Compile regex"
-msgstr ""
+msgstr "Compléter le mot"
 
 #: ../../src/wxMathml.cpp:53
 msgid "Compiler-Bug? wxMathml.lisp is shorter than expected!"
@@ -1463,12 +1548,13 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:892
+#, fuzzy
 msgid "Complete Word\tCtrl+Space"
-msgstr ""
+msgstr "Compléter l'expression\tCtrl+K"
 
 #: ../../src/wxMaximaFrame.cpp:893
 msgid "Complete word"
-msgstr ""
+msgstr "Compléter le mot"
 
 #: ../../src/ToolBar.cpp:230
 msgid "Completely stop maxima and restart it"
@@ -1476,44 +1562,47 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1503
 msgid "Compute continued fraction of a value"
-msgstr ""
+msgstr "Calculer la fraction continue d'une valeur"
 
 #: ../../src/wxMaximaFrame.cpp:1372
 msgid "Compute the adjoint matrix"
-msgstr ""
+msgstr "Calculer la matrice adjointe"
 
 #: ../../src/wxMaximaFrame.cpp:1359
 msgid "Compute the characteristic polynomial of a matrix"
-msgstr ""
+msgstr "Calculer le polynôme caractéristique d'une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1363
 msgid "Compute the determinant of a matrix"
-msgstr ""
+msgstr "Calculer le déterminant d'une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1491
 msgid "Compute the greatest common divisor"
-msgstr ""
+msgstr "Calculer le plus grand diviseur commun"
 
 #: ../../src/wxMaximaFrame.cpp:1356
 msgid "Compute the inverse of a matrix"
-msgstr ""
+msgstr "Calculer l'inverse d'une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1494
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
+"Calculer le plus petit multiple commun (faire load(functs) avant "
+"utilisation)"
 
 #: ../../src/wxMaximaFrame.cpp:1374
+#, fuzzy
 msgid "Compute the rank of a matrix"
-msgstr ""
+msgstr "Calculer le déterminant d'une matrice"
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Condition:"
-msgstr ""
+msgstr "Condition :"
 
 #: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "Configure wxMaxima"
-msgstr ""
+msgstr "Configurer wxMaxima"
 
 #: ../../src/wxMaxima.cpp:2504
 msgid "Connection attempt, but connection failed."
@@ -1524,16 +1613,19 @@ msgid "Connection to Maxima lost."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7921
+#, fuzzy
 msgid "Construct a fraction"
-msgstr ""
+msgstr "Fraction &continue"
 
 #: ../../src/wxMaximaFrame.cpp:1305
+#, fuzzy
 msgid "Construct fraction..."
-msgstr ""
+msgstr "Fraction &continue"
 
 #: ../../src/wxMaxima.cpp:7158
+#, fuzzy
 msgid "Contents:"
-msgstr ""
+msgstr "Constantes grecques"
 
 #: ../../src/wxMaximaFrame.cpp:1877
 msgid "Context-sensitive &Help\tCtrl+?"
@@ -1545,27 +1637,32 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1542
 msgid "Contract Logarithms"
-msgstr ""
+msgstr "Regrouper les logarithmes"
 
 #: ../../src/wxMaximaFrame.cpp:1161
+#, fuzzy
 msgid "Conversions"
-msgstr ""
+msgstr "Mettre sous forme ca&rtésienne"
 
 #: ../../src/wxMaximaFrame.cpp:1229
+#, fuzzy
 msgid "Convert"
-msgstr ""
+msgstr "Mettre sous forme ca&rtésienne"
 
 #: ../../src/wxMaximaFrame.cpp:1230
+#, fuzzy
 msgid "Convert + Write to file"
-msgstr ""
+msgstr "Convertir en &factorielles"
 
 #: ../../src/wxMaximaFrame.cpp:1434
+#, fuzzy
 msgid "Convert Column to list..."
-msgstr ""
+msgstr "Convertir en &factorielles"
 
 #: ../../src/wxMaximaFrame.cpp:1430
+#, fuzzy
 msgid "Convert Row to list..."
-msgstr ""
+msgstr "Convertir en &factorielles"
 
 #: ../../src/wxMaximaFrame.cpp:1044
 msgid "Convert a command to maxima code"
@@ -1577,60 +1674,67 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1574
 msgid "Convert binomials, beta and gamma function to factorials"
-msgstr ""
+msgstr "Convertir combinaisons, fonctions beta et gamma en factorielles"
 
 #: ../../src/wxMaximaFrame.cpp:1578
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
+"Convertir combinaisons, factorielles et fonctions beta en fonction gamma"
 
 #: ../../src/wxMaximaFrame.cpp:1613
 msgid "Convert complex expression to polar form"
-msgstr ""
+msgstr "Mettre une expression complexe sous forme polaire"
 
 #: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert complex expression to rect form"
-msgstr ""
+msgstr "Mettre une expression complexe sous forme cartésienne"
 
 #: ../../src/wxMaximaFrame.cpp:1622
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
+"Convertir une fonction exponentielle d'argument imaginaire sous forme "
+"trigonométrique"
 
 #: ../../src/wxMaxima.cpp:7411
+#, fuzzy
 msgid "Convert string to lowercase"
-msgstr ""
+msgstr "Convertir en &factorielles"
 
 #: ../../src/wxMaxima.cpp:7543
+#, fuzzy
 msgid "Convert string to matching regex"
-msgstr ""
+msgstr "Convertir en &Gamma"
 
 #: ../../src/wxMaximaFrame.cpp:1543
 msgid "Convert sum of logarithms to logarithm of product"
-msgstr ""
+msgstr "Convertir une somme de logarithmes en un logarithme d'un produit"
 
 #: ../../src/wxMaximaFrame.cpp:1573
 msgid "Convert to &Factorials"
-msgstr ""
+msgstr "Convertir en &factorielles"
 
 #: ../../src/wxMaximaFrame.cpp:1577
 msgid "Convert to &Gamma"
-msgstr ""
+msgstr "Convertir en &Gamma"
 
 #: ../../src/wxMaximaFrame.cpp:1612
 msgid "Convert to &Polarform"
-msgstr ""
+msgstr "Mettre sous forme &polaire"
 
 #: ../../src/wxMaximaFrame.cpp:1609
 msgid "Convert to &Rectform"
-msgstr ""
+msgstr "Mettre sous forme ca&rtésienne"
 
 #: ../../src/wxMaximaFrame.cpp:1166
+#, fuzzy
 msgid "Convert to downcase..."
-msgstr ""
+msgstr "Convertir en &factorielles"
 
 #: ../../src/wxMaxima.cpp:7016
+#, fuzzy
 msgid "Convert to programming language"
-msgstr ""
+msgstr "Convertir en &Gamma"
 
 #: ../../src/wxMaxima.cpp:7022
 msgid "Convert to programming language file"
@@ -1639,10 +1743,11 @@ msgstr ""
 #: ../../src/wxMaximaFrame.cpp:1602
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr ""
+"Convertir une expression trigonométrique en forme quasi-linéaire canonique"
 
 #: ../../src/wxMaximaFrame.cpp:1627
 msgid "Convert trigonometric functions to exponential form"
-msgstr ""
+msgstr "Convertir les fonctions trigonométriques en forme exponentielle"
 
 #: ../../src/wxMaximaFrame.cpp:1762
 msgid "Converts a matrix to a list of lists"
@@ -1656,24 +1761,27 @@ msgstr ""
 #: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
 #: ../../src/Worksheet.cpp:1684
 msgid "Copy"
-msgstr ""
+msgstr "Copier"
 
 #: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
 #: ../../src/Worksheet.cpp:1514
+#, fuzzy
 msgid "Copy Animation"
-msgstr ""
+msgstr "Arrêter l'animation"
 
 #: ../../src/wxMaximaFrame.cpp:887
 msgid "Copy Previous Input\tCtrl+I"
-msgstr ""
+msgstr "Copier l'entrée précédente\tCtrl+I"
 
 #: ../../src/wxMaximaFrame.cpp:890
+#, fuzzy
 msgid "Copy Previous Output\tCtrl+U"
-msgstr ""
+msgstr "Copier l'entrée précédente\tCtrl+I"
 
 #: ../../src/wxMaxima.cpp:7992
+#, fuzzy
 msgid "Copy a matrix"
-msgstr ""
+msgstr "Copier comme image"
 
 #: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
 #: ../../src/wxMaximaFrame.cpp:663
@@ -1683,16 +1791,17 @@ msgstr ""
 #: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Copy as Image"
-msgstr ""
+msgstr "Copier comme image"
 
 #: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
 #: ../../src/wxMaximaFrame.cpp:645
 msgid "Copy as LaTeX"
-msgstr ""
+msgstr "Copier comme code LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:648
+#, fuzzy
 msgid "Copy as MathML"
-msgstr ""
+msgstr "Copier comme image"
 
 #: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
 msgid "Copy as MathML (e.g. to word processor)"
@@ -1700,29 +1809,34 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
 #: ../../src/wxMaximaFrame.cpp:658
+#, fuzzy
 msgid "Copy as RTF"
-msgstr ""
+msgstr "Copier comme code LaTeX"
 
 #: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
 #: ../../src/wxMaximaFrame.cpp:655
+#, fuzzy
 msgid "Copy as SVG"
-msgstr ""
+msgstr "Copier comme code LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:640
 msgid "Copy as Text\tCtrl+Shift+C"
-msgstr ""
+msgstr "&Copier comme texte\tCtrl+Maj-C"
 
 #: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
+#, fuzzy
 msgid "Copy as plain text"
-msgstr ""
+msgstr "Copier comme image"
 
 #: ../../src/wxMaxima.cpp:7576
+#, fuzzy
 msgid "Copy file"
-msgstr ""
+msgstr "Copier"
 
 #: ../../src/wxMaximaFrame.cpp:1214
+#, fuzzy
 msgid "Copy file..."
-msgstr ""
+msgstr "Fru…"
 
 #: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
 #: ../../src/wxMaximaFrame.cpp:643
@@ -1731,32 +1845,34 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
 msgid "Copy selection"
-msgstr ""
+msgstr "Copier la sélection"
 
 #: ../../src/wxMaximaFrame.cpp:664
 msgid "Copy selection from document as an Enhanced Metafile"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:656
+#, fuzzy
 msgid "Copy selection from document as an SVG image"
-msgstr ""
+msgstr "Copier la sélection du document au format image"
 
 #: ../../src/wxMaximaFrame.cpp:653
 msgid "Copy selection from document as an image"
-msgstr ""
+msgstr "Copier la sélection du document au format image"
 
 #: ../../src/wxMaximaFrame.cpp:659
+#, fuzzy
 msgid ""
 "Copy selection from document as rtf that a word processor might understand"
-msgstr ""
+msgstr "Copier la sélection du document au format image"
 
 #: ../../src/wxMaximaFrame.cpp:641
 msgid "Copy selection from document as text"
-msgstr ""
+msgstr "Copier la sélection du document au format texte"
 
 #: ../../src/wxMaximaFrame.cpp:646
 msgid "Copy selection from document in LaTeX format"
-msgstr ""
+msgstr "Copier la sélection du document au format LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:644
 msgid "Copy selection from document in Matlab format"
@@ -1769,12 +1885,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7403
+#, fuzzy
 msgid "Copy string"
-msgstr ""
+msgstr "Copier la sélection"
 
 #: ../../src/wxMaximaFrame.cpp:1165
+#, fuzzy
 msgid "Copy string..."
-msgstr ""
+msgstr "&Sekcem isirew..."
 
 #: ../../src/ToolBar.cpp:623
 msgid "Copy, Cut and Paste button"
@@ -1805,20 +1923,23 @@ msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1325
+#, fuzzy
 msgid "Create Matrix"
-msgstr ""
+msgstr "Générer une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1688
+#, fuzzy
 msgid "Create a list"
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaxima.cpp:8487
 msgid "Create a list as a storage for the values of variables"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8463 ../../src/wxMaxima.cpp:8476
+#, fuzzy
 msgid "Create a list from a rule"
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaximaFrame.cpp:1670
 msgid "Create a list from comma-separated elements"
@@ -1826,43 +1947,50 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:888
 msgid "Create a new cell with previous input"
-msgstr ""
+msgstr "Créer une nouvelle cellule avec l'entrée précédente"
 
 #: ../../src/wxMaximaFrame.cpp:891
+#, fuzzy
 msgid "Create a new cell with previous output"
-msgstr ""
+msgstr "Créer une nouvelle cellule avec l'entrée précédente"
 
 #: ../../src/wxMaximaFrame.cpp:1348
 msgid "Create copy, not clone..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7561
+#, fuzzy
 msgid "Create directory"
-msgstr ""
+msgstr "Sirew tabdart"
 
 #: ../../src/wxMaximaFrame.cpp:1203
+#, fuzzy
 msgid "Create directory..."
-msgstr ""
+msgstr "Sirew tabdart"
 
 #: ../../src/wxMaxima.cpp:7419
+#, fuzzy
 msgid "Create empty string"
-msgstr ""
+msgstr "Générer une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1168
+#, fuzzy
 msgid "Create empty string..."
-msgstr ""
+msgstr "Sirew tabdart"
 
 #: ../../src/wxMaximaFrame.cpp:1687
+#, fuzzy
 msgid "Create list"
-msgstr ""
+msgstr "Sirew tabdart"
 
 #: ../../src/wxMaxima.cpp:8457
 msgid "Create list from comma-separated elements"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1082
+#, fuzzy
 msgid "Create struct..."
-msgstr ""
+msgstr "Sirew tabdart"
 
 #: ../../src/WXMXformat.cpp:80
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
@@ -1873,28 +2001,29 @@ msgid "Creates an independent matrix with the same contents"
 msgstr ""
 
 #: ../../src/Configuration.cpp:97
+#, fuzzy
 msgid "Cursor color"
-msgstr ""
+msgstr "Curseur"
 
 #: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
 msgid "Cut"
-msgstr ""
+msgstr "Couper"
 
 #: ../../src/wxMaximaFrame.cpp:636
 msgid "Cut\tCtrl+X"
-msgstr ""
+msgstr "&Couper\tCtrl+X"
 
 #: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
 msgid "Cut selection"
-msgstr ""
+msgstr "Couper la sélection"
 
 #: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
 msgid "Data Matrix:"
-msgstr ""
+msgstr "Matrice des données :"
 
 #: ../../src/wxMaxima.cpp:9599
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
-msgstr ""
+msgstr "Fichier de données (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wxMaxima.cpp:9529 ../../src/wxMaxima.cpp:9534
 #: ../../src/wxMaxima.cpp:9539 ../../src/wxMaxima.cpp:9543
@@ -1903,7 +2032,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9563 ../../src/wxMaxima.cpp:9577
 #: ../../src/wxMaxima.cpp:9582 ../../src/wxMaxima.cpp:10030
 msgid "Data:"
-msgstr ""
+msgstr "Isefka :"
 
 #: ../../src/wxMaximaFrame.cpp:1057
 msgid "Debugger trigger"
@@ -1927,8 +2056,9 @@ msgid "Declare facts about %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8800
+#, fuzzy
 msgid "Declare main variable:"
-msgstr ""
+msgstr "Kkes amutti"
 
 #: ../../src/wxMaxima.cpp:7171
 msgid "Declare the type of a function parameter"
@@ -1940,15 +2070,17 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1500 ../../src/wxMaximaFrame.cpp:1536
 msgid "Decompose rational function to partial fractions"
-msgstr ""
+msgstr "Décomposer une fonction rationnelle en éléments simples"
 
 #: ../../src/Worksheet.cpp:2010
+#, fuzzy
 msgid "Decreasing function f(x)<x"
-msgstr ""
+msgstr "Effacer la (les) fonction(s):"
 
 #: ../../src/wxMaxima.cpp:7134
+#, fuzzy
 msgid "Define a function"
-msgstr ""
+msgstr "Kkes tawuri"
 
 #: ../../src/wxMaxima.cpp:7147
 msgid "Define a macro"
@@ -1963,12 +2095,14 @@ msgid "Define a structure type"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7156
+#, fuzzy
 msgid "Define a variable"
-msgstr ""
+msgstr "Kkes amutti"
 
 #: ../../src/wxMaximaFrame.cpp:1072
+#, fuzzy
 msgid "Define function..."
-msgstr ""
+msgstr "Kkes tawuri"
 
 #: ../../src/wxMaximaFrame.cpp:1079
 msgid "Define macro..."
@@ -1983,8 +2117,9 @@ msgid "Define struct..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1080
+#, fuzzy
 msgid "Define variable..."
-msgstr ""
+msgstr "Kkes amutti"
 
 #: ../../src/wxMaximaFrame.cpp:1776
 msgid ""
@@ -1997,23 +2132,23 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:985
 msgid "Delete F&unction..."
-msgstr ""
+msgstr "Kkes tawuri"
 
 #: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
 msgid "Delete Selection"
-msgstr ""
+msgstr "Kkes tafrant"
 
 #: ../../src/wxMaximaFrame.cpp:987
 msgid "Delete V&ariable..."
-msgstr ""
+msgstr "Kkes a&mutti"
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Delete a function"
-msgstr ""
+msgstr "Kkes tawuri"
 
 #: ../../src/wxMaximaFrame.cpp:988
 msgid "Delete a variable"
-msgstr ""
+msgstr "Kkes amutti"
 
 #: ../../src/wxMaximaFrame.cpp:982
 msgid "Delete all objects with a given name"
@@ -2021,35 +2156,42 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:991
 msgid "Delete all values from memory"
-msgstr ""
+msgstr "Effacer toutes les valeurs de la mémoire"
 
 #: ../../src/wxMaxima.cpp:7588
+#, fuzzy
 msgid "Delete file"
-msgstr ""
+msgstr "Kkes amutti"
 
 #: ../../src/wxMaximaFrame.cpp:1216
+#, fuzzy
 msgid "Delete file..."
-msgstr ""
+msgstr "Kkes a&mutti"
 
 #: ../../src/wxMaxima.cpp:7683
+#, fuzzy
 msgid "Delete function(s)"
-msgstr ""
+msgstr "Effacer la (les) fonction(s):"
 
 #: ../../src/wxMaxima.cpp:7679
+#, fuzzy
 msgid "Delete named object(s)"
-msgstr ""
+msgstr "Effacer la (les) fonction(s):"
 
 #: ../../src/wxMaximaFrame.cpp:981
+#, fuzzy
 msgid "Delete named object..."
-msgstr ""
+msgstr "Kkes tawuri"
 
 #: ../../src/wxMaxima.cpp:7674
+#, fuzzy
 msgid "Delete variable(s)"
-msgstr ""
+msgstr "Kkes amutti(imuttiyen):"
 
 #: ../../src/wxMaxima.cpp:7430
+#, fuzzy
 msgid "Delimiter:"
-msgstr ""
+msgstr "Éliminer"
 
 #: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
 #, c-format
@@ -2062,7 +2204,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8927
 msgid "Denom. deg:"
-msgstr ""
+msgstr "denom deg :"
 
 #: ../../src/wxMaxima.cpp:7923
 msgid "Denominator:"
@@ -2078,7 +2220,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1497
 msgid "Di&vide Polynomials..."
-msgstr ""
+msgstr "Di&vision de polynômes…"
 
 #: ../../src/MaximaManual.cpp:517
 msgid "Didn't find the maxima HTML manual."
@@ -2092,35 +2234,38 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
 msgid "Differentiate"
-msgstr ""
+msgstr "Zlem"
 
 #: ../../src/wxMaximaFrame.cpp:1467
 msgid "Differentiate expression"
-msgstr ""
+msgstr "Zlem tanfalit"
 
 #: ../../src/Worksheet.cpp:1590
 msgid "Differentiate..."
-msgstr ""
+msgstr "Zlem…"
 
 #: ../../src/wxMaxima.cpp:9010
+#, fuzzy
 msgid "Differentiates an expression n times"
-msgstr ""
+msgstr "Zlem tanfalit"
 
 #: ../../src/wxMaxima.cpp:10055
+#, fuzzy
 msgid "Differentiates the expression n times"
-msgstr ""
+msgstr "Zlem tanfalit"
 
 #: ../../src/wxMaximaFrame.cpp:1212
+#, fuzzy
 msgid "Directory operations"
-msgstr ""
+msgstr "Tanila:"
 
 #: ../../src/wxMaximaFrame.cpp:1041
 msgid "Display Te&X Form"
-msgstr ""
+msgstr "Afficher en Te&X"
 
 #: ../../src/wxMaxima.cpp:6972
 msgid "Display algorithm"
-msgstr ""
+msgstr "Afficher l'algorithme"
 
 #: ../../src/wxMaximaFrame.cpp:751
 msgid "Display an expression as maxima's internal lisp representation"
@@ -2131,8 +2276,9 @@ msgid "Display an expression as wxMaxima's internal XML representation"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:758
+#, fuzzy
 msgid "Display equations"
-msgstr ""
+msgstr "Fru tagda (tagdiwin)"
 
 #: ../../src/wxMaxima.cpp:6508
 msgid "Display expression in maxima's internal representation"
@@ -2144,7 +2290,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1042
 msgid "Display last result in TeX form"
-msgstr ""
+msgstr "Afficher la dernière expression en TeX"
 
 #: ../../src/ToolBar.cpp:360
 #, c-format
@@ -2152,24 +2298,27 @@ msgid "Display resolution according to wxWidgets: %li x %li ppi"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:802
+#, fuzzy
 msgid "Display string quotation marks"
-msgstr ""
+msgstr "Fru tagda (tagdiwin)"
 
 #: ../../src/wxMaximaFrame.cpp:1036
 msgid "Display time used for evaluation"
-msgstr ""
+msgstr "Afficher le temps d'exécution"
 
 #: ../../src/wxMaxima.cpp:9206
+#, fuzzy
 msgid "Displayed Precision"
-msgstr ""
+msgstr "Fru tagda (tagdiwin)"
 
 #: ../../src/wxMaximaFrame.cpp:1913
 msgid "Displaying 3d curves"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1462
+#, fuzzy
 msgid "Dito, and evaluate the result..."
-msgstr ""
+msgstr "Évaluer les formes &nommées"
 
 #: ../../src/wxMaximaFrame.cpp:1445
 msgid "Dito, but affect all clones of the Matrix..."
@@ -2185,20 +2334,21 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
 msgid "Divide Cell"
-msgstr ""
+msgstr "Partager la cellule"
 
 #: ../../src/wxMaximaFrame.cpp:1498
 msgid "Divide numbers or polynomials"
-msgstr ""
+msgstr "Division de nombres ou de polynômes"
 
 #: ../../src/wxMaxima.cpp:8578
+#, fuzzy
 msgid "Do for each list element"
-msgstr ""
+msgstr "Appliquer une fonction à une liste"
 
 #: ../../src/wxMaxima.cpp:11197
-#, c-format
+#, fuzzy, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
-msgstr ""
+msgstr "Sauvegarder les modifications apportées au document ?\""
 
 #: ../../src/wxMaximaFrame.cpp:724
 msgid "Dock all Sidebars"
@@ -2206,35 +2356,43 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:94
 msgid "Document background"
-msgstr ""
+msgstr "Arrière-plan du document"
 
 #: ../../src/wxMaxima.cpp:4611
+#, fuzzy
 msgid ""
 "Document was saved using a newer version of wxMaxima so it may not load "
 "correctly. Please update your wxMaxima."
 msgstr ""
+"yettwasekles s lqem aneggaru n ‎wxMaxima, ihi ur yezmir ara ad d-yali akken "
+"iwata. Ma ulac aɣilif leqqem wxMaxima."
 
 #: ../../src/wxMaxima.cpp:4603
+#, fuzzy
 msgid ""
 "Document was saved using a newer version of wxMaxima. Please update your "
 "wxMaxima."
 msgstr ""
+"yettwasekles s lqem aneggaru n ‎wxMaxima. Ma ulac aɣilif leqqem wxMaxima."
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "Don't autosubscript after an underscore"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1086
+#, fuzzy
 msgid "Don't evaluate Expression..."
-msgstr ""
+msgstr "Intégrer une expression"
 
 #: ../../src/wxMaxima.cpp:7117
+#, fuzzy
 msgid "Don't evaluate one command"
-msgstr ""
+msgstr "Montrer un exemple pour la commande :"
 
 #: ../../src/wxMaxima.cpp:7129
+#, fuzzy
 msgid "Don't evaluate one whole expression"
-msgstr ""
+msgstr "Partie réelle d'une expression complexe"
 
 #: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
 msgid "Don't mark cells that contain tooltips in yellow"
@@ -2246,7 +2404,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Don't save"
-msgstr ""
+msgstr "Ur seklas ara"
 
 #: ../../src/Worksheet.cpp:1620
 msgid "Don't show labels"
@@ -2261,36 +2419,40 @@ msgid "Don't use parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8525
+#, fuzzy
 msgid "Drop the first n list elements"
-msgstr ""
+msgstr "Appliquer une fonction à une liste"
 
 #: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
+#, fuzzy
 msgid "Drop the last n list elements"
-msgstr ""
+msgstr "Appliquer une fonction à une liste"
 
 #: ../../src/wxMaximaFrame.cpp:1306
 msgid "E&quations"
-msgstr ""
+msgstr "Tiig&diwin"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "E&xit\tCtrl+Q"
-msgstr ""
+msgstr "&Quitter\tCtrl+Q"
 
 #: ../../src/wxMaximaFrame.cpp:1368
 msgid "Eige&nvectors"
-msgstr ""
+msgstr "Vecteurs propres"
 
 #: ../../src/wxMaximaFrame.cpp:1365
 msgid "Eigen&values"
-msgstr ""
+msgstr "&Valeurs propres"
 
 #: ../../src/wxMaximaFrame.cpp:1387
+#, fuzzy
 msgid "Eigenvalues (complex)"
-msgstr ""
+msgstr "&Valeurs propres"
 
 #: ../../src/wxMaximaFrame.cpp:1384
+#, fuzzy
 msgid "Eigenvalues (real)"
-msgstr ""
+msgstr "&Valeurs propres"
 
 #: ../../src/wxMaximaFrame.cpp:1393
 msgid "Eigenvalues, left+right eigenvectors (complex)"
@@ -2337,20 +2499,22 @@ msgid "Elements:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7847
+#, fuzzy
 msgid "Eliminate a variable"
-msgstr ""
+msgstr "&Éliminer une variable…"
 
 #: ../../src/wxMaximaFrame.cpp:1247
 msgid "Eliminate a variable from a system of equations"
-msgstr ""
+msgstr "Éliminer une variable dans un système d'équations"
 
 #: ../../src/wxMaxima.cpp:10651
 msgid "Empty command => re-triggering evaluation"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9225
+#, fuzzy
 msgid "Enable:"
-msgstr ""
+msgstr "Amutti:"
 
 #: ../../src/MathParser.cpp:99
 #, c-format
@@ -2375,35 +2539,37 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1319
 msgid "Enter a matrix"
-msgstr ""
+msgstr "Sekcem isirew"
 
 #: ../../src/wxMaxima.cpp:8866
 msgid "Enter an equation for rational simplification:"
-msgstr ""
+msgstr "Entrer une équation pour la simplification rationnelle :"
 
 #: ../../src/wxMaxima.cpp:8169
 msgid "Enter matrix"
-msgstr ""
+msgstr "Sekcem isirew"
 
 #: ../../src/wxMaxima.cpp:9095
 msgid "Enter new animation frame rate [Hz, integer]:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9201
+#, fuzzy
 msgid "Enter new precision for bigfloats:"
-msgstr ""
+msgstr "Entrer la nouvelle précision :"
 
 #: ../../src/wxMaxima.cpp:7922
 msgid "Enumerator:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1220
+#, fuzzy
 msgid "Environment variables"
-msgstr ""
+msgstr "Paramètres supplémentaires:"
 
 #: ../../src/wxMaxima.cpp:9045
 msgid "Epsilon:"
-msgstr ""
+msgstr "Epsilon :"
 
 #: ../../src/wxMaximaFrame.cpp:1124 ../../src/wxMaximaFrame.cpp:1135
 msgid "Equal, ignoring case?..."
@@ -2414,22 +2580,24 @@ msgid "Equal?..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8561
+#, fuzzy
 msgid "Equation"
-msgstr ""
+msgstr "Tagda :"
 
 #: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
+#, fuzzy
 msgid "Equation(s)"
-msgstr ""
+msgstr "Tagda(Ti-win):"
 
 #: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
 msgid "Equation(s):"
-msgstr ""
+msgstr "Tagda(Ti-win):"
 
 #: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
 #: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
 #: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
 msgid "Equation:"
-msgstr ""
+msgstr "Tagda :"
 
 #: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
 #: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
@@ -2441,7 +2609,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
 #: ../../src/wxMaxima.cpp:11166
 msgid "Error"
-msgstr ""
+msgstr "Tuccḍa"
 
 #: ../../src/wxMaxima.cpp:2456
 msgid "Error writing to Maxima"
@@ -2451,7 +2619,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
 #: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
 msgid "Error!"
-msgstr ""
+msgstr "Tuccḍa!"
 
 #: ../../src/Image.cpp:696
 #, c-format
@@ -2483,37 +2651,44 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1652
+#, fuzzy
 msgid "Evaluate &Noun Forms..."
-msgstr ""
+msgstr "Évaluer les formes &nommées"
 
 #: ../../src/wxMaximaFrame.cpp:856
+#, fuzzy
 msgid "Evaluate All Cells\tCtrl+Shift+R"
-msgstr ""
+msgstr "Évaluer toutes les cellules\tCtrl+R"
 
 #: ../../src/wxMaximaFrame.cpp:851
+#, fuzzy
 msgid "Evaluate All Visible Cells\tCtrl+R"
-msgstr ""
+msgstr "Évaluer toutes les cellules\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1395
+#, fuzzy
 msgid "Evaluate Cell"
-msgstr ""
+msgstr "Évaluer la (les) cellule(s)"
 
 #: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
 msgid "Evaluate Cell(s)"
-msgstr ""
+msgstr "Évaluer la (les) cellule(s)"
 
 #: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
+#, fuzzy
 msgid "Evaluate Cells Above"
-msgstr ""
+msgstr "Évaluer la (les) cellule(s)"
 
 #: ../../src/wxMaximaFrame.cpp:866
+#, fuzzy
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
-msgstr ""
+msgstr "Évaluer toutes les cellules\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
 #: ../../src/wxMaximaFrame.cpp:876
+#, fuzzy
 msgid "Evaluate Cells Below"
-msgstr ""
+msgstr "Évaluer la (les) cellule(s)"
 
 #: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
 #: ../../src/Worksheet.cpp:1890
@@ -2526,30 +2701,35 @@ msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8626
+#, fuzzy
 msgid "Evaluate Nouns"
-msgstr ""
+msgstr "Évaluer les formes &nommées"
 
 #: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
+#, fuzzy
 msgid "Evaluate Part\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "&Évaluer la cellule\tMaj-Entrée"
 
 #: ../../src/Worksheet.cpp:1431 ../../src/Worksheet.cpp:1741
+#, fuzzy
 msgid "Evaluate Section\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "&Évaluer la cellule\tMaj-Entrée"
 
 #: ../../src/Worksheet.cpp:1445 ../../src/Worksheet.cpp:1751
 #: ../../src/Worksheet.cpp:1879
+#, fuzzy
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "&Évaluer la cellule\tMaj-Entrée"
 
 #: ../../src/Worksheet.cpp:1438 ../../src/Worksheet.cpp:1746
 #: ../../src/Worksheet.cpp:1868
+#, fuzzy
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "&Évaluer la cellule\tMaj-Entrée"
 
 #: ../../src/wxMaximaFrame.cpp:845
 msgid "Evaluate active or selected cell(s)"
-msgstr ""
+msgstr "Réévaluer la cellule sélectionnée"
 
 #: ../../src/ToolBar.cpp:251
 msgid "Evaluate all"
@@ -2557,43 +2737,49 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:857
 msgid "Evaluate all cells in the document"
-msgstr ""
+msgstr "Réévaluer toutes les cellules du document"
 
 #: ../../src/wxMaximaFrame.cpp:1653
 msgid "Evaluate all noun forms in expression"
-msgstr ""
+msgstr "Evaluer toutes les formes nommées"
 
 #: ../../src/wxMaximaFrame.cpp:852
+#, fuzzy
 msgid "Evaluate all visible cells in the document"
-msgstr ""
+msgstr "Réévaluer toutes les cellules du document"
 
 #: ../../src/ToolBar.cpp:248
 msgid "Evaluate current cell"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7395
+#, fuzzy
 msgid "Evaluate string"
-msgstr ""
+msgstr "Évaluer les formes &nommées"
 
 #: ../../src/wxMaximaFrame.cpp:1151
+#, fuzzy
 msgid "Evaluate string..."
-msgstr ""
+msgstr "Évaluer les formes &nommées"
 
 #: ../../src/ToolBar.cpp:256
 msgid "Evaluate the file from its beginning to the cell above the cursor"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:259
+#, fuzzy
 msgid "Evaluate the file from the cursor to its end"
-msgstr ""
+msgstr "Réévaluer toutes les cellules du document"
 
 #: ../../src/ToolBar.cpp:258
+#, fuzzy
 msgid "Evaluate the rest"
-msgstr ""
+msgstr "Évaluer les formes &nommées"
 
 #: ../../src/ToolBar.cpp:255
+#, fuzzy
 msgid "Evaluate to point"
-msgstr ""
+msgstr "Évaluer les formes &nommées"
 
 #: ../../src/wxMaxima.cpp:10518
 msgid "Evaluation ended, since evaluation queue is empty."
@@ -2617,31 +2803,34 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1583
 msgid "Expand Expression"
-msgstr ""
+msgstr "Développer une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1525
 msgid "Expand an expression"
-msgstr ""
+msgstr "Développer une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1531
+#, fuzzy
 msgid "Expand for given variables"
-msgstr ""
+msgstr "Changer la variable"
 
 #: ../../src/wxMaxima.cpp:8781
 msgid "Expand for variable(s) including denominator:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8716
+#, fuzzy
 msgid "Expand for variable(s):"
-msgstr ""
+msgstr "dans la variable :"
 
 #: ../../src/wxMaximaFrame.cpp:1545
+#, fuzzy
 msgid "Expand log in previous expression"
-msgstr ""
+msgstr "Développer une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1598
 msgid "Expand trigonometric expression"
-msgstr ""
+msgstr "Développer une expression trigonométrique"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Expect numbers harder to be complex"
@@ -2653,27 +2842,32 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6121
 msgid "Export"
-msgstr ""
+msgstr "&Exporter"
 
 #: ../../src/wxMaximaFrame.cpp:1705
+#, fuzzy
 msgid "Export List to csv file..."
-msgstr ""
+msgstr "Échec de l'export en TeX !"
 
 #: ../../src/wxMaximaFrame.cpp:1706
+#, fuzzy
 msgid "Export a list to a csv file"
-msgstr ""
+msgstr "Sali-d afaylu akemmus n Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1332
+#, fuzzy
 msgid "Export a matrix to a csv file"
-msgstr ""
+msgstr "Sali-d afaylu akemmus n Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:619
+#, fuzzy
 msgid "Export document to a HTML or LaTeX file"
-msgstr ""
+msgstr "Exporter le document en HTML ou en pdfLateX"
 
 #: ../../src/wxMaximaFrame.cpp:579
+#, fuzzy
 msgid "Export failed."
-msgstr ""
+msgstr "Échec de l'export en TeX !"
 
 #: ../../src/wxMaximaFrame.cpp:567
 msgid "Export successful."
@@ -2681,34 +2875,38 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6187
 msgid "Exporting to HTML failed!"
-msgstr ""
+msgstr "Échec de l'export en HTML"
 
 #: ../../src/wxMaxima.cpp:6164
 msgid "Exporting to TeX failed!"
-msgstr ""
+msgstr "Échec de l'export en TeX !"
 
 #: ../../src/wxMaxima.cpp:6175
+#, fuzzy
 msgid "Exporting to maxima batch file failed!"
-msgstr ""
+msgstr "Échec de l'export en TeX !"
 
 #: ../../src/wxMaximaFrame.cpp:561
+#, fuzzy
 msgid "Exporting..."
-msgstr ""
+msgstr "&Exporter"
 
 #: ../../src/wxMaxima.cpp:6510 ../../src/wxMaxima.cpp:6516
 #: ../../src/wxMaxima.cpp:8218 ../../src/wxMaxima.cpp:8633
 #: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
 #: ../../src/wxMaxima.cpp:10065
 msgid "Expression"
-msgstr ""
+msgstr "Expression"
 
 #: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
+#, fuzzy
 msgid "Expression or a list of comma-separated expressions"
-msgstr ""
+msgstr "Liste x séparée par des virgules"
 
 #: ../../src/wxMaximaFrame.cpp:1088
+#, fuzzy
 msgid "Expression to string..."
-msgstr ""
+msgstr "Expression"
 
 #: ../../src/wxMaxima.cpp:7113
 msgid "Expression whose output is to be used as maxima's input."
@@ -2716,7 +2914,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7214
 msgid "Expression(s):"
-msgstr ""
+msgstr "Expression(s) :"
 
 #: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
 #: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
@@ -2725,19 +2923,21 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
 #: ../../src/wxMaxima.cpp:10056
 msgid "Expression:"
-msgstr ""
+msgstr "Expression :"
 
 #: ../../src/wxMaximaFrame.cpp:1423
+#, fuzzy
 msgid "Extract Column..."
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaximaFrame.cpp:1726
 msgid "Extract Elements"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1421
+#, fuzzy
 msgid "Extract Row..."
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaximaFrame.cpp:1424
 msgid "Extract a column from the matrix"
@@ -2748,32 +2948,38 @@ msgid "Extract a column from the matrix and convert it to a list"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7960
+#, fuzzy
 msgid "Extract a matrix column"
-msgstr ""
+msgstr "Sekcem isirew"
 
 #: ../../src/wxMaxima.cpp:7970
+#, fuzzy
 msgid "Extract a matrix column as a list"
-msgstr ""
+msgstr "Sekcem isirew"
 
 #: ../../src/wxMaximaFrame.cpp:1313
+#, fuzzy
 msgid "Extract a matrix from a 2-dimensional array"
-msgstr ""
+msgstr "Générer une matrice à partir d'un tableau à 2 dimensions"
 
 #: ../../src/wxMaxima.cpp:7955
+#, fuzzy
 msgid "Extract a matrix row"
-msgstr ""
+msgstr "Sekcem isirew"
 
 #: ../../src/wxMaxima.cpp:7965
+#, fuzzy
 msgid "Extract a matrix row as a list"
-msgstr ""
+msgstr "Sekcem isirew"
 
 #: ../../src/wxMaximaFrame.cpp:1422
 msgid "Extract a row from the matrix"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1431
+#, fuzzy
 msgid "Extract a row from the matrix and convert it to a list"
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaxima.cpp:8564
 msgid "Extract a variable's value from a list of variable values"
@@ -2784,60 +2990,72 @@ msgid "Extract an actual value for a variable"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1163
+#, fuzzy
 msgid "Extract char..."
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaximaFrame.cpp:1207
+#, fuzzy
 msgid "Extract dir from path..."
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaxima.cpp:7605
+#, fuzzy
 msgid "Extract directory part"
-msgstr ""
+msgstr "Ismawen n twuriwin"
 
 #: ../../src/wxMaxima.cpp:7617
+#, fuzzy
 msgid "Extract file type extension"
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaximaFrame.cpp:1209
 msgid "Extract filename from path..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7611
+#, fuzzy
 msgid "Extract filename part"
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaximaFrame.cpp:1211
 msgid "Extract filetype from path..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8445
+#, fuzzy
 msgid "Extract function arguments"
-msgstr ""
+msgstr "Ismawen n twuriwin"
 
 #: ../../src/wxMaximaFrame.cpp:1727
+#, fuzzy
 msgid "Extract list Elements"
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaxima.cpp:8187
+#, fuzzy
 msgid "Extract matrix from 2D array"
-msgstr ""
+msgstr "Sekcem isirew"
 
 #: ../../src/wxMaximaFrame.cpp:1686
+#, fuzzy
 msgid "Extract the argument list from a function call"
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaxima.cpp:8538
+#, fuzzy
 msgid "Extract the last n elements from a list"
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaxima.cpp:7376
+#, fuzzy
 msgid "Extract the nth char of a string"
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaxima.cpp:8544
+#, fuzzy
 msgid "Extract the nth list elements"
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaximaFrame.cpp:1724
 msgid "Extract the value for one variable assigned in a list"
@@ -2848,32 +3066,34 @@ msgid "Extract, append or delete rows or columns"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8188
+#, fuzzy
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaximaFrame.cpp:1521
 msgid "Factor Complex"
-msgstr ""
+msgstr "Factorisation &complexe"
 
 #: ../../src/Worksheet.cpp:1581
 msgid "Factor Expression"
-msgstr ""
+msgstr "Factoriser une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1519
+#, fuzzy
 msgid "Factor Expression including subexpressions"
-msgstr ""
+msgstr "Factoriser une expression en nombre gaussiens"
 
 #: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
 msgid "Factor an expression"
-msgstr ""
+msgstr "Factoriser une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1522
 msgid "Factor an expression in Gaussian numbers"
-msgstr ""
+msgstr "Factoriser une expression en nombre gaussiens"
 
 #: ../../src/wxMaximaFrame.cpp:1587
 msgid "Factorials and &Gamma"
-msgstr ""
+msgstr "Factorielles et &gamma"
 
 #: ../../src/Image.cpp:137
 #, c-format
@@ -2886,8 +3106,9 @@ msgid "Failed to delete gnuplot file %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:2667
+#, fuzzy
 msgid "Failed to start Maxima"
-msgstr ""
+msgstr "Senker tikelt nniḍen maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1418
 msgid "Fast fortran routines that perform numerical tasks"
@@ -2899,15 +3120,17 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:2553
 msgid "Fatal error"
-msgstr ""
+msgstr "Erreur fatale"
 
 #: ../../src/wxMaxima.cpp:7191
+#, fuzzy
 msgid "Field contents:"
-msgstr ""
+msgstr "Constantes grecques"
 
 #: ../../src/wxMaxima.cpp:7198
+#, fuzzy
 msgid "Field name:"
-msgstr ""
+msgstr "Ancienne variable :"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "Fields:"
@@ -2915,43 +3138,49 @@ msgstr ""
 
 #: ../../src/main.cpp:439
 msgid "File"
-msgstr ""
+msgstr "A&faylu"
 
 #: ../../src/wxMaximaFrame.cpp:1333
+#, fuzzy
 msgid "File I/O"
-msgstr ""
+msgstr "A&faylu"
 
 #: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
 #: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
 #: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
 #: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
+#, fuzzy
 msgid "File could not be opened"
-msgstr ""
+msgstr "Fichier non trouvé"
 
 #: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
 #: ../../src/wxMaxima.cpp:7251
+#, fuzzy
 msgid "File name:"
-msgstr ""
+msgstr "Ancienne variable :"
 
 #: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
 msgid "File not found"
-msgstr ""
+msgstr "Fichier non trouvé"
 
 #: ../../src/wxMaxima.cpp:5631
+#, fuzzy
 msgid "File opened"
-msgstr ""
+msgstr "Fichier non trouvé"
 
 #: ../../src/wxMaximaFrame.cpp:1217
+#, fuzzy
 msgid "File operations"
-msgstr ""
+msgstr "Fichier non trouvé"
 
 #: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
 msgid "File you tried to open does not exist."
-msgstr ""
+msgstr "Le fichier que vous tentez d'ouvrir n'existe pas."
 
 #: ../../src/wxMaximaFrame.cpp:1221
+#, fuzzy
 msgid "File/directory functions"
-msgstr ""
+msgstr "Tanila:"
 
 #: ../../src/wxMaxima.cpp:7027
 msgid "Filename or a list of comma-separated file names"
@@ -2959,27 +3188,27 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:222
 msgid "Find"
-msgstr ""
+msgstr "Nadi"
 
 #: ../../src/wxMaximaFrame.cpp:670
 msgid "Find\tCtrl+F"
-msgstr ""
+msgstr "Nadi\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:1468
 msgid "Find &Limit..."
-msgstr ""
+msgstr "Trouver la &limite…"
 
 #: ../../src/wxMaximaFrame.cpp:1470
 msgid "Find Minimum..."
-msgstr ""
+msgstr "Trouver le minimum…"
 
 #: ../../src/Worksheet.cpp:1576
 msgid "Find Root..."
-msgstr ""
+msgstr "Af aẓaṛ…"
 
 #: ../../src/wxMaximaFrame.cpp:1471
 msgid "Find a (unconstrained) minimum of an expression"
-msgstr ""
+msgstr "Trouver un minimum (sans contrainte) d'une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1804
 msgid "Find a fraction that represents this float exactly"
@@ -2987,35 +3216,36 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1469
 msgid "Find a limit of an expression"
-msgstr ""
+msgstr "Trouver la limite d'une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1807
 msgid "Find a nice fraction that is similar to this float"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1283
+#, fuzzy
 msgid "Find a numerical solution for a first degree ODE"
-msgstr ""
+msgstr "Résoudre une é.d.o. du premier ordre avec condition initiale"
 
 #: ../../src/wxMaximaFrame.cpp:1252
 msgid "Find a root of an equation on an interval"
-msgstr ""
+msgstr "Trouver une racine d'un polynôme dans un intervalle"
 
 #: ../../src/wxMaximaFrame.cpp:1259
 msgid "Find all roots of a polynomial"
-msgstr ""
+msgstr "Trouver toutes les racines d'un polynôme"
 
 #: ../../src/wxMaximaFrame.cpp:1262
 msgid "Find all roots of a polynomial (bfloat)"
-msgstr ""
+msgstr "Trouver toutes les racines d'un polynôme (bfloat)"
 
 #: ../../src/wxMaxima.cpp:6589
 msgid "Find and Replace"
-msgstr ""
+msgstr "Nadi & semselsi"
 
 #: ../../src/ToolBar.cpp:222 ../../src/wxMaximaFrame.cpp:670
 msgid "Find and replace"
-msgstr ""
+msgstr "Nadi & semselsi"
 
 #: ../../src/wxMaxima.cpp:7434
 msgid "Find char in string"
@@ -3031,11 +3261,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1366
 msgid "Find eigenvalues of a matrix"
-msgstr ""
+msgstr "Trouver les valeurs propres d'une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1369
 msgid "Find eigenvectors of a matrix"
-msgstr ""
+msgstr "Trouver les vecteurs propres d'une matrice"
 
 #: ../../src/wxMaxima.cpp:7424
 msgid "Find first difference"
@@ -3046,12 +3276,13 @@ msgid "Find first difference..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1256
+#, fuzzy
 msgid "Find fractions that real roots of a polynomial and "
-msgstr ""
+msgstr "Trouver les racines réelles d'un polynôme"
 
 #: ../../src/wxMaxima.cpp:9039
 msgid "Find minimum"
-msgstr ""
+msgstr "Trouver le minimum"
 
 #: ../../src/wxMaximaFrame.cpp:1251
 msgid "Find numerical solution..."
@@ -3062,8 +3293,9 @@ msgid "Find root (solve numerically)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
+#, fuzzy
 msgid "Find the maximum absolute value of a matrix entry"
-msgstr ""
+msgstr "Trouver les valeurs propres d'une matrice"
 
 #: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
 msgid "Find the maximum sum of the absolute values of a matrix column"
@@ -3094,8 +3326,9 @@ msgid "Flush..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:922
+#, fuzzy
 msgid "Fold All\tCtrl+Alt+["
-msgstr ""
+msgstr "Tout sélectionner"
 
 #: ../../src/wxMaximaFrame.cpp:923
 msgid "Fold all sections"
@@ -3103,7 +3336,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:240
 msgid "Follow"
-msgstr ""
+msgstr "Awraɣ"
 
 #: ../../src/ToolBar.cpp:285
 msgid ""
@@ -3182,59 +3415,64 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "From:"
-msgstr ""
+msgstr "seg :"
 
 #: ../../src/wxMaximaFrame.cpp:827
 msgid "Full Screen\tAlt+Enter"
-msgstr ""
+msgstr "Agdil aččuṛan\tAlt+Entrée"
 
 #: ../../src/wxMaximaFrame.cpp:824
 msgid "Full Screen\tF11"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7140
+#, fuzzy
 msgid "Function contents:"
-msgstr ""
+msgstr "Ismawen n twuriwin"
 
 #: ../../src/wxMaxima.cpp:7908
+#, fuzzy
 msgid "Function f(x):"
-msgstr ""
+msgstr "Tawurin(t-in) :"
 
 #: ../../src/wxMaxima.cpp:8572
+#, fuzzy
 msgid "Function name"
-msgstr ""
+msgstr "Ismawen n twuriwin"
 
 #: ../../src/wxMaxima.cpp:7167
+#, fuzzy
 msgid "Function name(s):"
-msgstr ""
+msgstr "Ismawen n twuriwin"
 
 #: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
+#, fuzzy
 msgid "Function name:"
-msgstr ""
+msgstr "Ismawen n twuriwin"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Function:"
-msgstr ""
+msgstr "Tawuri"
 
 #: ../../src/wxMaximaFrame.cpp:1630
 msgid "Functions for complex simplification"
-msgstr ""
+msgstr "Fonctions pour simplification complexe"
 
 #: ../../src/wxMaximaFrame.cpp:1588
 msgid "Functions for simplifying factorials and gamma function"
-msgstr ""
+msgstr "Fonctions pour simplifier les factorielles et fonction gamma"
 
 #: ../../src/wxMaximaFrame.cpp:1606
 msgid "Functions for simplifying trigonometric expressions"
-msgstr ""
+msgstr "Fonctions pour simplifier les expressions trigonométriques"
 
 #: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
 msgid "GCD"
-msgstr ""
+msgstr "PGCD"
 
 #: ../../src/wxMaxima.cpp:10186
 msgid "GIF image (*.gif)|*.gif"
-msgstr ""
+msgstr "image GIF (*.gif)|*.gif"
 
 #: ../../src/Worksheet.cpp:103
 msgid ""
@@ -3245,19 +3483,19 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:295
 msgid "General Math"
-msgstr ""
+msgstr "Tusnakt tamatut"
 
 #: ../../src/wxMaximaFrame.cpp:699
 msgid "General Math\tAlt+Shift+M"
-msgstr ""
+msgstr "Tusnakt tamatut\tAlt+Maj-M"
 
 #: ../../src/wxMaximaFrame.cpp:1316
 msgid "Generate Matrix from Expression..."
-msgstr ""
+msgstr "&Générer une matrice à partir d'une expression…"
 
 #: ../../src/wxMaximaFrame.cpp:1317
 msgid "Generate a matrix from a lambda expression"
-msgstr ""
+msgstr "Générer une matrice à partir d'une lambda-expression"
 
 #: ../../src/wxMaximaFrame.cpp:1675
 msgid "Generate a new list using a lists' elements"
@@ -3274,8 +3512,9 @@ msgid "Generate list elements using a rule"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8196
+#, fuzzy
 msgid "Generate matrix from a rule"
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaximaFrame.cpp:1094
 msgid "Generate unused symbol name"
@@ -3293,15 +3532,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1619
 msgid "Get &Imaginary Part"
-msgstr ""
+msgstr "Awi-d amur asu&gnan"
 
 #: ../../src/wxMaximaFrame.cpp:1485
 msgid "Get Laplace transformation of an expression"
-msgstr ""
+msgstr "Transformée de Laplace d'une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1615
 msgid "Get Real P&art"
-msgstr ""
+msgstr "Awi-d amur &ilaw"
 
 #: ../../src/wxMaximaFrame.cpp:1201
 msgid "Get current directory"
@@ -3309,23 +3548,24 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1489
 msgid "Get inverse Laplace transformation of an expression"
-msgstr ""
+msgstr "Obtenir la transformée de Laplace inverse  d'une expression"
 
 #: ../../src/wxMaxima.cpp:7223
 msgid "Get position in stream"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1102
+#, fuzzy
 msgid "Get position..."
-msgstr ""
+msgstr "Azza..."
 
 #: ../../src/wxMaximaFrame.cpp:1620
 msgid "Get the imaginary part of complex expression"
-msgstr ""
+msgstr "Partie imaginaire d'une expression complexe"
 
 #: ../../src/wxMaximaFrame.cpp:1616
 msgid "Get the real part of complex expression"
-msgstr ""
+msgstr "Partie réelle d'une expression complexe"
 
 #: ../../src/wxMaxima.cpp:3609
 #, c-format
@@ -3351,8 +3591,9 @@ msgid "Go to URL"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3989
+#, fuzzy
 msgid "Got a new input prompt!"
-msgstr ""
+msgstr "Insérer une nouvelle cellule d'entrée"
 
 #: ../../src/Worksheet.cpp:6354
 msgid ""
@@ -3365,46 +3606,51 @@ msgid "Gradefs"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1967
+#, fuzzy
 msgid "Greater or less than a value"
-msgstr ""
+msgstr "Cellule de sous-section"
 
 #: ../../src/wxMaximaFrame.cpp:1130
 msgid "Greater, ignoring case?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:260
+#, fuzzy
 msgid "Greek Letters"
-msgstr ""
+msgstr "Constantes grecques"
 
 #: ../../src/wxMaximaFrame.cpp:703
 msgid "Greek Letters\tAlt+Shift+G"
-msgstr ""
+msgstr "Tusnakt tamatut\tAlt+Maj-M"
 
 #: ../../src/wxMaximaFrame.cpp:1815
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:6123
+#, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file "
 "(*.tex)|*.tex"
-msgstr ""
+msgstr "Fichier HTML (*.html)|*.html|fichier pdfLaTeX (*.tex)|*.tex|Tous|*"
 
 #: ../../src/wxMaximaFrame.cpp:1341
 msgid "Hadamard (element-by-element) product..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8004
+#, fuzzy
 msgid "Hadamard Product"
-msgstr ""
+msgstr "Produit"
 
 #: ../../src/wxMaxima.cpp:8011
 msgid "Hadamard exponent"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1345
+#, fuzzy
 msgid "Hadamard exponent..."
-msgstr ""
+msgstr "Isem n isirew :"
 
 #: ../../src/MaximaManual.cpp:260
 #, c-format
@@ -3423,7 +3669,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
 msgid "Help"
-msgstr ""
+msgstr "Tallalt"
 
 #: ../../src/ToolBar.cpp:635
 msgid "Help button"
@@ -3435,16 +3681,19 @@ msgid "Help on \"%s\""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:729
+#, fuzzy
 msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr ""
+msgstr "Cacher tout\tAlt+Maj--"
 
 #: ../../src/ToolBar.cpp:264
+#, fuzzy
 msgid "Hide Code"
-msgstr ""
+msgstr "Partager la cellule"
 
 #: ../../src/wxMaximaFrame.cpp:727
+#, fuzzy
 msgid "Hide Code Cells\tAlt+Ctrl+H"
-msgstr ""
+msgstr "Insérer la cellule\tAlt+Maj-C"
 
 #: ../../src/Worksheet.cpp:1896
 msgid "Hide Heading 5"
@@ -3455,32 +3704,38 @@ msgid "Hide Heading 6"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1855
+#, fuzzy
 msgid "Hide Part"
-msgstr ""
+msgstr "Partager la cellule"
 
 #: ../../src/Worksheet.cpp:1863
+#, fuzzy
 msgid "Hide Section"
-msgstr ""
+msgstr "Tigezmi"
 
 #: ../../src/Worksheet.cpp:1874
+#, fuzzy
 msgid "Hide Subsection"
-msgstr ""
+msgstr "Sous-section"
 
 #: ../../src/Worksheet.cpp:1885
+#, fuzzy
 msgid "Hide Subsubsection"
-msgstr ""
+msgstr "Sous-section"
 
 #: ../../src/wxMaximaFrame.cpp:730
 msgid "Hide all panes"
-msgstr ""
+msgstr "Cacher tous les panneaux"
 
 #: ../../src/Worksheet.cpp:1491
+#, fuzzy
 msgid "Hide cell brackets"
-msgstr ""
+msgstr "Crochet de la cellule active"
 
 #: ../../src/Worksheet.cpp:1915
+#, fuzzy
 msgid "Hide contents"
-msgstr ""
+msgstr "Constantes grecques"
 
 #: ../../src/Worksheet.cpp:1552
 msgid "Hide multiplication dots"
@@ -3495,20 +3750,22 @@ msgid "Hide yellow tooltip marker for this message type"
 msgstr ""
 
 #: ../../src/Configuration.cpp:82
+#, fuzzy
 msgid "Highlight (box)"
-msgstr ""
+msgstr "Asebṛuṛeq"
 
 #: ../../src/wxMaxima.cpp:9528
 msgid "Histogram"
-msgstr ""
+msgstr "Amazrudlif"
 
 #: ../../src/wxMaximaFrame.cpp:232
 msgid "History"
-msgstr ""
+msgstr "Amazray"
 
 #: ../../src/wxMaximaFrame.cpp:709
+#, fuzzy
 msgid "History\tAlt+Shift+I"
-msgstr ""
+msgstr "Historique\tAlt+Maj-H"
 
 #: ../../src/wxMaximaFrame.cpp:1526
 msgid "Horner's rule"
@@ -3587,7 +3844,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Include columns:"
-msgstr ""
+msgstr "Inclure les colonnes :"
 
 #: ../../src/Worksheet.cpp:2008
 msgid "Increasing function f(x)>x"
@@ -3606,12 +3863,13 @@ msgid "Index Step:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
+#, fuzzy
 msgid "Index variable:"
-msgstr ""
+msgstr "dans la variable :"
 
 #: ../../src/wxMaximaFrame.cpp:1949
 msgid "Info about Maxima build"
-msgstr ""
+msgstr "Infos sur la compilation de Maxima"
 
 #: ../../src/Worksheet.cpp:2046
 msgid "Inform maxima about facts you know for this symbol"
@@ -3624,44 +3882,49 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
+#, fuzzy
 msgid "Initial Condition"
-msgstr ""
+msgstr "Condition :"
 
 #: ../../src/wxMaximaFrame.cpp:1270
 msgid "Initial Value Problem (&1)..."
-msgstr ""
+msgstr "Tawtilt n tazwara (&1)…"
 
 #: ../../src/wxMaximaFrame.cpp:1274
 msgid "Initial Value Problem (&2)..."
-msgstr ""
+msgstr "Tawtilt n tazwara (&2)…"
 
 #: ../../src/wxMaxima.cpp:9044
+#, fuzzy
 msgid "Initial estimates:"
-msgstr ""
+msgstr "Estimations initiales :"
 
 #: ../../src/wxMaxima.cpp:7840
+#, fuzzy
 msgid "Initial x:"
-msgstr ""
+msgstr "Estimations initiales :"
 
 #: ../../src/Configuration.cpp:78
 msgid "Input labels"
-msgstr ""
+msgstr "Étiquettes d'entrée"
 
 #: ../../src/wxMaximaFrame.cpp:314
 msgid "Insert"
-msgstr ""
+msgstr "Ger"
 
 #: ../../src/wxMaximaFrame.cpp:905
+#, fuzzy
 msgid "Insert &Section Cell\tCtrl+3"
-msgstr ""
+msgstr "Insérer une cellule de section\tF8"
 
 #: ../../src/wxMaximaFrame.cpp:901
+#, fuzzy
 msgid "Insert &Text Cell\tCtrl+1"
-msgstr ""
+msgstr "Insérer une cellule de texte \tF6"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Insert Cell\tAlt+Shift+C"
-msgstr ""
+msgstr "Insérer la cellule\tAlt+Maj-C"
 
 #: ../../src/Worksheet.cpp:1669
 msgid "Insert Heading5 Cell"
@@ -3673,51 +3936,61 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10854
 msgid "Insert Image"
-msgstr ""
+msgstr "Ger tugna"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert Image..."
-msgstr ""
+msgstr "Ger tugna..."
 
 #: ../../src/wxMaximaFrame.cpp:899
+#, fuzzy
 msgid "Insert Input &Cell\tCtrl+0"
-msgstr ""
+msgstr "Insérer une cellule d'entrée\tF5"
 
 #: ../../src/wxMaximaFrame.cpp:919
+#, fuzzy
 msgid "Insert Page Break"
-msgstr ""
+msgstr "Insérer un saut de page\tF10"
 
 #: ../../src/wxMaximaFrame.cpp:907
+#, fuzzy
 msgid "Insert S&ubsection Cell\tCtrl+4"
-msgstr ""
+msgstr "Insérer une cellule de sous-section\tF7"
 
 #: ../../src/wxMaximaFrame.cpp:910
+#, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
-msgstr ""
+msgstr "Insérer une cellule de sous-section\tF7"
 
 #: ../../src/Worksheet.cpp:1662
+#, fuzzy
 msgid "Insert Section Cell"
-msgstr ""
+msgstr "Insérer une cellule de section\tF8"
 
 #: ../../src/Worksheet.cpp:1664
+#, fuzzy
 msgid "Insert Subsection Cell"
-msgstr ""
+msgstr "Insérer une cellule de sous-section\tF7"
 
 #: ../../src/Worksheet.cpp:1667
+#, fuzzy
 msgid "Insert Subsubsection Cell"
-msgstr ""
+msgstr "Insérer une cellule de sous-section\tF7"
 
 #: ../../src/wxMaximaFrame.cpp:903
+#, fuzzy
 msgid "Insert T&itle Cell\tCtrl+2"
-msgstr ""
+msgstr "Insérer une cellule de titre\tF9"
 
 #: ../../src/Worksheet.cpp:1658
+#, fuzzy
 msgid "Insert Text Cell"
-msgstr ""
+msgstr "Insérer une cellule de texte \tF6"
 
 #: ../../src/Worksheet.cpp:1660
+#, fuzzy
 msgid "Insert Title Cell"
-msgstr ""
+msgstr "Insérer une cellule de titre\tF9"
 
 #: ../../src/wxMaximaFrame.cpp:913
 msgid "Insert a new heading5 cell"
@@ -3729,35 +4002,37 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:900
 msgid "Insert a new input cell"
-msgstr ""
+msgstr "Insérer une nouvelle cellule d'entrée"
 
 #: ../../src/wxMaximaFrame.cpp:906
 msgid "Insert a new section cell"
-msgstr ""
+msgstr "Insérer une nouvelle cellule de section"
 
 #: ../../src/wxMaximaFrame.cpp:908
 msgid "Insert a new subsection cell"
-msgstr ""
+msgstr "Insérer une nouvelle cellule de sous-section"
 
 #: ../../src/wxMaximaFrame.cpp:911
+#, fuzzy
 msgid "Insert a new subsubsection cell"
-msgstr ""
+msgstr "Insérer une nouvelle cellule de sous-section"
 
 #: ../../src/wxMaximaFrame.cpp:902
 msgid "Insert a new text cell"
-msgstr ""
+msgstr "Insérer une nouvelle cellule de texte"
 
 #: ../../src/wxMaximaFrame.cpp:904
 msgid "Insert a new title cell"
-msgstr ""
+msgstr "Insérer une nouvelle cellule de titre"
 
 #: ../../src/wxMaximaFrame.cpp:920
 msgid "Insert a page break"
-msgstr ""
+msgstr "Insérer un saut de page"
 
 #: ../../src/wxMaximaFrame.cpp:1164
+#, fuzzy
 msgid "Insert char..."
-msgstr ""
+msgstr "Ger tugna..."
 
 #: ../../src/wxMaximaFrame.cpp:912
 msgid "Insert heading5 Cell\tCtrl+6"
@@ -3772,8 +4047,9 @@ msgid "Insert image"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:916
+#, fuzzy
 msgid "Insert textbased cell"
-msgstr ""
+msgstr "Insérer une cellule de texte \tF6"
 
 #: ../../src/wxMaxima.cpp:3566
 msgid "Instructed to prefer gnuplot over wgnuplot"
@@ -3785,43 +4061,47 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
 msgid "Integral/Sum:"
-msgstr ""
+msgstr "Intégrale/somme"
 
 #: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
 msgid "Integrate"
-msgstr ""
+msgstr "Sidef"
 
 #: ../../src/wxMaxima.cpp:8980
 msgid "Integrate (risch)"
-msgstr ""
+msgstr "Sidef (Risch)"
 
 #: ../../src/wxMaximaFrame.cpp:1454
 msgid "Integrate expression"
-msgstr ""
+msgstr "Intégrer une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1456
 msgid "Integrate expression with Risch algorithm"
-msgstr ""
+msgstr "Intégrer une expression avec l'algorithme de Risch"
 
 #: ../../src/wxMaximaFrame.cpp:1869
+#, fuzzy
 msgid "Integrate numerically"
-msgstr ""
+msgstr "Sidef (Risch)"
 
 #: ../../src/Worksheet.cpp:1588
 msgid "Integrate..."
-msgstr ""
+msgstr "Sidef"
 
 #: ../../src/wxMaximaFrame.cpp:1737
+#, fuzzy
 msgid "Interleave"
-msgstr ""
+msgstr "Sidef"
 
 #: ../../src/wxMaximaFrame.cpp:1738
+#, fuzzy
 msgid "Interleave the values of two lists"
-msgstr ""
+msgstr "Sidef"
 
 #: ../../src/wxMaxima.cpp:8612
+#, fuzzy
 msgid "Interleave two lists"
-msgstr ""
+msgstr "Sidef"
 
 #: ../../src/wxMaximaFrame.cpp:1087
 msgid "Interpret like input..."
@@ -3836,16 +4116,17 @@ msgid "Interpret string as maxima code"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1089
+#, fuzzy
 msgid "Interpret string..."
-msgstr ""
+msgstr "&Sekcem isirew..."
 
 #: ../../src/ToolBar.cpp:231
 msgid "Interrupt"
-msgstr ""
+msgstr "Interrompre"
 
 #: ../../src/wxMaximaFrame.cpp:965
 msgid "Interrupt current computation"
-msgstr ""
+msgstr "Interrompre le calcul en cours"
 
 #: ../../src/ToolBar.cpp:232
 msgid ""
@@ -3872,11 +4153,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9003
 msgid "Inverse Laplace"
-msgstr ""
+msgstr "Inverse Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1488
 msgid "Inverse Laplace T&ransform..."
-msgstr ""
+msgstr "&Transformée de Laplace  inverse…"
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Invert worksheet brightness"
@@ -3887,8 +4168,9 @@ msgid "Is Char 1 greater than Char2, if case is ignored?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7333
+#, fuzzy
 msgid "Is Char 1 greater than Char2?"
-msgstr ""
+msgstr "Cellule de sous-section"
 
 #: ../../src/wxMaxima.cpp:7327
 msgid "Is Char 1 less than Char2, if case is ignored?"
@@ -3907,12 +4189,14 @@ msgid "Is a char?..."
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1952
+#, fuzzy
 msgid "Is a complex variable"
-msgstr ""
+msgstr "dans la variable :"
 
 #: ../../src/wxMaxima.cpp:7292
+#, fuzzy
 msgid "Is a digit?"
-msgstr ""
+msgstr "Afficher l'algorithme"
 
 #: ../../src/wxMaximaFrame.cpp:1118
 msgid "Is a digit?..."
@@ -3927,8 +4211,9 @@ msgid "Is a printable char?"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1949
+#, fuzzy
 msgid "Is a real variable"
-msgstr ""
+msgstr "Changer la variable"
 
 #: ../../src/wxMaxima.cpp:7300
 msgid "Is a uppercase char?"
@@ -3951,28 +4236,33 @@ msgid "Is an alphanumeric char?"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1991
+#, fuzzy
 msgid "Is an even function"
-msgstr ""
+msgstr "Kkes tawuri"
 
 #: ../../src/Worksheet.cpp:1955
+#, fuzzy
 msgid "Is an imaginary variable"
-msgstr ""
+msgstr "Changer la variable"
 
 #: ../../src/Worksheet.cpp:1960
+#, fuzzy
 msgid "Is an integer variable"
-msgstr ""
+msgstr "Changer la variable"
 
 #: ../../src/Worksheet.cpp:1993
+#, fuzzy
 msgid "Is an odd function"
-msgstr ""
+msgstr "Kkes tawuri"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Is equal?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1128
+#, fuzzy
 msgid "Is greater?..."
-msgstr ""
+msgstr "Sirew tabdart"
 
 #: ../../src/wxMaximaFrame.cpp:1125
 msgid "Is lower?..."
@@ -3983,8 +4273,9 @@ msgid "Is lowercase?..."
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1962
+#, fuzzy
 msgid "Is no integer variable"
-msgstr ""
+msgstr "Changer la variable"
 
 #: ../../src/wxMaximaFrame.cpp:1119
 msgid "Is printable?..."
@@ -4007,8 +4298,9 @@ msgid "Item"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8581
+#, fuzzy
 msgid "Iterator name:"
-msgstr ""
+msgstr "Isem n isirew :"
 
 #: ../../src/wxMaximaFrame.cpp:1048
 msgid "Jump to first error"
@@ -4020,7 +4312,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8960
 msgid "LCM"
-msgstr ""
+msgstr "PPCM"
 
 #: ../../src/wxMaximaFrame.cpp:1407
 msgid "L[1] Norm (complex)"
@@ -4039,12 +4331,13 @@ msgid "L[inf] Norm (real)"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1025
+#, fuzzy
 msgid "Labels"
-msgstr ""
+msgstr "Étiquettes d'entrée"
 
 #: ../../src/wxMaxima.cpp:7090
 msgid "Lambda"
-msgstr ""
+msgstr "Lambda"
 
 #: ../../src/wxMaxima.cpp:7091
 msgid ""
@@ -4055,11 +4348,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8997
 msgid "Laplace"
-msgstr ""
+msgstr "Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1484
 msgid "Laplace &Transform..."
-msgstr ""
+msgstr "&Transformée de Laplace…"
 
 #: ../../src/wxMaximaFrame.cpp:1718
 msgid "Last"
@@ -4076,8 +4369,9 @@ msgid "Last message from maxima's stdout: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1720
+#, fuzzy
 msgid "Last n"
-msgstr ""
+msgstr "Tabdart :"
 
 #: ../../src/wxMaxima.cpp:10400
 msgid "Last non-whitespace is a question mark"
@@ -4094,16 +4388,17 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1493
 msgid "Least Common Multiple..."
-msgstr ""
+msgstr "Plus petit commun multiple…"
 
 #: ../../src/wxMaxima.cpp:9587
 msgid "Least Squares Fit"
-msgstr ""
+msgstr "Aswati s tarrayt s usemẓi uzmir-sin"
 
 #: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
 #: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
+#, fuzzy
 msgid "Left Matrix:"
-msgstr ""
+msgstr "Sekcem isirew"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Left end"
@@ -4130,16 +4425,18 @@ msgid "Letrules"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1976
+#, fuzzy
 msgid "Likely to be the main variable"
-msgstr ""
+msgstr "Kkes amutti"
 
 #: ../../src/wxMaxima.cpp:9028
 msgid "Limit"
-msgstr ""
+msgstr "Talast"
 
 #: ../../src/wxMaxima.cpp:7256
+#, fuzzy
 msgid "Lisp format string:"
-msgstr ""
+msgstr "Isteqsiyen ɣef Maxima"
 
 #: ../../src/wxMaxima.cpp:7258
 msgid "Lisp format strings are more powerful than c++ format strings"
@@ -4162,16 +4459,19 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
 #: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
 #: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
+#, fuzzy
 msgid "List"
-msgstr ""
+msgstr "Tabdart :"
 
 #: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
+#, fuzzy
 msgid "List #1"
-msgstr ""
+msgstr "Tabdart :"
 
 #: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
+#, fuzzy
 msgid "List #2"
-msgstr ""
+msgstr "Tabdart :"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "List directory"
@@ -4186,57 +4486,66 @@ msgid "List of char to String"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1150
+#, fuzzy
 msgid "List of chars to string..."
-msgstr ""
+msgstr "Expression"
 
 #: ../../src/wxMaxima.cpp:7386
+#, fuzzy
 msgid "List of chars:"
-msgstr ""
+msgstr "Étiquettes d'entrée"
 
 #: ../../src/wxMaxima.cpp:8559
+#, fuzzy
 msgid "List with values"
-msgstr ""
+msgstr "la valeur est :"
 
 #: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
 msgid "List:"
-msgstr ""
+msgstr "Tabdart :"
 
 #: ../../src/wxMaxima.cpp:6200
 msgid "Load Package"
-msgstr ""
+msgstr "Sali-d akemmus\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:613
+#, fuzzy
 msgid "Load Recent Package"
-msgstr ""
+msgstr "Sali-d akemmus\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:616
 msgid "Load a Maxima file using the batch command"
-msgstr ""
+msgstr "Sali-d afaylu Maxima s useqdec n tladna s uɛemmuṛ"
 
 #: ../../src/wxMaximaFrame.cpp:611
 msgid "Load a Maxima package file"
-msgstr ""
+msgstr "Sali-d afaylu akemmus n Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1678
+#, fuzzy
 msgid "Load a list from a csv file"
-msgstr ""
+msgstr "Sali-d afaylu akemmus n Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
+#, fuzzy
 msgid "Load a matrix from a csv file"
-msgstr ""
+msgstr "Sali-d afaylu akemmus n Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
+#, fuzzy
 msgid "Load lapack"
-msgstr ""
+msgstr "Sali-d akemmus\tCtrl+L"
 
 #: ../../src/wxMaxima.cpp:7208
+#, fuzzy
 msgid "Load lisp code"
-msgstr ""
+msgstr "Sali-d akemmus\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1092
+#, fuzzy
 msgid "Load lisp..."
-msgstr ""
+msgstr "Sali-d akemmus\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1198
 msgid "Load the file/dir operations (operatingsystem)"
@@ -4251,28 +4560,32 @@ msgid "Load the translation generator (gentran)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8219
+#, fuzzy
 msgid "Loop variable"
-msgstr ""
+msgstr "Rnu amutti :"
 
 #: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
 msgid "Lower bound:"
-msgstr ""
+msgstr "talast n wadda :"
 
 #: ../../src/wxMaximaFrame.cpp:1127
 msgid "Lower, ignoring case?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1448
+#, fuzzy
 msgid "M&atrix"
-msgstr ""
+msgstr "Isirew"
 
 #: ../../src/wxMaxima.cpp:7153
+#, fuzzy
 msgid "Macro contents:"
-msgstr ""
+msgstr "Constantes grecques"
 
 #: ../../src/wxMaxima.cpp:7148
+#, fuzzy
 msgid "Macro name:"
-msgstr ""
+msgstr "Isem n isirew :"
 
 #: ../../src/wxMaximaFrame.cpp:1024
 msgid "Macros"
@@ -4280,7 +4593,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:697
 msgid "Main Toolbar\tAlt+Shift+B"
-msgstr ""
+msgstr "Afeggag n ifeckatAlt+Maj-T"
 
 #: ../../src/wxMaxima.cpp:7906
 msgid "Make a function value at a specific point known"
@@ -4291,28 +4604,32 @@ msgid "Make an eventual ev() evaluate this"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1070
+#, fuzzy
 msgid "Make function local..."
-msgstr ""
+msgstr "Snes tawuri ɣef tebdart"
 
 #: ../../src/wxMaxima.cpp:8207
 msgid "Map"
-msgstr ""
+msgstr "Snes"
 
 #: ../../src/wxMaxima.cpp:8215
+#, fuzzy
 msgid "Map an expression"
-msgstr ""
+msgstr "Développer une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "Map function to a matrix"
-msgstr ""
+msgstr "Snes tawuri ɣef isirew"
 
 #: ../../src/wxMaximaFrame.cpp:1446
+#, fuzzy
 msgid "Map function to a matrix, affecting all of its clones"
-msgstr ""
+msgstr "Snes tawuri ɣef isirew"
 
 #: ../../src/Configuration.cpp:109
+#, fuzzy
 msgid "Math Default"
-msgstr ""
+msgstr "Par défaut"
 
 #: ../../src/wxMaximaFrame.cpp:286
 msgid "Mathematical Symbols"
@@ -4332,39 +4649,45 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
 #: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
 msgid "Matrix"
-msgstr ""
+msgstr "Isirew"
 
 #: ../../src/wxMaxima.cpp:7986
+#, fuzzy
 msgid "Matrix Exponent"
-msgstr ""
+msgstr "Isem n isirew :"
 
 #: ../../src/wxMaximaFrame.cpp:1339
+#, fuzzy
 msgid "Matrix exponent..."
-msgstr ""
+msgstr "Isem n isirew :"
 
 #: ../../src/wxMaximaFrame.cpp:1329
+#, fuzzy
 msgid "Matrix from csv file"
-msgstr ""
+msgstr "Sali-d aɣanib seg ufaylu"
 
 #: ../../src/wxMaximaFrame.cpp:1323
+#, fuzzy
 msgid "Matrix from csv file..."
-msgstr ""
+msgstr "Sali-d aɣanib seg ufaylu"
 
 #: ../../src/wxMaxima.cpp:8137
 msgid "Matrix map"
-msgstr ""
+msgstr "Snes isirew"
 
 #: ../../src/wxMaxima.cpp:9630
 msgid "Matrix name:"
-msgstr ""
+msgstr "Isem n isirew :"
 
 #: ../../src/wxMaximaFrame.cpp:798
+#, fuzzy
 msgid "Matrix parenthesis"
-msgstr ""
+msgstr "Faire correspondre les parenthèses dans les entrées de texte."
 
 #: ../../src/wxMaximaFrame.cpp:1331
+#, fuzzy
 msgid "Matrix to csv file"
-msgstr ""
+msgstr "Sali-d aɣanib seg ufaylu"
 
 #: ../../src/wxMaximaFrame.cpp:1334
 msgid "Matrix to file or Matrix from file"
@@ -4379,7 +4702,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
 #: ../../src/wxMaxima.cpp:8136
 msgid "Matrix:"
-msgstr ""
+msgstr "Isirew :"
 
 #: ../../src/wxMaxima.cpp:8627
 msgid ""
@@ -4395,12 +4718,14 @@ msgid "Maxima architecture: %s"
 msgstr ""
 
 #: ../../src/StatusBar.cpp:252
+#, fuzzy
 msgid "Maxima asks a question"
-msgstr ""
+msgstr "Isteqsiyen ɣef Maxima"
 
 #: ../../src/wxMaxima.cpp:4066
+#, fuzzy
 msgid "Maxima asks a question!"
-msgstr ""
+msgstr "Isteqsiyen ɣef Maxima"
 
 #: ../../src/wxMaxima.cpp:7118
 msgid ""
@@ -4417,16 +4742,19 @@ msgid "Maxima errors"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3289
+#, fuzzy
 msgid "Maxima has authenticated!"
-msgstr ""
+msgstr "Maxima s'est arrêté."
 
 #: ../../src/wxMaxima.cpp:10533
+#, fuzzy
 msgid "Maxima has finished calculating."
-msgstr ""
+msgstr "Maxima est en train de calculer"
 
 #: ../../src/wxMaxima.cpp:5832
+#, fuzzy
 msgid "Maxima has issued an error!"
-msgstr ""
+msgstr "Isteqsiyen ɣef Maxima"
 
 #: ../../src/wxMaxima.cpp:3696
 #, c-format
@@ -4438,20 +4766,22 @@ msgid "Maxima has sent a new variable value."
 msgstr ""
 
 #: ../../src/MaximaManual.cpp:552
+#, fuzzy
 msgid "Maxima help file not found!"
-msgstr ""
+msgstr "Fichier non trouvé"
 
 #: ../../src/wxMaximaFrame.cpp:1043
 msgid "Maxima input"
-msgstr ""
+msgstr "Anekcam Maxima"
 
 #: ../../src/StatusBar.cpp:236
 msgid "Maxima is calculating"
-msgstr ""
+msgstr "Maxima est en train de calculer"
 
 #: ../../src/wxMaxima.cpp:5068
+#, fuzzy
 msgid "Maxima is ready for input."
-msgstr ""
+msgstr "Anekcam Maxima"
 
 #: ../../src/Dirstructure.cpp:144
 #, c-format
@@ -4460,19 +4790,20 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6211
 msgid "Maxima package (*.mac)|*.mac"
-msgstr ""
+msgstr "paquetage Maxima (*.mac)|*.mac|"
 
 #: ../../src/wxMaxima.cpp:6202
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
-msgstr ""
+msgstr "Paquetage Maxima (*.mac)|*.mac|Paquetage Lisp (*.lisp)|*.lisp|Tous|*"
 
 #: ../../src/wxMaxima.cpp:3012
 msgid "Maxima process terminated unexpectedly."
 msgstr ""
 
 #: ../../src/Configuration.cpp:79
+#, fuzzy
 msgid "Maxima question labels"
-msgstr ""
+msgstr "Isteqsiyen ɣef Maxima"
 
 #: ../../src/wxMaxima.cpp:3380
 msgid "Maxima sends a new set of auto-completable symbols."
@@ -4491,28 +4822,33 @@ msgid "Maxima shows help in a sidebar"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1935
+#, fuzzy
 msgid "Maxima shows help in the console"
-msgstr ""
+msgstr "Fichier non trouvé"
 
 #: ../../src/StatusBar.cpp:232
+#, fuzzy
 msgid "Maxima started. Waiting for authentication..."
-msgstr ""
+msgstr "Maxima  a démarré. Attente de la connection…"
 
 #: ../../src/StatusBar.cpp:212
 msgid "Maxima started. Waiting for connection..."
-msgstr ""
+msgstr "Maxima  a démarré. Attente de la connection…"
 
 #: ../../src/StatusBar.cpp:228
+#, fuzzy
 msgid "Maxima started. Waiting for initial prompt..."
-msgstr ""
+msgstr "Maxima  a démarré. Attente de la connection…"
 
 #: ../../src/wxMaximaFrame.cpp:1231
+#, fuzzy
 msgid "Maxima to other language"
-msgstr ""
+msgstr "Isteqsiyen ɣef Maxima"
 
 #: ../../src/wxMaxima.cpp:7213
+#, fuzzy
 msgid "Maxima to string"
-msgstr ""
+msgstr "Isteqsiyen ɣef Maxima"
 
 #: ../../src/wxMaxima.cpp:3397
 #, c-format
@@ -4535,12 +4871,14 @@ msgid "Maxima version: %s, Anchors cache version"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1925
+#, fuzzy
 msgid "Maxima vs. Programming languages"
-msgstr ""
+msgstr "Convertir en &Gamma"
 
 #: ../../src/Configuration.cpp:83
+#, fuzzy
 msgid "Maxima warnings"
-msgstr ""
+msgstr "Options de Maxima"
 
 #: ../../src/wxMaxima.cpp:3687
 #, c-format
@@ -4568,9 +4906,9 @@ msgid "Maxima's manual is located in directory %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3670
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's share files are located in directory %s"
-msgstr ""
+msgstr "Démarrer l'animation"
 
 #: ../../src/StatusBar.cpp:66
 msgid ""
@@ -4613,19 +4951,20 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9568
 msgid "Mean:"
-msgstr ""
+msgstr "Talemmast :"
 
 #: ../../src/wxMaximaFrame.cpp:1924
 msgid "Memoizing"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1013
+#, fuzzy
 msgid "Memory"
-msgstr ""
+msgstr "Effa&cer la mémoire"
 
 #: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
 msgid "Merge Cells"
-msgstr ""
+msgstr "Smezdi tibniqin"
 
 #: ../../src/wxMaxima.cpp:5780
 msgid "Message from the stdout of Maxima: "
@@ -4645,8 +4984,9 @@ msgid "Minimum absolute value printed without exponent:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:10449 ../../src/wxMaxima.cpp:10451
+#, fuzzy
 msgid "Mismatched parenthesis"
-msgstr ""
+msgstr "Faire correspondre les parenthèses dans les entrées de texte."
 
 #: ../../src/wxMaximaFrame.cpp:1352
 msgid "Multiplication, exponent and similar"
@@ -4665,16 +5005,19 @@ msgid "Multiply two matrices"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9581
+#, fuzzy
 msgid "Multivariate linear regression"
-msgstr ""
+msgstr "Talkeyt timziregt…"
 
 #: ../../src/wxMaxima.cpp:7842
+#, fuzzy
 msgid "Name of t:"
-msgstr ""
+msgstr "Isem :"
 
 #: ../../src/wxMaxima.cpp:7838
+#, fuzzy
 msgid "Name of x:"
-msgstr ""
+msgstr "Isem :"
 
 #: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
 msgid "Nested list to Matrix"
@@ -4698,11 +5041,11 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:174
 msgid "New"
-msgstr ""
+msgstr "Rnu"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "New\tCtrl+N"
-msgstr ""
+msgstr "&Rnu tiɣimit\tCtrl+N"
 
 #: ../../src/ToolBar.cpp:611
 msgid "New button"
@@ -4723,7 +5066,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:174
 msgid "New document"
-msgstr ""
+msgstr "Rnu isemli"
 
 #: ../../src/wxMaxima.cpp:3899
 #, c-format
@@ -4731,17 +5074,18 @@ msgid "New maxima Operators detected: %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7390
+#, fuzzy
 msgid "New part:"
-msgstr ""
+msgstr "Rnu amutti :"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
 #: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
 msgid "New variable:"
-msgstr ""
+msgstr "Rnu amutti :"
 
 #: ../../src/wxMaximaFrame.cpp:929
 msgid "Next Command\tAlt+Down"
-msgstr ""
+msgstr "Commande suivante\tAlt+Down"
 
 #: ../../src/wxMaximaFrame.cpp:748
 msgid "Nice Graphical Equations"
@@ -4749,11 +5093,12 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "No"
-msgstr ""
+msgstr "Ala"
 
 #: ../../src/Worksheet.cpp:1972
+#, fuzzy
 msgid "No Array"
-msgstr ""
+msgstr "Tableau :"
 
 #: ../../src/Worksheet.cpp:1974
 msgid "No Scalar"
@@ -4783,7 +5128,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:6662 ../../src/wxMaxima.cpp:6668
 #: ../../src/wxMaxima.cpp:6687 ../../src/wxMaxima.cpp:6697
 msgid "No matches found!"
-msgstr ""
+msgstr "Recherche infructueuse !"
 
 #: ../../src/wxMaxima.cpp:3240
 msgid "No topics found in topic flag"
@@ -4799,11 +5144,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8163
 msgid "Not a valid matrix dimension!"
-msgstr ""
+msgstr "Dimension de matrice incorrecte !"
 
 #: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
 msgid "Not a valid number of equations!"
-msgstr ""
+msgstr "Nombre d'équations incorrect !"
 
 #: ../../src/StatusBar.cpp:256
 msgid "Not connected to Maxima"
@@ -4823,63 +5168,75 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8926
 msgid "Num. deg:"
-msgstr ""
+msgstr "num deg :"
 
 #: ../../src/wxMaxima.cpp:8540
+#, fuzzy
 msgid "Number of elements"
-msgstr ""
+msgstr "Amḍan n tegdiwin :"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
 msgid "Number of equations:"
-msgstr ""
+msgstr "Amḍan n tegdiwin :"
 
 #: ../../src/wxMaxima.cpp:7481
+#, fuzzy
 msgid "Number to octets"
-msgstr ""
+msgstr "Amḍan n tegdiwin :"
 
 #: ../../src/wxMaximaFrame.cpp:1154
+#, fuzzy
 msgid "Number to octets..."
-msgstr ""
+msgstr "Amḍan n tegdiwin :"
 
 #: ../../src/wxMaximaFrame.cpp:1906
 msgid "Number types"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7482
+#, fuzzy
 msgid "Number:"
-msgstr ""
+msgstr "Imiḍanen"
 
 #: ../../src/wxMaximaFrame.cpp:1786
+#, fuzzy
 msgid "Numeric output"
 msgstr ""
+"Basculer l'affichage numérique entre valeur exacte et valeur approchée"
 
 #: ../../src/wxMaxima.cpp:8040
 msgid "Numerical QR decomposition of a matrix"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1417
+#, fuzzy
 msgid "Numerical operations (lapack)"
-msgstr ""
+msgstr "Intégration &numérique"
 
 #: ../../src/wxMaxima.cpp:7831
+#, fuzzy
 msgid "Numerical solution for 1st degree ODE"
-msgstr ""
+msgstr "Résoudre une é.d.o. du premier ordre avec condition initiale"
 
 #: ../../src/wxMaximaFrame.cpp:1282
+#, fuzzy
 msgid "Numerical solution..."
 msgstr ""
+"Basculer l'affichage numérique entre valeur exacte et valeur approchée"
 
 #: ../../src/wxMaximaFrame.cpp:1261
+#, fuzzy
 msgid "Numerical solutions of polynomial (bfloat)..."
-msgstr ""
+msgstr "Trouver toutes les racines d'un polynôme"
 
 #: ../../src/wxMaximaFrame.cpp:1258
+#, fuzzy
 msgid "Numerical solutions of polynomial..."
-msgstr ""
+msgstr "Trouver toutes les racines d'un polynôme"
 
 #: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
 msgid "OK"
-msgstr ""
+msgstr "Ih"
 
 #: ../../src/wxMaximaFrame.cpp:122
 #, c-format
@@ -4887,16 +5244,19 @@ msgid "OS: %s Version %li.%li"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
+#, fuzzy
 msgid "Object composed of elements"
-msgstr ""
+msgstr "Amḍan n tegdiwin :"
 
 #: ../../src/wxMaxima.cpp:7680
+#, fuzzy
 msgid "Object name:"
-msgstr ""
+msgstr "Tabdart :"
 
 #: ../../src/wxMaxima.cpp:7281
+#, fuzzy
 msgid "Object:"
-msgstr ""
+msgstr "Tabdart :"
 
 #: ../../src/wxMaxima.cpp:7486
 msgid "Octets to Number"
@@ -4911,8 +5271,9 @@ msgid "Octets to number..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1158
+#, fuzzy
 msgid "Octets to string..."
-msgstr ""
+msgstr "Expression"
 
 #: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
 msgid "Octets:"
@@ -4925,11 +5286,12 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
 #: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
 msgid "Old variable:"
-msgstr ""
+msgstr "Ancienne variable :"
 
 #: ../../src/wxMaximaFrame.cpp:1055
+#, fuzzy
 msgid "On all errors"
-msgstr ""
+msgstr "Erreur fatale"
 
 #: ../../src/wxMaximaFrame.cpp:1054
 msgid "On lisp errors"
@@ -4937,11 +5299,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9566
 msgid "One sample t-test"
-msgstr ""
+msgstr "Test de Student (t-test) à 1 échantillon…"
 
 #: ../../src/wxMaximaFrame.cpp:1927
 msgid "Online tutorials"
-msgstr ""
+msgstr "Tutoriels en ligne"
 
 #: ../../src/wxMaximaFrame.cpp:766
 msgid "Only Integers and single letters"
@@ -4950,15 +5312,15 @@ msgstr ""
 #: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593
 #: ../../src/wxMaxima.cpp:6074
 msgid "Open"
-msgstr ""
+msgstr "Ldi"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "Open a document"
-msgstr ""
+msgstr "Ldi isemli"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "Open a new window"
-msgstr ""
+msgstr "Ldi asfaylu amaynut"
 
 #: ../../src/ToolBar.cpp:617
 msgid "Open and save button"
@@ -4966,7 +5328,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:176
 msgid "Open document"
-msgstr ""
+msgstr "Ldi isemli"
 
 #: ../../src/wxMaxima.cpp:7239
 msgid "Open for appending"
@@ -4981,24 +5343,27 @@ msgid "Open for reading"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1098
+#, fuzzy
 msgid "Open for reading..."
-msgstr ""
+msgstr "Expression"
 
 #: ../../src/wxMaxima.cpp:7249
 msgid "Open for writing"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1100
+#, fuzzy
 msgid "Open for writing..."
-msgstr ""
+msgstr "&Exporter"
 
 #: ../../src/wxMaxima.cpp:9598
 msgid "Open matrix"
-msgstr ""
+msgstr "Sekcem isirew"
 
 #: ../../src/wxMaximaFrame.cpp:600
+#, fuzzy
 msgid "Open recent"
-msgstr ""
+msgstr "Ldi afaylu n meli kan"
 
 #: ../../src/wxMaxima.cpp:4309
 msgid "Opening a wxmx file"
@@ -5007,7 +5372,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4153 ../../src/wxMaxima.cpp:4214
 #: ../../src/wxMaxima.cpp:4313 ../../src/wxMaxima.cpp:4622
 msgid "Opening file"
-msgstr ""
+msgstr "Tulya n ufaylu"
 
 #: ../../src/wxMaxima.cpp:5030
 #, c-format
@@ -5024,11 +5389,12 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:199
 msgid "Options"
-msgstr ""
+msgstr "Iɣewwaṛ"
 
 #: ../../src/wxMaximaFrame.cpp:1225
+#, fuzzy
 msgid "Output C"
-msgstr ""
+msgstr "Étiquettes de sorties"
 
 #: ../../src/wxMaximaFrame.cpp:1226
 msgid "Output Fortran"
@@ -5040,11 +5406,12 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:80
 msgid "Output labels"
-msgstr ""
+msgstr "Étiquettes de sorties"
 
 #: ../../src/Configuration.cpp:73
+#, fuzzy
 msgid "Output: Function names"
-msgstr ""
+msgstr "Ismawen n twuriwin"
 
 #: ../../src/Configuration.cpp:75
 msgid "Output: Latin names as greek symbols"
@@ -5055,21 +5422,24 @@ msgid "Output: Numbers and Digits"
 msgstr ""
 
 #: ../../src/Configuration.cpp:71
+#, fuzzy
 msgid "Output: Operators"
-msgstr ""
+msgstr "Étiquettes de sorties"
 
 #: ../../src/Configuration.cpp:74
-#, c-format
+#, fuzzy, c-format
 msgid "Output: Special constants (%e,%i)"
-msgstr ""
+msgstr "Constantes spéciales"
 
 #: ../../src/Configuration.cpp:76
+#, fuzzy
 msgid "Output: Strings"
-msgstr ""
+msgstr "Chaînes"
 
 #: ../../src/Configuration.cpp:70
+#, fuzzy
 msgid "Output: Variable names"
-msgstr ""
+msgstr "Ancienne variable :"
 
 #: ../../src/wxMaxima.cpp:6442
 msgid ""
@@ -5088,39 +5458,43 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8924
 msgid "Pade approximation"
-msgstr ""
+msgstr "Approximant de Padé"
 
 #: ../../src/wxMaximaFrame.cpp:1478
 msgid "Pade approximation of a Taylor series"
-msgstr ""
+msgstr "Approximant de Padé d'un développement en série de Taylor"
 
 #: ../../src/wxMaximaFrame.cpp:1637
+#, fuzzy
 msgid "Parallel Substitute..."
-msgstr ""
+msgstr "Semselsi..."
 
 #: ../../src/wxMaxima.cpp:8738
 msgid "Parallel substitution"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7179
+#, fuzzy
 msgid "Parameter name:"
-msgstr ""
+msgstr "Isem n isirew :"
 
 #: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
+#, fuzzy
 msgid "Parameter(s):"
-msgstr ""
+msgstr "Amutti (i-en) :"
 
 #: ../../src/wxMaxima.cpp:7399
 msgid "Parse string"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1152
+#, fuzzy
 msgid "Parse string only..."
-msgstr ""
+msgstr "&Sekcem isirew..."
 
 #: ../../src/StatusBar.cpp:240
 msgid "Parsing output"
-msgstr ""
+msgstr "Analyse du résultat"
 
 #: ../../src/wxMaxima.cpp:7464
 msgid "Part:"
@@ -5128,64 +5502,65 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1499 ../../src/wxMaximaFrame.cpp:1535
 msgid "Partial &Fractions..."
-msgstr ""
+msgstr "Éléments simples…"
 
 #: ../../src/wxMaxima.cpp:8975
+#, fuzzy
 msgid "Partial Fractions"
-msgstr ""
+msgstr "Éléments simples"
 
 #: ../../src/wxMaxima.cpp:4702
 msgid "Parts of the document will not be loaded correctly!"
-msgstr ""
+msgstr "Des parties du document ne seront pas chargées correctement !"
 
 #: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
 #: ../../src/Worksheet.cpp:1685
 msgid "Paste"
-msgstr ""
+msgstr "Senṭeḍ"
 
 #: ../../src/wxMaximaFrame.cpp:667
 msgid "Paste\tCtrl+V"
-msgstr ""
+msgstr "&Coller\tCtrl+V"
 
 #: ../../src/ToolBar.cpp:211
 msgid "Paste from clipboard"
-msgstr ""
+msgstr "Coller le texte du presse-papier"
 
 #: ../../src/wxMaximaFrame.cpp:668
 msgid "Paste text from clipboard"
-msgstr ""
+msgstr "Coller le texte du presse-papier"
 
 #: ../../src/wxMaxima.cpp:4841
 msgid "Please configure wxMaxima with 'Edit->Configure'."
-msgstr ""
+msgstr "Configurer wxMaxima avec 'Édition->Configurer'."
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot &2d..."
-msgstr ""
+msgstr "Tamaknayt &2d…"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot &3d..."
-msgstr ""
+msgstr "Tamaknayt &3d…"
 
 #: ../../src/wxMaximaFrame.cpp:1772
 msgid "Plot &Format..."
-msgstr ""
+msgstr "&Format de la courbe…"
 
 #: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
 msgid "Plot 2D"
-msgstr ""
+msgstr "Tamaknayt 2D"
 
 #: ../../src/Worksheet.cpp:1593
 msgid "Plot 2D..."
-msgstr ""
+msgstr "Tamaknayt 2D..."
 
 #: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
 msgid "Plot 3D"
-msgstr ""
+msgstr "Tamaknayt 3D"
 
 #: ../../src/Worksheet.cpp:1595
 msgid "Plot 3D..."
-msgstr ""
+msgstr "Tamaknayt 3D"
 
 #: ../../src/wxMaxima.cpp:9538
 msgid "Plot as bars"
@@ -5201,27 +5576,29 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9112
 msgid "Plot format"
-msgstr ""
+msgstr "Format de la courbe"
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot in 2 dimensions"
-msgstr ""
+msgstr "Courbe en 2 dimensions"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot in 3 dimensions"
-msgstr ""
+msgstr "Courbe en 3 dimensions"
 
 #: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
 msgid "Plot using Draw"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7824
+#, fuzzy
 msgid "Point #1 with known value:"
-msgstr ""
+msgstr "la valeur est :"
 
 #: ../../src/wxMaxima.cpp:7826
+#, fuzzy
 msgid "Point #2 with known value:"
-msgstr ""
+msgstr "la valeur est :"
 
 #: ../../src/wxMaxima.cpp:7800 ../../src/wxMaxima.cpp:7811
 msgid "Point the value is known at:"
@@ -5229,22 +5606,23 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
 msgid "Point:"
-msgstr ""
+msgstr "Agaz :"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 1:"
-msgstr ""
+msgstr "Polynôme 1 :"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 2:"
-msgstr ""
+msgstr "Polynôme 2 :"
 
 #: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
 #: ../../src/wxMaxima.cpp:7739
+#, fuzzy
 msgid "Polynomial:"
-msgstr ""
+msgstr "Polynôme 1 :"
 
 #: ../../src/wxMaximaFrame.cpp:1754
 msgid "Pop"
@@ -5259,20 +5637,23 @@ msgid "Position of a match"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
+#, fuzzy
 msgid "Position:"
-msgstr ""
+msgstr "Condition :"
 
 #: ../../src/wxMaxima.cpp:8939
+#, fuzzy
 msgid "Power series"
-msgstr ""
+msgstr "Série entière"
 
 #: ../../src/wxMaximaFrame.cpp:1475
+#, fuzzy
 msgid "Power series..."
-msgstr ""
+msgstr "Série entière"
 
 #: ../../src/wxMaxima.cpp:9202
 msgid "Precision"
-msgstr ""
+msgstr "Précision"
 
 #: ../../src/Worksheet.cpp:1616
 msgid "Prefer user labels"
@@ -5291,28 +5672,30 @@ msgid "Preferences...\tCtrl+,"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1733
+#, fuzzy
 msgid "Prepend an element"
-msgstr ""
+msgstr "Ldi isemli"
 
 #: ../../src/wxMaximaFrame.cpp:927
 msgid "Previous Command\tAlt+Up"
-msgstr ""
+msgstr "Commande précédente\tAlt+Up"
 
 #: ../../src/ToolBar.cpp:184
 msgid "Print"
-msgstr ""
+msgstr "Imprimer"
 
 #: ../../src/ToolBar.cpp:620
 msgid "Print button"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1493
+#, fuzzy
 msgid "Print cell brackets"
-msgstr ""
+msgstr "Crochet de la cellule active"
 
 #: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
 msgid "Print document"
-msgstr ""
+msgstr "Imprimer le document"
 
 #: ../../src/wxMaximaFrame.cpp:1829
 msgid "Print floating-point numbers with exponents dividable by 3"
@@ -5326,15 +5709,17 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9061
 msgid "Product"
-msgstr ""
+msgstr "Produit"
 
 #: ../../src/wxMaximaFrame.cpp:1095
+#, fuzzy
 msgid "Program"
-msgstr ""
+msgstr "Amazrudlif"
 
 #: ../../src/wxMaxima.cpp:7061
+#, fuzzy
 msgid "Program (no local variables)"
-msgstr ""
+msgstr "Changer la variable"
 
 #: ../../src/wxMaxima.cpp:7052
 msgid "Program block"
@@ -5353,8 +5738,9 @@ msgid "Push"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8508
+#, fuzzy
 msgid "Push an element to a list"
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaximaFrame.cpp:1395
 msgid "QR decomposition"
@@ -5386,20 +5772,23 @@ msgid "Re-Reading the config from the default location."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:867
+#, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
-msgstr ""
+msgstr "Réévaluer toutes les cellules du document"
 
 #: ../../src/wxMaximaFrame.cpp:877
+#, fuzzy
 msgid "Re-evaluate all cells below the one the cursor is in"
-msgstr ""
+msgstr "Réévaluer toutes les cellules du document"
 
 #: ../../src/main.cpp:366
 msgid "Re-opening STDERR failed."
 msgstr ""
 
 #: ../../src/main.cpp:367
+#, fuzzy
 msgid "Re-opening STDIN failed."
-msgstr ""
+msgstr "Tulya n ufaylu"
 
 #: ../../src/main.cpp:365
 msgid "Re-opening STDOUT failed."
@@ -5412,16 +5801,18 @@ msgid ""
 msgstr ""
 
 #: ../../src/Worksheet.cpp:6668
+#, fuzzy
 msgid "Read .wxm data from clipboard"
-msgstr ""
+msgstr "Coller le texte du presse-papier"
 
 #: ../../src/wxMaxima.cpp:7599
 msgid "Read Directory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1677
+#, fuzzy
 msgid "Read List from csv file..."
-msgstr ""
+msgstr "Sali-d aɣanib seg ufaylu"
 
 #: ../../src/wxMaxima.cpp:7196
 msgid "Read a structure field"
@@ -5432,16 +5823,19 @@ msgid "Read byte"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7266
+#, fuzzy
 msgid "Read char"
-msgstr ""
+msgstr "&Ɣar isirew…"
 
 #: ../../src/wxMaxima.cpp:7593
+#, fuzzy
 msgid "Read environment variable"
-msgstr ""
+msgstr "Paramètres supplémentaires:"
 
 #: ../../src/wxMaximaFrame.cpp:1219
+#, fuzzy
 msgid "Read environment variable..."
-msgstr ""
+msgstr "Kkes amutti"
 
 #: ../../src/wxMaxima.cpp:7262
 msgid "Read line"
@@ -5454,7 +5848,7 @@ msgstr ""
 
 #: ../../src/StatusBar.cpp:245
 msgid "Reading Maxima output"
-msgstr ""
+msgstr "Lecture des résultats de Maxima"
 
 #: ../../src/StatusBar.cpp:247
 #, c-format
@@ -5481,7 +5875,7 @@ msgstr ""
 
 #: ../../src/StatusBar.cpp:224
 msgid "Ready for user input"
-msgstr ""
+msgstr "Prêt pour une entrée utilisateur"
 
 #: ../../src/Worksheet.cpp:960
 msgid "Recalculated the whole worksheet at once => Updating its size"
@@ -5493,11 +5887,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:930
 msgid "Recall next command from history"
-msgstr ""
+msgstr "Rappeler la commande suivante dans l'historique"
 
 #: ../../src/wxMaximaFrame.cpp:928
 msgid "Recall previous command from history"
-msgstr ""
+msgstr "Rappeler la commande précédent dans l'historique"
 
 #: ../../src/wxMaxima.cpp:3235
 #, c-format
@@ -5510,12 +5904,14 @@ msgid "Received maxima's first prompt: %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:603
+#, fuzzy
 msgid "Recover unsaved"
-msgstr ""
+msgstr "non sauvegardé"
 
 #: ../../src/wxMaximaFrame.cpp:1640
+#, fuzzy
 msgid "Recursive Substitute..."
-msgstr ""
+msgstr "Semselsi..."
 
 #: ../../src/wxMaxima.cpp:8746
 msgid "Recursive substitution"
@@ -5527,15 +5923,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo\tCtrl+Y"
-msgstr ""
+msgstr "&Sefsex\tCtrl+Z"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo last change"
-msgstr ""
+msgstr "Sefsex asnifel aneggaru"
 
 #: ../../src/wxMaximaFrame.cpp:1595
 msgid "Reduce trigonometric expression"
-msgstr ""
+msgstr "Réduire une expression trigonométrique"
 
 #: ../../src/wxMaxima.cpp:2366 ../../src/wxMaxima.cpp:10630
 msgid "Refusing to send cell to maxima: "
@@ -5550,16 +5946,19 @@ msgid "Regex match position"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1195
+#, fuzzy
 msgid "Regular expression that matches a string"
-msgstr ""
+msgstr "Liste x séparée par des virgules"
 
 #: ../../src/wxMaximaFrame.cpp:1196
+#, fuzzy
 msgid "Regular expressions"
-msgstr ""
+msgstr "Intégrer une expression"
 
 #: ../../src/Worksheet.cpp:1314
+#, fuzzy
 msgid "Reload Image"
-msgstr ""
+msgstr "Copier comme image"
 
 #: ../../src/Worksheet.cpp:1320
 #, c-format
@@ -5573,7 +5972,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:883
 msgid "Remove All Output"
-msgstr ""
+msgstr "Supprimer tous les résultats"
 
 #: ../../src/wxMaximaFrame.cpp:1426
 msgid "Remove Rows or Columns..."
@@ -5594,8 +5993,9 @@ msgid "Remove all occurrences of part"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8592
+#, fuzzy
 msgid "Remove an element from a list"
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaxima.cpp:7566
 msgid "Remove directory"
@@ -5619,7 +6019,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:884
 msgid "Remove output from input cells"
-msgstr ""
+msgstr "Supprimer les résultats des cellules"
 
 #: ../../src/wxMaxima.cpp:7975
 msgid "Remove rows and/or columns"
@@ -5630,16 +6030,19 @@ msgid "Remove rows and/or columns from the matrix"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7582
+#, fuzzy
 msgid "Rename file"
-msgstr ""
+msgstr "Tulya n ufaylu"
 
 #: ../../src/wxMaximaFrame.cpp:1215
+#, fuzzy
 msgid "Rename file..."
-msgstr ""
+msgstr "Kkes amutti"
 
 #: ../../src/wxMaximaFrame.cpp:1527
+#, fuzzy
 msgid "Reorganize an expression using horner's rule"
-msgstr ""
+msgstr "Factoriser une expression en nombre gaussiens"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "Repetitive element-by-element multiplication"
@@ -5654,37 +6057,42 @@ msgid "Replace first regex match"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7463
+#, fuzzy
 msgid "Replace the first occurrence of Part"
-msgstr ""
+msgstr "%d occurrences remplacées"
 
 #: ../../src/wxMaximaFrame.cpp:1180
+#, fuzzy
 msgid "Replace..."
-msgstr ""
+msgstr "Tout sélectionner"
 
 #: ../../src/wxMaxima.cpp:6719
-#, c-format
+#, fuzzy, c-format
 msgid "Replaced %li occurrences."
-msgstr ""
+msgstr "%d occurrences remplacées"
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "Report bug"
-msgstr ""
+msgstr "Rapport de bogue"
 
 #: ../../src/wxMaximaFrame.cpp:996
+#, fuzzy
 msgid "Reset option variables"
-msgstr ""
+msgstr "Changer la variable"
 
 #: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
 msgid "Restart Maxima"
-msgstr ""
+msgstr "Senker tikelt nniḍen maxima"
 
 #: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
+#, fuzzy
 msgid "Restrict Maximum size"
-msgstr ""
+msgstr "Senker tikelt nniḍen maxima"
 
 #: ../../src/wxMaxima.cpp:10031
+#, fuzzy
 msgid "Result variables:"
-msgstr ""
+msgstr "Kkes amutti(imuttiyen):"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Resulting Matrix name (may be empty):"
@@ -5758,8 +6166,9 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
 #: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
+#, fuzzy
 msgid "Right Matrix:"
-msgstr ""
+msgstr "Sekcem isirew"
 
 #: ../../src/wxMaxima.cpp:8190
 msgid "Right end"
@@ -5771,7 +6180,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1455
 msgid "Risch Integration..."
-msgstr ""
+msgstr "Intégration de Risch…"
 
 #: ../../src/wxMaximaFrame.cpp:785
 msgid "Rounded"
@@ -5787,12 +6196,14 @@ msgid "Row number:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7977
+#, fuzzy
 msgid "Row numbers:"
-msgstr ""
+msgstr "Imiḍanen"
 
 #: ../../src/wxMaxima.cpp:8203
+#, fuzzy
 msgid "Rows"
-msgstr ""
+msgstr "Lignes :"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Rule"
@@ -5807,8 +6218,9 @@ msgid "Rules"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1693
+#, fuzzy
 msgid "Run each element through an expression"
-msgstr ""
+msgstr "Trouver la limite d'une expression"
 
 #: ../../src/wxMaxima.cpp:6355
 #, c-format
@@ -5861,80 +6273,83 @@ msgid "Runs each element through a function"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1694
+#, fuzzy
 msgid "Runs each element through an expression"
-msgstr ""
+msgstr "Trouver la limite d'une expression"
 
 #: ../../src/wxMaxima.cpp:9572
 msgid "Sample 1:"
-msgstr ""
+msgstr "Échantillon 1 :"
 
 #: ../../src/wxMaxima.cpp:9573
 msgid "Sample 2:"
-msgstr ""
+msgstr "Échantillon 2 :"
 
 #: ../../src/wxMaxima.cpp:9567
 msgid "Sample:"
-msgstr ""
+msgstr "Échantillon"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
 msgid "Save"
-msgstr ""
+msgstr "Sekles"
 
 #: ../../src/Worksheet.cpp:1294
 msgid "Save Animation..."
-msgstr ""
+msgstr "Sekles amray…"
 
 #: ../../src/wxMaxima.cpp:5672
 msgid "Save As"
-msgstr ""
+msgstr "Sekles s yisem"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save As...\tShift+Ctrl+S"
-msgstr ""
+msgstr "&Sekles tiɣimit s yisem…\tMaj-Ctrl+S"
 
 #: ../../src/Worksheet.cpp:1291
 msgid "Save Image..."
-msgstr ""
+msgstr "Sekles tugna…"
 
 #: ../../src/wxMaxima.cpp:6440
 msgid "Save Selection to Image"
-msgstr ""
+msgstr "Sauvegarder la sélection comme image"
 
 #: ../../src/wxMaximaFrame.cpp:675
 msgid "Save Selection to Image..."
-msgstr ""
+msgstr "Sauvegarder la sélection comme image…"
 
 #: ../../src/wxMaxima.cpp:10184
 msgid "Save animation to file"
-msgstr ""
+msgstr "Sekles amray ɣer ufaylu"
 
 #: ../../src/wxMaxima.cpp:7203
 msgid "Save as lisp code"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1091
+#, fuzzy
 msgid "Save as lisp..."
-msgstr ""
+msgstr "Sali-d akemmus\tCtrl+L"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
 msgid "Save document"
-msgstr ""
+msgstr "Sekles isemli"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save document as"
-msgstr ""
+msgstr "Sekles isemli s yisem"
 
 #: ../../src/wxMaximaFrame.cpp:676
 msgid "Save selection from document to an image file"
-msgstr ""
+msgstr "Sauvegarder la sélection du document dans un fichier image "
 
 #: ../../src/wxMaxima.cpp:10125
 msgid "Save selection to file"
-msgstr ""
+msgstr "Enregistrer la sélection dans un fichier"
 
 #: ../../src/wxMaximaFrame.cpp:573
+#, fuzzy
 msgid "Saving failed."
-msgstr ""
+msgstr "Échec du démarrage du serveur"
 
 #: ../../src/WXMXformat.cpp:310
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
@@ -5950,7 +6365,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9533
 msgid "Scatterplot"
-msgstr ""
+msgstr "Asigna n wagazen"
 
 #: ../../src/Autocomplete.cpp:125
 msgid ""
@@ -5977,15 +6392,16 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:273
 msgid "Section"
-msgstr ""
+msgstr "Tigezmi"
 
 #: ../../src/Configuration.cpp:91
 msgid "Section cell (Heading 2)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7218
+#, fuzzy
 msgid "Seek to position"
-msgstr ""
+msgstr "Approximant de Padé"
 
 #: ../../src/BTextCtrl.cpp:45
 msgid "Seems like something is broken with a font."
@@ -5997,11 +6413,11 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
 msgid "Select All"
-msgstr ""
+msgstr "Tout sélectionner"
 
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select All\tCtrl+A"
-msgstr ""
+msgstr "Tout sélectionner"
 
 #: ../../src/ToolBar.cpp:629
 msgid "Select All button"
@@ -6009,20 +6425,21 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9631
 msgid "Select Subsample"
-msgstr ""
+msgstr "Choisir un sous-échantillon"
 
 #: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select all"
-msgstr ""
+msgstr "Fen imeṛṛa"
 
 #: ../../src/wxMaxima.cpp:6971
 msgid "Select math display algorithm"
-msgstr ""
+msgstr "Choisir l'algorithme d'affichage mathématique"
 
 #: ../../src/Configuration.cpp:98
+#, fuzzy
 msgid "Selection color"
-msgstr ""
+msgstr "Tafrant"
 
 #: ../../src/ToolBar.cpp:252
 msgid "Send all cells to maxima"
@@ -6057,24 +6474,27 @@ msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1533
+#, fuzzy
 msgid "Sequential Comparative Simplification"
-msgstr ""
+msgstr "Simplification &complexe"
 
 #: ../../src/wxMaxima.cpp:9016
 msgid "Series"
-msgstr ""
+msgstr "Imazraren"
 
 #: ../../src/wxMaximaFrame.cpp:1479
+#, fuzzy
 msgid "Series approximation"
-msgstr ""
+msgstr "Approximant de Padé"
 
 #: ../../src/wxMaxima.cpp:2561
 msgid "Server started"
-msgstr ""
+msgstr "Aqeddac yekker"
 
 #: ../../src/wxMaximaFrame.cpp:1824
+#, fuzzy
 msgid "Set &displayed Precision..."
-msgstr ""
+msgstr "Régler la &précision…"
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Set Maxima option variable logexpand:all"
@@ -6090,39 +6510,44 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:822
 msgid "Set Zoom"
-msgstr ""
+msgstr "Sbadu zoom"
 
 #: ../../src/wxMaximaFrame.cpp:1819
+#, fuzzy
 msgid "Set bigfloat &Precision..."
-msgstr ""
+msgstr "Régler la précision de la virgule flottante"
 
 #: ../../src/Worksheet.cpp:1306 ../../src/Worksheet.cpp:1479
 msgid "Set image resolution"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1510
+#, fuzzy
 msgid "Set main variable..."
-msgstr ""
+msgstr "Kkes amutti"
 
 #: ../../src/wxMaximaFrame.cpp:1773
 msgid "Set plot format"
-msgstr ""
+msgstr "Régler le format de courbe"
 
 #: ../../src/wxMaximaFrame.cpp:1101
+#, fuzzy
 msgid "Set position..."
-msgstr ""
+msgstr "Sekles amray…"
 
 #: ../../src/wxMaximaFrame.cpp:1656
+#, fuzzy
 msgid "Set the \"algebraic\" flag"
-msgstr ""
+msgstr "Basculer le mode algébrique"
 
 #: ../../src/wxMaxima.cpp:8314
 msgid "Set the diagram title"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1779
+#, fuzzy
 msgid "Set the frame rate for animations."
-msgstr ""
+msgstr "Démarrer l'animation"
 
 #: ../../src/wxMaxima.cpp:8377
 msgid "Set the grid density."
@@ -6140,27 +6565,27 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:811
 msgid "Set zoom to 100%"
-msgstr ""
+msgstr "Régler le zoom à 100%"
 
 #: ../../src/wxMaximaFrame.cpp:813
 msgid "Set zoom to 120%"
-msgstr ""
+msgstr "Régler le zoom à 120%"
 
 #: ../../src/wxMaximaFrame.cpp:815
 msgid "Set zoom to 150%"
-msgstr ""
+msgstr "Régler le zoom à 150%"
 
 #: ../../src/wxMaximaFrame.cpp:817
 msgid "Set zoom to 200%"
-msgstr ""
+msgstr "Régler le zoom à 200%"
 
 #: ../../src/wxMaximaFrame.cpp:819
 msgid "Set zoom to 300%"
-msgstr ""
+msgstr "Régler le zoom à 300%"
 
 #: ../../src/wxMaximaFrame.cpp:809
 msgid "Set zoom to 80%"
-msgstr ""
+msgstr "Régler le zoom à 80%"
 
 #: ../../src/wxMaxima.cpp:4731
 #, c-format
@@ -6168,16 +6593,19 @@ msgid "Setting gnuplot_binary to %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:4804
+#, fuzzy
 msgid "Setting prompt and help format"
-msgstr ""
+msgstr "Régler le format de courbe"
 
 #: ../../src/wxMaximaFrame.cpp:1292
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
+"Choisir 'à la valeur' pour la résolution d'une é.d.o. avec la transformée de"
+" Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1661
 msgid "Setup modulus computation"
-msgstr ""
+msgstr "Calculer le module"
 
 #: ../../src/wxMaxima.cpp:9220
 msgid "Setup the engineering format"
@@ -6192,28 +6620,31 @@ msgid "Shapiro-Wilk test for normality"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1543
+#, fuzzy
 msgid "Show \"%\" in special constants"
-msgstr ""
+msgstr "Constantes spéciales"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show &Tips..."
-msgstr ""
+msgstr "Montrer les as&tuces"
 
 #: ../../src/Worksheet.cpp:1556
 msgid "Show * as multiplication dot"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:895
+#, fuzzy
 msgid "Show Template\tCtrl+Shift+Space"
-msgstr ""
+msgstr "Montrer le modèle\tCtrl+Maj-K"
 
 #: ../../src/wxMaximaFrame.cpp:753
+#, fuzzy
 msgid "Show XML representation"
-msgstr ""
+msgstr "Montrer les expressions longues"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show a tip"
-msgstr ""
+msgstr "Montrer une astuce"
 
 #: ../../src/Worksheet.cpp:1607
 msgid "Show all + allow linebreaks in long numbers"
@@ -6221,51 +6652,54 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9475
 msgid "Show all commands similar to:"
-msgstr ""
+msgstr "Montrer toutes les commandes analogues à :"
 
 #: ../../src/wxMaxima.cpp:9468
 msgid "Show an example for the command:"
-msgstr ""
+msgstr "Montrer un exemple pour la commande :"
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "Show an example of usage"
-msgstr ""
+msgstr "Montrer un exemple d'utilisation"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "Show commands similar to"
-msgstr ""
+msgstr "Montrer les commandes analogues à"
 
 #: ../../src/wxMaximaFrame.cpp:1020
 msgid "Show defined functions"
-msgstr ""
+msgstr "Montrer les fonctions définies"
 
 #: ../../src/wxMaximaFrame.cpp:1022
 msgid "Show defined variables"
-msgstr ""
+msgstr "Montrer les variables déclarées"
 
 #: ../../src/wxMaximaFrame.cpp:1074
 msgid "Show definition of a function"
-msgstr ""
+msgstr "Montrer la définition d'une fonction"
 
 #: ../../src/wxMaximaFrame.cpp:740
 msgid "Show equations in their linear form"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1073
+#, fuzzy
 msgid "Show function &Definition..."
-msgstr ""
+msgstr "Montrer les &définitions"
 
 #: ../../src/wxMaximaFrame.cpp:896
 msgid "Show function template"
-msgstr ""
+msgstr "Montrer le modèle de la fonction"
 
 #: ../../src/Worksheet.cpp:1614
+#, fuzzy
 msgid "Show input labels"
-msgstr ""
+msgstr "Étiquettes d'entrée"
 
 #: ../../src/wxMaximaFrame.cpp:750
+#, fuzzy
 msgid "Show lisp representation"
-msgstr ""
+msgstr "Montrer les expressions longues"
 
 #: ../../src/Worksheet.cpp:1604
 msgid "Show max. 100 digits"
@@ -6304,8 +6738,9 @@ msgid "Show the Copy, Cut and the Paste button?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7033
+#, fuzzy
 msgid "Show the function's definition"
-msgstr ""
+msgstr "Montrer la définition de la fonction :"
 
 #: ../../src/ToolBar.cpp:618
 msgid "Show the open and the save button?"
@@ -6320,21 +6755,23 @@ msgid "Show the print button?"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:615
+#, fuzzy
 msgid "Show the undo and redo button?"
-msgstr ""
+msgstr "Montrer la définition de la fonction :"
 
 #: ../../src/wxMaximaFrame.cpp:1006 ../../src/wxMaximaFrame.cpp:1011
 msgid "Show used + to-be-freed memory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1033
+#, fuzzy
 msgid "Show user definitions"
-msgstr ""
+msgstr "Montrer la définition de la fonction :"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Show wxMaxima help"
-msgstr ""
+msgstr "Sken tallalt n Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1825
 msgid "Shows how many digits of a numbers are displayed"
@@ -6345,48 +6782,53 @@ msgid "Sidebars"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1513
+#, fuzzy
 msgid "Simplify &Radicals..."
-msgstr ""
+msgstr "Simplifier des &radicaux"
 
 #: ../../src/Worksheet.cpp:1579
 msgid "Simplify Expression"
-msgstr ""
+msgstr "Simplifier une expression"
 
 #: ../../src/wxMaximaFrame.cpp:1568
+#, fuzzy
 msgid "Simplify Logarithms"
-msgstr ""
+msgstr "Simplifier la somme"
 
 #: ../../src/wxMaximaFrame.cpp:1582
 msgid "Simplify an expression containing factorials"
-msgstr ""
+msgstr "Simplifier une expression contenant des factorielles"
 
 #: ../../src/wxMaximaFrame.cpp:1539
+#, fuzzy
 msgid "Simplify equations"
-msgstr ""
+msgstr "Fru tagda (tagdiwin)"
 
 #: ../../src/wxMaximaFrame.cpp:1514
 msgid "Simplify expression containing radicals"
-msgstr ""
+msgstr "Simplifier une expression contenant des radicaux"
 
 #: ../../src/wxMaxima.cpp:8649
+#, fuzzy
 msgid "Simplify radicals"
-msgstr ""
+msgstr "Simplifier des &radicaux"
 
 #: ../../src/wxMaximaFrame.cpp:1512
 msgid "Simplify rational expression"
-msgstr ""
+msgstr "Simplifier une expression rationnelle"
 
 #: ../../src/wxMaximaFrame.cpp:1538
 msgid "Simplify sum() commands..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8636
+#, fuzzy
 msgid "Simplify sums"
-msgstr ""
+msgstr "Sefres"
 
 #: ../../src/wxMaximaFrame.cpp:1592
 msgid "Simplify trigonometric expression"
-msgstr ""
+msgstr "Simplifier une expression trigonométrique"
 
 #: ../../src/wxMaximaFrame.cpp:1399
 msgid "Singular Values"
@@ -6401,105 +6843,115 @@ msgid "Singular values, left + right vectors"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1635
+#, fuzzy
 msgid "Smart Substitute..."
-msgstr ""
+msgstr "Semselsi..."
 
 #: ../../src/wxMaxima.cpp:8730
+#, fuzzy
 msgid "Smart substitution"
-msgstr ""
+msgstr "Semselsi"
 
 #: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
 #: ../../src/wxMaxima.cpp:7823
+#, fuzzy
 msgid "Solution of the ODE:"
-msgstr ""
+msgstr "Tifrat :"
 
 #: ../../src/wxMaxima.cpp:10017
 msgid "Solve"
-msgstr ""
+msgstr "Fru"
 
 #: ../../src/wxMaximaFrame.cpp:1244
 msgid "Solve &Algebraic System..."
-msgstr ""
+msgstr "Fru a&nagraw aljibṛan..."
 
 #: ../../src/wxMaximaFrame.cpp:1242
 msgid "Solve &Linear System..."
-msgstr ""
+msgstr "Résoudre un système &linéaire…"
 
 #: ../../src/wxMaximaFrame.cpp:1266
 msgid "Solve &ODE..."
-msgstr ""
+msgstr "Fru tagda ta&meẓlayt…"
 
 #: ../../src/wxMaximaFrame.cpp:1240
 msgid "Solve (to_poly)..."
-msgstr ""
+msgstr "Fru (to_poly)…"
 
 #: ../../src/wxMaxima.cpp:8045
 msgid "Solve A*x=b numerically"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1397
+#, fuzzy
 msgid "Solve Ax=b"
-msgstr ""
+msgstr "Fru"
 
 #: ../../src/wxMaxima.cpp:7783
 msgid "Solve ODE"
-msgstr ""
+msgstr "Fru tagda tameẓlayt"
 
 #: ../../src/wxMaximaFrame.cpp:1287
 msgid "Solve ODE with Lapla&ce..."
-msgstr ""
+msgstr "Fru tagda tameẓlayt s Lapla&ce…"
 
 #: ../../src/wxMaximaFrame.cpp:1398
+#, fuzzy
 msgid "Solve a linear equation system using dgesv"
-msgstr ""
+msgstr "Résoudre un système d'équations linéaires"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
 msgid "Solve algebraic system"
-msgstr ""
+msgstr "Fru anagraw aljibṛan"
 
 #: ../../src/wxMaximaFrame.cpp:1245
 msgid "Solve algebraic system of equations"
-msgstr ""
+msgstr "Fru anagraw n tegdiwin tiljibṛanin"
 
 #: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve boundary value problem for second degree ODE"
-msgstr ""
+msgstr "Résoudre un problème aux limites pour une é.d.o. du second ordre"
 
 #: ../../src/wxMaxima.cpp:7895
+#, fuzzy
 msgid "Solve differential equations using laplace()"
 msgstr ""
+"Résoudre une équation différentielle ordinaire avec la transformée de "
+"Laplace"
 
 #: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
 msgid "Solve equation(s)"
-msgstr ""
+msgstr "Fru tagda (tagdiwin)"
 
 #: ../../src/wxMaximaFrame.cpp:1241
 msgid "Solve equation(s) with to_poly_solve"
-msgstr ""
+msgstr "Résoudre une (des) équation(s) avec to_poly_solve"
 
 #: ../../src/wxMaxima.cpp:7773
+#, fuzzy
 msgid "Solve equations numerically"
-msgstr ""
+msgstr "Fru tagda (tagdiwin)"
 
 #: ../../src/wxMaxima.cpp:7757
+#, fuzzy
 msgid "Solve equations to polynom"
-msgstr ""
+msgstr "Résoudre une (des) équation(s) avec to_poly_solve"
 
 #: ../../src/wxMaximaFrame.cpp:1271
 msgid "Solve initial value problem for first degree ODE"
-msgstr ""
+msgstr "Résoudre une é.d.o. du premier ordre avec condition initiale"
 
 #: ../../src/wxMaximaFrame.cpp:1275
 msgid "Solve initial value problem for second degree ODE"
-msgstr ""
+msgstr "Résoudre une é.d.o. du second ordre avec conditions initiales"
 
 #: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
 msgid "Solve linear system"
-msgstr ""
+msgstr "Résoudre un système &linéaire"
 
 #: ../../src/wxMaximaFrame.cpp:1243
 msgid "Solve linear system of equations"
-msgstr ""
+msgstr "Résoudre un système d'équations linéaires"
 
 #: ../../src/wxMaximaFrame.cpp:1263
 msgid "Solve numerical, 1 Variable"
@@ -6507,31 +6959,37 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1267
 msgid "Solve ordinary differential equation of maximum degree 2"
-msgstr ""
+msgstr "Résoudre une équation différentielle ordinaire de degré au plus 2"
 
 #: ../../src/wxMaximaFrame.cpp:1288
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
+"Résoudre une équation différentielle ordinaire avec la transformée de "
+"Laplace"
 
 #: ../../src/wxMaxima.cpp:7708
+#, fuzzy
 msgid "Solve polynomials numerically"
-msgstr ""
+msgstr "Fru tagda (tagdiwin)"
 
 #: ../../src/wxMaxima.cpp:7718
+#, fuzzy
 msgid "Solve polynomials numerically (bfloats)"
-msgstr ""
+msgstr "Fru tagda (tagdiwin)"
 
 #: ../../src/wxMaxima.cpp:7729
+#, fuzzy
 msgid "Solve polynomials numerically (real roots)"
-msgstr ""
+msgstr "Fru tagda (tagdiwin)"
 
 #: ../../src/wxMaximaFrame.cpp:1249
+#, fuzzy
 msgid "Solve symbolically"
-msgstr ""
+msgstr "Fru tagda (tagdiwin)"
 
 #: ../../src/Worksheet.cpp:1574
 msgid "Solve..."
-msgstr ""
+msgstr "Fru…"
 
 #: ../../src/wxMaximaFrame.cpp:1916
 msgid "Solving differential equations"
@@ -6553,20 +7011,23 @@ msgid "Sort"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8496
+#, fuzzy
 msgid "Sort a list"
-msgstr ""
+msgstr "&Créer un fichier batch"
 
 #: ../../src/wxMaxima.cpp:7459
 msgid "Sort all characters in string"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1179
+#, fuzzy
 msgid "Sort the characters..."
-msgstr ""
+msgstr "Constantes grecques"
 
 #: ../../src/wxMaxima.cpp:8482
+#, fuzzy
 msgid "Source list:"
-msgstr ""
+msgstr "Sirew tabdart"
 
 #: ../../src/wxMaxima.cpp:7429
 msgid "Split"
@@ -6585,28 +7046,31 @@ msgid "Split string into tokens"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1171
+#, fuzzy
 msgid "Split..."
-msgstr ""
+msgstr "Udlif n tnaka…"
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Square"
 msgstr ""
 
 #: ../../src/Configuration.cpp:86
+#, fuzzy
 msgid "Standard Text"
-msgstr ""
+msgstr "Iɣewwaṛ"
 
 #: ../../src/Worksheet.cpp:1298
 msgid "Start Animation"
-msgstr ""
+msgstr "Démarrer l'animation"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Start of t:"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:305
+#, fuzzy
 msgid "Start or Stop animation"
-msgstr ""
+msgstr "Démarrer l'animation"
 
 #: ../../src/ToolBar.cpp:306
 msgid ""
@@ -6616,11 +7080,12 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:386
 msgid "Starting Maxima process failed"
-msgstr ""
+msgstr "Le démarrage de Maxima a échoué"
 
 #: ../../src/main.cpp:667
+#, fuzzy
 msgid "Starting a new wxMaxima process for a new window"
-msgstr ""
+msgstr "Le démarrage de Maxima a échoué"
 
 #: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:5633
 msgid "Starting evaluation of the document"
@@ -6628,7 +7093,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:2544
 msgid "Starting server failed"
-msgstr ""
+msgstr "Échec du démarrage du serveur"
 
 #: ../../src/WXMXformat.cpp:64
 msgid "Starting to save the worksheet as .wxmx"
@@ -6636,15 +7101,16 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:252
 msgid "Statistics"
-msgstr ""
+msgstr "Tiddadanin"
 
 #: ../../src/wxMaximaFrame.cpp:701
 msgid "Statistics\tAlt+Shift+S"
-msgstr ""
+msgstr "Tiddadanin\tAlt+Maj-S"
 
 #: ../../src/wxMaxima.cpp:7844
+#, fuzzy
 msgid "Step width:"
-msgstr ""
+msgstr "Produit"
 
 #: ../../src/wxMaximaFrame.cpp:794
 msgid "Straight lines"
@@ -6669,26 +7135,31 @@ msgid "Stream:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1185
+#, fuzzy
 msgid "String"
-msgstr ""
+msgstr "Chaînes"
 
 #: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
 #: ../../src/wxMaxima.cpp:7425
+#, fuzzy
 msgid "String #1:"
-msgstr ""
+msgstr "Chaînes"
 
 #: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
 #: ../../src/wxMaxima.cpp:7426
+#, fuzzy
 msgid "String #2:"
-msgstr ""
+msgstr "Chaînes"
 
 #: ../../src/wxMaximaFrame.cpp:1136
+#, fuzzy
 msgid "String Tests"
-msgstr ""
+msgstr "Chaînes"
 
 #: ../../src/wxMaxima.cpp:7415
+#, fuzzy
 msgid "String length"
-msgstr ""
+msgstr "Chaînes"
 
 #: ../../src/wxMaxima.cpp:7381
 msgid "String to list of char"
@@ -6699,8 +7170,9 @@ msgid "String to list of chars..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7496
+#, fuzzy
 msgid "String to octets"
-msgstr ""
+msgstr "Chaînes"
 
 #: ../../src/wxMaximaFrame.cpp:1160
 msgid "String to octets..."
@@ -6717,8 +7189,9 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7465 ../../src/wxMaxima.cpp:7470
 #: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
 #: ../../src/wxMaxima.cpp:7497
+#, fuzzy
 msgid "String:"
-msgstr ""
+msgstr "Chaînes"
 
 #: ../../src/wxMaxima.cpp:7197
 msgid "Struct :"
@@ -6734,7 +7207,7 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:274
 msgid "Subsection"
-msgstr ""
+msgstr "Sous-section"
 
 #: ../../src/Configuration.cpp:90
 msgid "Subsection cell (Heading 3)"
@@ -6751,19 +7224,21 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
 #: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
 msgid "Substitute"
-msgstr ""
+msgstr "Semselsi"
 
 #: ../../src/wxMaximaFrame.cpp:1193
+#, fuzzy
 msgid "Substitute all matches"
-msgstr ""
+msgstr "Semselsi..."
 
 #: ../../src/wxMaximaFrame.cpp:1192
 msgid "Substitute first match"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1646
+#, fuzzy
 msgid "Substitute only in parts..."
-msgstr ""
+msgstr "Semselsi..."
 
 #: ../../src/wxMaxima.cpp:8763
 msgid "Substitute only in specific parts"
@@ -6775,7 +7250,7 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
 msgid "Substitute..."
-msgstr ""
+msgstr "Semselsi..."
 
 #: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
 msgid "Substitutes until the equation no more changes"
@@ -6810,16 +7285,18 @@ msgid ""
 msgstr ""
 
 #: ../../src/ToolBar.cpp:275
+#, fuzzy
 msgid "Subsubsection"
-msgstr ""
+msgstr "Sous-section"
 
 #: ../../src/Configuration.cpp:89
 msgid "Subsubsection cell (Heading 4)"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1831
+#, fuzzy
 msgid "Suggestion: "
-msgstr ""
+msgstr "Sous-section"
 
 #: ../../src/Worksheet.cpp:2030
 msgid "Suitable as flag for ev()"
@@ -6827,7 +7304,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9049
 msgid "Sum"
-msgstr ""
+msgstr "Somme"
 
 #: ../../src/wxMaximaFrame.cpp:1551
 msgid ""
@@ -6844,12 +7321,13 @@ msgid "Switched to lisp mode after receiving a lisp prompt!"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1971
+#, fuzzy
 msgid "Symbolic Constant"
-msgstr ""
+msgstr "Choisir une constante"
 
 #: ../../src/wxMaximaFrame.cpp:705
 msgid "Symbols\tAlt+Shift+Y"
-msgstr ""
+msgstr "Tiddadanin\tAlt+Maj-S"
 
 #: ../../src/Worksheet.cpp:2006
 msgid "Symmetric function: f(x)=f(-x)"
@@ -6860,20 +7338,23 @@ msgid "Table of Contents"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:711
+#, fuzzy
 msgid "Table of Contents\tAlt+Shift+T"
-msgstr ""
+msgstr "Barre d'outils\tAlt+Maj-T"
 
 #: ../../src/wxMaxima.cpp:8930
+#, fuzzy
 msgid "Taylor series"
-msgstr ""
+msgstr "Séries de Taylor :"
 
 #: ../../src/wxMaximaFrame.cpp:1474
+#, fuzzy
 msgid "Taylor series..."
-msgstr ""
+msgstr "Séries de Taylor :"
 
 #: ../../src/wxMaxima.cpp:8925
 msgid "Taylor series:"
-msgstr ""
+msgstr "Séries de Taylor :"
 
 #: ../../src/wxMaxima.cpp:4132
 msgid "Telling maxima about the new working directory."
@@ -6900,11 +7381,11 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:271
 msgid "Text"
-msgstr ""
+msgstr "Aḍris"
 
 #: ../../src/Configuration.cpp:93
 msgid "Text cell background"
-msgstr ""
+msgstr "Agilal n tebliqt n uḍris"
 
 #: ../../src/wxMaxima.cpp:6541
 msgid "Text snippet"
@@ -6945,8 +7426,9 @@ msgid "The comma-separated contents of the struct fields"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7186
+#, fuzzy
 msgid "The comma-separated names of the struct fields"
-msgstr ""
+msgstr "Entrer une liste de variables séparées par des virgules"
 
 #: ../../src/wxMaxima.cpp:7070
 msgid ""
@@ -7006,8 +7488,9 @@ msgid "The manual of Maxima"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1881
+#, fuzzy
 msgid "The manual of wxMaxima"
-msgstr ""
+msgstr "Bienvenue dans wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7125
 msgid "The name of a function we don't want to be evaluated here"
@@ -7082,8 +7565,9 @@ msgid "The variables to search the optimum solution for"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:193
+#, fuzzy
 msgid "The worksheet"
-msgstr ""
+msgstr "Afer"
 
 #: ../../src/Worksheet.cpp:8122
 msgid "The worksheet containing maxima's input and output"
@@ -7096,10 +7580,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:2143
+#, fuzzy
 msgid ""
 "There was an error in the XML maxima has generated.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Il y a eu une erreur en générant le XML!\n"
+"\n"
+"Merci de faire un rapport de bogue."
 
 #: ../../src/wxMaxima.cpp:3911
 msgid ""
@@ -7120,10 +7608,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3257
+#, fuzzy
 msgid ""
 "There was an error in the XML that should describe the manual topics.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Il y a eu une erreur en générant le XML!\n"
+"\n"
+"Merci de faire un rapport de bogue."
 
 #: ../../src/wxMaxima.cpp:3202
 msgid ""
@@ -7164,11 +7656,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9013 ../../src/wxMaxima.cpp:10058
 msgid "Times:"
-msgstr ""
+msgstr "fois :"
 
 #: ../../src/ToolBar.cpp:272
 msgid "Title"
-msgstr ""
+msgstr "Titre"
 
 #: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
@@ -7180,35 +7672,37 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1794
 msgid "To &Bigfloat"
-msgstr ""
+msgstr "Valeur approchée (bfloat)"
 
 #: ../../src/wxMaximaFrame.cpp:1791
 msgid "To &Float"
-msgstr ""
+msgstr "En virgule flottante"
 
 #: ../../src/Worksheet.cpp:1571
 msgid "To Float"
-msgstr ""
+msgstr "En virgule &flottante"
 
 #: ../../src/wxMaximaFrame.cpp:1797
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1803
+#, fuzzy
 msgid "To exact fraction"
-msgstr ""
+msgstr "Éléments simples"
 
 #: ../../src/wxMaximaFrame.cpp:1814
+#, fuzzy
 msgid "To exact number"
-msgstr ""
+msgstr "Montrer les &fonctions"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "To:"
-msgstr ""
+msgstr "ɣer :"
 
 #: ../../src/wxMaximaFrame.cpp:825 ../../src/wxMaximaFrame.cpp:828
 msgid "Toggle full screen editing"
-msgstr ""
+msgstr "Basculer en plein écran d'édition"
 
 #: ../../src/ToolBar.cpp:265
 msgid "Toggle the visibility of code cells"
@@ -7227,20 +7721,23 @@ msgid "Top end"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1078
+#, fuzzy
 msgid "Trace a function..."
-msgstr ""
+msgstr "Kkes tawuri"
 
 #: ../../src/wxMaxima.cpp:7084
+#, fuzzy
 msgid "Trace function(s)"
-msgstr ""
+msgstr "Effacer la (les) fonction(s):"
 
 #: ../../src/wxMaximaFrame.cpp:1184
+#, fuzzy
 msgid "Transformations"
-msgstr ""
+msgstr "Transposer une matrice"
 
 #: ../../src/wxMaximaFrame.cpp:1376
 msgid "Transpose a matrix"
-msgstr ""
+msgstr "Transposer une matrice"
 
 #: ../../src/wxMaxima.cpp:7832
 msgid ""
@@ -7293,12 +7790,14 @@ msgid "Trim both ends..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1182
+#, fuzzy
 msgid "Trim left..."
-msgstr ""
+msgstr "Talast..."
 
 #: ../../src/wxMaximaFrame.cpp:1183
+#, fuzzy
 msgid "Trim right..."
-msgstr ""
+msgstr "Talast..."
 
 #: ../../src/wxMaxima.cpp:7473
 msgid "Trim string left"
@@ -7369,19 +7868,20 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1928
 msgid "Tutorials"
-msgstr ""
+msgstr "Tutoriels"
 
 #: ../../src/wxMaxima.cpp:9571
 msgid "Two sample t-test"
-msgstr ""
+msgstr "Test de Student (t-test) à 2 échantillons…"
 
 #: ../../src/Worksheet.cpp:8013
+#, fuzzy
 msgid "Type"
-msgstr ""
+msgstr "Tawsit :"
 
 #: ../../src/wxMaxima.cpp:7180
 msgid "Type:"
-msgstr ""
+msgstr "Tawsit :"
 
 #: ../../src/wxMaxima.cpp:9429
 msgid "URL"
@@ -7406,8 +7906,9 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1007
+#, fuzzy
 msgid "Undefine"
-msgstr ""
+msgstr "Souligné"
 
 #: ../../src/ToolBar.cpp:191
 msgid "Undo"
@@ -7415,7 +7916,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo\tCtrl+Z"
-msgstr ""
+msgstr "&Sefsex\tCtrl+Z"
 
 #: ../../src/ToolBar.cpp:614
 msgid "Undo and redo button"
@@ -7423,15 +7924,17 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo last change"
-msgstr ""
+msgstr "Sefsex asnifel aneggaru"
 
 #: ../../src/wxMaximaFrame.cpp:924
+#, fuzzy
 msgid "Unfold All\tCtrl+Alt+]"
-msgstr ""
+msgstr "Tout sélectionner"
 
 #: ../../src/wxMaximaFrame.cpp:925
+#, fuzzy
 msgid "Unfold all folded sections"
-msgstr ""
+msgstr "Déplier tous les groupes"
 
 #: ../../src/Worksheet.cpp:1893
 msgid "Unhide Heading 5"
@@ -7446,24 +7949,29 @@ msgid "Unhide Part"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1860
+#, fuzzy
 msgid "Unhide Section"
-msgstr ""
+msgstr "Tigezmi"
 
 #: ../../src/Worksheet.cpp:1871
+#, fuzzy
 msgid "Unhide Subsection"
-msgstr ""
+msgstr "Sous-section"
 
 #: ../../src/Worksheet.cpp:1882
+#, fuzzy
 msgid "Unhide Subsubsection"
-msgstr ""
+msgstr "Sous-section"
 
 #: ../../src/Worksheet.cpp:1912
+#, fuzzy
 msgid "Unhide contents"
-msgstr ""
+msgstr "Constantes grecques"
 
 #: ../../src/wxMaximaFrame.cpp:266
+#, fuzzy
 msgid "Unicode characters"
-msgstr ""
+msgstr "Constantes grecques"
 
 #: ../../src/wxMaximaFrame.cpp:707
 msgid "Unicode chars\tAlt+Shift+U"
@@ -7492,8 +8000,9 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:10418
+#, fuzzy
 msgid "Unterminated comment."
-msgstr ""
+msgstr "Décommenter"
 
 #: ../../src/wxMaxima.cpp:10461
 msgid "Unterminated string."
@@ -7506,27 +8015,29 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:11150 ../../src/wxMaxima.cpp:11157
 #: ../../src/wxMaxima.cpp:11163
 msgid "Upgrade"
-msgstr ""
+msgstr "Mettre à jour"
 
 #: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
 msgid "Upper bound:"
-msgstr ""
+msgstr "borne supérieure :"
 
 #: ../../src/wxMaximaFrame.cpp:792
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
+#, fuzzy
 msgid "Use a list"
-msgstr ""
+msgstr "Sirew tabdart"
 
 #: ../../src/wxMaxima.cpp:8571
 msgid "Use a list as parameter list for a function"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1708
+#, fuzzy
 msgid "Use list"
-msgstr ""
+msgstr "Sirew tabdart"
 
 #: ../../src/wxMaximaFrame.cpp:1701
 msgid "Use list as the arguments of a function"
@@ -7541,8 +8052,9 @@ msgid "Use square parenthesis for matrices"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1083
+#, fuzzy
 msgid "Use struct field..."
-msgstr ""
+msgstr "Fraction &continue"
 
 #: ../../src/wxMaximaFrame.cpp:795
 msgid "Use vertical lines instead of parenthesis for matrices"
@@ -7566,8 +8078,9 @@ msgid "Using Maxima path from command line."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:4822
+#, fuzzy
 msgid "Using configured Maxima path."
-msgstr ""
+msgstr "Configurer wxMaxima"
 
 #: ../../src/wxMaxima.cpp:2961
 msgid ""
@@ -7589,25 +8102,28 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8755
+#, fuzzy
 msgid "Value at a given point"
-msgstr ""
+msgstr "Évaluer les formes &nommées"
 
 #: ../../src/Worksheet.cpp:1987
 msgid "Value at a specific point"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7801
+#, fuzzy
 msgid "Value at that point:"
-msgstr ""
+msgstr "Évaluer les formes &nommées"
 
 #: ../../src/wxMaxima.cpp:7812 ../../src/wxMaxima.cpp:7825
 #: ../../src/wxMaxima.cpp:7827
+#, fuzzy
 msgid "Value y at that point:"
-msgstr ""
+msgstr "Évaluer les formes &nommées"
 
 #: ../../src/wxMaxima.cpp:7910
 msgid "Value:"
-msgstr ""
+msgstr "Azal:"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Var #1"
@@ -7623,25 +8139,29 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
 #: ../../src/wxMaxima.cpp:8568
+#, fuzzy
 msgid "Variable name"
-msgstr ""
+msgstr "Ancienne variable :"
 
 #: ../../src/wxMaximaFrame.cpp:1085
+#, fuzzy
 msgid "Variable name, not contents..."
-msgstr ""
+msgstr "Ancienne variable :"
 
 #: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
+#, fuzzy
 msgid "Variable name:"
-msgstr ""
+msgstr "Ancienne variable :"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
+#, fuzzy
 msgid "Variable(s)"
-msgstr ""
+msgstr "Amutti (i-en) :"
 
 #: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
 #: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
 msgid "Variable(s):"
-msgstr ""
+msgstr "Amutti (i-en) :"
 
 #: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
 #: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
@@ -7649,15 +8169,15 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
 #: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
 msgid "Variable:"
-msgstr ""
+msgstr "Amutti:"
 
 #: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
 msgid "Variables"
-msgstr ""
+msgstr "Imuttiyen"
 
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
 msgid "Variables:"
-msgstr ""
+msgstr "Imuttiyen:"
 
 #: ../../src/WXMXformat.cpp:337
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -7665,7 +8185,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:836
 msgid "View"
-msgstr ""
+msgstr "Timeẓriwt"
 
 #: ../../src/Autocomplete.cpp:235
 msgid "Waiting for m_addFiles_backgroundThread to finish"
@@ -7687,11 +8207,12 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
 #: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
 msgid "Warning"
-msgstr ""
+msgstr "Alerte"
 
 #: ../../src/wxMaximaFrame.cpp:1556
+#, fuzzy
 msgid "Warning:"
-msgstr ""
+msgstr "Alerte"
 
 #: ../../src/Dirstructure.cpp:72
 #, c-format
@@ -7707,7 +8228,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5063
 msgid "Welcome to wxMaxima"
-msgstr ""
+msgstr "Bienvenue dans wxMaxima"
 
 #: ../../src/wxMaxima.cpp:8583
 msgid "What to do:"
@@ -7760,44 +8281,47 @@ msgid "Wrote the mimetype info"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:11147
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have version %s. The newest version source code is available for is %s.\n"
 "\n"
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
+"Vous avez la version %s. La dernière version est %s.\n"
+"\n"
+"Appuyez sur OK pour visiter le site de wxMaxima."
 
 #: ../../src/wxMaxima.cpp:11202
 msgid "Your changes will be lost if you don't save them."
-msgstr ""
+msgstr "Les changements seront perdus si vous ne les enregistrez pas"
 
 #: ../../src/wxMaxima.cpp:11156
 msgid "Your version of wxMaxima is up to date."
-msgstr ""
+msgstr "Lqem inek n wxMaximar d aneggaru."
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom &In\tCtrl++"
-msgstr ""
+msgstr "Zoom ɣer zdat\tAlt+I"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom Ou&t\tCtrl+-"
-msgstr ""
+msgstr "Zoom ɣer deffir\tAlt+O"
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom in 10%"
-msgstr ""
+msgstr "Zoom ɣer zdat s 10%"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom out 10%"
-msgstr ""
+msgstr "Zoom ɣer deffir s 10%"
 
 #: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
 msgid "[ unsaved ]"
-msgstr ""
+msgstr "[ ur yettwasekles ara ]"
 
 #: ../../src/wxMaxima.cpp:10920
 msgid "[ unsaved* ]"
-msgstr ""
+msgstr "[ ur yettwasekles ara ]"
 
 #: ../../src/Worksheet.cpp:5278
 #, c-format
@@ -7810,8 +8334,9 @@ msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"la
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1690
+#, fuzzy
 msgid "apply function to each element"
-msgstr ""
+msgstr "Appliquer une fonction à une liste"
 
 #: ../../src/wxMaximaFrame.cpp:739
 msgid "as 1D ASCII"
@@ -7846,44 +8371,50 @@ msgid "ev() shall evaluate this automatically"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7130
+#, fuzzy
 msgid "expression:"
-msgstr ""
+msgstr "Expression :"
 
 #: ../../src/Worksheet.cpp:2025
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
+#, fuzzy
 msgid "filename:"
-msgstr ""
+msgstr "Ancienne variable :"
 
 #: ../../src/wxMaximaFrame.cpp:1674
+#, fuzzy
 msgid "from a list"
-msgstr ""
+msgstr "Sirew tabdart"
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "from a rule"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1685
+#, fuzzy
 msgid "from function arguments"
-msgstr ""
+msgstr "Ismawen n twuriwin"
 
 #: ../../src/wxMaximaFrame.cpp:1669
 msgid "from individual elements"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
+#, fuzzy
 msgid "function"
-msgstr ""
+msgstr "Tawuri"
 
 #: ../../src/wxMaximaFrame.cpp:747
 msgid "in 2D"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8554
+#, fuzzy
 msgid "list"
-msgstr ""
+msgstr "Sirew tabdart"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "max(abs(A(i,j))) (complex)"
@@ -7894,13 +8425,15 @@ msgid "max(abs(A(i,j))) (real)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8046
+#, fuzzy
 msgid "m×n Matrix A:"
-msgstr ""
+msgstr "Isirew :"
 
 #: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533
+#, fuzzy
 msgid "n:"
-msgstr ""
+msgstr "dans :"
 
 #: ../../src/Worksheet.cpp:2000
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -7911,8 +8444,9 @@ msgid "noun: Not evaluated by default"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1710
+#, fuzzy
 msgid "nth"
-msgstr ""
+msgstr "Non"
 
 #: ../../src/Worksheet.cpp:2021
 msgid "outative: f(2*x) = 2*f(x)"
@@ -7924,20 +8458,24 @@ msgid "part:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8942
+#, fuzzy
 msgid "point:"
-msgstr ""
+msgstr "Agaz :"
 
 #: ../../src/wxMaxima.cpp:7740
+#, fuzzy
 msgid "precision:"
-msgstr ""
+msgstr "Précision"
 
 #: ../../src/wxMaxima.cpp:7255
+#, fuzzy
 msgid "printf"
-msgstr ""
+msgstr "Imprimer"
 
 #: ../../src/wxMaximaFrame.cpp:1108
+#, fuzzy
 msgid "printf..."
-msgstr ""
+msgstr "Zlem.."
 
 #: ../../src/wxMaxima.cpp:8650
 msgid ""
@@ -7953,16 +8491,19 @@ msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1111
+#, fuzzy
 msgid "readbyte..."
-msgstr ""
+msgstr "Sidef"
 
 #: ../../src/wxMaximaFrame.cpp:1110
+#, fuzzy
 msgid "readchar..."
-msgstr ""
+msgstr "Udlif uwnis…"
 
 #: ../../src/wxMaximaFrame.cpp:1109
+#, fuzzy
 msgid "readline..."
-msgstr ""
+msgstr "Awliwel…"
 
 #: ../../src/wxMaxima.cpp:10018
 msgid ""
@@ -7993,16 +8534,17 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11190
 msgid "unsaved"
-msgstr ""
+msgstr "non sauvegardé"
 
 #: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
 #: ../../src/wxMaximaFrame.cpp:189
 msgid "untitled"
-msgstr ""
+msgstr "sans nom"
 
 #: ../../src/wxMaximaFrame.cpp:1700
+#, fuzzy
 msgid "use as function arguments"
-msgstr ""
+msgstr "Ismawen n twuriwin"
 
 #: ../../src/wxMaximaFrame.cpp:1696
 msgid "use the actual values stored"
@@ -8017,16 +8559,16 @@ msgid "wxMaxima"
 msgstr ""
 
 #: ../../src/main.cpp:516
-#, c-format
+#, fuzzy, c-format
 msgid "wxMaxima %ld"
-msgstr ""
+msgstr "wxMaxima %s"
 
 #: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
 #: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
 #: ../../src/wxMaximaFrame.cpp:185
-#, c-format
+#, fuzzy, c-format
 msgid "wxMaxima %s (%s) "
-msgstr ""
+msgstr "wxMaxima %s"
 
 #: ../../src/wxMaxima.cpp:4490
 msgid "wxMaxima cannot read the xml contents of "
@@ -8042,12 +8584,12 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5285
 msgid "wxMaxima document"
-msgstr ""
+msgstr "Isemli wxMaxima "
 
 #: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
 #: ../../src/wxMaxima.cpp:4230
 msgid "wxMaxima encountered an error loading "
-msgstr ""
+msgstr "Erreur de wxMaxima au chargement"
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "wxMaxima help"
@@ -8066,12 +8608,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1896
+#, fuzzy
 msgid "wxMaxima shows help in a browser"
-msgstr ""
+msgstr "Fichier non trouvé"
 
 #: ../../src/wxMaximaFrame.cpp:1894
+#, fuzzy
 msgid "wxMaxima shows help in the sidebar"
-msgstr ""
+msgstr "Fichier non trouvé"
 
 #: ../../src/wxMaximaFrame.cpp:111
 #, c-format
@@ -8079,8 +8623,9 @@ msgid "wxMaxima version %s"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1954
+#, fuzzy
 msgid "wxMaxima's ChangeLog"
-msgstr ""
+msgstr "Tignit wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "wxMaxima's license"
@@ -8144,8 +8689,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:10
+#, fuzzy
 msgid "# Introduction to wxMaxima"
-msgstr ""
+msgstr "Bienvenue dans wxMaxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:12
@@ -8184,8 +8730,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:18
+#, fuzzy
 msgid "### _Maxima_"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:20
@@ -8220,8 +8767,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:26
+#, fuzzy
 msgid "### WxMaxima"
-msgstr ""
+msgstr "&Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:28
@@ -8344,8 +8892,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:54
+#, fuzzy
 msgid "### Cells"
-msgstr ""
+msgstr "Smezdi tibniqin"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:56
@@ -8366,8 +8915,9 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Image cells."
-msgstr ""
+msgstr "Smezdi tibniqin"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
@@ -8383,8 +8933,9 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Page breaks."
-msgstr ""
+msgstr "Saut de page"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:65
@@ -8538,8 +9089,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:102
+#, fuzzy
 msgid "#### Greek characters"
-msgstr ""
+msgstr "Constantes grecques"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:104
@@ -8954,8 +9506,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:282
+#, fuzzy
 msgid "## File Formats"
-msgstr ""
+msgstr "Fichier non trouvé"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:284
@@ -9295,8 +9848,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:403
+#, fuzzy
 msgid "### Match parenthesis in text controls"
-msgstr ""
+msgstr "Sélectionner une police à chasse fixe dans les entrées de texte."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:405
@@ -9392,8 +9946,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:432
+#, fuzzy
 msgid "## Subscripted variables"
-msgstr ""
+msgstr "Montrer les variables déclarées"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:434
@@ -10041,8 +10596,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:704
+#, fuzzy
 msgid "#### Expression"
-msgstr ""
+msgstr "Expression"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:706
@@ -10069,8 +10625,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:712
+#, fuzzy
 msgid "#### Parametric plot"
-msgstr ""
+msgstr "Courbe paramétrée"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:714
@@ -10083,8 +10640,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:716
+#, fuzzy
 msgid "#### Points"
-msgstr ""
+msgstr "Agaz :"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:718
@@ -10131,8 +10689,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:732
+#, fuzzy
 msgid "#### Plot name"
-msgstr ""
+msgstr "Tabdart :"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:734
@@ -10168,8 +10727,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:744
+#, fuzzy
 msgid "#### Grid"
-msgstr ""
+msgstr "Iẓiki:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:746
@@ -10308,8 +10868,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:794
+#, fuzzy
 msgid "## Special variables wx..."
-msgstr ""
+msgstr "Kkes amutti"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:805
@@ -10481,8 +11042,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:837
+#, fuzzy
 msgid "Example:"
-msgstr ""
+msgstr "Exemple"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:842
@@ -10533,8 +11095,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:856
+#, fuzzy
 msgid "## Output rendering."
-msgstr ""
+msgstr "Chaînes"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:858
@@ -10612,8 +11175,11 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:885
+#, fuzzy
 msgid "## Cannot connect to _Maxima_"
 msgstr ""
+"\n"
+"Ur yeqqin ara."
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:887
@@ -10960,8 +11526,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:988
+#, fuzzy
 msgid "E.g. start wxMaxima with:"
-msgstr ""
+msgstr "Senker tikelt nniḍen maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:990
@@ -11321,8 +11888,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1140
+#, fuzzy
 msgid "# Command-line arguments"
-msgstr ""
+msgstr "Liste x séparée par des virgules"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:1142

--- a/locales/wxMaxima/ru.po
+++ b/locales/wxMaxima/ru.po
@@ -29,524 +29,544 @@ msgid ""
 "\n"
 "Maxima is currently using %3.3f%% of all available CPUs."
 msgstr ""
+"\n"
+"\n"
+"Сейчас Maxima использует %3.3f%% всех доступных ресурсов ЦП."
 
 #: ../../src/Image.cpp:690
 msgid ""
 "\n"
 "Image was loaded from a .wxmx file"
 msgstr ""
+"\n"
+"Изображение загружено из файла .wxmx"
 
 #: ../../src/wxMaxima.cpp:5153
 msgid ""
 "\n"
 "Use the menu \"View->Toggle log window\" to show/hide a log window with all debug messages."
 msgstr ""
+"\n"
+"Меню «Вид -> Переключить окно журнала» позволяет показать или скрыть окно журнала со всеми сообщениями отладки."
 
 #: ../../src/wxMaxima.cpp:4230
 msgid " (File format (WXM version 1, first line of the file) not recognized)"
-msgstr ""
+msgstr " (Формат файла (WXM версии 1, первая строка файла) не распознан)"
 
 #: ../../src/wxMaximaFrame.cpp:1559
 msgid " Wrong, if a is complex"
-msgstr ""
+msgstr " Неверно, если a является комплексным"
 
 #: ../../src/wxMaxima.cpp:7601
 msgid ""
 "\".\" = \"The current directory\"\n"
 "\"..\" = \"One directory up\""
 msgstr ""
+"«.» = «Текущий каталог»\n"
+"«..» = «На один каталог выше»"
 
 #: ../../src/wxMaxima.cpp:7557 ../../src/wxMaxima.cpp:7563
 #: ../../src/wxMaxima.cpp:7568
 msgid "\"..\" means \"one directory up\"."
-msgstr ""
+msgstr "«..» означает «на один каталог выше»."
 
 #: ../../src/wxMaxima.cpp:5053
 #, c-format
 msgid "%i cells in evaluation queue"
-msgstr ""
+msgstr "%i полей в очереди на вычисление"
 
 #: ../../src/Worksheet.cpp:330
 #, c-format
 msgid "%s image, %li×%li, %li ppi"
-msgstr ""
+msgstr "%s изображение, %li×%li, %li пикс. на дюйм"
 
 #: ../../src/Autocomplete.cpp:319
 #, c-format
 msgid "%s: Can't interpret line: %s"
-msgstr ""
+msgstr "%s: не удалось интерпретировать строку: %s"
 
 #: ../../src/wxMaximaFrame.cpp:1655
 msgid "&Algebraic Mode"
-msgstr ""
+msgstr "&Алгебраический режим"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "&Apropos..."
-msgstr ""
+msgstr "&Похожие..."
 
 #: ../../src/wxMaximaFrame.cpp:615
 msgid "&Batch File...\tCtrl+B"
-msgstr ""
+msgstr "&Пакетный файл...\tCtrl+B"
 
 #: ../../src/wxMaximaFrame.cpp:1278
 msgid "&Boundary Value Problem..."
-msgstr ""
+msgstr "&Граничная задача..."
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "&Bug Report"
-msgstr ""
+msgstr "&Сообщение об ошибке"
 
 #: ../../src/wxMaximaFrame.cpp:1505
 msgid "&Calculus"
-msgstr ""
+msgstr "&Анализ"
 
 #: ../../src/wxMaximaFrame.cpp:1601
 msgid "&Canonical Form"
-msgstr ""
+msgstr "&Каноническая форма"
 
 #: ../../src/wxMaximaFrame.cpp:1358
 msgid "&Characteristic Polynomial..."
-msgstr ""
+msgstr "&Характеристический полином..."
 
 #: ../../src/wxMaximaFrame.cpp:990
 msgid "&Clear Memory"
-msgstr ""
+msgstr "&Очистить память"
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "&Combine Factorials"
-msgstr ""
+msgstr "&Объединить факториалы"
 
 #: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Complex Simplification"
-msgstr ""
+msgstr "&Комплексное упрощение"
 
 #: ../../src/wxMaximaFrame.cpp:1502
 msgid "&Continued Fraction"
-msgstr ""
+msgstr "&Цепная дробь"
 
 #: ../../src/wxMaximaFrame.cpp:638
 msgid "&Copy\tCtrl+C"
-msgstr ""
+msgstr "&Копировать\tCtrl+C"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "&Demoivre"
-msgstr ""
+msgstr "&В тригонометрическую форму"
 
 #: ../../src/wxMaximaFrame.cpp:1362
 msgid "&Determinant"
-msgstr ""
+msgstr "&Определитель"
 
 #: ../../src/wxMaximaFrame.cpp:1466
 msgid "&Differentiate..."
-msgstr ""
+msgstr "&Дифференцировать..."
 
 #: ../../src/wxMaximaFrame.cpp:689
 msgid "&Edit"
-msgstr ""
+msgstr "&Правка"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "&Eliminate Variable..."
-msgstr ""
+msgstr "&Исключить переменную..."
 
 #: ../../src/wxMaximaFrame.cpp:1318
 msgid "&Enter Matrix..."
-msgstr ""
+msgstr "&Ввести матрицу..."
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "&Example..."
-msgstr ""
+msgstr "&Пример..."
 
 #: ../../src/wxMaximaFrame.cpp:1524
 msgid "&Expand Expression"
-msgstr ""
+msgstr "&Раскрыть выражение"
 
 #: ../../src/wxMaximaFrame.cpp:1597
 msgid "&Expand Trigonometric"
-msgstr ""
+msgstr "&Раскрыть тригонометрически"
 
 #: ../../src/wxMaximaFrame.cpp:1626
 msgid "&Exponentialize"
-msgstr ""
+msgstr "&В экспоненциальное представление"
 
 #: ../../src/wxMaximaFrame.cpp:618
 msgid "&Export..."
-msgstr ""
+msgstr "&Экспортировать..."
 
 #: ../../src/wxMaximaFrame.cpp:1516
 msgid "&Factor Expression"
-msgstr ""
+msgstr "&Факторизовать выражение"
 
 #: ../../src/wxMaximaFrame.cpp:626
 msgid "&File"
-msgstr ""
+msgstr "&Файл"
 
 #: ../../src/wxMaximaFrame.cpp:1019
 msgid "&Functions"
-msgstr ""
+msgstr "&Функции"
 
 #: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Greatest Common Divisor..."
-msgstr ""
+msgstr "&Наибольший общий делитель..."
 
 #: ../../src/wxMaximaFrame.cpp:1968
 msgid "&Help"
-msgstr ""
+msgstr "&Справка"
 
 #: ../../src/wxMaximaFrame.cpp:1453
 msgid "&Integrate..."
-msgstr ""
+msgstr "&Интегрировать..."
 
 #: ../../src/wxMaximaFrame.cpp:964
 msgid "&Interrupt\tCtrl+G"
-msgstr ""
+msgstr "&Прервать\tCtrl+G"
 
 #: ../../src/wxMaximaFrame.cpp:1355
 msgid "&Invert Matrix"
-msgstr ""
+msgstr "&Обратить матрицу"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "&License"
-msgstr ""
+msgstr "&Лицензия"
 
 #: ../../src/wxMaximaFrame.cpp:1763
 msgid "&List"
-msgstr ""
+msgstr "&Список"
 
 #: ../../src/wxMaximaFrame.cpp:610
 msgid "&Load Package...\tCtrl+L"
-msgstr ""
+msgstr "&Загрузить пакет...\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "&Maxima"
-msgstr ""
+msgstr "&Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "&Maxima help"
-msgstr ""
+msgstr "&Справка по Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1660
 msgid "&Modulus Computation..."
-msgstr ""
+msgstr "&Вычисления по модулю..."
 
 #: ../../src/main.cpp:435
 msgid "&New\tCtrl+N"
-msgstr ""
+msgstr "&Создать\tCtrl+N"
 
 #: ../../src/wxMaximaFrame.cpp:1870
 msgid "&Numeric"
-msgstr ""
+msgstr "&Численные расчёты"
 
 #: ../../src/wxMaximaFrame.cpp:1785
 msgid "&Numeric Output"
-msgstr ""
+msgstr "&Цифровой вывод"
 
 #: ../../src/main.cpp:436
 msgid "&Open\tCtrl+O"
-msgstr ""
+msgstr "&Открыть\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "&Open...\tCtrl+O"
-msgstr ""
+msgstr "&Открыть...\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "&Plot"
-msgstr ""
+msgstr "&Графики"
 
 #: ../../src/wxMaximaFrame.cpp:622
 msgid "&Print...\tCtrl+P"
-msgstr ""
+msgstr "&Печать...\tCtrl+P"
 
 #: ../../src/wxMaximaFrame.cpp:1594
 msgid "&Reduce Trigonometric"
-msgstr ""
+msgstr "&Тригонометрическое приведение"
 
 #: ../../src/wxMaximaFrame.cpp:974
 msgid "&Restart Maxima\tCtrl+Alt+R"
-msgstr ""
+msgstr "&Перезапустить Maxima\tCtrl+Alt+R"
 
 #: ../../src/wxMaximaFrame.cpp:608
 msgid "&Save\tCtrl+S"
-msgstr ""
+msgstr "&Сохранить\tCtrl+S"
 
 #: ../../src/wxMaximaFrame.cpp:1662
 msgid "&Simplify"
-msgstr ""
+msgstr "&Упростить"
 
 #: ../../src/wxMaximaFrame.cpp:1581
 msgid "&Simplify Factorials"
-msgstr ""
+msgstr "&Упростить факториалы"
 
 #: ../../src/wxMaximaFrame.cpp:1591
 msgid "&Simplify Trigonometric"
-msgstr ""
+msgstr "&Упростить тригонометрически"
 
 #: ../../src/wxMaximaFrame.cpp:1238
 msgid "&Solve..."
-msgstr ""
+msgstr "&Решить..."
 
 #: ../../src/wxMaximaFrame.cpp:1035
 msgid "&Time Display"
-msgstr ""
+msgstr "&Отображение времени"
 
 #: ../../src/wxMaximaFrame.cpp:1375
 msgid "&Transpose Matrix"
-msgstr ""
+msgstr "&Транспонировать матрицу"
 
 #: ../../src/wxMaximaFrame.cpp:1605
 msgid "&Trigonometric Simplification"
-msgstr ""
+msgstr "&Тригонометрическое упрощение"
 
 #: ../../src/wxMaximaFrame.cpp:1021
 msgid "&Variables"
-msgstr ""
+msgstr "&Переменные"
 
 #: ../../src/wxMaxima.cpp:2443
 msgid "(Config tells to suppress the output of long cells)"
-msgstr ""
+msgstr "(В конфигурации указано подавление вывода длинных полей)"
 
 #: ../../src/MathParser.cpp:1288
 msgid "(Invalid XML from maxima)"
-msgstr ""
+msgstr "(Недопустимый код XML от Maxima)"
 
 #: ../../src/wxMaxima.cpp:4221
 msgid "(Maybe a permission problem?)"
-msgstr ""
+msgstr "(Вероятно, проблема с правами?)"
 
 #: ../../src/wxMaxima.cpp:9248
 msgid "(f(x),x,a,b)), Epsilon algorithm"
-msgstr ""
+msgstr "(f(x),x,a,b)), эпсилон-алгоритм"
 
 #: ../../src/wxMaxima.cpp:9235
 msgid "(f(x),x,a,b)), Strategy of Aind"
-msgstr ""
+msgstr "(f(x),x,a,b)), стратегия Айнда"
 
 #: ../../src/wxMaxima.cpp:9258
 msgid "(f(x),x,a,b), (semi-) infinite interval"
-msgstr ""
+msgstr "(f(x),x,a,b), (полу)бесконечный интервал"
 
 #: ../../src/wxMaximaFrame.cpp:1841
 msgid "(f(x),x,a,b), Epsilon algorithm"
-msgstr ""
+msgstr "(f(x),x,a,b), эпсилон-алгоритм"
 
 #: ../../src/wxMaximaFrame.cpp:1843
 msgid "(f(x),x,a,b), infinite interval"
-msgstr ""
+msgstr "(f(x),x,a,b), бесконечный интервал"
 
 #: ../../src/wxMaximaFrame.cpp:1839
 msgid "(f(x),x,a,b), strategy of Aind"
-msgstr ""
+msgstr "(f(x),x,a,b), стратегия Айнда"
 
 #: ../../src/wxMaxima.cpp:9361 ../../src/wxMaximaFrame.cpp:1867
 msgid "(f(x),x,y) with singularities+discontinuities"
-msgstr ""
+msgstr "(f(x),x,y) с сингулярностями и разрывами"
 
 #: ../../src/wxMaxima.cpp:2065
 msgid ""
 "... [suppressed additional lines as the output is longer than allowed in the"
 " wxMaxima configuration] "
 msgstr ""
+"... [дополнительные строки скрыты, так как длина вывода превышает "
+"разрешённую конфигурацией wxMaxima] "
 
 #: ../../src/Worksheet.cpp:6666
 msgid ".wxm clipboard data with unusual header"
-msgstr ""
+msgstr "Данные .wxm в буфере обмена с необычным заголовком"
 
 #: ../../src/wxMaxima.cpp:8047
 msgid "1×n Matrix b:"
-msgstr ""
+msgstr "Матрица b 1×n:"
 
 #: ../../src/wxMaximaFrame.cpp:1312
 msgid "2D Array to Matrix..."
-msgstr ""
+msgstr "Двухмерный массив в матрицу..."
 
 #: ../../src/wxMaximaFrame.cpp:743
 msgid "2D equations using ASCII Art"
-msgstr ""
+msgstr "Двухмерные уравнения из символов ASCII"
 
 #: ../../src/wxMaximaFrame.cpp:746
 msgid "2D equations using ASCII Art with unicode characters, if available"
 msgstr ""
+"Двухмерные уравнения из символов ASCII с символами Юникода, если доступно"
 
 #: ../../src/wxMaxima.cpp:5057
 #, c-format
 msgid "; %i commands left in the current cell"
-msgstr ""
+msgstr "; %i команд осталось в текущем поле"
 
 #: ../../src/wxMaxima.cpp:10617
 msgid "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
+"При использовании «:lisp» в качестве первой команды, возможно, не будет "
+"отправлен сигнал «завершено»."
 
 #: ../../src/wxMaxima.cpp:6585
 msgid "A Ctrl-F event"
-msgstr ""
+msgstr "Событие Ctrl-F"
 
 #: ../../src/Worksheet.cpp:1973
 msgid "A Scalar"
-msgstr ""
+msgstr "Скаляр"
 
 #: ../../src/wxMaxima.cpp:6653
 #, c-format
 msgid "A find event, %s"
-msgstr ""
+msgstr "Событие поиска, %s"
 
 #: ../../src/Worksheet.cpp:2012
 msgid "A function returning integers"
-msgstr ""
+msgstr "Функция, возвращающая целые числа"
 
 #: ../../src/Worksheet.cpp:2014
 msgid "A function returning positive numbers"
-msgstr ""
+msgstr "Функция, возвращающая положительные числа"
 
 #: ../../src/Worksheet.cpp:1965
 msgid "A irrational variable"
-msgstr ""
+msgstr "Иррациональная переменная"
 
 #: ../../src/Worksheet.cpp:2016
 msgid "A left-associative function"
-msgstr ""
+msgstr "Левоассоциативная функция"
 
 #: ../../src/Worksheet.cpp:2019
 msgid "A linear function"
-msgstr ""
+msgstr "Линейная функция"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "A matrix in which each row is a set of variables"
-msgstr ""
+msgstr "Матрица, каждая строка которой является набором переменных"
 
 #: ../../src/Worksheet.cpp:1963
 msgid "A rational variable"
-msgstr ""
+msgstr "Рациональная переменная"
 
 #: ../../src/Worksheet.cpp:2018
 msgid "A right-associative function"
-msgstr ""
+msgstr "Правоассоциативная функция"
 
 #: ../../src/wxMaximaFrame.cpp:1634
 msgid "A search-and-replace for equations"
-msgstr ""
+msgstr "Поиск и замена для уравнений"
 
 #: ../../src/wxMaximaFrame.cpp:1636
 msgid "A subst with basic maths knowledge"
-msgstr ""
+msgstr "subst со знанием базовой математики"
 
 #: ../../src/BTextCtrl.cpp:64
 msgid "A text control got the mouse focus"
-msgstr ""
+msgstr "Текстовый ввод получил фокус мыши"
 
 #: ../../src/wxMaximaFrame.cpp:1442
 msgid "A&pply function to each Matrix element..."
-msgstr ""
+msgstr "П&рименить функцию к каждому элементу матрицы..."
 
 #: ../../src/wxMaximaFrame.cpp:1291
 msgid "A&t Value..."
-msgstr ""
+msgstr "Значение в &точке..."
 
 #: ../../src/Configuration.cpp:85
 msgid "ASCII maths"
-msgstr ""
+msgstr "Расчёты ASCII"
 
 #: ../../src/wxMaximaFrame.cpp:1963
 msgid "About"
-msgstr ""
+msgstr "О программе"
 
 #: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
 msgid "About wxMaxima"
-msgstr ""
+msgstr "О wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7837
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
-msgstr ""
+msgstr "Принимает одно выражение или список в формате [ode1,ode2,...]"
 
 #: ../../src/wxMaxima.cpp:7841
 msgid "Accepts one variable or a list in the format [1,4,...]"
-msgstr ""
+msgstr "Принимает одну переменную или список в формате [1,4,...]"
 
 #: ../../src/wxMaxima.cpp:7839
 msgid "Accepts one variable or a list in the format [var1,var2,...]"
-msgstr ""
+msgstr "Принимает одну переменную или список в формате [var1,var2,...]"
 
 #: ../../src/wxMaximaFrame.cpp:1371
 msgid "Ad&joint Matrix"
-msgstr ""
+msgstr "&Сопряжённая матрица"
 
 #: ../../src/wxMaximaFrame.cpp:1657
 msgid "Add Algebraic E&quality..."
-msgstr ""
+msgstr "Добавить &алгебраическое равенство..."
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add a directory to search path"
-msgstr ""
+msgstr "Добавить каталог к пути поиска"
 
 #: ../../src/wxMaximaFrame.cpp:1752
 msgid ""
 "Add a new item to the beginning of the list. Useful for creating stacks."
 msgstr ""
+"Добавить новый элемент в начало списка. Эта возможность полезна при создании"
+" стеков."
 
 #: ../../src/wxMaxima.cpp:8602
 msgid "Add an element to the end of a list"
-msgstr ""
+msgstr "Добавить элемент в конец списка"
 
 #: ../../src/wxMaxima.cpp:8597
 msgid "Add an element to the start of a list"
-msgstr ""
+msgstr "Добавить элемент в начало списка"
 
 #: ../../src/wxMaxima.cpp:7625
 msgid "Add dir to path:"
-msgstr ""
+msgstr "Добавить каталог к пути:"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "Add equality to the rational simplifier"
-msgstr ""
+msgstr "Добавить равенство в упроститель рациональных выражений"
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add to &Path..."
-msgstr ""
+msgstr "Добавить к &пути..."
 
 #: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
 #: ../../src/Worksheet.cpp:1704
 msgid "Add to watchlist"
-msgstr ""
+msgstr "Добавить в список отслеживания"
 
 #: ../../src/wxMaximaFrame.cpp:1562
 msgid "Additionally: log(a*b)=log(a)+log(b)"
-msgstr ""
+msgstr "Дополнительно: log(a*b)=log(a)+log(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1566
 msgid "Additionally: log(a/b)=log(a)-log(b), a and b positive integers"
 msgstr ""
+"Дополнительно: log(a/b)=log(a)-log(b), a и b — положительные целые числа"
 
 #: ../../src/Worksheet.cpp:1996
 msgid "Additive function: f(a+b)=f(a)+f(b)"
-msgstr ""
+msgstr "Аддитивная функция: f(a+b)=f(a)+f(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1911
 msgid "Advanced 2d plotting"
-msgstr ""
+msgstr "Расширенное построение в 2d"
 
 #: ../../src/wxMaximaFrame.cpp:1809
 msgid "Advanced guess (PSLQ algorithm)"
-msgstr ""
+msgstr "Улучшенное приближение (алгоритм PSLQ)"
 
 #: ../../src/wxMaximaFrame.cpp:1920
 msgid "Advanced variable names"
-msgstr ""
+msgstr "Расширенные имена переменных"
 
 #: ../../src/ToolBar.cpp:321 ../../src/ToolBar.cpp:589
 msgid ""
 "After clicking on animations created with with_slider_draw() or similar this"
 " slider allows to change the current frame."
 msgstr ""
+"После нажатия на анимацию, созданную с помощью with_slider_draw() или "
+"аналогичных функций, этот ползунок можно использовать для смены текущего "
+"кадра."
 
 #: ../../src/wxMaximaFrame.cpp:1028
 msgid "Aliases"
-msgstr ""
+msgstr "Псевдонимы"
 
 #: ../../src/wxMaximaFrame.cpp:1714
 msgid "All but the 1st n elements"
-msgstr ""
+msgstr "Все, кроме первых n элементов"
 
 #: ../../src/wxMaximaFrame.cpp:1716
 msgid "All but the last n elements"
-msgstr ""
+msgstr "Все, кроме последних n элементов"
 
 #: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
 msgid ""
@@ -555,93 +575,102 @@ msgid ""
 "*.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session "
 "(*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr ""
+"Все типы, которые можно открыть (*.wxm, *.wxmx, *.mac, *.out, "
+"*.xml)|*.wxm;*.wxmx;*.mac;*.out;*.xml|документ wxMaxima (*.wxm, "
+"*.wxmx)|*.wxm;*.wxmx|сеанс Maxima (*.mac)|*.mac|сеанс Xmaxima "
+"(*.out)|*.out|xml из повреждённого .wxmx (*.xml)|*.xml"
 
 #: ../../src/wxMaximaFrame.cpp:733
 msgid "All visible sidebars"
-msgstr ""
+msgstr "Все видимые боковые панели"
 
 #: ../../src/wxMaximaFrame.cpp:1650
 msgid "Allow to substitute operators"
-msgstr ""
+msgstr "Разрешить подставлять операторы"
 
 #: ../../src/wxMaxima.cpp:9040
 msgid ""
 "Allows to vary the parameters of a function until it fits experimental data."
 msgstr ""
+"Позволяет изменять параметры функции при аппроксимации экспериментальных "
+"данных."
 
 #: ../../src/wxMaximaFrame.cpp:763
 msgid "Always after underscores"
-msgstr ""
+msgstr "Всегда после подчёркивания"
 
 #: ../../src/wxMaximaFrame.cpp:764
 msgid "Always autosubscript after an underscore"
 msgstr ""
+"Всегда автоматически переводить символы в нижний индекс после подчёркивания"
 
 #: ../../src/wxMaximaFrame.cpp:774
 msgid "Always display this variable with subscript"
-msgstr ""
+msgstr "Всегда показывать эту переменную в нижнем индексе"
 
 #: ../../src/Worksheet.cpp:1605
 msgid "Always show all digits"
-msgstr ""
+msgstr "Всегда показывать все цифры"
 
 #: ../../src/wxMaxima.cpp:9241
 msgid ""
 "An integer between 1..6; Higher numbers work better for oscillating "
 "integrands"
 msgstr ""
+"Целое число в пределах от 1 до 6; большие значения лучше работают для "
+"подынтегральной функции с осцилляцией"
 
 #: ../../src/MaximaManual.cpp:385
 msgid "Anchors file has no top node."
-msgstr ""
+msgstr "Файл привязок не имеет узла верхнего уровня."
 
 #: ../../src/wxMaximaFrame.cpp:791
 msgid "Angles"
-msgstr ""
+msgstr "Углы"
 
 #: ../../src/wxMaximaFrame.cpp:1775
 msgid "Animation autoplay"
-msgstr ""
+msgstr "Автоматическое воспроизведение анимации"
 
 #: ../../src/wxMaximaFrame.cpp:1778
 msgid "Animation framerate..."
-msgstr ""
+msgstr "Частота кадров анимации..."
 
 #: ../../src/Worksheet.cpp:2002
 msgid "Antisymmetric function: f(x)=-f(-x)"
-msgstr ""
+msgstr "Антисимметричная функция: f(x)=-f(-x)"
 
 #: ../../src/wxMaximaFrame.cpp:1739
 msgid "Append"
-msgstr ""
+msgstr "Добавить"
 
 #: ../../src/wxMaximaFrame.cpp:1735
 msgid "Append a list"
-msgstr ""
+msgstr "Добавить список"
 
 #: ../../src/wxMaximaFrame.cpp:1736
 msgid "Append a list to an existing list"
-msgstr ""
+msgstr "Добавить список к существующему списку"
 
 #: ../../src/wxMaxima.cpp:8607
 msgid "Append a list to another list"
-msgstr ""
+msgstr "Добавить список к другому списку"
 
 #: ../../src/wxMaximaFrame.cpp:1729
 msgid "Append an element"
-msgstr ""
+msgstr "Добавить элемент"
 
 #: ../../src/wxMaximaFrame.cpp:1734
 msgid "Append an element to the beginning an existing list"
-msgstr ""
+msgstr "Добавить элемент в начало существующего списка"
 
 #: ../../src/wxMaximaFrame.cpp:1730
 msgid "Append an element to the end of an existing list"
-msgstr ""
+msgstr "Добавить элемент в конец существующего списка"
 
 #: ../../src/wxMaxima.cpp:8552
 msgid "Apply a function to each list element"
-msgstr ""
+msgstr "Применить функцию к каждому элементу списка"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 #, c-format
@@ -649,204 +678,224 @@ msgid ""
 "Approximate by a fraction using log(), sqrt() and %pi, when needed. Only "
 "available in maxima > 5.46.0"
 msgstr ""
+"При необходимости аппроксимировать дробью с помощью log(), sqrt() и %pi. "
+"Доступно только в Maxima > 5.46.0"
 
 #: ../../src/wxMaximaFrame.cpp:1806
 msgid "Approximate by nice fraction"
-msgstr ""
+msgstr "Аппроксимировать процентной дробью (nice fraction)"
 
 #: ../../src/wxMaxima.cpp:8931
 msgid ""
 "Approximates a expression around a point as a polynom\n"
 "The trailing \"...\" can be removed by using ratdisrep()"
 msgstr ""
+"Аппроксимирует выражение вблизи точки как полином\n"
+"«...» в конце можно удалить с помощью ratdisrep()"
 
 #: ../../src/wxMaxima.cpp:8939
 msgid "Approximates a expression as a polynom"
-msgstr ""
+msgstr "Аппроксимирует выражение как полином"
 
 #: ../../src/wxMaxima.cpp:9474
 msgid "Apropos"
-msgstr ""
+msgstr "Похожие"
 
 #: ../../src/wxMaxima.cpp:7317
 msgid "Are the chars equal, if case is ignored?"
-msgstr ""
+msgstr "Все символы равны, если игнорировать регистр?"
 
 #: ../../src/wxMaxima.cpp:7312
 msgid "Are the chars equal?"
-msgstr ""
+msgstr "Символы равны?"
 
 #: ../../src/wxMaxima.cpp:7349
 msgid "Are these strings equal if case is ignored?"
-msgstr ""
+msgstr "Эти строки равны, если игнорировать регистр?"
 
 #: ../../src/wxMaxima.cpp:7344
 msgid "Are these strings equal?"
-msgstr ""
+msgstr "Эти строки равны?"
 
 #: ../../src/wxMaxima.cpp:7259
 msgid "Arguments:"
-msgstr ""
+msgstr "Аргументы:"
 
 #: ../../src/wxMaxima.cpp:8189
 msgid "Array"
-msgstr ""
+msgstr "Массив"
 
 #: ../../src/wxMaximaFrame.cpp:1023
 msgid "Arrays"
-msgstr ""
+msgstr "Массивы"
 
 #: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
 msgid "Ascii code to char"
-msgstr ""
+msgstr "Код ASCII в символ"
 
 #: ../../src/wxMaximaFrame.cpp:1138
 msgid "Ascii code to char..."
-msgstr ""
+msgstr "Код ASCII в символ..."
 
 #: ../../src/wxMaxima.cpp:10063
 msgid "Assignment(s):"
-msgstr ""
+msgstr "Установки значений:"
 
 #: ../../src/wxMaxima.cpp:10064
 msgid "Assignments of the format a=10,b=20"
-msgstr ""
+msgstr "Установки значений в формате a=10,b=20"
 
 #: ../../src/wxMaxima.cpp:6851
 msgid "Assume a value range for a variable"
-msgstr ""
+msgstr "Допустить диапазон значений для переменной"
 
 #: ../../src/wxMaxima.cpp:8545
 msgid ""
 "Attention: Extracting a random list element isn't efficient for long "
 "lists.Iterating over lists using makelist() or for loops is way faster."
 msgstr ""
+"Внимание! Для длинных списков извлечение случайного элемента из списка "
+"неэффективно. Гораздо быстрее будет итеративный проход по спискам с помощью "
+"makelist() или циклов for."
 
 #: ../../src/Worksheet.cpp:1618
 msgid "Automatic labels"
-msgstr ""
+msgstr "Автоматические метки"
 
 #: ../../src/wxMaximaFrame.cpp:952
 msgid "Automatically answer questions"
-msgstr ""
+msgstr "Автоматически отвечать на вопросы"
 
 #: ../../src/wxMaximaFrame.cpp:953
 msgid "Automatically fill in answers known from the last run"
-msgstr ""
+msgstr "Автоматически заполнять ответы, известные с прошлого выполнения"
 
 #: ../../src/Worksheet.cpp:1464 ../../src/Worksheet.cpp:1838
 msgid "Automatically send known answers"
-msgstr ""
+msgstr "Автоматически отправлять известные ответы"
 
 #: ../../src/wxMaxima.cpp:6021
 #, c-format
 msgid "Autosaving as temp file %s"
-msgstr ""
+msgstr "Автосохранение во временный файл %s"
 
 #: ../../src/wxMaxima.cpp:6033
 #, c-format
 msgid "Autosaving the .wxmx file as %s"
-msgstr ""
+msgstr "Автосохранение файла .wxmx как %s"
 
 #: ../../src/wxMaximaFrame.cpp:781
 msgid "Autosubscript"
-msgstr ""
+msgstr "Автоперевод в нижний индекс"
 
 #: ../../src/wxMaximaFrame.cpp:782
 msgid "Autosubscript chars after an underscore"
-msgstr ""
+msgstr "Автоперевод символов в нижний индекс после подчёркивания"
 
 #: ../../src/wxMaximaFrame.cpp:767
 msgid "Autosubscript numbers and text following single letters"
 msgstr ""
+"Автоперевод чисел и текста, следующего за отдельными буквами, в нижний "
+"индекс"
 
 #: ../../src/wxMaxima.cpp:6529
 msgid "Autosubscript this variable"
-msgstr ""
+msgstr "Автоперевод этой переменной в нижний индекс"
 
 #: ../../src/MaximaManual.cpp:536
 msgid "Background task that compiles the Manual anchors scheduled."
 msgstr ""
+"Запланирована фоновая задача, которая выполняет компиляцию ключевых слов "
+"руководства пользователя."
 
 #: ../../src/wxMaximaFrame.cpp:1350
 msgid "Basic matrix operations"
-msgstr ""
+msgstr "Базовые матричные операции"
 
 #: ../../src/wxMaxima.cpp:6210
 msgid "Batch File"
-msgstr ""
+msgstr "Пакетный файл"
 
 #: ../../src/wxMaxima.cpp:5318
 msgid "Both horizontal and vertical cursor active at the same time"
-msgstr ""
+msgstr "Одновременно активны и горизонтальный, и вертикальный курсоры"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Bottom end"
-msgstr ""
+msgstr "Нижняя сторона"
 
 #: ../../src/wxMaxima.cpp:7817
 msgid "Boundary value problem"
-msgstr ""
+msgstr "Граничная задача"
 
 #: ../../src/wxMathml.cpp:101
 msgid ""
 "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
-msgstr ""
+msgstr "Ошибка: после удаления пробелов длина wxMathml.lisp короче ожидаемой!"
 
 #: ../../src/Autocomplete.cpp:509
 msgid "Bug: Autocompletion requested for unknown type of item."
-msgstr ""
+msgstr "Ошибка: автодополнение запрошено для неизвестного типа элемента."
 
 #: ../../src/Worksheet.cpp:2992
 msgid "Bug: Cell left but not entered."
-msgstr ""
+msgstr "Ошибка: поле оставлено без ввода данных."
 
 #: ../../src/Worksheet.cpp:6203
 msgid "Bug: Cell with negative y position!"
-msgstr ""
+msgstr "Ошибка: поле с отрицательным положением по y!"
 
 #: ../../src/Worksheet.cpp:7723
 msgid ""
 "Bug: Encountered a heading I don't know how to move in one sectioning unit"
 msgstr ""
+"Ошибка: обнаружен заголовок, который невозможно поднять на один уровень"
 
 #: ../../src/Worksheet.cpp:7766
 msgid ""
 "Bug: Encountered a heading I don't know how to move out one sectioning unit"
 msgstr ""
+"Ошибка: обнаружен заголовок, который невозможно опустить на один уровень"
 
 #: ../../src/Worksheet.cpp:3112
 msgid "Bug: Got a question but no cell to answer it in"
-msgstr ""
+msgstr "Ошибка: есть вопрос, но нет поля для ответа на него."
 
 #: ../../src/Worksheet.cpp:6378
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of"
 " the worksheet."
 msgstr ""
+"Ошибка: получен запрос на изменение содержимого поля, расположенного над "
+"началом листа."
 
 #: ../../src/Worksheet.cpp:6346
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
+"Ошибка: получен запрос на удаление содержимого поля, расположенного над "
+"началом листа."
 
 #: ../../src/Worksheet.cpp:6415
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
 msgstr ""
+"Ошибка: получен запрос на изменение содержимого поля и последующую отмену "
+"его удаления."
 
 #: ../../src/Worksheet.cpp:5578
 msgid "Bug: HTML output is no valid XML"
-msgstr ""
+msgstr "Ошибка: вывод HTML не является корректным XML."
 
 #: ../../src/Configuration.h:615
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
 msgstr ""
+"Ошибка: слишком маленькое максимальное количество цифр для отображения!"
 
 #: ../../src/MathParser.cpp:523
 msgid "Bug: Missing contents"
-msgstr ""
+msgstr "Ошибка: отсутствует содержимое."
 
 #: ../../src/Worksheet.cpp:2597 ../../src/Worksheet.cpp:2711
 #: ../../src/Worksheet.cpp:2753 ../../src/Worksheet.cpp:2787
@@ -854,135 +903,144 @@ msgstr ""
 #: ../../src/Worksheet.cpp:4442 ../../src/Worksheet.cpp:6650
 #: ../../src/Worksheet.cpp:6863
 msgid "Bug: The clipboard is already opened"
-msgstr ""
+msgstr "Ошибка: буфер обмена уже открыт."
 
 #: ../../src/Worksheet.cpp:7763
 msgid "Bug: Trying to move a title out by one sectioning unit"
-msgstr ""
+msgstr "Ошибка: попытка опустить заголовок на один уровень"
 
 #: ../../src/Worksheet.cpp:6934
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
+"Ошибка: попытка переместить горизонтальный курсор внутрь группового поля."
 
 #: ../../src/Worksheet.h:247 ../../src/Worksheet.h:252
 msgid "Bug: Trying to record a cell contents change for undo without a cell."
 msgstr ""
+"Ошибка: попытка записи изменений содержимого поля для операции отмены без "
+"определения поля."
 
 #: ../../src/Worksheet.cpp:6417
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
+"Ошибка: действие отмены с одновременным изменением содержимого поля и "
+"добавлением поля."
 
 #: ../../src/Worksheet.cpp:6383
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
+"Ошибка: запрос на отмену действия для поля, расположенного за пределами "
+"листа."
 
 #: ../../src/wxMaximaFrame.cpp:1948
 msgid "Build &Info"
-msgstr ""
+msgstr "Информация о сборке"
 
 #: ../../src/wxMaxima.cpp:7275
 msgid "Byte:"
-msgstr ""
+msgstr "Байт:"
 
 #: ../../src/wxMaximaFrame.cpp:1458
 msgid "C&hange Variable in Integrate..."
-msgstr ""
+msgstr "&Заменить переменную в интеграле..."
 
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "C&onfigure"
-msgstr ""
+msgstr "Н&астройка"
 
 #: ../../src/wxMaximaFrame.cpp:1482
 msgid "Calculate &Product..."
-msgstr ""
+msgstr "Вычислить &произведение..."
 
 #: ../../src/wxMaxima.cpp:8057
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
-msgstr ""
+msgstr "Вычислить сингулярное разложение матрицы численно"
 
 #: ../../src/wxMaxima.cpp:8050
 msgid ""
 "Calculate Singular Value Decomposition, left and right singular vectors "
 "numerically"
 msgstr ""
+"Вычислить сингулярное разложение, вырождающиеся слева и справа векторы, "
+"численно"
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate Su&m..."
-msgstr ""
+msgstr "Вычислить &сумму..."
 
 #: ../../src/wxMaximaFrame.cpp:1795
 msgid "Calculate bigfloat value of the last result"
-msgstr ""
+msgstr "Вычислить последний результат с повышенной точностью"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Calculate float value of the last result"
-msgstr ""
+msgstr "Вычислить последний результат с обычной точностью"
 
 #: ../../src/wxMaxima.cpp:9550
 msgid "Calculate mean value"
-msgstr ""
+msgstr "Вычислить среднее значение"
 
 #: ../../src/wxMaxima.cpp:9554
 msgid "Calculate median value"
-msgstr ""
+msgstr "Вычислить медианное значение"
 
 #: ../../src/wxMaxima.cpp:8871
 msgid "Calculate modulus:"
-msgstr ""
+msgstr "Вычислить модуль:"
 
 #: ../../src/wxMaximaFrame.cpp:1798
 msgid "Calculate numeric value of the last result"
-msgstr ""
+msgstr "Вычислить числовое значение последнего результата"
 
 #: ../../src/wxMaximaFrame.cpp:1483
 msgid "Calculate products"
-msgstr ""
+msgstr "Вычислить произведения"
 
 #: ../../src/wxMaxima.cpp:9562
 msgid "Calculate standard deviation"
-msgstr ""
+msgstr "Вычислить стандартное отклонение"
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate sums"
-msgstr ""
+msgstr "Вычислить суммы"
 
 #: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
 msgid "Calculate the eigenvalues and eigenvectors numerically"
-msgstr ""
+msgstr "Вычислить собственные значения и собственные векторы численно"
 
 #: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
 msgid "Calculate the eigenvalues of a matrix numerically"
-msgstr ""
+msgstr "Вычислить собственные значения матрицы численно"
 
 #: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
 msgid "Calculate the root of the sum of squares of matrix entries"
-msgstr ""
+msgstr "Вычислить корень из суммы квадратов элементов матрицы"
 
 #: ../../src/wxMaxima.cpp:9558
 msgid "Calculate variation"
-msgstr ""
+msgstr "Вычислить вариацию"
 
 #: ../../src/wxMaxima.cpp:8949
 msgid "Calculates the fourier coefficients for the expression from -p to p"
-msgstr ""
+msgstr "Вычисляет коэффициенты Фурье для выражения от -p до p"
 
 #: ../../src/Worksheet.cpp:1968
 msgid "Calls assume() in order to tell maxima about the variable's range"
-msgstr ""
+msgstr "Вызывает assume() для назначения диапазона переменной в Maxima"
 
 #: ../../src/Worksheet.cpp:2031
 msgid "Can be specified as flag in ev(exp, flag)"
-msgstr ""
+msgstr "Может быть указано как флаг в ev(выражение, флаг)"
 
 #: ../../src/wxMaxima.cpp:11125
 msgid "Can not connect to the web server."
-msgstr ""
+msgstr "Не удалось соединиться с веб-сервером."
 
 #: ../../src/wxMaxima.cpp:11166
 msgid "Can not download version info."
-msgstr ""
+msgstr "Не удалось загрузить сведения о версии."
 
 #: ../../src/wxMaxima.cpp:3016 ../../src/wxMaxima.cpp:4836
 msgid ""
@@ -990,149 +1048,154 @@ msgid ""
 " (it can be downloaded from https://maxima.sourceforge.io) or in wxMaxima's "
 "config dialogue the setting for Maxima's location is wrong."
 msgstr ""
+"Не удалось запустить Maxima. Наиболее вероятная причина: программа Maxima не"
+" установлена (её можно загрузить с веб-сайта https://maxima.sourceforge.io) "
+"или в диалоге настройки указано неверное расположение её исполняемого файла."
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Cancel"
-msgstr ""
+msgstr "Отменить"
 
 #: ../../src/wxMaxima.cpp:3292
 msgid "Cannot authenticate Maxima!"
-msgstr ""
+msgstr "Не удалось выполнить аутентификацию Maxima!"
 
 #: ../../src/wxMaxima.cpp:2677
 msgid ""
 "Cannot find a maxima binary and no binary chosen in the config dialogue."
 msgstr ""
+"Не удалось найти исполняемый файл Maxima, и он не указан в диалоге "
+"настройки."
 
 #: ../../src/Autocomplete.cpp:583
 #, c-format
 msgid "Cannot interpret template %s"
-msgstr ""
+msgstr "Не удалось интерпретировать шаблон %s"
 
 #: ../../src/wxMaxima.cpp:3082
 #, c-format
 msgid "Cannot interpret the numeric value of pid %s"
-msgstr ""
+msgstr "Не удалось интерпретировать числовое значение pid %s"
 
 #: ../../src/wxMaxima.cpp:11066 ../../src/wxMaxima.cpp:11073
 #: ../../src/wxMaxima.cpp:11080
 #, c-format
 msgid "Cannot interpret version number component %s"
-msgstr ""
+msgstr "Не удалось интерпретировать компонент номера версии %s"
 
 #: ../../src/wxMaxima.cpp:2530
 msgid "Cannot set the communication address to localhost."
-msgstr ""
+msgstr "Не удалось установить адрес связи в значение localhost."
 
 #: ../../src/wxMaxima.cpp:2532
 #, c-format
 msgid "Cannot set the communication port to %i."
-msgstr ""
+msgstr "Не удалось установить порт связи в значение %i."
 
 #: ../../src/wxMaxima.cpp:3656 ../../src/wxMaxima.cpp:6359
 msgid "Cannot start gnuplot"
-msgstr ""
+msgstr "Не удалось запустить Gnuplot"
 
 #: ../../src/StatusBar.cpp:216 ../../src/wxMaxima.cpp:2662
 msgid "Cannot start the maxima binary"
-msgstr ""
+msgstr "Не удалось запустить исполняемый файл Maxima"
 
 #: ../../src/wxMaxima.cpp:9268
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
-msgstr ""
+msgstr "Главное значение Коши f(x)/(x-c), конечный интервал"
 
 #: ../../src/wxMaximaFrame.cpp:1845
 msgid "Cauchy principal value, finite interval"
-msgstr ""
+msgstr "Главное значение Коши, конечный интервал"
 
 #: ../../src/wxMaximaFrame.cpp:955
 msgid "Ce&ll"
-msgstr ""
+msgstr "&Поле"
 
 #: ../../src/Configuration.cpp:96
 msgid "Cell bracket fill, Active"
-msgstr ""
+msgstr "Заполнение квадратных скобок полей, активно"
 
 #: ../../src/Configuration.cpp:95
 msgid "Cell bracket fill, Inactive"
-msgstr ""
+msgstr "Заполнение квадратных скобок полей, неактивно"
 
 #: ../../src/wxMaxima.cpp:10395
 msgid "Cell ends in a backslash"
-msgstr ""
+msgstr "Поле заканчивается обратной косой чертой"
 
 #: ../../src/wxMaximaFrame.cpp:1038
 msgid "Change &2d Display"
-msgstr ""
+msgstr "Изменить способ отображения"
 
 #: ../../src/wxMaxima.cpp:10146
 msgid "Change Image"
-msgstr ""
+msgstr "Сменить изображение"
 
 #: ../../src/Worksheet.cpp:1324
 msgid "Change Image..."
-msgstr ""
+msgstr "Сменить изображение..."
 
 #: ../../src/wxMaximaFrame.cpp:1954
 msgid "Change Log"
-msgstr ""
+msgstr "Журнал изменений"
 
 #: ../../src/wxMaxima.cpp:7555
 msgid "Change directory"
-msgstr ""
+msgstr "Сменить каталог"
 
 #: ../../src/wxMaximaFrame.cpp:1202
 msgid "Change directory..."
-msgstr ""
+msgstr "Сменить каталог..."
 
 #: ../../src/wxMaximaFrame.cpp:1039
 msgid "Change the 2d display algorithm used to display math output"
-msgstr ""
+msgstr "Изменить способ, применяемый для отображения математических выражений"
 
 #: ../../src/wxMaxima.cpp:8885
 msgid "Change variable"
-msgstr ""
+msgstr "Заменить переменную"
 
 #: ../../src/wxMaxima.cpp:8905
 msgid "Change variable and evaluate"
-msgstr ""
+msgstr "Заменить переменную и вычислить"
 
 #: ../../src/wxMaximaFrame.cpp:1459
 msgid "Change variable in integral or sum"
-msgstr ""
+msgstr "Заменить переменную в интеграле или сумме"
 
 #: ../../src/wxMaximaFrame.cpp:1463
 msgid "Change variable in integral or sum and evaluate the result"
-msgstr ""
+msgstr "Заменить переменную в интеграле или сумме и вычислить результат"
 
 #: ../../src/wxMaximaFrame.cpp:1026
 msgid "Changed option variables"
-msgstr ""
+msgstr "Заменённые переменные"
 
 #: ../../src/wxMaxima.cpp:10170
 #, c-format
 msgid "Changing image originally loaded from file %s to %s."
-msgstr ""
+msgstr "Смена изображения, изначально загруженного из файла, с %s на %s."
 
 #: ../../src/wxMaxima.cpp:7313 ../../src/wxMaxima.cpp:7318
 #: ../../src/wxMaxima.cpp:7323 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7334 ../../src/wxMaxima.cpp:7340
 msgid "Char #1:"
-msgstr ""
+msgstr "Символ 1:"
 
 #: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
 #: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
 msgid "Char #2:"
-msgstr ""
+msgstr "Символ 2:"
 
 #: ../../src/wxMaximaFrame.cpp:1140
 msgid "Char to Unicode code point..."
-msgstr ""
+msgstr "Символ в точку кода Юникода..."
 
 #: ../../src/wxMaxima.cpp:7358 ../../src/wxMaxima.cpp:7362
 msgid "Char to unicode code point"
-msgstr ""
+msgstr "Символ в точку кода Юникода"
 
 #: ../../src/wxMaxima.cpp:7285 ../../src/wxMaxima.cpp:7289
 #: ../../src/wxMaxima.cpp:7293 ../../src/wxMaxima.cpp:7297
@@ -1140,324 +1203,332 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7359 ../../src/wxMaxima.cpp:7363
 #: ../../src/wxMaxima.cpp:7435
 msgid "Char:"
-msgstr ""
+msgstr "Символ:"
 
 #: ../../src/wxMaximaFrame.cpp:1131
 msgid "Character Tests"
-msgstr ""
+msgstr "Проверки символа"
 
 #: ../../src/wxMaxima.cpp:8181
 msgid "Characteristic polynom"
-msgstr ""
+msgstr "Характеристический полином"
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Chars are strings that are one character long"
-msgstr ""
+msgstr "Символ — это строка длиной в один символ"
 
 #: ../../src/wxMaximaFrame.cpp:1957
 msgid "Check for Updates"
-msgstr ""
+msgstr "Проверка обновлений"
 
 #: ../../src/wxMaximaFrame.cpp:1958
 msgid "Check if a newer version of wxMaxima is available."
-msgstr ""
+msgstr "Проверка доступности новой версии wxMaxima/Maxima."
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Choose the parenthesis type for Matrices"
-msgstr ""
+msgstr "Выбор типа скобок для матриц"
 
 #: ../../src/wxMaxima.cpp:9530 ../../src/wxMaxima.cpp:9535
 msgid "Classes:"
-msgstr ""
+msgstr "Классы:"
 
 #: ../../src/wxMaximaFrame.cpp:1378
 msgid "Classic matrix operations"
-msgstr ""
+msgstr "Классические матричные операции"
 
 #: ../../src/wxMaximaFrame.cpp:998
 msgid "Clear all aliases"
-msgstr ""
+msgstr "Очистить все псевдонимы"
 
 #: ../../src/wxMaximaFrame.cpp:995
 msgid "Clear all arrays"
-msgstr ""
+msgstr "Очистить все массивы"
 
 #: ../../src/wxMaximaFrame.cpp:992
 msgid "Clear all dependencies"
-msgstr ""
+msgstr "Очистить все зависимости"
 
 #: ../../src/wxMaximaFrame.cpp:994
 msgid "Clear all functions"
-msgstr ""
+msgstr "Очистить все функции"
 
 #: ../../src/wxMaximaFrame.cpp:1001
 msgid "Clear all gradefs"
-msgstr ""
+msgstr "Очистить все gradefs"
 
 #: ../../src/wxMaximaFrame.cpp:1000
 msgid "Clear all labels"
-msgstr ""
+msgstr "Очистить все метки"
 
 #: ../../src/wxMaximaFrame.cpp:1004
 msgid "Clear all let rule packages"
-msgstr ""
+msgstr "Очистить все пакеты правил «let»"
 
 #: ../../src/wxMaximaFrame.cpp:1003
 msgid "Clear all macros"
-msgstr ""
+msgstr "Очистить все макросы"
 
 #: ../../src/wxMaximaFrame.cpp:1002
 msgid "Clear all props"
-msgstr ""
+msgstr "Очистить все свойства"
 
 #: ../../src/wxMaximaFrame.cpp:997
 msgid "Clear all rules"
-msgstr ""
+msgstr "Очистить все правила"
 
 #: ../../src/wxMaximaFrame.cpp:999
 msgid "Clear all structures"
-msgstr ""
+msgstr "Очистить все структуры"
 
 #: ../../src/wxMaximaFrame.cpp:993
 msgid "Clear all variables"
-msgstr ""
+msgstr "Очистить все переменные"
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close\tCtrl+W"
-msgstr ""
+msgstr "Закрыть\tCtrl+W"
 
 #: ../../src/wxMaxima.cpp:7235
 msgid "Close Stream"
-msgstr ""
+msgstr "Закрыть поток"
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close window"
-msgstr ""
+msgstr "Закрыть окно"
 
 #: ../../src/wxMaximaFrame.cpp:1105
 msgid "Close..."
-msgstr ""
+msgstr "Закрыть..."
 
 #: ../../src/WXMXformat.cpp:301
 msgid "Closed the zip archive"
-msgstr ""
+msgstr "Закрыт zip-архив"
 
 #: ../../src/Configuration.cpp:77
 msgid "Code Default (Maxima input)"
-msgstr ""
+msgstr "Код по умолчанию (ввод Maxima)"
 
 #: ../../src/Configuration.cpp:103
 msgid "Code highlighting: Comments"
-msgstr ""
+msgstr "Выделение кода: комментарии"
 
 #: ../../src/Configuration.cpp:108
 msgid "Code highlighting: End of line markers"
-msgstr ""
+msgstr "Выделение кода: обозначения конца строки"
 
 #: ../../src/Configuration.cpp:102
 msgid "Code highlighting: Functions"
-msgstr ""
+msgstr "Выделение кода: функции"
 
 #: ../../src/Configuration.cpp:107
 msgid "Code highlighting: Lisp"
-msgstr ""
+msgstr "Выделение кода: Lisp"
 
 #: ../../src/Configuration.cpp:104
 msgid "Code highlighting: Numbers"
-msgstr ""
+msgstr "Выделение кода: числа"
 
 #: ../../src/Configuration.cpp:106
 msgid "Code highlighting: Operators"
-msgstr ""
+msgstr "Выделение кода: операторы"
 
 #: ../../src/Configuration.cpp:105
 msgid "Code highlighting: Strings"
-msgstr ""
+msgstr "Выделение кода: строки"
 
 #: ../../src/Configuration.cpp:101
 msgid "Code highlighting: Variables"
-msgstr ""
+msgstr "Выделение кода: переменные"
 
 #: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
 msgid "Code number:"
-msgstr ""
+msgstr "Номер кода:"
 
 #: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
 msgid "Codepoint number:"
-msgstr ""
+msgstr "Номер кодовой точки:"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "Col. names:"
-msgstr ""
+msgstr "Названия столбцов:"
 
 #: ../../src/Configuration.cpp:100
 msgid "Color of Outdated cells"
-msgstr ""
+msgstr "Цвет устаревших полей"
 
 #: ../../src/Configuration.cpp:99
 msgid "Color of text equal to selection"
-msgstr ""
+msgstr "Цвет текста, который совпадает с выделением"
 
 #: ../../src/wxMaxima.cpp:7962
 msgid "Column number:"
-msgstr ""
+msgstr "Номер столбца:"
 
 #: ../../src/wxMaxima.cpp:7978
 msgid "Column numbers:"
-msgstr ""
+msgstr "Номера столбцов:"
 
 #: ../../src/wxMaxima.cpp:8202
 msgid "Columns"
-msgstr ""
+msgstr "Столбцы"
 
 #: ../../src/wxMaximaFrame.cpp:1584
 msgid "Combine factorials in an expression"
-msgstr ""
+msgstr "Объединить факториалы в выражении"
 
 #: ../../src/wxMaxima.cpp:10454
 msgid "Comma directly followed by a closing parenthesis"
-msgstr ""
+msgstr "Закрывающая скобка сразу после запятой"
 
 #: ../../src/wxMaxima.cpp:7259
 msgid "Comma-separated arguments"
-msgstr ""
+msgstr "Разделённые запятыми аргументы"
 
 #: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
 msgid "Comma-separated commands"
-msgstr ""
+msgstr "Разделённые запятыми команды"
 
 #: ../../src/wxMaxima.cpp:8458
 msgid "Comma-separated elements"
-msgstr ""
+msgstr "Элементы, разделённые запятыми"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 #: ../../src/wxMaxima.cpp:10031
 msgid "Comma-separated equations"
-msgstr ""
+msgstr "Уравнения, разделённые запятыми"
 
 #: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
 #: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
 #: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
 msgid "Comma-separated expressions"
-msgstr ""
+msgstr "Разделённые запятыми выражения"
 
 #: ../../src/wxMaxima.cpp:7215
 msgid "Comma-separated expressions that shall be converted to a string"
-msgstr ""
+msgstr "Разделённые запятыми выражения, которые будут преобразованы в строку"
 
 #: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
 msgid "Comma-separated expressions."
-msgstr ""
+msgstr "Разделённые запятыми выражения."
 
 #: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
 msgid "Comma-separated function names"
-msgstr ""
+msgstr "Разделённые запятыми имена функций"
 
 #: ../../src/wxMaxima.cpp:7086
 msgid "Comma-separated function names."
-msgstr ""
+msgstr "Разделённые запятыми имена функций."
 
 #: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
 #: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
 msgid "Comma-separated list entry in the format val1=1,val2=2"
-msgstr ""
+msgstr "Запись разделённого запятыми списка в формате значение1=1,значение2=2"
 
 #: ../../src/wxMaxima.cpp:7205
 msgid "Comma-separated names of the elements that shall be written"
-msgstr ""
+msgstr "Разделённые запятыми имена элементов, которые будут записаны"
 
 #: ../../src/wxMaxima.cpp:7099
 msgid "Comma-separated names the parameters will be referenced by later."
 msgstr ""
+"Разделённые запятыми имена, которые будут использоваться для параметров в "
+"дальнейшем."
 
 #: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
 msgid "Comma-separated numbers from 0 to 255"
-msgstr ""
+msgstr "Разделённые запятыми числа от 0 до 255"
 
 #: ../../src/wxMaxima.cpp:8770
 msgid "Comma-separated numbers of the terms to substitute in"
 msgstr ""
+"Разделённые запятыми номера условий, в которые следует выполнить подстановку"
 
 #: ../../src/wxMaxima.cpp:7137 ../../src/wxMaxima.cpp:7150
 msgid ""
 "Comma-separated parameter names. A parameter in square brackets [] will be "
 "filled with the list of any additional arguments the function gets."
 msgstr ""
+"Разделённые запятыми имена параметров. Параметр в квадратных скобках [] "
+"будет заполнен списком всех дополнительных аргументов, которые получит "
+"функция."
 
 #: ../../src/wxMaxima.cpp:7054
 msgid "Comma-separated variable names, can be initialized by the \":\" operator."
 msgstr ""
+"Разделённые запятыми имена переменных, можно инициализировать оператором "
+"\":\"."
 
 #: ../../src/wxMaxima.cpp:7753 ../../src/wxMaxima.cpp:7767
 #: ../../src/wxMaxima.cpp:8719 ../../src/wxMaxima.cpp:8785
 #: ../../src/wxMaxima.cpp:10032
 msgid "Comma-separated variables"
-msgstr ""
+msgstr "Переменные, разделённые запятыми"
 
 #: ../../src/wxMaxima.cpp:9469
 msgid "Command:"
-msgstr ""
+msgstr "Команда:"
 
 #: ../../src/Worksheet.cpp:1692
 msgid "Comment Selection"
-msgstr ""
+msgstr "Комментировать выделение"
 
 #: ../../src/wxMaximaFrame.cpp:681
 msgid "Comment out the currently selected text"
-msgstr ""
+msgstr "Закомментировать текущий выделенный текст"
 
 #: ../../src/wxMaximaFrame.cpp:680
 msgid "Comment selection\tCtrl+/"
-msgstr ""
+msgstr "Комментировать выделение\tCtrl+/"
 
 #: ../../src/Worksheet.cpp:2004
 msgid "Commutative function"
-msgstr ""
+msgstr "Коммутативная функция"
 
 #: ../../src/wxMaximaFrame.cpp:1396
 msgid "Compile a QR decomposition using dgeqrf"
-msgstr ""
+msgstr "Собрать QR-разложение с помощью dgeqrf"
 
 #: ../../src/wxMaxima.cpp:7162
 msgid "Compile a function"
-msgstr ""
+msgstr "Скомпилировать функцию"
 
 #: ../../src/wxMaximaFrame.cpp:1188
 msgid "Compile a regular expression"
-msgstr ""
+msgstr "Скомпилировать регулярное выражение"
 
 #: ../../src/wxMaximaFrame.cpp:1385
 msgid "Compile eigenvalues using dgeev"
-msgstr ""
+msgstr "Собрать собственные значения с помощью dgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1388
 msgid "Compile eigenvalues using zgeev"
-msgstr ""
+msgstr "Собрать собственные значения с помощью zgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1391
 msgid "Compile eigenvalues+eigenvectors using dgeev"
-msgstr ""
+msgstr "Собрать собственные значения+собственные векторы с помощью dgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1394
 msgid "Compile eigenvalues+eigenvectors using zgeev"
-msgstr ""
+msgstr "Собрать собственные значения+собственные векторы с помощью zgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1076
 msgid "Compile function..."
-msgstr ""
+msgstr "Скомпилировать функцию..."
 
 #: ../../src/wxMaxima.cpp:7511
 msgid "Compile regex"
-msgstr ""
+msgstr "Скомпилировать регулярное выражение"
 
 #: ../../src/wxMathml.cpp:53
 msgid "Compiler-Bug? wxMathml.lisp is shorter than expected!"
-msgstr ""
+msgstr "Ошибка компилятора? Длина wxMathml.lisp короче ожидаемой!"
 
 #: ../../src/wxMaxima.cpp:2234
 #, c-format
 msgid "Compiling %s"
-msgstr ""
+msgstr "Компиляция %s"
 
 #: ../../src/wxMaxima.cpp:7163
 msgid ""
@@ -1465,440 +1536,462 @@ msgid ""
 " the function parameters are made known to the function before it is "
 "compiled. Else the generated code has to be hideously generic."
 msgstr ""
+"Компиляцию функции можно значительно ускорить, если сообщить функции типы "
+"функциональных параметров до компиляции. В ином случае сгенерированный код "
+"будет крайне базовым."
 
 #: ../../src/wxMaximaFrame.cpp:892
 msgid "Complete Word\tCtrl+Space"
-msgstr ""
+msgstr "Завершить слово\tCtrl+Пробел"
 
 #: ../../src/wxMaximaFrame.cpp:893
 msgid "Complete word"
-msgstr ""
+msgstr "Завершить слово"
 
 #: ../../src/ToolBar.cpp:230
 msgid "Completely stop maxima and restart it"
-msgstr ""
+msgstr "Полностью завершить работу программы Maxima и перезапустить её"
 
 #: ../../src/wxMaximaFrame.cpp:1503
 msgid "Compute continued fraction of a value"
-msgstr ""
+msgstr "Вычислить цепную дробь"
 
 #: ../../src/wxMaximaFrame.cpp:1372
 msgid "Compute the adjoint matrix"
-msgstr ""
+msgstr "Вычислить сопряжённую матрицу"
 
 #: ../../src/wxMaximaFrame.cpp:1359
 msgid "Compute the characteristic polynomial of a matrix"
-msgstr ""
+msgstr "Вычислить характеристический полином матрицы"
 
 #: ../../src/wxMaximaFrame.cpp:1363
 msgid "Compute the determinant of a matrix"
-msgstr ""
+msgstr "Вычислить определитель матрицы"
 
 #: ../../src/wxMaximaFrame.cpp:1491
 msgid "Compute the greatest common divisor"
-msgstr ""
+msgstr "Вычислить наибольший общий делитель"
 
 #: ../../src/wxMaximaFrame.cpp:1356
 msgid "Compute the inverse of a matrix"
-msgstr ""
+msgstr "Вычислить обратную матрицу"
 
 #: ../../src/wxMaximaFrame.cpp:1494
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
+"Вычислить наименьшее общее кратное (выполните load(functs) перед "
+"использованием)"
 
 #: ../../src/wxMaximaFrame.cpp:1374
 msgid "Compute the rank of a matrix"
-msgstr ""
+msgstr "Вычислить ранг матрицы"
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Condition:"
-msgstr ""
+msgstr "Условие:"
 
 #: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "Configure wxMaxima"
-msgstr ""
+msgstr "Настроить wxMaxima"
 
 #: ../../src/wxMaxima.cpp:2504
 msgid "Connection attempt, but connection failed."
-msgstr ""
+msgstr "Сбой попытки соединения."
 
 #: ../../src/wxMaxima.cpp:2459
 msgid "Connection to Maxima lost."
-msgstr ""
+msgstr "Соединение с Maxima потеряно."
 
 #: ../../src/wxMaxima.cpp:7921
 msgid "Construct a fraction"
-msgstr ""
+msgstr "Построить дробь"
 
 #: ../../src/wxMaximaFrame.cpp:1305
 msgid "Construct fraction..."
-msgstr ""
+msgstr "Построить дробь..."
 
 #: ../../src/wxMaxima.cpp:7158
 msgid "Contents:"
-msgstr ""
+msgstr "Содержимое:"
 
 #: ../../src/wxMaximaFrame.cpp:1877
 msgid "Context-sensitive &Help\tCtrl+?"
-msgstr ""
+msgstr "Контекстная &справка\tCtrl+?"
 
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Context-sensitive &Help\tF1"
-msgstr ""
+msgstr "Контекстная &справка\tF1"
 
 #: ../../src/wxMaximaFrame.cpp:1542
 msgid "Contract Logarithms"
-msgstr ""
+msgstr "Объединить логарифмы"
 
 #: ../../src/wxMaximaFrame.cpp:1161
 msgid "Conversions"
-msgstr ""
+msgstr "Преобразования"
 
 #: ../../src/wxMaximaFrame.cpp:1229
 msgid "Convert"
-msgstr ""
+msgstr "Преобразовать"
 
 #: ../../src/wxMaximaFrame.cpp:1230
 msgid "Convert + Write to file"
-msgstr ""
+msgstr "Преобразовать + записать в файл"
 
 #: ../../src/wxMaximaFrame.cpp:1434
 msgid "Convert Column to list..."
-msgstr ""
+msgstr "Преобразовать столбец в список..."
 
 #: ../../src/wxMaximaFrame.cpp:1430
 msgid "Convert Row to list..."
-msgstr ""
+msgstr "Преобразовать строку в список..."
 
 #: ../../src/wxMaximaFrame.cpp:1044
 msgid "Convert a command to maxima code"
-msgstr ""
+msgstr "Преобразовать команду в код Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1321
 msgid "Convert a list of lists to a matrix"
-msgstr ""
+msgstr "Преобразовать список списков в матрицу"
 
 #: ../../src/wxMaximaFrame.cpp:1574
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr ""
+"Преобразовать биномиальные коэффициенты, бета- и гамма-функции в факториалы"
 
 #: ../../src/wxMaximaFrame.cpp:1578
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
+"Преобразовать биномиальные коэффициенты, факториалы и бета-функции в гамма-"
+"функции"
 
 #: ../../src/wxMaximaFrame.cpp:1613
 msgid "Convert complex expression to polar form"
-msgstr ""
+msgstr "Преобразовать комплексное выражение в полярную форму"
 
 #: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert complex expression to rect form"
-msgstr ""
+msgstr "Преобразовать комплексное выражение в стандартную форму"
 
 #: ../../src/wxMaximaFrame.cpp:1622
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
+"Преобразовать экспоненциальную функцию мнимого аргумента в "
+"тригонометрическую форму"
 
 #: ../../src/wxMaxima.cpp:7411
 msgid "Convert string to lowercase"
-msgstr ""
+msgstr "Преобразовать строку в нижний регистр"
 
 #: ../../src/wxMaxima.cpp:7543
 msgid "Convert string to matching regex"
-msgstr ""
+msgstr "Преобразовать строку в соответствующее регулярное выражение"
 
 #: ../../src/wxMaximaFrame.cpp:1543
 msgid "Convert sum of logarithms to logarithm of product"
-msgstr ""
+msgstr "Преобразовать сумму логарифмов в логарифм произведения"
 
 #: ../../src/wxMaximaFrame.cpp:1573
 msgid "Convert to &Factorials"
-msgstr ""
+msgstr "Преобразовать в &факториалы"
 
 #: ../../src/wxMaximaFrame.cpp:1577
 msgid "Convert to &Gamma"
-msgstr ""
+msgstr "Преобразовать в &гамма-функцию"
 
 #: ../../src/wxMaximaFrame.cpp:1612
 msgid "Convert to &Polarform"
-msgstr ""
+msgstr "Преобразовать в &полярную форму"
 
 #: ../../src/wxMaximaFrame.cpp:1609
 msgid "Convert to &Rectform"
-msgstr ""
+msgstr "Преобразовать в &стандартную форму"
 
 #: ../../src/wxMaximaFrame.cpp:1166
 msgid "Convert to downcase..."
-msgstr ""
+msgstr "Преобразовать в нижний регистр..."
 
 #: ../../src/wxMaxima.cpp:7016
 msgid "Convert to programming language"
-msgstr ""
+msgstr "Преобразовать в язык программирования"
 
 #: ../../src/wxMaxima.cpp:7022
 msgid "Convert to programming language file"
-msgstr ""
+msgstr "Преобразовать в файл языка программирования"
 
 #: ../../src/wxMaximaFrame.cpp:1602
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr ""
+"Преобразовать тригонометрическое выражение в каноническую квазилинейную "
+"форму"
 
 #: ../../src/wxMaximaFrame.cpp:1627
 msgid "Convert trigonometric functions to exponential form"
-msgstr ""
+msgstr "Преобразовать тригонометрические функции в экспоненциальную форму"
 
 #: ../../src/wxMaximaFrame.cpp:1762
 msgid "Converts a matrix to a list of lists"
-msgstr ""
+msgstr "Преобразует матрицу в список списков"
 
 #: ../../src/wxMaximaFrame.cpp:1760
 msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
-msgstr ""
+msgstr "Преобразует вложенный список вида [[1,2],[3,4]] в матрицу"
 
 #: ../../src/ToolBar.cpp:209 ../../src/Worksheet.cpp:1290
 #: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
 #: ../../src/Worksheet.cpp:1684
 msgid "Copy"
-msgstr ""
+msgstr "Копировать"
 
 #: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
 #: ../../src/Worksheet.cpp:1514
 msgid "Copy Animation"
-msgstr ""
+msgstr "Копировать анимацию"
 
 #: ../../src/wxMaximaFrame.cpp:887
 msgid "Copy Previous Input\tCtrl+I"
-msgstr ""
+msgstr "Копировать предыдущий ввод\tCtrl+I"
 
 #: ../../src/wxMaximaFrame.cpp:890
 msgid "Copy Previous Output\tCtrl+U"
-msgstr ""
+msgstr "Копировать предыдущий вывод\tCtrl+U"
 
 #: ../../src/wxMaxima.cpp:7992
 msgid "Copy a matrix"
-msgstr ""
+msgstr "Копировать матрицу"
 
 #: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
 #: ../../src/wxMaximaFrame.cpp:663
 msgid "Copy as EMF"
-msgstr ""
+msgstr "Копировать как EMF"
 
 #: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Copy as Image"
-msgstr ""
+msgstr "Копировать как изображение"
 
 #: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
 #: ../../src/wxMaximaFrame.cpp:645
 msgid "Copy as LaTeX"
-msgstr ""
+msgstr "Копировать как LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:648
 msgid "Copy as MathML"
-msgstr ""
+msgstr "Копировать как MathML"
 
 #: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
 msgid "Copy as MathML (e.g. to word processor)"
-msgstr ""
+msgstr "Копировать как MathML (например, в текстовый процессор)"
 
 #: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
 #: ../../src/wxMaximaFrame.cpp:658
 msgid "Copy as RTF"
-msgstr ""
+msgstr "Копировать как RTF"
 
 #: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "Copy as SVG"
-msgstr ""
+msgstr "Копировать как SVG"
 
 #: ../../src/wxMaximaFrame.cpp:640
 msgid "Copy as Text\tCtrl+Shift+C"
-msgstr ""
+msgstr "Копировать как текст\tCtrl+Shift+C"
 
 #: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
 msgid "Copy as plain text"
-msgstr ""
+msgstr "Копировать как простой текст"
 
 #: ../../src/wxMaxima.cpp:7576
 msgid "Copy file"
-msgstr ""
+msgstr "Копировать файл"
 
 #: ../../src/wxMaximaFrame.cpp:1214
 msgid "Copy file..."
-msgstr ""
+msgstr "Копировать файл..."
 
 #: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
 #: ../../src/wxMaximaFrame.cpp:643
 msgid "Copy for Octave/Matlab"
-msgstr ""
+msgstr "Копировать для Octave/Matlab"
 
 #: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
 msgid "Copy selection"
-msgstr ""
+msgstr "Копировать выделение"
 
 #: ../../src/wxMaximaFrame.cpp:664
 msgid "Copy selection from document as an Enhanced Metafile"
-msgstr ""
+msgstr "Копировать выделение в документе как расширенный метафайл"
 
 #: ../../src/wxMaximaFrame.cpp:656
 msgid "Copy selection from document as an SVG image"
-msgstr ""
+msgstr "Копировать выделение в документе как изображение SVG"
 
 #: ../../src/wxMaximaFrame.cpp:653
 msgid "Copy selection from document as an image"
-msgstr ""
+msgstr "Копировать выделение в документе как изображение"
 
 #: ../../src/wxMaximaFrame.cpp:659
 msgid ""
 "Copy selection from document as rtf that a word processor might understand"
 msgstr ""
+"Копировать выделение в документе как RTF, который распознаётся текстовым "
+"процессором"
 
 #: ../../src/wxMaximaFrame.cpp:641
 msgid "Copy selection from document as text"
-msgstr ""
+msgstr "Копировать выделение в документе как текст"
 
 #: ../../src/wxMaximaFrame.cpp:646
 msgid "Copy selection from document in LaTeX format"
-msgstr ""
+msgstr "Копировать выделение в документе в формате LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:644
 msgid "Copy selection from document in Matlab format"
-msgstr ""
+msgstr "Копировать выделение в документе в формате Matlab"
 
 #: ../../src/wxMaximaFrame.cpp:649
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
+"Копировать выделение в документе в формате MathML, который многие текстовые "
+"процессоры могут отображать как двухмерное уравнение"
 
 #: ../../src/wxMaxima.cpp:7403
 msgid "Copy string"
-msgstr ""
+msgstr "Копировать строку"
 
 #: ../../src/wxMaximaFrame.cpp:1165
 msgid "Copy string..."
-msgstr ""
+msgstr "Копировать строку..."
 
 #: ../../src/ToolBar.cpp:623
 msgid "Copy, Cut and Paste button"
-msgstr ""
+msgstr "Кнопки «Копировать», «Вырезать» и «Вставить»"
 
 #: ../../src/WXMXformat.cpp:295
 msgid "Could not create the backup file during saving => aborting."
 msgstr ""
+"Не удалось создать файл резервной копии во время сохранения => прерывание."
 
 #: ../../src/wxMaxima.cpp:3294 ../../src/wxMaxima.cpp:3306
 msgid ""
 "Could not make sure that we talk to the maxima we started => discarding all "
 "data it sends."
 msgstr ""
+"Не удалось обратиться к запущенной Maxima => все отправленные ей данные "
+"отбрасываются."
 
 #: ../../src/wxMaxima.cpp:2783
 msgid ""
 "Could not map view of the file needed in order to send an interrupt signal "
 "to maxima."
 msgstr ""
+"Не удалось отобразить представление файла, необходимого для отправки сигнала"
+" прерывания в Maxima."
 
 #: ../../src/wxMaxima.cpp:2763 ../../src/wxMaxima.cpp:2805
 msgid "Could not send an interrupt signal to maxima."
-msgstr ""
+msgstr "Не удалось отправить сигнал прерывания в Maxima."
 
 #: ../../src/WXMXformat.cpp:287
 msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
+"Не удалось записать содержимое файла во время сохранения => прерывание."
 
 #: ../../src/wxMaximaFrame.cpp:1325
 msgid "Create Matrix"
-msgstr ""
+msgstr "Создать матрицу"
 
 #: ../../src/wxMaximaFrame.cpp:1688
 msgid "Create a list"
-msgstr ""
+msgstr "Создать список"
 
 #: ../../src/wxMaxima.cpp:8487
 msgid "Create a list as a storage for the values of variables"
-msgstr ""
+msgstr "Создать список для хранения значений переменных"
 
 #: ../../src/wxMaxima.cpp:8463 ../../src/wxMaxima.cpp:8476
 msgid "Create a list from a rule"
-msgstr ""
+msgstr "Создать список на основе правила"
 
 #: ../../src/wxMaximaFrame.cpp:1670
 msgid "Create a list from comma-separated elements"
-msgstr ""
+msgstr "Создать список на основе элементов, разделённых запятыми"
 
 #: ../../src/wxMaximaFrame.cpp:888
 msgid "Create a new cell with previous input"
-msgstr ""
+msgstr "Создать новое поле с предыдущим вводом"
 
 #: ../../src/wxMaximaFrame.cpp:891
 msgid "Create a new cell with previous output"
-msgstr ""
+msgstr "Создать новое поле с предыдущим выводом"
 
 #: ../../src/wxMaximaFrame.cpp:1348
 msgid "Create copy, not clone..."
-msgstr ""
+msgstr "Создать копию, а не клон..."
 
 #: ../../src/wxMaxima.cpp:7561
 msgid "Create directory"
-msgstr ""
+msgstr "Создать каталог"
 
 #: ../../src/wxMaximaFrame.cpp:1203
 msgid "Create directory..."
-msgstr ""
+msgstr "Создать каталог..."
 
 #: ../../src/wxMaxima.cpp:7419
 msgid "Create empty string"
-msgstr ""
+msgstr "Создать пустую строку"
 
 #: ../../src/wxMaximaFrame.cpp:1168
 msgid "Create empty string..."
-msgstr ""
+msgstr "Создать пустую строку..."
 
 #: ../../src/wxMaximaFrame.cpp:1687
 msgid "Create list"
-msgstr ""
+msgstr "Создать список"
 
 #: ../../src/wxMaxima.cpp:8457
 msgid "Create list from comma-separated elements"
-msgstr ""
+msgstr "Создать список на основе элементов, разделённых запятыми"
 
 #: ../../src/wxMaximaFrame.cpp:1082
 msgid "Create struct..."
-msgstr ""
+msgstr "Создать структуру..."
 
 #: ../../src/WXMXformat.cpp:80
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
-msgstr ""
+msgstr "Создан zip-архив (wxmx-файл технически является zip-файлом)"
 
 #: ../../src/wxMaximaFrame.cpp:1349
 msgid "Creates an independent matrix with the same contents"
-msgstr ""
+msgstr "Создаёт независимую матрицу с тем же содержимым"
 
 #: ../../src/Configuration.cpp:97
 msgid "Cursor color"
-msgstr ""
+msgstr "Цвет курсора"
 
 #: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
 msgid "Cut"
-msgstr ""
+msgstr "Вырезать"
 
 #: ../../src/wxMaximaFrame.cpp:636
 msgid "Cut\tCtrl+X"
-msgstr ""
+msgstr "Вырезать\tCtrl+X"
 
 #: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
 msgid "Cut selection"
-msgstr ""
+msgstr "Вырезать выделение"
 
 #: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
 msgid "Data Matrix:"
-msgstr ""
+msgstr "Матрица данных:"
 
 #: ../../src/wxMaxima.cpp:9599
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
-msgstr ""
+msgstr "Файл данных (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wxMaxima.cpp:9529 ../../src/wxMaxima.cpp:9534
 #: ../../src/wxMaxima.cpp:9539 ../../src/wxMaxima.cpp:9543
@@ -1907,402 +2000,409 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9563 ../../src/wxMaxima.cpp:9577
 #: ../../src/wxMaxima.cpp:9582 ../../src/wxMaxima.cpp:10030
 msgid "Data:"
-msgstr ""
+msgstr "Данные:"
 
 #: ../../src/wxMaximaFrame.cpp:1057
 msgid "Debugger trigger"
-msgstr ""
+msgstr "Срабатывание средства отладки"
 
 #: ../../src/wxMaximaFrame.cpp:779
 msgid "Declare Text to always be displayed as subscript"
-msgstr ""
+msgstr "Всегда показывать текст в нижнем индексе"
 
 #: ../../src/wxMaxima.cpp:7069
 msgid "Declare a function local to a Program"
-msgstr ""
+msgstr "Объявить функцию локальной для программы"
 
 #: ../../src/wxMaxima.cpp:6539
 msgid "Declare a text snippet to always be displayed as subscript"
-msgstr ""
+msgstr "Всегда показывать фрагмент текста как нижний индекс"
 
 #: ../../src/Worksheet.cpp:2044
 #, c-format
 msgid "Declare facts about %s"
-msgstr ""
+msgstr "Объявить свойства %s"
 
 #: ../../src/wxMaxima.cpp:8800
 msgid "Declare main variable:"
-msgstr ""
+msgstr "Объявить основную переменную:"
 
 #: ../../src/wxMaxima.cpp:7171
 msgid "Declare the type of a function parameter"
-msgstr ""
+msgstr "Объявить тип функционального параметра"
 
 #: ../../src/Worksheet.cpp:2038
 msgid "Declare these chars as ordinary letters"
-msgstr ""
+msgstr "Объявить эти символы обычными буквами"
 
 #: ../../src/wxMaximaFrame.cpp:1500 ../../src/wxMaximaFrame.cpp:1536
 msgid "Decompose rational function to partial fractions"
-msgstr ""
+msgstr "Разложить рациональную функцию на простые дроби"
 
 #: ../../src/Worksheet.cpp:2010
 msgid "Decreasing function f(x)<x"
-msgstr ""
+msgstr "Убывающая функция f(x)<x"
 
 #: ../../src/wxMaxima.cpp:7134
 msgid "Define a function"
-msgstr ""
+msgstr "Определить функцию"
 
 #: ../../src/wxMaxima.cpp:7147
 msgid "Define a macro"
-msgstr ""
+msgstr "Определить макрос"
 
 #: ../../src/wxMaxima.cpp:7189
 msgid "Define a structure"
-msgstr ""
+msgstr "Определить структуру"
 
 #: ../../src/wxMaxima.cpp:7183
 msgid "Define a structure type"
-msgstr ""
+msgstr "Определить тип структуры"
 
 #: ../../src/wxMaxima.cpp:7156
 msgid "Define a variable"
-msgstr ""
+msgstr "Определить переменную"
 
 #: ../../src/wxMaximaFrame.cpp:1072
 msgid "Define function..."
-msgstr ""
+msgstr "Определить функцию..."
 
 #: ../../src/wxMaximaFrame.cpp:1079
 msgid "Define macro..."
-msgstr ""
+msgstr "Определить макрос..."
 
 #: ../../src/wxMaximaFrame.cpp:1077
 msgid "Define parameter type..."
-msgstr ""
+msgstr "Определить параметрический тип..."
 
 #: ../../src/wxMaximaFrame.cpp:1081
 msgid "Define struct..."
-msgstr ""
+msgstr "Определить структуру..."
 
 #: ../../src/wxMaximaFrame.cpp:1080
 msgid "Define variable..."
-msgstr ""
+msgstr "Определить переменную..."
 
 #: ../../src/wxMaximaFrame.cpp:1776
 msgid ""
 "Defines if an animation is automatically started or only by clicking on it."
 msgstr ""
+"Определяет, запускается ли анимация автоматически или только по щелчку."
 
 #: ../../src/wxMaxima.cpp:8935
 msgid "Degree:"
-msgstr ""
+msgstr "Порядок:"
 
 #: ../../src/wxMaximaFrame.cpp:985
 msgid "Delete F&unction..."
-msgstr ""
+msgstr "Удалить ф&ункцию..."
 
 #: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
 msgid "Delete Selection"
-msgstr ""
+msgstr "Удалить выделение"
 
 #: ../../src/wxMaximaFrame.cpp:987
 msgid "Delete V&ariable..."
-msgstr ""
+msgstr "Удалить п&еременную..."
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Delete a function"
-msgstr ""
+msgstr "Удалить функцию"
 
 #: ../../src/wxMaximaFrame.cpp:988
 msgid "Delete a variable"
-msgstr ""
+msgstr "Удалить переменную"
 
 #: ../../src/wxMaximaFrame.cpp:982
 msgid "Delete all objects with a given name"
-msgstr ""
+msgstr "Удалить все объекты с указанным именем"
 
 #: ../../src/wxMaximaFrame.cpp:991
 msgid "Delete all values from memory"
-msgstr ""
+msgstr "Удалить все значения из памяти"
 
 #: ../../src/wxMaxima.cpp:7588
 msgid "Delete file"
-msgstr ""
+msgstr "Удалить файл"
 
 #: ../../src/wxMaximaFrame.cpp:1216
 msgid "Delete file..."
-msgstr ""
+msgstr "Удалить файл..."
 
 #: ../../src/wxMaxima.cpp:7683
 msgid "Delete function(s)"
-msgstr ""
+msgstr "Удалить функцию(и)"
 
 #: ../../src/wxMaxima.cpp:7679
 msgid "Delete named object(s)"
-msgstr ""
+msgstr "Удалить именованный(ые) объект(ы):"
 
 #: ../../src/wxMaximaFrame.cpp:981
 msgid "Delete named object..."
-msgstr ""
+msgstr "Удалить именованный объект..."
 
 #: ../../src/wxMaxima.cpp:7674
 msgid "Delete variable(s)"
-msgstr ""
+msgstr "Удалить переменную(ые)"
 
 #: ../../src/wxMaxima.cpp:7430
 msgid "Delimiter:"
-msgstr ""
+msgstr "Разделитель:"
 
 #: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
 #, c-format
 msgid "Demo for \"%s\""
-msgstr ""
+msgstr "Демо для «%s»"
 
 #: ../../src/wxMaximaFrame.cpp:1930
 msgid "Demos"
-msgstr ""
+msgstr "Демо"
 
 #: ../../src/wxMaxima.cpp:8927
 msgid "Denom. deg:"
-msgstr ""
+msgstr "Степень знаменателя:"
 
 #: ../../src/wxMaxima.cpp:7923
 msgid "Denominator:"
-msgstr ""
+msgstr "Знаменатель:"
 
 #: ../../src/wxMaximaFrame.cpp:1030
 msgid "Dependencies"
-msgstr ""
+msgstr "Зависимости"
 
 #: ../../src/wxMaxima.cpp:7813
 msgid "Derivate of y at that point:"
-msgstr ""
+msgstr "Производная y в этой точке:"
 
 #: ../../src/wxMaximaFrame.cpp:1497
 msgid "Di&vide Polynomials..."
-msgstr ""
+msgstr "Де&лить полиномы..."
 
 #: ../../src/MaximaManual.cpp:517
 msgid "Didn't find the maxima HTML manual."
-msgstr ""
+msgstr "Руководство пользователя Maxima в формате HTML не найдено."
 
 #: ../../src/wxMaxima.cpp:4907
 msgid ""
 "Didn't get a help browser launch program command line, but can request the "
 "system's default help browser."
 msgstr ""
+"Командная строка программы запуска браузера справки не получена, но можно "
+"запросить системный браузер справки по умолчанию."
 
 #: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
 msgid "Differentiate"
-msgstr ""
+msgstr "Дифференцировать"
 
 #: ../../src/wxMaximaFrame.cpp:1467
 msgid "Differentiate expression"
-msgstr ""
+msgstr "Дифференцировать выражение"
 
 #: ../../src/Worksheet.cpp:1590
 msgid "Differentiate..."
-msgstr ""
+msgstr "Дифференцировать..."
 
 #: ../../src/wxMaxima.cpp:9010
 msgid "Differentiates an expression n times"
-msgstr ""
+msgstr "Дифференцирует выражение n раз"
 
 #: ../../src/wxMaxima.cpp:10055
 msgid "Differentiates the expression n times"
-msgstr ""
+msgstr "Дифференцирует выражение n раз"
 
 #: ../../src/wxMaximaFrame.cpp:1212
 msgid "Directory operations"
-msgstr ""
+msgstr "Операции с каталогом"
 
 #: ../../src/wxMaximaFrame.cpp:1041
 msgid "Display Te&X Form"
-msgstr ""
+msgstr "Вывести в форма&те TeX"
 
 #: ../../src/wxMaxima.cpp:6972
 msgid "Display algorithm"
-msgstr ""
+msgstr "Способ вывода"
 
 #: ../../src/wxMaximaFrame.cpp:751
 msgid "Display an expression as maxima's internal lisp representation"
-msgstr ""
+msgstr "Показать выражение как внутреннее Lisp-представление Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:754
 msgid "Display an expression as wxMaxima's internal XML representation"
-msgstr ""
+msgstr "Показать выражение как внутреннее XML-представление wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:758
 msgid "Display equations"
-msgstr ""
+msgstr "Отображать уравнения"
 
 #: ../../src/wxMaxima.cpp:6508
 msgid "Display expression in maxima's internal representation"
-msgstr ""
+msgstr "Показать выражение во внутреннем представлении Maxima"
 
 #: ../../src/wxMaxima.cpp:6514
 msgid "Display expression in wxMaxima's internal representation"
-msgstr ""
+msgstr "Показать выражение во внутреннем представлении wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1042
 msgid "Display last result in TeX form"
-msgstr ""
+msgstr "Показать последний результат в формате TeX"
 
 #: ../../src/ToolBar.cpp:360
 #, c-format
 msgid "Display resolution according to wxWidgets: %li x %li ppi"
-msgstr ""
+msgstr "Разрешение экрана по данным wxWidgets: %li x %li пикс. на дюйм"
 
 #: ../../src/wxMaximaFrame.cpp:802
 msgid "Display string quotation marks"
-msgstr ""
+msgstr "Отображать кавычки строк"
 
 #: ../../src/wxMaximaFrame.cpp:1036
 msgid "Display time used for evaluation"
-msgstr ""
+msgstr "Отображать время, затраченное на вычисление"
 
 #: ../../src/wxMaxima.cpp:9206
 msgid "Displayed Precision"
-msgstr ""
+msgstr "Отображаемая точность"
 
 #: ../../src/wxMaximaFrame.cpp:1913
 msgid "Displaying 3d curves"
-msgstr ""
+msgstr "Отображение трёхмерных кривых"
 
 #: ../../src/wxMaximaFrame.cpp:1462
 msgid "Dito, and evaluate the result..."
-msgstr ""
+msgstr "То же, и вычислить результат..."
 
 #: ../../src/wxMaximaFrame.cpp:1445
 msgid "Dito, but affect all clones of the Matrix..."
-msgstr ""
+msgstr "То же, но влияет на все клоны матрицы..."
 
 #: ../../src/wxMaximaFrame.cpp:1255
 msgid "Dito, but as fraction (real only)..."
-msgstr ""
+msgstr "То же, но как дробь (только вещественное)..."
 
 #: ../../src/wxMaximaFrame.cpp:1532
 msgid "Dito, including denominator"
-msgstr ""
+msgstr "То же, включая знаменатель"
 
 #: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
 msgid "Divide Cell"
-msgstr ""
+msgstr "Разделить поле"
 
 #: ../../src/wxMaximaFrame.cpp:1498
 msgid "Divide numbers or polynomials"
-msgstr ""
+msgstr "Делить числа или полиномы"
 
 #: ../../src/wxMaxima.cpp:8578
 msgid "Do for each list element"
-msgstr ""
+msgstr "Выполнить для каждого элемента списка"
 
 #: ../../src/wxMaxima.cpp:11197
 #, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
-msgstr ""
+msgstr "Сохранить изменения в документе «%s»?"
 
 #: ../../src/wxMaximaFrame.cpp:724
 msgid "Dock all Sidebars"
-msgstr ""
+msgstr "Закрепить все боковые панели"
 
 #: ../../src/Configuration.cpp:94
 msgid "Document background"
-msgstr ""
+msgstr "Фон документа"
 
 #: ../../src/wxMaxima.cpp:4611
 msgid ""
 "Document was saved using a newer version of wxMaxima so it may not load "
 "correctly. Please update your wxMaxima."
 msgstr ""
+"Документ был сохранён в более новой версии wxMaxima, поэтому он может "
+"загружаться некорректно. Обновите свою версию wxMaxima."
 
 #: ../../src/wxMaxima.cpp:4603
 msgid ""
 "Document was saved using a newer version of wxMaxima. Please update your "
 "wxMaxima."
 msgstr ""
+"Документ был сохранён в более новой версии wxMaxima. Обновите свою версию "
+"wxMaxima."
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "Don't autosubscript after an underscore"
-msgstr ""
+msgstr "Не выполнять автоперевод в нижний индекс после подчёркивания"
 
 #: ../../src/wxMaximaFrame.cpp:1086
 msgid "Don't evaluate Expression..."
-msgstr ""
+msgstr "Не вычислять выражение..."
 
 #: ../../src/wxMaxima.cpp:7117
 msgid "Don't evaluate one command"
-msgstr ""
+msgstr "Не вычислять одну команду"
 
 #: ../../src/wxMaxima.cpp:7129
 msgid "Don't evaluate one whole expression"
-msgstr ""
+msgstr "Не вычислять одно выражение целиком"
 
 #: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
 msgid "Don't mark cells that contain tooltips in yellow"
-msgstr ""
+msgstr "Не отмечать поля, содержащие подсказки, жёлтым цветом"
 
 #: ../../src/Worksheet.cpp:1938 ../../src/Worksheet.cpp:2070
 msgid "Don't mark this message text in yellow"
-msgstr ""
+msgstr "Не выделять текст этого сообщения жёлтым цветом"
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Don't save"
-msgstr ""
+msgstr "Не сохранять"
 
 #: ../../src/Worksheet.cpp:1620
 msgid "Don't show labels"
-msgstr ""
+msgstr "Не показывать метки"
 
 #: ../../src/Worksheet.cpp:1979
 msgid "Don't use if unassigned"
-msgstr ""
+msgstr "Не использовать, если не имеет значения"
 
 #: ../../src/wxMaximaFrame.cpp:797
 msgid "Don't use parenthesis for matrices"
-msgstr ""
+msgstr "Не использовать скобки для матриц"
 
 #: ../../src/wxMaxima.cpp:8525
 msgid "Drop the first n list elements"
-msgstr ""
+msgstr "Отбросить первые n элементов списка"
 
 #: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
 msgid "Drop the last n list elements"
-msgstr ""
+msgstr "Отбросить последние n элементов списка"
 
 #: ../../src/wxMaximaFrame.cpp:1306
 msgid "E&quations"
-msgstr ""
+msgstr "У&равнения"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "E&xit\tCtrl+Q"
-msgstr ""
+msgstr "В&ыход\tCtrl+Q"
 
 #: ../../src/wxMaximaFrame.cpp:1368
 msgid "Eige&nvectors"
-msgstr ""
+msgstr "Собственные &векторы"
 
 #: ../../src/wxMaximaFrame.cpp:1365
 msgid "Eigen&values"
-msgstr ""
+msgstr "Собственные &значения"
 
 #: ../../src/wxMaximaFrame.cpp:1387
 msgid "Eigenvalues (complex)"
-msgstr ""
+msgstr "Собственные значения (комплексные)"
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Eigenvalues (real)"
-msgstr ""
+msgstr "Собственные значения (действительные)"
 
 #: ../../src/wxMaximaFrame.cpp:1393
 msgid "Eigenvalues, left+right eigenvectors (complex)"
-msgstr ""
+msgstr "Собственные значения, левый+правый собственные векторы (комплексные)"
 
 #: ../../src/wxMaximaFrame.cpp:1390
 msgid "Eigenvalues, left+right eigenvectors (real)"
-msgstr ""
+msgstr "Собственные значения, левый+правый собственные векторы (вещественные)"
 
 #: ../../src/wxMaxima.cpp:8584
 msgid ""
@@ -2310,130 +2410,135 @@ msgid ""
 "parenthesis. In the latter case the result of the last expression in the "
 "parenthesis is used."
 msgstr ""
+"Либо отдельное выражение, либо список разделённых запятыми выражений в "
+"скобках. В последнем случае используется результат последнего выражения в "
+"скобках."
 
 #: ../../src/wxMaxima.cpp:8593
 msgid "Element"
-msgstr ""
+msgstr "Элемент"
 
 #: ../../src/wxMaxima.cpp:8549
 msgid "Element number"
-msgstr ""
+msgstr "Номер элемента"
 
 #: ../../src/wxMaxima.cpp:8005
 msgid ""
 "Element-by-element Product of matrices of the same size (Hadamard product)"
 msgstr ""
+"Покомпонентное произведение матриц одного размера (произведение Адамара)"
 
 #: ../../src/wxMaxima.cpp:8012
 msgid "Element-by-element exponentiation of two matrices"
-msgstr ""
+msgstr "Поэлементное возведение в степень двух матриц"
 
 #: ../../src/wxMaximaFrame.cpp:1342
 msgid "Element-by-element multiplication"
-msgstr ""
+msgstr "Покомпонентное умножение"
 
 #: ../../src/wxMaxima.cpp:8510
 msgid "Element:"
-msgstr ""
+msgstr "Элемент:"
 
 #: ../../src/wxMaxima.cpp:7204
 msgid "Elements:"
-msgstr ""
+msgstr "Элементы:"
 
 #: ../../src/wxMaxima.cpp:7847
 msgid "Eliminate a variable"
-msgstr ""
+msgstr "Исключить переменную"
 
 #: ../../src/wxMaximaFrame.cpp:1247
 msgid "Eliminate a variable from a system of equations"
-msgstr ""
+msgstr "Исключить переменную из системы уравнений"
 
 #: ../../src/wxMaxima.cpp:10651
 msgid "Empty command => re-triggering evaluation"
-msgstr ""
+msgstr "Пустая команда => повторная активация вычисления"
 
 #: ../../src/wxMaxima.cpp:9225
 msgid "Enable:"
-msgstr ""
+msgstr "Включить:"
 
 #: ../../src/MathParser.cpp:99
 #, c-format
 msgid "Encountered an unknown XML tag: <%s>"
-msgstr ""
+msgstr "Неизвестный тег XML: <%s>"
 
 #: ../../src/wxMaxima.cpp:2476
 msgid "Encountered an unknown socket event."
-msgstr ""
+msgstr "Неизвестное событие сокета."
 
 #: ../../src/wxMaxima.cpp:7843
 msgid "End of t:"
-msgstr ""
+msgstr "Конец t:"
 
 #: ../../src/wxMaxima.cpp:4097
 msgid "Ended lisp mode after receiving a maxima prompt!"
-msgstr ""
+msgstr "Режим Lisp завершён после получения запроса Maxima!"
 
 #: ../../src/wxMaximaFrame.cpp:1828
 msgid "Engineering format (12.1e6 etc.)"
-msgstr ""
+msgstr "Инженерный формат (12.1e6 и так далее)"
 
 #: ../../src/wxMaximaFrame.cpp:1319
 msgid "Enter a matrix"
-msgstr ""
+msgstr "Введите матрицу"
 
 #: ../../src/wxMaxima.cpp:8866
 msgid "Enter an equation for rational simplification:"
-msgstr ""
+msgstr "Введите уравнение для рационального упрощения:"
 
 #: ../../src/wxMaxima.cpp:8169
 msgid "Enter matrix"
-msgstr ""
+msgstr "Ввести матрицу"
 
 #: ../../src/wxMaxima.cpp:9095
 msgid "Enter new animation frame rate [Hz, integer]:"
-msgstr ""
+msgstr "Введите новую частоту кадров анимации [Гц, целое число]:"
 
 #: ../../src/wxMaxima.cpp:9201
 msgid "Enter new precision for bigfloats:"
 msgstr ""
+"Введите новую точность для чисел с плавающей точкой с повышенной точностью:"
 
 #: ../../src/wxMaxima.cpp:7922
 msgid "Enumerator:"
-msgstr ""
+msgstr "Энумератор:"
 
 #: ../../src/wxMaximaFrame.cpp:1220
 msgid "Environment variables"
-msgstr ""
+msgstr "Переменные среды"
 
 #: ../../src/wxMaxima.cpp:9045
 msgid "Epsilon:"
-msgstr ""
+msgstr "Эпсилон:"
 
 #: ../../src/wxMaximaFrame.cpp:1124 ../../src/wxMaximaFrame.cpp:1135
 msgid "Equal, ignoring case?..."
-msgstr ""
+msgstr "Равно, если игнорировать регистр?..."
 
 #: ../../src/wxMaximaFrame.cpp:1133
 msgid "Equal?..."
-msgstr ""
+msgstr "Равно?..."
 
 #: ../../src/wxMaxima.cpp:8561
 msgid "Equation"
-msgstr ""
+msgstr "Уравнение"
 
 #: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
 msgid "Equation(s)"
-msgstr ""
+msgstr "Уравнения"
 
 #: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
 msgid "Equation(s):"
-msgstr ""
+msgstr "Уравнения:"
 
 #: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
 #: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
 #: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
 msgid "Equation:"
-msgstr ""
+msgstr "Уравнение:"
 
 #: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
 #: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
@@ -2445,22 +2550,22 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
 #: ../../src/wxMaxima.cpp:11166
 msgid "Error"
-msgstr ""
+msgstr "Ошибка"
 
 #: ../../src/wxMaxima.cpp:2456
 msgid "Error writing to Maxima"
-msgstr ""
+msgstr "Ошибка записи в Maxima"
 
 #: ../../src/wxMaxima.cpp:6164 ../../src/wxMaxima.cpp:6176
 #: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
 #: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
 msgid "Error!"
-msgstr ""
+msgstr "Ошибка!"
 
 #: ../../src/Image.cpp:696
 #, c-format
 msgid "Error: Cannot render %s."
-msgstr ""
+msgstr "Ошибка: не удалось обработать %s."
 
 #: ../../src/Image.cpp:699
 #, c-format
@@ -2468,10 +2573,12 @@ msgid ""
 "Error: Cannot render %s:\n"
 "%s"
 msgstr ""
+"Ошибка: не удалось обработать %s:\n"
+"%s"
 
 #: ../../src/Image.cpp:704
 msgid "Error: Cannot render the image."
-msgstr ""
+msgstr "Ошибка: не удалось обработать изображение."
 
 #: ../../src/Image.cpp:706
 #, c-format
@@ -2479,248 +2586,254 @@ msgid ""
 "Error: Cannot render the image:\n"
 "%s"
 msgstr ""
+"Ошибка: не удалось обработать изображение:\n"
+"%s"
 
 #: ../../src/wxMaxima.cpp:7544
 msgid ""
 "Escapes all special characters in a string. The result is a regex that "
 "matches this string exactly."
 msgstr ""
+"Экранирует все специальные символы в строке. Результатом является регулярное"
+" выражение, точно соответствующее строке."
 
 #: ../../src/wxMaximaFrame.cpp:1652
 msgid "Evaluate &Noun Forms..."
-msgstr ""
+msgstr "Вычислить &невычисляемые (noun) формы..."
 
 #: ../../src/wxMaximaFrame.cpp:856
 msgid "Evaluate All Cells\tCtrl+Shift+R"
-msgstr ""
+msgstr "Вычислить все поля\tCtrl+Shift+R"
 
 #: ../../src/wxMaximaFrame.cpp:851
 msgid "Evaluate All Visible Cells\tCtrl+R"
-msgstr ""
+msgstr "Вычислить все видимые поля\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1395
 msgid "Evaluate Cell"
-msgstr ""
+msgstr "Вычислить поле"
 
 #: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
 msgid "Evaluate Cell(s)"
-msgstr ""
+msgstr "Вычислить поля"
 
 #: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
 msgid "Evaluate Cells Above"
-msgstr ""
+msgstr "Вычислить поля выше"
 
 #: ../../src/wxMaximaFrame.cpp:866
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
-msgstr ""
+msgstr "Вычислить поля выше\tCtrl+Shift+P"
 
 #: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
 #: ../../src/wxMaximaFrame.cpp:876
 msgid "Evaluate Cells Below"
-msgstr ""
+msgstr "Вычислить поля ниже"
 
 #: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
 #: ../../src/Worksheet.cpp:1890
 msgid "Evaluate Heading 5\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Вычислить Заголовок 5\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1457 ../../src/Worksheet.cpp:1761
 #: ../../src/Worksheet.cpp:1901
 msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Вычислить Заголовок 6\tShift+Ctrl+Enter"
 
 #: ../../src/wxMaxima.cpp:8626
 msgid "Evaluate Nouns"
-msgstr ""
+msgstr "Вычислить &невычисляемые (noun) формы"
 
 #: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
 msgid "Evaluate Part\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Вычислить часть\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1431 ../../src/Worksheet.cpp:1741
 msgid "Evaluate Section\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Вычислить раздел\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1445 ../../src/Worksheet.cpp:1751
 #: ../../src/Worksheet.cpp:1879
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Вычислить под-подраздел\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1438 ../../src/Worksheet.cpp:1746
 #: ../../src/Worksheet.cpp:1868
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Вычислить подраздел\tShift+Ctrl+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:845
 msgid "Evaluate active or selected cell(s)"
-msgstr ""
+msgstr "Вычислить выделенные поля"
 
 #: ../../src/ToolBar.cpp:251
 msgid "Evaluate all"
-msgstr ""
+msgstr "Вычислить все"
 
 #: ../../src/wxMaximaFrame.cpp:857
 msgid "Evaluate all cells in the document"
-msgstr ""
+msgstr "Вычислить все поля в документе"
 
 #: ../../src/wxMaximaFrame.cpp:1653
 msgid "Evaluate all noun forms in expression"
-msgstr ""
+msgstr "Вычислить все невычисляемые (noun) формы в выражении"
 
 #: ../../src/wxMaximaFrame.cpp:852
 msgid "Evaluate all visible cells in the document"
-msgstr ""
+msgstr "Вычислить все видимые поля в документе"
 
 #: ../../src/ToolBar.cpp:248
 msgid "Evaluate current cell"
-msgstr ""
+msgstr "Вычислить текущее поле"
 
 #: ../../src/wxMaxima.cpp:7395
 msgid "Evaluate string"
-msgstr ""
+msgstr "Вычислить строку"
 
 #: ../../src/wxMaximaFrame.cpp:1151
 msgid "Evaluate string..."
-msgstr ""
+msgstr "Вычислить строку..."
 
 #: ../../src/ToolBar.cpp:256
 msgid "Evaluate the file from its beginning to the cell above the cursor"
-msgstr ""
+msgstr "Выполнить вычисление файла от его начала до поля над курсором"
 
 #: ../../src/ToolBar.cpp:259
 msgid "Evaluate the file from the cursor to its end"
-msgstr ""
+msgstr "Выполнить вычисление файла от курсора до конца файла"
 
 #: ../../src/ToolBar.cpp:258
 msgid "Evaluate the rest"
-msgstr ""
+msgstr "Вычислить остальное"
 
 #: ../../src/ToolBar.cpp:255
 msgid "Evaluate to point"
-msgstr ""
+msgstr "Вычислить до поля над курсором"
 
 #: ../../src/wxMaxima.cpp:10518
 msgid "Evaluation ended, since evaluation queue is empty."
-msgstr ""
+msgstr "Вычисление завершилось, так как очередь на вычисление пуста."
 
 #: ../../src/Worksheet.cpp:1957
 msgid "Even number"
-msgstr ""
+msgstr "Чётное число"
 
 #: ../../src/wxMaximaFrame.cpp:1703
 msgid "Execute a command for each element of the list"
-msgstr ""
+msgstr "Выполнить команду для каждого элемента списка"
 
 #: ../../src/main.cpp:438
 msgid "Exit"
-msgstr ""
+msgstr "Выход"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "Exit wxMaxima"
-msgstr ""
+msgstr "Выйти из wxMaxima"
 
 #: ../../src/Worksheet.cpp:1583
 msgid "Expand Expression"
-msgstr ""
+msgstr "Раскрыть выражение"
 
 #: ../../src/wxMaximaFrame.cpp:1525
 msgid "Expand an expression"
-msgstr ""
+msgstr "Раскрыть выражение"
 
 #: ../../src/wxMaximaFrame.cpp:1531
 msgid "Expand for given variables"
-msgstr ""
+msgstr "Раскрыть для указанных переменных"
 
 #: ../../src/wxMaxima.cpp:8781
 msgid "Expand for variable(s) including denominator:"
-msgstr ""
+msgstr "Раскрыть для переменной(ых), включая знаменатель:"
 
 #: ../../src/wxMaxima.cpp:8716
 msgid "Expand for variable(s):"
-msgstr ""
+msgstr "Раскрыть для переменной(ых):"
 
 #: ../../src/wxMaximaFrame.cpp:1545
 msgid "Expand log in previous expression"
-msgstr ""
+msgstr "Раскрыть логарифм в предыдущем выражении"
 
 #: ../../src/wxMaximaFrame.cpp:1598
 msgid "Expand trigonometric expression"
-msgstr ""
+msgstr "Раскрыть тригонометрическое выражение"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Expect numbers harder to be complex"
-msgstr ""
+msgstr "Ожидать комплексные числа в большем количестве мест"
 
 #: ../../src/wxMaximaFrame.cpp:1789
 msgid "Expect variables to contain complex numbers"
-msgstr ""
+msgstr "Ожидать, что переменные будут содержать комплексные числа"
 
 #: ../../src/wxMaxima.cpp:6121
 msgid "Export"
-msgstr ""
+msgstr "Экспорт"
 
 #: ../../src/wxMaximaFrame.cpp:1705
 msgid "Export List to csv file..."
-msgstr ""
+msgstr "Экспортировать список в файл CSV..."
 
 #: ../../src/wxMaximaFrame.cpp:1706
 msgid "Export a list to a csv file"
-msgstr ""
+msgstr "Экспортировать список в файл CSV"
 
 #: ../../src/wxMaximaFrame.cpp:1332
 msgid "Export a matrix to a csv file"
-msgstr ""
+msgstr "Экспортировать матрицу в файл CSV"
 
 #: ../../src/wxMaximaFrame.cpp:619
 msgid "Export document to a HTML or LaTeX file"
-msgstr ""
+msgstr "Экспортировать документ в файл HTML или LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:579
 msgid "Export failed."
-msgstr ""
+msgstr "Не удалось выполнить экспорт."
 
 #: ../../src/wxMaximaFrame.cpp:567
 msgid "Export successful."
-msgstr ""
+msgstr "Экспорт завершён успешно."
 
 #: ../../src/wxMaxima.cpp:6187
 msgid "Exporting to HTML failed!"
-msgstr ""
+msgstr "Не удалось выполнить экспорт в HTML."
 
 #: ../../src/wxMaxima.cpp:6164
 msgid "Exporting to TeX failed!"
-msgstr ""
+msgstr "Не удалось выполнить экспорт в TeX."
 
 #: ../../src/wxMaxima.cpp:6175
 msgid "Exporting to maxima batch file failed!"
-msgstr ""
+msgstr "Не удалось выполнить экспорт в пакетный файл Maxima!"
 
 #: ../../src/wxMaximaFrame.cpp:561
 msgid "Exporting..."
-msgstr ""
+msgstr "Экспорт..."
 
 #: ../../src/wxMaxima.cpp:6510 ../../src/wxMaxima.cpp:6516
 #: ../../src/wxMaxima.cpp:8218 ../../src/wxMaxima.cpp:8633
 #: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
 #: ../../src/wxMaxima.cpp:10065
 msgid "Expression"
-msgstr ""
+msgstr "Выражение"
 
 #: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
 msgid "Expression or a list of comma-separated expressions"
-msgstr ""
+msgstr "Выражение или список выражений, разделённых запятыми"
 
 #: ../../src/wxMaximaFrame.cpp:1088
 msgid "Expression to string..."
-msgstr ""
+msgstr "Выражение в строку..."
 
 #: ../../src/wxMaxima.cpp:7113
 msgid "Expression whose output is to be used as maxima's input."
 msgstr ""
+"Выражение, выходные данные которого будет использоваться в качестве входных "
+"данных Maxima."
 
 #: ../../src/wxMaxima.cpp:7214
 msgid "Expression(s):"
-msgstr ""
+msgstr "Выражения:"
 
 #: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
 #: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
@@ -2729,385 +2842,388 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
 #: ../../src/wxMaxima.cpp:10056
 msgid "Expression:"
-msgstr ""
+msgstr "Выражение:"
 
 #: ../../src/wxMaximaFrame.cpp:1423
 msgid "Extract Column..."
-msgstr ""
+msgstr "Извлечь столбец..."
 
 #: ../../src/wxMaximaFrame.cpp:1726
 msgid "Extract Elements"
-msgstr ""
+msgstr "Извлечь элементы"
 
 #: ../../src/wxMaximaFrame.cpp:1421
 msgid "Extract Row..."
-msgstr ""
+msgstr "Извлечь строку..."
 
 #: ../../src/wxMaximaFrame.cpp:1424
 msgid "Extract a column from the matrix"
-msgstr ""
+msgstr "Извлечь столбец из матрицы"
 
 #: ../../src/wxMaximaFrame.cpp:1435
 msgid "Extract a column from the matrix and convert it to a list"
-msgstr ""
+msgstr "Извлечь столбец из матрицы и преобразовать его в список"
 
 #: ../../src/wxMaxima.cpp:7960
 msgid "Extract a matrix column"
-msgstr ""
+msgstr "Извлечь столбец из матрицы"
 
 #: ../../src/wxMaxima.cpp:7970
 msgid "Extract a matrix column as a list"
-msgstr ""
+msgstr "Извлечь столбец из матрицы как список"
 
 #: ../../src/wxMaximaFrame.cpp:1313
 msgid "Extract a matrix from a 2-dimensional array"
-msgstr ""
+msgstr "Извлечь матрицу из двухмерного массива"
 
 #: ../../src/wxMaxima.cpp:7955
 msgid "Extract a matrix row"
-msgstr ""
+msgstr "Извлечь строку из матрицы"
 
 #: ../../src/wxMaxima.cpp:7965
 msgid "Extract a matrix row as a list"
-msgstr ""
+msgstr "Извлечь строку из матрицы как список"
 
 #: ../../src/wxMaximaFrame.cpp:1422
 msgid "Extract a row from the matrix"
-msgstr ""
+msgstr "Извлечь строку из матрицы"
 
 #: ../../src/wxMaximaFrame.cpp:1431
 msgid "Extract a row from the matrix and convert it to a list"
-msgstr ""
+msgstr "Извлечь строку из матрицы и преобразовать её в список"
 
 #: ../../src/wxMaxima.cpp:8564
 msgid "Extract a variable's value from a list of variable values"
-msgstr ""
+msgstr "Извлечь значение переменной из списка значений переменных"
 
 #: ../../src/wxMaximaFrame.cpp:1723
 msgid "Extract an actual value for a variable"
-msgstr ""
+msgstr "Извлечь фактическое значение переменной"
 
 #: ../../src/wxMaximaFrame.cpp:1163
 msgid "Extract char..."
-msgstr ""
+msgstr "Извлечь символ..."
 
 #: ../../src/wxMaximaFrame.cpp:1207
 msgid "Extract dir from path..."
-msgstr ""
+msgstr "Извлечь каталог из пути..."
 
 #: ../../src/wxMaxima.cpp:7605
 msgid "Extract directory part"
-msgstr ""
+msgstr "Извлечь часть с каталогом..."
 
 #: ../../src/wxMaxima.cpp:7617
 msgid "Extract file type extension"
-msgstr ""
+msgstr "Извлечь расширение типа файла"
 
 #: ../../src/wxMaximaFrame.cpp:1209
 msgid "Extract filename from path..."
-msgstr ""
+msgstr "Извлечь имя файла из пути..."
 
 #: ../../src/wxMaxima.cpp:7611
 msgid "Extract filename part"
-msgstr ""
+msgstr "Извлечь часть с именем файла"
 
 #: ../../src/wxMaximaFrame.cpp:1211
 msgid "Extract filetype from path..."
-msgstr ""
+msgstr "Извлечь тип файла из пути..."
 
 #: ../../src/wxMaxima.cpp:8445
 msgid "Extract function arguments"
-msgstr ""
+msgstr "Извлечь аргументы функции"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "Extract list Elements"
-msgstr ""
+msgstr "Извлечь элементы списка"
 
 #: ../../src/wxMaxima.cpp:8187
 msgid "Extract matrix from 2D array"
-msgstr ""
+msgstr "Извлечь матрицу из двухмерного массива"
 
 #: ../../src/wxMaximaFrame.cpp:1686
 msgid "Extract the argument list from a function call"
-msgstr ""
+msgstr "Извлечь список аргументов из вызова функции"
 
 #: ../../src/wxMaxima.cpp:8538
 msgid "Extract the last n elements from a list"
-msgstr ""
+msgstr "Извлечь последние n элементов из списка"
 
 #: ../../src/wxMaxima.cpp:7376
 msgid "Extract the nth char of a string"
-msgstr ""
+msgstr "Извлечь n-й символ строки"
 
 #: ../../src/wxMaxima.cpp:8544
 msgid "Extract the nth list elements"
-msgstr ""
+msgstr "Извлечь элементы n-го списка"
 
 #: ../../src/wxMaximaFrame.cpp:1724
 msgid "Extract the value for one variable assigned in a list"
-msgstr ""
+msgstr "Извлечь для одной переменной значение, назначенное ей в списке"
 
 #: ../../src/wxMaximaFrame.cpp:1439
 msgid "Extract, append or delete rows or columns"
-msgstr ""
+msgstr "Извлечь, добавить или удалить строки или столбцы"
 
 #: ../../src/wxMaxima.cpp:8188
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
 msgstr ""
+"Извлекает прямоугольник из двухмерного массива и преобразует его в матрицу"
 
 #: ../../src/wxMaximaFrame.cpp:1521
 msgid "Factor Complex"
-msgstr ""
+msgstr "Факторизовать комплексное число"
 
 #: ../../src/Worksheet.cpp:1581
 msgid "Factor Expression"
-msgstr ""
+msgstr "Факторизовать выражение"
 
 #: ../../src/wxMaximaFrame.cpp:1519
 msgid "Factor Expression including subexpressions"
-msgstr ""
+msgstr "Факторизовать выражение, включая подвыражения"
 
 #: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
 msgid "Factor an expression"
-msgstr ""
+msgstr "Факторизовать выражение"
 
 #: ../../src/wxMaximaFrame.cpp:1522
 msgid "Factor an expression in Gaussian numbers"
-msgstr ""
+msgstr "Факторизовать выражение в гауссовых числах"
 
 #: ../../src/wxMaximaFrame.cpp:1587
 msgid "Factorials and &Gamma"
-msgstr ""
+msgstr "Факториалы и &гамма-функции"
 
 #: ../../src/Image.cpp:137
 #, c-format
 msgid "Failed to delete gnuplot data file %s"
-msgstr ""
+msgstr "Не удалось удалить файл данных Gnuplot %s"
 
 #: ../../src/Image.cpp:121 ../../src/Image.cpp:128
 #, c-format
 msgid "Failed to delete gnuplot file %s"
-msgstr ""
+msgstr "Не удалось удалить файл Gnuplot %s"
 
 #: ../../src/wxMaxima.cpp:2667
 msgid "Failed to start Maxima"
-msgstr ""
+msgstr "Не удалось запустить Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1418
 msgid "Fast fortran routines that perform numerical tasks"
-msgstr ""
+msgstr "Быстрые подпрограммы fortran, которые выполняют вычислительные задачи"
 
 #: ../../src/wxMaximaFrame.cpp:1922
 msgid "Fast list access"
-msgstr ""
+msgstr "Быстрый доступ к списку"
 
 #: ../../src/wxMaxima.cpp:2553
 msgid "Fatal error"
-msgstr ""
+msgstr "Фатальная ошибка"
 
 #: ../../src/wxMaxima.cpp:7191
 msgid "Field contents:"
-msgstr ""
+msgstr "Данные полей:"
 
 #: ../../src/wxMaxima.cpp:7198
 msgid "Field name:"
-msgstr ""
+msgstr "Имя поля:"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "Fields:"
-msgstr ""
+msgstr "Поля:"
 
 #: ../../src/main.cpp:439
 msgid "File"
-msgstr ""
+msgstr "Файл"
 
 #: ../../src/wxMaximaFrame.cpp:1333
 msgid "File I/O"
-msgstr ""
+msgstr "Файловый ввод/вывод"
 
 #: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
 #: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
 #: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
 #: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
 msgid "File could not be opened"
-msgstr ""
+msgstr "Не удалось открыть файл"
 
 #: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
 #: ../../src/wxMaxima.cpp:7251
 msgid "File name:"
-msgstr ""
+msgstr "Имя файла:"
 
 #: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
 msgid "File not found"
-msgstr ""
+msgstr "Файл не найден"
 
 #: ../../src/wxMaxima.cpp:5631
 msgid "File opened"
-msgstr ""
+msgstr "Файл открыт"
 
 #: ../../src/wxMaximaFrame.cpp:1217
 msgid "File operations"
-msgstr ""
+msgstr "Операции с файлами"
 
 #: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
 msgid "File you tried to open does not exist."
-msgstr ""
+msgstr "Файл не существует."
 
 #: ../../src/wxMaximaFrame.cpp:1221
 msgid "File/directory functions"
-msgstr ""
+msgstr "Функции файлов/каталогов"
 
 #: ../../src/wxMaxima.cpp:7027
 msgid "Filename or a list of comma-separated file names"
-msgstr ""
+msgstr "Имя файла или список имён файлов, разделённых запятыми"
 
 #: ../../src/ToolBar.cpp:222
 msgid "Find"
-msgstr ""
+msgstr "Найти"
 
 #: ../../src/wxMaximaFrame.cpp:670
 msgid "Find\tCtrl+F"
-msgstr ""
+msgstr "Найти\tCtrl+F"
 
 #: ../../src/wxMaximaFrame.cpp:1468
 msgid "Find &Limit..."
-msgstr ""
+msgstr "Найти &предел..."
 
 #: ../../src/wxMaximaFrame.cpp:1470
 msgid "Find Minimum..."
-msgstr ""
+msgstr "Найти минимум..."
 
 #: ../../src/Worksheet.cpp:1576
 msgid "Find Root..."
-msgstr ""
+msgstr "Найти корень ..."
 
 #: ../../src/wxMaximaFrame.cpp:1471
 msgid "Find a (unconstrained) minimum of an expression"
-msgstr ""
+msgstr "Найти (безусловный) минимум выражения"
 
 #: ../../src/wxMaximaFrame.cpp:1804
 msgid "Find a fraction that represents this float exactly"
-msgstr ""
+msgstr "Найти дробь, точно представляющую это число с плавающей точкой"
 
 #: ../../src/wxMaximaFrame.cpp:1469
 msgid "Find a limit of an expression"
-msgstr ""
+msgstr "Найти предел выражения"
 
 #: ../../src/wxMaximaFrame.cpp:1807
 msgid "Find a nice fraction that is similar to this float"
 msgstr ""
+"Найти процентную дробь (nice fraction), аналогичную этому числу с плавающей "
+"точкой"
 
 #: ../../src/wxMaximaFrame.cpp:1283
 msgid "Find a numerical solution for a first degree ODE"
-msgstr ""
+msgstr "Найти численное решение для ОДУ первого порядка"
 
 #: ../../src/wxMaximaFrame.cpp:1252
 msgid "Find a root of an equation on an interval"
-msgstr ""
+msgstr "Найти корень уравнения на интервале"
 
 #: ../../src/wxMaximaFrame.cpp:1259
 msgid "Find all roots of a polynomial"
-msgstr ""
+msgstr "Найти все корни полинома"
 
 #: ../../src/wxMaximaFrame.cpp:1262
 msgid "Find all roots of a polynomial (bfloat)"
-msgstr ""
+msgstr "Найти все корни полинома (повышенная точность)"
 
 #: ../../src/wxMaxima.cpp:6589
 msgid "Find and Replace"
-msgstr ""
+msgstr "Найти и заменить"
 
 #: ../../src/ToolBar.cpp:222 ../../src/wxMaximaFrame.cpp:670
 msgid "Find and replace"
-msgstr ""
+msgstr "Найти и заменить"
 
 #: ../../src/wxMaxima.cpp:7434
 msgid "Find char in string"
-msgstr ""
+msgstr "Найти"
 
 #: ../../src/wxMaximaFrame.cpp:1172
 msgid "Find char in string..."
-msgstr ""
+msgstr "Найти символ в строке..."
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Find common denominator"
-msgstr ""
+msgstr "Найти общий знаменатель"
 
 #: ../../src/wxMaximaFrame.cpp:1366
 msgid "Find eigenvalues of a matrix"
-msgstr ""
+msgstr "Найти собственные значения матрицы"
 
 #: ../../src/wxMaximaFrame.cpp:1369
 msgid "Find eigenvectors of a matrix"
-msgstr ""
+msgstr "Найти собственные векторы матрицы"
 
 #: ../../src/wxMaxima.cpp:7424
 msgid "Find first difference"
-msgstr ""
+msgstr "Найти первую разность"
 
 #: ../../src/wxMaximaFrame.cpp:1170
 msgid "Find first difference..."
-msgstr ""
+msgstr "Найти первую разность..."
 
 #: ../../src/wxMaximaFrame.cpp:1256
 msgid "Find fractions that real roots of a polynomial and "
-msgstr ""
+msgstr "Найти дроби, которые являются вещественными корнями полинома, и "
 
 #: ../../src/wxMaxima.cpp:9039
 msgid "Find minimum"
-msgstr ""
+msgstr "Найти минимум"
 
 #: ../../src/wxMaximaFrame.cpp:1251
 msgid "Find numerical solution..."
-msgstr ""
+msgstr "Найти численное решение..."
 
 #: ../../src/wxMaxima.cpp:10035
 msgid "Find root (solve numerically)"
-msgstr ""
+msgstr "Найти корень (решить численно)"
 
 #: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
 msgid "Find the maximum absolute value of a matrix entry"
-msgstr ""
+msgstr "Найти максимальное абсолютное значение элемента матрицы"
 
 #: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
 msgid "Find the maximum sum of the absolute values of a matrix column"
-msgstr ""
+msgstr "Найти максимальную сумму значений по модулю в столбце матрицы"
 
 #: ../../src/wxMaxima.cpp:8073 ../../src/wxMaxima.cpp:8094
 msgid "Find the maximum sum of the absolute values of a matrix row"
-msgstr ""
+msgstr "Найти максимальную сумму значений по модулю в строке матрицы"
 
 #: ../../src/wxMaximaFrame.cpp:1832
 msgid "Fine-tune the display of engineering-format numbers"
-msgstr ""
+msgstr "Настроить отображение чисел в инженерном формате"
 
 #: ../../src/wxMaximaFrame.cpp:1712
 msgid "First"
-msgstr ""
+msgstr "Первый"
 
 #: ../../src/wxMaximaFrame.cpp:1918
 msgid "Fitting curves to measurement data"
-msgstr ""
+msgstr "Аппроксимация кривых по данным измерений"
 
 #: ../../src/wxMaxima.cpp:7227
 msgid "Flush stream"
-msgstr ""
+msgstr "Очистить поток"
 
 #: ../../src/wxMaximaFrame.cpp:1103
 msgid "Flush..."
-msgstr ""
+msgstr "Очистить..."
 
 #: ../../src/wxMaximaFrame.cpp:922
 msgid "Fold All\tCtrl+Alt+["
-msgstr ""
+msgstr "Свернуть все\tCtrl+Alt+["
 
 #: ../../src/wxMaximaFrame.cpp:923
 msgid "Fold all sections"
-msgstr ""
+msgstr "Свернуть все разделы"
 
 #: ../../src/ToolBar.cpp:240
 msgid "Follow"
-msgstr ""
+msgstr "Следовать"
 
 #: ../../src/ToolBar.cpp:285
 msgid ""
@@ -3122,123 +3238,137 @@ msgid ""
 "   Ctrl+6: Heading5 cell\n"
 "   Ctrl+7: Heading6 cell\n"
 msgstr ""
+"Следующие комбинации клавиш позволяют ускорить создание полей:\n"
+"\n"
+"   Ctrl+0: математическое поле\n"
+"   Ctrl+1: текстовое поле\n"
+"   Ctrl+2: поле заголовка\n"
+"   Ctrl+3: поле раздела\n"
+"   Ctrl+4: поле подраздела\n"
+"   Ctrl+5: поле под-подраздела\n"
+"   Ctrl+6: поле Заголовок5\n"
+"   Ctrl+7: поле Заголовок6\n"
 
 #: ../../src/wxMaxima.cpp:7038
 msgid "For loop"
-msgstr ""
+msgstr "Цикл for"
 
 #: ../../src/wxMaximaFrame.cpp:1062
 msgid "For loop..."
-msgstr ""
+msgstr "Цикл for..."
 
 #: ../../src/Worksheet.cpp:237 ../../src/wxMaxima.cpp:11217
 msgid "Forwarding the keyboard focus to a text control"
-msgstr ""
+msgstr "Перенаправление фокуса клавиатуры на текстовый ввод"
 
 #: ../../src/wxMaxima.cpp:11220
 msgid "Forwarding the keyboard focus to the worksheet"
-msgstr ""
+msgstr "Перенаправление фокуса клавиатуры на лист"
 
 #: ../../src/MaximaManual.cpp:452
 #, c-format
 msgid ""
 "Found %li anchors, URLs (individual files): %li, URLs (singlepage): %li"
 msgstr ""
+"Найдено привязок: %li, URL-адресов (отдельные файлы): %li, URL-адресов (одна"
+" страница): %li"
 
 #: ../../src/MaximaManual.cpp:313
 #, c-format
 msgid "Found only %li keywords in maxima's manual. Not caching them to disc."
 msgstr ""
+"В руководстве пользователя Maxima найдено следующее количество ключевых "
+"слов: %li. Кэширование на диск выполнено не будет."
 
 #: ../../src/MaximaManual.cpp:513
 #, c-format
 msgid "Found the maxima HTML manual in the folder %s."
-msgstr ""
+msgstr "Руководство пользователя Maxima в формате HTML находится в папке %s."
 
 #: ../../src/wxMaxima.cpp:8948
 msgid "Fourier coefficients"
-msgstr ""
+msgstr "Коэффициенты Фурье"
 
 #: ../../src/wxMaximaFrame.cpp:1476
 msgid "Fourier coefficients..."
-msgstr ""
+msgstr "Коэффициенты Фурье..."
 
 #: ../../src/ToolBar.cpp:137
 #, c-format
 msgid "Frame %li of %li"
-msgstr ""
+msgstr "Кадр %li из %li"
 
 #: ../../src/wxMaxima.cpp:9097
 msgid "Frame rate"
-msgstr ""
+msgstr "Частота кадров"
 
 #: ../../src/wxMaximaFrame.cpp:1005 ../../src/wxMaximaFrame.cpp:1009
 msgid "Free all unused items now"
-msgstr ""
+msgstr "Освободить все неиспользуемые объекты"
 
 #: ../../src/wxMaximaFrame.cpp:1413
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
-msgstr ""
+msgstr "Норма Фробениуса sqrt(sum((A(i,j))^2)) (комплексная)"
 
 #: ../../src/wxMaximaFrame.cpp:1411
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (real)"
-msgstr ""
+msgstr "Норма Фробениуса sqrt(sum((A(i,j))^2)) (вещественная)"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "From:"
-msgstr ""
+msgstr "Из:"
 
 #: ../../src/wxMaximaFrame.cpp:827
 msgid "Full Screen\tAlt+Enter"
-msgstr ""
+msgstr "Полноэкранный режим\tAlt+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:824
 msgid "Full Screen\tF11"
-msgstr ""
+msgstr "Полноэкранный режим\tF11"
 
 #: ../../src/wxMaxima.cpp:7140
 msgid "Function contents:"
-msgstr ""
+msgstr "Содержимое функции:"
 
 #: ../../src/wxMaxima.cpp:7908
 msgid "Function f(x):"
-msgstr ""
+msgstr "Функция f(x):"
 
 #: ../../src/wxMaxima.cpp:8572
 msgid "Function name"
-msgstr ""
+msgstr "Имя функции"
 
 #: ../../src/wxMaxima.cpp:7167
 msgid "Function name(s):"
-msgstr ""
+msgstr "Имя(ена) функции(й):"
 
 #: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
 msgid "Function name:"
-msgstr ""
+msgstr "Имя функции:"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Function:"
-msgstr ""
+msgstr "Функция:"
 
 #: ../../src/wxMaximaFrame.cpp:1630
 msgid "Functions for complex simplification"
-msgstr ""
+msgstr "Функции для упрощения комплексных чисел"
 
 #: ../../src/wxMaximaFrame.cpp:1588
 msgid "Functions for simplifying factorials and gamma function"
-msgstr ""
+msgstr "Функции для упрощения факториалов и гамма-функций"
 
 #: ../../src/wxMaximaFrame.cpp:1606
 msgid "Functions for simplifying trigonometric expressions"
-msgstr ""
+msgstr "Функции для упрощения тригонометрических выражений"
 
 #: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
 msgid "GCD"
-msgstr ""
+msgstr "НОД"
 
 #: ../../src/wxMaxima.cpp:10186
 msgid "GIF image (*.gif)|*.gif"
-msgstr ""
+msgstr "GIF (*.gif)|*.gif"
 
 #: ../../src/Worksheet.cpp:103
 msgid ""
@@ -3246,169 +3376,180 @@ msgid ""
 " hotkeys to be broken, see for example "
 "https://trac.wxwidgets.org/ticket/18462."
 msgstr ""
+"Для GTK_IM_MODULE установлено значение «xim». Окно программы будет сильно "
+"мерцать, комбинации клавиш не будут работать, см. "
+"https://trac.wxwidgets.org/ticket/18462."
 
 #: ../../src/wxMaximaFrame.cpp:295
 msgid "General Math"
-msgstr ""
+msgstr "Математика"
 
 #: ../../src/wxMaximaFrame.cpp:699
 msgid "General Math\tAlt+Shift+M"
-msgstr ""
+msgstr "Математика\tAlt+Shift+M"
 
 #: ../../src/wxMaximaFrame.cpp:1316
 msgid "Generate Matrix from Expression..."
-msgstr ""
+msgstr "Создать матрицу из выражения..."
 
 #: ../../src/wxMaximaFrame.cpp:1317
 msgid "Generate a matrix from a lambda expression"
-msgstr ""
+msgstr "Создать матрицу из лямбда-выражения"
 
 #: ../../src/wxMaximaFrame.cpp:1675
 msgid "Generate a new list using a lists' elements"
-msgstr ""
+msgstr "Создать новый список на основе элементов существующего списка"
 
 #: ../../src/wxMaximaFrame.cpp:1681
 msgid ""
 "Generate a storage for variable values that can be introduced into equations"
 " at any time"
 msgstr ""
+"Создать хранилище значений переменных, которые в любой момент можно будет "
+"вводить в уравнения"
 
 #: ../../src/wxMaximaFrame.cpp:1672
 msgid "Generate list elements using a rule"
-msgstr ""
+msgstr "Создать элементы списка на основе правила"
 
 #: ../../src/wxMaxima.cpp:8196
 msgid "Generate matrix from a rule"
-msgstr ""
+msgstr "Создать матрицу на основе правила"
 
 #: ../../src/wxMaximaFrame.cpp:1094
 msgid "Generate unused symbol name"
-msgstr ""
+msgstr "Создать неиспользуемый идентификатор"
 
 #: ../../src/WXMXformat.cpp:231
 msgid "Generated the XML representation of the document"
-msgstr ""
+msgstr "Создано XML-представление документа"
 
 #: ../../src/wxMaxima.cpp:8197
 msgid ""
 "Generates a matrix and fills each element with the result of the expression "
 "\"Rule\"."
 msgstr ""
+"Создаёт матрицу и заполняет каждый элемент результатом выражения «Правило»."
 
 #: ../../src/wxMaximaFrame.cpp:1619
 msgid "Get &Imaginary Part"
-msgstr ""
+msgstr "&Мнимая часть"
 
 #: ../../src/wxMaximaFrame.cpp:1485
 msgid "Get Laplace transformation of an expression"
-msgstr ""
+msgstr "Вычислить преобразование Лапласа"
 
 #: ../../src/wxMaximaFrame.cpp:1615
 msgid "Get Real P&art"
-msgstr ""
+msgstr "&Вещественная часть"
 
 #: ../../src/wxMaximaFrame.cpp:1201
 msgid "Get current directory"
-msgstr ""
+msgstr "Получить текущий каталог"
 
 #: ../../src/wxMaximaFrame.cpp:1489
 msgid "Get inverse Laplace transformation of an expression"
-msgstr ""
+msgstr "Вычислить обратное преобразование Лапласа"
 
 #: ../../src/wxMaxima.cpp:7223
 msgid "Get position in stream"
-msgstr ""
+msgstr "Получить положение в потоке"
 
 #: ../../src/wxMaximaFrame.cpp:1102
 msgid "Get position..."
-msgstr ""
+msgstr "Получить положение..."
 
 #: ../../src/wxMaximaFrame.cpp:1620
 msgid "Get the imaginary part of complex expression"
-msgstr ""
+msgstr "Вычислить мнимую часть комплексного выражения"
 
 #: ../../src/wxMaximaFrame.cpp:1616
 msgid "Get the real part of complex expression"
-msgstr ""
+msgstr "Вычислить вещественную часть комплексного выражения"
 
 #: ../../src/wxMaxima.cpp:3609
 #, c-format
 msgid "Gnuplot (command line) found at: %s"
-msgstr ""
+msgstr "Gnuplot (командная строка) найден по адресу: %s"
 
 #: ../../src/wxMaxima.cpp:3607
 #, c-format
 msgid "Gnuplot found at: %s"
-msgstr ""
+msgstr "Gnuplot найден по адресу: %s"
 
 #: ../../src/wxMaxima.cpp:2974
 msgid "Gnuplot has closed."
-msgstr ""
+msgstr "Работа Gnuplot прекращена."
 
 #: ../../src/wxMaxima.cpp:3598 ../../src/wxMaxima.cpp:3603
 #, c-format
 msgid "Gnuplot not found, using the default: %s"
-msgstr ""
+msgstr "Gnuplot не найден, используется стандартный: %s"
 
 #: ../../src/wxMaxima.cpp:9428 ../../src/wxMaximaFrame.cpp:1887
 msgid "Go to URL"
-msgstr ""
+msgstr "Перейти по URL-адресу"
 
 #: ../../src/wxMaxima.cpp:3989
 msgid "Got a new input prompt!"
-msgstr ""
+msgstr "Получен новый запрос на ввод!"
 
 #: ../../src/Worksheet.cpp:6354
 msgid ""
 "Got a request to undo an action that involves a delete which isn't possible "
 "at this moment."
 msgstr ""
+"Запрашиваемая отмена действия включает в себя удаление, которое в настоящее "
+"время не может быть выполнено."
 
 #: ../../src/wxMaximaFrame.cpp:1031
 msgid "Gradefs"
-msgstr ""
+msgstr "Gradefs"
 
 #: ../../src/Worksheet.cpp:1967
 msgid "Greater or less than a value"
-msgstr ""
+msgstr "Больше или меньше значения"
 
 #: ../../src/wxMaximaFrame.cpp:1130
 msgid "Greater, ignoring case?..."
-msgstr ""
+msgstr "Больше, если игнорировать регистр?..."
 
 #: ../../src/wxMaximaFrame.cpp:260
 msgid "Greek Letters"
-msgstr ""
+msgstr "Греческие буквы"
 
 #: ../../src/wxMaximaFrame.cpp:703
 msgid "Greek Letters\tAlt+Shift+G"
-msgstr ""
+msgstr "Греческие буквы\tAlt+Shift+G"
 
 #: ../../src/wxMaximaFrame.cpp:1815
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
+"Подсчёт точного числа, которое может обозначать это число с плавающей точкой"
 
 #: ../../src/wxMaxima.cpp:6123
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file "
 "(*.tex)|*.tex"
 msgstr ""
+"файл HTML (*.html)|*.html|пакетный файл Maxima (*.mac)|*.mac|файл LaTeX "
+"(*.tex)|*.tex"
 
 #: ../../src/wxMaximaFrame.cpp:1341
 msgid "Hadamard (element-by-element) product..."
-msgstr ""
+msgstr "Произведение Адамара (покомпонентное)..."
 
 #: ../../src/wxMaxima.cpp:8004
 msgid "Hadamard Product"
-msgstr ""
+msgstr "Произведение Адамара"
 
 #: ../../src/wxMaxima.cpp:8011
 msgid "Hadamard exponent"
-msgstr ""
+msgstr "Экспонента Адамара"
 
 #: ../../src/wxMaximaFrame.cpp:1345
 msgid "Hadamard exponent..."
-msgstr ""
+msgstr "Экспонента Адамара..."
 
 #: ../../src/MaximaManual.cpp:260
 #, c-format
@@ -3416,119 +3557,122 @@ msgid ""
 "Have only %li keyword anchors at the end of parsing the maxima manual => Not"
 " caching the result of using the built-in keyword list"
 msgstr ""
+"Всего привязок ключевых слов по окончанию анализа руководства пользователя "
+"Maxima: %li => Не кэшируется результат использования встроенного списка "
+"ключевых слов"
 
 #: ../../src/Configuration.cpp:88 ../../src/ToolBar.cpp:276
 msgid "Heading 5"
-msgstr ""
+msgstr "Заголовок 5"
 
 #: ../../src/Configuration.cpp:87 ../../src/ToolBar.cpp:277
 msgid "Heading 6"
-msgstr ""
+msgstr "Заголовок 6"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
 msgid "Help"
-msgstr ""
+msgstr "Справка"
 
 #: ../../src/ToolBar.cpp:635
 msgid "Help button"
-msgstr ""
+msgstr "Кнопка «Справка»"
 
 #: ../../src/Worksheet.cpp:1340 ../../src/Worksheet.cpp:1778
 #, c-format
 msgid "Help on \"%s\""
-msgstr ""
+msgstr "Справка по «%s»"
 
 #: ../../src/wxMaximaFrame.cpp:729
 msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr ""
+msgstr "Скрыть все панели инструментов\tAlt+Shift+-"
 
 #: ../../src/ToolBar.cpp:264
 msgid "Hide Code"
-msgstr ""
+msgstr "Скрыть код"
 
 #: ../../src/wxMaximaFrame.cpp:727
 msgid "Hide Code Cells\tAlt+Ctrl+H"
-msgstr ""
+msgstr "Скрыть поля кода\tAlt+Ctrl+H"
 
 #: ../../src/Worksheet.cpp:1896
 msgid "Hide Heading 5"
-msgstr ""
+msgstr "Скрыть Заголовок 5"
 
 #: ../../src/Worksheet.cpp:1907
 msgid "Hide Heading 6"
-msgstr ""
+msgstr "Скрыть Заголовок 6"
 
 #: ../../src/Worksheet.cpp:1855
 msgid "Hide Part"
-msgstr ""
+msgstr "Скрыть часть"
 
 #: ../../src/Worksheet.cpp:1863
 msgid "Hide Section"
-msgstr ""
+msgstr "Скрыть раздел"
 
 #: ../../src/Worksheet.cpp:1874
 msgid "Hide Subsection"
-msgstr ""
+msgstr "Скрыть подраздел"
 
 #: ../../src/Worksheet.cpp:1885
 msgid "Hide Subsubsection"
-msgstr ""
+msgstr "Скрыть под-подраздел"
 
 #: ../../src/wxMaximaFrame.cpp:730
 msgid "Hide all panes"
-msgstr ""
+msgstr "Скрыть все панели"
 
 #: ../../src/Worksheet.cpp:1491
 msgid "Hide cell brackets"
-msgstr ""
+msgstr "Скрыть квадратные скобки полей"
 
 #: ../../src/Worksheet.cpp:1915
 msgid "Hide contents"
-msgstr ""
+msgstr "Скрыть содержимое"
 
 #: ../../src/Worksheet.cpp:1552
 msgid "Hide multiplication dots"
-msgstr ""
+msgstr "Скрывать знаки умножения"
 
 #: ../../src/Worksheet.cpp:1930 ../../src/Worksheet.cpp:2063
 msgid "Hide yellow tooltip marker for this cell"
-msgstr ""
+msgstr "Скрыть жёлтый маркер подсказки для этого поля"
 
 #: ../../src/Worksheet.cpp:1937 ../../src/Worksheet.cpp:2069
 msgid "Hide yellow tooltip marker for this message type"
-msgstr ""
+msgstr "Скрыть жёлтый маркер подсказки для этого типа сообщения"
 
 #: ../../src/Configuration.cpp:82
 msgid "Highlight (box)"
-msgstr ""
+msgstr "Выделение (рамка)"
 
 #: ../../src/wxMaxima.cpp:9528
 msgid "Histogram"
-msgstr ""
+msgstr "Гистограмма"
 
 #: ../../src/wxMaximaFrame.cpp:232
 msgid "History"
-msgstr ""
+msgstr "Журнал"
 
 #: ../../src/wxMaximaFrame.cpp:709
 msgid "History\tAlt+Shift+I"
-msgstr ""
+msgstr "Журнал\tAlt+Shift+I"
 
 #: ../../src/wxMaximaFrame.cpp:1526
 msgid "Horner's rule"
-msgstr ""
+msgstr "Правило Горнера"
 
 #: ../../src/wxMaxima.cpp:9207
 msgid "How many digits to show:"
-msgstr ""
+msgstr "Сколько цифр показывать:"
 
 #: ../../src/wxMaximaFrame.cpp:759
 msgid "How to display new equations"
-msgstr ""
+msgstr "Способ отображения новых уравнений"
 
 #: ../../src/wxMaximaFrame.cpp:1113
 msgid "I/O"
-msgstr ""
+msgstr "Ввод/вывод"
 
 #: ../../src/wxMaxima.cpp:7062
 msgid ""
@@ -3536,6 +3680,9 @@ msgid ""
 "between parenthesis. The result of the last operation is the return value of"
 " the program."
 msgstr ""
+"Если программа не требует локальных переменных, Maxima позволяет помещать "
+"команды в скобки. Результат последней операции является возвращаемым "
+"значением программы."
 
 #: ../../src/wxMaxima.cpp:7172
 msgid ""
@@ -3544,511 +3691,529 @@ msgid ""
 "\n"
 "array, boolean, integer, fixnum (machine-length integer), float (machine-size floating-point numbers), real or any (which is useful for declaring arrays of any)"
 msgstr ""
+"Если тип функционального параметра известен, при компиляции функции можно значительно оптимизировать код.\n"
+"Известные типы:\n"
+"\n"
+"array, boolean, integer, fixnum (целое число длиной в машинное слово), float (число с плавающей точкой машинного размера), real или any (полезно для объявления массивов any)"
 
 #: ../../src/MathParser.cpp:890
 msgid ""
 "If this isn't a function returning a lambda() expression a multiplication "
 "sign (*) between closing and opening parenthesis is missing here."
 msgstr ""
+"Если это не функция, возвращающая лямбда-выражение, здесь не хватает знака "
+"умножения (*) между закрывающей и открывающей скобками."
 
 #: ../../src/MaximaManual.cpp:403
 msgid "Ignoring the cache version for the manual anchors."
-msgstr ""
+msgstr "Игнорируется версия кэша для ключевых слов руководства пользователя."
 
 #: ../../src/Image.cpp:79
 msgid "Image data had zero length!"
-msgstr ""
+msgstr "Нулевая длина данных изображения!"
 
 #: ../../src/wxMaxima.cpp:10147 ../../src/wxMaxima.cpp:10855
 msgid ""
 "Image files (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, "
 "*.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
 msgstr ""
+"Файлы изображений (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, "
+"*.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
 
 #: ../../src/Worksheet.cpp:5509
 msgid "ImageCell without image."
-msgstr ""
+msgstr "ImageCell без изображения."
 
 #: ../../src/MathParser.cpp:347
 msgid "Importing compressed gnuplot sources for an animation"
-msgstr ""
+msgstr "Импорт сжатых исходников Gnuplot для анимации"
 
 #: ../../src/MathParser.cpp:334
 msgid "Importing uncompressed gnuplot sources for an animation"
-msgstr ""
+msgstr "Импорт несжатых исходников Gnuplot для анимации"
 
 #: ../../src/wxMaxima.cpp:7993
 msgid ""
 "In order to save memory the \":\" operator does clone the matrix, not copy it:\n"
 "If you change an element of one matrix the same element will change in all of its clones. copymatrix() instead generates a copy of a matrix: A new matrix that, if changed in any way, won't change the original."
 msgstr ""
+"Для экономии памяти оператор \":\" клонирует матрицу, а не копирует её:\n"
+"Если изменить какой-либо элемент в матрице, тот же элемент изменится во всех её клонах. copymatrix() вместо этого создаёт копию матрицы: новую матрицу, любые изменения в которой не повлияют на оригинал."
 
 #: ../../src/wxMaxima.cpp:7404
 msgid ""
 "In order to save memory the : operator doesn't create an individual copy of "
 "the string, but a clone that changes when the original string changes."
 msgstr ""
+"Для экономии памяти оператор : создаёт не отдельную копию строки, а её клон,"
+" который изменяется при изменении исходной строки."
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Include columns:"
-msgstr ""
+msgstr "Включить столбцы:"
 
 #: ../../src/Worksheet.cpp:2008
 msgid "Increasing function f(x)>x"
-msgstr ""
+msgstr "Возрастающая функция f(x)>x"
 
 #: ../../src/wxMaxima.cpp:8470
 msgid "Index End:"
-msgstr ""
+msgstr "Конечный индекс:"
 
 #: ../../src/wxMaxima.cpp:8470
 msgid "Index Start:"
-msgstr ""
+msgstr "Начальный индекс:"
 
 #: ../../src/wxMaxima.cpp:8471
 msgid "Index Step:"
-msgstr ""
+msgstr "Шаг индекса:"
 
 #: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
 msgid "Index variable:"
-msgstr ""
+msgstr "Индексная переменная:"
 
 #: ../../src/wxMaximaFrame.cpp:1949
 msgid "Info about Maxima build"
-msgstr ""
+msgstr "Информация о сборке Maxima"
 
 #: ../../src/Worksheet.cpp:2046
 msgid "Inform maxima about facts you know for this symbol"
-msgstr ""
+msgstr "Сообщить Maxima об известных свойствах этого символа"
 
 #: ../../src/Worksheet.cpp:1988
 msgid ""
 "Inform maxima about the value of the function at a specific point, e.G. for "
 "declaring initial conditions"
 msgstr ""
+"Сообщить Maxima о значении функции в определённой точке, например, чтобы "
+"объявить начальные условия"
 
 #: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
 msgid "Initial Condition"
-msgstr ""
+msgstr "Начальное условие:"
 
 #: ../../src/wxMaximaFrame.cpp:1270
 msgid "Initial Value Problem (&1)..."
-msgstr ""
+msgstr "Задача с начальным условием (&1) ..."
 
 #: ../../src/wxMaximaFrame.cpp:1274
 msgid "Initial Value Problem (&2)..."
-msgstr ""
+msgstr "Задача с начальным условием (&2) ..."
 
 #: ../../src/wxMaxima.cpp:9044
 msgid "Initial estimates:"
-msgstr ""
+msgstr "Начальное приближение:"
 
 #: ../../src/wxMaxima.cpp:7840
 msgid "Initial x:"
-msgstr ""
+msgstr "Начальное x:"
 
 #: ../../src/Configuration.cpp:78
 msgid "Input labels"
-msgstr ""
+msgstr "Метки ввода"
 
 #: ../../src/wxMaximaFrame.cpp:314
 msgid "Insert"
-msgstr ""
+msgstr "Вставить"
 
 #: ../../src/wxMaximaFrame.cpp:905
 msgid "Insert &Section Cell\tCtrl+3"
-msgstr ""
+msgstr "Вставить поле &раздела\tCtrl+3"
 
 #: ../../src/wxMaximaFrame.cpp:901
 msgid "Insert &Text Cell\tCtrl+1"
-msgstr ""
+msgstr "Вставить &текстовое поле\tCtrl+1"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Insert Cell\tAlt+Shift+C"
-msgstr ""
+msgstr "Вставка полей\tAlt+Shift+C"
 
 #: ../../src/Worksheet.cpp:1669
 msgid "Insert Heading5 Cell"
-msgstr ""
+msgstr "Вставить поле Заголовок5"
 
 #: ../../src/Worksheet.cpp:1671
 msgid "Insert Heading6 Cell"
-msgstr ""
+msgstr "Вставить поле Заголовок6"
 
 #: ../../src/wxMaxima.cpp:10854
 msgid "Insert Image"
-msgstr ""
+msgstr "Вставить изображение"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert Image..."
-msgstr ""
+msgstr "Вставить изображение..."
 
 #: ../../src/wxMaximaFrame.cpp:899
 msgid "Insert Input &Cell\tCtrl+0"
-msgstr ""
+msgstr "Вставить поле &ввода\tCtrl+0"
 
 #: ../../src/wxMaximaFrame.cpp:919
 msgid "Insert Page Break"
-msgstr ""
+msgstr "Вставить разрыв страницы"
 
 #: ../../src/wxMaximaFrame.cpp:907
 msgid "Insert S&ubsection Cell\tCtrl+4"
-msgstr ""
+msgstr "Вставить поле п&одраздела\tCtrl+4"
 
 #: ../../src/wxMaximaFrame.cpp:910
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
-msgstr ""
+msgstr "Вставить поле по&д-подраздела\tCtrl+5"
 
 #: ../../src/Worksheet.cpp:1662
 msgid "Insert Section Cell"
-msgstr ""
+msgstr "Вставить поле раздела"
 
 #: ../../src/Worksheet.cpp:1664
 msgid "Insert Subsection Cell"
-msgstr ""
+msgstr "Вставить поле подраздела"
 
 #: ../../src/Worksheet.cpp:1667
 msgid "Insert Subsubsection Cell"
-msgstr ""
+msgstr "Вставить поле под-подраздела"
 
 #: ../../src/wxMaximaFrame.cpp:903
 msgid "Insert T&itle Cell\tCtrl+2"
-msgstr ""
+msgstr "Вставить поле &заголовка\tCtrl+2"
 
 #: ../../src/Worksheet.cpp:1658
 msgid "Insert Text Cell"
-msgstr ""
+msgstr "Вставить текстовое поле"
 
 #: ../../src/Worksheet.cpp:1660
 msgid "Insert Title Cell"
-msgstr ""
+msgstr "Вставить поле заголовка"
 
 #: ../../src/wxMaximaFrame.cpp:913
 msgid "Insert a new heading5 cell"
-msgstr ""
+msgstr "Вставить новое поле Заголовок5"
 
 #: ../../src/wxMaximaFrame.cpp:915
 msgid "Insert a new heading6 cell"
-msgstr ""
+msgstr "Вставить новое поле Заголовок6"
 
 #: ../../src/wxMaximaFrame.cpp:900
 msgid "Insert a new input cell"
-msgstr ""
+msgstr "Вставить новое поле ввода"
 
 #: ../../src/wxMaximaFrame.cpp:906
 msgid "Insert a new section cell"
-msgstr ""
+msgstr "Вставить новое поле раздела"
 
 #: ../../src/wxMaximaFrame.cpp:908
 msgid "Insert a new subsection cell"
-msgstr ""
+msgstr "Вставить новое поле подраздела"
 
 #: ../../src/wxMaximaFrame.cpp:911
 msgid "Insert a new subsubsection cell"
-msgstr ""
+msgstr "Вставить новое поле под-подраздела"
 
 #: ../../src/wxMaximaFrame.cpp:902
 msgid "Insert a new text cell"
-msgstr ""
+msgstr "Вставить новое текстовое поле"
 
 #: ../../src/wxMaximaFrame.cpp:904
 msgid "Insert a new title cell"
-msgstr ""
+msgstr "Вставить новое поле заголовка"
 
 #: ../../src/wxMaximaFrame.cpp:920
 msgid "Insert a page break"
-msgstr ""
+msgstr "Вставить разрыв страницы"
 
 #: ../../src/wxMaximaFrame.cpp:1164
 msgid "Insert char..."
-msgstr ""
+msgstr "Вставить символ..."
 
 #: ../../src/wxMaximaFrame.cpp:912
 msgid "Insert heading5 Cell\tCtrl+6"
-msgstr ""
+msgstr "Вставить поле Заголовок5\tCtrl+6"
 
 #: ../../src/wxMaximaFrame.cpp:914
 msgid "Insert heading6 Cell\tCtrl+7"
-msgstr ""
+msgstr "Вставить поле &Заголовок6\tCtrl+7"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert image"
-msgstr ""
+msgstr "Вставить изображение"
 
 #: ../../src/wxMaximaFrame.cpp:916
 msgid "Insert textbased cell"
-msgstr ""
+msgstr "Вставить текстовое поле"
 
 #: ../../src/wxMaxima.cpp:3566
 msgid "Instructed to prefer gnuplot over wgnuplot"
-msgstr ""
+msgstr "Указано отдавать gnuplot приоритет над wgnuplot"
 
 #: ../../src/wxMaxima.cpp:3554
 msgid "Instructed to prefer wgnuplot over gnuplot"
-msgstr ""
+msgstr "Указано отдавать wgnuplot приоритет над gnuplot"
 
 #: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
 msgid "Integral/Sum:"
-msgstr ""
+msgstr "Интеграл/сумма:"
 
 #: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
 msgid "Integrate"
-msgstr ""
+msgstr "Интегрировать"
 
 #: ../../src/wxMaxima.cpp:8980
 msgid "Integrate (risch)"
-msgstr ""
+msgstr "Интегрировать (Рич)"
 
 #: ../../src/wxMaximaFrame.cpp:1454
 msgid "Integrate expression"
-msgstr ""
+msgstr "Интегрировать выражение"
 
 #: ../../src/wxMaximaFrame.cpp:1456
 msgid "Integrate expression with Risch algorithm"
-msgstr ""
+msgstr "Интегрировать выражение с помощью алгоритма Рича"
 
 #: ../../src/wxMaximaFrame.cpp:1869
 msgid "Integrate numerically"
-msgstr ""
+msgstr "Проинтегрировать численно"
 
 #: ../../src/Worksheet.cpp:1588
 msgid "Integrate..."
-msgstr ""
+msgstr "Интегрировать..."
 
 #: ../../src/wxMaximaFrame.cpp:1737
 msgid "Interleave"
-msgstr ""
+msgstr "Чередовать"
 
 #: ../../src/wxMaximaFrame.cpp:1738
 msgid "Interleave the values of two lists"
-msgstr ""
+msgstr "Чередовать значения из двух списков"
 
 #: ../../src/wxMaxima.cpp:8612
 msgid "Interleave two lists"
-msgstr ""
+msgstr "Чередовать два списка"
 
 #: ../../src/wxMaximaFrame.cpp:1087
 msgid "Interpret like input..."
-msgstr ""
+msgstr "Интерпретировать как входные данные..."
 
 #: ../../src/wxMaxima.cpp:7104
 msgid "Interpret maxima's output as input"
-msgstr ""
+msgstr "Интерпретировать выходные данные Maxima как входные"
 
 #: ../../src/wxMaxima.cpp:7502
 msgid "Interpret string as maxima code"
-msgstr ""
+msgstr "Интерпретировать строку как код Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1089
 msgid "Interpret string..."
-msgstr ""
+msgstr "Интерпретировать строку..."
 
 #: ../../src/ToolBar.cpp:231
 msgid "Interrupt"
-msgstr ""
+msgstr "Прервать"
 
 #: ../../src/wxMaximaFrame.cpp:965
 msgid "Interrupt current computation"
-msgstr ""
+msgstr "Прервать текущее вычисление"
 
 #: ../../src/ToolBar.cpp:232
 msgid ""
 "Interrupt current computation. To completely restart maxima press the button"
 " left to this one."
 msgstr ""
+"Прервать текущее вычисление. Чтобы полностью перезапустить Maxima, нажмите "
+"кнопку, расположенную слева от этой кнопки."
 
 #: ../../src/wxMaxima.cpp:2766
 #, c-format
 msgid "Interrupting maxima: %s"
-msgstr ""
+msgstr "Прерывание работы Maxima: %s"
 
 #: ../../src/wxMaxima.cpp:8557
 msgid "Introduce a list of actual values into an equation"
-msgstr ""
+msgstr "Вставить список фактических значений в уравнение"
 
 #: ../../src/wxMaximaFrame.cpp:1697
 msgid "Introduce the actual values for variables stored in the list"
-msgstr ""
+msgstr "Вставить фактические значения переменных, хранящиеся в списке"
 
 #: ../../src/wxMaxima.cpp:10062
 msgid "Introduces one or more assignments into an expression"
-msgstr ""
+msgstr "Вводит одну или несколько установок значений в выражение"
 
 #: ../../src/wxMaxima.cpp:9003
 msgid "Inverse Laplace"
-msgstr ""
+msgstr "Обратное преобразование Лапласа"
 
 #: ../../src/wxMaximaFrame.cpp:1488
 msgid "Inverse Laplace T&ransform..."
-msgstr ""
+msgstr "Обратное п&реобразование Лапласа..."
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Invert worksheet brightness"
-msgstr ""
+msgstr "Инвертировать яркость рабочего листа"
 
 #: ../../src/wxMaxima.cpp:7338
 msgid "Is Char 1 greater than Char2, if case is ignored?"
-msgstr ""
+msgstr "Символ 1 больше символа 2, если игнорировать регистр?"
 
 #: ../../src/wxMaxima.cpp:7333
 msgid "Is Char 1 greater than Char2?"
-msgstr ""
+msgstr "Символ 1 больше символа 2?"
 
 #: ../../src/wxMaxima.cpp:7327
 msgid "Is Char 1 less than Char2, if case is ignored?"
-msgstr ""
+msgstr "Символ 1 меньше символа 2, если игнорировать регистр?"
 
 #: ../../src/wxMaxima.cpp:7322
 msgid "Is Char 1 less than Char2?"
-msgstr ""
+msgstr "Символ 1 меньше символа 2?"
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Is a char?"
-msgstr ""
+msgstr "Символ?"
 
 #: ../../src/wxMaximaFrame.cpp:1115
 msgid "Is a char?..."
-msgstr ""
+msgstr "Символ?..."
 
 #: ../../src/Worksheet.cpp:1952
 msgid "Is a complex variable"
-msgstr ""
+msgstr "Является комплексной переменной"
 
 #: ../../src/wxMaxima.cpp:7292
 msgid "Is a digit?"
-msgstr ""
+msgstr "Цифра?"
 
 #: ../../src/wxMaximaFrame.cpp:1118
 msgid "Is a digit?..."
-msgstr ""
+msgstr "Цифра?..."
 
 #: ../../src/wxMaxima.cpp:7304
 msgid "Is a lowercase char?"
-msgstr ""
+msgstr "Символ в нижнем регистре?"
 
 #: ../../src/wxMaxima.cpp:7296
 msgid "Is a printable char?"
-msgstr ""
+msgstr "Печатаемый символ?"
 
 #: ../../src/Worksheet.cpp:1949
 msgid "Is a real variable"
-msgstr ""
+msgstr "Является вещественной переменной"
 
 #: ../../src/wxMaxima.cpp:7300
 msgid "Is a uppercase char?"
-msgstr ""
+msgstr "Символ в верхнем регистре?"
 
 #: ../../src/wxMaximaFrame.cpp:1116
 msgid "Is alphabetic?..."
-msgstr ""
+msgstr "Буква?..."
 
 #: ../../src/wxMaximaFrame.cpp:1117
 msgid "Is alphanumeric?..."
-msgstr ""
+msgstr "Буква или цифра?..."
 
 #: ../../src/wxMaxima.cpp:7284
 msgid "Is an alphabetic char?"
-msgstr ""
+msgstr "Буква?"
 
 #: ../../src/wxMaxima.cpp:7288
 msgid "Is an alphanumeric char?"
-msgstr ""
+msgstr "Буква или цифра?"
 
 #: ../../src/Worksheet.cpp:1991
 msgid "Is an even function"
-msgstr ""
+msgstr "Является чётной функцией"
 
 #: ../../src/Worksheet.cpp:1955
 msgid "Is an imaginary variable"
-msgstr ""
+msgstr "Является мнимой переменной"
 
 #: ../../src/Worksheet.cpp:1960
 msgid "Is an integer variable"
-msgstr ""
+msgstr "Является целочисленной переменной"
 
 #: ../../src/Worksheet.cpp:1993
 msgid "Is an odd function"
-msgstr ""
+msgstr "Является нечётной функцией"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Is equal?..."
-msgstr ""
+msgstr "Равняется?..."
 
 #: ../../src/wxMaximaFrame.cpp:1128
 msgid "Is greater?..."
-msgstr ""
+msgstr "Больше?..."
 
 #: ../../src/wxMaximaFrame.cpp:1125
 msgid "Is lower?..."
-msgstr ""
+msgstr "Меньше?..."
 
 #: ../../src/wxMaximaFrame.cpp:1121
 msgid "Is lowercase?..."
-msgstr ""
+msgstr "В нижнем регистре?..."
 
 #: ../../src/Worksheet.cpp:1962
 msgid "Is no integer variable"
-msgstr ""
+msgstr "Не является целочисленной переменной"
 
 #: ../../src/wxMaximaFrame.cpp:1119
 msgid "Is printable?..."
-msgstr ""
+msgstr "Печатаемый?..."
 
 #: ../../src/wxMaximaFrame.cpp:1120
 msgid "Is uppercase?..."
-msgstr ""
+msgstr "В верхнем регистре?..."
 
 #: ../../src/Worksheet.cpp:6256
 msgid "Issuing the active cell's undo function"
-msgstr ""
+msgstr "Срабатывание функции отмены в активном поле"
 
 #: ../../src/Worksheet.cpp:6261
 msgid "Issuing the worksheet's undo function"
-msgstr ""
+msgstr "Срабатывание функции отмены на листе"
 
 #: ../../src/wxMaxima.cpp:8598 ../../src/wxMaxima.cpp:8604
 msgid "Item"
-msgstr ""
+msgstr "Элемент"
 
 #: ../../src/wxMaxima.cpp:8581
 msgid "Iterator name:"
-msgstr ""
+msgstr "Название итератора:"
 
 #: ../../src/wxMaximaFrame.cpp:1048
 msgid "Jump to first error"
-msgstr ""
+msgstr "Перейти к первой ошибке"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Jump to the first cell Maxima has reported an error in."
 msgstr ""
+"Перейти к первому полю, в отношении которого от Maxima поступило сообщение "
+"об ошибке."
 
 #: ../../src/wxMaxima.cpp:8960
 msgid "LCM"
-msgstr ""
+msgstr "НОК"
 
 #: ../../src/wxMaximaFrame.cpp:1407
 msgid "L[1] Norm (complex)"
-msgstr ""
+msgstr "Норма L[1] (комплексная)"
 
 #: ../../src/wxMaximaFrame.cpp:1406
 msgid "L[1] Norm (real)"
-msgstr ""
+msgstr "Норма L[1] (вещественная)"
 
 #: ../../src/wxMaximaFrame.cpp:1409
 msgid "L[inf] Norm (complex)"
-msgstr ""
+msgstr "Норма L[inf] (комплексная)"
 
 #: ../../src/wxMaximaFrame.cpp:1408
 msgid "L[inf] Norm (real)"
-msgstr ""
+msgstr "Норма L[inf] (вещественная)"
 
 #: ../../src/wxMaximaFrame.cpp:1025
 msgid "Labels"
-msgstr ""
+msgstr "Метки"
 
 #: ../../src/wxMaxima.cpp:7090
 msgid "Lambda"
-msgstr ""
+msgstr "Λ"
 
 #: ../../src/wxMaxima.cpp:7091
 msgid ""
@@ -4056,275 +4221,282 @@ msgid ""
 "This is useful if you want to use a function only once, perhaps as a parameter to another function and don't need it to be named.\n"
 "Also you can fill a variable with a lambda() construct, effectively generating a function pointer: A variable that can be used as a function, and filled with a different function, if needed."
 msgstr ""
+"Лямбда генерирует функцию, но не даёт ей имя.\n"
+"Это удобно, если функцией нужно воспользоваться только один раз (возможно, как параметром для другой функции) и для неё не требуется имя.\n"
+"Также возможно заполнить переменную конструкцией lambda(), по сути создавая указатель функции (переменная, которая может использоваться как функция и заполняться другой переменной при необходимости)."
 
 #: ../../src/wxMaxima.cpp:8997
 msgid "Laplace"
-msgstr ""
+msgstr "Преобразование Лапласа"
 
 #: ../../src/wxMaximaFrame.cpp:1484
 msgid "Laplace &Transform..."
-msgstr ""
+msgstr "Преобразование Лапласа ..."
 
 #: ../../src/wxMaximaFrame.cpp:1718
 msgid "Last"
-msgstr ""
+msgstr "Последние"
 
 #: ../../src/wxMaxima.cpp:3006
 #, c-format
 msgid "Last message from maxima's stderr: %s"
-msgstr ""
+msgstr "Последнее сообщение из стандартного потока ошибок Maxima: %s"
 
 #: ../../src/wxMaxima.cpp:2993
 #, c-format
 msgid "Last message from maxima's stdout: %s"
-msgstr ""
+msgstr "Последнее сообщение из стандартного вывода Maxima: %s"
 
 #: ../../src/wxMaximaFrame.cpp:1720
 msgid "Last n"
-msgstr ""
+msgstr "Последние n"
 
 #: ../../src/wxMaxima.cpp:10400
 msgid "Last non-whitespace is a question mark"
-msgstr ""
+msgstr "Последний символ, отличный от пробела, является знаком вопроса"
 
 #: ../../src/wxMaxima.cpp:4899
 #, c-format
 msgid "Launching the system's default help browser as %s."
-msgstr ""
+msgstr "Запуск системного браузера справки по умолчанию как %s."
 
 #: ../../src/wxMaxima.cpp:4909
 msgid "Launching the system's default help browser failed."
-msgstr ""
+msgstr "Не удалось запустить системный браузер справки по умолчанию."
 
 #: ../../src/wxMaximaFrame.cpp:1493
 msgid "Least Common Multiple..."
-msgstr ""
+msgstr "Наименьшее общее кратное..."
 
 #: ../../src/wxMaxima.cpp:9587
 msgid "Least Squares Fit"
-msgstr ""
+msgstr "Прив. методом наименьших квадратов"
 
 #: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
 #: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
 msgid "Left Matrix:"
-msgstr ""
+msgstr "Левая матрица:"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Left end"
-msgstr ""
+msgstr "Левая сторона"
 
 #: ../../src/wxMaximaFrame.cpp:1297
 msgid "Left side to the \"=\""
-msgstr ""
+msgstr "Левая сторона «=»"
 
 #: ../../src/wxMaximaFrame.cpp:1741
 msgid "Length"
-msgstr ""
+msgstr "Длина"
 
 #: ../../src/wxMaximaFrame.cpp:1104 ../../src/wxMaximaFrame.cpp:1167
 msgid "Length..."
-msgstr ""
+msgstr "Длина..."
 
 #: ../../src/wxMaxima.cpp:7421
 msgid "Length:"
-msgstr ""
+msgstr "Длина:"
 
 #: ../../src/wxMaximaFrame.cpp:1032
 msgid "Letrules"
-msgstr ""
+msgstr "Letrules"
 
 #: ../../src/Worksheet.cpp:1976
 msgid "Likely to be the main variable"
-msgstr ""
+msgstr "Вероятно, является основной переменной"
 
 #: ../../src/wxMaxima.cpp:9028
 msgid "Limit"
-msgstr ""
+msgstr "Предел"
 
 #: ../../src/wxMaxima.cpp:7256
 msgid "Lisp format string:"
-msgstr ""
+msgstr "Строка в формате Lisp:"
 
 #: ../../src/wxMaxima.cpp:7258
 msgid "Lisp format strings are more powerful than c++ format strings"
 msgstr ""
+"Строки в формате Lisp предоставляют более широкие возможности, чем строки в "
+"формате C++"
 
 #: ../../src/wxMaxima.cpp:5066
 msgid "Lisp mode."
-msgstr ""
+msgstr "Режим Lisp."
 
 #: ../../src/wxMaximaFrame.cpp:1010 ../../src/wxMaximaFrame.cpp:1012
 msgid "Lisp normally frees memory only when it has time or runs out of space"
 msgstr ""
+"Lisp обычно высвобождает память только тогда, когда у него достаточно "
+"времени или недостаточно пространства"
 
 #: ../../src/wxMaxima.cpp:3691
 #, c-format
 msgid "Lisp version: %s"
-msgstr ""
+msgstr "Версия Lisp: %s"
 
 #: ../../src/wxMaxima.cpp:8435 ../../src/wxMaxima.cpp:8539
 #: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
 #: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
 #: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
 msgid "List"
-msgstr ""
+msgstr "Список"
 
 #: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
 msgid "List #1"
-msgstr ""
+msgstr "Список 1"
 
 #: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
 msgid "List #2"
-msgstr ""
+msgstr "Список 2"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "List directory"
-msgstr ""
+msgstr "Вывести содержимое каталога"
 
 #: ../../src/wxMaximaFrame.cpp:1205
 msgid "List directory..."
-msgstr ""
+msgstr "Вывести содержимое каталога..."
 
 #: ../../src/wxMaxima.cpp:7385 ../../src/wxMaxima.cpp:7389
 msgid "List of char to String"
-msgstr ""
+msgstr "Список символов в строку"
 
 #: ../../src/wxMaximaFrame.cpp:1150
 msgid "List of chars to string..."
-msgstr ""
+msgstr "Список символов в строку..."
 
 #: ../../src/wxMaxima.cpp:7386
 msgid "List of chars:"
-msgstr ""
+msgstr "Список символов:"
 
 #: ../../src/wxMaxima.cpp:8559
 msgid "List with values"
-msgstr ""
+msgstr "Список со значениями"
 
 #: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
 msgid "List:"
-msgstr ""
+msgstr "Список:"
 
 #: ../../src/wxMaxima.cpp:6200
 msgid "Load Package"
-msgstr ""
+msgstr "Загрузить пакет"
 
 #: ../../src/wxMaximaFrame.cpp:613
 msgid "Load Recent Package"
-msgstr ""
+msgstr "Загрузить последний пакет"
 
 #: ../../src/wxMaximaFrame.cpp:616
 msgid "Load a Maxima file using the batch command"
-msgstr ""
+msgstr "Загрузить файл Maxima с помощью команды batch"
 
 #: ../../src/wxMaximaFrame.cpp:611
 msgid "Load a Maxima package file"
-msgstr ""
+msgstr "Загрузить пакетный файл Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1678
 msgid "Load a list from a csv file"
-msgstr ""
+msgstr "Загрузить список из файла CSV"
 
 #: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
 msgid "Load a matrix from a csv file"
-msgstr ""
+msgstr "Загрузить матрицу из файла CSV"
 
 #: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
 msgid "Load lapack"
-msgstr ""
+msgstr "Загрузить lapack"
 
 #: ../../src/wxMaxima.cpp:7208
 msgid "Load lisp code"
-msgstr ""
+msgstr "Загрузить код Lisp"
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "Load lisp..."
-msgstr ""
+msgstr "Загрузить Lisp..."
 
 #: ../../src/wxMaximaFrame.cpp:1198
 msgid "Load the file/dir operations (operatingsystem)"
-msgstr ""
+msgstr "Загрузить операции с файлами/каталогами (operatingsystem)"
 
 #: ../../src/wxMaximaFrame.cpp:1187
 msgid "Load the regular expression package (sregex)"
-msgstr ""
+msgstr "Загрузить пакет регулярных выражений (sregex)"
 
 #: ../../src/wxMaximaFrame.cpp:1224
 msgid "Load the translation generator (gentran)"
-msgstr ""
+msgstr "Загрузить генератор трансляций (gentran)"
 
 #: ../../src/wxMaxima.cpp:8219
 msgid "Loop variable"
-msgstr ""
+msgstr "Переменная цикла"
 
 #: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
 msgid "Lower bound:"
-msgstr ""
+msgstr "Нижняя граница:"
 
 #: ../../src/wxMaximaFrame.cpp:1127
 msgid "Lower, ignoring case?..."
-msgstr ""
+msgstr "Меньше, если игнорировать регистр?..."
 
 #: ../../src/wxMaximaFrame.cpp:1448
 msgid "M&atrix"
-msgstr ""
+msgstr "М&атрица"
 
 #: ../../src/wxMaxima.cpp:7153
 msgid "Macro contents:"
-msgstr ""
+msgstr "Содержимое макроса:"
 
 #: ../../src/wxMaxima.cpp:7148
 msgid "Macro name:"
-msgstr ""
+msgstr "Имя макроса:"
 
 #: ../../src/wxMaximaFrame.cpp:1024
 msgid "Macros"
-msgstr ""
+msgstr "Макросы"
 
 #: ../../src/wxMaximaFrame.cpp:697
 msgid "Main Toolbar\tAlt+Shift+B"
-msgstr ""
+msgstr "Основная панель инструментов\tAlt+Shift+B"
 
 #: ../../src/wxMaxima.cpp:7906
 msgid "Make a function value at a specific point known"
-msgstr ""
+msgstr "Сообщить значение функции в определённой точке"
 
 #: ../../src/Worksheet.cpp:2028
 msgid "Make an eventual ev() evaluate this"
-msgstr ""
+msgstr "Вычислить в конце с помощью ev()"
 
 #: ../../src/wxMaximaFrame.cpp:1070
 msgid "Make function local..."
-msgstr ""
+msgstr "Сделать функцию локальной..."
 
 #: ../../src/wxMaxima.cpp:8207
 msgid "Map"
-msgstr ""
+msgstr "Применить к элементам"
 
 #: ../../src/wxMaxima.cpp:8215
 msgid "Map an expression"
-msgstr ""
+msgstr "Применить выражение"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "Map function to a matrix"
-msgstr ""
+msgstr "Применить функцию к элементам матрицы"
 
 #: ../../src/wxMaximaFrame.cpp:1446
 msgid "Map function to a matrix, affecting all of its clones"
-msgstr ""
+msgstr "Применить функцию к элементам матрицы, затрагивая все её клоны"
 
 #: ../../src/Configuration.cpp:109
 msgid "Math Default"
-msgstr ""
+msgstr "Значения по умолчанию для математики"
 
 #: ../../src/wxMaximaFrame.cpp:286
 msgid "Mathematical Symbols"
-msgstr ""
+msgstr "Математические символы"
 
 #: ../../src/ToolBar.cpp:270
 msgid "Maths"
-msgstr ""
+msgstr "Расчёты"
 
 #: ../../src/wxMaxima.cpp:7945 ../../src/wxMaxima.cpp:8022
 #: ../../src/wxMaxima.cpp:8027 ../../src/wxMaxima.cpp:8032
@@ -4336,54 +4508,54 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
 #: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
 msgid "Matrix"
-msgstr ""
+msgstr "Матрица"
 
 #: ../../src/wxMaxima.cpp:7986
 msgid "Matrix Exponent"
-msgstr ""
+msgstr "Матричная экспонента"
 
 #: ../../src/wxMaximaFrame.cpp:1339
 msgid "Matrix exponent..."
-msgstr ""
+msgstr "Матричная экспонента..."
 
 #: ../../src/wxMaximaFrame.cpp:1329
 msgid "Matrix from csv file"
-msgstr ""
+msgstr "Матрица из файла CSV"
 
 #: ../../src/wxMaximaFrame.cpp:1323
 msgid "Matrix from csv file..."
-msgstr ""
+msgstr "Матрица из файла CSV..."
 
 #: ../../src/wxMaxima.cpp:8137
 msgid "Matrix map"
-msgstr ""
+msgstr "Применить к матрице"
 
 #: ../../src/wxMaxima.cpp:9630
 msgid "Matrix name:"
-msgstr ""
+msgstr "Матрица:"
 
 #: ../../src/wxMaximaFrame.cpp:798
 msgid "Matrix parenthesis"
-msgstr ""
+msgstr "Скобки матрицы"
 
 #: ../../src/wxMaximaFrame.cpp:1331
 msgid "Matrix to csv file"
-msgstr ""
+msgstr "Матрицу в файл CSV"
 
 #: ../../src/wxMaximaFrame.cpp:1334
 msgid "Matrix to file or Matrix from file"
-msgstr ""
+msgstr "Матрица в файл или матрица из файла"
 
 #: ../../src/wxMaximaFrame.cpp:1761
 msgid "Matrix to nested List"
-msgstr ""
+msgstr "Матрицу во вложенный список"
 
 #: ../../src/wxMaxima.cpp:7956 ../../src/wxMaxima.cpp:7961
 #: ../../src/wxMaxima.cpp:7966 ../../src/wxMaxima.cpp:7971
 #: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
 #: ../../src/wxMaxima.cpp:8136
 msgid "Matrix:"
-msgstr ""
+msgstr "Матрица:"
 
 #: ../../src/wxMaxima.cpp:8627
 msgid ""
@@ -4392,189 +4564,196 @@ msgid ""
 "\n"
 "This command tells maxima that the nouns in this expression shall now be evaluated, too."
 msgstr ""
+"Maxima позволяет делать функции невычисляемыми (noun); это означает, что они не будут автоматически вычисляться, когда встретятся Maxima.\n"
+"Чтобы сделать функций невычисляемой, можно объявить её таковой (noun), предварить её символом ' или поместить в скобки '().\n"
+"\n"
+"Эта команда указывает Maxima, что невычисляемые формы в выражении теперь тоже следует вычислить."
 
 #: ../../src/wxMaxima.cpp:3473
 #, c-format
 msgid "Maxima architecture: %s"
-msgstr ""
+msgstr "Архитектура Maxima: %s"
 
 #: ../../src/StatusBar.cpp:252
 msgid "Maxima asks a question"
-msgstr ""
+msgstr "У Maxima есть вопрос"
 
 #: ../../src/wxMaxima.cpp:4066
 msgid "Maxima asks a question!"
-msgstr ""
+msgstr "У Maxima есть вопрос!"
 
 #: ../../src/wxMaxima.cpp:7118
 msgid ""
 "Maxima automatically simplifies expressions it gets as input and then tries to evaluate their value. The ' operator tells maxima that we want a command to be in noun form, which means: stand here as is, and unevaluated.\n"
 "The ' operator can be undone by using the '' operator."
 msgstr ""
+"Maxima автоматически упрощает выражения, получаемые на входе, и затем пытается вычислить их значение. Оператор ' указывает Maxima, что команда должна быть в невычисляемой форме (noun), что означает: оставить как есть и не вычислять.\n"
+"Оператор ' можно отменить с помощью оператора ''."
 
 #: ../../src/wxMaxima.cpp:3304
 msgid "Maxima didn't attempt to authenticate!"
-msgstr ""
+msgstr "Maxima не попыталась выполнить аутентификацию!"
 
 #: ../../src/Configuration.cpp:84
 msgid "Maxima errors"
-msgstr ""
+msgstr "Ошибки Maxima"
 
 #: ../../src/wxMaxima.cpp:3289
 msgid "Maxima has authenticated!"
-msgstr ""
+msgstr "Maxima выполнила аутентификацию!"
 
 #: ../../src/wxMaxima.cpp:10533
 msgid "Maxima has finished calculating."
-msgstr ""
+msgstr "Maxima завершила вычисления."
 
 #: ../../src/wxMaxima.cpp:5832
 msgid "Maxima has issued an error!"
-msgstr ""
+msgstr "Программой Maxima обнаружена ошибка!"
 
 #: ../../src/wxMaxima.cpp:3696
 #, c-format
 msgid "Maxima has loaded the file %s."
-msgstr ""
+msgstr "Maxima загрузила файл %s."
 
 #: ../../src/wxMaxima.cpp:3382
 msgid "Maxima has sent a new variable value."
-msgstr ""
+msgstr "Maxima отправила новое значение переменной."
 
 #: ../../src/MaximaManual.cpp:552
 msgid "Maxima help file not found!"
-msgstr ""
+msgstr "Файл справки по Maxima не найден!"
 
 #: ../../src/wxMaximaFrame.cpp:1043
 msgid "Maxima input"
-msgstr ""
+msgstr "Ввод Maxima"
 
 #: ../../src/StatusBar.cpp:236
 msgid "Maxima is calculating"
-msgstr ""
+msgstr "Maxima выполняет вычисления"
 
 #: ../../src/wxMaxima.cpp:5068
 msgid "Maxima is ready for input."
-msgstr ""
+msgstr "Maxima готова к вводу."
 
 #: ../../src/Dirstructure.cpp:144
 #, c-format
 msgid "Maxima not found as %s"
-msgstr ""
+msgstr "Maxima не найдена по адресу %s"
 
 #: ../../src/wxMaxima.cpp:6211
 msgid "Maxima package (*.mac)|*.mac"
-msgstr ""
+msgstr "Пакет Maxima (*.mac)|*.mac"
 
 #: ../../src/wxMaxima.cpp:6202
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
-msgstr ""
+msgstr "Пакет Maxima (*.mac)|*.mac|Пакет Lisp (*.lisp)|*.lisp|Все|*"
 
 #: ../../src/wxMaxima.cpp:3012
 msgid "Maxima process terminated unexpectedly."
-msgstr ""
+msgstr "Процесс Maxima неожиданно завершился."
 
 #: ../../src/Configuration.cpp:79
 msgid "Maxima question labels"
-msgstr ""
+msgstr "Метки вопросов Maxima"
 
 #: ../../src/wxMaxima.cpp:3380
 msgid "Maxima sends a new set of auto-completable symbols."
-msgstr ""
+msgstr "Maxima отправляет новый набор символов для автодополнения."
 
 #: ../../src/wxMaxima.cpp:3908
 msgid "Maxima sends us a new set of variables for the watch list."
-msgstr ""
+msgstr "Maxima отправляет новый набор переменных для списка отслеживания."
 
 #: ../../src/wxMaximaFrame.cpp:1944
 msgid "Maxima shows help in a browser"
-msgstr ""
+msgstr "Maxima отображает справку в браузере"
 
 #: ../../src/wxMaximaFrame.cpp:1940
 msgid "Maxima shows help in a sidebar"
-msgstr ""
+msgstr "Maxima отображает справку на боковой панели"
 
 #: ../../src/wxMaximaFrame.cpp:1935
 msgid "Maxima shows help in the console"
-msgstr ""
+msgstr "Maxima показывает справку в терминале"
 
 #: ../../src/StatusBar.cpp:232
 msgid "Maxima started. Waiting for authentication..."
-msgstr ""
+msgstr "Maxima запущена. Ожидание аутентификации..."
 
 #: ../../src/StatusBar.cpp:212
 msgid "Maxima started. Waiting for connection..."
-msgstr ""
+msgstr "Maxima запущена. Установка связи..."
 
 #: ../../src/StatusBar.cpp:228
 msgid "Maxima started. Waiting for initial prompt..."
-msgstr ""
+msgstr "Maxima запущена. Ожидание начального запроса..."
 
 #: ../../src/wxMaximaFrame.cpp:1231
 msgid "Maxima to other language"
-msgstr ""
+msgstr "Maxima на другом языке"
 
 #: ../../src/wxMaxima.cpp:7213
 msgid "Maxima to string"
-msgstr ""
+msgstr "Maxima в строку"
 
 #: ../../src/wxMaxima.cpp:3397
 #, c-format
 msgid "Maxima user configuration is located in directory %s"
-msgstr ""
+msgstr "Пользовательская конфигурация Maxima находится в каталоге %s"
 
 #: ../../src/wxMaxima.cpp:3443
 #, c-format
 msgid "Maxima uses temp directory %s"
-msgstr ""
+msgstr "Maxima использует временный каталог %s"
 
 #: ../../src/wxMaxima.cpp:3469
 #, c-format
 msgid "Maxima version: %s"
-msgstr ""
+msgstr "Версия Maxima: %s"
 
 #: ../../src/MaximaManual.cpp:390
 #, c-format
 msgid "Maxima version: %s, Anchors cache version"
-msgstr ""
+msgstr "Версия Maxima: %s, версия привязок из кэша"
 
 #: ../../src/wxMaximaFrame.cpp:1925
 msgid "Maxima vs. Programming languages"
-msgstr ""
+msgstr "Maxima vs. языки программирования"
 
 #: ../../src/Configuration.cpp:83
 msgid "Maxima warnings"
-msgstr ""
+msgstr "Предупреждения Maxima"
 
 #: ../../src/wxMaxima.cpp:3687
 #, c-format
 msgid "Maxima was compiled using %s"
-msgstr ""
+msgstr "Сборка Maxima была выполнена с помощью %s"
 
 #: ../../src/wxMaxima.cpp:3487
 #, c-format
 msgid "Maxima's HTML manuals are in directory %s"
 msgstr ""
+"Руководство пользователя Maxima в формате HTML находится в каталоге %s"
 
 #: ../../src/wxMaxima.cpp:3099
 #, c-format
 msgid "Maxima's PID is %li"
-msgstr ""
+msgstr "PID Maxima: %li"
 
 #: ../../src/wxMaxima.cpp:3681
 #, c-format
 msgid "Maxima's demo files are located in directory %s"
-msgstr ""
+msgstr "Демо-файлы Maxima находятся в каталоге %s"
 
 #: ../../src/wxMaxima.cpp:3478
 #, c-format
 msgid "Maxima's manual is located in directory %s"
-msgstr ""
+msgstr "Руководство пользователя Maxima находится в каталоге %s"
 
 #: ../../src/wxMaxima.cpp:3670
 #, c-format
 msgid "Maxima's share files are located in directory %s"
-msgstr ""
+msgstr "Общие файлы Maxima находятся в каталоге %s"
 
 #: ../../src/StatusBar.cpp:66
 msgid ""
@@ -4586,6 +4765,13 @@ msgid ""
 "not only intercepts connections from the outside, but also to intercept "
 "connections between two programs that run on the same computer."
 msgstr ""
+"Maxima, выполняющая фактические вычисления программа, и wxMaxima, "
+"отображающая лист программа, содержатся в отдельных процессах. Это означает,"
+" что при сбое Maxima программа wxMaxima (а, следовательно, и лист) "
+"продолжает работать. Обмен данными между программами выполняется с помощью "
+"сокета локальной сети. В настоящее время сокет создать не удалось; возможно,"
+" межсетевой экран настроен на перехват не только внешних соединений, но и "
+"соединений между двумя программами, запущенными на одном компьютере."
 
 #: ../../src/StatusBar.cpp:75
 msgid ""
@@ -4600,480 +4786,499 @@ msgid ""
 "might be that maxima cannot be found (see wxMaxima's Configuration dialogue "
 "for a way to specify maxima's location) or isn't in a working order."
 msgstr ""
+"Maxima, выполняющая фактические вычисления программа, и wxMaxima, "
+"отображающая лист программа, содержатся в отдельных процессах. Это означает,"
+" что при сбое Maxima программа wxMaxima (а, следовательно, и лист) "
+"продолжает работать. В настоящее время программы не соединены друг с другом;"
+" Maxima, возможно, ещё запускается или не может быть запущена. Кроме того, "
+"причиной может быть настройка межсетевого экрана на перехват не только "
+"внешних соединений, но и соединений между двумя программами, запущенными на "
+"одном компьютере. Maxima также может не запускаться из-за того, что не "
+"удаётся найти исполняемый файл (указать расположение этого файла можно в "
+"диалоге настройки wxMaxima), или из-за неработоспособности программы."
 
 #: ../../src/StatusBar.cpp:61
 msgid ""
 "Maxima, the program that does the actual mathematics is started as a separate process. This has the advantage that an eventual crash of maxima cannot harm wxMaxima, which displays the worksheet.\n"
 "This icon indicates if data is transferred between maxima and wxMaxima."
 msgstr ""
+"Программа Maxima, которая выполняет фактические вычисления, запускается в отдельном процессе. Это означает, что сбой Maxima не окажет влияния на работу программы wxMaxima, которая отображает лист.\n"
+"Этот значок показывает, выполняется ли обмен данными между Maxima и wxMaxima."
 
 #: ../../src/wxMaxima.cpp:9228
 msgid "Maximum absolute value printed without exponent"
-msgstr ""
+msgstr "Максимальное абсолютное значение, которое отображается без экспоненты"
 
 #: ../../src/wxMaxima.cpp:9230
 msgid "Maximum number of digits to be displayed:"
-msgstr ""
+msgstr "Максимальное количество цифр для отображения:"
 
 #: ../../src/wxMaxima.cpp:9568
 msgid "Mean:"
-msgstr ""
+msgstr "Среднее:"
 
 #: ../../src/wxMaximaFrame.cpp:1924
 msgid "Memoizing"
-msgstr ""
+msgstr "Мемоизация"
 
 #: ../../src/wxMaximaFrame.cpp:1013
 msgid "Memory"
-msgstr ""
+msgstr "Память"
 
 #: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
 msgid "Merge Cells"
-msgstr ""
+msgstr "Объединить поля"
 
 #: ../../src/wxMaxima.cpp:5780
 msgid "Message from the stdout of Maxima: "
-msgstr ""
+msgstr "Сообщение потока stdout Maxima: "
 
 #: ../../src/wxMaximaFrame.cpp:1326
 msgid "Methods of generating a matrix"
-msgstr ""
+msgstr "Методы генерации матрицы"
 
 #: ../../src/Worksheet.cpp:6866
 #, c-format
 msgid "Middle-click clipboard data: %s"
-msgstr ""
+msgstr "Данные буфера обмена для щелчков средней кнопкой мыши: %s"
 
 #: ../../src/wxMaxima.cpp:9226
 msgid "Minimum absolute value printed without exponent:"
-msgstr ""
+msgstr "Минимальное абсолютное значение, которое отображается без экспоненты:"
 
 #: ../../src/wxMaxima.cpp:10449 ../../src/wxMaxima.cpp:10451
 msgid "Mismatched parenthesis"
-msgstr ""
+msgstr "Непарная скобка"
 
 #: ../../src/wxMaximaFrame.cpp:1352
 msgid "Multiplication, exponent and similar"
-msgstr ""
+msgstr "Умножение, возведение в степень и подобное"
 
 #: ../../src/Worksheet.cpp:1998
 msgid "Multiplicative function: f(a*b)=f(a)*f(b)"
-msgstr ""
+msgstr "Мультипликативная функция: f(a*b)=f(a)*f(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1338
 msgid "Multiply matrices..."
-msgstr ""
+msgstr "Перемножить матрицы..."
 
 #: ../../src/wxMaxima.cpp:7981
 msgid "Multiply two matrices"
-msgstr ""
+msgstr "Перемножить две матрицы"
 
 #: ../../src/wxMaxima.cpp:9581
 msgid "Multivariate linear regression"
-msgstr ""
+msgstr "Многомерная линейная регрессия"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Name of t:"
-msgstr ""
+msgstr "Имя t:"
 
 #: ../../src/wxMaxima.cpp:7838
 msgid "Name of x:"
-msgstr ""
+msgstr "Имя x:"
 
 #: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
 msgid "Nested list to Matrix"
-msgstr ""
+msgstr "Вложенный список в матрицу"
 
 #: ../../src/wxMaximaFrame.cpp:769 ../../src/wxMaximaFrame.cpp:1053
 msgid "Never"
-msgstr ""
+msgstr "Никогда"
 
 #: ../../src/wxMaxima.cpp:6534
 msgid "Never autosubscript this variable"
 msgstr ""
+"Никогда не использовать для этой переменной автоперевод в нижний индекс"
 
 #: ../../src/wxMaximaFrame.cpp:776
 msgid "Never display this variable with subscript"
-msgstr ""
+msgstr "Никогда не показывать эту переменную в нижнем индексе"
 
 #: ../../src/Worksheet.cpp:1469 ../../src/Worksheet.cpp:1843
 msgid "Never offer known answers"
-msgstr ""
+msgstr "Никогда не предлагать известные ответы"
 
 #: ../../src/ToolBar.cpp:174
 msgid "New"
-msgstr ""
+msgstr "Создать"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "New\tCtrl+N"
-msgstr ""
+msgstr "Создать\tCtrl+N"
 
 #: ../../src/ToolBar.cpp:611
 msgid "New button"
-msgstr ""
+msgstr "Кнопка «Создать»"
 
 #: ../../src/wxMaxima.cpp:2483
 msgid "New connection attempt whilst already connected."
-msgstr ""
+msgstr "Новая попытка соединения при уже установленном соединении."
 
 #: ../../src/wxMaxima.cpp:2491
 msgid ""
 "New connection attempt, but no currently no socket maxima could connect to."
 msgstr ""
+"Новая попытка соединения при отсутствии сокета, доступного для подключения "
+"Maxima."
 
 #: ../../src/wxMaxima.cpp:2487
 msgid "New connection attempt, but no currently running maxima process."
-msgstr ""
+msgstr "Новая попытка соединения при отсутствии работающего процесса Maxima."
 
 #: ../../src/ToolBar.cpp:174
 msgid "New document"
-msgstr ""
+msgstr "Создать документ"
 
 #: ../../src/wxMaxima.cpp:3899
 #, c-format
 msgid "New maxima Operators detected: %s"
-msgstr ""
+msgstr "Обнаружены новые операторы Maxima: %s"
 
 #: ../../src/wxMaxima.cpp:7390
 msgid "New part:"
-msgstr ""
+msgstr "Новая часть:"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
 #: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
 msgid "New variable:"
-msgstr ""
+msgstr "Новая переменная:"
 
 #: ../../src/wxMaximaFrame.cpp:929
 msgid "Next Command\tAlt+Down"
-msgstr ""
+msgstr "Следующая команда\tAlt+Down"
 
 #: ../../src/wxMaximaFrame.cpp:748
 msgid "Nice Graphical Equations"
-msgstr ""
+msgstr "Графическое представление уравнений"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "No"
-msgstr ""
+msgstr "Нет"
 
 #: ../../src/Worksheet.cpp:1972
 msgid "No Array"
-msgstr ""
+msgstr "Не массив"
 
 #: ../../src/Worksheet.cpp:1974
 msgid "No Scalar"
-msgstr ""
+msgstr "Не скаляр"
 
 #: ../../src/wxMaxima.cpp:10482
 msgid "No dollar ($) or semicolon (;) at the end of command"
-msgstr ""
+msgstr "Без знака доллара ($) или точки с запятой (;) в конце команды"
 
 #: ../../src/MaximaManual.cpp:406
 msgid "No entries in the caches for the subjects the manual contains."
-msgstr ""
+msgstr "В кэше нет записей для тем, которые содержатся в руководстве."
 
 #: ../../src/MaximaManual.cpp:101
 msgid ""
 "No file with the subjects the manual contained in the last wxMaxima run."
 msgstr ""
+"Нет файла с темами, которые содержатся в руководстве, с последнего запуска "
+"wxMaxima."
 
 #: ../../src/Image.cpp:495
 msgid "No gnuplot data!"
-msgstr ""
+msgstr "Нет данных Gnuplot!"
 
 #: ../../src/Image.cpp:530
 msgid "No gnuplot source!"
-msgstr ""
+msgstr "Нет исходного кода Gnuplot!"
 
 #: ../../src/wxMaxima.cpp:6662 ../../src/wxMaxima.cpp:6668
 #: ../../src/wxMaxima.cpp:6687 ../../src/wxMaxima.cpp:6697
 msgid "No matches found!"
-msgstr ""
+msgstr "Совпадений не найдено"
 
 #: ../../src/wxMaxima.cpp:3240
 msgid "No topics found in topic flag"
-msgstr ""
+msgstr "Не найдено тем по флагу тем"
 
 #: ../../src/wxMaxima.cpp:3227
 msgid "No topics found in topic tag"
-msgstr ""
+msgstr "Не найдено тем по метке тем"
 
 #: ../../src/wxMaximaFrame.cpp:797
 msgid "None"
-msgstr ""
+msgstr "Нет"
 
 #: ../../src/wxMaxima.cpp:8163
 msgid "Not a valid matrix dimension!"
-msgstr ""
+msgstr "Неверная размерность матрицы!"
 
 #: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
 msgid "Not a valid number of equations!"
-msgstr ""
+msgstr "Неверное число уравнений!"
 
 #: ../../src/StatusBar.cpp:256
 msgid "Not connected to Maxima"
-msgstr ""
+msgstr "Нет соединения с Maxima"
 
 #: ../../src/wxMaxima.cpp:10496
 msgid "Not triggering evaluation as maxima is still busy!"
-msgstr ""
+msgstr "Вычисление не активировано, так как программа Maxima всё ещё занята!"
 
 #: ../../src/wxMaxima.cpp:10503
 msgid "Not triggering evaluation as maxima still asks a question!"
 msgstr ""
+"Вычисление не активировано, так как на вопрос программы Maxima всё ещё нет "
+"ответа!"
 
 #: ../../src/wxMaxima.cpp:10511
 msgid "Not triggering evaluation as there is no working maxima process"
-msgstr ""
+msgstr "Вычисление не активировано, так как нет работающего процесса Maxima"
 
 #: ../../src/wxMaxima.cpp:8926
 msgid "Num. deg:"
-msgstr ""
+msgstr "Степень числителя:"
 
 #: ../../src/wxMaxima.cpp:8540
 msgid "Number of elements"
-msgstr ""
+msgstr "Количество элементов"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
 msgid "Number of equations:"
-msgstr ""
+msgstr "Число уравнений:"
 
 #: ../../src/wxMaxima.cpp:7481
 msgid "Number to octets"
-msgstr ""
+msgstr "Число в октеты"
 
 #: ../../src/wxMaximaFrame.cpp:1154
 msgid "Number to octets..."
-msgstr ""
+msgstr "Число в октеты..."
 
 #: ../../src/wxMaximaFrame.cpp:1906
 msgid "Number types"
-msgstr ""
+msgstr "Типы чисел"
 
 #: ../../src/wxMaxima.cpp:7482
 msgid "Number:"
-msgstr ""
+msgstr "Число:"
 
 #: ../../src/wxMaximaFrame.cpp:1786
 msgid "Numeric output"
-msgstr ""
+msgstr "Цифровой вывод"
 
 #: ../../src/wxMaxima.cpp:8040
 msgid "Numerical QR decomposition of a matrix"
-msgstr ""
+msgstr "Числовое QR-разложение матрицы"
 
 #: ../../src/wxMaximaFrame.cpp:1417
 msgid "Numerical operations (lapack)"
-msgstr ""
+msgstr "Численные операции (lapack)"
 
 #: ../../src/wxMaxima.cpp:7831
 msgid "Numerical solution for 1st degree ODE"
-msgstr ""
+msgstr "Численное решение для ОДУ первого порядка"
 
 #: ../../src/wxMaximaFrame.cpp:1282
 msgid "Numerical solution..."
-msgstr ""
+msgstr "Численное решение..."
 
 #: ../../src/wxMaximaFrame.cpp:1261
 msgid "Numerical solutions of polynomial (bfloat)..."
-msgstr ""
+msgstr "Численные решения полинома (повышенная точность)..."
 
 #: ../../src/wxMaximaFrame.cpp:1258
 msgid "Numerical solutions of polynomial..."
-msgstr ""
+msgstr "Численные решения полинома..."
 
 #: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: ../../src/wxMaximaFrame.cpp:122
 #, c-format
 msgid "OS: %s Version %li.%li"
-msgstr ""
+msgstr "ОС: %s версии %li.%li"
 
 #: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
 msgid "Object composed of elements"
-msgstr ""
+msgstr "Объект, состоящий из элементов"
 
 #: ../../src/wxMaxima.cpp:7680
 msgid "Object name:"
-msgstr ""
+msgstr "Имя объекта:"
 
 #: ../../src/wxMaxima.cpp:7281
 msgid "Object:"
-msgstr ""
+msgstr "Объект:"
 
 #: ../../src/wxMaxima.cpp:7486
 msgid "Octets to Number"
-msgstr ""
+msgstr "Октеты в число"
 
 #: ../../src/wxMaxima.cpp:7491
 msgid "Octets to String"
-msgstr ""
+msgstr "Октеты в строку"
 
 #: ../../src/wxMaximaFrame.cpp:1156
 msgid "Octets to number..."
-msgstr ""
+msgstr "Октеты в число..."
 
 #: ../../src/wxMaximaFrame.cpp:1158
 msgid "Octets to string..."
-msgstr ""
+msgstr "Октеты в строку..."
 
 #: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
 msgid "Octets:"
-msgstr ""
+msgstr "Октеты:"
 
 #: ../../src/Worksheet.cpp:1958
 msgid "Odd number"
-msgstr ""
+msgstr "Нечётное число"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
 #: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
 msgid "Old variable:"
-msgstr ""
+msgstr "Старая переменная:"
 
 #: ../../src/wxMaximaFrame.cpp:1055
 msgid "On all errors"
-msgstr ""
+msgstr "При всех ошибках"
 
 #: ../../src/wxMaximaFrame.cpp:1054
 msgid "On lisp errors"
-msgstr ""
+msgstr "При ошибках Lisp"
 
 #: ../../src/wxMaxima.cpp:9566
 msgid "One sample t-test"
-msgstr ""
+msgstr "Одновыборочный t-тест"
 
 #: ../../src/wxMaximaFrame.cpp:1927
 msgid "Online tutorials"
-msgstr ""
+msgstr "Онлайн-учебники"
 
 #: ../../src/wxMaximaFrame.cpp:766
 msgid "Only Integers and single letters"
-msgstr ""
+msgstr "Только целые числа и отдельные буквы"
 
 #: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593
 #: ../../src/wxMaxima.cpp:6074
 msgid "Open"
-msgstr ""
+msgstr "Открыть"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "Open a document"
-msgstr ""
+msgstr "Открыть документ"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "Open a new window"
-msgstr ""
+msgstr "Открыть новое окно"
 
 #: ../../src/ToolBar.cpp:617
 msgid "Open and save button"
-msgstr ""
+msgstr "Кнопки «Открыть» и «Сохранить»"
 
 #: ../../src/ToolBar.cpp:176
 msgid "Open document"
-msgstr ""
+msgstr "Открыть документ"
 
 #: ../../src/wxMaxima.cpp:7239
 msgid "Open for appending"
-msgstr ""
+msgstr "Открыть для добавления"
 
 #: ../../src/wxMaximaFrame.cpp:1099
 msgid "Open for appending..."
-msgstr ""
+msgstr "Открыть для добавления..."
 
 #: ../../src/wxMaxima.cpp:7244
 msgid "Open for reading"
-msgstr ""
+msgstr "Открыть для чтения"
 
 #: ../../src/wxMaximaFrame.cpp:1098
 msgid "Open for reading..."
-msgstr ""
+msgstr "Открыть для чтения..."
 
 #: ../../src/wxMaxima.cpp:7249
 msgid "Open for writing"
-msgstr ""
+msgstr "Открыть для записи"
 
 #: ../../src/wxMaximaFrame.cpp:1100
 msgid "Open for writing..."
-msgstr ""
+msgstr "Открыть для записи..."
 
 #: ../../src/wxMaxima.cpp:9598
 msgid "Open matrix"
-msgstr ""
+msgstr "Открыть матрицу"
 
 #: ../../src/wxMaximaFrame.cpp:600
 msgid "Open recent"
-msgstr ""
+msgstr "Открыть последние"
 
 #: ../../src/wxMaxima.cpp:4309
 msgid "Opening a wxmx file"
-msgstr ""
+msgstr "Открытие файла .wxmx"
 
 #: ../../src/wxMaxima.cpp:4153 ../../src/wxMaxima.cpp:4214
 #: ../../src/wxMaxima.cpp:4313 ../../src/wxMaxima.cpp:4622
 msgid "Opening file"
-msgstr ""
+msgstr "Открытие файла"
 
 #: ../../src/wxMaxima.cpp:5030
 #, c-format
 msgid "Opening help file %s"
-msgstr ""
+msgstr "Открытие файла справки %s"
 
 #: ../../src/wxMaximaFrame.cpp:1530
 msgid "Optimize for CPU time"
-msgstr ""
+msgstr "Оптимизировать для экономии времени ЦП"
 
 #: ../../src/wxMaximaFrame.cpp:1529
 msgid "Optimize for memory"
-msgstr ""
+msgstr "Оптимизировать для экономии памяти"
 
 #: ../../src/ToolBar.cpp:199
 msgid "Options"
-msgstr ""
+msgstr "Опции"
 
 #: ../../src/wxMaximaFrame.cpp:1225
 msgid "Output C"
-msgstr ""
+msgstr "Вывод C"
 
 #: ../../src/wxMaximaFrame.cpp:1226
 msgid "Output Fortran"
-msgstr ""
+msgstr "Вывод Fortran"
 
 #: ../../src/wxMaximaFrame.cpp:1228
 msgid "Output Rational Fortran"
-msgstr ""
+msgstr "Вывод Rational Fortran"
 
 #: ../../src/Configuration.cpp:80
 msgid "Output labels"
-msgstr ""
+msgstr "Метки вывода"
 
 #: ../../src/Configuration.cpp:73
 msgid "Output: Function names"
-msgstr ""
+msgstr "Вывод: имена функций"
 
 #: ../../src/Configuration.cpp:75
 msgid "Output: Latin names as greek symbols"
-msgstr ""
+msgstr "Вывод: латинские названия в виде греческих символов"
 
 #: ../../src/Configuration.cpp:72
 msgid "Output: Numbers and Digits"
-msgstr ""
+msgstr "Вывод: числа и цифры"
 
 #: ../../src/Configuration.cpp:71
 msgid "Output: Operators"
-msgstr ""
+msgstr "Вывод: операторы"
 
 #: ../../src/Configuration.cpp:74
 #, c-format
 msgid "Output: Special constants (%e,%i)"
-msgstr ""
+msgstr "Вывод: специальные константы (%e,%i)"
 
 #: ../../src/Configuration.cpp:76
 msgid "Output: Strings"
-msgstr ""
+msgstr "Вывод: строки"
 
 #: ../../src/Configuration.cpp:70
 msgid "Output: Variable names"
-msgstr ""
+msgstr "Вывод: имена переменных"
 
 #: ../../src/wxMaxima.cpp:6442
 msgid ""
@@ -5082,6 +5287,9 @@ msgid ""
 "(*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format "
 "(*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"PNG (*.png)|*.png|JPEG (*.jpg)|*.jpg|GIF (*.gif)|*.gif|SVG "
+"(*.svg)|*.svg|Windows Bitmap (*.bmp)|*.bmp|Portable anymap "
+"(*.pnm)|*.pnm|TIFF (*.tif)|*.tif|X PixMap (*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:10117
 msgid ""
@@ -5089,860 +5297,880 @@ msgid ""
 "(*.bmp)|*.bmp|GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged "
 "image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"PNG (*.png)|*.png|JPEG (*.jpg)|*.jpg|Windows Bitmap (*.bmp)|*.bmp|GIF "
+"(*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|TIFF (*.tif)|*.tif|X PixMap "
+"(*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:8924
 msgid "Pade approximation"
-msgstr ""
+msgstr "Аппроксимация Паде"
 
 #: ../../src/wxMaximaFrame.cpp:1478
 msgid "Pade approximation of a Taylor series"
-msgstr ""
+msgstr "Паде-аппроксимация ряда Тейлора"
 
 #: ../../src/wxMaximaFrame.cpp:1637
 msgid "Parallel Substitute..."
-msgstr ""
+msgstr "Параллельная подстановка..."
 
 #: ../../src/wxMaxima.cpp:8738
 msgid "Parallel substitution"
-msgstr ""
+msgstr "Параллельная подстановка"
 
 #: ../../src/wxMaxima.cpp:7179
 msgid "Parameter name:"
-msgstr ""
+msgstr "Имя параметра:"
 
 #: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
 msgid "Parameter(s):"
-msgstr ""
+msgstr "Параметр(ы):"
 
 #: ../../src/wxMaxima.cpp:7399
 msgid "Parse string"
-msgstr ""
+msgstr "Проанализировать строку"
 
 #: ../../src/wxMaximaFrame.cpp:1152
 msgid "Parse string only..."
-msgstr ""
+msgstr "Проанализировать только строку..."
 
 #: ../../src/StatusBar.cpp:240
 msgid "Parsing output"
-msgstr ""
+msgstr "Анализ вывода"
 
 #: ../../src/wxMaxima.cpp:7464
 msgid "Part:"
-msgstr ""
+msgstr "Часть:"
 
 #: ../../src/wxMaximaFrame.cpp:1499 ../../src/wxMaximaFrame.cpp:1535
 msgid "Partial &Fractions..."
-msgstr ""
+msgstr "Простые &дроби..."
 
 #: ../../src/wxMaxima.cpp:8975
 msgid "Partial Fractions"
-msgstr ""
+msgstr "Простые дроби"
 
 #: ../../src/wxMaxima.cpp:4702
 msgid "Parts of the document will not be loaded correctly!"
-msgstr ""
+msgstr "Части документа будут загружены некорректно!"
 
 #: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
 #: ../../src/Worksheet.cpp:1685
 msgid "Paste"
-msgstr ""
+msgstr "Вставить"
 
 #: ../../src/wxMaximaFrame.cpp:667
 msgid "Paste\tCtrl+V"
-msgstr ""
+msgstr "Вставить\tCtrl+V"
 
 #: ../../src/ToolBar.cpp:211
 msgid "Paste from clipboard"
-msgstr ""
+msgstr "Вставить из буфера обмена"
 
 #: ../../src/wxMaximaFrame.cpp:668
 msgid "Paste text from clipboard"
-msgstr ""
+msgstr "Вставить текст из буфера обмена"
 
 #: ../../src/wxMaxima.cpp:4841
 msgid "Please configure wxMaxima with 'Edit->Configure'."
-msgstr ""
+msgstr "Настройте wxMaxima с помощью меню «Правка -> Настройка»."
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot &2d..."
-msgstr ""
+msgstr "Двухмерный график..."
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot &3d..."
-msgstr ""
+msgstr "Трёхмерный график..."
 
 #: ../../src/wxMaximaFrame.cpp:1772
 msgid "Plot &Format..."
-msgstr ""
+msgstr "Формат &графика..."
 
 #: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
 msgid "Plot 2D"
-msgstr ""
+msgstr "Двухмерный график"
 
 #: ../../src/Worksheet.cpp:1593
 msgid "Plot 2D..."
-msgstr ""
+msgstr "Двухмерный график..."
 
 #: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
 msgid "Plot 3D"
-msgstr ""
+msgstr "Трёхмерный график"
 
 #: ../../src/Worksheet.cpp:1595
 msgid "Plot 3D..."
-msgstr ""
+msgstr "Трёхмерный график..."
 
 #: ../../src/wxMaxima.cpp:9538
 msgid "Plot as bars"
-msgstr ""
+msgstr "График в виде столбиков"
 
 #: ../../src/wxMaxima.cpp:9542
 msgid "Plot as error bars"
-msgstr ""
+msgstr "График в виде столбиков погрешностей"
 
 #: ../../src/wxMaxima.cpp:9546
 msgid "Plot as pie chart"
-msgstr ""
+msgstr "График в виде круговой диаграммы"
 
 #: ../../src/wxMaxima.cpp:9112
 msgid "Plot format"
-msgstr ""
+msgstr "Формат графика"
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot in 2 dimensions"
-msgstr ""
+msgstr "Двухмерный график"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot in 3 dimensions"
-msgstr ""
+msgstr "Трёхмерный график"
 
 #: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
 msgid "Plot using Draw"
-msgstr ""
+msgstr "График с помощью Draw"
 
 #: ../../src/wxMaxima.cpp:7824
 msgid "Point #1 with known value:"
-msgstr ""
+msgstr "Точка 1 с известным значением:"
 
 #: ../../src/wxMaxima.cpp:7826
 msgid "Point #2 with known value:"
-msgstr ""
+msgstr "Точка 2 с известным значением:"
 
 #: ../../src/wxMaxima.cpp:7800 ../../src/wxMaxima.cpp:7811
 msgid "Point the value is known at:"
-msgstr ""
+msgstr "Точка, в которой известно значение:"
 
 #: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
 msgid "Point:"
-msgstr ""
+msgstr "Точка:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 1:"
-msgstr ""
+msgstr "Полином 1:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 2:"
-msgstr ""
+msgstr "Полином 2:"
 
 #: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
 #: ../../src/wxMaxima.cpp:7739
 msgid "Polynomial:"
-msgstr ""
+msgstr "Полином:"
 
 #: ../../src/wxMaximaFrame.cpp:1754
 msgid "Pop"
-msgstr ""
+msgstr "Вытолкнуть"
 
 #: ../../src/Worksheet.cpp:1331 ../../src/Worksheet.cpp:1485
 msgid "Popout interactively"
-msgstr ""
+msgstr "Интерактивное появление"
 
 #: ../../src/wxMaximaFrame.cpp:1189
 msgid "Position of a match"
-msgstr ""
+msgstr "Положение совпадения"
 
 #: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
 msgid "Position:"
-msgstr ""
+msgstr "Положение:"
 
 #: ../../src/wxMaxima.cpp:8939
 msgid "Power series"
-msgstr ""
+msgstr "Степенной ряд"
 
 #: ../../src/wxMaximaFrame.cpp:1475
 msgid "Power series..."
-msgstr ""
+msgstr "Степенной ряд..."
 
 #: ../../src/wxMaxima.cpp:9202
 msgid "Precision"
-msgstr ""
+msgstr "Точность"
 
 #: ../../src/Worksheet.cpp:1616
 msgid "Prefer user labels"
-msgstr ""
+msgstr "Предпочитать пользовательские метки"
 
 #: ../../src/main.cpp:437
 msgid "Preferences"
-msgstr ""
+msgstr "Параметры"
 
 #: ../../src/ToolBar.cpp:626
 msgid "Preferences button"
-msgstr ""
+msgstr "Кнопка «Параметры»"
 
 #: ../../src/wxMaximaFrame.cpp:685
 msgid "Preferences...\tCtrl+,"
-msgstr ""
+msgstr "Параметры...\tCtrl+,"
 
 #: ../../src/wxMaximaFrame.cpp:1733
 msgid "Prepend an element"
-msgstr ""
+msgstr "Добавить элемент в начало"
 
 #: ../../src/wxMaximaFrame.cpp:927
 msgid "Previous Command\tAlt+Up"
-msgstr ""
+msgstr "Предыдущая команда\tAlt+Up"
 
 #: ../../src/ToolBar.cpp:184
 msgid "Print"
-msgstr ""
+msgstr "Печать"
 
 #: ../../src/ToolBar.cpp:620
 msgid "Print button"
-msgstr ""
+msgstr "Кнопка «Печать»"
 
 #: ../../src/Worksheet.cpp:1493
 msgid "Print cell brackets"
-msgstr ""
+msgstr "Отображать квадратные скобки полей"
 
 #: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
 msgid "Print document"
-msgstr ""
+msgstr "Напечатать документ"
 
 #: ../../src/wxMaximaFrame.cpp:1829
 msgid "Print floating-point numbers with exponents dividable by 3"
 msgstr ""
+"Отображать числа с плавающей точкой с экспонентами, которые делятся на 3"
 
 #: ../../src/WXMXformat.cpp:255
 msgid ""
 "Produced invalid XML. The erroneous XML data has therefore not been saved "
 "but has been put on the clipboard in order to allow to debug it."
 msgstr ""
+"Создан недопустимый код XML. Поэтому неверные данные XML не были сохранены, "
+"но были помещены в буфер обмена для обеспечения возможности отладки."
 
 #: ../../src/wxMaxima.cpp:9061
 msgid "Product"
-msgstr ""
+msgstr "Произведение"
 
 #: ../../src/wxMaximaFrame.cpp:1095
 msgid "Program"
-msgstr ""
+msgstr "Программа"
 
 #: ../../src/wxMaxima.cpp:7061
 msgid "Program (no local variables)"
-msgstr ""
+msgstr "Программа (без локальных переменных)"
 
 #: ../../src/wxMaxima.cpp:7052
 msgid "Program block"
-msgstr ""
+msgstr "Программный блок"
 
 #: ../../src/wxMaximaFrame.cpp:1066
 msgid "Program block with local variables..."
-msgstr ""
+msgstr "Программный блок с локальными переменными..."
 
 #: ../../src/wxMaximaFrame.cpp:1068
 msgid "Program block, no local variables..."
-msgstr ""
+msgstr "Программный блок без локальных переменных..."
 
 #: ../../src/wxMaximaFrame.cpp:1751
 msgid "Push"
-msgstr ""
+msgstr "Втолкнуть"
 
 #: ../../src/wxMaxima.cpp:8508
 msgid "Push an element to a list"
-msgstr ""
+msgstr "Вставить элемент в список"
 
 #: ../../src/wxMaximaFrame.cpp:1395
 msgid "QR decomposition"
-msgstr ""
+msgstr "QR-разложение"
 
 #: ../../src/wxMaxima.cpp:3621
 msgid "Querying gnuplot which graphics drivers it supports."
-msgstr ""
+msgstr "Запрос к Gnuplot о поддерживаемых графических драйверах."
 
 #: ../../src/wxMaxima.cpp:8953
 msgid "Range radius:"
-msgstr ""
+msgstr "Радиус диапазона:"
 
 #: ../../src/wxMaximaFrame.cpp:1374
 msgid "Rank"
-msgstr ""
+msgstr "Ранг"
 
 #: ../../src/wxMaximaFrame.cpp:246 ../../src/wxMaximaFrame.cpp:722
 msgid "Raw XML monitor"
-msgstr ""
+msgstr "Отслеживание необработанных XML-данных"
 
 #: ../../src/wxMaximaFrame.cpp:2117
 #, c-format
 msgid "Re-Reading the config from %s."
-msgstr ""
+msgstr "Повторное чтение конфигурации по адресу %s."
 
 #: ../../src/wxMaximaFrame.cpp:2114
 msgid "Re-Reading the config from the default location."
-msgstr ""
+msgstr "Повторное чтение конфигурации по адресу, заданному по умолчанию."
 
 #: ../../src/wxMaximaFrame.cpp:867
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr ""
+"Повторно вычислить все поля, расположенные выше поля, в котором находится "
+"курсор"
 
 #: ../../src/wxMaximaFrame.cpp:877
 msgid "Re-evaluate all cells below the one the cursor is in"
 msgstr ""
+"Повторно вычислить все поля, расположенные ниже поля, в котором находится "
+"курсор"
 
 #: ../../src/main.cpp:366
 msgid "Re-opening STDERR failed."
-msgstr ""
+msgstr "Не удалось заново открыть STDERR."
 
 #: ../../src/main.cpp:367
 msgid "Re-opening STDIN failed."
-msgstr ""
+msgstr "Не удалось заново открыть STDIN."
 
 #: ../../src/main.cpp:365
 msgid "Re-opening STDOUT failed."
-msgstr ""
+msgstr "Не удалось заново открыть STDOUT."
 
 #: ../../src/wxMaxima.cpp:7512
 msgid ""
 "Re-using a compiled regex is faster that using the same regex string "
 "multiple times."
 msgstr ""
+"Быстрее будет повторно использовать скомпилированное регулярное выражение, "
+"чем несколько раз использовать одну и ту же строку регулярного выражения."
 
 #: ../../src/Worksheet.cpp:6668
 msgid "Read .wxm data from clipboard"
-msgstr ""
+msgstr "Прочитать данные .wxm из буфера обмена"
 
 #: ../../src/wxMaxima.cpp:7599
 msgid "Read Directory"
-msgstr ""
+msgstr "Прочитать каталог"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Read List from csv file..."
-msgstr ""
+msgstr "Прочитать список из файла CSV..."
 
 #: ../../src/wxMaxima.cpp:7196
 msgid "Read a structure field"
-msgstr ""
+msgstr "Прочитать поле структуры"
 
 #: ../../src/wxMaxima.cpp:7270 ../../src/wxMaxima.cpp:7274
 msgid "Read byte"
-msgstr ""
+msgstr "Прочитать байт"
 
 #: ../../src/wxMaxima.cpp:7266
 msgid "Read char"
-msgstr ""
+msgstr "Прочитать символ"
 
 #: ../../src/wxMaxima.cpp:7593
 msgid "Read environment variable"
-msgstr ""
+msgstr "Прочитать переменную среды"
 
 #: ../../src/wxMaximaFrame.cpp:1219
 msgid "Read environment variable..."
-msgstr ""
+msgstr "Прочитать переменную среды..."
 
 #: ../../src/wxMaxima.cpp:7262
 msgid "Read line"
-msgstr ""
+msgstr "Прочитать строку"
 
 #: ../../src/MaximaManual.cpp:113
 #, c-format
 msgid "Read the entries the maxima manual offers from %s"
-msgstr ""
+msgstr "Прочитать записи руководства пользователя Maxima по адресу %s"
 
 #: ../../src/StatusBar.cpp:245
 msgid "Reading Maxima output"
-msgstr ""
+msgstr "Чтение вывода Maxima"
 
 #: ../../src/StatusBar.cpp:247
 #, c-format
 msgid "Reading Maxima output: %li bytes"
-msgstr ""
+msgstr "Чтение вывода Maxima: %li байт"
 
 #: ../../src/wxMathml.cpp:55
 #, c-format
 msgid "Reading the Lisp part of wxMaxima from the file %s"
-msgstr ""
+msgstr "Чтение части Lisp wxMaxima из файла %s"
 
 #: ../../src/wxMathml.cpp:43
 msgid "Reading the Lisp part of wxMaxima from the included header file."
-msgstr ""
+msgstr "Чтение части Lisp wxMaxima из включённого файла заголовка."
 
 #: ../../src/wxMaximaFrame.cpp:148
 #, c-format
 msgid "Reading the config from %s."
-msgstr ""
+msgstr "Чтение конфигурации по адресу %s."
 
 #: ../../src/wxMaximaFrame.cpp:151
 msgid "Reading the config from the default location."
-msgstr ""
+msgstr "Чтение конфигурации по адресу, заданному по умолчанию."
 
 #: ../../src/StatusBar.cpp:224
 msgid "Ready for user input"
-msgstr ""
+msgstr "Готова к вводу"
 
 #: ../../src/Worksheet.cpp:960
 msgid "Recalculated the whole worksheet at once => Updating its size"
-msgstr ""
+msgstr "Пересчитан сразу весь лист => Обновление его размера"
 
 #: ../../src/Worksheet.cpp:946
 msgid "Recalculation hit the end of the worksheet => Updating its size"
-msgstr ""
+msgstr "Пересчёт достиг конца листа => Обновление его размера"
 
 #: ../../src/wxMaximaFrame.cpp:930
 msgid "Recall next command from history"
-msgstr ""
+msgstr "Вызвать следующую команду из журнала выполнения"
 
 #: ../../src/wxMaximaFrame.cpp:928
 msgid "Recall previous command from history"
-msgstr ""
+msgstr "Вызвать предыдущую команду из журнала выполнения"
 
 #: ../../src/wxMaxima.cpp:3235
 #, c-format
 msgid "Received manual topic request: %s"
-msgstr ""
+msgstr "Получен запрос темы руководства: %s"
 
 #: ../../src/wxMaxima.cpp:3097
 #, c-format
 msgid "Received maxima's first prompt: %s"
-msgstr ""
+msgstr "Получен первый запрос Maxima: %s"
 
 #: ../../src/wxMaximaFrame.cpp:603
 msgid "Recover unsaved"
-msgstr ""
+msgstr "Восстановить несохранённые"
 
 #: ../../src/wxMaximaFrame.cpp:1640
 msgid "Recursive Substitute..."
-msgstr ""
+msgstr "Рекурсивная подстановка..."
 
 #: ../../src/wxMaxima.cpp:8746
 msgid "Recursive substitution"
-msgstr ""
+msgstr "Рекурсивная подстановка"
 
 #: ../../src/ToolBar.cpp:192
 msgid "Redo"
-msgstr ""
+msgstr "Повторить"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo\tCtrl+Y"
-msgstr ""
+msgstr "Повторить\tCtrl+Y"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo last change"
-msgstr ""
+msgstr "Повторить последнее действие"
 
 #: ../../src/wxMaximaFrame.cpp:1595
 msgid "Reduce trigonometric expression"
-msgstr ""
+msgstr "Привести тригонометрическое выражение"
 
 #: ../../src/wxMaxima.cpp:2366 ../../src/wxMaxima.cpp:10630
 msgid "Refusing to send cell to maxima: "
-msgstr ""
+msgstr "Отказ в отправке поля в Maxima: "
 
 #: ../../src/wxMaxima.cpp:7523
 msgid "Regex match"
-msgstr ""
+msgstr "Совпадение по регулярному выражению"
 
 #: ../../src/wxMaxima.cpp:7518
 msgid "Regex match position"
-msgstr ""
+msgstr "Положение совпадения по регулярному выражению"
 
 #: ../../src/wxMaximaFrame.cpp:1195
 msgid "Regular expression that matches a string"
-msgstr ""
+msgstr "Регулярное выражение, которое соответствует строке"
 
 #: ../../src/wxMaximaFrame.cpp:1196
 msgid "Regular expressions"
-msgstr ""
+msgstr "Регулярные выражения"
 
 #: ../../src/Worksheet.cpp:1314
 msgid "Reload Image"
-msgstr ""
+msgstr "Перезагрузить изображение"
 
 #: ../../src/Worksheet.cpp:1320
 #, c-format
 msgid "Reload Image \"%s\""
-msgstr ""
+msgstr "Перезагрузить изображение «%s»"
 
 #: ../../src/wxMaxima.cpp:9809
 #, c-format
 msgid "Reloading image file %s."
-msgstr ""
+msgstr "Перезагрузка файла изображения %s."
 
 #: ../../src/wxMaximaFrame.cpp:883
 msgid "Remove All Output"
-msgstr ""
+msgstr "Удалить весь вывод"
 
 #: ../../src/wxMaximaFrame.cpp:1426
 msgid "Remove Rows or Columns..."
-msgstr ""
+msgstr "Удалить строки или столбцы..."
 
 #: ../../src/wxMaximaFrame.cpp:1748
 msgid ""
 "Remove all list elements that appear twice in a row. Normally used in "
 "conjunction with sort."
 msgstr ""
+"Удалить все элементы списка, которые встречаются два раза подряд. Обычно "
+"используется совместно с сортировкой."
 
 #: ../../src/wxMaximaFrame.cpp:1174
 msgid "Remove all occurrences of a word..."
-msgstr ""
+msgstr "Удалить все вхождения слова..."
 
 #: ../../src/wxMaxima.cpp:7439
 msgid "Remove all occurrences of part"
-msgstr ""
+msgstr "Удалить все вхождения части"
 
 #: ../../src/wxMaxima.cpp:8592
 msgid "Remove an element from a list"
-msgstr ""
+msgstr "Удалить элемент из списка"
 
 #: ../../src/wxMaxima.cpp:7566
 msgid "Remove directory"
-msgstr ""
+msgstr "Удалить каталог"
 
 #: ../../src/wxMaximaFrame.cpp:1204
 msgid "Remove directory..."
-msgstr ""
+msgstr "Удалить каталог..."
 
 #: ../../src/wxMaximaFrame.cpp:1747
 msgid "Remove duplicates"
-msgstr ""
+msgstr "Удалить дубликаты"
 
 #: ../../src/wxMaximaFrame.cpp:1176
 msgid "Remove first occurrence of a word..."
-msgstr ""
+msgstr "Удалить первое вхождение слова..."
 
 #: ../../src/wxMaxima.cpp:7444
 msgid "Remove first occurrence of part"
-msgstr ""
+msgstr "Удалить первое вхождение части"
 
 #: ../../src/wxMaximaFrame.cpp:884
 msgid "Remove output from input cells"
-msgstr ""
+msgstr "Удалить вывод из полей ввода"
 
 #: ../../src/wxMaxima.cpp:7975
 msgid "Remove rows and/or columns"
-msgstr ""
+msgstr "Удалить строки и/или столбцы"
 
 #: ../../src/wxMaximaFrame.cpp:1427
 msgid "Remove rows and/or columns from the matrix"
-msgstr ""
+msgstr "Удалить строки и/или столбцы из матрицы"
 
 #: ../../src/wxMaxima.cpp:7582
 msgid "Rename file"
-msgstr ""
+msgstr "Переименовать файл"
 
 #: ../../src/wxMaximaFrame.cpp:1215
 msgid "Rename file..."
-msgstr ""
+msgstr "Переименовать файл..."
 
 #: ../../src/wxMaximaFrame.cpp:1527
 msgid "Reorganize an expression using horner's rule"
-msgstr ""
+msgstr "Реорганизовать выражение с помощью правила Горнера"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "Repetitive element-by-element multiplication"
-msgstr ""
+msgstr "Циклическое покомпонентное умножение"
 
 #: ../../src/wxMaxima.cpp:7538
 msgid "Replace all regex matches"
-msgstr ""
+msgstr "Заменить все совпадения по регулярному выражению"
 
 #: ../../src/wxMaxima.cpp:7533
 msgid "Replace first regex match"
-msgstr ""
+msgstr "Заменить первое совпадение по регулярному выражению"
 
 #: ../../src/wxMaxima.cpp:7463
 msgid "Replace the first occurrence of Part"
-msgstr ""
+msgstr "Заменить первое вхождение части"
 
 #: ../../src/wxMaximaFrame.cpp:1180
 msgid "Replace..."
-msgstr ""
+msgstr "Заменить..."
 
 #: ../../src/wxMaxima.cpp:6719
 #, c-format
 msgid "Replaced %li occurrences."
-msgstr ""
+msgstr "Заменено вхождений: %li."
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "Report bug"
-msgstr ""
+msgstr "Сообщить об ошибке"
 
 #: ../../src/wxMaximaFrame.cpp:996
 msgid "Reset option variables"
-msgstr ""
+msgstr "Сбросить переменные"
 
 #: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
 msgid "Restart Maxima"
-msgstr ""
+msgstr "Перезапустить Maxima"
 
 #: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
 msgid "Restrict Maximum size"
-msgstr ""
+msgstr "Ограничить максимальный размер"
 
 #: ../../src/wxMaxima.cpp:10031
 msgid "Result variables:"
-msgstr ""
+msgstr "Переменные результата:"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Resulting Matrix name (may be empty):"
-msgstr ""
+msgstr "Имя конечной матрицы (может быть пустым):"
 
 #: ../../src/wxMaximaFrame.cpp:1190
 msgid "Return a match"
-msgstr ""
+msgstr "Вернуть совпадение"
 
 #: ../../src/wxMaxima.cpp:7077
 msgid "Return from a block or loop"
-msgstr ""
+msgstr "Вернуться из блока или цикла"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "Return from current block/loop..."
-msgstr ""
+msgstr "Вернуться из текущего блока/цикла..."
 
 #: ../../src/wxMaximaFrame.cpp:1755
 msgid ""
 "Return the first item of the list and remove it from the list. Useful for "
 "creating stacks."
 msgstr ""
+"Вернуть первый элемент списка и удалить его из списка. Эта возможность "
+"полезна при создании стеков."
 
 #: ../../src/wxMaxima.cpp:8526
 msgid "Return the list without its first n elements"
-msgstr ""
+msgstr "Вернуть список без его первых n элементов"
 
 #: ../../src/wxMaxima.cpp:8532
 msgid "Return the list without its last n elements"
-msgstr ""
+msgstr "Вернуть список без его последних n элементов"
 
 #: ../../src/ToolBar.cpp:241
 msgid "Return to the cell that is currently being evaluated"
-msgstr ""
+msgstr "Вернуться в поле, которое вычисляется в настоящий момент"
 
 #: ../../src/wxMaximaFrame.cpp:1711
 msgid "Returns an arbitrary list item"
-msgstr ""
+msgstr "Возвращает произвольный элемент списка"
 
 #: ../../src/wxMaximaFrame.cpp:1713
 msgid "Returns the first item of the list"
-msgstr ""
+msgstr "Возвращает первый элемент списка"
 
 #: ../../src/wxMaximaFrame.cpp:1719
 msgid "Returns the last item of the list"
-msgstr ""
+msgstr "Возвращает последний элемент списка"
 
 #: ../../src/wxMaximaFrame.cpp:1721
 msgid "Returns the last n items of the list"
-msgstr ""
+msgstr "Возвращает последние n элементов списка"
 
 #: ../../src/wxMaximaFrame.cpp:1742
 msgid "Returns the length of the list"
-msgstr ""
+msgstr "Возвращает длину списка"
 
 #: ../../src/wxMaximaFrame.cpp:1715
 msgid "Returns the list without its first n elements"
-msgstr ""
+msgstr "Возвращает список без первых n элементов"
 
 #: ../../src/wxMaximaFrame.cpp:1717
 msgid "Returns the list without its last n elements"
-msgstr ""
+msgstr "Возвращает список без последних n элементов"
 
 #: ../../src/wxMaximaFrame.cpp:1743
 msgid "Reverse"
-msgstr ""
+msgstr "Обратить"
 
 #: ../../src/wxMaximaFrame.cpp:1744
 msgid "Reverse the order of the list items"
-msgstr ""
+msgstr "Обратить порядок элементов списка"
 
 #: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
 #: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
 msgid "Right Matrix:"
-msgstr ""
+msgstr "Правая матрица:"
 
 #: ../../src/wxMaxima.cpp:8190
 msgid "Right end"
-msgstr ""
+msgstr "Правая сторона"
 
 #: ../../src/wxMaximaFrame.cpp:1301
 msgid "Right side to the \"=\""
-msgstr ""
+msgstr "Правая сторона «=»"
 
 #: ../../src/wxMaximaFrame.cpp:1455
 msgid "Risch Integration..."
-msgstr ""
+msgstr "Интегрирование по Ричу..."
 
 #: ../../src/wxMaximaFrame.cpp:785
 msgid "Rounded"
-msgstr ""
+msgstr "Круглые"
 
 #: ../../src/wxMaximaFrame.cpp:1437
 msgid "Row and column operations"
-msgstr ""
+msgstr "Операции со строками и столбцами"
 
 #: ../../src/wxMaxima.cpp:7957 ../../src/wxMaxima.cpp:7967
 #: ../../src/wxMaxima.cpp:7972
 msgid "Row number:"
-msgstr ""
+msgstr "Номер строки:"
 
 #: ../../src/wxMaxima.cpp:7977
 msgid "Row numbers:"
-msgstr ""
+msgstr "Номера строк:"
 
 #: ../../src/wxMaxima.cpp:8203
 msgid "Rows"
-msgstr ""
+msgstr "Строки"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Rule"
-msgstr ""
+msgstr "Правило"
 
 #: ../../src/wxMaxima.cpp:8464 ../../src/wxMaxima.cpp:8477
 msgid "Rule:"
-msgstr ""
+msgstr "Правило:"
 
 #: ../../src/wxMaximaFrame.cpp:1027
 msgid "Rules"
-msgstr ""
+msgstr "Правила"
 
 #: ../../src/wxMaximaFrame.cpp:1693
 msgid "Run each element through an expression"
-msgstr ""
+msgstr "Применить выражение к каждому элементу"
 
 #: ../../src/wxMaxima.cpp:6355
 #, c-format
 msgid "Running %s on the file %s: "
-msgstr ""
+msgstr "Выполняется %s для файла %s: "
 
 #: ../../src/wxMaxima.cpp:2633
 #, c-format
 msgid "Running maxima as: %s"
-msgstr ""
+msgstr "Maxima выполняется как: %s"
 
 #: ../../src/wxMaximaFrame.cpp:130
 msgid "Running on DirectFB"
-msgstr ""
+msgstr "Выполняется под управлением DirectFB"
 
 #: ../../src/wxMaximaFrame.cpp:114
 msgid "Running on MS Windows"
-msgstr ""
+msgstr "Выполняется под управлением MS Windows"
 
 #: ../../src/wxMaximaFrame.cpp:116
 msgid "Running on MS Windows using DirectDraw"
-msgstr ""
+msgstr "Выполняется под управлением MS Windows с использованием DirectDraw"
 
 #: ../../src/wxMaximaFrame.cpp:136
 msgid "Running on Mac OS"
-msgstr ""
+msgstr "Выполняется под управлением Mac OS"
 
 #: ../../src/wxMaximaFrame.cpp:127
 msgid "Running on Motif"
-msgstr ""
+msgstr "Выполняется под управлением Motif"
 
 #: ../../src/wxMaximaFrame.cpp:133
 msgid "Running on the universal wxWidgets port"
-msgstr ""
+msgstr "Выполняется под управлением универсального порта wxWidgets"
 
 #: ../../src/wxMaxima.cpp:8208
 msgid ""
 "Runs each element of an object (list, matrix, equation,...) through a "
 "function individually"
 msgstr ""
+"Применяет функцию к каждому элементу объекта (список, матрица, уравнение...)"
+" по отдельности"
 
 #: ../../src/wxMaxima.cpp:8216
 msgid ""
 "Runs each element of an object (list, matrix, equation,...) through an "
 "expression individually"
 msgstr ""
+"Применяет выражение к каждому элементу объекта (список, матрица, "
+"уравнение...) по отдельности"
 
 #: ../../src/wxMaximaFrame.cpp:1691
 msgid "Runs each element through a function"
-msgstr ""
+msgstr "Применяет функцию к каждому элементу"
 
 #: ../../src/wxMaximaFrame.cpp:1694
 msgid "Runs each element through an expression"
-msgstr ""
+msgstr "Применяет выражение к каждому элементу"
 
 #: ../../src/wxMaxima.cpp:9572
 msgid "Sample 1:"
-msgstr ""
+msgstr "Выборка 1:"
 
 #: ../../src/wxMaxima.cpp:9573
 msgid "Sample 2:"
-msgstr ""
+msgstr "Выборка 2:"
 
 #: ../../src/wxMaxima.cpp:9567
 msgid "Sample:"
-msgstr ""
+msgstr "Выборка:"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
 msgid "Save"
-msgstr ""
+msgstr "Сохранить"
 
 #: ../../src/Worksheet.cpp:1294
 msgid "Save Animation..."
-msgstr ""
+msgstr "Сохранить анимацию..."
 
 #: ../../src/wxMaxima.cpp:5672
 msgid "Save As"
-msgstr ""
+msgstr "Сохранить как"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save As...\tShift+Ctrl+S"
-msgstr ""
+msgstr "Сохранить как...\tShift+Ctrl+S"
 
 #: ../../src/Worksheet.cpp:1291
 msgid "Save Image..."
-msgstr ""
+msgstr "Сохранить изображение..."
 
 #: ../../src/wxMaxima.cpp:6440
 msgid "Save Selection to Image"
-msgstr ""
+msgstr "Сохранить выделение в изображение"
 
 #: ../../src/wxMaximaFrame.cpp:675
 msgid "Save Selection to Image..."
-msgstr ""
+msgstr "Сохранить выделение в изображение..."
 
 #: ../../src/wxMaxima.cpp:10184
 msgid "Save animation to file"
-msgstr ""
+msgstr "Сохранить анимацию в файл"
 
 #: ../../src/wxMaxima.cpp:7203
 msgid "Save as lisp code"
-msgstr ""
+msgstr "Сохранить как код Lisp"
 
 #: ../../src/wxMaximaFrame.cpp:1091
 msgid "Save as lisp..."
-msgstr ""
+msgstr "Сохранить как Lisp..."
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
 msgid "Save document"
-msgstr ""
+msgstr "Сохранить документ"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save document as"
-msgstr ""
+msgstr "Сохранить документ как"
 
 #: ../../src/wxMaximaFrame.cpp:676
 msgid "Save selection from document to an image file"
-msgstr ""
+msgstr "Сохранить выделение в документе в графический файл"
 
 #: ../../src/wxMaxima.cpp:10125
 msgid "Save selection to file"
-msgstr ""
+msgstr "Сохранить выделение в файл"
 
 #: ../../src/wxMaximaFrame.cpp:573
 msgid "Saving failed."
-msgstr ""
+msgstr "Не удалось выполнить сохранение."
 
 #: ../../src/WXMXformat.cpp:310
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
-msgstr ""
+msgstr "Сохранение выполнено успешно, но пропали конечные файлы!?"
 
 #: ../../src/wxMaxima.cpp:10107
 msgid ""
@@ -5951,599 +6179,611 @@ msgid ""
 "(*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|Portable anymap "
 "(*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"SVG (*.svg)|*.svg|SVGZ (*.svgz)|*.svgz|PNG(*.png)|*.png|JPEG "
+"(*.jpg)|*.jpg|GIF (*.gif)|*.gif|Windows Bitmap (*.bmp)|*.bmp|Portable anymap"
+" (*.pnm)|*.pnm|TIFF (*.tif)|*.tif|X PixMap (*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:9533
 msgid "Scatterplot"
-msgstr ""
+msgstr "График рассеяния"
 
 #: ../../src/Autocomplete.cpp:125
 msgid ""
 "Scheduling a background task that compiles a new list of autocompletable "
 "maxima commands."
 msgstr ""
+"Планирование фоновой задачи по компиляции нового списка команд Maxima для "
+"автодополнения."
 
 #: ../../src/Autocomplete.cpp:458
 msgid ""
 "Scheduling a background task that scans for autocompletable file names."
-msgstr ""
+msgstr "Планирование фоновой задачи по поиску файлов для автодополнения."
 
 #: ../../src/ToolBar.cpp:632
 msgid "Search button"
-msgstr ""
+msgstr "Кнопка «Найти»"
 
 #: ../../src/wxMaxima.cpp:7454
 msgid "Search first occurrence of part"
-msgstr ""
+msgstr "Найти первое вхождение части"
 
 #: ../../src/wxMaximaFrame.cpp:1178
 msgid "Search..."
-msgstr ""
+msgstr "Поиск..."
 
 #: ../../src/ToolBar.cpp:273
 msgid "Section"
-msgstr ""
+msgstr "Раздел"
 
 #: ../../src/Configuration.cpp:91
 msgid "Section cell (Heading 2)"
-msgstr ""
+msgstr "Поле раздела (Заголовок 2)"
 
 #: ../../src/wxMaxima.cpp:7218
 msgid "Seek to position"
-msgstr ""
+msgstr "Перейти к позиции"
 
 #: ../../src/BTextCtrl.cpp:45
 msgid "Seems like something is broken with a font."
-msgstr ""
+msgstr "Вероятно, что-то не так со шрифтом."
 
 #: ../../src/Autocomplete.cpp:350
 msgid "Seems like the package with the maxima share files isn't installed."
-msgstr ""
+msgstr "Вероятно, пакет с общими файлами Maxima не установлен."
 
 #: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
 msgid "Select All"
-msgstr ""
+msgstr "Выделить все"
 
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select All\tCtrl+A"
-msgstr ""
+msgstr "Выделить все\tCtrl+A"
 
 #: ../../src/ToolBar.cpp:629
 msgid "Select All button"
-msgstr ""
+msgstr "Кнопка «Выделить все»"
 
 #: ../../src/wxMaxima.cpp:9631
 msgid "Select Subsample"
-msgstr ""
+msgstr "Выделить подвыборку"
 
 #: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select all"
-msgstr ""
+msgstr "Выделить все"
 
 #: ../../src/wxMaxima.cpp:6971
 msgid "Select math display algorithm"
-msgstr ""
+msgstr "Выбрать способ отображения"
 
 #: ../../src/Configuration.cpp:98
 msgid "Selection color"
-msgstr ""
+msgstr "Цвет выделения"
 
 #: ../../src/ToolBar.cpp:252
 msgid "Send all cells to maxima"
-msgstr ""
+msgstr "Отправить все поля в Maxima"
 
 #: ../../src/ToolBar.cpp:249
 msgid "Send the current cell to maxima"
-msgstr ""
+msgstr "Отправить текущее поле в Maxima"
 
 #: ../../src/wxMaxima.cpp:2810
 msgid "Sending Maxima a SIGINT signal."
-msgstr ""
+msgstr "Отправка сигнала SIGINT в Maxima."
 
 #: ../../src/StatusBar.cpp:220
 msgid "Sending a command to Maxima"
-msgstr ""
+msgstr "Отправка команды в Maxima."
 
 #: ../../src/wxMaxima.cpp:10598
 msgid "Sending a new command to Maxima."
-msgstr ""
+msgstr "Отправка новой команды в Maxima."
 
 #: ../../src/wxMaxima.cpp:2792
 msgid "Sending an interrupt signal to Maxima."
-msgstr ""
+msgstr "Отправка сигнала прерывания в Maxima."
 
 #: ../../src/wxMaxima.cpp:169
 msgid "Sending configuration data to maxima."
-msgstr ""
+msgstr "Отправка данных конфигурации в Maxima."
 
 #: ../../src/wxMaxima.cpp:4718
 msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
+"Отправка в Maxima сведений о том, как выражать двухмерные расчёты как XML."
 
 #: ../../src/wxMaximaFrame.cpp:1533
 msgid "Sequential Comparative Simplification"
-msgstr ""
+msgstr "Последовательное сравнительное упрощение"
 
 #: ../../src/wxMaxima.cpp:9016
 msgid "Series"
-msgstr ""
+msgstr "Ряд"
 
 #: ../../src/wxMaximaFrame.cpp:1479
 msgid "Series approximation"
-msgstr ""
+msgstr "Аппроксимация ряда"
 
 #: ../../src/wxMaxima.cpp:2561
 msgid "Server started"
-msgstr ""
+msgstr "Сервер запущен"
 
 #: ../../src/wxMaximaFrame.cpp:1824
 msgid "Set &displayed Precision..."
-msgstr ""
+msgstr "Установить &отображаемую точность..."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Set Maxima option variable logexpand:all"
-msgstr ""
+msgstr "Указать для переменной Maxima logexpand:all"
 
 #: ../../src/wxMaximaFrame.cpp:1567
 msgid "Set Maxima option variable logexpand:super"
-msgstr ""
+msgstr "Указать для переменной Maxima logexpand:super"
 
 #: ../../src/wxMaximaFrame.cpp:1560
 msgid "Set Maxima option variable logexpand:true"
-msgstr ""
+msgstr "Указать для переменной Maxima logexpand:true"
 
 #: ../../src/wxMaximaFrame.cpp:822
 msgid "Set Zoom"
-msgstr ""
+msgstr "Установить увеличение"
 
 #: ../../src/wxMaximaFrame.cpp:1819
 msgid "Set bigfloat &Precision..."
 msgstr ""
+"Установить точность для &чисел с плавающей точкой повышенной точности..."
 
 #: ../../src/Worksheet.cpp:1306 ../../src/Worksheet.cpp:1479
 msgid "Set image resolution"
-msgstr ""
+msgstr "Установить разрешение изображения"
 
 #: ../../src/wxMaximaFrame.cpp:1510
 msgid "Set main variable..."
-msgstr ""
+msgstr "Установить основную переменную..."
 
 #: ../../src/wxMaximaFrame.cpp:1773
 msgid "Set plot format"
-msgstr ""
+msgstr "Установить формат графиков"
 
 #: ../../src/wxMaximaFrame.cpp:1101
 msgid "Set position..."
-msgstr ""
+msgstr "Установить положение..."
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Set the \"algebraic\" flag"
-msgstr ""
+msgstr "Установить флаг «algebraic»"
 
 #: ../../src/wxMaxima.cpp:8314
 msgid "Set the diagram title"
-msgstr ""
+msgstr "Установить заголовок диаграммы"
 
 #: ../../src/wxMaximaFrame.cpp:1779
 msgid "Set the frame rate for animations."
-msgstr ""
+msgstr "Установить частоту кадров для анимации."
 
 #: ../../src/wxMaxima.cpp:8377
 msgid "Set the grid density."
-msgstr ""
+msgstr "Установить плотность сетки."
 
 #: ../../src/wxMaxima.cpp:8327
 msgid "Set the next plot's title. Empty = no title."
-msgstr ""
+msgstr "Установить заголовок следующего графика. Пустой = без заголовка."
 
 #: ../../src/wxMaximaFrame.cpp:1820
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can"
 " be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
+"Установить точность для чисел, объявленных как числа с плавающей точкой "
+"повышенной точности. Такие числа можно создать, введя 1.5b12 или "
+"bfloat(1.234)"
 
 #: ../../src/wxMaximaFrame.cpp:811
 msgid "Set zoom to 100%"
-msgstr ""
+msgstr "Установить увеличение в 100%"
 
 #: ../../src/wxMaximaFrame.cpp:813
 msgid "Set zoom to 120%"
-msgstr ""
+msgstr "Установить увеличение в 120%"
 
 #: ../../src/wxMaximaFrame.cpp:815
 msgid "Set zoom to 150%"
-msgstr ""
+msgstr "Установить увеличение в 150%"
 
 #: ../../src/wxMaximaFrame.cpp:817
 msgid "Set zoom to 200%"
-msgstr ""
+msgstr "Установить увеличение в 200%"
 
 #: ../../src/wxMaximaFrame.cpp:819
 msgid "Set zoom to 300%"
-msgstr ""
+msgstr "Установить увеличение в 300%"
 
 #: ../../src/wxMaximaFrame.cpp:809
 msgid "Set zoom to 80%"
-msgstr ""
+msgstr "Установить увеличение в 80%"
 
 #: ../../src/wxMaxima.cpp:4731
 #, c-format
 msgid "Setting gnuplot_binary to %s"
-msgstr ""
+msgstr "Установка gnuplot_binary в значение %s"
 
 #: ../../src/wxMaxima.cpp:4804
 msgid "Setting prompt and help format"
-msgstr ""
+msgstr "Установка формата запросов и справки"
 
 #: ../../src/wxMaximaFrame.cpp:1292
 msgid "Setup atvalues for solving ODE with Laplace transformation"
-msgstr ""
+msgstr "Установить значения для решения ОДУ с помощью преобразования Лапласа"
 
 #: ../../src/wxMaximaFrame.cpp:1661
 msgid "Setup modulus computation"
-msgstr ""
+msgstr "Установить вычисления по модулю"
 
 #: ../../src/wxMaxima.cpp:9220
 msgid "Setup the engineering format"
-msgstr ""
+msgstr "Настроить инженерный формат"
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "Setup the engineering format..."
-msgstr ""
+msgstr "Настроить инженерный формат..."
 
 #: ../../src/wxMaxima.cpp:9576
 msgid "Shapiro-Wilk test for normality"
-msgstr ""
+msgstr "Тест на нормальность Шапиро — Уилка"
 
 #: ../../src/Worksheet.cpp:1543
 msgid "Show \"%\" in special constants"
-msgstr ""
+msgstr "Показывать «%» в специальных константах"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show &Tips..."
-msgstr ""
+msgstr "Показать &подсказки..."
 
 #: ../../src/Worksheet.cpp:1556
 msgid "Show * as multiplication dot"
-msgstr ""
+msgstr "Показывать * в качестве знака умножения"
 
 #: ../../src/wxMaximaFrame.cpp:895
 msgid "Show Template\tCtrl+Shift+Space"
-msgstr ""
+msgstr "Показать шаблон\tCtrl+Shift+Пробел"
 
 #: ../../src/wxMaximaFrame.cpp:753
 msgid "Show XML representation"
-msgstr ""
+msgstr "Показать XML-представление"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show a tip"
-msgstr ""
+msgstr "Показать подсказку"
 
 #: ../../src/Worksheet.cpp:1607
 msgid "Show all + allow linebreaks in long numbers"
-msgstr ""
+msgstr "Показать все + включить перенос строки для длинных чисел"
 
 #: ../../src/wxMaxima.cpp:9475
 msgid "Show all commands similar to:"
-msgstr ""
+msgstr "Показать все команды, похожие на:"
 
 #: ../../src/wxMaxima.cpp:9468
 msgid "Show an example for the command:"
-msgstr ""
+msgstr "Показать пример для команды:"
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "Show an example of usage"
-msgstr ""
+msgstr "Показать пример использования"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "Show commands similar to"
-msgstr ""
+msgstr "Показать команды, подобные"
 
 #: ../../src/wxMaximaFrame.cpp:1020
 msgid "Show defined functions"
-msgstr ""
+msgstr "Показать определённые функции"
 
 #: ../../src/wxMaximaFrame.cpp:1022
 msgid "Show defined variables"
-msgstr ""
+msgstr "Показать определённые переменные"
 
 #: ../../src/wxMaximaFrame.cpp:1074
 msgid "Show definition of a function"
-msgstr ""
+msgstr "Показать определение функции"
 
 #: ../../src/wxMaximaFrame.cpp:740
 msgid "Show equations in their linear form"
-msgstr ""
+msgstr "Показать уравнения в линейной форме"
 
 #: ../../src/wxMaximaFrame.cpp:1073
 msgid "Show function &Definition..."
-msgstr ""
+msgstr "Показать &определение функции..."
 
 #: ../../src/wxMaximaFrame.cpp:896
 msgid "Show function template"
-msgstr ""
+msgstr "Показать шаблон функции"
 
 #: ../../src/Worksheet.cpp:1614
 msgid "Show input labels"
-msgstr ""
+msgstr "Показывать метки ввода"
 
 #: ../../src/wxMaximaFrame.cpp:750
 msgid "Show lisp representation"
-msgstr ""
+msgstr "Показать Lisp-представление"
 
 #: ../../src/Worksheet.cpp:1604
 msgid "Show max. 100 digits"
-msgstr ""
+msgstr "Показывать не более 100 цифр"
 
 #: ../../src/Worksheet.cpp:1602
 msgid "Show max. 20 digits"
-msgstr ""
+msgstr "Показывать не более 20 цифр"
 
 #: ../../src/Worksheet.cpp:1603
 msgid "Show max. 50 digits"
-msgstr ""
+msgstr "Показывать не более 50 цифр"
 
 #: ../../src/wxMaximaFrame.cpp:835
 msgid "Show or hide the wxMaxima logging window"
-msgstr ""
+msgstr "Показать или скрыть окно журнала wxMaxima"
 
 #: ../../src/ToolBar.cpp:612
 msgid "Show the \"New\" button?"
-msgstr ""
+msgstr "Показывать кнопку «Создать»?"
 
 #: ../../src/ToolBar.cpp:636
 msgid "Show the \"help\" button?"
-msgstr ""
+msgstr "Показывать кнопку «Справка»?"
 
 #: ../../src/ToolBar.cpp:633
 msgid "Show the \"search\" button?"
-msgstr ""
+msgstr "Показывать кнопку «Найти»?"
 
 #: ../../src/ToolBar.cpp:630
 msgid "Show the \"select all\" button?"
-msgstr ""
+msgstr "Показывать кнопку «Выделить все»?"
 
 #: ../../src/ToolBar.cpp:624
 msgid "Show the Copy, Cut and the Paste button?"
-msgstr ""
+msgstr "Показывать кнопки «Копировать», «Вырезать» и «Вставить»?"
 
 #: ../../src/wxMaxima.cpp:7033
 msgid "Show the function's definition"
-msgstr ""
+msgstr "Показать определение функции"
 
 #: ../../src/ToolBar.cpp:618
 msgid "Show the open and the save button?"
-msgstr ""
+msgstr "Показывать кнопки «Открыть» и «Сохранить»?"
 
 #: ../../src/ToolBar.cpp:627
 msgid "Show the preferences button?"
-msgstr ""
+msgstr "Показывать кнопку «Параметры»?"
 
 #: ../../src/ToolBar.cpp:621
 msgid "Show the print button?"
-msgstr ""
+msgstr "Показывать кнопку «Печать»?"
 
 #: ../../src/ToolBar.cpp:615
 msgid "Show the undo and redo button?"
-msgstr ""
+msgstr "Показывать кнопку отмены и повторения действий?"
 
 #: ../../src/wxMaximaFrame.cpp:1006 ../../src/wxMaximaFrame.cpp:1011
 msgid "Show used + to-be-freed memory"
-msgstr ""
+msgstr "Показать используемую + подлежащую высвобождению память"
 
 #: ../../src/wxMaximaFrame.cpp:1033
 msgid "Show user definitions"
-msgstr ""
+msgstr "Показать пользовательские определения"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Show wxMaxima help"
-msgstr ""
+msgstr "Показать справку по wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1825
 msgid "Shows how many digits of a numbers are displayed"
-msgstr ""
+msgstr "Показывает, сколько цифр чисел отображается"
 
 #: ../../src/wxMaximaFrame.cpp:732
 msgid "Sidebars"
-msgstr ""
+msgstr "Боковые панели"
 
 #: ../../src/wxMaximaFrame.cpp:1513
 msgid "Simplify &Radicals..."
-msgstr ""
+msgstr "Упростить &радикалы..."
 
 #: ../../src/Worksheet.cpp:1579
 msgid "Simplify Expression"
-msgstr ""
+msgstr "Упростить выражение"
 
 #: ../../src/wxMaximaFrame.cpp:1568
 msgid "Simplify Logarithms"
-msgstr ""
+msgstr "Упростить логарифмы"
 
 #: ../../src/wxMaximaFrame.cpp:1582
 msgid "Simplify an expression containing factorials"
-msgstr ""
+msgstr "Упростить выражение с факториалами"
 
 #: ../../src/wxMaximaFrame.cpp:1539
 msgid "Simplify equations"
-msgstr ""
+msgstr "Упростить уравнения"
 
 #: ../../src/wxMaximaFrame.cpp:1514
 msgid "Simplify expression containing radicals"
-msgstr ""
+msgstr "Упростить выражение с радикалами"
 
 #: ../../src/wxMaxima.cpp:8649
 msgid "Simplify radicals"
-msgstr ""
+msgstr "Упростить радикалы"
 
 #: ../../src/wxMaximaFrame.cpp:1512
 msgid "Simplify rational expression"
-msgstr ""
+msgstr "Упростить рациональное выражение"
 
 #: ../../src/wxMaximaFrame.cpp:1538
 msgid "Simplify sum() commands..."
-msgstr ""
+msgstr "Упростить команды sum()..."
 
 #: ../../src/wxMaxima.cpp:8636
 msgid "Simplify sums"
-msgstr ""
+msgstr "Упростить суммы"
 
 #: ../../src/wxMaximaFrame.cpp:1592
 msgid "Simplify trigonometric expression"
-msgstr ""
+msgstr "Упростить тригонометрическое выражение"
 
 #: ../../src/wxMaximaFrame.cpp:1399
 msgid "Singular Values"
-msgstr ""
+msgstr "Сингулярные значения"
 
 #: ../../src/wxMaximaFrame.cpp:1400 ../../src/wxMaximaFrame.cpp:1403
 msgid "Singular values using dgesvd"
-msgstr ""
+msgstr "Сингулярные значения с помощью dgesvd"
 
 #: ../../src/wxMaximaFrame.cpp:1402
 msgid "Singular values, left + right vectors"
-msgstr ""
+msgstr "Сингулярные значения, левые + правые векторы"
 
 #: ../../src/wxMaximaFrame.cpp:1635
 msgid "Smart Substitute..."
-msgstr ""
+msgstr "Умная подстановка..."
 
 #: ../../src/wxMaxima.cpp:8730
 msgid "Smart substitution"
-msgstr ""
+msgstr "Умная подстановка"
 
 #: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
 #: ../../src/wxMaxima.cpp:7823
 msgid "Solution of the ODE:"
-msgstr ""
+msgstr "Решение ОДУ:"
 
 #: ../../src/wxMaxima.cpp:10017
 msgid "Solve"
-msgstr ""
+msgstr "Решить"
 
 #: ../../src/wxMaximaFrame.cpp:1244
 msgid "Solve &Algebraic System..."
-msgstr ""
+msgstr "Решить &алгебраическую систему..."
 
 #: ../../src/wxMaximaFrame.cpp:1242
 msgid "Solve &Linear System..."
-msgstr ""
+msgstr "Решить &линейную систему..."
 
 #: ../../src/wxMaximaFrame.cpp:1266
 msgid "Solve &ODE..."
-msgstr ""
+msgstr "Решить ОД&У..."
 
 #: ../../src/wxMaximaFrame.cpp:1240
 msgid "Solve (to_poly)..."
-msgstr ""
+msgstr "Решить (to_poly)..."
 
 #: ../../src/wxMaxima.cpp:8045
 msgid "Solve A*x=b numerically"
-msgstr ""
+msgstr "Решить A*x=b численно"
 
 #: ../../src/wxMaximaFrame.cpp:1397
 msgid "Solve Ax=b"
-msgstr ""
+msgstr "Решить Ax=b"
 
 #: ../../src/wxMaxima.cpp:7783
 msgid "Solve ODE"
-msgstr ""
+msgstr "Решить ОДУ"
 
 #: ../../src/wxMaximaFrame.cpp:1287
 msgid "Solve ODE with Lapla&ce..."
-msgstr ""
+msgstr "Решить ОДУ с помощью &преобразования Лапласа..."
 
 #: ../../src/wxMaximaFrame.cpp:1398
 msgid "Solve a linear equation system using dgesv"
-msgstr ""
+msgstr "Решить систему линейных уравнений с помощью dgesv"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
 msgid "Solve algebraic system"
-msgstr ""
+msgstr "Решить алгебраическую систему"
 
 #: ../../src/wxMaximaFrame.cpp:1245
 msgid "Solve algebraic system of equations"
-msgstr ""
+msgstr "Решить систему алгебраических уравнений"
 
 #: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve boundary value problem for second degree ODE"
-msgstr ""
+msgstr "Решить граничную задачу для ОДУ второго порядка"
 
 #: ../../src/wxMaxima.cpp:7895
 msgid "Solve differential equations using laplace()"
-msgstr ""
+msgstr "Решить дифференциальные уравнения с помощью laplace()"
 
 #: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
 msgid "Solve equation(s)"
-msgstr ""
+msgstr "Решить уравнения"
 
 #: ../../src/wxMaximaFrame.cpp:1241
 msgid "Solve equation(s) with to_poly_solve"
-msgstr ""
+msgstr "Решить уравнения c помощью to_poly_solve"
 
 #: ../../src/wxMaxima.cpp:7773
 msgid "Solve equations numerically"
-msgstr ""
+msgstr "Решить уравнения численно"
 
 #: ../../src/wxMaxima.cpp:7757
 msgid "Solve equations to polynom"
-msgstr ""
+msgstr "Решить уравнения для полинома"
 
 #: ../../src/wxMaximaFrame.cpp:1271
 msgid "Solve initial value problem for first degree ODE"
-msgstr ""
+msgstr "Решить задачу с начальным условием для ОДУ первого порядка"
 
 #: ../../src/wxMaximaFrame.cpp:1275
 msgid "Solve initial value problem for second degree ODE"
-msgstr ""
+msgstr "Решить задачу с начальным условием для ОДУ второго порядка"
 
 #: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
 msgid "Solve linear system"
-msgstr ""
+msgstr "Решить линейную систему"
 
 #: ../../src/wxMaximaFrame.cpp:1243
 msgid "Solve linear system of equations"
-msgstr ""
+msgstr "Решить систему линейных уравнений"
 
 #: ../../src/wxMaximaFrame.cpp:1263
 msgid "Solve numerical, 1 Variable"
-msgstr ""
+msgstr "Решить численно, 1 переменная"
 
 #: ../../src/wxMaximaFrame.cpp:1267
 msgid "Solve ordinary differential equation of maximum degree 2"
-msgstr ""
+msgstr "Решить обычное дифференциальное уравнение не выше второго порядка"
 
 #: ../../src/wxMaximaFrame.cpp:1288
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
+"Решить обыкновенное дифференциальное уравнение с помощью преобразования "
+"Лапласа"
 
 #: ../../src/wxMaxima.cpp:7708
 msgid "Solve polynomials numerically"
-msgstr ""
+msgstr "Решить полиномы численно"
 
 #: ../../src/wxMaxima.cpp:7718
 msgid "Solve polynomials numerically (bfloats)"
-msgstr ""
+msgstr "Решить полиномы численно (повышенная точность)"
 
 #: ../../src/wxMaxima.cpp:7729
 msgid "Solve polynomials numerically (real roots)"
-msgstr ""
+msgstr "Решить полиномы численно (вещественные корни)"
 
 #: ../../src/wxMaximaFrame.cpp:1249
 msgid "Solve symbolically"
-msgstr ""
+msgstr "Решить символьно"
 
 #: ../../src/Worksheet.cpp:1574
 msgid "Solve..."
-msgstr ""
+msgstr "Решить..."
 
 #: ../../src/wxMaximaFrame.cpp:1916
 msgid "Solving differential equations"
-msgstr ""
+msgstr "Решение дифференциальных уравнений"
 
 #: ../../src/wxMaximaFrame.cpp:1904
 msgid "Solving equations with Maxima"
-msgstr ""
+msgstr "Решение уравнений с помощью Maxima"
 
 #: ../../src/wxMaxima.cpp:7105
 #, c-format
@@ -6551,116 +6791,120 @@ msgid ""
 "Sometimes one wants maxima to loose the information that a function name was used with the ' operator in order to make maxima not evaluate it. In other places one wants % to mean \"the last expression at the time this function was created\", not \"the last expression now\".\n"
 "In both cases the '' operator will do what is requested."
 msgstr ""
+"Иногда нужно убрать из Maxima информацию о том, что имя функции использовалось с оператором ', чтобы Maxima не вычисляла её. В других случаях требуется, чтобы %toзначало «последнее выражение на момент создания этой функции», а не «последнее выражение сейчас».\n"
+"И в той, и в другой ситуации решить вопрос позволит оператор ''."
 
 #: ../../src/wxMaximaFrame.cpp:1746
 msgid "Sort"
-msgstr ""
+msgstr "Сортировать"
 
 #: ../../src/wxMaxima.cpp:8496
 msgid "Sort a list"
-msgstr ""
+msgstr "Сортировать список"
 
 #: ../../src/wxMaxima.cpp:7459
 msgid "Sort all characters in string"
-msgstr ""
+msgstr "Сортировать все символы в строке"
 
 #: ../../src/wxMaximaFrame.cpp:1179
 msgid "Sort the characters..."
-msgstr ""
+msgstr "Сортировать символы..."
 
 #: ../../src/wxMaxima.cpp:8482
 msgid "Source list:"
-msgstr ""
+msgstr "Исходный список:"
 
 #: ../../src/wxMaxima.cpp:7429
 msgid "Split"
-msgstr ""
+msgstr "Разбить"
 
 #: ../../src/wxMaximaFrame.cpp:1191
 msgid "Split on match"
-msgstr ""
+msgstr "Разбить при совпадении"
 
 #: ../../src/wxMaxima.cpp:7528
 msgid "Split on regex match"
-msgstr ""
+msgstr "Разбить при совпадении по регулярному выражению"
 
 #: ../../src/wxMaxima.cpp:7449
 msgid "Split string into tokens"
-msgstr ""
+msgstr "Разбить строку на лексемы"
 
 #: ../../src/wxMaximaFrame.cpp:1171
 msgid "Split..."
-msgstr ""
+msgstr "Разбить..."
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Square"
-msgstr ""
+msgstr "Квадратные"
 
 #: ../../src/Configuration.cpp:86
 msgid "Standard Text"
-msgstr ""
+msgstr "Стандартный текст"
 
 #: ../../src/Worksheet.cpp:1298
 msgid "Start Animation"
-msgstr ""
+msgstr "Запустить анимацию"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Start of t:"
-msgstr ""
+msgstr "Начало t:"
 
 #: ../../src/ToolBar.cpp:305
 msgid "Start or Stop animation"
-msgstr ""
+msgstr "Запустить или остановить анимацию"
 
 #: ../../src/ToolBar.cpp:306
 msgid ""
 "Start or stop the currently selected animation that has been created with "
 "the with_slider class of commands"
 msgstr ""
+"Запустить или остановить текущую выбранную анимацию, созданную с помощью "
+"класса команд with_slider"
 
 #: ../../src/wxMaxima.cpp:386
 msgid "Starting Maxima process failed"
-msgstr ""
+msgstr "Не удалось запустить Maxima"
 
 #: ../../src/main.cpp:667
 msgid "Starting a new wxMaxima process for a new window"
-msgstr ""
+msgstr "Запуск нового процесса wxMaxima для нового окна"
 
 #: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:5633
 msgid "Starting evaluation of the document"
-msgstr ""
+msgstr "Начало вычисления документа"
 
 #: ../../src/wxMaxima.cpp:2544
 msgid "Starting server failed"
-msgstr ""
+msgstr "Не удалось запустить сервер"
 
 #: ../../src/WXMXformat.cpp:64
 msgid "Starting to save the worksheet as .wxmx"
-msgstr ""
+msgstr "Начало сохранения листа в формате .wxmx"
 
 #: ../../src/wxMaximaFrame.cpp:252
 msgid "Statistics"
-msgstr ""
+msgstr "Статистика"
 
 #: ../../src/wxMaximaFrame.cpp:701
 msgid "Statistics\tAlt+Shift+S"
-msgstr ""
+msgstr "Статистика\tAlt+Shift+S"
 
 #: ../../src/wxMaxima.cpp:7844
 msgid "Step width:"
-msgstr ""
+msgstr "Ширина шага:"
 
 #: ../../src/wxMaximaFrame.cpp:794
 msgid "Straight lines"
-msgstr ""
+msgstr "Прямые линии"
 
 #: ../../src/wxMaximaFrame.cpp:1106
 msgid "Stream"
-msgstr ""
+msgstr "Поток"
 
 #: ../../src/wxMaxima.cpp:7231
 msgid "Stream length"
-msgstr ""
+msgstr "Длина потока"
 
 #: ../../src/wxMaxima.cpp:7219 ../../src/wxMaxima.cpp:7224
 #: ../../src/wxMaxima.cpp:7228 ../../src/wxMaxima.cpp:7232
@@ -6670,45 +6914,45 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7267 ../../src/wxMaxima.cpp:7271
 #: ../../src/wxMaxima.cpp:7276
 msgid "Stream:"
-msgstr ""
+msgstr "Поток:"
 
 #: ../../src/wxMaximaFrame.cpp:1185
 msgid "String"
-msgstr ""
+msgstr "Строка"
 
 #: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
 #: ../../src/wxMaxima.cpp:7425
 msgid "String #1:"
-msgstr ""
+msgstr "Строка 1:"
 
 #: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
 #: ../../src/wxMaxima.cpp:7426
 msgid "String #2:"
-msgstr ""
+msgstr "Строка 2:"
 
 #: ../../src/wxMaximaFrame.cpp:1136
 msgid "String Tests"
-msgstr ""
+msgstr "Проверки строки"
 
 #: ../../src/wxMaxima.cpp:7415
 msgid "String length"
-msgstr ""
+msgstr "Длина строки"
 
 #: ../../src/wxMaxima.cpp:7381
 msgid "String to list of char"
-msgstr ""
+msgstr "Строку в список символов"
 
 #: ../../src/wxMaximaFrame.cpp:1148
 msgid "String to list of chars..."
-msgstr ""
+msgstr "Строку в список символов..."
 
 #: ../../src/wxMaxima.cpp:7496
 msgid "String to octets"
-msgstr ""
+msgstr "Строку в октеты"
 
 #: ../../src/wxMaximaFrame.cpp:1160
 msgid "String to octets..."
-msgstr ""
+msgstr "Строку в октеты..."
 
 #: ../../src/wxMaxima.cpp:7377 ../../src/wxMaxima.cpp:7382
 #: ../../src/wxMaxima.cpp:7391 ../../src/wxMaxima.cpp:7396
@@ -6722,74 +6966,76 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
 #: ../../src/wxMaxima.cpp:7497
 msgid "String:"
-msgstr ""
+msgstr "Строка:"
 
 #: ../../src/wxMaxima.cpp:7197
 msgid "Struct :"
-msgstr ""
+msgstr "Структура:"
 
 #: ../../src/wxMaxima.cpp:7184 ../../src/wxMaxima.cpp:7190
 msgid "Struct type name:"
-msgstr ""
+msgstr "Имя типа структуры:"
 
 #: ../../src/wxMaximaFrame.cpp:1029
 msgid "Structs"
-msgstr ""
+msgstr "Структуры"
 
 #: ../../src/ToolBar.cpp:274
 msgid "Subsection"
-msgstr ""
+msgstr "Подраздел"
 
 #: ../../src/Configuration.cpp:90
 msgid "Subsection cell (Heading 3)"
-msgstr ""
+msgstr "Поле подраздела (Заголовок 3)"
 
 #: ../../src/wxMaximaFrame.cpp:1643
 msgid "Subst constant t into eq with diff(x,t)..."
-msgstr ""
+msgstr "Подставить константу t в уравнение с помощью diff(x,t)..."
 
 #: ../../src/wxMaxima.cpp:8724
 msgid "Subst is a better string-search-and-replace for expressions."
-msgstr ""
+msgstr "Subst — это улучшенные поиск и замена строк для выражений."
 
 #: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
 #: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
 msgid "Substitute"
-msgstr ""
+msgstr "Подставить"
 
 #: ../../src/wxMaximaFrame.cpp:1193
 msgid "Substitute all matches"
-msgstr ""
+msgstr "Подставить все совпадения"
 
 #: ../../src/wxMaximaFrame.cpp:1192
 msgid "Substitute first match"
-msgstr ""
+msgstr "Подставить первое совпадение"
 
 #: ../../src/wxMaximaFrame.cpp:1646
 msgid "Substitute only in parts..."
-msgstr ""
+msgstr "Подставить только в частях..."
 
 #: ../../src/wxMaxima.cpp:8763
 msgid "Substitute only in specific parts"
-msgstr ""
+msgstr "Подставить только в определённых частях"
 
 #: ../../src/wxMaximaFrame.cpp:1647
 msgid "Substitute only in the elements n_1, n_2,..."
-msgstr ""
+msgstr "Подставить только в элементах n_1, n_2,..."
 
 #: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
 msgid "Substitute..."
-msgstr ""
+msgstr "Подставить..."
 
 #: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
 msgid "Substitutes until the equation no more changes"
-msgstr ""
+msgstr "Подстановка, пока выражение не перестанет меняться"
 
 #: ../../src/wxMaxima.cpp:8747
 msgid ""
 "Substitutes up to lrats_max_iter times, or until the expression stops "
 "changing when substituting."
 msgstr ""
+"Подстановка до lrats_max_iter раз или до тех пор, пока выражение не "
+"перестанет меняться при подстановке."
 
 #: ../../src/wxMaxima.cpp:8756
 #, c-format
@@ -6797,259 +7043,285 @@ msgid ""
 "Substitutes, but makes sure that if substituting t=0 in diff(x,t) the result"
 " isn't 0 (as t no more changes), but %at(diff(x,t),t=0)."
 msgstr ""
+"Подстановка, обеспечивающая, что при подстановке t=0 в diff(x,t) результатом"
+" является не 0 (так как t больше не меняется), а %at(diff(x,t),t=0)."
 
 #: ../../src/wxMaxima.cpp:8739
 msgid ""
 "Substitutes, but makes sure that nothing is substituted into the other "
 "substituents."
 msgstr ""
+"Подстановка, обеспечивающая отсутствие подстановки в остальные заменители."
 
 #: ../../src/wxMaximaFrame.cpp:1638
 msgid "Substitutes, but not in the other substituents"
-msgstr ""
+msgstr "Подстановка, но в остальные заместители"
 
 #: ../../src/wxMaxima.cpp:8764
 msgid ""
 "Substitutes, but only in the n_1th, n_2th and so on term of the equation."
-msgstr ""
+msgstr "Подстановка, но только в n_1-е, n_2-е и так далее условия уравнения."
 
 #: ../../src/ToolBar.cpp:275
 msgid "Subsubsection"
-msgstr ""
+msgstr "Под-подраздел"
 
 #: ../../src/Configuration.cpp:89
 msgid "Subsubsection cell (Heading 4)"
-msgstr ""
+msgstr "Поле под-подраздела (Заголовок 4)"
 
 #: ../../src/Worksheet.cpp:1831
 msgid "Suggestion: "
-msgstr ""
+msgstr "Предложение: "
 
 #: ../../src/Worksheet.cpp:2030
 msgid "Suitable as flag for ev()"
-msgstr ""
+msgstr "Подходит в качестве флага для ev()"
 
 #: ../../src/wxMaxima.cpp:9049
 msgid "Sum"
-msgstr ""
+msgstr "Сумма"
 
 #: ../../src/wxMaximaFrame.cpp:1551
 msgid ""
 "Switch off simplifications of log(). Set Maxima option variable "
 "logexpand:false"
 msgstr ""
+"Отключить упрощения log(). Указать для переменной Maxima logexpand:false"
 
 #: ../../src/wxMaxima.cpp:4090
 msgid "Switched to lisp mode after receiving a lisp debug prompt!"
 msgstr ""
+"Выполнено переключение в режим Lisp после получения запроса отладки Lisp!"
 
 #: ../../src/wxMaxima.cpp:4092
 msgid "Switched to lisp mode after receiving a lisp prompt!"
-msgstr ""
+msgstr "Выполнено переключение в режим Lisp после получения запроса Lisp!"
 
 #: ../../src/Worksheet.cpp:1971
 msgid "Symbolic Constant"
-msgstr ""
+msgstr "Символьная константа"
 
 #: ../../src/wxMaximaFrame.cpp:705
 msgid "Symbols\tAlt+Shift+Y"
-msgstr ""
+msgstr "Символы\tAlt+Shift+Y"
 
 #: ../../src/Worksheet.cpp:2006
 msgid "Symmetric function: f(x)=f(-x)"
-msgstr ""
+msgstr "Симметричная функция: f(x)=f(-x)"
 
 #: ../../src/wxMaximaFrame.cpp:238
 msgid "Table of Contents"
-msgstr ""
+msgstr "Содержание"
 
 #: ../../src/wxMaximaFrame.cpp:711
 msgid "Table of Contents\tAlt+Shift+T"
-msgstr ""
+msgstr "Содержание\tAlt+Shift+T"
 
 #: ../../src/wxMaxima.cpp:8930
 msgid "Taylor series"
-msgstr ""
+msgstr "Ряд Тейлора"
 
 #: ../../src/wxMaximaFrame.cpp:1474
 msgid "Taylor series..."
-msgstr ""
+msgstr "Ряд Тейлора..."
 
 #: ../../src/wxMaxima.cpp:8925
 msgid "Taylor series:"
-msgstr ""
+msgstr "Ряд Тейлора:"
 
 #: ../../src/wxMaxima.cpp:4132
 msgid "Telling maxima about the new working directory."
-msgstr ""
+msgstr "Передача сведений о новом рабочем каталоге в Maxima."
 
 #: ../../src/wxMaxima.cpp:7907
 msgid "Tells maxima for an f(x), that f(x=t)=a"
-msgstr ""
+msgstr "Сообщает Maxima об f(x), что f(x=t)=a"
 
 #: ../../src/wxMaximaFrame.cpp:1945
 msgid ""
 "Tells maxima to show the help for ?, ?? and describe() in a separate browser"
 " window"
 msgstr ""
+"Указывает Maxima показывать справку для ?, ?? и describe() в отдельном окне "
+"браузера"
 
 #: ../../src/wxMaximaFrame.cpp:1941
 msgid ""
 "Tells maxima to show the help for ?, ?? and describe() in a wxMaxima sidebar"
 msgstr ""
+"Указывает Maxima показывать справку для ?, ?? и describe() на боковой панели"
+" wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1936
 msgid "Tells maxima to show the help for ?, ?? and describe() on the console"
 msgstr ""
+"Указывает Maxima показывать справку для ?, ?? и describe() в терминале"
 
 #: ../../src/ToolBar.cpp:271
 msgid "Text"
-msgstr ""
+msgstr "Текст"
 
 #: ../../src/Configuration.cpp:93
 msgid "Text cell background"
-msgstr ""
+msgstr "Фон текстового поля"
 
 #: ../../src/wxMaxima.cpp:6541
 msgid "Text snippet"
-msgstr ""
+msgstr "Фрагмент текста"
 
 #: ../../src/wxMaxima.cpp:4632
 msgid ""
 "The .xml file doesn't seem to be valid xml or isn't a content.xml extracted "
 "from a .wxmx zip archive"
 msgstr ""
+"Файл .xml содержит недопустимый XML-код или не является файлом content.xml, "
+"извлечённым из архива zip .wxmx"
 
 #: ../../src/wxMaxima.cpp:2734
 msgid ""
 "The Maxima process doesn't offer a shared memory segment we can send an "
 "interrupt signal to."
 msgstr ""
+"У процесса Maxima не предусмотрен сегмент разделяемой памяти, в который "
+"можно было бы отправить сигнал прерывания."
 
 #: ../../src/MaximaManual.cpp:107
 msgid "The cache for the subjects the manual contains cannot be read."
-msgstr ""
+msgstr "Не удалось прочесть кэш с темами, которые содержатся в руководстве."
 
 #: ../../src/MaximaManual.cpp:378
 msgid "The cache for the subjects the manual contains has no head node."
 msgstr ""
+"У кэша с темами, которые содержатся в руководстве, отсутствует головной "
+"узел."
 
 #: ../../src/MaximaManual.cpp:396
 msgid ""
 "The cache for the subjects the manual contains is from a different Maxima "
 "version."
 msgstr ""
+"Кэш с темами, которые содержатся в руководстве, относится к другой версии "
+"Maxima."
 
 #: ../../src/wxMaximaFrame.cpp:1379
 msgid "The classic operations one typically uses matrices for"
-msgstr ""
+msgstr "Классические операции, для которых обычно используются матрицы"
 
 #: ../../src/wxMaxima.cpp:7193
 msgid "The comma-separated contents of the struct fields"
-msgstr ""
+msgstr "Разделённое запятыми содержимое полей структуры"
 
 #: ../../src/wxMaxima.cpp:7186
 msgid "The comma-separated names of the struct fields"
-msgstr ""
+msgstr "Разделённые запятыми имена полей структуры"
 
 #: ../../src/wxMaxima.cpp:7070
 msgid ""
 "The command local() allows to tell maxima which functions to make local to "
 "the current program when defined."
 msgstr ""
+"Команда local() позволяет указать Maxima, какие функции следует сделать "
+"локальными для текущей программы при определении."
 
 #: ../../src/wxMaximaFrame.cpp:303
 msgid "The current Wizard"
-msgstr ""
+msgstr "Текущий мастер"
 
 #: ../../src/wxMaxima.cpp:9592
 msgid "The equation to fit the data to"
-msgstr ""
+msgstr "Уравнение, по которому следует аппроксимировать данные"
 
 #: ../../src/wxMaxima.cpp:8447
 msgid "The function call whose arguments to extract"
-msgstr ""
+msgstr "Вызов функции, аргументы которой следует извлечь"
 
 #: ../../src/wxMaximaFrame.cpp:1298
 msgid "The half of the equation that is to the left of the \"=\""
-msgstr ""
+msgstr "Половина уравнения, которая находится слева от «=»"
 
 #: ../../src/wxMaximaFrame.cpp:1302
 msgid "The half of the equation that is to the right of the \"=\""
-msgstr ""
+msgstr "Половина уравнения, которая находится справа от «=»"
 
 #: ../../src/MaximaManual.cpp:399
 msgid "The help dir from the cache differs from the current one."
-msgstr ""
+msgstr "Каталог справки из кэша отличается от текущего."
 
 #: ../../src/Image.cpp:985
 msgid ""
 "The image could not be displayed. It may be broken, in a wrong format or be the result of gnuplot not being able to write the image or not being able to understand what maxima wanted to plot.\n"
 "One example of the latter would be: Gnuplot refuses to plot entirely empty images"
 msgstr ""
+"Не удалось отобразить изображение. Оно может быть повреждено или иметь неверный формат. Кроме того, причиной может быть то, что Gnuplot не удалось записать изображение или разобрать запрос на построение графика от Maxima.\n"
+"Примером последнего является то, что Gnuplot отказывается чертить полностью пустые изображения."
 
 #: ../../src/wxMaxima.cpp:9799 ../../src/wxMaxima.cpp:10158
 #, c-format
 msgid "The image file \"%s\" cannot be found."
-msgstr ""
+msgstr "Не удалось найти файл изображения «%s»."
 
 #: ../../src/wxMaximaFrame.cpp:718
 msgid "The integrated help browser"
-msgstr ""
+msgstr "Встроенный браузер справки"
 
 #: ../../src/wxMaxima.cpp:9591
 msgid "The list of variables contained in each matrix row"
-msgstr ""
+msgstr "Список переменных, содержащихся в каждой строке матрицы"
 
 #: ../../src/wxMaximaFrame.cpp:214
 msgid "The main toolbar"
-msgstr ""
+msgstr "Основная панель инструментов"
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "The manual of Maxima"
-msgstr ""
+msgstr "Руководство по Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "The manual of wxMaxima"
-msgstr ""
+msgstr "Руководство по wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7125
 msgid "The name of a function we don't want to be evaluated here"
-msgstr ""
+msgstr "Имя функции, которую не следует вычислять"
 
 #: ../../src/wxMaxima.cpp:7131
 msgid "The name of an expression that we don't want to be evaluated."
-msgstr ""
+msgstr "Имя выражения, которое не следует вычислять."
 
 #: ../../src/wxMaxima.cpp:7199
 msgid "The name of the field to read"
-msgstr ""
+msgstr "Имя поля для чтения"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "The name of the new struct type"
-msgstr ""
+msgstr "Имя нового типа структуры"
 
 #: ../../src/wxMaxima.cpp:7198
 msgid "The name of the struct"
-msgstr ""
+msgstr "Имя структуры"
 
 #: ../../src/wxMaxima.cpp:7191
 msgid "The name of the struct type"
-msgstr ""
+msgstr "Имя типа структуры"
 
 #: ../../src/wxMaxima.cpp:8220
 msgid "The name of the variable that shall contain the current element"
-msgstr ""
+msgstr "Имя переменной, которая будет содержать текущий элемент"
 
 #: ../../src/wxMaxima.cpp:8468
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
 msgstr ""
+"Номер элемента, для которого выполняется пошаговый переход от «Начального "
+"индекса» до «Конечного индекса»."
 
 #: ../../src/wxMaxima.cpp:8465 ../../src/wxMaxima.cpp:8478
 msgid ""
 "The rule that explains how to generate the value of a list item.\n"
 "Might be something like \"i\", \"i^2\" or \"sin(i)\""
 msgstr ""
+"Правило, которое объясняет, как создавать значение элемента списка.\n"
+"Например: «i», «i^2» или «sin(i)»"
 
 #: ../../src/wxMaxima.cpp:7785
 msgid ""
@@ -7057,18 +7329,24 @@ msgid ""
 "The actual height of that curve is defined by the initial condition or "
 "boundary values, later on."
 msgstr ""
+"Решение ОДУ описывает общую форму интегральной кривой. Фактическая высота "
+"этой кривой определяется начальным условием или граничными значениями позже."
 
 #: ../../src/wxMaxima.cpp:7818
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's result is known at two points this function fills in the correct values for the  constants"
 msgstr ""
+"Решение ОДУ сообщает форму, но не высоту решения.\n"
+"Если известен результат решения ОДУ в двух точках, эта функция устанавливает надлежащие значения констант"
 
 #: ../../src/wxMaxima.cpp:7794 ../../src/wxMaxima.cpp:7805
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's state is known at a point this function fills in the correct values for the constants"
 msgstr ""
+"Решение ОДУ сообщает форму, но не высоту решения.\n"
+"Если известно состояние ОДУ в точке, эта функция устанавливает надлежащие значения констант"
 
 #: ../../src/wxMaxima.cpp:7896
 msgid ""
@@ -7076,64 +7354,81 @@ msgid ""
 "   U(t)=1/2*U(t)+3*diff(U(t),t)\n"
 "for this to work; Initial conditions can be specified using atvalue()."
 msgstr ""
+"Чтобы это сработало, переменная решения должна иметь вид\n"
+"   U(t)=1/2*U(t)+3*diff(U(t),t)\n"
+"Начальные условия можно указать с помощью atvalue()."
 
 #: ../../src/wxMaxima.cpp:8481 ../../src/wxMaxima.cpp:8582
 msgid "The variable the value of the current source item is stored in."
-msgstr ""
+msgstr "Переменная, в которой хранится значение текущего исходного элемента."
 
 #: ../../src/wxMaxima.cpp:9594
 msgid "The variables to search the optimum solution for"
-msgstr ""
+msgstr "Переменные, для которых следует найти оптимальное решение"
 
 #: ../../src/wxMaximaFrame.cpp:193
 msgid "The worksheet"
-msgstr ""
+msgstr "Лист"
 
 #: ../../src/Worksheet.cpp:8122
 msgid "The worksheet containing maxima's input and output"
-msgstr ""
+msgstr "Лист, содержащий ввод и вывод Maxima"
 
 #: ../../src/MathParser.cpp:629
 msgid ""
 "The xml data from maxima or from the .wxmx file was missing data here.\n"
 "If you find a way how to reproduce this problem please file a bug report against wxMaxima."
 msgstr ""
+"Здесь не хватает данных XML от Maxima или из файла .wxmx.\n"
+"Если у вас получится воспроизвести эту ошибку, пожалуйста, отправьте отчёт о ней в wxMaxima."
 
 #: ../../src/wxMaxima.cpp:2143
 msgid ""
 "There was an error in the XML maxima has generated.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Ошибка в XML, сгенерированном Maxima.\n"
+"Сообщите об этой ошибке разработчикам wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3911
 msgid ""
 "There was an error in the XML that should contain a list of watch variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Ошибка в XML, который должен содержать список переменных наблюдения.\n"
+"Сообщите об этой ошибке разработчикам wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3869
 msgid ""
 "There was an error in the XML that should contain the list of operators.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Ошибка в XML, который должен содержать список операторов.\n"
+"Сообщите об этой ошибке разработчикам wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3321
 msgid ""
 "There was an error in the XML that should describe the contents of some variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Ошибка в XML, который должен описывать содержимое некоторых переменных.\n"
+"Сообщите об этой ошибке разработчикам wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3257
 msgid ""
 "There was an error in the XML that should describe the manual topics.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Ошибка в XML, который должен описывать темы руководства пользователя.\n"
+"Сообщите об этой ошибке разработчикам wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3202
 msgid ""
 "There was an error in the XML that should describe the status bar message.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"Ошибка в XML, который должен описывать сообщение строки состояния.\n"
+"Сообщите об этой ошибке разработчикам wxMaxima."
 
 #: ../../src/MaximaManual.cpp:363
 msgid ""
@@ -7141,110 +7436,115 @@ msgid ""
 "It caches the list of subjects maxima's manual offers and is automatically\n"
 "overwritten if maxima's version changes or the file cannot be read"
 msgstr ""
+"Этот файл генерируется wxMaxima\n"
+"В нём хранится кэш тем руководства пользователя Maxima. Он автоматически\n"
+"перезаписывается в случае изменения версии Maxima или невозможности прочитать файл"
 
 #: ../../src/Worksheet.cpp:1992
 msgid "This function will return even integers"
-msgstr ""
+msgstr "Эта функция возвращает чётные целые числа"
 
 #: ../../src/Worksheet.cpp:1994
 msgid "This function will return odd integers"
-msgstr ""
+msgstr "Эта функция возвращает нечётные целые числа"
 
 #: ../../src/Worksheet.cpp:1950
 msgid "This symbol has no imaginary part"
-msgstr ""
+msgstr "У этого символа нет мнимой части"
 
 #: ../../src/Worksheet.cpp:1956
 msgid "This symbol has no real part"
-msgstr ""
+msgstr "У этого символа нет вещественной части"
 
 #: ../../src/Worksheet.cpp:1953
 msgid "This symbol might have both real and imaginary part"
-msgstr ""
+msgstr "У этого символа может быть как вещественная, так и мнимая часть"
 
 #: ../../src/Worksheet.cpp:1980
 msgid "Throw an error if this symbol is used before assigning it any contents"
 msgstr ""
+"Вывести сообщение об ошибке, если этот символ использован без "
+"предварительной установки его значения"
 
 #: ../../src/wxMaxima.cpp:9013 ../../src/wxMaxima.cpp:10058
 msgid "Times:"
-msgstr ""
+msgstr "Умножить:"
 
 #: ../../src/ToolBar.cpp:272
 msgid "Title"
-msgstr ""
+msgstr "Заголовок"
 
 #: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
-msgstr ""
+msgstr "Заголовок (нижний и верхний индексы как x_{10} или x^{10})"
 
 #: ../../src/Configuration.cpp:92
 msgid "Title cell (Heading 1)"
-msgstr ""
+msgstr "Поле заголовка (Заголовок 1)"
 
 #: ../../src/wxMaximaFrame.cpp:1794
 msgid "To &Bigfloat"
-msgstr ""
+msgstr "В число с плавающей точкой &повышенной точности"
 
 #: ../../src/wxMaximaFrame.cpp:1791
 msgid "To &Float"
-msgstr ""
+msgstr "В &число с плавающей точкой"
 
 #: ../../src/Worksheet.cpp:1571
 msgid "To Float"
-msgstr ""
+msgstr "В число с плавающей точкой"
 
 #: ../../src/wxMaximaFrame.cpp:1797
 msgid "To Numeri&c\tCtrl+Shift+N"
-msgstr ""
+msgstr "В числовое &значение\tCtrl+Shift+N"
 
 #: ../../src/wxMaximaFrame.cpp:1803
 msgid "To exact fraction"
-msgstr ""
+msgstr "В правильную дробь"
 
 #: ../../src/wxMaximaFrame.cpp:1814
 msgid "To exact number"
-msgstr ""
+msgstr "В точное число"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "To:"
-msgstr ""
+msgstr "К:"
 
 #: ../../src/wxMaximaFrame.cpp:825 ../../src/wxMaximaFrame.cpp:828
 msgid "Toggle full screen editing"
-msgstr ""
+msgstr "Переключить режим полноэкранного редактирования"
 
 #: ../../src/ToolBar.cpp:265
 msgid "Toggle the visibility of code cells"
-msgstr ""
+msgstr "Переключить состояние видимости полей кода"
 
 #: ../../src/wxMaximaFrame.cpp:1177
 msgid "Tokenize..."
-msgstr ""
+msgstr "Разбить на лексемы..."
 
 #: ../../src/wxMaximaFrame.cpp:1909
 msgid "Tolerance calculations with Maxima"
-msgstr ""
+msgstr "Расчёты допусков с помощью Maxima"
 
 #: ../../src/wxMaxima.cpp:8192
 msgid "Top end"
-msgstr ""
+msgstr "Верхняя сторона"
 
 #: ../../src/wxMaximaFrame.cpp:1078
 msgid "Trace a function..."
-msgstr ""
+msgstr "Трассировка функции..."
 
 #: ../../src/wxMaxima.cpp:7084
 msgid "Trace function(s)"
-msgstr ""
+msgstr "Трассировка функции(ий)"
 
 #: ../../src/wxMaximaFrame.cpp:1184
 msgid "Transformations"
-msgstr ""
+msgstr "Преобразования"
 
 #: ../../src/wxMaximaFrame.cpp:1376
 msgid "Transpose a matrix"
-msgstr ""
+msgstr "Транспонировать матрицу"
 
 #: ../../src/wxMaxima.cpp:7832
 msgid ""
@@ -7252,17 +7552,21 @@ msgid ""
 " equation of the format depends(x,t);diff(x,t)=(something containing x and "
 "t)"
 msgstr ""
+"Пытается найти численное решение ОДУ первого порядка. Иными словами: "
+"уравнение формата зависит(x,t);diff(x,t)=(что-то, содержащее x и t)"
 
 #: ../../src/wxMaxima.cpp:10036
 msgid ""
 "Tries to find a solution of the equation that lies between the two bounds."
-msgstr ""
+msgstr "Пытается найти решение уравнения, которое лежит в указанных границах."
 
 #: ../../src/wxMaxima.cpp:7774
 msgid ""
 "Tries to find a value of the variable that solves the equation between the "
 "two bonds"
 msgstr ""
+"Пытается найти лежащее в указанных границах значение переменной, которое "
+"решает уравнение"
 
 #: ../../src/wxMaxima.cpp:7719
 msgid ""
@@ -7271,6 +7575,11 @@ msgid ""
 "\n"
 "    bfallroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
+"Пытается найти все решения полинома численно с помощью\n"
+"чисел с плавающей точкой повышенной точности.\n"
+"Также может определить решения в неполиномах, если выражение заранее аппроксимировано с помощью полинома:\n"
+"\n"
+"    bfallroots(ratdisrep(taylor(expression,0,30)));"
 
 #: ../../src/wxMaxima.cpp:7709
 msgid ""
@@ -7279,6 +7588,10 @@ msgid ""
 "\n"
 "    allroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
+"Пытается найти все решения полинома численно.\n"
+"Также может определить решения в неполиномах, если выражение заранее аппроксимировано с помощью полинома:\n"
+"\n"
+"    allroots(ratdisrep(taylor(expression,0,30)));"
 
 #: ../../src/wxMaxima.cpp:7730
 #, c-format
@@ -7291,78 +7604,87 @@ msgid ""
 "\n"
 "See also guess_exact_value()"
 msgstr ""
+"Пытается найти правильные дроби, которые соответствуют численным решениям полинома.\n"
+"Не может работать с решениями с мнимой частью. Численные константы наподобие %pi% nеобходимо исключить с помощью float() или аналогичной функции.\n"
+"Также может определить решения в неполиномах, если выражение заранее аппроксимировано с помощью полинома:\n"
+"\n"
+"    realroots(ratdisrep(taylor(expression,0,30)));\n"
+"\n"
+"См. также guess_exact_value()"
 
 #: ../../src/wxMaximaFrame.cpp:1181
 msgid "Trim both ends..."
-msgstr ""
+msgstr "Обрезать оба конца..."
 
 #: ../../src/wxMaximaFrame.cpp:1182
 msgid "Trim left..."
-msgstr ""
+msgstr "Обрезать слева..."
 
 #: ../../src/wxMaximaFrame.cpp:1183
 msgid "Trim right..."
-msgstr ""
+msgstr "Обрезать справа..."
 
 #: ../../src/wxMaxima.cpp:7473
 msgid "Trim string left"
-msgstr ""
+msgstr "Обрезать строку слева"
 
 #: ../../src/wxMaxima.cpp:7469
 msgid "Trim string on both ends"
-msgstr ""
+msgstr "Обрезать строку на обоих концах"
 
 #: ../../src/wxMaxima.cpp:7477
 msgid "Trim string right"
-msgstr ""
+msgstr "Обрезать строку справа"
 
 #: ../../src/wxMaximaFrame.cpp:1511
 msgid "Try to guess which form is &simple"
-msgstr ""
+msgstr "Пытаться определить, какая форма является &простой"
 
 #: ../../src/wxMaxima.cpp:8637
 msgid "Try to simplify sums that result from sum() commands."
 msgstr ""
+"Пытаться упростить суммы, которые являются результатом выполнения команд "
+"sum()."
 
 #: ../../src/MaximaManual.cpp:369
 #, c-format
 msgid ""
 "Trying to cache the list of subjects the manual contains in the file %s."
-msgstr ""
+msgstr "Попытка сохранить кэш тем руководства пользователя в файле %s."
 
 #: ../../src/wxMaxima.cpp:4423
 msgid "Trying to discard all output."
-msgstr ""
+msgstr "Попытка отбросить весь вывод."
 
 #: ../../src/wxMaxima.cpp:4380
 msgid "Trying to extract content.xml out of a broken .zip file."
-msgstr ""
+msgstr "Попытка извлечь файл content.xml из повреждённого файла .zip."
 
 #: ../../src/wxMaxima.cpp:5519
 msgid "Trying to open a file with an empty name!"
-msgstr ""
+msgstr "Попытка открыть файл с пустым именем!"
 
 #: ../../src/wxMaxima.cpp:5523
 #, c-format
 msgid "Trying to open the non-existing file %s"
-msgstr ""
+msgstr "Попытка открыть несуществующий файл %s"
 
 #: ../../src/wxMaxima.cpp:4457
 msgid "Trying to reconstruct the xml closing markers."
-msgstr ""
+msgstr "Попытка восстановить закрывающие теги XML."
 
 #: ../../src/wxMaxima.cpp:4376
 msgid "Trying to recover a broken .wxmx file."
-msgstr ""
+msgstr "Попытка восстановить повреждённый файл .wxmx."
 
 #: ../../src/wxMaxima.cpp:6026
 #, c-format
 msgid "Trying to remove the old temp file %s"
-msgstr ""
+msgstr "Попытка удалить старый временный файл %s"
 
 #: ../../src/wxMaxima.cpp:2507
 msgid "Trying to restart maxima."
-msgstr ""
+msgstr "Попытка перезапустить Maxima."
 
 #: ../../src/wxMaxima.cpp:2523
 #, c-format
@@ -7370,282 +7692,295 @@ msgid ""
 "Trying to start the socket a Maxima on the local machine can connect to on "
 "port %i"
 msgstr ""
+"Попытка запуска сокета, к которому может подключиться Maxima на локальном "
+"компьютере, на порте %i"
 
 #: ../../src/wxMaximaFrame.cpp:1928
 msgid "Tutorials"
-msgstr ""
+msgstr "Учебники"
 
 #: ../../src/wxMaxima.cpp:9571
 msgid "Two sample t-test"
-msgstr ""
+msgstr "Двухвыборочный t-тест"
 
 #: ../../src/Worksheet.cpp:8013
 msgid "Type"
-msgstr ""
+msgstr "Тип"
 
 #: ../../src/wxMaxima.cpp:7180
 msgid "Type:"
-msgstr ""
+msgstr "Тип:"
 
 #: ../../src/wxMaxima.cpp:9429
 msgid "URL"
-msgstr ""
+msgstr "URL-адрес"
 
 #: ../../src/wxMaximaFrame.cpp:1146
 msgid "UTF8 to Unicode code point..."
-msgstr ""
+msgstr "UTF8 в точку кода Юникода..."
 
 #: ../../src/wxMaxima.cpp:10479
 msgid "Un-closed parenthesis"
-msgstr ""
+msgstr "Незакрытая скобка"
 
 #: ../../src/wxMaxima.cpp:10467
 msgid "Un-closed parenthesis on encountering ; or $"
-msgstr ""
+msgstr "«;» или «$», где были закрыты не все скобки"
 
 #: ../../src/wxMaxima.cpp:11160
 msgid ""
 "Unable to interpret the version info I got from http://wxMaxima-"
 "developers.github.io/wxmaxima/version.txt: "
 msgstr ""
+"Не удалось интерпретировать сведения о версии из файла http://wxMaxima-"
+"developers.github.io/wxmaxima/version.txt: "
 
 #: ../../src/wxMaximaFrame.cpp:1007
 msgid "Undefine"
-msgstr ""
+msgstr "Снять определение"
 
 #: ../../src/ToolBar.cpp:191
 msgid "Undo"
-msgstr ""
+msgstr "Отменить"
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo\tCtrl+Z"
-msgstr ""
+msgstr "Отменить\tCtrl+Z"
 
 #: ../../src/ToolBar.cpp:614
 msgid "Undo and redo button"
-msgstr ""
+msgstr "Кнопка отмены и повторения действий"
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo last change"
-msgstr ""
+msgstr "Отменить последнее действие"
 
 #: ../../src/wxMaximaFrame.cpp:924
 msgid "Unfold All\tCtrl+Alt+]"
-msgstr ""
+msgstr "Развернуть все\tCtrl+Alt+]"
 
 #: ../../src/wxMaximaFrame.cpp:925
 msgid "Unfold all folded sections"
-msgstr ""
+msgstr "Развернуть все свёрнутые разделы"
 
 #: ../../src/Worksheet.cpp:1893
 msgid "Unhide Heading 5"
-msgstr ""
+msgstr "Показать Заголовок 5"
 
 #: ../../src/Worksheet.cpp:1904
 msgid "Unhide Heading 6"
-msgstr ""
+msgstr "Показать Заголовок 6"
 
 #: ../../src/Worksheet.cpp:1852
 msgid "Unhide Part"
-msgstr ""
+msgstr "Показать часть"
 
 #: ../../src/Worksheet.cpp:1860
 msgid "Unhide Section"
-msgstr ""
+msgstr "Показать раздел"
 
 #: ../../src/Worksheet.cpp:1871
 msgid "Unhide Subsection"
-msgstr ""
+msgstr "Показать подраздел"
 
 #: ../../src/Worksheet.cpp:1882
 msgid "Unhide Subsubsection"
-msgstr ""
+msgstr "Показать под-подраздел"
 
 #: ../../src/Worksheet.cpp:1912
 msgid "Unhide contents"
-msgstr ""
+msgstr "Показать содержимое"
 
 #: ../../src/wxMaximaFrame.cpp:266
 msgid "Unicode characters"
-msgstr ""
+msgstr "Символы Юникода"
 
 #: ../../src/wxMaximaFrame.cpp:707
 msgid "Unicode chars\tAlt+Shift+U"
-msgstr ""
+msgstr "Символы Юникода\tAlt+Shift+U"
 
 #: ../../src/wxMaximaFrame.cpp:1144
 msgid "Unicode code point to UTF8..."
-msgstr ""
+msgstr "Точку кода Юникода в UTF8..."
 
 #: ../../src/wxMaxima.cpp:7366
 msgid "Unicode code point to char"
-msgstr ""
+msgstr "Точку кода Юникода в символ"
 
 #: ../../src/wxMaximaFrame.cpp:1142
 msgid "Unicode code point to char..."
-msgstr ""
+msgstr "Точку кода Юникода в символ"
 
 #: ../../src/wxMaxima.cpp:7371
 msgid "Unicode code point to utf8 numbers"
-msgstr ""
+msgstr "Точку кода Юникода в код utf8"
 
 #: ../../src/wxMaxima.cpp:7078
 msgid ""
 "Unlike in other programming language return() only exits from the current "
 "loop or block(), not from the whole function."
 msgstr ""
+"В отличие от других языков программирования, return() выполняет выход только"
+" из текущего цикла или block(), а не из всей функции."
 
 #: ../../src/wxMaxima.cpp:10418
 msgid "Unterminated comment."
-msgstr ""
+msgstr "Незавершённый комментарий."
 
 #: ../../src/wxMaxima.cpp:10461
 msgid "Unterminated string."
-msgstr ""
+msgstr "Незавершённая строка."
 
 #: ../../src/wxMaxima.cpp:4786
 msgid "Updating maxima's configuration"
-msgstr ""
+msgstr "Обновление конфигурации Maxima"
 
 #: ../../src/wxMaxima.cpp:11150 ../../src/wxMaxima.cpp:11157
 #: ../../src/wxMaxima.cpp:11163
 msgid "Upgrade"
-msgstr ""
+msgstr "Обновить"
 
 #: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
 msgid "Upper bound:"
-msgstr ""
+msgstr "Верхняя граница:"
 
 #: ../../src/wxMaximaFrame.cpp:792
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
-msgstr ""
+msgstr "Использовать «<» и «>» как скобки для матриц"
 
 #: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
 msgid "Use a list"
-msgstr ""
+msgstr "Использовать список"
 
 #: ../../src/wxMaxima.cpp:8571
 msgid "Use a list as parameter list for a function"
-msgstr ""
+msgstr "Использовать список в качестве списка параметров для функции"
 
 #: ../../src/wxMaximaFrame.cpp:1708
 msgid "Use list"
-msgstr ""
+msgstr "Использовать список"
 
 #: ../../src/wxMaximaFrame.cpp:1701
 msgid "Use list as the arguments of a function"
-msgstr ""
+msgstr "Использовать список в качестве аргументов функции"
 
 #: ../../src/wxMaximaFrame.cpp:786
 msgid "Use rounded parenthesis for matrices"
-msgstr ""
+msgstr "Использовать круглые скобки для матриц"
 
 #: ../../src/wxMaximaFrame.cpp:789
 msgid "Use square parenthesis for matrices"
-msgstr ""
+msgstr "Использовать квадратные скобки для матриц"
 
 #: ../../src/wxMaximaFrame.cpp:1083
 msgid "Use struct field..."
-msgstr ""
+msgstr "Использовать поле структуры..."
 
 #: ../../src/wxMaximaFrame.cpp:795
 msgid "Use vertical lines instead of parenthesis for matrices"
-msgstr ""
+msgstr "Использовать вертикальные линии вместо скобок для матриц"
 
 #: ../../src/Worksheet.cpp:1619
 msgid "User labels only"
-msgstr ""
+msgstr "Только пользовательские метки"
 
 #: ../../src/Configuration.cpp:81
 msgid "User-defined labels"
-msgstr ""
+msgstr "Пользовательские метки"
 
 #: ../../src/MaximaManual.cpp:483
 msgid ""
 "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
 msgstr ""
+"Использование файла справки по Maxima из файла конфигурации wxMaxima "
+"(helpFile=...))"
 
 #: ../../src/wxMaxima.cpp:4825
 msgid "Using Maxima path from command line."
-msgstr ""
+msgstr "Использование пути Maxima из командной строки."
 
 #: ../../src/wxMaxima.cpp:4822
 msgid "Using configured Maxima path."
-msgstr ""
+msgstr "Использование настроенного пути Maxima."
 
 #: ../../src/wxMaxima.cpp:2961
 msgid ""
 "Using gnuplot's antialiassing-less png driver for embedded plots as pngcairo"
 " could not be found"
 msgstr ""
+"Для встроенных графиков используется не поддерживающий сглаживание png-"
+"драйвер Gnuplot, поскольку компиляция Gnuplot была выполнена без pngcairo"
 
 #: ../../src/wxMaxima.cpp:2956
 msgid "Using gnuplot's pngcairo driver for embedded plots"
-msgstr ""
+msgstr "Для встроенных графиков используется драйвер pngcairo Gnuplot"
 
 #: ../../src/MaximaManual.cpp:88
 msgid "Using the built-in list of manual anchors."
 msgstr ""
+"Использование встроенного списка ключевых слов руководства пользователя."
 
 #: ../../src/WXMXformat.cpp:266
 msgid ""
 "Validated that the XML representation of the document actually is valid XML"
 msgstr ""
+"Проверено, что XML-представление документа действительно представляет собой "
+"корректный XML"
 
 #: ../../src/wxMaxima.cpp:8755
 msgid "Value at a given point"
-msgstr ""
+msgstr "Значение в указанной точке"
 
 #: ../../src/Worksheet.cpp:1987
 msgid "Value at a specific point"
-msgstr ""
+msgstr "Значение в определённой точке"
 
 #: ../../src/wxMaxima.cpp:7801
 msgid "Value at that point:"
-msgstr ""
+msgstr "Значение в этой точке:"
 
 #: ../../src/wxMaxima.cpp:7812 ../../src/wxMaxima.cpp:7825
 #: ../../src/wxMaxima.cpp:7827
 msgid "Value y at that point:"
-msgstr ""
+msgstr "Значение y в этой точке:"
 
 #: ../../src/wxMaxima.cpp:7910
 msgid "Value:"
-msgstr ""
+msgstr "Значение:"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Var #1"
-msgstr ""
+msgstr "Переменная 1"
 
 #: ../../src/wxMaxima.cpp:8202
 msgid "Var #2"
-msgstr ""
+msgstr "Переменная 2"
 
 #: ../../src/wxMaxima.cpp:6852 ../../src/wxMaxima.cpp:8183
 msgid "Variable"
-msgstr ""
+msgstr "Переменная"
 
 #: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
 #: ../../src/wxMaxima.cpp:8568
 msgid "Variable name"
-msgstr ""
+msgstr "Имя переменной"
 
 #: ../../src/wxMaximaFrame.cpp:1085
 msgid "Variable name, not contents..."
-msgstr ""
+msgstr "Имя переменной, не содержимое..."
 
 #: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
 msgid "Variable name:"
-msgstr ""
+msgstr "Имя переменной:"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 msgid "Variable(s)"
-msgstr ""
+msgstr "Переменные"
 
 #: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
 #: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
 msgid "Variable(s):"
-msgstr ""
+msgstr "Переменные:"
 
 #: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
 #: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
@@ -7653,49 +7988,53 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
 #: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
 msgid "Variable:"
-msgstr ""
+msgstr "Переменная:"
 
 #: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
 msgid "Variables"
-msgstr ""
+msgstr "Переменные"
 
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
 msgid "Variables:"
-msgstr ""
+msgstr "Переменные:"
 
 #: ../../src/WXMXformat.cpp:337
 msgid "Verified that we are able to read the whole .zip archive we produced."
-msgstr ""
+msgstr "Проверено, что можно прочитать весь созданный zip-архив."
 
 #: ../../src/wxMaximaFrame.cpp:836
 msgid "View"
-msgstr ""
+msgstr "Вид"
 
 #: ../../src/Autocomplete.cpp:235
 msgid "Waiting for m_addFiles_backgroundThread to finish"
-msgstr ""
+msgstr "Ожидание завершения m_addFiles_backgroundThread"
 
 #: ../../src/Autocomplete.cpp:122 ../../src/Autocomplete.cpp:240
 msgid "Waiting for m_addSymbols_backgroundThread to finish"
-msgstr ""
+msgstr "Ожидание завершения m_addSymbols_backgroundThread"
 
 #: ../../src/MaximaManual.cpp:533
 msgid "Waiting for the Manual anchors background task."
 msgstr ""
+"Ожидание завершения фоновой задачи по компиляции ключевых слов руководства "
+"пользователя."
 
 #: ../../src/MaximaManual.cpp:562
 msgid "Waiting for the thread that parses the maxima manual to finish"
 msgstr ""
+"Ожидание окончания работы потока, анализирующего руководство пользователя "
+"Maxima"
 
 #: ../../src/MathParser.cpp:1229 ../../src/wxMaxima.cpp:3296
 #: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
 #: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
 msgid "Warning"
-msgstr ""
+msgstr "Предупреждение"
 
 #: ../../src/wxMaximaFrame.cpp:1556
 msgid "Warning:"
-msgstr ""
+msgstr "Предупреждение:"
 
 #: ../../src/Dirstructure.cpp:72
 #, c-format
@@ -7703,65 +8042,72 @@ msgid ""
 "Warning: Cannot create %s, the directory maxima keeps configuration, user packages and caches in.\n"
 "Make sure that your system's home directory is set up correctly"
 msgstr ""
+"Предупреждение: не удалось создать %s, каталог, в котором Maxima сохраняет конфигурационные данные, пользовательские пакеты и кэш.\n"
+"Убедитесь, что системный домашний каталог настроен правильно"
 
 #: ../../src/wxMaximaFrame.cpp:1546
 msgid ""
 "Warning: No test if the argument of the log is complex, positive or negative"
 msgstr ""
+"Предупреждение: нет проверки того, является ли аргумент логарифма "
+"комплексным, положительным или отрицательным"
 
 #: ../../src/wxMaxima.cpp:5063
 msgid "Welcome to wxMaxima"
-msgstr ""
+msgstr "Добро пожаловать в wxMaxima"
 
 #: ../../src/wxMaxima.cpp:8583
 msgid "What to do:"
-msgstr ""
+msgstr "Что делать:"
 
 #: ../../src/wxMaximaFrame.cpp:1058
 msgid "When to invoke the lisp compiler's debugger"
-msgstr ""
+msgstr "Когда следует активировать средство отладки компилятора Lisp"
 
 #: ../../src/wxMaxima.cpp:7046
 msgid "While loop"
-msgstr ""
+msgstr "Цикл while"
 
 #: ../../src/wxMaximaFrame.cpp:1063
 msgid "While loop..."
-msgstr ""
+msgstr "Цикл while..."
 
 #: ../../src/wxMaxima.cpp:5673
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38)"
 " (*.wxm)|*.wxm|All Files (*.*)|*"
 msgstr ""
+"Весь документ (*.wxmx)|*.wxmx|Ввод, доступный для чтения функцией load() "
+"(Maxima > 5.38) (*.wxm)|*.wxm|Все файлы (*.*)|*"
 
 #: ../../src/wxMaxima.cpp:210
 msgid "Will try to generate a stack backtrace, if the program ever crashes"
 msgstr ""
+"Попытаться сгенерировать трассировку стека, если произойдёт сбой программы"
 
 #: ../../src/Worksheet.cpp:6920
 msgid "Worksheet got activated"
-msgstr ""
+msgstr "Лист активирован"
 
 #: ../../src/Worksheet.cpp:6840
 msgid "Worksheet got the mouse focus"
-msgstr ""
+msgstr "Лист получил фокус мыши"
 
 #: ../../src/Worksheet.cpp:7191 ../../src/Worksheet.cpp:7279
 msgid "Wrapped search"
-msgstr ""
+msgstr "Поиск завершён"
 
 #: ../../src/WXMXformat.cpp:282
 msgid "Wrote all image and gnuplot files to the zip archive"
-msgstr ""
+msgstr "Все файлы изображений и Gnuplot записаны в zip-архив"
 
 #: ../../src/WXMXformat.cpp:272
 msgid "Wrote the XML representation of the document to the zip archive"
-msgstr ""
+msgstr "XML-представление документа записано в zip-архив"
 
 #: ../../src/WXMXformat.cpp:116
 msgid "Wrote the mimetype info"
-msgstr ""
+msgstr "Записана информация о типе MIME"
 
 #: ../../src/wxMaxima.cpp:11147
 #, c-format
@@ -7770,178 +8116,181 @@ msgid ""
 "\n"
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
+"У вас установлена версия %s. Последняя доступная версия исходного кода — %s.\n"
+"\n"
+"Нажмите кнопку «ОК» для перехода на веб-страницу wxMaxima."
 
 #: ../../src/wxMaxima.cpp:11202
 msgid "Your changes will be lost if you don't save them."
-msgstr ""
+msgstr "Изменения будут утеряны, если их не сохранить."
 
 #: ../../src/wxMaxima.cpp:11156
 msgid "Your version of wxMaxima is up to date."
-msgstr ""
+msgstr "Вы используете последнюю версию wxMaxima."
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom &In\tCtrl++"
-msgstr ""
+msgstr "У&величить\tCtrl++"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom Ou&t\tCtrl+-"
-msgstr ""
+msgstr "У&меньшить\tCtrl+-"
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom in 10%"
-msgstr ""
+msgstr "Увеличить на 10%"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom out 10%"
-msgstr ""
+msgstr "Уменьшить на 10%"
 
 #: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
 msgid "[ unsaved ]"
-msgstr ""
+msgstr "[ не сохранено ]"
 
 #: ../../src/wxMaxima.cpp:10920
 msgid "[ unsaved* ]"
-msgstr ""
+msgstr "[ не сохранено* ]"
 
 #: ../../src/Worksheet.cpp:5278
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" loading=\"lazy\" style=\"max-width:90%%;\">\n"
-msgstr ""
+msgstr "_%d.gif\"  alt=\"Анимация\" loading=\"lazy\" style=\"max-width:90%%;\">\n"
 
 #: ../../src/Worksheet.cpp:5484
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"lazy\">"
-msgstr ""
+msgstr "_%d.gif\" alt=\"Анимация\" style=\"max-width:90%%;\" loading=\"lazy\">"
 
 #: ../../src/wxMaximaFrame.cpp:1690
 msgid "apply function to each element"
-msgstr ""
+msgstr "Применить функцию к каждому элементу"
 
 #: ../../src/wxMaximaFrame.cpp:739
 msgid "as 1D ASCII"
-msgstr ""
+msgstr "как 1D ASCII"
 
 #: ../../src/wxMaximaFrame.cpp:742
 msgid "as ASCII Art"
-msgstr ""
+msgstr "как символы ASCII"
 
 #: ../../src/wxMaximaFrame.cpp:745
 msgid "as ASCII+Unicode Art"
-msgstr ""
+msgstr "как символы ASCII и Юникода"
 
 #: ../../src/wxMaximaFrame.cpp:1680
 msgid "as storage for actual values for variables"
-msgstr ""
+msgstr "как хранилище для фактических значений переменных"
 
 #: ../../src/wxMaximaFrame.cpp:1139
 msgid "char to Ascii code..."
-msgstr ""
+msgstr "символ в код ASCII..."
 
 #: ../../src/wxMaxima.cpp:7836
 msgid "diff(x,t)="
-msgstr ""
+msgstr "diff(x,t)="
 
 #: ../../src/wxMaximaFrame.cpp:1064 ../../src/wxMaximaFrame.cpp:1702
 msgid "do for each element"
-msgstr ""
+msgstr "Выполнить для каждого элемента"
 
 #: ../../src/Worksheet.cpp:2027
 msgid "ev() shall evaluate this automatically"
-msgstr ""
+msgstr "ev() автоматически вычислит это"
 
 #: ../../src/wxMaxima.cpp:7130
 msgid "expression:"
-msgstr ""
+msgstr "выражение:"
 
 #: ../../src/Worksheet.cpp:2025
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
-msgstr ""
+msgstr "f(x) остаётся f(x), даже если значение f(x) можно вычислить"
 
 #: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
 msgid "filename:"
-msgstr ""
+msgstr "имя файла:"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "from a list"
-msgstr ""
+msgstr "из списка"
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "from a rule"
-msgstr ""
+msgstr "из правила"
 
 #: ../../src/wxMaximaFrame.cpp:1685
 msgid "from function arguments"
-msgstr ""
+msgstr "из аргументов функции"
 
 #: ../../src/wxMaximaFrame.cpp:1669
 msgid "from individual elements"
-msgstr ""
+msgstr "из отдельных элементов"
 
 #: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
 msgid "function"
-msgstr ""
+msgstr "функция"
 
 #: ../../src/wxMaximaFrame.cpp:747
 msgid "in 2D"
-msgstr ""
+msgstr "в 2D"
 
 #: ../../src/wxMaxima.cpp:8554
 msgid "list"
-msgstr ""
+msgstr "список"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "max(abs(A(i,j))) (complex)"
-msgstr ""
+msgstr "max(abs(A(i,j))) (комплексное)"
 
 #: ../../src/wxMaximaFrame.cpp:1404
 msgid "max(abs(A(i,j))) (real)"
-msgstr ""
+msgstr "max(abs(A(i,j))) (вещественное)"
 
 #: ../../src/wxMaxima.cpp:8046
 msgid "m×n Matrix A:"
-msgstr ""
+msgstr "Матрица A m×n:"
 
 #: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533
 msgid "n:"
-msgstr ""
+msgstr "n:"
 
 #: ../../src/Worksheet.cpp:2000
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
-msgstr ""
+msgstr "nary: f(x, f(y,z)) = foo(x,y,z)"
 
 #: ../../src/Worksheet.cpp:2024
 msgid "noun: Not evaluated by default"
-msgstr ""
+msgstr "noun: не вычисляется по умолчанию"
 
 #: ../../src/wxMaximaFrame.cpp:1710
 msgid "nth"
-msgstr ""
+msgstr "n-й"
 
 #: ../../src/Worksheet.cpp:2021
 msgid "outative: f(2*x) = 2*f(x)"
-msgstr ""
+msgstr "Константа за скобками: f(2*x) = 2*f(x)"
 
 #: ../../src/wxMaxima.cpp:7440 ../../src/wxMaxima.cpp:7445
 #: ../../src/wxMaxima.cpp:7455
 msgid "part:"
-msgstr ""
+msgstr "часть:"
 
 #: ../../src/wxMaxima.cpp:8942
 msgid "point:"
-msgstr ""
+msgstr "точка:"
 
 #: ../../src/wxMaxima.cpp:7740
 msgid "precision:"
-msgstr ""
+msgstr "точность:"
 
 #: ../../src/wxMaxima.cpp:7255
 msgid "printf"
-msgstr ""
+msgstr "printf"
 
 #: ../../src/wxMaximaFrame.cpp:1108
 msgid "printf..."
-msgstr ""
+msgstr "printf..."
 
 #: ../../src/wxMaxima.cpp:8650
 msgid ""
@@ -7951,22 +8300,28 @@ msgid ""
 " makes sense for the problem that resulted in the Expression that is to be "
 "simplified."
 msgstr ""
+"radcan() — мощный инструмент для упрощения тригонометрических функций, но "
+"его следует использовать с осторожностью: если у функции несколько ветвей, "
+"radcan использует ту, которая выглядит наиболее подходящей, не обязательно "
+"ту, которая подходит к задаче, выраженной упрощаемым выражением."
 
 #: ../../src/wxMaxima.cpp:8731
 msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
+"ratsubst работает как subst, но при необходимости позволяет использовать "
+"базовую математику"
 
 #: ../../src/wxMaximaFrame.cpp:1111
 msgid "readbyte..."
-msgstr ""
+msgstr "readbyte..."
 
 #: ../../src/wxMaximaFrame.cpp:1110
 msgid "readchar..."
-msgstr ""
+msgstr "readchar..."
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "readline..."
-msgstr ""
+msgstr "readline..."
 
 #: ../../src/wxMaxima.cpp:10018
 msgid ""
@@ -7974,67 +8329,74 @@ msgid ""
 "If only one result variable is of interest the other result variables can be used to to tell solve() which variables to eliminate from the solution\n"
 "solve() searches for a global solution. If a problem has different solutions depending on the range its variables are in one way to successfully use solve() is to use solve() to eliminate variables one by one and to manually choose which of the solutions solve() found matches the current problem."
 msgstr ""
+"solve() выполнит решение списка уравнений только в том случае, если для n независимых уравнений имеется n неизвестных переменных.\n"
+"Если требуется найти значение только одной переменной, можно заменить другие переменные на выражения через нужную вам переменную, чтобы функция solve() смогла исключить из решения все лишние переменные.\n"
+"solve() ищет глобальное решение. Если у задачи есть разные решения в зависимости от диапазона, в котором находятся её переменные, одним из способов успешного применения solve() будет следующий: использовать эту функцию для исключения переменных по одной и выбрать вручную из найденных solve() решений то, которое соответствует текущей задаче."
 
 #: ../../src/wxMaxima.cpp:7745
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables solve needs to do its work can be used to tell solve() which variables to eliminate in the solution for the interesting variable."
 msgstr ""
+"solve() выполнит решение списка уравнений только в том случае, если для n независимых уравнений имеется n неизвестных переменных.\n"
+"Если требуется найти значение только одной переменной, можно заменить другие переменные на выражения через нужную вам переменную, чтобы функция solve() смогла исключить из решения все лишние переменные."
 
 #: ../../src/wxMaxima.cpp:7784
 msgid ""
 "solves an equation of the form\n"
 "    'diff(y,t) = -y;"
 msgstr ""
+"решает уравнение вида\n"
+"    'diff(y,t) = -y;"
 
 #: ../../src/wxMaxima.cpp:7789
 msgid "t:"
-msgstr ""
+msgstr "t:"
 
 #: ../../src/wxMaximaFrame.cpp:1075
 msgid "unnamed function (lambda)..."
-msgstr ""
+msgstr "безымянная функция (лямбда)..."
 
 #: ../../src/wxMaxima.cpp:11190
 msgid "unsaved"
-msgstr ""
+msgstr "несохранённый"
 
 #: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
 #: ../../src/wxMaximaFrame.cpp:189
 msgid "untitled"
-msgstr ""
+msgstr "без названия"
 
 #: ../../src/wxMaximaFrame.cpp:1700
 msgid "use as function arguments"
-msgstr ""
+msgstr "Использовать как аргументы функции"
 
 #: ../../src/wxMaximaFrame.cpp:1696
 msgid "use the actual values stored"
-msgstr ""
+msgstr "Использовать сохранённые фактические значения"
 
 #: ../../src/wxMaximaFrame.cpp:1112
 msgid "writebyte..."
-msgstr ""
+msgstr "writebyte..."
 
 #: ../../src/main.cpp:509
 msgid "wxMaxima"
-msgstr ""
+msgstr "wxMaxima"
 
 #: ../../src/main.cpp:516
 #, c-format
 msgid "wxMaxima %ld"
-msgstr ""
+msgstr "wxMaxima %ld"
 
 #: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
 #: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
 #: ../../src/wxMaximaFrame.cpp:185
 #, c-format
 msgid "wxMaxima %s (%s) "
-msgstr ""
+msgstr "wxMaxima %s (%s) "
 
 #: ../../src/wxMaxima.cpp:4490
 msgid "wxMaxima cannot read the xml contents of "
-msgstr ""
+msgstr "wxMaxima не удалось прочесть содержимое XML "
 
 #: ../../src/wxMaxima.cpp:2546
 msgid ""
@@ -8043,80 +8405,88 @@ msgid ""
 "Please check you have network support\n"
 "enabled, that no internet safety appliance is configured to intercept creation of servers even if said server only accepts connections from local application (maxima insists on the graphical frontend acting as a server it can connect on over a local socket) and try again!"
 msgstr ""
+"wxMaxima не удалось выполнить запуск сервера.\n"
+"\n"
+"Убедитесь, что поддержка сети включена,\n"
+"а программа, обеспечивающая безопасность в Интернете, не настроена на перехват создания серверов, даже если такой сервер принимает только соединения от локального приложения (для Maxima графический интерфейс обязательно должен работать как сервер, к которому программа может подключиться по локальному сокету), и попробуйте снова!"
 
 #: ../../src/wxMaxima.cpp:5285
 msgid "wxMaxima document"
-msgstr ""
+msgstr "Документ wxMaxima"
 
 #: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
 #: ../../src/wxMaxima.cpp:4230
 msgid "wxMaxima encountered an error loading "
-msgstr ""
+msgstr "Ошибка при загрузке wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "wxMaxima help"
-msgstr ""
+msgstr "Справка по wxMaxima"
 
 #: ../../src/Worksheet.cpp:1465 ../../src/Worksheet.cpp:1839
 msgid ""
 "wxMaxima remembers answers from the last run and is able to automatically "
 "send them to maxima, if requested"
 msgstr ""
+"wxMaxima запоминает ответы с прошлого выполнения и может автоматически "
+"отправлять их в Maxima, если это будет запрошено"
 
 #: ../../src/Worksheet.cpp:1470 ../../src/Worksheet.cpp:1844
 msgid ""
 "wxMaxima remembers answers from the last run and is able to offer them as "
 "the default answer"
 msgstr ""
+"wxMaxima запоминает ответы с прошлого выполнения и может предлагать их в "
+"качестве ответа по умолчанию"
 
 #: ../../src/wxMaximaFrame.cpp:1896
 msgid "wxMaxima shows help in a browser"
-msgstr ""
+msgstr "wxMaxima отображает справку в браузере"
 
 #: ../../src/wxMaximaFrame.cpp:1894
 msgid "wxMaxima shows help in the sidebar"
-msgstr ""
+msgstr "wxMaxima отображает справку на боковой панели"
 
 #: ../../src/wxMaximaFrame.cpp:111
 #, c-format
 msgid "wxMaxima version %s"
-msgstr ""
+msgstr "wxMaxima версии %s"
 
 #: ../../src/wxMaximaFrame.cpp:1954
 msgid "wxMaxima's ChangeLog"
-msgstr ""
+msgstr "Журнал изменений wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "wxMaxima's license"
-msgstr ""
+msgstr "Лицензия wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:144
 msgid "wxWidgets is using GTK 2"
-msgstr ""
+msgstr "wxWidgets использует GTK 2"
 
 #: ../../src/wxMaximaFrame.cpp:142
 msgid "wxWidgets is using GTK 3"
-msgstr ""
+msgstr "wxWidgets использует GTK 3"
 
 #: ../../src/WXMXformat.cpp:367
 msgid "wxmx file saved"
-msgstr ""
+msgstr "файл .wxmx сохранён"
 
 #: ../../src/wxMaxima.cpp:8375
 msgid "x direction [in multiples of the tick frequency]"
-msgstr ""
+msgstr "направление x [в единицах частоты делений]"
 
 #: ../../src/wxMaxima.cpp:4500 ../../src/wxMaxima.cpp:4643
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
-msgstr ""
+msgstr "XML, включённый в файл, сообщает, что не является листом wxMaxima."
 
 #: ../../src/wxMaxima.cpp:8376
 msgid "y direction [in multiples of the tick frequency]"
-msgstr ""
+msgstr "направление y [в единицах частоты делений]"
 
 #: ../../src/wxMaxima.cpp:7789
 msgid "y:"
-msgstr ""
+msgstr "y:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:2
@@ -11345,8 +11715,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:837
+#, fuzzy
 msgid "Example:"
-msgstr ""
+msgstr "Примеры:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:842

--- a/locales/wxMaxima/tr.po
+++ b/locales/wxMaxima/tr.po
@@ -28,6 +28,9 @@ msgid ""
 "\n"
 "Maxima is currently using %3.3f%% of all available CPUs."
 msgstr ""
+"\n"
+"\n"
+"Maxima tüm CPU ların %3.3f%% nı kullanıyor."
 
 #: ../../src/Image.cpp:690
 msgid ""
@@ -61,9 +64,9 @@ msgid "\"..\" means \"one directory up\"."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:5053
-#, c-format
+#, fuzzy, c-format
 msgid "%i cells in evaluation queue"
-msgstr ""
+msgstr "%i hücreleri değerlendirme sırasında (bekliyor)"
 
 #: ../../src/Worksheet.cpp:330
 #, c-format
@@ -71,233 +74,239 @@ msgid "%s image, %li×%li, %li ppi"
 msgstr ""
 
 #: ../../src/Autocomplete.cpp:319
-#, c-format
+#, fuzzy, c-format
 msgid "%s: Can't interpret line: %s"
-msgstr ""
+msgstr ": Satır yorumlanamıyor:% s"
 
 #: ../../src/wxMaximaFrame.cpp:1655
+#, fuzzy
 msgid "&Algebraic Mode"
-msgstr ""
+msgstr "&Cebir"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "&Apropos..."
-msgstr ""
+msgstr "&İlgili..."
 
 #: ../../src/wxMaximaFrame.cpp:615
 msgid "&Batch File...\tCtrl+B"
-msgstr ""
+msgstr "&Kütük Dosyası\tCtrl+B"
 
 #: ../../src/wxMaximaFrame.cpp:1278
 msgid "&Boundary Value Problem..."
-msgstr ""
+msgstr "&Sınır Değeri Problemi..."
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "&Bug Report"
-msgstr ""
+msgstr "&Hata Raporu"
 
 #: ../../src/wxMaximaFrame.cpp:1505
 msgid "&Calculus"
-msgstr ""
+msgstr "&Kalkülüs"
 
 #: ../../src/wxMaximaFrame.cpp:1601
 msgid "&Canonical Form"
-msgstr ""
+msgstr "&Kanonik Form"
 
 #: ../../src/wxMaximaFrame.cpp:1358
 msgid "&Characteristic Polynomial..."
-msgstr ""
+msgstr "&Karakteristik Polinom..."
 
 #: ../../src/wxMaximaFrame.cpp:990
 msgid "&Clear Memory"
-msgstr ""
+msgstr "&Belleği temizle"
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "&Combine Factorials"
-msgstr ""
+msgstr "&Çarpanları Birleştir"
 
 #: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Complex Simplification"
-msgstr ""
+msgstr "&Karmaşık Sadeleştirme"
 
 #: ../../src/wxMaximaFrame.cpp:1502
 msgid "&Continued Fraction"
-msgstr ""
+msgstr "&Sürekli Kesirler"
 
 #: ../../src/wxMaximaFrame.cpp:638
 msgid "&Copy\tCtrl+C"
-msgstr ""
+msgstr "&Kopyala\tCtrl+C"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "&Demoivre"
-msgstr ""
+msgstr "&de Moivre formülü"
 
 #: ../../src/wxMaximaFrame.cpp:1362
 msgid "&Determinant"
-msgstr ""
+msgstr "&Determinant"
 
 #: ../../src/wxMaximaFrame.cpp:1466
 msgid "&Differentiate..."
-msgstr ""
+msgstr "&Türevini al..."
 
 #: ../../src/wxMaximaFrame.cpp:689
 msgid "&Edit"
-msgstr ""
+msgstr "&Düzen"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "&Eliminate Variable..."
-msgstr ""
+msgstr "&Değişkeni yok et..."
 
 #: ../../src/wxMaximaFrame.cpp:1318
 msgid "&Enter Matrix..."
-msgstr ""
+msgstr "&Matris gir..."
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "&Example..."
-msgstr ""
+msgstr "&Örnek..."
 
 #: ../../src/wxMaximaFrame.cpp:1524
 msgid "&Expand Expression"
-msgstr ""
+msgstr "&İfadeyi Genişlet"
 
 #: ../../src/wxMaximaFrame.cpp:1597
 msgid "&Expand Trigonometric"
-msgstr ""
+msgstr "&Trigonometrik Genişlet"
 
 #: ../../src/wxMaximaFrame.cpp:1626
 msgid "&Exponentialize"
-msgstr ""
+msgstr "&Üstel Hale Getir"
 
 #: ../../src/wxMaximaFrame.cpp:618
 msgid "&Export..."
-msgstr ""
+msgstr "&Çıkart..."
 
 #: ../../src/wxMaximaFrame.cpp:1516
 msgid "&Factor Expression"
-msgstr ""
+msgstr "&İfadenin Özdeşi"
 
 #: ../../src/wxMaximaFrame.cpp:626
 msgid "&File"
-msgstr ""
+msgstr "&Dosya"
 
 #: ../../src/wxMaximaFrame.cpp:1019
+#, fuzzy
 msgid "&Functions"
-msgstr ""
+msgstr "Fonksiyon:"
 
 #: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Greatest Common Divisor..."
-msgstr ""
+msgstr "&OBEB..."
 
 #: ../../src/wxMaximaFrame.cpp:1968
 msgid "&Help"
-msgstr ""
+msgstr "&Yardım"
 
 #: ../../src/wxMaximaFrame.cpp:1453
 msgid "&Integrate..."
-msgstr ""
+msgstr "&İntegral..."
 
 #: ../../src/wxMaximaFrame.cpp:964
 msgid "&Interrupt\tCtrl+G"
-msgstr ""
+msgstr "&Yarıda Kes\tCtrl+G"
 
 #: ../../src/wxMaximaFrame.cpp:1355
 msgid "&Invert Matrix"
-msgstr ""
+msgstr "&Ters Matris"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "&License"
-msgstr ""
+msgstr "&Lisans"
 
 #: ../../src/wxMaximaFrame.cpp:1763
 msgid "&List"
-msgstr ""
+msgstr "&Liste"
 
 #: ../../src/wxMaximaFrame.cpp:610
 msgid "&Load Package...\tCtrl+L"
-msgstr ""
+msgstr "&Paket Yükle\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "&Maxima"
-msgstr ""
+msgstr "&Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "&Maxima help"
-msgstr ""
+msgstr "&Maxima Yardımı"
 
 #: ../../src/wxMaximaFrame.cpp:1660
 msgid "&Modulus Computation..."
-msgstr ""
+msgstr "&Modüler Hesaplama..."
 
 #: ../../src/main.cpp:435
 msgid "&New\tCtrl+N"
-msgstr ""
+msgstr "&Yeni\tCtrl+N"
 
 #: ../../src/wxMaximaFrame.cpp:1870
 msgid "&Numeric"
-msgstr ""
+msgstr "&Numerik"
 
 #: ../../src/wxMaximaFrame.cpp:1785
+#, fuzzy
 msgid "&Numeric Output"
-msgstr ""
+msgstr "Numerik Çıktıyı çalıştır"
 
 #: ../../src/main.cpp:436
 msgid "&Open\tCtrl+O"
-msgstr ""
+msgstr "&Aç\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "&Open...\tCtrl+O"
-msgstr ""
+msgstr "&Aç...\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "&Plot"
-msgstr ""
+msgstr "&Grafik Çiz"
 
 #: ../../src/wxMaximaFrame.cpp:622
 msgid "&Print...\tCtrl+P"
-msgstr ""
+msgstr "&Yazdır...\tCtrl+P"
 
 #: ../../src/wxMaximaFrame.cpp:1594
 msgid "&Reduce Trigonometric"
-msgstr ""
+msgstr "&Trigonometrik İndirge"
 
 #: ../../src/wxMaximaFrame.cpp:974
+#, fuzzy
 msgid "&Restart Maxima\tCtrl+Alt+R"
-msgstr ""
+msgstr "&Maxima'yı Yeniden Başlat"
 
 #: ../../src/wxMaximaFrame.cpp:608
 msgid "&Save\tCtrl+S"
-msgstr ""
+msgstr "&Kaydet\tCtrl+S"
 
 #: ../../src/wxMaximaFrame.cpp:1662
 msgid "&Simplify"
-msgstr ""
+msgstr "&Sadeleştir"
 
 #: ../../src/wxMaximaFrame.cpp:1581
 msgid "&Simplify Factorials"
-msgstr ""
+msgstr "&Faktöryelleri Sadeleştir"
 
 #: ../../src/wxMaximaFrame.cpp:1591
 msgid "&Simplify Trigonometric"
-msgstr ""
+msgstr "&Trigonometrik Sadeleştir"
 
 #: ../../src/wxMaximaFrame.cpp:1238
 msgid "&Solve..."
-msgstr ""
+msgstr "&Çöz..."
 
 #: ../../src/wxMaximaFrame.cpp:1035
+#, fuzzy
 msgid "&Time Display"
-msgstr ""
+msgstr "Zaman gösterimini çalıştır"
 
 #: ../../src/wxMaximaFrame.cpp:1375
 msgid "&Transpose Matrix"
-msgstr ""
+msgstr "&Matrisin Transpozesi"
 
 #: ../../src/wxMaximaFrame.cpp:1605
 msgid "&Trigonometric Simplification"
-msgstr ""
+msgstr "&Trigonometrik Sadeleştirme"
 
 #: ../../src/wxMaximaFrame.cpp:1021
+#, fuzzy
 msgid "&Variables"
-msgstr ""
+msgstr "Değişken(ler)"
 
 #: ../../src/wxMaxima.cpp:2443
 msgid "(Config tells to suppress the output of long cells)"
@@ -340,39 +349,46 @@ msgid "(f(x),x,y) with singularities+discontinuities"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:2065
+#, fuzzy
 msgid ""
 "... [suppressed additional lines as the output is longer than allowed in the"
 " wxMaxima configuration] "
 msgstr ""
+"....[Çıktı yapılandırmada belirtilenden daha uzun olduğundan çıkarılan ek "
+"satırlar] "
 
 #: ../../src/Worksheet.cpp:6666
 msgid ".wxm clipboard data with unusual header"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8047
+#, fuzzy
 msgid "1×n Matrix b:"
-msgstr ""
+msgstr "Matris:"
 
 #: ../../src/wxMaximaFrame.cpp:1312
+#, fuzzy
 msgid "2D Array to Matrix..."
-msgstr ""
+msgstr "Matrise Eşle..."
 
 #: ../../src/wxMaximaFrame.cpp:743
 msgid "2D equations using ASCII Art"
-msgstr ""
+msgstr "ASCII kullanan 2B eşitlikler"
 
 #: ../../src/wxMaximaFrame.cpp:746
 msgid "2D equations using ASCII Art with unicode characters, if available"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:5057
-#, c-format
+#, fuzzy, c-format
 msgid "; %i commands left in the current cell"
-msgstr ""
+msgstr "; %i komutları geçerli hücrede kaldı"
 
 #: ../../src/wxMaxima.cpp:10617
 msgid "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
+"A \":lisp\" birinci komut gönderme hatalı olduğunda bir \"finished-bitti \" "
+"sinyali."
 
 #: ../../src/wxMaxima.cpp:6585
 msgid "A Ctrl-F event"
@@ -396,24 +412,27 @@ msgid "A function returning positive numbers"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1965
+#, fuzzy
 msgid "A irrational variable"
-msgstr ""
+msgstr "Değişkeni değiştir"
 
 #: ../../src/Worksheet.cpp:2016
 msgid "A left-associative function"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:2019
+#, fuzzy
 msgid "A linear function"
-msgstr ""
+msgstr "Bir Fonksiyonu Sil"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "A matrix in which each row is a set of variables"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1963
+#, fuzzy
 msgid "A rational variable"
-msgstr ""
+msgstr "Değişkeni değiştir"
 
 #: ../../src/Worksheet.cpp:2018
 msgid "A right-associative function"
@@ -432,24 +451,26 @@ msgid "A text control got the mouse focus"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1442
+#, fuzzy
 msgid "A&pply function to each Matrix element..."
-msgstr ""
+msgstr "Fonksiyonu bir listenin her ögesine uygula"
 
 #: ../../src/wxMaximaFrame.cpp:1291
 msgid "A&t Value..."
-msgstr ""
+msgstr "&Başlangıç Şartı..."
 
 #: ../../src/Configuration.cpp:85
+#, fuzzy
 msgid "ASCII maths"
-msgstr ""
+msgstr "'ASCII Art' olarak"
 
 #: ../../src/wxMaximaFrame.cpp:1963
 msgid "About"
-msgstr ""
+msgstr "Hakkında"
 
 #: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
 msgid "About wxMaxima"
-msgstr ""
+msgstr "'wxMaxima' hakkında"
 
 #: ../../src/wxMaxima.cpp:7837
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
@@ -465,45 +486,48 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1371
 msgid "Ad&joint Matrix"
-msgstr ""
+msgstr "&Ek Matris"
 
 #: ../../src/wxMaximaFrame.cpp:1657
 msgid "Add Algebraic E&quality..."
-msgstr ""
+msgstr "&Cebirsel Eşitlik Ekle..."
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add a directory to search path"
-msgstr ""
+msgstr "Arama yoluna dizin ekle"
 
 #: ../../src/wxMaximaFrame.cpp:1752
 msgid ""
 "Add a new item to the beginning of the list. Useful for creating stacks."
 msgstr ""
+"Listenin başına yeni bir madde ekleyin. Yığın oluşturmak için kullanışlıdır."
 
 #: ../../src/wxMaxima.cpp:8602
+#, fuzzy
 msgid "Add an element to the end of a list"
-msgstr ""
+msgstr "Listeye bir öge ekle"
 
 #: ../../src/wxMaxima.cpp:8597
+#, fuzzy
 msgid "Add an element to the start of a list"
-msgstr ""
+msgstr "Listeye bir öge ekle"
 
 #: ../../src/wxMaxima.cpp:7625
 msgid "Add dir to path:"
-msgstr ""
+msgstr "Yola dizin ekle :"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "Add equality to the rational simplifier"
-msgstr ""
+msgstr "Rasyonel sadeleştiriciye eşitlik ekle"
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add to &Path..."
-msgstr ""
+msgstr "&Yola ekle..."
 
 #: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
 #: ../../src/Worksheet.cpp:1704
 msgid "Add to watchlist"
-msgstr ""
+msgstr "İzleme listesine ekle"
 
 #: ../../src/wxMaximaFrame.cpp:1562
 msgid "Additionally: log(a*b)=log(a)+log(b)"
@@ -527,25 +551,28 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1920
 msgid "Advanced variable names"
-msgstr ""
+msgstr "Gelişmiş değişken adları"
 
 #: ../../src/ToolBar.cpp:321 ../../src/ToolBar.cpp:589
 msgid ""
 "After clicking on animations created with with_slider_draw() or similar this"
 " slider allows to change the current frame."
 msgstr ""
+"'with_slider_draw () veya benzeri ile oluşturulmuş animasyonlara tıkladıktan"
+" sonra bu kaydırıcı mevcut kareyi değiştirmenize izin verir."
 
 #: ../../src/wxMaximaFrame.cpp:1028
+#, fuzzy
 msgid "Aliases"
-msgstr ""
+msgstr "Örtüşme önleme çizgileri."
 
 #: ../../src/wxMaximaFrame.cpp:1714
 msgid "All but the 1st n elements"
-msgstr ""
+msgstr "'n' tane ögenin birincisi hariç hepsi"
 
 #: ../../src/wxMaximaFrame.cpp:1716
 msgid "All but the last n elements"
-msgstr ""
+msgstr "'n' tane ögenin sonuncusu hariç hepsi"
 
 #: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
 msgid ""
@@ -554,10 +581,15 @@ msgid ""
 "*.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session "
 "(*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr ""
+"Açılabilecek tüm dosya türleri (*.wxm, *.wxmx, *.mac, *.out, "
+"*.xml)|*.wxm;*.wxmx;*.mac;*.out;*.xml|wxMaxima document (*.wxm, "
+"*.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session "
+"(*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 
 #: ../../src/wxMaximaFrame.cpp:733
+#, fuzzy
 msgid "All visible sidebars"
-msgstr ""
+msgstr "Tüm değişken isimleri"
 
 #: ../../src/wxMaximaFrame.cpp:1650
 msgid "Allow to substitute operators"
@@ -569,12 +601,13 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:763
+#, fuzzy
 msgid "Always after underscores"
-msgstr ""
+msgstr "Bir alt çizgiden sonra her zaman otomatik altyazı"
 
 #: ../../src/wxMaximaFrame.cpp:764
 msgid "Always autosubscript after an underscore"
-msgstr ""
+msgstr "Bir alt çizgiden sonra her zaman otomatik altyazı"
 
 #: ../../src/wxMaximaFrame.cpp:774
 msgid "Always display this variable with subscript"
@@ -582,7 +615,7 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1605
 msgid "Always show all digits"
-msgstr ""
+msgstr "Her zaman tüm sayı basamaklarını göster"
 
 #: ../../src/wxMaxima.cpp:9241
 msgid ""
@@ -599,12 +632,13 @@ msgid "Angles"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1775
+#, fuzzy
 msgid "Animation autoplay"
-msgstr ""
+msgstr "Animasyon otomatik oynatmayı aç / kapat"
 
 #: ../../src/wxMaximaFrame.cpp:1778
 msgid "Animation framerate..."
-msgstr ""
+msgstr "Animasyon çerçeve hızı..."
 
 #: ../../src/Worksheet.cpp:2002
 msgid "Antisymmetric function: f(x)=-f(-x)"
@@ -612,35 +646,38 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1739
 msgid "Append"
-msgstr ""
+msgstr "Ekle"
 
 #: ../../src/wxMaximaFrame.cpp:1735
 msgid "Append a list"
-msgstr ""
+msgstr "Bir liste ekle"
 
 #: ../../src/wxMaximaFrame.cpp:1736
 msgid "Append a list to an existing list"
-msgstr ""
+msgstr "Varolan bir listeye bir liste ekle"
 
 #: ../../src/wxMaxima.cpp:8607
+#, fuzzy
 msgid "Append a list to another list"
-msgstr ""
+msgstr "Bir listeye liste ekle"
 
 #: ../../src/wxMaximaFrame.cpp:1729
 msgid "Append an element"
-msgstr ""
+msgstr "Bir öge ekle"
 
 #: ../../src/wxMaximaFrame.cpp:1734
+#, fuzzy
 msgid "Append an element to the beginning an existing list"
-msgstr ""
+msgstr "Var olan bir lsiteye bir öge ekle"
 
 #: ../../src/wxMaximaFrame.cpp:1730
+#, fuzzy
 msgid "Append an element to the end of an existing list"
-msgstr ""
+msgstr "Var olan bir lsiteye bir öge ekle"
 
 #: ../../src/wxMaxima.cpp:8552
 msgid "Apply a function to each list element"
-msgstr ""
+msgstr "Fonksiyonu bir listenin her ögesine uygula"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 #, c-format
@@ -665,15 +702,16 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9474
 msgid "Apropos"
-msgstr ""
+msgstr "İlgili"
 
 #: ../../src/wxMaxima.cpp:7317
 msgid "Are the chars equal, if case is ignored?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7312
+#, fuzzy
 msgid "Are the chars equal?"
-msgstr ""
+msgstr "büyük ya da eşit"
 
 #: ../../src/wxMaxima.cpp:7349
 msgid "Are these strings equal if case is ignored?"
@@ -688,12 +726,14 @@ msgid "Arguments:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8189
+#, fuzzy
 msgid "Array"
-msgstr ""
+msgstr "Dizin:"
 
 #: ../../src/wxMaximaFrame.cpp:1023
+#, fuzzy
 msgid "Arrays"
-msgstr ""
+msgstr "Dizin:"
 
 #: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
 msgid "Ascii code to char"
@@ -712,8 +752,9 @@ msgid "Assignments of the format a=10,b=20"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:6851
+#, fuzzy
 msgid "Assume a value range for a variable"
-msgstr ""
+msgstr "Bir değişken için gerçek bir değer ayıkla"
 
 #: ../../src/wxMaxima.cpp:8545
 msgid ""
@@ -723,45 +764,47 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1618
 msgid "Automatic labels"
-msgstr ""
+msgstr "Otomatik etiketler"
 
 #: ../../src/wxMaximaFrame.cpp:952
 msgid "Automatically answer questions"
-msgstr ""
+msgstr "Soruları otomatik olarak cevapla"
 
 #: ../../src/wxMaximaFrame.cpp:953
 msgid "Automatically fill in answers known from the last run"
-msgstr ""
+msgstr "Son çalıştırmadaki cevapları otomatik olarak doldur"
 
 #: ../../src/Worksheet.cpp:1464 ../../src/Worksheet.cpp:1838
+#, fuzzy
 msgid "Automatically send known answers"
-msgstr ""
+msgstr "Soruları otomatik olarak cevapla"
 
 #: ../../src/wxMaxima.cpp:6021
 #, c-format
 msgid "Autosaving as temp file %s"
-msgstr ""
+msgstr "%s geçici dosyası olarak otomatik kaydetme"
 
 #: ../../src/wxMaxima.cpp:6033
 #, c-format
 msgid "Autosaving the .wxmx file as %s"
-msgstr ""
+msgstr ".wxmx dosyasını %s olarak otomatik kaydetme"
 
 #: ../../src/wxMaximaFrame.cpp:781
 msgid "Autosubscript"
-msgstr ""
+msgstr "Otomatik alt karakter"
 
 #: ../../src/wxMaximaFrame.cpp:782
 msgid "Autosubscript chars after an underscore"
-msgstr ""
+msgstr "Bir alt çizgiden sonra Autosubscript karakterleri"
 
 #: ../../src/wxMaximaFrame.cpp:767
 msgid "Autosubscript numbers and text following single letters"
-msgstr ""
+msgstr "Autosubscript sayıları ve tek harflerden sonra gelen metinler"
 
 #: ../../src/wxMaxima.cpp:6529
+#, fuzzy
 msgid "Autosubscript this variable"
-msgstr ""
+msgstr "Otomatik alt karakter"
 
 #: ../../src/MaximaManual.cpp:536
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -773,36 +816,38 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6210
 msgid "Batch File"
-msgstr ""
+msgstr "Kütük Dosyası"
 
 #: ../../src/wxMaxima.cpp:5318
 msgid "Both horizontal and vertical cursor active at the same time"
-msgstr ""
+msgstr "Hem yatay hem de dikey imleç aynı anda etkin"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Bottom end"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7817
+#, fuzzy
 msgid "Boundary value problem"
-msgstr ""
+msgstr "&Sınır Değeri Problemi..."
 
 #: ../../src/wxMathml.cpp:101
 msgid ""
 "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
 msgstr ""
+"Hata: Boşlukları çıkardıktan sonra wxMathml.lisp beklenenden daha kısa!"
 
 #: ../../src/Autocomplete.cpp:509
 msgid "Bug: Autocompletion requested for unknown type of item."
-msgstr ""
+msgstr "Hata: Bilinmeyen bir öge için otomatik tamamlama isteği."
 
 #: ../../src/Worksheet.cpp:2992
 msgid "Bug: Cell left but not entered."
-msgstr ""
+msgstr "Hata: Hücre geride bırakıldı ancak (değerlendirmeye) girmedi."
 
 #: ../../src/Worksheet.cpp:6203
 msgid "Bug: Cell with negative y position!"
-msgstr ""
+msgstr "Hata: Negatif y değerli bir hücre!"
 
 #: ../../src/Worksheet.cpp:7723
 msgid ""
@@ -816,36 +861,41 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:3112
 msgid "Bug: Got a question but no cell to answer it in"
-msgstr ""
+msgstr "Hata: Bir soru alındı ama yanıtı içeren bir hücre yok"
 
 #: ../../src/Worksheet.cpp:6378
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of"
 " the worksheet."
 msgstr ""
+"Hata: Çalışma yaprağının başladığı noktanın üstünde bir hücrenin içeriğini "
+"değiştirme istemi."
 
 #: ../../src/Worksheet.cpp:6346
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
+"Hata: Çalışma yaprağının başlangıcının üstünde bir hücreyi silme isteği."
 
 #: ../../src/Worksheet.cpp:6415
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
 msgstr ""
+"Hata: Önce içerik değiştirme sonra da silem işlemini geri alma komutu "
+"alındı."
 
 #: ../../src/Worksheet.cpp:5578
 msgid "Bug: HTML output is no valid XML"
-msgstr ""
+msgstr "Hata: HTML çıktısı geçerli bir XML değil"
 
 #: ../../src/Configuration.h:615
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
-msgstr ""
+msgstr "Hata : Gösterimi çok uzun sürecek öok basamaklı bir sayı!"
 
 #: ../../src/MathParser.cpp:523
 msgid "Bug: Missing contents"
-msgstr ""
+msgstr "Hata: Eksik içerik"
 
 #: ../../src/Worksheet.cpp:2597 ../../src/Worksheet.cpp:2711
 #: ../../src/Worksheet.cpp:2753 ../../src/Worksheet.cpp:2787
@@ -853,7 +903,7 @@ msgstr ""
 #: ../../src/Worksheet.cpp:4442 ../../src/Worksheet.cpp:6650
 #: ../../src/Worksheet.cpp:6863
 msgid "Bug: The clipboard is already opened"
-msgstr ""
+msgstr "Hata:Pano zaten açılmış"
 
 #: ../../src/Worksheet.cpp:7763
 msgid "Bug: Trying to move a title out by one sectioning unit"
@@ -864,38 +914,44 @@ msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
+"Hata:Yatay-çizilen imleci bir HücreGrubu içinde hareket ettirmeye çalışıyor."
 
 #: ../../src/Worksheet.h:247 ../../src/Worksheet.h:252
 msgid "Bug: Trying to record a cell contents change for undo without a cell."
 msgstr ""
+"Hata: Bir hücre içermeyen geri alma işlemi için bir hücre içeriği "
+"değişikliği kaydetmeye çalışılıyor."
 
 #: ../../src/Worksheet.cpp:6417
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
+"Hata: Hücre içeriği değişiklikleri ve hücre ekleme durumlarının her ikisi "
+"için Geri Al eylemi."
 
 #: ../../src/Worksheet.cpp:6383
 msgid "Bug: Undo request for cell outside worksheet."
-msgstr ""
+msgstr "Hata: Geri al isteği çalışma yaprağı dışındaki bir hücreye ait."
 
 #: ../../src/wxMaximaFrame.cpp:1948
 msgid "Build &Info"
-msgstr ""
+msgstr "Derleme &Bilgi"
 
 #: ../../src/wxMaxima.cpp:7275
 msgid "Byte:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1458
+#, fuzzy
 msgid "C&hange Variable in Integrate..."
-msgstr ""
+msgstr "&Değişkeni değiştir..."
 
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "C&onfigure"
-msgstr ""
+msgstr "&Yapılandır"
 
 #: ../../src/wxMaximaFrame.cpp:1482
 msgid "Calculate &Product..."
-msgstr ""
+msgstr "&Çarpımı hesapla..."
 
 #: ../../src/wxMaxima.cpp:8057
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
@@ -909,35 +965,37 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate Su&m..."
-msgstr ""
+msgstr "&Toplamı hesapla.."
 
 #: ../../src/wxMaximaFrame.cpp:1795
 msgid "Calculate bigfloat value of the last result"
-msgstr ""
+msgstr "En Son Sonucun Büyük Kayan Sayı Değerini Heapla"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Calculate float value of the last result"
-msgstr ""
+msgstr "En Son Sonucunu Kayan Sayı Değerini Heapla"
 
 #: ../../src/wxMaxima.cpp:9550
+#, fuzzy
 msgid "Calculate mean value"
-msgstr ""
+msgstr "Modülleri Hesapla:"
 
 #: ../../src/wxMaxima.cpp:9554
+#, fuzzy
 msgid "Calculate median value"
-msgstr ""
+msgstr "Modülleri Hesapla:"
 
 #: ../../src/wxMaxima.cpp:8871
 msgid "Calculate modulus:"
-msgstr ""
+msgstr "Modülleri Hesapla:"
 
 #: ../../src/wxMaximaFrame.cpp:1798
 msgid "Calculate numeric value of the last result"
-msgstr ""
+msgstr "En son sonucun sayısal değerini hesapla"
 
 #: ../../src/wxMaximaFrame.cpp:1483
 msgid "Calculate products"
-msgstr ""
+msgstr "Çarpımları Hesapla"
 
 #: ../../src/wxMaxima.cpp:9562
 msgid "Calculate standard deviation"
@@ -945,23 +1003,25 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate sums"
-msgstr ""
+msgstr "Toplamları Hesapla"
 
 #: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
 msgid "Calculate the eigenvalues and eigenvectors numerically"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
+#, fuzzy
 msgid "Calculate the eigenvalues of a matrix numerically"
-msgstr ""
+msgstr "Bir matrisin tersini hesapla"
 
 #: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
 msgid "Calculate the root of the sum of squares of matrix entries"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9558
+#, fuzzy
 msgid "Calculate variation"
-msgstr ""
+msgstr "Çarpımları Hesapla"
 
 #: ../../src/wxMaxima.cpp:8949
 msgid "Calculates the fourier coefficients for the expression from -p to p"
@@ -977,22 +1037,26 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11125
 msgid "Can not connect to the web server."
-msgstr ""
+msgstr "Web sunucusuna bağlanamıyor."
 
 #: ../../src/wxMaxima.cpp:11166
 msgid "Can not download version info."
-msgstr ""
+msgstr "Sürüm bilgisi indirilemiyor."
 
 #: ../../src/wxMaxima.cpp:3016 ../../src/wxMaxima.cpp:4836
+#, fuzzy
 msgid ""
 "Can not start Maxima. The most probable cause is that Maxima isn't installed"
 " (it can be downloaded from https://maxima.sourceforge.io) or in wxMaxima's "
 "config dialogue the setting for Maxima's location is wrong."
 msgstr ""
+"Maxima başlatılamıyor. En olası neden, maxima'nın yüklenmemiş olması "
+"(http://maxima.sourceforge.net adresinden indirilebilir) veya wxMaxima'nın "
+"yapılandırma iletişim kutusunda maxima'nın konum ayarının yanlış olmasıdır."
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Cancel"
-msgstr ""
+msgstr "İptal et"
 
 #: ../../src/wxMaxima.cpp:3292
 msgid "Cannot authenticate Maxima!"
@@ -1002,11 +1066,13 @@ msgstr ""
 msgid ""
 "Cannot find a maxima binary and no binary chosen in the config dialogue."
 msgstr ""
+"Bir Maxima ikili dosyası bulunamıyor ve Yapılandır diyalog penceresinde "
+"hiçbir ikili seçilmemiş."
 
 #: ../../src/Autocomplete.cpp:583
-#, c-format
+#, fuzzy, c-format
 msgid "Cannot interpret template %s"
-msgstr ""
+msgstr ": Satır yorumlanamıyor:% s"
 
 #: ../../src/wxMaxima.cpp:3082
 #, c-format
@@ -1021,20 +1087,20 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:2530
 msgid "Cannot set the communication address to localhost."
-msgstr ""
+msgstr "İletişim adresi localhost olarak ayarlanamıyor."
 
 #: ../../src/wxMaxima.cpp:2532
-#, c-format
+#, fuzzy, c-format
 msgid "Cannot set the communication port to %i."
-msgstr ""
+msgstr "İletişim bağlantı noktası%i olarak ayarlanamıyor."
 
 #: ../../src/wxMaxima.cpp:3656 ../../src/wxMaxima.cpp:6359
 msgid "Cannot start gnuplot"
-msgstr ""
+msgstr "Gnuplot u başlatamadı"
 
 #: ../../src/StatusBar.cpp:216 ../../src/wxMaxima.cpp:2662
 msgid "Cannot start the maxima binary"
-msgstr ""
+msgstr "Maxima binary dosyaları başlatılamıyor"
 
 #: ../../src/wxMaxima.cpp:9268
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
@@ -1046,67 +1112,78 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:955
 msgid "Ce&ll"
-msgstr ""
+msgstr "&Hücre"
 
 #: ../../src/Configuration.cpp:96
+#, fuzzy
 msgid "Cell bracket fill, Active"
-msgstr ""
+msgstr "Hücre parantezi"
 
 #: ../../src/Configuration.cpp:95
+#, fuzzy
 msgid "Cell bracket fill, Inactive"
-msgstr ""
+msgstr "Hücre parantezi"
 
 #: ../../src/wxMaxima.cpp:10395
 msgid "Cell ends in a backslash"
-msgstr ""
+msgstr "Hücre ters kesme işareti ile bitiyor"
 
 #: ../../src/wxMaximaFrame.cpp:1038
 msgid "Change &2d Display"
-msgstr ""
+msgstr "2B gösterimini değiştir"
 
 #: ../../src/wxMaxima.cpp:10146
+#, fuzzy
 msgid "Change Image"
-msgstr ""
+msgstr "Değişkeni değiştir"
 
 #: ../../src/Worksheet.cpp:1324
+#, fuzzy
 msgid "Change Image..."
-msgstr ""
+msgstr "Resmi Kaydet..."
 
 #: ../../src/wxMaximaFrame.cpp:1954
+#, fuzzy
 msgid "Change Log"
-msgstr ""
+msgstr "Değişkeni değiştir"
 
 #: ../../src/wxMaxima.cpp:7555
 msgid "Change directory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1202
+#, fuzzy
 msgid "Change directory..."
-msgstr ""
+msgstr "Resmi Kaydet..."
 
 #: ../../src/wxMaximaFrame.cpp:1039
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
+"'Matemetiksel çıktı (sonuç)'ları göstermek için kullanılan 2B algoritmasını "
+"değiştir"
 
 #: ../../src/wxMaxima.cpp:8885
 msgid "Change variable"
-msgstr ""
+msgstr "Değişkeni değiştir"
 
 #: ../../src/wxMaxima.cpp:8905
+#, fuzzy
 msgid "Change variable and evaluate"
-msgstr ""
+msgstr "İntegral ve ya toplam daki değişkeni değiştir"
 
 #: ../../src/wxMaximaFrame.cpp:1459
 msgid "Change variable in integral or sum"
-msgstr ""
+msgstr "İntegral ve ya toplam daki değişkeni değiştir"
 
 #: ../../src/wxMaximaFrame.cpp:1463
+#, fuzzy
 msgid "Change variable in integral or sum and evaluate the result"
-msgstr ""
+msgstr "İntegral ve ya toplam daki değişkeni değiştir"
 
 #: ../../src/wxMaximaFrame.cpp:1026
+#, fuzzy
 msgid "Changed option variables"
-msgstr ""
+msgstr "Değişkeni değiştir"
 
 #: ../../src/wxMaxima.cpp:10170
 #, c-format
@@ -1122,8 +1199,9 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
 #: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
+#, fuzzy
 msgid "Char #2:"
-msgstr ""
+msgstr "Matris:"
 
 #: ../../src/wxMaximaFrame.cpp:1140
 msgid "Char to Unicode code point..."
@@ -1146,8 +1224,9 @@ msgid "Character Tests"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8181
+#, fuzzy
 msgid "Characteristic polynom"
-msgstr ""
+msgstr "&Karakteristik Polinom..."
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Chars are strings that are one character long"
@@ -1155,75 +1234,88 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1957
 msgid "Check for Updates"
-msgstr ""
+msgstr "Güncellemeleri denetle"
 
 #: ../../src/wxMaximaFrame.cpp:1958
+#, fuzzy
 msgid "Check if a newer version of wxMaxima is available."
-msgstr ""
+msgstr "'wxMaxima/Maxima'nın' daha yeni bir sürümü olup olmadığına bak."
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Choose the parenthesis type for Matrices"
-msgstr ""
+msgstr "Matrisler için parantez türünü seçin"
 
 #: ../../src/wxMaxima.cpp:9530 ../../src/wxMaxima.cpp:9535
 msgid "Classes:"
-msgstr ""
+msgstr "Sınıflar:"
 
 #: ../../src/wxMaximaFrame.cpp:1378
 msgid "Classic matrix operations"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:998
+#, fuzzy
 msgid "Clear all aliases"
-msgstr ""
+msgstr "&Belleği temizle"
 
 #: ../../src/wxMaximaFrame.cpp:995
+#, fuzzy
 msgid "Clear all arrays"
-msgstr ""
+msgstr "&Belleği temizle"
 
 #: ../../src/wxMaximaFrame.cpp:992
+#, fuzzy
 msgid "Clear all dependencies"
-msgstr ""
+msgstr "&Belleği temizle"
 
 #: ../../src/wxMaximaFrame.cpp:994
+#, fuzzy
 msgid "Clear all functions"
-msgstr ""
+msgstr "Bir Fonksiyonu Sil"
 
 #: ../../src/wxMaximaFrame.cpp:1001
+#, fuzzy
 msgid "Clear all gradefs"
-msgstr ""
+msgstr "&Belleği temizle"
 
 #: ../../src/wxMaximaFrame.cpp:1000
+#, fuzzy
 msgid "Clear all labels"
-msgstr ""
+msgstr "&Belleği temizle"
 
 #: ../../src/wxMaximaFrame.cpp:1004
+#, fuzzy
 msgid "Clear all let rule packages"
-msgstr ""
+msgstr "Kullanıcı tanımlı izin kuralı paketlerinin listesi"
 
 #: ../../src/wxMaximaFrame.cpp:1003
+#, fuzzy
 msgid "Clear all macros"
-msgstr ""
+msgstr "&Belleği temizle"
 
 #: ../../src/wxMaximaFrame.cpp:1002
+#, fuzzy
 msgid "Clear all props"
-msgstr ""
+msgstr "&Belleği temizle"
 
 #: ../../src/wxMaximaFrame.cpp:997
+#, fuzzy
 msgid "Clear all rules"
-msgstr ""
+msgstr "&Belleği temizle"
 
 #: ../../src/wxMaximaFrame.cpp:999
+#, fuzzy
 msgid "Clear all structures"
-msgstr ""
+msgstr "&Belleği temizle"
 
 #: ../../src/wxMaximaFrame.cpp:993
+#, fuzzy
 msgid "Clear all variables"
-msgstr ""
+msgstr "Bir Değişkeni Sil"
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close\tCtrl+W"
-msgstr ""
+msgstr "Kapat\tCtrl+W"
 
 #: ../../src/wxMaxima.cpp:7235
 msgid "Close Stream"
@@ -1231,130 +1323,147 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close window"
-msgstr ""
+msgstr "Pencereyi kapat"
 
 #: ../../src/wxMaximaFrame.cpp:1105
+#, fuzzy
 msgid "Close..."
-msgstr ""
+msgstr "Çöz..."
 
 #: ../../src/WXMXformat.cpp:301
 msgid "Closed the zip archive"
 msgstr ""
 
 #: ../../src/Configuration.cpp:77
+#, fuzzy
 msgid "Code Default (Maxima input)"
-msgstr ""
+msgstr "Maxima girdisi"
 
 #: ../../src/Configuration.cpp:103
 msgid "Code highlighting: Comments"
-msgstr ""
+msgstr "Kod vurgulama: Açıklamalar"
 
 #: ../../src/Configuration.cpp:108
+#, fuzzy
 msgid "Code highlighting: End of line markers"
-msgstr ""
+msgstr "Kod vurgulama: Satır sonu"
 
 #: ../../src/Configuration.cpp:102
 msgid "Code highlighting: Functions"
-msgstr ""
+msgstr "Kod vurgulama: Fonksiyonlar"
 
 #: ../../src/Configuration.cpp:107
 msgid "Code highlighting: Lisp"
-msgstr ""
+msgstr "Kod vurgulama: Lisp"
 
 #: ../../src/Configuration.cpp:104
 msgid "Code highlighting: Numbers"
-msgstr ""
+msgstr "Kod vurgulama: Sayılar"
 
 #: ../../src/Configuration.cpp:106
 msgid "Code highlighting: Operators"
-msgstr ""
+msgstr "Kod vurgulama: İşlemciler"
 
 #: ../../src/Configuration.cpp:105
 msgid "Code highlighting: Strings"
-msgstr ""
+msgstr "Kod vurgulama: Karakter dizilimleri"
 
 #: ../../src/Configuration.cpp:101
 msgid "Code highlighting: Variables"
-msgstr ""
+msgstr "Kod vurgulama: Değişkenler"
 
 #: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
+#, fuzzy
 msgid "Code number:"
-msgstr ""
+msgstr "öge numarası n"
 
 #: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
+#, fuzzy
 msgid "Codepoint number:"
-msgstr ""
+msgstr "öge numarası n"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "Col. names:"
-msgstr ""
+msgstr "Sütun adları:"
 
 #: ../../src/Configuration.cpp:100
+#, fuzzy
 msgid "Color of Outdated cells"
-msgstr ""
+msgstr "Kullanılmayan Hücreler"
 
 #: ../../src/Configuration.cpp:99
+#, fuzzy
 msgid "Color of text equal to selection"
-msgstr ""
+msgstr "Metin seçime eşit"
 
 #: ../../src/wxMaxima.cpp:7962
+#, fuzzy
 msgid "Column number:"
-msgstr ""
+msgstr "öge numarası n"
 
 #: ../../src/wxMaxima.cpp:7978
+#, fuzzy
 msgid "Column numbers:"
-msgstr ""
+msgstr "Sütunlar:"
 
 #: ../../src/wxMaxima.cpp:8202
+#, fuzzy
 msgid "Columns"
-msgstr ""
+msgstr "Sütunlar:"
 
 #: ../../src/wxMaximaFrame.cpp:1584
 msgid "Combine factorials in an expression"
-msgstr ""
+msgstr "Bir ifadedeki faktöriyelleri ortak paranteze alarak düzenle"
 
 #: ../../src/wxMaxima.cpp:10454
 msgid "Comma directly followed by a closing parenthesis"
-msgstr ""
+msgstr "Virgül kapatılan bir parantezden hemen sonra gelir"
 
 #: ../../src/wxMaxima.cpp:7259
+#, fuzzy
 msgid "Comma-separated arguments"
-msgstr ""
+msgstr "Virgülle ayrılmış ögeler"
 
 #: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
+#, fuzzy
 msgid "Comma-separated commands"
-msgstr ""
+msgstr "Virgülle ayrılmış ögeler"
 
 #: ../../src/wxMaxima.cpp:8458
 msgid "Comma-separated elements"
-msgstr ""
+msgstr "Virgülle ayrılmış ögeler"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 #: ../../src/wxMaxima.cpp:10031
 msgid "Comma-separated equations"
-msgstr ""
+msgstr "Virgülle ayrılmış denklemler"
 
 #: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
 #: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
 #: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
+#, fuzzy
 msgid "Comma-separated expressions"
-msgstr ""
+msgstr "Virgülle ayrılmış denklemler"
 
 #: ../../src/wxMaxima.cpp:7215
+#, fuzzy
 msgid "Comma-separated expressions that shall be converted to a string"
-msgstr ""
+msgstr "Virgülle ayrılmış denklemler"
 
 #: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
+#, fuzzy
 msgid "Comma-separated expressions."
-msgstr ""
+msgstr "Virgülle ayrılmış denklemler"
 
 #: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
+#, fuzzy
 msgid "Comma-separated function names"
-msgstr ""
+msgstr "Virgülle ayrılmış denklemler"
 
 #: ../../src/wxMaxima.cpp:7086
+#, fuzzy
 msgid "Comma-separated function names."
-msgstr ""
+msgstr "Virgülle ayrılmış denklemler"
 
 #: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
 #: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
@@ -1370,8 +1479,9 @@ msgid "Comma-separated names the parameters will be referenced by later."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
+#, fuzzy
 msgid "Comma-separated numbers from 0 to 255"
-msgstr ""
+msgstr "Virgülle ayrılmış değişkenler"
 
 #: ../../src/wxMaxima.cpp:8770
 msgid "Comma-separated numbers of the terms to substitute in"
@@ -1391,7 +1501,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8719 ../../src/wxMaxima.cpp:8785
 #: ../../src/wxMaxima.cpp:10032
 msgid "Comma-separated variables"
-msgstr ""
+msgstr "Virgülle ayrılmış değişkenler"
 
 #: ../../src/wxMaxima.cpp:9469
 msgid "Command:"
@@ -1399,15 +1509,15 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1692
 msgid "Comment Selection"
-msgstr ""
+msgstr "Yorum Seçimi"
 
 #: ../../src/wxMaximaFrame.cpp:681
 msgid "Comment out the currently selected text"
-msgstr ""
+msgstr "Seçili metni açıklama"
 
 #: ../../src/wxMaximaFrame.cpp:680
 msgid "Comment selection\tCtrl+/"
-msgstr ""
+msgstr "Yorum Seçimi\tCtrl+/"
 
 #: ../../src/Worksheet.cpp:2004
 msgid "Commutative function"
@@ -1418,12 +1528,14 @@ msgid "Compile a QR decomposition using dgeqrf"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7162
+#, fuzzy
 msgid "Compile a function"
-msgstr ""
+msgstr "Bir Fonksiyonu Sil"
 
 #: ../../src/wxMaximaFrame.cpp:1188
+#, fuzzy
 msgid "Compile a regular expression"
-msgstr ""
+msgstr "Bir Fonksiyonu Sil"
 
 #: ../../src/wxMaximaFrame.cpp:1385
 msgid "Compile eigenvalues using dgeev"
@@ -1442,21 +1554,23 @@ msgid "Compile eigenvalues+eigenvectors using zgeev"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1076
+#, fuzzy
 msgid "Compile function..."
-msgstr ""
+msgstr "Fonksiyonu Sil..."
 
 #: ../../src/wxMaxima.cpp:7511
+#, fuzzy
 msgid "Compile regex"
-msgstr ""
+msgstr "Kelimeyi tamamla"
 
 #: ../../src/wxMathml.cpp:53
 msgid "Compiler-Bug? wxMathml.lisp is shorter than expected!"
-msgstr ""
+msgstr "Derleyici-Hatası? wxMathml.lisp beklenenden daha kısa!"
 
 #: ../../src/wxMaxima.cpp:2234
 #, c-format
 msgid "Compiling %s"
-msgstr ""
+msgstr "%s ı derliyor"
 
 #: ../../src/wxMaxima.cpp:7163
 msgid ""
@@ -1466,322 +1580,348 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:892
+#, fuzzy
 msgid "Complete Word\tCtrl+Space"
-msgstr ""
+msgstr "Kelimeyi tamamla \tCtrl+K"
 
 #: ../../src/wxMaximaFrame.cpp:893
 msgid "Complete word"
-msgstr ""
+msgstr "Kelimeyi tamamla"
 
 #: ../../src/ToolBar.cpp:230
 msgid "Completely stop maxima and restart it"
-msgstr ""
+msgstr "Maxima'yı tamamen kapat ve yeniden başlat"
 
 #: ../../src/wxMaximaFrame.cpp:1503
 msgid "Compute continued fraction of a value"
-msgstr ""
+msgstr "Bir değerin sürekli kesirlerini hesapla"
 
 #: ../../src/wxMaximaFrame.cpp:1372
 msgid "Compute the adjoint matrix"
-msgstr ""
+msgstr "Ek (adjoint) Matrisi hesapla"
 
 #: ../../src/wxMaximaFrame.cpp:1359
 msgid "Compute the characteristic polynomial of a matrix"
-msgstr ""
+msgstr "Bir Matrisin karakteristik polinomunu hesapla"
 
 #: ../../src/wxMaximaFrame.cpp:1363
 msgid "Compute the determinant of a matrix"
-msgstr ""
+msgstr "Bir matrisin determinantını hesapla"
 
 #: ../../src/wxMaximaFrame.cpp:1491
 msgid "Compute the greatest common divisor"
-msgstr ""
+msgstr "OBEB i hesapla"
 
 #: ../../src/wxMaximaFrame.cpp:1356
 msgid "Compute the inverse of a matrix"
-msgstr ""
+msgstr "Bir matrisin tersini hesapla"
 
 #: ../../src/wxMaximaFrame.cpp:1494
 msgid "Compute the least common multiple (do load(functs) before using)"
-msgstr ""
+msgstr "OKEK hesapla (önce load(functs) paketini yükle)"
 
 #: ../../src/wxMaximaFrame.cpp:1374
+#, fuzzy
 msgid "Compute the rank of a matrix"
-msgstr ""
+msgstr "Bir matrisin determinantını hesapla"
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Condition:"
-msgstr ""
+msgstr "Şart:"
 
 #: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "Configure wxMaxima"
-msgstr ""
+msgstr "'wxMaxima'yı' yapılandır"
 
 #: ../../src/wxMaxima.cpp:2504
 msgid "Connection attempt, but connection failed."
-msgstr ""
+msgstr "Bağlantı denemesi, ancak bağlantı başarısız."
 
 #: ../../src/wxMaxima.cpp:2459
 msgid "Connection to Maxima lost."
-msgstr ""
+msgstr "Maxima bağlantısı kesildi."
 
 #: ../../src/wxMaxima.cpp:7921
+#, fuzzy
 msgid "Construct a fraction"
-msgstr ""
+msgstr "&Sürekli Kesirler"
 
 #: ../../src/wxMaximaFrame.cpp:1305
+#, fuzzy
 msgid "Construct fraction..."
-msgstr ""
+msgstr "&Sürekli Kesirler"
 
 #: ../../src/wxMaxima.cpp:7158
+#, fuzzy
 msgid "Contents:"
-msgstr ""
+msgstr "İçerik"
 
 #: ../../src/wxMaximaFrame.cpp:1877
 msgid "Context-sensitive &Help\tCtrl+?"
-msgstr ""
+msgstr "Bağlama-duyarlı Yardım &Help\tCtrl+?"
 
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Context-sensitive &Help\tF1"
-msgstr ""
+msgstr "Bağlama-duyarlı Yardım &Help\tF1"
 
 #: ../../src/wxMaximaFrame.cpp:1542
 msgid "Contract Logarithms"
-msgstr ""
+msgstr "Logaritmik ifadeyi kısalt"
 
 #: ../../src/wxMaximaFrame.cpp:1161
+#, fuzzy
 msgid "Conversions"
-msgstr ""
+msgstr "Kartezyen forma dönüştür"
 
 #: ../../src/wxMaximaFrame.cpp:1229
+#, fuzzy
 msgid "Convert"
-msgstr ""
+msgstr "Kartezyen forma dönüştür"
 
 #: ../../src/wxMaximaFrame.cpp:1230
+#, fuzzy
 msgid "Convert + Write to file"
-msgstr ""
+msgstr "Faktöriyellere dönüştür"
 
 #: ../../src/wxMaximaFrame.cpp:1434
+#, fuzzy
 msgid "Convert Column to list..."
-msgstr ""
+msgstr "Faktöriyellere dönüştür"
 
 #: ../../src/wxMaximaFrame.cpp:1430
+#, fuzzy
 msgid "Convert Row to list..."
-msgstr ""
+msgstr "Faktöriyellere dönüştür"
 
 #: ../../src/wxMaximaFrame.cpp:1044
+#, fuzzy
 msgid "Convert a command to maxima code"
-msgstr ""
+msgstr "Maxima'ya bir komut gönderme"
 
 #: ../../src/wxMaximaFrame.cpp:1321
+#, fuzzy
 msgid "Convert a list of lists to a matrix"
-msgstr ""
+msgstr "[[1,2],[3,4]] gibi bir diziye çevirir"
 
 #: ../../src/wxMaximaFrame.cpp:1574
 msgid "Convert binomials, beta and gamma function to factorials"
-msgstr ""
+msgstr "İkilileri, Beta Gama fonksiyonlarının faktöriyeline çevir"
 
 #: ../../src/wxMaximaFrame.cpp:1578
 msgid "Convert binomials, factorials and beta function to gamma function"
-msgstr ""
+msgstr "İkilileri, Beta Gama fonksiyonlarının faktöriyeline çevir"
 
 #: ../../src/wxMaximaFrame.cpp:1613
 msgid "Convert complex expression to polar form"
-msgstr ""
+msgstr "Karmaşık ifadeyi kutupsal forma çevir"
 
 #: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert complex expression to rect form"
-msgstr ""
+msgstr "Karmaşık ifadeyi kartezyen forma çevir"
 
 #: ../../src/wxMaximaFrame.cpp:1622
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
-msgstr ""
+msgstr "Sanal argümanın üstel fonksiyonunu trigonometrik olarak ifade et"
 
 #: ../../src/wxMaxima.cpp:7411
+#, fuzzy
 msgid "Convert string to lowercase"
-msgstr ""
+msgstr "Faktöriyellere dönüştür"
 
 #: ../../src/wxMaxima.cpp:7543
+#, fuzzy
 msgid "Convert string to matching regex"
-msgstr ""
+msgstr "Başlık 5 i Göster"
 
 #: ../../src/wxMaximaFrame.cpp:1543
 msgid "Convert sum of logarithms to logarithm of product"
-msgstr ""
+msgstr "Logaritmaların toplamını çarpımın logaritmasına dönüştür"
 
 #: ../../src/wxMaximaFrame.cpp:1573
 msgid "Convert to &Factorials"
-msgstr ""
+msgstr "Faktöriyellere dönüştür"
 
 #: ../../src/wxMaximaFrame.cpp:1577
 msgid "Convert to &Gamma"
-msgstr ""
+msgstr "Gama'ya dönüştür"
 
 #: ../../src/wxMaximaFrame.cpp:1612
 msgid "Convert to &Polarform"
-msgstr ""
+msgstr "Kutupsal forma dönüştür"
 
 #: ../../src/wxMaximaFrame.cpp:1609
 msgid "Convert to &Rectform"
-msgstr ""
+msgstr "Kartezyen forma dönüştür"
 
 #: ../../src/wxMaximaFrame.cpp:1166
+#, fuzzy
 msgid "Convert to downcase..."
-msgstr ""
+msgstr "Faktöriyellere dönüştür"
 
 #: ../../src/wxMaxima.cpp:7016
+#, fuzzy
 msgid "Convert to programming language"
-msgstr ""
+msgstr "Başlık 5 i Göster"
 
 #: ../../src/wxMaxima.cpp:7022
+#, fuzzy
 msgid "Convert to programming language file"
-msgstr ""
+msgstr "% i dilini ayarlamıyor"
 
 #: ../../src/wxMaximaFrame.cpp:1602
 msgid "Convert trigonometric expression to canonical quasilinear form"
-msgstr ""
+msgstr "Trigonometric ifadeyi kanonik yarı-doğrusal forma dönüştür"
 
 #: ../../src/wxMaximaFrame.cpp:1627
 msgid "Convert trigonometric functions to exponential form"
-msgstr ""
+msgstr "Trigonometric ifadeyi üstel forma dönüştür"
 
 #: ../../src/wxMaximaFrame.cpp:1762
 msgid "Converts a matrix to a list of lists"
-msgstr ""
+msgstr "Matris için iç içe geçmiş dizin"
 
 #: ../../src/wxMaximaFrame.cpp:1760
 msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
-msgstr ""
+msgstr "[[1,2],[3,4]] gibi bir diziye çevirir"
 
 #: ../../src/ToolBar.cpp:209 ../../src/Worksheet.cpp:1290
 #: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
 #: ../../src/Worksheet.cpp:1684
 msgid "Copy"
-msgstr ""
+msgstr "Kopyala"
 
 #: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
 #: ../../src/Worksheet.cpp:1514
 msgid "Copy Animation"
-msgstr ""
+msgstr "Animasyonu kopyala"
 
 #: ../../src/wxMaximaFrame.cpp:887
 msgid "Copy Previous Input\tCtrl+I"
-msgstr ""
+msgstr "Bir önceki girdiyi Kopyala\tCtrl+I"
 
 #: ../../src/wxMaximaFrame.cpp:890
 msgid "Copy Previous Output\tCtrl+U"
-msgstr ""
+msgstr "Bir önceki çıktıyı Kopyala\tCtrl+U"
 
 #: ../../src/wxMaxima.cpp:7992
+#, fuzzy
 msgid "Copy a matrix"
-msgstr ""
+msgstr "Resim olarak Kopyala"
 
 #: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
 #: ../../src/wxMaximaFrame.cpp:663
 msgid "Copy as EMF"
-msgstr ""
+msgstr "EMF olarak kopyala"
 
 #: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Copy as Image"
-msgstr ""
+msgstr "Resim olarak Kopyala"
 
 #: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
 #: ../../src/wxMaximaFrame.cpp:645
 msgid "Copy as LaTeX"
-msgstr ""
+msgstr "LaTeX metni olarak Kopyala"
 
 #: ../../src/wxMaximaFrame.cpp:648
 msgid "Copy as MathML"
-msgstr ""
+msgstr "MathML olarak kopyala"
 
 #: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
 msgid "Copy as MathML (e.g. to word processor)"
-msgstr ""
+msgstr "MathML olarak kopyala (örn. Word'e)"
 
 #: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
 #: ../../src/wxMaximaFrame.cpp:658
 msgid "Copy as RTF"
-msgstr ""
+msgstr "RTF olarak kopyala"
 
 #: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "Copy as SVG"
-msgstr ""
+msgstr "SVG olarak kopyala"
 
 #: ../../src/wxMaximaFrame.cpp:640
 msgid "Copy as Text\tCtrl+Shift+C"
-msgstr ""
+msgstr "Düz metin olarak Kopyala\tCtrl+Shift+C"
 
 #: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
 msgid "Copy as plain text"
-msgstr ""
+msgstr "Düz metin olarak kopyala"
 
 #: ../../src/wxMaxima.cpp:7576
+#, fuzzy
 msgid "Copy file"
-msgstr ""
+msgstr "Kopyala"
 
 #: ../../src/wxMaximaFrame.cpp:1214
+#, fuzzy
 msgid "Copy file..."
-msgstr ""
+msgstr "Çöz..."
 
 #: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
 #: ../../src/wxMaximaFrame.cpp:643
 msgid "Copy for Octave/Matlab"
-msgstr ""
+msgstr "Octave/Matlab için kopyala"
 
 #: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
 msgid "Copy selection"
-msgstr ""
+msgstr "Seçimi Kopyala"
 
 #: ../../src/wxMaximaFrame.cpp:664
 msgid "Copy selection from document as an Enhanced Metafile"
-msgstr ""
+msgstr "Seçili belgeden bir Geliştirilmiş Meta Dosyası (EMF) olarak kopyala"
 
 #: ../../src/wxMaximaFrame.cpp:656
 msgid "Copy selection from document as an SVG image"
-msgstr ""
+msgstr "Belgeden seçileni SVG resmi olarak kopyala"
 
 #: ../../src/wxMaximaFrame.cpp:653
 msgid "Copy selection from document as an image"
-msgstr ""
+msgstr "Belgeden seçileni resim olarak kopyala"
 
 #: ../../src/wxMaximaFrame.cpp:659
 msgid ""
 "Copy selection from document as rtf that a word processor might understand"
 msgstr ""
+"Belgeden seçileni kelime işlemcisi programın anlayacağı türden rtf olarak "
+"kopyala"
 
 #: ../../src/wxMaximaFrame.cpp:641
 msgid "Copy selection from document as text"
-msgstr ""
+msgstr "Belgeden seçileni metin olarak kopyala"
 
 #: ../../src/wxMaximaFrame.cpp:646
 msgid "Copy selection from document in LaTeX format"
-msgstr ""
+msgstr "LaTeX belgesinde seçileni kopyala"
 
 #: ../../src/wxMaximaFrame.cpp:644
 msgid "Copy selection from document in Matlab format"
-msgstr ""
+msgstr "Seçimi belgeden Matlab biçiminde kopyala"
 
 #: ../../src/wxMaximaFrame.cpp:649
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
+"MathML biçiminde olan bir belgede seçimin kopyalanmasını birçok kelime "
+"işlemci 2d denklemi olarak görüntüler"
 
 #: ../../src/wxMaxima.cpp:7403
+#, fuzzy
 msgid "Copy string"
-msgstr ""
+msgstr "Seçimi Kopyala"
 
 #: ../../src/wxMaximaFrame.cpp:1165
+#, fuzzy
 msgid "Copy string..."
-msgstr ""
+msgstr "Sonlandırılmamış dizin."
 
 #: ../../src/ToolBar.cpp:623
 msgid "Copy, Cut and Paste button"
-msgstr ""
+msgstr "Kopyala, Kes ve Yapıştır düğmesi"
 
 #: ../../src/WXMXformat.cpp:295
 msgid "Could not create the backup file during saving => aborting."
@@ -1798,74 +1938,83 @@ msgid ""
 "Could not map view of the file needed in order to send an interrupt signal "
 "to maxima."
 msgstr ""
+"Maxima'ya bir kesme sinyali göndermek için gerekli olan dosyanın görünümü "
+"haritalanamadı."
 
 #: ../../src/wxMaxima.cpp:2763 ../../src/wxMaxima.cpp:2805
 msgid "Could not send an interrupt signal to maxima."
-msgstr ""
+msgstr "Maxima'ya Durdur sinyali gönderilemedi."
 
 #: ../../src/WXMXformat.cpp:287
 msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1325
+#, fuzzy
 msgid "Create Matrix"
-msgstr ""
+msgstr "Matris oluştur"
 
 #: ../../src/wxMaximaFrame.cpp:1688
 msgid "Create a list"
-msgstr ""
+msgstr "Liste oluştur"
 
 #: ../../src/wxMaxima.cpp:8487
 msgid "Create a list as a storage for the values of variables"
 msgstr ""
+"Değişkenlerin değerleri için bir saklama alanı olarak bir liste oluştur"
 
 #: ../../src/wxMaxima.cpp:8463 ../../src/wxMaxima.cpp:8476
 msgid "Create a list from a rule"
-msgstr ""
+msgstr "Kuraldan liste oluştur"
 
 #: ../../src/wxMaximaFrame.cpp:1670
 msgid "Create a list from comma-separated elements"
-msgstr ""
+msgstr "Virgülle ayrılmış öğelerden bir liste oluştur"
 
 #: ../../src/wxMaximaFrame.cpp:888
 msgid "Create a new cell with previous input"
-msgstr ""
+msgstr "Bir önceki girdi ile yeni bir hücre oluştur"
 
 #: ../../src/wxMaximaFrame.cpp:891
 msgid "Create a new cell with previous output"
-msgstr ""
+msgstr "Bir önceki çıktı ile yeni bir hücre oluştur"
 
 #: ../../src/wxMaximaFrame.cpp:1348
 msgid "Create copy, not clone..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7561
+#, fuzzy
 msgid "Create directory"
-msgstr ""
+msgstr "Liste oluştur"
 
 #: ../../src/wxMaximaFrame.cpp:1203
+#, fuzzy
 msgid "Create directory..."
-msgstr ""
+msgstr "Liste oluştur"
 
 #: ../../src/wxMaxima.cpp:7419
+#, fuzzy
 msgid "Create empty string"
-msgstr ""
+msgstr "Matris oluştur"
 
 #: ../../src/wxMaximaFrame.cpp:1168
+#, fuzzy
 msgid "Create empty string..."
-msgstr ""
+msgstr "Liste oluştur"
 
 #: ../../src/wxMaximaFrame.cpp:1687
 msgid "Create list"
-msgstr ""
+msgstr "Liste oluştur"
 
 #: ../../src/wxMaxima.cpp:8457
 msgid "Create list from comma-separated elements"
-msgstr ""
+msgstr "Virgülle ayrılmış öğelerden  liste oluştur"
 
 #: ../../src/wxMaximaFrame.cpp:1082
+#, fuzzy
 msgid "Create struct..."
-msgstr ""
+msgstr "Liste oluştur"
 
 #: ../../src/WXMXformat.cpp:80
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
@@ -1876,28 +2025,29 @@ msgid "Creates an independent matrix with the same contents"
 msgstr ""
 
 #: ../../src/Configuration.cpp:97
+#, fuzzy
 msgid "Cursor color"
-msgstr ""
+msgstr "İmleç"
 
 #: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
 msgid "Cut"
-msgstr ""
+msgstr "Kes"
 
 #: ../../src/wxMaximaFrame.cpp:636
 msgid "Cut\tCtrl+X"
-msgstr ""
+msgstr "Kes\tCtrl+X"
 
 #: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
 msgid "Cut selection"
-msgstr ""
+msgstr "Seçimi kes"
 
 #: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
 msgid "Data Matrix:"
-msgstr ""
+msgstr "Veri Matrisi:"
 
 #: ../../src/wxMaxima.cpp:9599
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
-msgstr ""
+msgstr "Veri dosyası (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wxMaxima.cpp:9529 ../../src/wxMaxima.cpp:9534
 #: ../../src/wxMaxima.cpp:9539 ../../src/wxMaxima.cpp:9543
@@ -1906,7 +2056,7 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9563 ../../src/wxMaxima.cpp:9577
 #: ../../src/wxMaxima.cpp:9582 ../../src/wxMaxima.cpp:10030
 msgid "Data:"
-msgstr ""
+msgstr "Veri:"
 
 #: ../../src/wxMaximaFrame.cpp:1057
 msgid "Debugger trigger"
@@ -1930,8 +2080,9 @@ msgid "Declare facts about %s"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8800
+#, fuzzy
 msgid "Declare main variable:"
-msgstr ""
+msgstr "Bir Değişkeni Sil"
 
 #: ../../src/wxMaxima.cpp:7171
 msgid "Declare the type of a function parameter"
@@ -1943,15 +2094,17 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1500 ../../src/wxMaximaFrame.cpp:1536
 msgid "Decompose rational function to partial fractions"
-msgstr ""
+msgstr "Rasyonel fonksiyonu parçalı fonksiyonlara ayır"
 
 #: ../../src/Worksheet.cpp:2010
+#, fuzzy
 msgid "Decreasing function f(x)<x"
-msgstr ""
+msgstr "Fonksiyon(ları) Sil:"
 
 #: ../../src/wxMaxima.cpp:7134
+#, fuzzy
 msgid "Define a function"
-msgstr ""
+msgstr "Bir Fonksiyonu Sil"
 
 #: ../../src/wxMaxima.cpp:7147
 msgid "Define a macro"
@@ -1966,12 +2119,14 @@ msgid "Define a structure type"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7156
+#, fuzzy
 msgid "Define a variable"
-msgstr ""
+msgstr "Bir Değişkeni Sil"
 
 #: ../../src/wxMaximaFrame.cpp:1072
+#, fuzzy
 msgid "Define function..."
-msgstr ""
+msgstr "Fonksiyonu Sil..."
 
 #: ../../src/wxMaximaFrame.cpp:1079
 msgid "Define macro..."
@@ -1986,13 +2141,15 @@ msgid "Define struct..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1080
+#, fuzzy
 msgid "Define variable..."
-msgstr ""
+msgstr "Bir Değişkeni Sil"
 
 #: ../../src/wxMaximaFrame.cpp:1776
 msgid ""
 "Defines if an animation is automatically started or only by clicking on it."
 msgstr ""
+"Bir animasyonun otomatik olarak  veya tıklatılarak başlatılacağını tanımlar."
 
 #: ../../src/wxMaxima.cpp:8935
 msgid "Degree:"
@@ -2000,23 +2157,23 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:985
 msgid "Delete F&unction..."
-msgstr ""
+msgstr "Fonksiyonu Sil..."
 
 #: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
 msgid "Delete Selection"
-msgstr ""
+msgstr "Seçimi Sil"
 
 #: ../../src/wxMaximaFrame.cpp:987
 msgid "Delete V&ariable..."
-msgstr ""
+msgstr "Değişkeni Sil..."
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Delete a function"
-msgstr ""
+msgstr "Bir Fonksiyonu Sil"
 
 #: ../../src/wxMaximaFrame.cpp:988
 msgid "Delete a variable"
-msgstr ""
+msgstr "Bir Değişkeni Sil"
 
 #: ../../src/wxMaximaFrame.cpp:982
 msgid "Delete all objects with a given name"
@@ -2024,40 +2181,47 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:991
 msgid "Delete all values from memory"
-msgstr ""
+msgstr "Bellekteki Tüm Değerleri Sil"
 
 #: ../../src/wxMaxima.cpp:7588
+#, fuzzy
 msgid "Delete file"
-msgstr ""
+msgstr "Bir Değişkeni Sil"
 
 #: ../../src/wxMaximaFrame.cpp:1216
+#, fuzzy
 msgid "Delete file..."
-msgstr ""
+msgstr "Değişkeni Sil..."
 
 #: ../../src/wxMaxima.cpp:7683
+#, fuzzy
 msgid "Delete function(s)"
-msgstr ""
+msgstr "Fonksiyon(ları) Sil:"
 
 #: ../../src/wxMaxima.cpp:7679
+#, fuzzy
 msgid "Delete named object(s)"
-msgstr ""
+msgstr "Fonksiyon(ları) Sil:"
 
 #: ../../src/wxMaximaFrame.cpp:981
+#, fuzzy
 msgid "Delete named object..."
-msgstr ""
+msgstr "Fonksiyonu Sil..."
 
 #: ../../src/wxMaxima.cpp:7674
+#, fuzzy
 msgid "Delete variable(s)"
-msgstr ""
+msgstr "Değiken(leri) sil:"
 
 #: ../../src/wxMaxima.cpp:7430
+#, fuzzy
 msgid "Delimiter:"
-msgstr ""
+msgstr "Yok et"
 
 #: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
-#, c-format
+#, fuzzy, c-format
 msgid "Demo for \"%s\""
-msgstr ""
+msgstr "\"%s\" konusunda yardım"
 
 #: ../../src/wxMaximaFrame.cpp:1930
 msgid "Demos"
@@ -2065,7 +2229,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8927
 msgid "Denom. deg:"
-msgstr ""
+msgstr "Payda derecesi:"
 
 #: ../../src/wxMaxima.cpp:7923
 msgid "Denominator:"
@@ -2081,7 +2245,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1497
 msgid "Di&vide Polynomials..."
-msgstr ""
+msgstr "Polinomları Böl."
 
 #: ../../src/MaximaManual.cpp:517
 msgid "Didn't find the maxima HTML manual."
@@ -2095,35 +2259,38 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
 msgid "Differentiate"
-msgstr ""
+msgstr "Türevini al"
 
 #: ../../src/wxMaximaFrame.cpp:1467
 msgid "Differentiate expression"
-msgstr ""
+msgstr "İfadenin diferansiyelini al"
 
 #: ../../src/Worksheet.cpp:1590
 msgid "Differentiate..."
-msgstr ""
+msgstr "Türevini al..."
 
 #: ../../src/wxMaxima.cpp:9010
+#, fuzzy
 msgid "Differentiates an expression n times"
-msgstr ""
+msgstr "İfadenin diferansiyelini al"
 
 #: ../../src/wxMaxima.cpp:10055
+#, fuzzy
 msgid "Differentiates the expression n times"
-msgstr ""
+msgstr "İfadenin diferansiyelini al"
 
 #: ../../src/wxMaximaFrame.cpp:1212
+#, fuzzy
 msgid "Directory operations"
-msgstr ""
+msgstr "Uyarı:"
 
 #: ../../src/wxMaximaFrame.cpp:1041
 msgid "Display Te&X Form"
-msgstr ""
+msgstr "Te&X formatını göster"
 
 #: ../../src/wxMaxima.cpp:6972
 msgid "Display algorithm"
-msgstr ""
+msgstr "Algoritmayı Göster"
 
 #: ../../src/wxMaximaFrame.cpp:751
 msgid "Display an expression as maxima's internal lisp representation"
@@ -2135,7 +2302,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:758
 msgid "Display equations"
-msgstr ""
+msgstr "Eşitlikleri göster"
 
 #: ../../src/wxMaxima.cpp:6508
 msgid "Display expression in maxima's internal representation"
@@ -2147,32 +2314,34 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1042
 msgid "Display last result in TeX form"
-msgstr ""
+msgstr "Son sonucu TeX formunda göster"
 
 #: ../../src/ToolBar.cpp:360
-#, c-format
+#, fuzzy, c-format
 msgid "Display resolution according to wxWidgets: %li x %li ppi"
-msgstr ""
+msgstr "WxWidgets'e göre ekran çözünürlüğü:% i x% i ppi"
 
 #: ../../src/wxMaximaFrame.cpp:802
+#, fuzzy
 msgid "Display string quotation marks"
-msgstr ""
+msgstr "Eşitlikleri göster"
 
 #: ../../src/wxMaximaFrame.cpp:1036
 msgid "Display time used for evaluation"
-msgstr ""
+msgstr "Değerlendirme süresini göster"
 
 #: ../../src/wxMaxima.cpp:9206
 msgid "Displayed Precision"
-msgstr ""
+msgstr "Görüntülenen Hassasiyet"
 
 #: ../../src/wxMaximaFrame.cpp:1913
 msgid "Displaying 3d curves"
-msgstr ""
+msgstr "3B eğrileri görüntüleme"
 
 #: ../../src/wxMaximaFrame.cpp:1462
+#, fuzzy
 msgid "Dito, and evaluate the result..."
-msgstr ""
+msgstr "Kalan kısmı değerlendir"
 
 #: ../../src/wxMaximaFrame.cpp:1445
 msgid "Dito, but affect all clones of the Matrix..."
@@ -2188,20 +2357,20 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
 msgid "Divide Cell"
-msgstr ""
+msgstr "Hücreyi Böl"
 
 #: ../../src/wxMaximaFrame.cpp:1498
 msgid "Divide numbers or polynomials"
-msgstr ""
+msgstr "Sayıları yada polinomları böl"
 
 #: ../../src/wxMaxima.cpp:8578
 msgid "Do for each list element"
-msgstr ""
+msgstr "Her dizin ögesi için uygula"
 
 #: ../../src/wxMaxima.cpp:11197
 #, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
-msgstr ""
+msgstr "Belgede\"%s\" yaptığınız değişiklikleri kaydetmek istiyor musunuz?"
 
 #: ../../src/wxMaximaFrame.cpp:724
 msgid "Dock all Sidebars"
@@ -2209,35 +2378,42 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:94
 msgid "Document background"
-msgstr ""
+msgstr "Belge arkaplanı"
 
 #: ../../src/wxMaxima.cpp:4611
 msgid ""
 "Document was saved using a newer version of wxMaxima so it may not load "
 "correctly. Please update your wxMaxima."
 msgstr ""
+"'wxMaxima'nın' daha yeni bir sürümü ile kaydedildi. Bu yüzden doğru şekilde "
+"yüklenmeyebilir  Lütfen wxMaxima'yı güncelleyin."
 
 #: ../../src/wxMaxima.cpp:4603
 msgid ""
 "Document was saved using a newer version of wxMaxima. Please update your "
 "wxMaxima."
 msgstr ""
+"'wxMaxima'nın' daha yeni bir sürümü ile kaydedildi. Lütfen wxMaxima'yı "
+"güncelleyin."
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "Don't autosubscript after an underscore"
-msgstr ""
+msgstr "Alt çizgiden sonra otomatik olarak alt (indis) karakter yazmayın"
 
 #: ../../src/wxMaximaFrame.cpp:1086
+#, fuzzy
 msgid "Don't evaluate Expression..."
-msgstr ""
+msgstr "İfadenin İntegralini Al"
 
 #: ../../src/wxMaxima.cpp:7117
+#, fuzzy
 msgid "Don't evaluate one command"
-msgstr ""
+msgstr "'...:' Komutu için bir örnek Göster:"
 
 #: ../../src/wxMaxima.cpp:7129
+#, fuzzy
 msgid "Don't evaluate one whole expression"
-msgstr ""
+msgstr "KarmaşıkSayı bir ifadenin gerçek kısmını hesapla"
 
 #: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
 msgid "Don't mark cells that contain tooltips in yellow"
@@ -2249,51 +2425,56 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Don't save"
-msgstr ""
+msgstr "Kaydetme"
 
 #: ../../src/Worksheet.cpp:1620
 msgid "Don't show labels"
-msgstr ""
+msgstr "Etiketleri gizle"
 
 #: ../../src/Worksheet.cpp:1979
 msgid "Don't use if unassigned"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:797
+#, fuzzy
 msgid "Don't use parenthesis for matrices"
-msgstr ""
+msgstr "Matrisler için köşeli parantez kullanın"
 
 #: ../../src/wxMaxima.cpp:8525
+#, fuzzy
 msgid "Drop the first n list elements"
-msgstr ""
+msgstr "Her dizin ögesi için uygula"
 
 #: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
+#, fuzzy
 msgid "Drop the last n list elements"
-msgstr ""
+msgstr "'n' tane ögenin sonuncusu hariç hepsi"
 
 #: ../../src/wxMaximaFrame.cpp:1306
 msgid "E&quations"
-msgstr ""
+msgstr "&Denklemler"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "E&xit\tCtrl+Q"
-msgstr ""
+msgstr "&Çık\tCtrl+Q"
 
 #: ../../src/wxMaximaFrame.cpp:1368
 msgid "Eige&nvectors"
-msgstr ""
+msgstr "Özvektörler"
 
 #: ../../src/wxMaximaFrame.cpp:1365
 msgid "Eigen&values"
-msgstr ""
+msgstr "Özdeğerler"
 
 #: ../../src/wxMaximaFrame.cpp:1387
+#, fuzzy
 msgid "Eigenvalues (complex)"
-msgstr ""
+msgstr "Özdeğerler"
 
 #: ../../src/wxMaximaFrame.cpp:1384
+#, fuzzy
 msgid "Eigenvalues (real)"
-msgstr ""
+msgstr "Özdeğerler"
 
 #: ../../src/wxMaximaFrame.cpp:1393
 msgid "Eigenvalues, left+right eigenvectors (complex)"
@@ -2309,14 +2490,17 @@ msgid ""
 "parenthesis. In the latter case the result of the last expression in the "
 "parenthesis is used."
 msgstr ""
+"Bir parantez içinde tek bir ifade yada virgülle ayrılmış birçok ifade. "
+"Parantez içindeki son virgülden sonraki işlem kullanılır."
 
 #: ../../src/wxMaxima.cpp:8593
 msgid "Element"
-msgstr ""
+msgstr "Öge"
 
 #: ../../src/wxMaxima.cpp:8549
+#, fuzzy
 msgid "Element number"
-msgstr ""
+msgstr "öge numarası n"
 
 #: ../../src/wxMaxima.cpp:8005
 msgid ""
@@ -2333,19 +2517,21 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8510
 msgid "Element:"
-msgstr ""
+msgstr "Öge:"
 
 #: ../../src/wxMaxima.cpp:7204
+#, fuzzy
 msgid "Elements:"
-msgstr ""
+msgstr "Öge:"
 
 #: ../../src/wxMaxima.cpp:7847
+#, fuzzy
 msgid "Eliminate a variable"
-msgstr ""
+msgstr "&Değişkeni yok et..."
 
 #: ../../src/wxMaximaFrame.cpp:1247
 msgid "Eliminate a variable from a system of equations"
-msgstr ""
+msgstr "Bir denklem sisteminde bir değişkeni (sadeleştirerek) yok et"
 
 #: ../../src/wxMaxima.cpp:10651
 msgid "Empty command => re-triggering evaluation"
@@ -2353,60 +2539,63 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9225
 msgid "Enable:"
-msgstr ""
+msgstr "Etkinleştirme:"
 
 #: ../../src/MathParser.cpp:99
-#, c-format
+#, fuzzy, c-format
 msgid "Encountered an unknown XML tag: <%s>"
-msgstr ""
+msgstr "Bilinmeyen bir soket olayıyla karşılaştı."
 
 #: ../../src/wxMaxima.cpp:2476
 msgid "Encountered an unknown socket event."
-msgstr ""
+msgstr "Bilinmeyen bir soket olayıyla karşılaştı."
 
 #: ../../src/wxMaxima.cpp:7843
+#, fuzzy
 msgid "End of t:"
-msgstr ""
+msgstr "İspat ın sonu"
 
 #: ../../src/wxMaxima.cpp:4097
 msgid "Ended lisp mode after receiving a maxima prompt!"
-msgstr ""
+msgstr "Bir maxima istemi aldıktan sonra lisp modu sona erdi!"
 
 #: ../../src/wxMaximaFrame.cpp:1828
 msgid "Engineering format (12.1e6 etc.)"
-msgstr ""
+msgstr "Mühendislik formatı (12.1e6 vb.)"
 
 #: ../../src/wxMaximaFrame.cpp:1319
 msgid "Enter a matrix"
-msgstr ""
+msgstr "Bir Matris Girin"
 
 #: ../../src/wxMaxima.cpp:8866
 msgid "Enter an equation for rational simplification:"
-msgstr ""
+msgstr "Rasyonel sadeleştirilmek üzere bir denklem girin:"
 
 #: ../../src/wxMaxima.cpp:8169
 msgid "Enter matrix"
-msgstr ""
+msgstr "Matris Oluşturun"
 
 #: ../../src/wxMaxima.cpp:9095
 msgid "Enter new animation frame rate [Hz, integer]:"
-msgstr ""
+msgstr "Yeni bir animasyon çerçeve oranı gir [Hz, tamsayı]"
 
 #: ../../src/wxMaxima.cpp:9201
 msgid "Enter new precision for bigfloats:"
-msgstr ""
+msgstr "Yeni ondalık-hassasiyeti belirleyin:"
 
 #: ../../src/wxMaxima.cpp:7922
+#, fuzzy
 msgid "Enumerator:"
-msgstr ""
+msgstr "Yineleyici:"
 
 #: ../../src/wxMaximaFrame.cpp:1220
+#, fuzzy
 msgid "Environment variables"
-msgstr ""
+msgstr "Maxima için ek parametreler"
 
 #: ../../src/wxMaxima.cpp:9045
 msgid "Epsilon:"
-msgstr ""
+msgstr "Epsilon:"
 
 #: ../../src/wxMaximaFrame.cpp:1124 ../../src/wxMaximaFrame.cpp:1135
 msgid "Equal, ignoring case?..."
@@ -2418,21 +2607,22 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8561
 msgid "Equation"
-msgstr ""
+msgstr "Denklem"
 
 #: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
+#, fuzzy
 msgid "Equation(s)"
-msgstr ""
+msgstr "Denklem(ler):"
 
 #: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
 msgid "Equation(s):"
-msgstr ""
+msgstr "Denklem(ler):"
 
 #: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
 #: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
 #: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
 msgid "Equation:"
-msgstr ""
+msgstr "Denklem:"
 
 #: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
 #: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
@@ -2444,40 +2634,40 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
 #: ../../src/wxMaxima.cpp:11166
 msgid "Error"
-msgstr ""
+msgstr "HATA"
 
 #: ../../src/wxMaxima.cpp:2456
 msgid "Error writing to Maxima"
-msgstr ""
+msgstr "Maxima'ya yazma hatası"
 
 #: ../../src/wxMaxima.cpp:6164 ../../src/wxMaxima.cpp:6176
 #: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
 #: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
 msgid "Error!"
-msgstr ""
+msgstr "HATA!"
 
 #: ../../src/Image.cpp:696
 #, c-format
 msgid "Error: Cannot render %s."
-msgstr ""
+msgstr "Hata:% s oluşturulamıyor."
 
 #: ../../src/Image.cpp:699
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Error: Cannot render %s:\n"
 "%s"
-msgstr ""
+msgstr "Hata:% s oluşturulamıyor."
 
 #: ../../src/Image.cpp:704
 msgid "Error: Cannot render the image."
-msgstr ""
+msgstr "Hata: resim oluşturulamıyor."
 
 #: ../../src/Image.cpp:706
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Error: Cannot render the image:\n"
 "%s"
-msgstr ""
+msgstr "Hata: resim oluşturulamıyor."
 
 #: ../../src/wxMaxima.cpp:7544
 msgid ""
@@ -2486,129 +2676,135 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1652
+#, fuzzy
 msgid "Evaluate &Noun Forms..."
-msgstr ""
+msgstr "&İsim Formlarını Değerlendir"
 
 #: ../../src/wxMaximaFrame.cpp:856
 msgid "Evaluate All Cells\tCtrl+Shift+R"
-msgstr ""
+msgstr "Bütün Hücreleri Değerlendir \tCtrl+R"
 
 #: ../../src/wxMaximaFrame.cpp:851
 msgid "Evaluate All Visible Cells\tCtrl+R"
-msgstr ""
+msgstr "Görünen bütün hücreleri Değerlendir \tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1395
+#, fuzzy
 msgid "Evaluate Cell"
-msgstr ""
+msgstr "Hücre(leri) Değerlendir"
 
 #: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
 msgid "Evaluate Cell(s)"
-msgstr ""
+msgstr "Hücre(leri) Değerlendir"
 
 #: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
 msgid "Evaluate Cells Above"
-msgstr ""
+msgstr "Üstteki Hücreleri Değerlendir"
 
 #: ../../src/wxMaximaFrame.cpp:866
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
-msgstr ""
+msgstr "Üstteki Hücreleri Değerlendir \tCtrl+Shift+P"
 
 #: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
 #: ../../src/wxMaximaFrame.cpp:876
 msgid "Evaluate Cells Below"
-msgstr ""
+msgstr "Aşağıdaki Hücreleri Değerlendir"
 
 #: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
 #: ../../src/Worksheet.cpp:1890
 msgid "Evaluate Heading 5\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Başlık  5 i değerlendir\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1457 ../../src/Worksheet.cpp:1761
 #: ../../src/Worksheet.cpp:1901
 msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Başlık 6 yı değerlendir\tShift+Ctrl+Enter"
 
 #: ../../src/wxMaxima.cpp:8626
+#, fuzzy
 msgid "Evaluate Nouns"
-msgstr ""
+msgstr "&İsim Formlarını Değerlendir"
 
 #: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
 msgid "Evaluate Part\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Kısmı Değerlendir\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1431 ../../src/Worksheet.cpp:1741
 msgid "Evaluate Section\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Seçimi Değerlendir\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1445 ../../src/Worksheet.cpp:1751
 #: ../../src/Worksheet.cpp:1879
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Alt+Alt kısmı değerlendir \tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1438 ../../src/Worksheet.cpp:1746
 #: ../../src/Worksheet.cpp:1868
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Alt kısmı Değerlendir\\tShift+Ctrl+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:845
 msgid "Evaluate active or selected cell(s)"
-msgstr ""
+msgstr "Aktif yada seçilmiş hücreleri değerlendir"
 
 #: ../../src/ToolBar.cpp:251
 msgid "Evaluate all"
-msgstr ""
+msgstr "Tümünü değerlendir"
 
 #: ../../src/wxMaximaFrame.cpp:857
 msgid "Evaluate all cells in the document"
-msgstr ""
+msgstr "Belgedeki tüm hücreleri değerlendir"
 
 #: ../../src/wxMaximaFrame.cpp:1653
 msgid "Evaluate all noun forms in expression"
-msgstr ""
+msgstr "İfadedeki bütün isim formlarını değerlendir"
 
 #: ../../src/wxMaximaFrame.cpp:852
 msgid "Evaluate all visible cells in the document"
-msgstr ""
+msgstr "Belgedeki Görünen bütün hücreleri değerlendir"
 
 #: ../../src/ToolBar.cpp:248
 msgid "Evaluate current cell"
-msgstr ""
+msgstr "Mevcut hücreyi değerlendirin"
 
 #: ../../src/wxMaxima.cpp:7395
+#, fuzzy
 msgid "Evaluate string"
-msgstr ""
+msgstr "Noktaya Değerlendir"
 
 #: ../../src/wxMaximaFrame.cpp:1151
+#, fuzzy
 msgid "Evaluate string..."
-msgstr ""
+msgstr "Noktaya Değerlendir"
 
 #: ../../src/ToolBar.cpp:256
 msgid "Evaluate the file from its beginning to the cell above the cursor"
-msgstr ""
+msgstr "Dosyayı başlangıcından imlecin üstündeki hücreye kadar değerlendir"
 
 #: ../../src/ToolBar.cpp:259
 msgid "Evaluate the file from the cursor to its end"
-msgstr ""
+msgstr "Dosyayı imlecin sonuna kadar değerlendirin"
 
 #: ../../src/ToolBar.cpp:258
 msgid "Evaluate the rest"
-msgstr ""
+msgstr "Kalan kısmı değerlendir"
 
 #: ../../src/ToolBar.cpp:255
 msgid "Evaluate to point"
-msgstr ""
+msgstr "Noktaya Değerlendir"
 
 #: ../../src/wxMaxima.cpp:10518
 msgid "Evaluation ended, since evaluation queue is empty."
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1957
+#, fuzzy
 msgid "Even number"
-msgstr ""
+msgstr "öge numarası n"
 
 #: ../../src/wxMaximaFrame.cpp:1703
 msgid "Execute a command for each element of the list"
-msgstr ""
+msgstr "Listenin her öğesi için bir komut yürütün"
 
 #: ../../src/main.cpp:438
 msgid "Exit"
@@ -2616,35 +2812,38 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "Exit wxMaxima"
-msgstr ""
+msgstr "'wxMaxima'dan çık"
 
 #: ../../src/Worksheet.cpp:1583
 msgid "Expand Expression"
-msgstr ""
+msgstr "İfadeyi Genişlet"
 
 #: ../../src/wxMaximaFrame.cpp:1525
 msgid "Expand an expression"
-msgstr ""
+msgstr "Bir ifadeyi genişlet"
 
 #: ../../src/wxMaximaFrame.cpp:1531
+#, fuzzy
 msgid "Expand for given variables"
-msgstr ""
+msgstr "Değişkeni değiştir"
 
 #: ../../src/wxMaxima.cpp:8781
 msgid "Expand for variable(s) including denominator:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8716
+#, fuzzy
 msgid "Expand for variable(s):"
-msgstr ""
+msgstr "Dizin değişkeni:"
 
 #: ../../src/wxMaximaFrame.cpp:1545
+#, fuzzy
 msgid "Expand log in previous expression"
-msgstr ""
+msgstr "Bir ifadeyi genişlet"
 
 #: ../../src/wxMaximaFrame.cpp:1598
 msgid "Expand trigonometric expression"
-msgstr ""
+msgstr "Trigonometrik ifadeyi genişlet"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Expect numbers harder to be complex"
@@ -2656,62 +2855,68 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6121
 msgid "Export"
-msgstr ""
+msgstr "Çıkart"
 
 #: ../../src/wxMaximaFrame.cpp:1705
+#, fuzzy
 msgid "Export List to csv file..."
-msgstr ""
+msgstr "TeX formatına dönüştürme işlemi başarılamadı!"
 
 #: ../../src/wxMaximaFrame.cpp:1706
+#, fuzzy
 msgid "Export a list to a csv file"
-msgstr ""
+msgstr "Bir Maxima dosyasını yükle"
 
 #: ../../src/wxMaximaFrame.cpp:1332
+#, fuzzy
 msgid "Export a matrix to a csv file"
-msgstr ""
+msgstr "Bir Maxima dosyasını yükle"
 
 #: ../../src/wxMaximaFrame.cpp:619
+#, fuzzy
 msgid "Export document to a HTML or LaTeX file"
-msgstr ""
+msgstr "Belgeyi HTML yada pdfLaTeX olarak çıkart"
 
 #: ../../src/wxMaximaFrame.cpp:579
 msgid "Export failed."
-msgstr ""
+msgstr "Çıkarım başarısız."
 
 #: ../../src/wxMaximaFrame.cpp:567
 msgid "Export successful."
-msgstr ""
+msgstr "Çıkarım başarılı."
 
 #: ../../src/wxMaxima.cpp:6187
 msgid "Exporting to HTML failed!"
-msgstr ""
+msgstr "HTML formatına dönüştürme işlemi başarılamadı!"
 
 #: ../../src/wxMaxima.cpp:6164
 msgid "Exporting to TeX failed!"
-msgstr ""
+msgstr "TeX formatına dönüştürme işlemi başarılamadı!"
 
 #: ../../src/wxMaxima.cpp:6175
 msgid "Exporting to maxima batch file failed!"
-msgstr ""
+msgstr "Maxima Kütük Dosyası olarak çıkarım başarısız!"
 
 #: ../../src/wxMaximaFrame.cpp:561
 msgid "Exporting..."
-msgstr ""
+msgstr "Çıkarılıyor..."
 
 #: ../../src/wxMaxima.cpp:6510 ../../src/wxMaxima.cpp:6516
 #: ../../src/wxMaxima.cpp:8218 ../../src/wxMaxima.cpp:8633
 #: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
 #: ../../src/wxMaxima.cpp:10065
 msgid "Expression"
-msgstr ""
+msgstr "İfade"
 
 #: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
+#, fuzzy
 msgid "Expression or a list of comma-separated expressions"
-msgstr ""
+msgstr "Virgülle ayrılmış öğelerden bir liste oluştur"
 
 #: ../../src/wxMaximaFrame.cpp:1088
+#, fuzzy
 msgid "Expression to string..."
-msgstr ""
+msgstr "Çizimi yapılacak olan İfade"
 
 #: ../../src/wxMaxima.cpp:7113
 msgid "Expression whose output is to be used as maxima's input."
@@ -2719,7 +2924,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7214
 msgid "Expression(s):"
-msgstr ""
+msgstr "İfade(ler):"
 
 #: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
 #: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
@@ -2728,87 +2933,102 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
 #: ../../src/wxMaxima.cpp:10056
 msgid "Expression:"
-msgstr ""
+msgstr "İfade:"
 
 #: ../../src/wxMaximaFrame.cpp:1423
+#, fuzzy
 msgid "Extract Column..."
-msgstr ""
+msgstr "Ögeleri ayıkla"
 
 #: ../../src/wxMaximaFrame.cpp:1726
 msgid "Extract Elements"
-msgstr ""
+msgstr "Ögeleri ayıkla"
 
 #: ../../src/wxMaximaFrame.cpp:1421
+#, fuzzy
 msgid "Extract Row..."
-msgstr ""
+msgstr "Ögeleri ayıkla"
 
 #: ../../src/wxMaximaFrame.cpp:1424
+#, fuzzy
 msgid "Extract a column from the matrix"
-msgstr ""
+msgstr "Bir değişken için gerçek bir değer ayıkla"
 
 #: ../../src/wxMaximaFrame.cpp:1435
+#, fuzzy
 msgid "Extract a column from the matrix and convert it to a list"
-msgstr ""
+msgstr "Listede atanan bir değişkenin değerini çıkarın"
 
 #: ../../src/wxMaxima.cpp:7960
+#, fuzzy
 msgid "Extract a matrix column"
-msgstr ""
+msgstr "Bir Matris Girin"
 
 #: ../../src/wxMaxima.cpp:7970
+#, fuzzy
 msgid "Extract a matrix column as a list"
-msgstr ""
+msgstr "Bir Matris Girin"
 
 #: ../../src/wxMaximaFrame.cpp:1313
+#, fuzzy
 msgid "Extract a matrix from a 2-dimensional array"
-msgstr ""
+msgstr "2B dizinden matris oluştur"
 
 #: ../../src/wxMaxima.cpp:7955
+#, fuzzy
 msgid "Extract a matrix row"
-msgstr ""
+msgstr "Bir Matris Girin"
 
 #: ../../src/wxMaxima.cpp:7965
+#, fuzzy
 msgid "Extract a matrix row as a list"
-msgstr ""
+msgstr "Bir Matris Girin"
 
 #: ../../src/wxMaximaFrame.cpp:1422
 msgid "Extract a row from the matrix"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1431
+#, fuzzy
 msgid "Extract a row from the matrix and convert it to a list"
-msgstr ""
+msgstr "Listeden son n elemanlarını ayıklayın"
 
 #: ../../src/wxMaxima.cpp:8564
 msgid "Extract a variable's value from a list of variable values"
-msgstr ""
+msgstr "Değişken değerlerin bir listesinden bir değişkenin değerini çıkarın"
 
 #: ../../src/wxMaximaFrame.cpp:1723
 msgid "Extract an actual value for a variable"
-msgstr ""
+msgstr "Bir değişken için gerçek bir değer ayıkla"
 
 #: ../../src/wxMaximaFrame.cpp:1163
+#, fuzzy
 msgid "Extract char..."
-msgstr ""
+msgstr "Ögeleri ayıkla"
 
 #: ../../src/wxMaximaFrame.cpp:1207
+#, fuzzy
 msgid "Extract dir from path..."
-msgstr ""
+msgstr "Ögeleri ayıkla"
 
 #: ../../src/wxMaxima.cpp:7605
+#, fuzzy
 msgid "Extract directory part"
-msgstr ""
+msgstr "Fonksiyon argümanlarını ayıkla"
 
 #: ../../src/wxMaxima.cpp:7617
+#, fuzzy
 msgid "Extract file type extension"
-msgstr ""
+msgstr "Dizi elemanlarını ayıkla"
 
 #: ../../src/wxMaximaFrame.cpp:1209
 msgid "Extract filename from path..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7611
+#, fuzzy
 msgid "Extract filename part"
-msgstr ""
+msgstr "Ögeleri ayıkla"
 
 #: ../../src/wxMaximaFrame.cpp:1211
 msgid "Extract filetype from path..."
@@ -2816,81 +3036,87 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8445
 msgid "Extract function arguments"
-msgstr ""
+msgstr "Fonksiyon argümanlarını ayıkla"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "Extract list Elements"
-msgstr ""
+msgstr "Dizi elemanlarını ayıkla"
 
 #: ../../src/wxMaxima.cpp:8187
+#, fuzzy
 msgid "Extract matrix from 2D array"
-msgstr ""
+msgstr "Bir Matris Girin"
 
 #: ../../src/wxMaximaFrame.cpp:1686
 msgid "Extract the argument list from a function call"
-msgstr ""
+msgstr "Bir fonksiyon çağrısından bağımsız değişken listesini ayıklayın"
 
 #: ../../src/wxMaxima.cpp:8538
 msgid "Extract the last n elements from a list"
-msgstr ""
+msgstr "Listeden son n elemanlarını ayıklayın"
 
 #: ../../src/wxMaxima.cpp:7376
+#, fuzzy
 msgid "Extract the nth char of a string"
-msgstr ""
+msgstr "Dizi elemanlarını ayıkla"
 
 #: ../../src/wxMaxima.cpp:8544
+#, fuzzy
 msgid "Extract the nth list elements"
-msgstr ""
+msgstr "Dizi elemanlarını ayıkla"
 
 #: ../../src/wxMaximaFrame.cpp:1724
 msgid "Extract the value for one variable assigned in a list"
-msgstr ""
+msgstr "Listede atanan bir değişkenin değerini çıkarın"
 
 #: ../../src/wxMaximaFrame.cpp:1439
 msgid "Extract, append or delete rows or columns"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8188
+#, fuzzy
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
-msgstr ""
+msgstr "Listeden son n elemanlarını ayıklayın"
 
 #: ../../src/wxMaximaFrame.cpp:1521
 msgid "Factor Complex"
-msgstr ""
+msgstr "KarmaşıkSayı Çarpanları"
 
 #: ../../src/Worksheet.cpp:1581
 msgid "Factor Expression"
-msgstr ""
+msgstr "İfadeyi çarpanlarına ayır"
 
 #: ../../src/wxMaximaFrame.cpp:1519
+#, fuzzy
 msgid "Factor Expression including subexpressions"
-msgstr ""
+msgstr "Gauss sayıları şeklindeki bir ifadeyi çarpanlarına ayır"
 
 #: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
 msgid "Factor an expression"
-msgstr ""
+msgstr "Bir İfadeyi çarpanlarına ayır"
 
 #: ../../src/wxMaximaFrame.cpp:1522
 msgid "Factor an expression in Gaussian numbers"
-msgstr ""
+msgstr "Gauss sayıları şeklindeki bir ifadeyi çarpanlarına ayır"
 
 #: ../../src/wxMaximaFrame.cpp:1587
 msgid "Factorials and &Gamma"
-msgstr ""
+msgstr "Faktöriyeller ve &Gamma"
 
 #: ../../src/Image.cpp:137
-#, c-format
+#, fuzzy, c-format
 msgid "Failed to delete gnuplot data file %s"
-msgstr ""
+msgstr "%s  gnuplot dosyasını silmeye çalışılıyor"
 
 #: ../../src/Image.cpp:121 ../../src/Image.cpp:128
-#, c-format
+#, fuzzy, c-format
 msgid "Failed to delete gnuplot file %s"
-msgstr ""
+msgstr "%s  gnuplot dosyasını silmeye çalışılıyor"
 
 #: ../../src/wxMaxima.cpp:2667
+#, fuzzy
 msgid "Failed to start Maxima"
-msgstr ""
+msgstr "Maxima'yı Yeniden Başlat"
 
 #: ../../src/wxMaximaFrame.cpp:1418
 msgid "Fast fortran routines that perform numerical tasks"
@@ -2898,19 +3124,21 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1922
 msgid "Fast list access"
-msgstr ""
+msgstr "Hızlı liste erişimi"
 
 #: ../../src/wxMaxima.cpp:2553
 msgid "Fatal error"
-msgstr ""
+msgstr "Ölümcül Hata"
 
 #: ../../src/wxMaxima.cpp:7191
+#, fuzzy
 msgid "Field contents:"
-msgstr ""
+msgstr "İçerikleri gizle"
 
 #: ../../src/wxMaxima.cpp:7198
+#, fuzzy
 msgid "Field name:"
-msgstr ""
+msgstr "Değişken adı"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "Fields:"
@@ -2918,71 +3146,76 @@ msgstr ""
 
 #: ../../src/main.cpp:439
 msgid "File"
-msgstr ""
+msgstr "Dosya"
 
 #: ../../src/wxMaximaFrame.cpp:1333
+#, fuzzy
 msgid "File I/O"
-msgstr ""
+msgstr "Dosya"
 
 #: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
 #: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
 #: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
 #: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
 msgid "File could not be opened"
-msgstr ""
+msgstr "Dosya açılamadı"
 
 #: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
 #: ../../src/wxMaxima.cpp:7251
+#, fuzzy
 msgid "File name:"
-msgstr ""
+msgstr "Değişken adı"
 
 #: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
 msgid "File not found"
-msgstr ""
+msgstr "Dosya bulunamadı"
 
 #: ../../src/wxMaxima.cpp:5631
 msgid "File opened"
-msgstr ""
+msgstr "Dosya açıldı"
 
 #: ../../src/wxMaximaFrame.cpp:1217
+#, fuzzy
 msgid "File operations"
-msgstr ""
+msgstr "Dosya açıldı"
 
 #: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
 msgid "File you tried to open does not exist."
-msgstr ""
+msgstr "Açmaya çalıştığınız dosya yok."
 
 #: ../../src/wxMaximaFrame.cpp:1221
+#, fuzzy
 msgid "File/directory functions"
-msgstr ""
+msgstr "Uyarı:"
 
 #: ../../src/wxMaxima.cpp:7027
+#, fuzzy
 msgid "Filename or a list of comma-separated file names"
-msgstr ""
+msgstr "Virgülle ayrılmış öğelerden bir liste oluştur"
 
 #: ../../src/ToolBar.cpp:222
 msgid "Find"
-msgstr ""
+msgstr "Bul"
 
 #: ../../src/wxMaximaFrame.cpp:670
 msgid "Find\tCtrl+F"
-msgstr ""
+msgstr "Bul\tCtrl+F"
 
 #: ../../src/wxMaximaFrame.cpp:1468
 msgid "Find &Limit..."
-msgstr ""
+msgstr "Limit&Hesapla."
 
 #: ../../src/wxMaximaFrame.cpp:1470
 msgid "Find Minimum..."
-msgstr ""
+msgstr "Minimumu hesapla..."
 
 #: ../../src/Worksheet.cpp:1576
 msgid "Find Root..."
-msgstr ""
+msgstr "Kökünü bul..."
 
 #: ../../src/wxMaximaFrame.cpp:1471
 msgid "Find a (unconstrained) minimum of an expression"
-msgstr ""
+msgstr "Bir ifadenin (sıkıştırılmamış) minimumunu bul"
 
 #: ../../src/wxMaximaFrame.cpp:1804
 msgid "Find a fraction that represents this float exactly"
@@ -2990,35 +3223,36 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1469
 msgid "Find a limit of an expression"
-msgstr ""
+msgstr "Bir ifadenin bir limitini bul"
 
 #: ../../src/wxMaximaFrame.cpp:1807
 msgid "Find a nice fraction that is similar to this float"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1283
+#, fuzzy
 msgid "Find a numerical solution for a first degree ODE"
-msgstr ""
+msgstr "Birinci derece ADD için Başlangıç Değer Problemini Çöz"
 
 #: ../../src/wxMaximaFrame.cpp:1252
 msgid "Find a root of an equation on an interval"
-msgstr ""
+msgstr "Bir denklemin bir aralıkta bir kökünü bul"
 
 #: ../../src/wxMaximaFrame.cpp:1259
 msgid "Find all roots of a polynomial"
-msgstr ""
+msgstr "Polinomun bütün köklerini bul"
 
 #: ../../src/wxMaximaFrame.cpp:1262
 msgid "Find all roots of a polynomial (bfloat)"
-msgstr ""
+msgstr "(Büyük kayan sayı) polinomun bütün köklerini bul"
 
 #: ../../src/wxMaxima.cpp:6589
 msgid "Find and Replace"
-msgstr ""
+msgstr "Bul ve yerleştir"
 
 #: ../../src/ToolBar.cpp:222 ../../src/wxMaximaFrame.cpp:670
 msgid "Find and replace"
-msgstr ""
+msgstr "Bul ve yerleştir"
 
 #: ../../src/wxMaxima.cpp:7434
 msgid "Find char in string"
@@ -3034,11 +3268,11 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1366
 msgid "Find eigenvalues of a matrix"
-msgstr ""
+msgstr "Bir matrisini özdeğerlerini bul"
 
 #: ../../src/wxMaximaFrame.cpp:1369
 msgid "Find eigenvectors of a matrix"
-msgstr ""
+msgstr "Bir matrisini özvektörlerini bul"
 
 #: ../../src/wxMaxima.cpp:7424
 msgid "Find first difference"
@@ -3049,12 +3283,13 @@ msgid "Find first difference..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1256
+#, fuzzy
 msgid "Find fractions that real roots of a polynomial and "
-msgstr ""
+msgstr "Polinomun gerçel köklerini bul"
 
 #: ../../src/wxMaxima.cpp:9039
 msgid "Find minimum"
-msgstr ""
+msgstr "Minimum hesapla"
 
 #: ../../src/wxMaximaFrame.cpp:1251
 msgid "Find numerical solution..."
@@ -3065,8 +3300,9 @@ msgid "Find root (solve numerically)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
+#, fuzzy
 msgid "Find the maximum absolute value of a matrix entry"
-msgstr ""
+msgstr "Bir matrisini özdeğerlerini bul"
 
 #: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
 msgid "Find the maximum sum of the absolute values of a matrix column"
@@ -3078,15 +3314,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1832
 msgid "Fine-tune the display of engineering-format numbers"
-msgstr ""
+msgstr "Mühendislik formatı numaralarının görüntüsüne ince ayar yapın"
 
 #: ../../src/wxMaximaFrame.cpp:1712
 msgid "First"
-msgstr ""
+msgstr "İlk"
 
 #: ../../src/wxMaximaFrame.cpp:1918
 msgid "Fitting curves to measurement data"
-msgstr ""
+msgstr "Ölçüm verilerine eğrilerin yerleştirilmesi"
 
 #: ../../src/wxMaxima.cpp:7227
 msgid "Flush stream"
@@ -3098,15 +3334,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:922
 msgid "Fold All\tCtrl+Alt+["
-msgstr ""
+msgstr "Hepsini Klasörle\tCtrl+A-["
 
 #: ../../src/wxMaximaFrame.cpp:923
 msgid "Fold all sections"
-msgstr ""
+msgstr "Bütün bölümleri Klasörle"
 
 #: ../../src/ToolBar.cpp:240
 msgid "Follow"
-msgstr ""
+msgstr "Takip et"
 
 #: ../../src/ToolBar.cpp:285
 msgid ""
@@ -3121,6 +3357,16 @@ msgid ""
 "   Ctrl+6: Heading5 cell\n"
 "   Ctrl+7: Heading6 cell\n"
 msgstr ""
+"Hücreleri daha hızlı oluşturmak için kısayollar:\n"
+"\n"
+"   Ctrl+0: Matematik hücresi\n"
+"   Ctrl+1: Metin hücresi\n"
+"   Ctrl+2: Başlıkhücresi\n"
+"   Ctrl+3: Bölüm hücresi\n"
+"   Ctrl+4: Alt bölüm hücresi\n"
+"   Ctrl+5: Alt-altkısım hücresi\n"
+"   Ctrl+6: Başlık5 hücresi\n"
+"   Ctrl+7: Başlık7 hücresil\n"
 
 #: ../../src/wxMaxima.cpp:7038
 msgid "For loop"
@@ -3150,9 +3396,9 @@ msgid "Found only %li keywords in maxima's manual. Not caching them to disc."
 msgstr ""
 
 #: ../../src/MaximaManual.cpp:513
-#, c-format
+#, fuzzy, c-format
 msgid "Found the maxima HTML manual in the folder %s."
-msgstr ""
+msgstr "Maxima'nın kılavuzu% s dizininde yer alır"
 
 #: ../../src/wxMaxima.cpp:8948
 msgid "Fourier coefficients"
@@ -3163,13 +3409,13 @@ msgid "Fourier coefficients..."
 msgstr ""
 
 #: ../../src/ToolBar.cpp:137
-#, c-format
+#, fuzzy, c-format
 msgid "Frame %li of %li"
-msgstr ""
+msgstr "Çerçeve %i nın %i'si"
 
 #: ../../src/wxMaxima.cpp:9097
 msgid "Frame rate"
-msgstr ""
+msgstr "Çerçeve hızı"
 
 #: ../../src/wxMaximaFrame.cpp:1005 ../../src/wxMaximaFrame.cpp:1009
 msgid "Free all unused items now"
@@ -3185,108 +3431,120 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "From:"
-msgstr ""
+msgstr "İlk değer:"
 
 #: ../../src/wxMaximaFrame.cpp:827
 msgid "Full Screen\tAlt+Enter"
-msgstr ""
+msgstr "Tüm Ekran\tAlt+Return"
 
 #: ../../src/wxMaximaFrame.cpp:824
 msgid "Full Screen\tF11"
-msgstr ""
+msgstr "Tam Ekran \tF11"
 
 #: ../../src/wxMaxima.cpp:7140
+#, fuzzy
 msgid "Function contents:"
-msgstr ""
+msgstr "Fonksiyon isimleri"
 
 #: ../../src/wxMaxima.cpp:7908
+#, fuzzy
 msgid "Function f(x):"
-msgstr ""
+msgstr "Fonksiyon(lar):"
 
 #: ../../src/wxMaxima.cpp:8572
 msgid "Function name"
-msgstr ""
+msgstr "Fonksiyon adı"
 
 #: ../../src/wxMaxima.cpp:7167
+#, fuzzy
 msgid "Function name(s):"
-msgstr ""
+msgstr "Fonksiyon isimleri"
 
 #: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
+#, fuzzy
 msgid "Function name:"
-msgstr ""
+msgstr "Fonksiyon adı"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Function:"
-msgstr ""
+msgstr "Fonksiyon:"
 
 #: ../../src/wxMaximaFrame.cpp:1630
 msgid "Functions for complex simplification"
-msgstr ""
+msgstr "Karmaşık sadeleştirme fonksiyonları"
 
 #: ../../src/wxMaximaFrame.cpp:1588
 msgid "Functions for simplifying factorials and gamma function"
-msgstr ""
+msgstr "Gamma fonksiyonu ve çarpanlarına ayırma fonksiyonları"
 
 #: ../../src/wxMaximaFrame.cpp:1606
 msgid "Functions for simplifying trigonometric expressions"
-msgstr ""
+msgstr "Trigonometrik ifadeleri sadeleştirme fonksiyonları"
 
 #: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
 msgid "GCD"
-msgstr ""
+msgstr "OBEB"
 
 #: ../../src/wxMaxima.cpp:10186
 msgid "GIF image (*.gif)|*.gif"
-msgstr ""
+msgstr "GIF resmi (*.gif)|*.gif"
 
 #: ../../src/Worksheet.cpp:103
+#, fuzzy
 msgid ""
 "GTK_IM_MODULE is set to \"xim\". Expect the program to hideously flicker and"
 " hotkeys to be broken, see for example "
 "https://trac.wxwidgets.org/ticket/18462."
 msgstr ""
+"TK_IM_MODULE \"xim\" olarak ayarlanmış ve GTK3 kullanımda. Programın korkunç"
+" bir şekilde titremesini bekleyin, bkz. "
+"Https://trac.wxwidgets.org/ticket/18462."
 
 #: ../../src/wxMaximaFrame.cpp:295
 msgid "General Math"
-msgstr ""
+msgstr "Genel Matematik"
 
 #: ../../src/wxMaximaFrame.cpp:699
 msgid "General Math\tAlt+Shift+M"
-msgstr ""
+msgstr "Genel Matematik\tAlt+Shift+M"
 
 #: ../../src/wxMaximaFrame.cpp:1316
 msgid "Generate Matrix from Expression..."
-msgstr ""
+msgstr "Bir ifadeden matris oluştur..."
 
 #: ../../src/wxMaximaFrame.cpp:1317
 msgid "Generate a matrix from a lambda expression"
-msgstr ""
+msgstr "Bir Lambda ifadesinden matris oluştur"
 
 #: ../../src/wxMaximaFrame.cpp:1675
 msgid "Generate a new list using a lists' elements"
-msgstr ""
+msgstr "Listelerin elemanlarını  kullanılarak yeni bir liste oluşturun"
 
 #: ../../src/wxMaximaFrame.cpp:1681
 msgid ""
 "Generate a storage for variable values that can be introduced into equations"
 " at any time"
 msgstr ""
+"Herhangi bir zamanda denklemlere dahil edilebilecek değişken değerler için "
+"bir depo oluşturun"
 
 #: ../../src/wxMaximaFrame.cpp:1672
 msgid "Generate list elements using a rule"
-msgstr ""
+msgstr "Bir kural kullanarak liste öğeleri üret"
 
 #: ../../src/wxMaxima.cpp:8196
+#, fuzzy
 msgid "Generate matrix from a rule"
-msgstr ""
+msgstr "Kuraldan liste oluştur"
 
 #: ../../src/wxMaximaFrame.cpp:1094
 msgid "Generate unused symbol name"
 msgstr ""
 
 #: ../../src/WXMXformat.cpp:231
+#, fuzzy
 msgid "Generated the XML representation of the document"
-msgstr ""
+msgstr "Belgenin değerlendirilmesine başlama"
 
 #: ../../src/wxMaxima.cpp:8197
 msgid ""
@@ -3296,15 +3554,15 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1619
 msgid "Get &Imaginary Part"
-msgstr ""
+msgstr "Sanal bölümü hesapla"
 
 #: ../../src/wxMaximaFrame.cpp:1485
 msgid "Get Laplace transformation of an expression"
-msgstr ""
+msgstr "Bir ifadenin Laplace Dönüşümünü hesapla"
 
 #: ../../src/wxMaximaFrame.cpp:1615
 msgid "Get Real P&art"
-msgstr ""
+msgstr "Gerçel &Bölümü Hesapla"
 
 #: ../../src/wxMaximaFrame.cpp:1201
 msgid "Get current directory"
@@ -3312,64 +3570,69 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1489
 msgid "Get inverse Laplace transformation of an expression"
-msgstr ""
+msgstr "Bir İfadenin Ters Laplace Dönüşümünü Hesapla"
 
 #: ../../src/wxMaxima.cpp:7223
 msgid "Get position in stream"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1102
+#, fuzzy
 msgid "Get position..."
-msgstr ""
+msgstr "Sapma..."
 
 #: ../../src/wxMaximaFrame.cpp:1620
 msgid "Get the imaginary part of complex expression"
-msgstr ""
+msgstr "KarmaşıkSayı bir ifadenin sanal kısmını hesapla"
 
 #: ../../src/wxMaximaFrame.cpp:1616
 msgid "Get the real part of complex expression"
-msgstr ""
+msgstr "KarmaşıkSayı bir ifadenin gerçek kısmını hesapla"
 
 #: ../../src/wxMaxima.cpp:3609
-#, c-format
+#, fuzzy, c-format
 msgid "Gnuplot (command line) found at: %s"
-msgstr ""
+msgstr "Gnuplot% s adresinde bulunabilir"
 
 #: ../../src/wxMaxima.cpp:3607
-#, c-format
+#, fuzzy, c-format
 msgid "Gnuplot found at: %s"
-msgstr ""
+msgstr "Gnuplot şurada bulundu: "
 
 #: ../../src/wxMaxima.cpp:2974
 msgid "Gnuplot has closed."
-msgstr ""
+msgstr "Gnuplot sonlandırıldı."
 
 #: ../../src/wxMaxima.cpp:3598 ../../src/wxMaxima.cpp:3603
-#, c-format
+#, fuzzy, c-format
 msgid "Gnuplot not found, using the default: %s"
-msgstr ""
+msgstr "Gnuplot bulunamadı, varsayılanı kullanıyor : "
 
 #: ../../src/wxMaxima.cpp:9428 ../../src/wxMaximaFrame.cpp:1887
 msgid "Go to URL"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3989
+#, fuzzy
 msgid "Got a new input prompt!"
-msgstr ""
+msgstr "Yeni Girdi Hücresi Ekle"
 
 #: ../../src/Worksheet.cpp:6354
 msgid ""
 "Got a request to undo an action that involves a delete which isn't possible "
 "at this moment."
 msgstr ""
+"Hata: Şu anda mümkün olmayan bir silme konutu içeren geri al eylemi isteği "
+"alındı."
 
 #: ../../src/wxMaximaFrame.cpp:1031
 msgid "Gradefs"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1967
+#, fuzzy
 msgid "Greater or less than a value"
-msgstr ""
+msgstr "X değeri için değişken"
 
 #: ../../src/wxMaximaFrame.cpp:1130
 msgid "Greater, ignoring case?..."
@@ -3377,37 +3640,42 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:260
 msgid "Greek Letters"
-msgstr ""
+msgstr "Yunanca harfler"
 
 #: ../../src/wxMaximaFrame.cpp:703
 msgid "Greek Letters\tAlt+Shift+G"
-msgstr ""
+msgstr "Yunanca harfler\tAlt+Shift+G"
 
 #: ../../src/wxMaximaFrame.cpp:1815
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:6123
+#, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file "
 "(*.tex)|*.tex"
 msgstr ""
+"HTML Dosyası (*.html)|*.html|Kütük Dosyası (*mac.).*mac |pdfLaTeX dosyası "
+"(*.tex)|*.tex)"
 
 #: ../../src/wxMaximaFrame.cpp:1341
 msgid "Hadamard (element-by-element) product..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8004
+#, fuzzy
 msgid "Hadamard Product"
-msgstr ""
+msgstr "Çarpım"
 
 #: ../../src/wxMaxima.cpp:8011
 msgid "Hadamard exponent"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1345
+#, fuzzy
 msgid "Hadamard exponent..."
-msgstr ""
+msgstr "Matrisin adı:"
 
 #: ../../src/MaximaManual.cpp:260
 #, c-format
@@ -3418,76 +3686,78 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:88 ../../src/ToolBar.cpp:276
 msgid "Heading 5"
-msgstr ""
+msgstr "Başlık 5"
 
 #: ../../src/Configuration.cpp:87 ../../src/ToolBar.cpp:277
 msgid "Heading 6"
-msgstr ""
+msgstr "Başlık 6"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
 msgid "Help"
-msgstr ""
+msgstr "Yardım"
 
 #: ../../src/ToolBar.cpp:635
 msgid "Help button"
-msgstr ""
+msgstr "Tardim Butonu"
 
 #: ../../src/Worksheet.cpp:1340 ../../src/Worksheet.cpp:1778
 #, c-format
 msgid "Help on \"%s\""
-msgstr ""
+msgstr "\"%s\" konusunda yardım"
 
 #: ../../src/wxMaximaFrame.cpp:729
 msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr ""
+msgstr "Araç çubuklarının hepsini gizle\tAlt+Shift+-"
 
 #: ../../src/ToolBar.cpp:264
 msgid "Hide Code"
-msgstr ""
+msgstr "Kodları gizle"
 
 #: ../../src/wxMaximaFrame.cpp:727
 msgid "Hide Code Cells\tAlt+Ctrl+H"
-msgstr ""
+msgstr "Kod hücrelerini gizle\tAlt+Ctrl+H"
 
 #: ../../src/Worksheet.cpp:1896
 msgid "Hide Heading 5"
-msgstr ""
+msgstr "Başlık 5 i gizle"
 
 #: ../../src/Worksheet.cpp:1907
 msgid "Hide Heading 6"
-msgstr ""
+msgstr "Başlık 6 yı gizle"
 
 #: ../../src/Worksheet.cpp:1855
 msgid "Hide Part"
-msgstr ""
+msgstr "Bölümü gizle"
 
 #: ../../src/Worksheet.cpp:1863
 msgid "Hide Section"
-msgstr ""
+msgstr "Kısmı gizle"
 
 #: ../../src/Worksheet.cpp:1874
 msgid "Hide Subsection"
-msgstr ""
+msgstr "Alt Kısmı gizle"
 
 #: ../../src/Worksheet.cpp:1885
 msgid "Hide Subsubsection"
-msgstr ""
+msgstr "Alt+alt Kısmı gizle"
 
 #: ../../src/wxMaximaFrame.cpp:730
 msgid "Hide all panes"
-msgstr ""
+msgstr "Bütün panoları gizle"
 
 #: ../../src/Worksheet.cpp:1491
+#, fuzzy
 msgid "Hide cell brackets"
-msgstr ""
+msgstr "Aktif hücre ayıracı"
 
 #: ../../src/Worksheet.cpp:1915
 msgid "Hide contents"
-msgstr ""
+msgstr "İçerikleri gizle"
 
 #: ../../src/Worksheet.cpp:1552
+#, fuzzy
 msgid "Hide multiplication dots"
-msgstr ""
+msgstr "Mümkünse çarpma işaretlerini gizle"
 
 #: ../../src/Worksheet.cpp:1930 ../../src/Worksheet.cpp:2063
 msgid "Hide yellow tooltip marker for this cell"
@@ -3498,20 +3768,21 @@ msgid "Hide yellow tooltip marker for this message type"
 msgstr ""
 
 #: ../../src/Configuration.cpp:82
+#, fuzzy
 msgid "Highlight (box)"
-msgstr ""
+msgstr "Belirginleştir"
 
 #: ../../src/wxMaxima.cpp:9528
 msgid "Histogram"
-msgstr ""
+msgstr "Histogram"
 
 #: ../../src/wxMaximaFrame.cpp:232
 msgid "History"
-msgstr ""
+msgstr "Geçmiş"
 
 #: ../../src/wxMaximaFrame.cpp:709
 msgid "History\tAlt+Shift+I"
-msgstr ""
+msgstr "Geçmiş\tAlt+Shift+I"
 
 #: ../../src/wxMaximaFrame.cpp:1526
 msgid "Horner's rule"
@@ -3519,11 +3790,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9207
 msgid "How many digits to show:"
-msgstr ""
+msgstr "Gösterilecek basamak sayısı:"
 
 #: ../../src/wxMaximaFrame.cpp:759
 msgid "How to display new equations"
-msgstr ""
+msgstr "Yeni denklemler nasıl gösterilir"
 
 #: ../../src/wxMaximaFrame.cpp:1113
 msgid "I/O"
@@ -3549,6 +3820,8 @@ msgid ""
 "If this isn't a function returning a lambda() expression a multiplication "
 "sign (*) between closing and opening parenthesis is missing here."
 msgstr ""
+"Bu lambda () ifadesini döndüren bir işlev değilse, kapanış ve açılış "
+"parantezi arasında bir çarpma işareti (*) yoktur."
 
 #: ../../src/MaximaManual.cpp:403
 msgid "Ignoring the cache version for the manual anchors."
@@ -3563,6 +3836,8 @@ msgid ""
 "Image files (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, "
 "*.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
 msgstr ""
+"Resim Dosyaları (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, "
+"*.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
 
 #: ../../src/Worksheet.cpp:5509
 msgid "ImageCell without image."
@@ -3590,7 +3865,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Include columns:"
-msgstr ""
+msgstr "Sütunları kapsa:"
 
 #: ../../src/Worksheet.cpp:2008
 msgid "Increasing function f(x)>x"
@@ -3598,23 +3873,23 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8470
 msgid "Index End:"
-msgstr ""
+msgstr "İndeks Sonu:"
 
 #: ../../src/wxMaxima.cpp:8470
 msgid "Index Start:"
-msgstr ""
+msgstr "İndeks Başlangıcı:"
 
 #: ../../src/wxMaxima.cpp:8471
 msgid "Index Step:"
-msgstr ""
+msgstr "Dizin adım:"
 
 #: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
 msgid "Index variable:"
-msgstr ""
+msgstr "Dizin değişkeni:"
 
 #: ../../src/wxMaximaFrame.cpp:1949
 msgid "Info about Maxima build"
-msgstr ""
+msgstr "Maxima yapısı hakkında bilgi"
 
 #: ../../src/Worksheet.cpp:2046
 msgid "Inform maxima about facts you know for this symbol"
@@ -3627,156 +3902,161 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
+#, fuzzy
 msgid "Initial Condition"
-msgstr ""
+msgstr "Şart:"
 
 #: ../../src/wxMaximaFrame.cpp:1270
 msgid "Initial Value Problem (&1)..."
-msgstr ""
+msgstr "Başlangıç Değer Problemi (&1)"
 
 #: ../../src/wxMaximaFrame.cpp:1274
 msgid "Initial Value Problem (&2)..."
-msgstr ""
+msgstr "Başlangıç Değer Problemi (&2)"
 
 #: ../../src/wxMaxima.cpp:9044
+#, fuzzy
 msgid "Initial estimates:"
-msgstr ""
+msgstr "Başlangıç Tahminleri:"
 
 #: ../../src/wxMaxima.cpp:7840
+#, fuzzy
 msgid "Initial x:"
-msgstr ""
+msgstr "Başlangıç Tahminleri:"
 
 #: ../../src/Configuration.cpp:78
 msgid "Input labels"
-msgstr ""
+msgstr "Girdi Etiketleri"
 
 #: ../../src/wxMaximaFrame.cpp:314
 msgid "Insert"
-msgstr ""
+msgstr "Ekle"
 
 #: ../../src/wxMaximaFrame.cpp:905
 msgid "Insert &Section Cell\tCtrl+3"
-msgstr ""
+msgstr "Bölüm Hücresi Ekle\tCtrl+3"
 
 #: ../../src/wxMaximaFrame.cpp:901
 msgid "Insert &Text Cell\tCtrl+1"
-msgstr ""
+msgstr "Metin Hücresi Ekle\tCtrl+1"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Insert Cell\tAlt+Shift+C"
-msgstr ""
+msgstr "Hücre Ekle\tAlt+Shift+C"
 
 #: ../../src/Worksheet.cpp:1669
 msgid "Insert Heading5 Cell"
-msgstr ""
+msgstr "Başlık5 hücresi ekle"
 
 #: ../../src/Worksheet.cpp:1671
 msgid "Insert Heading6 Cell"
-msgstr ""
+msgstr "Başlık6 hücresi ekle"
 
 #: ../../src/wxMaxima.cpp:10854
 msgid "Insert Image"
-msgstr ""
+msgstr "Resim Ekle"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert Image..."
-msgstr ""
+msgstr "Resim Ekle..."
 
 #: ../../src/wxMaximaFrame.cpp:899
 msgid "Insert Input &Cell\tCtrl+0"
-msgstr ""
+msgstr "Girdi Hücresi Ekle"
 
 #: ../../src/wxMaximaFrame.cpp:919
 msgid "Insert Page Break"
-msgstr ""
+msgstr "Sayfa Kesmesi Ekle"
 
 #: ../../src/wxMaximaFrame.cpp:907
 msgid "Insert S&ubsection Cell\tCtrl+4"
-msgstr ""
+msgstr "Alt Bölüm hücresi Ekle\tCtrl+4"
 
 #: ../../src/wxMaximaFrame.cpp:910
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
-msgstr ""
+msgstr "Alt+alt &Bölüm hücresi Ekle\tCtrl+5"
 
 #: ../../src/Worksheet.cpp:1662
 msgid "Insert Section Cell"
-msgstr ""
+msgstr "Bölüm Hücresi Ekle"
 
 #: ../../src/Worksheet.cpp:1664
 msgid "Insert Subsection Cell"
-msgstr ""
+msgstr "Alt Bölüm hücresi Ekle"
 
 #: ../../src/Worksheet.cpp:1667
 msgid "Insert Subsubsection Cell"
-msgstr ""
+msgstr "Alt+alt Bölüm hücresi Ekle"
 
 #: ../../src/wxMaximaFrame.cpp:903
 msgid "Insert T&itle Cell\tCtrl+2"
-msgstr ""
+msgstr "Başlık Hücresi Ekle\tCtrl+2"
 
 #: ../../src/Worksheet.cpp:1658
 msgid "Insert Text Cell"
-msgstr ""
+msgstr "Metin Hücresi Ekle"
 
 #: ../../src/Worksheet.cpp:1660
 msgid "Insert Title Cell"
-msgstr ""
+msgstr "Başlık Hücresi Ekle"
 
 #: ../../src/wxMaximaFrame.cpp:913
 msgid "Insert a new heading5 cell"
-msgstr ""
+msgstr "Yeni bir Başlık5 hücresi ekle"
 
 #: ../../src/wxMaximaFrame.cpp:915
 msgid "Insert a new heading6 cell"
-msgstr ""
+msgstr "Yeni bir başlık6 hücresi ekle"
 
 #: ../../src/wxMaximaFrame.cpp:900
 msgid "Insert a new input cell"
-msgstr ""
+msgstr "Yeni Girdi Hücresi Ekle"
 
 #: ../../src/wxMaximaFrame.cpp:906
 msgid "Insert a new section cell"
-msgstr ""
+msgstr "Yeni Bölüm Hücresi Ekle"
 
 #: ../../src/wxMaximaFrame.cpp:908
 msgid "Insert a new subsection cell"
-msgstr ""
+msgstr "Yeni Alt Bölüm Hücresi Ekle"
 
 #: ../../src/wxMaximaFrame.cpp:911
 msgid "Insert a new subsubsection cell"
-msgstr ""
+msgstr "Yeni bir Alt+alt Bölüm Hücresi Ekle"
 
 #: ../../src/wxMaximaFrame.cpp:902
 msgid "Insert a new text cell"
-msgstr ""
+msgstr "Yeni Metin Hücresi Ekle"
 
 #: ../../src/wxMaximaFrame.cpp:904
 msgid "Insert a new title cell"
-msgstr ""
+msgstr "Yeni Bir Başlık Hücresi Ekle"
 
 #: ../../src/wxMaximaFrame.cpp:920
 msgid "Insert a page break"
-msgstr ""
+msgstr "Bir Sayfa Kesmesi Ekle"
 
 #: ../../src/wxMaximaFrame.cpp:1164
+#, fuzzy
 msgid "Insert char..."
-msgstr ""
+msgstr "Resim Ekle..."
 
 #: ../../src/wxMaximaFrame.cpp:912
 msgid "Insert heading5 Cell\tCtrl+6"
-msgstr ""
+msgstr "Başlık5 hücresi ekle\tCtrl+6"
 
 #: ../../src/wxMaximaFrame.cpp:914
 msgid "Insert heading6 Cell\tCtrl+7"
-msgstr ""
+msgstr "Başlık6 hücresi ekle\tCtrl+7"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert image"
-msgstr ""
+msgstr "Resim yerleştir"
 
 #: ../../src/wxMaximaFrame.cpp:916
+#, fuzzy
 msgid "Insert textbased cell"
-msgstr ""
+msgstr "Metin Hücresi Ekle"
 
 #: ../../src/wxMaxima.cpp:3566
 msgid "Instructed to prefer gnuplot over wgnuplot"
@@ -3788,43 +4068,44 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
 msgid "Integral/Sum:"
-msgstr ""
+msgstr "İntegral/Toplam:"
 
 #: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
 msgid "Integrate"
-msgstr ""
+msgstr "İntegralini Al"
 
 #: ../../src/wxMaxima.cpp:8980
 msgid "Integrate (risch)"
-msgstr ""
+msgstr "İntegralini Al (risch)"
 
 #: ../../src/wxMaximaFrame.cpp:1454
 msgid "Integrate expression"
-msgstr ""
+msgstr "İfadenin İntegralini Al"
 
 #: ../../src/wxMaximaFrame.cpp:1456
 msgid "Integrate expression with Risch algorithm"
-msgstr ""
+msgstr "Risch algoritmasıyla İntegralini al"
 
 #: ../../src/wxMaximaFrame.cpp:1869
+#, fuzzy
 msgid "Integrate numerically"
-msgstr ""
+msgstr "İntegralini Al (risch)"
 
 #: ../../src/Worksheet.cpp:1588
 msgid "Integrate..."
-msgstr ""
+msgstr "İntegralini Al..."
 
 #: ../../src/wxMaximaFrame.cpp:1737
 msgid "Interleave"
-msgstr ""
+msgstr "Serpiştir"
 
 #: ../../src/wxMaximaFrame.cpp:1738
 msgid "Interleave the values of two lists"
-msgstr ""
+msgstr "İki listenin değerlerini iliştir"
 
 #: ../../src/wxMaxima.cpp:8612
 msgid "Interleave two lists"
-msgstr ""
+msgstr "İki listeyi serpiştir"
 
 #: ../../src/wxMaximaFrame.cpp:1087
 msgid "Interpret like input..."
@@ -3835,39 +4116,43 @@ msgid "Interpret maxima's output as input"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7502
+#, fuzzy
 msgid "Interpret string as maxima code"
-msgstr ""
+msgstr "Maxima'yı durduruyor: % s"
 
 #: ../../src/wxMaximaFrame.cpp:1089
+#, fuzzy
 msgid "Interpret string..."
-msgstr ""
+msgstr "Sonlandırılmamış dizin."
 
 #: ../../src/ToolBar.cpp:231
 msgid "Interrupt"
-msgstr ""
+msgstr "Yarıda Kes"
 
 #: ../../src/wxMaximaFrame.cpp:965
 msgid "Interrupt current computation"
-msgstr ""
+msgstr "Yapılan İşlemi Yarıda Kes"
 
 #: ../../src/ToolBar.cpp:232
 msgid ""
 "Interrupt current computation. To completely restart maxima press the button"
 " left to this one."
 msgstr ""
+"Bu hesaplamayı durdur. Maxima'yı yeniden başlatmak için bunun solundaki "
+"butona bas."
 
 #: ../../src/wxMaxima.cpp:2766
 #, c-format
 msgid "Interrupting maxima: %s"
-msgstr ""
+msgstr "Maxima'yı durduruyor: % s"
 
 #: ../../src/wxMaxima.cpp:8557
 msgid "Introduce a list of actual values into an equation"
-msgstr ""
+msgstr "Bir denklem içine gerçek değerlerin bir listesini tanıt"
 
 #: ../../src/wxMaximaFrame.cpp:1697
 msgid "Introduce the actual values for variables stored in the list"
-msgstr ""
+msgstr "Listede saklanan değişkenlerin gerçek değerlerini tanıtmak"
 
 #: ../../src/wxMaxima.cpp:10062
 msgid "Introduces one or more assignments into an expression"
@@ -3875,23 +4160,24 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9003
 msgid "Inverse Laplace"
-msgstr ""
+msgstr "Ters Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1488
 msgid "Inverse Laplace T&ransform..."
-msgstr ""
+msgstr "Ters Laplace Dönüşümü..."
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Invert worksheet brightness"
-msgstr ""
+msgstr "Çalışma sayfası parlaklığını tersine çevir"
 
 #: ../../src/wxMaxima.cpp:7338
 msgid "Is Char 1 greater than Char2, if case is ignored?"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7333
+#, fuzzy
 msgid "Is Char 1 greater than Char2?"
-msgstr ""
+msgstr "'den daha büyük"
 
 #: ../../src/wxMaxima.cpp:7327
 msgid "Is Char 1 less than Char2, if case is ignored?"
@@ -3910,12 +4196,14 @@ msgid "Is a char?..."
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1952
+#, fuzzy
 msgid "Is a complex variable"
-msgstr ""
+msgstr "Dizin değişkeni:"
 
 #: ../../src/wxMaxima.cpp:7292
+#, fuzzy
 msgid "Is a digit?"
-msgstr ""
+msgstr "Algoritmayı Göster"
 
 #: ../../src/wxMaximaFrame.cpp:1118
 msgid "Is a digit?..."
@@ -3930,8 +4218,9 @@ msgid "Is a printable char?"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1949
+#, fuzzy
 msgid "Is a real variable"
-msgstr ""
+msgstr "Değişkeni değiştir"
 
 #: ../../src/wxMaxima.cpp:7300
 msgid "Is a uppercase char?"
@@ -3954,28 +4243,33 @@ msgid "Is an alphanumeric char?"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1991
+#, fuzzy
 msgid "Is an even function"
-msgstr ""
+msgstr "Kullanıcı fonksiyonlarının listesi"
 
 #: ../../src/Worksheet.cpp:1955
+#, fuzzy
 msgid "Is an imaginary variable"
-msgstr ""
+msgstr "Değişkeni değiştir"
 
 #: ../../src/Worksheet.cpp:1960
+#, fuzzy
 msgid "Is an integer variable"
-msgstr ""
+msgstr "Değişkeni değiştir"
 
 #: ../../src/Worksheet.cpp:1993
+#, fuzzy
 msgid "Is an odd function"
-msgstr ""
+msgstr "Bir Fonksiyonu Sil"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Is equal?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1128
+#, fuzzy
 msgid "Is greater?..."
-msgstr ""
+msgstr "Liste oluştur"
 
 #: ../../src/wxMaximaFrame.cpp:1125
 msgid "Is lower?..."
@@ -3986,8 +4280,9 @@ msgid "Is lowercase?..."
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1962
+#, fuzzy
 msgid "Is no integer variable"
-msgstr ""
+msgstr "Kullanıcı değişkenlerinin listesi"
 
 #: ../../src/wxMaximaFrame.cpp:1119
 msgid "Is printable?..."
@@ -4007,23 +4302,24 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8598 ../../src/wxMaxima.cpp:8604
 msgid "Item"
-msgstr ""
+msgstr "Madde"
 
 #: ../../src/wxMaxima.cpp:8581
+#, fuzzy
 msgid "Iterator name:"
-msgstr ""
+msgstr "Yineleyici:"
 
 #: ../../src/wxMaximaFrame.cpp:1048
 msgid "Jump to first error"
-msgstr ""
+msgstr "İlk hataya git"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Jump to the first cell Maxima has reported an error in."
-msgstr ""
+msgstr "İlk hücreye atla Maxima bir hata bildirdi."
 
 #: ../../src/wxMaxima.cpp:8960
 msgid "LCM"
-msgstr ""
+msgstr "OKEK"
 
 #: ../../src/wxMaximaFrame.cpp:1407
 msgid "L[1] Norm (complex)"
@@ -4042,12 +4338,13 @@ msgid "L[inf] Norm (real)"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1025
+#, fuzzy
 msgid "Labels"
-msgstr ""
+msgstr "Dizilerin listesi"
 
 #: ../../src/wxMaxima.cpp:7090
 msgid "Lambda"
-msgstr ""
+msgstr "Lambda"
 
 #: ../../src/wxMaxima.cpp:7091
 msgid ""
@@ -4058,29 +4355,29 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8997
 msgid "Laplace"
-msgstr ""
+msgstr "Laplace"
 
 #: ../../src/wxMaximaFrame.cpp:1484
 msgid "Laplace &Transform..."
-msgstr ""
+msgstr "Laplace &Dönüşümü..."
 
 #: ../../src/wxMaximaFrame.cpp:1718
 msgid "Last"
-msgstr ""
+msgstr "Sonuncu"
 
 #: ../../src/wxMaxima.cpp:3006
 #, c-format
 msgid "Last message from maxima's stderr: %s"
-msgstr ""
+msgstr "Maxima'nın stderr' in den son mesaj: %s"
 
 #: ../../src/wxMaxima.cpp:2993
 #, c-format
 msgid "Last message from maxima's stdout: %s"
-msgstr ""
+msgstr "Maxima'nın stdout 'un dan son mesaj: %s"
 
 #: ../../src/wxMaximaFrame.cpp:1720
 msgid "Last n"
-msgstr ""
+msgstr "Son n"
 
 #: ../../src/wxMaxima.cpp:10400
 msgid "Last non-whitespace is a question mark"
@@ -4097,16 +4394,17 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1493
 msgid "Least Common Multiple..."
-msgstr ""
+msgstr "OKEK..."
 
 #: ../../src/wxMaxima.cpp:9587
 msgid "Least Squares Fit"
-msgstr ""
+msgstr "En Az Karelere uydur"
 
 #: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
 #: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
+#, fuzzy
 msgid "Left Matrix:"
-msgstr ""
+msgstr "Matris Aç"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Left end"
@@ -4114,35 +4412,39 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1297
 msgid "Left side to the \"=\""
-msgstr ""
+msgstr "Sol taraf \"=\""
 
 #: ../../src/wxMaximaFrame.cpp:1741
 msgid "Length"
-msgstr ""
+msgstr "Uzunluk"
 
 #: ../../src/wxMaximaFrame.cpp:1104 ../../src/wxMaximaFrame.cpp:1167
+#, fuzzy
 msgid "Length..."
-msgstr ""
+msgstr "Uzunluk"
 
 #: ../../src/wxMaxima.cpp:7421
+#, fuzzy
 msgid "Length:"
-msgstr ""
+msgstr "Uzunluk"
 
 #: ../../src/wxMaximaFrame.cpp:1032
 msgid "Letrules"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1976
+#, fuzzy
 msgid "Likely to be the main variable"
-msgstr ""
+msgstr "Bir Değişkeni Sil"
 
 #: ../../src/wxMaxima.cpp:9028
 msgid "Limit"
-msgstr ""
+msgstr "Limit"
 
 #: ../../src/wxMaxima.cpp:7256
+#, fuzzy
 msgid "Lisp format string:"
-msgstr ""
+msgstr "Maxima sorular"
 
 #: ../../src/wxMaxima.cpp:7258
 msgid "Lisp format strings are more powerful than c++ format strings"
@@ -4150,7 +4452,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5066
 msgid "Lisp mode."
-msgstr ""
+msgstr "Lisp modu."
 
 #: ../../src/wxMaximaFrame.cpp:1010 ../../src/wxMaximaFrame.cpp:1012
 msgid "Lisp normally frees memory only when it has time or runs out of space"
@@ -4159,87 +4461,98 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:3691
 #, c-format
 msgid "Lisp version: %s"
-msgstr ""
+msgstr "Lisp versiyonu: %s"
 
 #: ../../src/wxMaxima.cpp:8435 ../../src/wxMaxima.cpp:8539
 #: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
 #: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
 #: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
 msgid "List"
-msgstr ""
+msgstr "Dizin"
 
 #: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
+#, fuzzy
 msgid "List #1"
-msgstr ""
+msgstr "Dizin1"
 
 #: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
+#, fuzzy
 msgid "List #2"
-msgstr ""
+msgstr "Dizin2"
 
 #: ../../src/wxMaximaFrame.cpp:1200
+#, fuzzy
 msgid "List directory"
-msgstr ""
+msgstr "Maxima% s geçici dizinini kullanıyor"
 
 #: ../../src/wxMaximaFrame.cpp:1205
 msgid "List directory..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7385 ../../src/wxMaxima.cpp:7389
+#, fuzzy
 msgid "List of char to String"
-msgstr ""
+msgstr "Değiştirilen seçeneklerin listesi"
 
 #: ../../src/wxMaximaFrame.cpp:1150
+#, fuzzy
 msgid "List of chars to string..."
-msgstr ""
+msgstr "Değiştirilen seçeneklerin listesi"
 
 #: ../../src/wxMaxima.cpp:7386
+#, fuzzy
 msgid "List of chars:"
-msgstr ""
+msgstr "Dizilerin listesi"
 
 #: ../../src/wxMaxima.cpp:8559
 msgid "List with values"
-msgstr ""
+msgstr "Değerleri ile bir Dizin"
 
 #: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
 msgid "List:"
-msgstr ""
+msgstr "Liste:"
 
 #: ../../src/wxMaxima.cpp:6200
 msgid "Load Package"
-msgstr ""
+msgstr "Paket Yükle"
 
 #: ../../src/wxMaximaFrame.cpp:613
 msgid "Load Recent Package"
-msgstr ""
+msgstr "En son Paketi Yükle"
 
 #: ../../src/wxMaximaFrame.cpp:616
 msgid "Load a Maxima file using the batch command"
-msgstr ""
+msgstr "Bir Maxima dosyasını kütük komutu ile yükle"
 
 #: ../../src/wxMaximaFrame.cpp:611
 msgid "Load a Maxima package file"
-msgstr ""
+msgstr "Bir Maxima dosyasını yükle"
 
 #: ../../src/wxMaximaFrame.cpp:1678
+#, fuzzy
 msgid "Load a list from a csv file"
-msgstr ""
+msgstr "Bir Maxima dosyasını yükle"
 
 #: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
+#, fuzzy
 msgid "Load a matrix from a csv file"
-msgstr ""
+msgstr "Bir Maxima dosyasını yükle"
 
 #: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
+#, fuzzy
 msgid "Load lapack"
-msgstr ""
+msgstr "Paket Yükle"
 
 #: ../../src/wxMaxima.cpp:7208
+#, fuzzy
 msgid "Load lisp code"
-msgstr ""
+msgstr "Lisp modu."
 
 #: ../../src/wxMaximaFrame.cpp:1092
+#, fuzzy
 msgid "Load lisp..."
-msgstr ""
+msgstr "Paket Yükle"
 
 #: ../../src/wxMaximaFrame.cpp:1198
 msgid "Load the file/dir operations (operatingsystem)"
@@ -4254,28 +4567,32 @@ msgid "Load the translation generator (gentran)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8219
+#, fuzzy
 msgid "Loop variable"
-msgstr ""
+msgstr "Yeni Değişken:"
 
 #: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
 msgid "Lower bound:"
-msgstr ""
+msgstr "Alt Sınır:"
 
 #: ../../src/wxMaximaFrame.cpp:1127
 msgid "Lower, ignoring case?..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1448
+#, fuzzy
 msgid "M&atrix"
-msgstr ""
+msgstr "Matris"
 
 #: ../../src/wxMaxima.cpp:7153
+#, fuzzy
 msgid "Macro contents:"
-msgstr ""
+msgstr "İçerikleri gizle"
 
 #: ../../src/wxMaxima.cpp:7148
+#, fuzzy
 msgid "Macro name:"
-msgstr ""
+msgstr "Matrisin adı:"
 
 #: ../../src/wxMaximaFrame.cpp:1024
 msgid "Macros"
@@ -4283,7 +4600,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:697
 msgid "Main Toolbar\tAlt+Shift+B"
-msgstr ""
+msgstr "Temel Araç Çubuğu\tAlt+Shift+B"
 
 #: ../../src/wxMaxima.cpp:7906
 msgid "Make a function value at a specific point known"
@@ -4294,36 +4611,40 @@ msgid "Make an eventual ev() evaluate this"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1070
+#, fuzzy
 msgid "Make function local..."
-msgstr ""
+msgstr "Fonksiyonu listeye Eşle"
 
 #: ../../src/wxMaxima.cpp:8207
 msgid "Map"
-msgstr ""
+msgstr "Eşle"
 
 #: ../../src/wxMaxima.cpp:8215
+#, fuzzy
 msgid "Map an expression"
-msgstr ""
+msgstr "Bir ifadeyi genişlet"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "Map function to a matrix"
-msgstr ""
+msgstr "Fonksiyonu matrise Eşle"
 
 #: ../../src/wxMaximaFrame.cpp:1446
+#, fuzzy
 msgid "Map function to a matrix, affecting all of its clones"
-msgstr ""
+msgstr "Fonksiyonu matrise Eşle"
 
 #: ../../src/Configuration.cpp:109
+#, fuzzy
 msgid "Math Default"
-msgstr ""
+msgstr "Varsayılan"
 
 #: ../../src/wxMaximaFrame.cpp:286
 msgid "Mathematical Symbols"
-msgstr ""
+msgstr "Matematik Sembolleri"
 
 #: ../../src/ToolBar.cpp:270
 msgid "Maths"
-msgstr ""
+msgstr "Matematik"
 
 #: ../../src/wxMaxima.cpp:7945 ../../src/wxMaxima.cpp:8022
 #: ../../src/wxMaxima.cpp:8027 ../../src/wxMaxima.cpp:8032
@@ -4335,39 +4656,44 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
 #: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
 msgid "Matrix"
-msgstr ""
+msgstr "Matris"
 
 #: ../../src/wxMaxima.cpp:7986
+#, fuzzy
 msgid "Matrix Exponent"
-msgstr ""
+msgstr "Matrisin adı:"
 
 #: ../../src/wxMaximaFrame.cpp:1339
+#, fuzzy
 msgid "Matrix exponent..."
-msgstr ""
+msgstr "Matrisin adı:"
 
 #: ../../src/wxMaximaFrame.cpp:1329
+#, fuzzy
 msgid "Matrix from csv file"
-msgstr ""
+msgstr "Sitili dosyadan yükle"
 
 #: ../../src/wxMaximaFrame.cpp:1323
+#, fuzzy
 msgid "Matrix from csv file..."
-msgstr ""
+msgstr "Sitili dosyadan yükle"
 
 #: ../../src/wxMaxima.cpp:8137
 msgid "Matrix map"
-msgstr ""
+msgstr "Matris Eşle"
 
 #: ../../src/wxMaxima.cpp:9630
 msgid "Matrix name:"
-msgstr ""
+msgstr "Matrisin adı:"
 
 #: ../../src/wxMaximaFrame.cpp:798
 msgid "Matrix parenthesis"
-msgstr ""
+msgstr "Matris parantezi"
 
 #: ../../src/wxMaximaFrame.cpp:1331
+#, fuzzy
 msgid "Matrix to csv file"
-msgstr ""
+msgstr "Sitili dosyadan yükle"
 
 #: ../../src/wxMaximaFrame.cpp:1334
 msgid "Matrix to file or Matrix from file"
@@ -4375,14 +4701,14 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1761
 msgid "Matrix to nested List"
-msgstr ""
+msgstr "İç içe geçmiş Listeye Matris"
 
 #: ../../src/wxMaxima.cpp:7956 ../../src/wxMaxima.cpp:7961
 #: ../../src/wxMaxima.cpp:7966 ../../src/wxMaxima.cpp:7971
 #: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
 #: ../../src/wxMaxima.cpp:8136
 msgid "Matrix:"
-msgstr ""
+msgstr "Matris:"
 
 #: ../../src/wxMaxima.cpp:8627
 msgid ""
@@ -4395,15 +4721,15 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:3473
 #, c-format
 msgid "Maxima architecture: %s"
-msgstr ""
+msgstr "Maxima mimarisi:% s"
 
 #: ../../src/StatusBar.cpp:252
 msgid "Maxima asks a question"
-msgstr ""
+msgstr "Maxima bir soru soruyor"
 
 #: ../../src/wxMaxima.cpp:4066
 msgid "Maxima asks a question!"
-msgstr ""
+msgstr "Maxima'nın bir sorusu var!"
 
 #: ../../src/wxMaxima.cpp:7118
 msgid ""
@@ -4417,73 +4743,77 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:84
 msgid "Maxima errors"
-msgstr ""
+msgstr "Maxima Hataları"
 
 #: ../../src/wxMaxima.cpp:3289
+#, fuzzy
 msgid "Maxima has authenticated!"
-msgstr ""
+msgstr "Maxima sonlandı."
 
 #: ../../src/wxMaxima.cpp:10533
 msgid "Maxima has finished calculating."
-msgstr ""
+msgstr "Maxima hesaplamayı bitirdi."
 
 #: ../../src/wxMaxima.cpp:5832
 msgid "Maxima has issued an error!"
-msgstr ""
+msgstr "Maxima'nın bir sorunla karşılaştı!"
 
 #: ../../src/wxMaxima.cpp:3696
 #, c-format
 msgid "Maxima has loaded the file %s."
-msgstr ""
+msgstr "Maxima% s dosyasını yükledi."
 
 #: ../../src/wxMaxima.cpp:3382
 msgid "Maxima has sent a new variable value."
-msgstr ""
+msgstr "Maxima yeni bir değişken değeri gönderdi."
 
 #: ../../src/MaximaManual.cpp:552
+#, fuzzy
 msgid "Maxima help file not found!"
-msgstr ""
+msgstr "Dosya bulunamadı"
 
 #: ../../src/wxMaximaFrame.cpp:1043
 msgid "Maxima input"
-msgstr ""
+msgstr "Maxima girdisi"
 
 #: ../../src/StatusBar.cpp:236
 msgid "Maxima is calculating"
-msgstr ""
+msgstr "Maxima hesaplıyor"
 
 #: ../../src/wxMaxima.cpp:5068
 msgid "Maxima is ready for input."
-msgstr ""
+msgstr "Maxima girdi için hazır."
 
 #: ../../src/Dirstructure.cpp:144
 #, c-format
 msgid "Maxima not found as %s"
-msgstr ""
+msgstr "Maxima %s olarak bulamadı"
 
 #: ../../src/wxMaxima.cpp:6211
 msgid "Maxima package (*.mac)|*.mac"
-msgstr ""
+msgstr "Maxima Paketi (*.mac)|*.mac"
 
 #: ../../src/wxMaxima.cpp:6202
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
-msgstr ""
+msgstr "Maxima Paketi (*.mac)|*.mac|Lisp Paketi (*.lisp)|*.lisp|Tümü|*"
 
 #: ../../src/wxMaxima.cpp:3012
 msgid "Maxima process terminated unexpectedly."
-msgstr ""
+msgstr "Maxima süreci beklenmedik şekilde sona erdi."
 
 #: ../../src/Configuration.cpp:79
+#, fuzzy
 msgid "Maxima question labels"
-msgstr ""
+msgstr "Maxima sorular"
 
 #: ../../src/wxMaxima.cpp:3380
 msgid "Maxima sends a new set of auto-completable symbols."
-msgstr ""
+msgstr "Maxima yeni bir otomatik tamamlanabilir sembol seti gönderir."
 
 #: ../../src/wxMaxima.cpp:3908
 msgid "Maxima sends us a new set of variables for the watch list."
 msgstr ""
+"Maxima, izleme listesi için bize yeni bir değişkenler kümesi gönderir."
 
 #: ../../src/wxMaximaFrame.cpp:1944
 msgid "Maxima shows help in a browser"
@@ -4494,86 +4824,92 @@ msgid "Maxima shows help in a sidebar"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1935
+#, fuzzy
 msgid "Maxima shows help in the console"
-msgstr ""
+msgstr "Dosya bulunamadı"
 
 #: ../../src/StatusBar.cpp:232
+#, fuzzy
 msgid "Maxima started. Waiting for authentication..."
-msgstr ""
+msgstr "Maxima başlatıldı.Bağlantı için bekleniyor..."
 
 #: ../../src/StatusBar.cpp:212
 msgid "Maxima started. Waiting for connection..."
-msgstr ""
+msgstr "Maxima başlatıldı.Bağlantı için bekleniyor..."
 
 #: ../../src/StatusBar.cpp:228
+#, fuzzy
 msgid "Maxima started. Waiting for initial prompt..."
-msgstr ""
+msgstr "Maxima başlatıldı.Bağlantı için bekleniyor..."
 
 #: ../../src/wxMaximaFrame.cpp:1231
+#, fuzzy
 msgid "Maxima to other language"
-msgstr ""
+msgstr "Maxima sorular"
 
 #: ../../src/wxMaxima.cpp:7213
+#, fuzzy
 msgid "Maxima to string"
-msgstr ""
+msgstr "Maxima sorular"
 
 #: ../../src/wxMaxima.cpp:3397
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima user configuration is located in directory %s"
-msgstr ""
+msgstr "Maxima kullanıcı yapılandırması% s dizininde yer alır"
 
 #: ../../src/wxMaxima.cpp:3443
 #, c-format
 msgid "Maxima uses temp directory %s"
-msgstr ""
+msgstr "Maxima% s geçici dizinini kullanıyor"
 
 #: ../../src/wxMaxima.cpp:3469
 #, c-format
 msgid "Maxima version: %s"
-msgstr ""
+msgstr "Maxima Sürümü:%s"
 
 #: ../../src/MaximaManual.cpp:390
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima version: %s, Anchors cache version"
-msgstr ""
+msgstr "Maxima Sürümü:%s"
 
 #: ../../src/wxMaximaFrame.cpp:1925
+#, fuzzy
 msgid "Maxima vs. Programming languages"
-msgstr ""
+msgstr "Başlık 5 i Göster"
 
 #: ../../src/Configuration.cpp:83
 msgid "Maxima warnings"
-msgstr ""
+msgstr "Maxima uyarılar"
 
 #: ../../src/wxMaxima.cpp:3687
 #, c-format
 msgid "Maxima was compiled using %s"
-msgstr ""
+msgstr "Maxima% s kullanılarak derlendi"
 
 #: ../../src/wxMaxima.cpp:3487
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's HTML manuals are in directory %s"
-msgstr ""
+msgstr "Maxima'nın kılavuzu% s dizininde yer alır"
 
 #: ../../src/wxMaxima.cpp:3099
 #, c-format
 msgid "Maxima's PID is %li"
-msgstr ""
+msgstr "MAxima'nın PID 'si %li dir"
 
 #: ../../src/wxMaxima.cpp:3681
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's demo files are located in directory %s"
-msgstr ""
+msgstr "Maxima'nın paylaşım dosyaları% s dizininde"
 
 #: ../../src/wxMaxima.cpp:3478
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's manual is located in directory %s"
-msgstr ""
+msgstr "Maxima'nın kılavuzu% s dizininde yer alır"
 
 #: ../../src/wxMaxima.cpp:3670
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's share files are located in directory %s"
-msgstr ""
+msgstr "Maxima'nın paylaşım dosyaları% s dizininde"
 
 #: ../../src/StatusBar.cpp:66
 msgid ""
@@ -4585,6 +4921,13 @@ msgid ""
 "not only intercepts connections from the outside, but also to intercept "
 "connections between two programs that run on the same computer."
 msgstr ""
+"Gerçek matematik yapan program olan Maxima ve çalışma sayfasını görüntüleyen"
+" wxMaxima ayrı işlemlerde tutulmaktadır. Bu maxima çöküyor olsa bile "
+"wxMaxima (ve bu nedenle çalışma sayfası) bozulmadan kalır demektir. Her iki "
+"program da yerel bir ağ soketi üzerinden iletişim kurar. Bu sefer yalnızca "
+"dışarıdan bağlantıları kesmekle kalmayan aynı bilgisayarda çalışan iki "
+"programı arasındaki bağlantıyı kesmek için kurulan bir güvenlik duvarı "
+"nedeniyle bu soket oluşturulamadı."
 
 #: ../../src/StatusBar.cpp:75
 msgid ""
@@ -4599,40 +4942,55 @@ msgid ""
 "might be that maxima cannot be found (see wxMaxima's Configuration dialogue "
 "for a way to specify maxima's location) or isn't in a working order."
 msgstr ""
+"Gerçek matematik yapan program olan Maxima ve çalışma sayfasını görüntüleyen"
+" wxMaxima ayrı işlemlerde tutulmaktadır. Bu, maxima çöküyor olsa bile "
+"wxMaxima (ve bu nedenle çalışma sayfası) bozulmadan kalır demektir. Şu anda "
+"iki program birbirine bağlı değildir, bu da Maxima'nın henüz başlatıldığı "
+"veya başlatılamayacağı anlamına gelebilir. Alternatif olarak, yalnızca "
+"dışardan gelen bağlantıları kesmekle kalmayan aynı bilgisayarda çalışan iki "
+"programı arasındaki bağlantıyı kesmek için kurulan bir güvenlik duvarı da "
+"neden olabilir. Maxima'nın başlamamasının bir başka nedeni Maxima "
+"bulunamaması olabilir (Maxima'nın konumunu belirtmenin bir yolu için "
+"wxMaxima'nın Yapılandırma diyaloğuna bakın) veya çalışma düzeni içinde "
+"olmayabilir."
 
 #: ../../src/StatusBar.cpp:61
 msgid ""
 "Maxima, the program that does the actual mathematics is started as a separate process. This has the advantage that an eventual crash of maxima cannot harm wxMaxima, which displays the worksheet.\n"
 "This icon indicates if data is transferred between maxima and wxMaxima."
 msgstr ""
+"Maxima, gerçek matematiğin yaptığı programı ayrı bir süreç olarak başlatır. Bu, nihai bir kaza anında çalışma sayfasını görüntüleyen wxMaxima'ya zarar verememe avantajına sahiptir.\n"
+"Bu simge, verilerin maxima ile wxMaxima arasında aktarılıp aktarılmadığını gösterir."
 
 #: ../../src/wxMaxima.cpp:9228
+#, fuzzy
 msgid "Maximum absolute value printed without exponent"
-msgstr ""
+msgstr "Üstsüz yazdırılan maksimum mutlak değer:"
 
 #: ../../src/wxMaxima.cpp:9230
 msgid "Maximum number of digits to be displayed:"
-msgstr ""
+msgstr "Gösterilecek maksimum basamak sayısı:"
 
 #: ../../src/wxMaxima.cpp:9568
 msgid "Mean:"
-msgstr ""
+msgstr "Ortalama:"
 
 #: ../../src/wxMaximaFrame.cpp:1924
 msgid "Memoizing"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1013
+#, fuzzy
 msgid "Memory"
-msgstr ""
+msgstr "&Belleği temizle"
 
 #: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
 msgid "Merge Cells"
-msgstr ""
+msgstr "Hücreleri birleştir"
 
 #: ../../src/wxMaxima.cpp:5780
 msgid "Message from the stdout of Maxima: "
-msgstr ""
+msgstr "Maxima'nın stdout (standard çıkış) ın dan mesaj: "
 
 #: ../../src/wxMaximaFrame.cpp:1326
 msgid "Methods of generating a matrix"
@@ -4645,11 +5003,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9226
 msgid "Minimum absolute value printed without exponent:"
-msgstr ""
+msgstr "Üssüz yazdırılan minimum mutlak değer:"
 
 #: ../../src/wxMaxima.cpp:10449 ../../src/wxMaxima.cpp:10451
 msgid "Mismatched parenthesis"
-msgstr ""
+msgstr "Eşleşmeyen parantezler"
 
 #: ../../src/wxMaximaFrame.cpp:1352
 msgid "Multiplication, exponent and similar"
@@ -4668,24 +5026,27 @@ msgid "Multiply two matrices"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9581
+#, fuzzy
 msgid "Multivariate linear regression"
-msgstr ""
+msgstr "Doğrusal Regresyon..."
 
 #: ../../src/wxMaxima.cpp:7842
+#, fuzzy
 msgid "Name of t:"
-msgstr ""
+msgstr "İsim:"
 
 #: ../../src/wxMaxima.cpp:7838
+#, fuzzy
 msgid "Name of x:"
-msgstr ""
+msgstr "İsim:"
 
 #: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
 msgid "Nested list to Matrix"
-msgstr ""
+msgstr "Matris için iç içe geçmiş dizin"
 
 #: ../../src/wxMaximaFrame.cpp:769 ../../src/wxMaximaFrame.cpp:1053
 msgid "Never"
-msgstr ""
+msgstr "Asla"
 
 #: ../../src/wxMaxima.cpp:6534
 msgid "Never autosubscript this variable"
@@ -4696,67 +5057,71 @@ msgid "Never display this variable with subscript"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1469 ../../src/Worksheet.cpp:1843
+#, fuzzy
 msgid "Never offer known answers"
-msgstr ""
+msgstr "Bilinen cevaplar sunun"
 
 #: ../../src/ToolBar.cpp:174
 msgid "New"
-msgstr ""
+msgstr "Yeni"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "New\tCtrl+N"
-msgstr ""
+msgstr "Yeni\tCtrl+N"
 
 #: ../../src/ToolBar.cpp:611
 msgid "New button"
-msgstr ""
+msgstr "Yeni buton"
 
 #: ../../src/wxMaxima.cpp:2483
 msgid "New connection attempt whilst already connected."
-msgstr ""
+msgstr "Zaten bağlıyken yeni bağlantı girişimi."
 
 #: ../../src/wxMaxima.cpp:2491
+#, fuzzy
 msgid ""
 "New connection attempt, but no currently no socket maxima could connect to."
-msgstr ""
+msgstr "Yeni bağlantı girişimi, ancak şu anda maxima işlemi çalışmıyor."
 
 #: ../../src/wxMaxima.cpp:2487
 msgid "New connection attempt, but no currently running maxima process."
-msgstr ""
+msgstr "Yeni bağlantı girişimi, ancak şu anda maxima işlemi çalışmıyor."
 
 #: ../../src/ToolBar.cpp:174
 msgid "New document"
-msgstr ""
+msgstr "Yeni belge"
 
 #: ../../src/wxMaxima.cpp:3899
-#, c-format
+#, fuzzy, c-format
 msgid "New maxima Operators detected: %s"
-msgstr ""
+msgstr "Maxima mimarisi:% s"
 
 #: ../../src/wxMaxima.cpp:7390
+#, fuzzy
 msgid "New part:"
-msgstr ""
+msgstr "Yeni Değişken:"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
 #: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
 msgid "New variable:"
-msgstr ""
+msgstr "Yeni Değişken:"
 
 #: ../../src/wxMaximaFrame.cpp:929
 msgid "Next Command\tAlt+Down"
-msgstr ""
+msgstr "Sonraki komut\tAlt+Down"
 
 #: ../../src/wxMaximaFrame.cpp:748
 msgid "Nice Graphical Equations"
-msgstr ""
+msgstr "Güzel Grafiksel Eşitlikler"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "No"
-msgstr ""
+msgstr "Hayır"
 
 #: ../../src/Worksheet.cpp:1972
+#, fuzzy
 msgid "No Array"
-msgstr ""
+msgstr "Dizin:"
 
 #: ../../src/Worksheet.cpp:1974
 msgid "No Scalar"
@@ -4764,7 +5129,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10482
 msgid "No dollar ($) or semicolon (;) at the end of command"
-msgstr ""
+msgstr "Komut sonunda ($) ya da (;) yok"
 
 #: ../../src/MaximaManual.cpp:406
 msgid "No entries in the caches for the subjects the manual contains."
@@ -4777,16 +5142,16 @@ msgstr ""
 
 #: ../../src/Image.cpp:495
 msgid "No gnuplot data!"
-msgstr ""
+msgstr "Gnuplot verisi yok!"
 
 #: ../../src/Image.cpp:530
 msgid "No gnuplot source!"
-msgstr ""
+msgstr "Gnuplot kaynağı yok!"
 
 #: ../../src/wxMaxima.cpp:6662 ../../src/wxMaxima.cpp:6668
 #: ../../src/wxMaxima.cpp:6687 ../../src/wxMaxima.cpp:6697
 msgid "No matches found!"
-msgstr ""
+msgstr "Eşleşme bulunamadı!"
 
 #: ../../src/wxMaxima.cpp:3240
 msgid "No topics found in topic flag"
@@ -4802,15 +5167,15 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8163
 msgid "Not a valid matrix dimension!"
-msgstr ""
+msgstr "Geçerli bir matris boyutu değil!"
 
 #: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
 msgid "Not a valid number of equations!"
-msgstr ""
+msgstr "Geçerli bir denklemler sayısı değil!"
 
 #: ../../src/StatusBar.cpp:256
 msgid "Not connected to Maxima"
-msgstr ""
+msgstr "Maxima'ya bağlı değil"
 
 #: ../../src/wxMaxima.cpp:10496
 msgid "Not triggering evaluation as maxima is still busy!"
@@ -4826,80 +5191,92 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8926
 msgid "Num. deg:"
-msgstr ""
+msgstr "Say.derecesi:"
 
 #: ../../src/wxMaxima.cpp:8540
 msgid "Number of elements"
-msgstr ""
+msgstr "Ögelerin sayısı"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
 msgid "Number of equations:"
-msgstr ""
+msgstr "Denklemlerin sayısı:"
 
 #: ../../src/wxMaxima.cpp:7481
+#, fuzzy
 msgid "Number to octets"
-msgstr ""
+msgstr "Sayı türleri"
 
 #: ../../src/wxMaximaFrame.cpp:1154
+#, fuzzy
 msgid "Number to octets..."
-msgstr ""
+msgstr "Ögelerin sayısı"
 
 #: ../../src/wxMaximaFrame.cpp:1906
 msgid "Number types"
-msgstr ""
+msgstr "Sayı türleri"
 
 #: ../../src/wxMaxima.cpp:7482
+#, fuzzy
 msgid "Number:"
-msgstr ""
+msgstr "Sayılar"
 
 #: ../../src/wxMaximaFrame.cpp:1786
+#, fuzzy
 msgid "Numeric output"
-msgstr ""
+msgstr "Numerik Çıktıyı Çalıştır"
 
 #: ../../src/wxMaxima.cpp:8040
 msgid "Numerical QR decomposition of a matrix"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1417
+#, fuzzy
 msgid "Numerical operations (lapack)"
-msgstr ""
+msgstr "&Numerik İntegral"
 
 #: ../../src/wxMaxima.cpp:7831
+#, fuzzy
 msgid "Numerical solution for 1st degree ODE"
-msgstr ""
+msgstr "Birinci derece ADD için Başlangıç Değer Problemini Çöz"
 
 #: ../../src/wxMaximaFrame.cpp:1282
+#, fuzzy
 msgid "Numerical solution..."
-msgstr ""
+msgstr "Numerik Çıktıyı Çalıştır"
 
 #: ../../src/wxMaximaFrame.cpp:1261
+#, fuzzy
 msgid "Numerical solutions of polynomial (bfloat)..."
-msgstr ""
+msgstr "Polinomun bütün köklerini bul"
 
 #: ../../src/wxMaximaFrame.cpp:1258
+#, fuzzy
 msgid "Numerical solutions of polynomial..."
-msgstr ""
+msgstr "Polinomun bütün köklerini bul"
 
 #: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: ../../src/wxMaximaFrame.cpp:122
-#, c-format
+#, fuzzy, c-format
 msgid "OS: %s Version %li.%li"
-msgstr ""
+msgstr "İşletim Sistemi:% s Sürüm% i.% i"
 
 #: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
+#, fuzzy
 msgid "Object composed of elements"
-msgstr ""
+msgstr "Ögelerin sayısı"
 
 #: ../../src/wxMaxima.cpp:7680
+#, fuzzy
 msgid "Object name:"
-msgstr ""
+msgstr "Dizin adı:"
 
 #: ../../src/wxMaxima.cpp:7281
+#, fuzzy
 msgid "Object:"
-msgstr ""
+msgstr "Dizin adı:"
 
 #: ../../src/wxMaxima.cpp:7486
 msgid "Octets to Number"
@@ -4914,8 +5291,9 @@ msgid "Octets to number..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1158
+#, fuzzy
 msgid "Octets to string..."
-msgstr ""
+msgstr "Çizimi yapılacak olan İfade"
 
 #: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
 msgid "Octets:"
@@ -4928,11 +5306,12 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
 #: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
 msgid "Old variable:"
-msgstr ""
+msgstr "Eski Değişken:"
 
 #: ../../src/wxMaximaFrame.cpp:1055
+#, fuzzy
 msgid "On all errors"
-msgstr ""
+msgstr "Ölümcül Hata"
 
 #: ../../src/wxMaximaFrame.cpp:1054
 msgid "On lisp errors"
@@ -4940,36 +5319,37 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9566
 msgid "One sample t-test"
-msgstr ""
+msgstr "Bir örnek t-testi"
 
 #: ../../src/wxMaximaFrame.cpp:1927
 msgid "Online tutorials"
-msgstr ""
+msgstr "Çevirimiçi Çalışma Notları"
 
 #: ../../src/wxMaximaFrame.cpp:766
+#, fuzzy
 msgid "Only Integers and single letters"
-msgstr ""
+msgstr "Tamsayılar ve tek harfler"
 
 #: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593
 #: ../../src/wxMaxima.cpp:6074
 msgid "Open"
-msgstr ""
+msgstr "Aç"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "Open a document"
-msgstr ""
+msgstr "Bir Belge Aç"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "Open a new window"
-msgstr ""
+msgstr "Yeni Bir Pencere Aç"
 
 #: ../../src/ToolBar.cpp:617
 msgid "Open and save button"
-msgstr ""
+msgstr "Aç ve Kaydet Butonu"
 
 #: ../../src/ToolBar.cpp:176
 msgid "Open document"
-msgstr ""
+msgstr "Belge Aç"
 
 #: ../../src/wxMaxima.cpp:7239
 msgid "Open for appending"
@@ -4984,38 +5364,41 @@ msgid "Open for reading"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1098
+#, fuzzy
 msgid "Open for reading..."
-msgstr ""
+msgstr "Çizimi yapılacak olan İfade"
 
 #: ../../src/wxMaxima.cpp:7249
 msgid "Open for writing"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1100
+#, fuzzy
 msgid "Open for writing..."
-msgstr ""
+msgstr "Çıkarılıyor..."
 
 #: ../../src/wxMaxima.cpp:9598
 msgid "Open matrix"
-msgstr ""
+msgstr "Matris Aç"
 
 #: ../../src/wxMaximaFrame.cpp:600
+#, fuzzy
 msgid "Open recent"
-msgstr ""
+msgstr "Yakın Geçmişi Aç"
 
 #: ../../src/wxMaxima.cpp:4309
 msgid "Opening a wxmx file"
-msgstr ""
+msgstr "'wxmx' dosyasını açıyor"
 
 #: ../../src/wxMaxima.cpp:4153 ../../src/wxMaxima.cpp:4214
 #: ../../src/wxMaxima.cpp:4313 ../../src/wxMaxima.cpp:4622
 msgid "Opening file"
-msgstr ""
+msgstr "Dosya açılıyor"
 
 #: ../../src/wxMaxima.cpp:5030
 #, c-format
 msgid "Opening help file %s"
-msgstr ""
+msgstr "%s yardım dosyası açılıyor"
 
 #: ../../src/wxMaximaFrame.cpp:1530
 msgid "Optimize for CPU time"
@@ -5027,11 +5410,12 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:199
 msgid "Options"
-msgstr ""
+msgstr "Seçenekler"
 
 #: ../../src/wxMaximaFrame.cpp:1225
+#, fuzzy
 msgid "Output C"
-msgstr ""
+msgstr "Çıktı Etiketleri"
 
 #: ../../src/wxMaximaFrame.cpp:1226
 msgid "Output Fortran"
@@ -5043,11 +5427,12 @@ msgstr ""
 
 #: ../../src/Configuration.cpp:80
 msgid "Output labels"
-msgstr ""
+msgstr "Çıktı Etiketleri"
 
 #: ../../src/Configuration.cpp:73
+#, fuzzy
 msgid "Output: Function names"
-msgstr ""
+msgstr "Fonksiyon isimleri"
 
 #: ../../src/Configuration.cpp:75
 msgid "Output: Latin names as greek symbols"
@@ -5058,21 +5443,24 @@ msgid "Output: Numbers and Digits"
 msgstr ""
 
 #: ../../src/Configuration.cpp:71
+#, fuzzy
 msgid "Output: Operators"
-msgstr ""
+msgstr "Çıktı Etiketleri"
 
 #: ../../src/Configuration.cpp:74
-#, c-format
+#, fuzzy, c-format
 msgid "Output: Special constants (%e,%i)"
-msgstr ""
+msgstr "Özel Sabitler"
 
 #: ../../src/Configuration.cpp:76
+#, fuzzy
 msgid "Output: Strings"
-msgstr ""
+msgstr "Diziler"
 
 #: ../../src/Configuration.cpp:70
+#, fuzzy
 msgid "Output: Variable names"
-msgstr ""
+msgstr "Değişken adı"
 
 #: ../../src/wxMaxima.cpp:6442
 msgid ""
@@ -5081,6 +5469,10 @@ msgid ""
 "(*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format "
 "(*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image "
+"(*.gif)|*.gif|Scaleable vector graphics (*.svg)|*.svg|Windows bitmap "
+"(*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format "
+"(*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:10117
 msgid ""
@@ -5088,42 +5480,50 @@ msgid ""
 "(*.bmp)|*.bmp|GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged "
 "image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap "
+"(*.bmp)|*.bmp|GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged "
+"image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:8924
 msgid "Pade approximation"
-msgstr ""
+msgstr "Padé Yaklaşımı"
 
 #: ../../src/wxMaximaFrame.cpp:1478
 msgid "Pade approximation of a Taylor series"
-msgstr ""
+msgstr "Bir Taylor Serisinin Padé Yaklaşımı"
 
 #: ../../src/wxMaximaFrame.cpp:1637
+#, fuzzy
 msgid "Parallel Substitute..."
-msgstr ""
+msgstr "Yerine koy..."
 
 #: ../../src/wxMaxima.cpp:8738
+#, fuzzy
 msgid "Parallel substitution"
-msgstr ""
+msgstr "'e paralel"
 
 #: ../../src/wxMaxima.cpp:7179
+#, fuzzy
 msgid "Parameter name:"
-msgstr ""
+msgstr "Yineleyici:"
 
 #: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
+#, fuzzy
 msgid "Parameter(s):"
-msgstr ""
+msgstr "Değişken(ler):"
 
 #: ../../src/wxMaxima.cpp:7399
 msgid "Parse string"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1152
+#, fuzzy
 msgid "Parse string only..."
-msgstr ""
+msgstr "Sonlandırılmamış dizin."
 
 #: ../../src/StatusBar.cpp:240
 msgid "Parsing output"
-msgstr ""
+msgstr "Çıktı Analiz Ediliyor"
 
 #: ../../src/wxMaxima.cpp:7464
 msgid "Part:"
@@ -5131,64 +5531,65 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1499 ../../src/wxMaximaFrame.cpp:1535
 msgid "Partial &Fractions..."
-msgstr ""
+msgstr "Parçalı Kesirler..."
 
 #: ../../src/wxMaxima.cpp:8975
+#, fuzzy
 msgid "Partial Fractions"
-msgstr ""
+msgstr "Parçalı Kesirler"
 
 #: ../../src/wxMaxima.cpp:4702
 msgid "Parts of the document will not be loaded correctly!"
-msgstr ""
+msgstr "Belgenin parçaları düzgün olarak yüklenemedi!"
 
 #: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
 #: ../../src/Worksheet.cpp:1685
 msgid "Paste"
-msgstr ""
+msgstr "Yapıştır"
 
 #: ../../src/wxMaximaFrame.cpp:667
 msgid "Paste\tCtrl+V"
-msgstr ""
+msgstr "Yapıştır\tCtrl+V"
 
 #: ../../src/ToolBar.cpp:211
 msgid "Paste from clipboard"
-msgstr ""
+msgstr "Panodan Yapıştır"
 
 #: ../../src/wxMaximaFrame.cpp:668
 msgid "Paste text from clipboard"
-msgstr ""
+msgstr "Metni Panodan Yapıştır"
 
 #: ../../src/wxMaxima.cpp:4841
 msgid "Please configure wxMaxima with 'Edit->Configure'."
-msgstr ""
+msgstr "Lütfen wxMaxima'yı 'Düzenle-> Yapılandır' ile yapılandırınız."
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot &2d..."
-msgstr ""
+msgstr "2B Grafik..."
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot &3d..."
-msgstr ""
+msgstr "3B Grafik..."
 
 #: ../../src/wxMaximaFrame.cpp:1772
 msgid "Plot &Format..."
-msgstr ""
+msgstr "Grafik Formatı..."
 
 #: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
 msgid "Plot 2D"
-msgstr ""
+msgstr "2B Grafik"
 
 #: ../../src/Worksheet.cpp:1593
 msgid "Plot 2D..."
-msgstr ""
+msgstr "2B Grafik..."
 
 #: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
 msgid "Plot 3D"
-msgstr ""
+msgstr "3B Grafik"
 
 #: ../../src/Worksheet.cpp:1595
 msgid "Plot 3D..."
-msgstr ""
+msgstr "3B Grafik..."
 
 #: ../../src/wxMaxima.cpp:9538
 msgid "Plot as bars"
@@ -5199,32 +5600,35 @@ msgid "Plot as error bars"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9546
+#, fuzzy
 msgid "Plot as pie chart"
-msgstr ""
+msgstr "Parametrik ir ifadeyi çiz"
 
 #: ../../src/wxMaxima.cpp:9112
 msgid "Plot format"
-msgstr ""
+msgstr "Grafik Formatı"
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot in 2 dimensions"
-msgstr ""
+msgstr "2 Boyutlu Grafik çiz"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot in 3 dimensions"
-msgstr ""
+msgstr "3 Boyutlu Grafik çiz"
 
 #: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
 msgid "Plot using Draw"
-msgstr ""
+msgstr "Draw  kullanarak grafik çiz"
 
 #: ../../src/wxMaxima.cpp:7824
+#, fuzzy
 msgid "Point #1 with known value:"
-msgstr ""
+msgstr "Değerleri ile bir Dizin"
 
 #: ../../src/wxMaxima.cpp:7826
+#, fuzzy
 msgid "Point #2 with known value:"
-msgstr ""
+msgstr "Değerleri ile bir Dizin"
 
 #: ../../src/wxMaxima.cpp:7800 ../../src/wxMaxima.cpp:7811
 msgid "Point the value is known at:"
@@ -5232,112 +5636,124 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
 msgid "Point:"
-msgstr ""
+msgstr "Nokta:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 1:"
-msgstr ""
+msgstr "Polinom 1:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 2:"
-msgstr ""
+msgstr "Polinom 2:"
 
 #: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
 #: ../../src/wxMaxima.cpp:7739
+#, fuzzy
 msgid "Polynomial:"
-msgstr ""
+msgstr "Polinom 1:"
 
 #: ../../src/wxMaximaFrame.cpp:1754
 msgid "Pop"
-msgstr ""
+msgstr "Pop"
 
 #: ../../src/Worksheet.cpp:1331 ../../src/Worksheet.cpp:1485
 msgid "Popout interactively"
-msgstr ""
+msgstr "Etkileşimli olarak popout yap"
 
 #: ../../src/wxMaximaFrame.cpp:1189
 msgid "Position of a match"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
+#, fuzzy
 msgid "Position:"
-msgstr ""
+msgstr "Şart:"
 
 #: ../../src/wxMaxima.cpp:8939
+#, fuzzy
 msgid "Power series"
-msgstr ""
+msgstr "&Kuvvet Serileri"
 
 #: ../../src/wxMaximaFrame.cpp:1475
+#, fuzzy
 msgid "Power series..."
-msgstr ""
+msgstr "&Kuvvet Serileri"
 
 #: ../../src/wxMaxima.cpp:9202
 msgid "Precision"
-msgstr ""
+msgstr "OndalıkHassasiyet"
 
 #: ../../src/Worksheet.cpp:1616
 msgid "Prefer user labels"
-msgstr ""
+msgstr "Kullanıcı etiketlerini tercih et"
 
 #: ../../src/main.cpp:437
+#, fuzzy
 msgid "Preferences"
-msgstr ""
+msgstr "Tercihler düğmesi"
 
 #: ../../src/ToolBar.cpp:626
 msgid "Preferences button"
-msgstr ""
+msgstr "Tercihler düğmesi"
 
 #: ../../src/wxMaximaFrame.cpp:685
 msgid "Preferences...\tCtrl+,"
-msgstr ""
+msgstr "Öncelikli Tercihler\tCtrl+,"
 
 #: ../../src/wxMaximaFrame.cpp:1733
+#, fuzzy
 msgid "Prepend an element"
-msgstr ""
+msgstr "Bir öge ekle"
 
 #: ../../src/wxMaximaFrame.cpp:927
 msgid "Previous Command\tAlt+Up"
-msgstr ""
+msgstr "Bir Önceki Komut\tAlt+Up"
 
 #: ../../src/ToolBar.cpp:184
 msgid "Print"
-msgstr ""
+msgstr "Yazdır"
 
 #: ../../src/ToolBar.cpp:620
 msgid "Print button"
-msgstr ""
+msgstr "Yazdır Butonu"
 
 #: ../../src/Worksheet.cpp:1493
+#, fuzzy
 msgid "Print cell brackets"
-msgstr ""
+msgstr "Aktif hücre ayıracı"
 
 #: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
 msgid "Print document"
-msgstr ""
+msgstr "Belgeyi Yazdır"
 
 #: ../../src/wxMaximaFrame.cpp:1829
+#, fuzzy
 msgid "Print floating-point numbers with exponents dividable by 3"
-msgstr ""
+msgstr "Üstler 2 ile bölünebilir şekilde kayan nokta sayıları yazdır"
 
 #: ../../src/WXMXformat.cpp:255
 msgid ""
 "Produced invalid XML. The erroneous XML data has therefore not been saved "
 "but has been put on the clipboard in order to allow to debug it."
 msgstr ""
+"Geçersiz XML üretildi. Hatalı XML verileri bu nedenle kaydedilmedi, ancak "
+"hata ayıklamaya izin vermek için panoya konuldu."
 
 #: ../../src/wxMaxima.cpp:9061
 msgid "Product"
-msgstr ""
+msgstr "Çarpım"
 
 #: ../../src/wxMaximaFrame.cpp:1095
+#, fuzzy
 msgid "Program"
-msgstr ""
+msgstr "Histogram"
 
 #: ../../src/wxMaxima.cpp:7061
+#, fuzzy
 msgid "Program (no local variables)"
-msgstr ""
+msgstr "Değişkeni değiştir"
 
 #: ../../src/wxMaxima.cpp:7052
 msgid "Program block"
@@ -5353,11 +5769,12 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1751
 msgid "Push"
-msgstr ""
+msgstr "İtekle"
 
 #: ../../src/wxMaxima.cpp:8508
+#, fuzzy
 msgid "Push an element to a list"
-msgstr ""
+msgstr "Dizinden bir öge çıkar"
 
 #: ../../src/wxMaximaFrame.cpp:1395
 msgid "QR decomposition"
@@ -5377,32 +5794,35 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:246 ../../src/wxMaximaFrame.cpp:722
 msgid "Raw XML monitor"
-msgstr ""
+msgstr "Raw XML monitor"
 
 #: ../../src/wxMaximaFrame.cpp:2117
 #, c-format
 msgid "Re-Reading the config from %s."
-msgstr ""
+msgstr "%s 'den yapılandırmayı yeniden okuma."
 
 #: ../../src/wxMaximaFrame.cpp:2114
 msgid "Re-Reading the config from the default location."
-msgstr ""
+msgstr "Yapılandırmayı varsayılan konumdan yeniden okuma."
 
 #: ../../src/wxMaximaFrame.cpp:867
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr ""
+"İmlecin bulunduğu hücrenin üstündeki bütün hücreleri tekrar değerlendir"
 
 #: ../../src/wxMaximaFrame.cpp:877
 msgid "Re-evaluate all cells below the one the cursor is in"
 msgstr ""
+"İmlecin bulunduğu hücrenin altındaki bütün hücreleri tekrar değerlendir"
 
 #: ../../src/main.cpp:366
 msgid "Re-opening STDERR failed."
 msgstr ""
 
 #: ../../src/main.cpp:367
+#, fuzzy
 msgid "Re-opening STDIN failed."
-msgstr ""
+msgstr "Dosya açılıyor"
 
 #: ../../src/main.cpp:365
 msgid "Re-opening STDOUT failed."
@@ -5415,16 +5835,18 @@ msgid ""
 msgstr ""
 
 #: ../../src/Worksheet.cpp:6668
+#, fuzzy
 msgid "Read .wxm data from clipboard"
-msgstr ""
+msgstr "Metni Panodan Yapıştır"
 
 #: ../../src/wxMaxima.cpp:7599
 msgid "Read Directory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1677
+#, fuzzy
 msgid "Read List from csv file..."
-msgstr ""
+msgstr "Sitili dosyadan yükle"
 
 #: ../../src/wxMaxima.cpp:7196
 msgid "Read a structure field"
@@ -5435,16 +5857,19 @@ msgid "Read byte"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7266
+#, fuzzy
 msgid "Read char"
-msgstr ""
+msgstr "Matrisi Oku...."
 
 #: ../../src/wxMaxima.cpp:7593
+#, fuzzy
 msgid "Read environment variable"
-msgstr ""
+msgstr "Maxima için ek parametreler"
 
 #: ../../src/wxMaximaFrame.cpp:1219
+#, fuzzy
 msgid "Read environment variable..."
-msgstr ""
+msgstr "Bir Değişkeni Sil"
 
 #: ../../src/wxMaxima.cpp:7262
 msgid "Read line"
@@ -5457,12 +5882,12 @@ msgstr ""
 
 #: ../../src/StatusBar.cpp:245
 msgid "Reading Maxima output"
-msgstr ""
+msgstr "'Maxima çıktısı'nı okuyor"
 
 #: ../../src/StatusBar.cpp:247
 #, c-format
 msgid "Reading Maxima output: %li bytes"
-msgstr ""
+msgstr "Maxima çıktısını okuma:% li bayt"
 
 #: ../../src/wxMathml.cpp:55
 #, c-format
@@ -5476,15 +5901,15 @@ msgstr ""
 #: ../../src/wxMaximaFrame.cpp:148
 #, c-format
 msgid "Reading the config from %s."
-msgstr ""
+msgstr "Yapılandırmayı % s' den okuma ."
 
 #: ../../src/wxMaximaFrame.cpp:151
 msgid "Reading the config from the default location."
-msgstr ""
+msgstr "Yapılandırmayı varsayılan konumdan okuma."
 
 #: ../../src/StatusBar.cpp:224
 msgid "Ready for user input"
-msgstr ""
+msgstr "Kullanıcı girdisine hazır"
 
 #: ../../src/Worksheet.cpp:960
 msgid "Recalculated the whole worksheet at once => Updating its size"
@@ -5496,29 +5921,31 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:930
 msgid "Recall next command from history"
-msgstr ""
+msgstr "Sonraki komutu geçmişten bul"
 
 #: ../../src/wxMaximaFrame.cpp:928
 msgid "Recall previous command from history"
-msgstr ""
+msgstr "Sonraki komutu geçmişten bul"
 
 #: ../../src/wxMaxima.cpp:3235
-#, c-format
+#, fuzzy, c-format
 msgid "Received manual topic request: %s"
-msgstr ""
+msgstr "Maxima'nın ilk istemini aldı:% s"
 
 #: ../../src/wxMaxima.cpp:3097
 #, c-format
 msgid "Received maxima's first prompt: %s"
-msgstr ""
+msgstr "Maxima'nın ilk istemini aldı:% s"
 
 #: ../../src/wxMaximaFrame.cpp:603
+#, fuzzy
 msgid "Recover unsaved"
-msgstr ""
+msgstr "kaydedilmemiş"
 
 #: ../../src/wxMaximaFrame.cpp:1640
+#, fuzzy
 msgid "Recursive Substitute..."
-msgstr ""
+msgstr "Yerine koy..."
 
 #: ../../src/wxMaxima.cpp:8746
 msgid "Recursive substitution"
@@ -5530,19 +5957,19 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo\tCtrl+Y"
-msgstr ""
+msgstr "Yinele\tCtrl+Y"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo last change"
-msgstr ""
+msgstr "Son değişkliği Yinele"
 
 #: ../../src/wxMaximaFrame.cpp:1595
 msgid "Reduce trigonometric expression"
-msgstr ""
+msgstr "Trigonometric İfadeyi İndirge"
 
 #: ../../src/wxMaxima.cpp:2366 ../../src/wxMaxima.cpp:10630
 msgid "Refusing to send cell to maxima: "
-msgstr ""
+msgstr "Hücreyi Maxima'ya göndermeyi reddediyor: "
 
 #: ../../src/wxMaxima.cpp:7523
 msgid "Regex match"
@@ -5553,16 +5980,19 @@ msgid "Regex match position"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1195
+#, fuzzy
 msgid "Regular expression that matches a string"
-msgstr ""
+msgstr "Virgülle ayrılmış denklemler"
 
 #: ../../src/wxMaximaFrame.cpp:1196
+#, fuzzy
 msgid "Regular expressions"
-msgstr ""
+msgstr "İfadenin İntegralini Al"
 
 #: ../../src/Worksheet.cpp:1314
+#, fuzzy
 msgid "Reload Image"
-msgstr ""
+msgstr "Resim olarak Kopyala"
 
 #: ../../src/Worksheet.cpp:1320
 #, c-format
@@ -5570,13 +6000,13 @@ msgid "Reload Image \"%s\""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9809
-#, c-format
+#, fuzzy, c-format
 msgid "Reloading image file %s."
-msgstr ""
+msgstr "%s geçici dosyası olarak otomatik kaydetme"
 
 #: ../../src/wxMaximaFrame.cpp:883
 msgid "Remove All Output"
-msgstr ""
+msgstr "Tüm Çıktıları Temizle"
 
 #: ../../src/wxMaximaFrame.cpp:1426
 msgid "Remove Rows or Columns..."
@@ -5587,6 +6017,8 @@ msgid ""
 "Remove all list elements that appear twice in a row. Normally used in "
 "conjunction with sort."
 msgstr ""
+"Bir satırda iki defa görünen bütün dizin ögelerini temizle. Normalde "
+"sıralama ile birlikte kullanılır."
 
 #: ../../src/wxMaximaFrame.cpp:1174
 msgid "Remove all occurrences of a word..."
@@ -5598,19 +6030,21 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8592
 msgid "Remove an element from a list"
-msgstr ""
+msgstr "Dizinden bir öge çıkar"
 
 #: ../../src/wxMaxima.cpp:7566
+#, fuzzy
 msgid "Remove directory"
-msgstr ""
+msgstr "Tekrarları çıkart"
 
 #: ../../src/wxMaximaFrame.cpp:1204
+#, fuzzy
 msgid "Remove directory..."
-msgstr ""
+msgstr "Tekrarları çıkart"
 
 #: ../../src/wxMaximaFrame.cpp:1747
 msgid "Remove duplicates"
-msgstr ""
+msgstr "Tekrarları çıkart"
 
 #: ../../src/wxMaximaFrame.cpp:1176
 msgid "Remove first occurrence of a word..."
@@ -5622,7 +6056,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:884
 msgid "Remove output from input cells"
-msgstr ""
+msgstr "Girdi Hücrelerindeki Çıktıları Temizle"
 
 #: ../../src/wxMaxima.cpp:7975
 msgid "Remove rows and/or columns"
@@ -5633,16 +6067,19 @@ msgid "Remove rows and/or columns from the matrix"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7582
+#, fuzzy
 msgid "Rename file"
-msgstr ""
+msgstr "Dosya açılıyor"
 
 #: ../../src/wxMaximaFrame.cpp:1215
+#, fuzzy
 msgid "Rename file..."
-msgstr ""
+msgstr "Bir Değişkeni Sil"
 
 #: ../../src/wxMaximaFrame.cpp:1527
+#, fuzzy
 msgid "Reorganize an expression using horner's rule"
-msgstr ""
+msgstr "Gauss sayıları şeklindeki bir ifadeyi çarpanlarına ayır"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "Repetitive element-by-element multiplication"
@@ -5657,41 +6094,45 @@ msgid "Replace first regex match"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7463
+#, fuzzy
 msgid "Replace the first occurrence of Part"
-msgstr ""
+msgstr "Yerleştirilmiş %d Olgular."
 
 #: ../../src/wxMaximaFrame.cpp:1180
+#, fuzzy
 msgid "Replace..."
-msgstr ""
+msgstr "Tümünü Yeniden Yerleştir"
 
 #: ../../src/wxMaxima.cpp:6719
-#, c-format
+#, fuzzy, c-format
 msgid "Replaced %li occurrences."
-msgstr ""
+msgstr "Yerleştirilmiş %d Olgular."
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "Report bug"
-msgstr ""
+msgstr "Hatayı Bildir"
 
 #: ../../src/wxMaximaFrame.cpp:996
+#, fuzzy
 msgid "Reset option variables"
-msgstr ""
+msgstr "Değişkeni değiştir"
 
 #: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
 msgid "Restart Maxima"
-msgstr ""
+msgstr "Maxima'yı Yeniden Başlat"
 
 #: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
 msgid "Restrict Maximum size"
-msgstr ""
+msgstr "Maksimum boyutu tekrar ayarla"
 
 #: ../../src/wxMaxima.cpp:10031
+#, fuzzy
 msgid "Result variables:"
-msgstr ""
+msgstr "Değiken(leri) sil:"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Resulting Matrix name (may be empty):"
-msgstr ""
+msgstr "Sonuç Matris adı (boş olabilir):"
 
 #: ../../src/wxMaximaFrame.cpp:1190
 msgid "Return a match"
@@ -5710,75 +6151,79 @@ msgid ""
 "Return the first item of the list and remove it from the list. Useful for "
 "creating stacks."
 msgstr ""
+"Listenin ilk öğesini döndürüp listeden çıkarın. Yığın oluşturmak için "
+"kullanışlıdır."
 
 #: ../../src/wxMaxima.cpp:8526
 msgid "Return the list without its first n elements"
-msgstr ""
+msgstr "İlk n elemanı olmadan listeyi döndürür"
 
 #: ../../src/wxMaxima.cpp:8532
 msgid "Return the list without its last n elements"
-msgstr ""
+msgstr "Son n elemanı olmadan listeyi döndürür"
 
 #: ../../src/ToolBar.cpp:241
 msgid "Return to the cell that is currently being evaluated"
-msgstr ""
+msgstr "Değerlendirilmekte olan hücreye dön"
 
 #: ../../src/wxMaximaFrame.cpp:1711
 msgid "Returns an arbitrary list item"
-msgstr ""
+msgstr "Rasgele bir liste öğesine döner"
 
 #: ../../src/wxMaximaFrame.cpp:1713
 msgid "Returns the first item of the list"
-msgstr ""
+msgstr "Listenin ilk öğesine döner"
 
 #: ../../src/wxMaximaFrame.cpp:1719
 msgid "Returns the last item of the list"
-msgstr ""
+msgstr "Listenin son öğesine döner"
 
 #: ../../src/wxMaximaFrame.cpp:1721
 msgid "Returns the last n items of the list"
-msgstr ""
+msgstr "Dizinin son ögesine döner"
 
 #: ../../src/wxMaximaFrame.cpp:1742
 msgid "Returns the length of the list"
-msgstr ""
+msgstr "Dizinin uzunluğuna döner"
 
 #: ../../src/wxMaximaFrame.cpp:1715
 msgid "Returns the list without its first n elements"
-msgstr ""
+msgstr "İlk n ögesi olmadan dizine döner"
 
 #: ../../src/wxMaximaFrame.cpp:1717
 msgid "Returns the list without its last n elements"
-msgstr ""
+msgstr "Sonuncu ögesi olmadan dizine döner"
 
 #: ../../src/wxMaximaFrame.cpp:1743
 msgid "Reverse"
-msgstr ""
+msgstr "Tersi"
 
 #: ../../src/wxMaximaFrame.cpp:1744
 msgid "Reverse the order of the list items"
-msgstr ""
+msgstr "Liste öğelerinin sırasını tersine çevir"
 
 #: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
 #: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
+#, fuzzy
 msgid "Right Matrix:"
-msgstr ""
+msgstr "Sağ ok"
 
 #: ../../src/wxMaxima.cpp:8190
+#, fuzzy
 msgid "Right end"
-msgstr ""
+msgstr "Sağ ok"
 
 #: ../../src/wxMaximaFrame.cpp:1301
 msgid "Right side to the \"=\""
-msgstr ""
+msgstr "\"=\" nin sağ tarafı."
 
 #: ../../src/wxMaximaFrame.cpp:1455
 msgid "Risch Integration..."
-msgstr ""
+msgstr "Risch İntegrali...."
 
 #: ../../src/wxMaximaFrame.cpp:785
 msgid "Rounded"
-msgstr ""
+msgstr "Yuvarlanmış"
 
 #: ../../src/wxMaximaFrame.cpp:1437
 msgid "Row and column operations"
@@ -5790,154 +6235,163 @@ msgid "Row number:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7977
+#, fuzzy
 msgid "Row numbers:"
-msgstr ""
+msgstr "Sayılar"
 
 #: ../../src/wxMaxima.cpp:8203
+#, fuzzy
 msgid "Rows"
-msgstr ""
+msgstr "Satırlar:"
 
 #: ../../src/wxMaxima.cpp:8201
+#, fuzzy
 msgid "Rule"
-msgstr ""
+msgstr "Kural:"
 
 #: ../../src/wxMaxima.cpp:8464 ../../src/wxMaxima.cpp:8477
 msgid "Rule:"
-msgstr ""
+msgstr "Kural:"
 
 #: ../../src/wxMaximaFrame.cpp:1027
+#, fuzzy
 msgid "Rules"
-msgstr ""
+msgstr "Kural:"
 
 #: ../../src/wxMaximaFrame.cpp:1693
+#, fuzzy
 msgid "Run each element through an expression"
-msgstr ""
+msgstr "Her öğeyi bir fonksiyonla çalıştırır"
 
 #: ../../src/wxMaxima.cpp:6355
-#, c-format
+#, fuzzy, c-format
 msgid "Running %s on the file %s: "
-msgstr ""
+msgstr "%s geçici dosyası olarak otomatik kaydetme"
 
 #: ../../src/wxMaxima.cpp:2633
 #, c-format
 msgid "Running maxima as: %s"
-msgstr ""
+msgstr "Maxima'yı %s olarak çalıştırma"
 
 #: ../../src/wxMaximaFrame.cpp:130
 msgid "Running on DirectFB"
-msgstr ""
+msgstr "DirectFB üzerinde çalışıyor"
 
 #: ../../src/wxMaximaFrame.cpp:114
 msgid "Running on MS Windows"
-msgstr ""
+msgstr "MS Windows'ta çalışıyor"
 
 #: ../../src/wxMaximaFrame.cpp:116
 msgid "Running on MS Windows using DirectDraw"
-msgstr ""
+msgstr "DirectDraw kullanarak MS Windows üzerinde çalıştırma"
 
 #: ../../src/wxMaximaFrame.cpp:136
 msgid "Running on Mac OS"
-msgstr ""
+msgstr "Mac OS ta çalışışyor"
 
 #: ../../src/wxMaximaFrame.cpp:127
 msgid "Running on Motif"
-msgstr ""
+msgstr "Motif'te çalışıyor"
 
 #: ../../src/wxMaximaFrame.cpp:133
 msgid "Running on the universal wxWidgets port"
-msgstr ""
+msgstr "Evrensel wxWidgets portunda çalışıyor"
 
 #: ../../src/wxMaxima.cpp:8208
+#, fuzzy
 msgid ""
 "Runs each element of an object (list, matrix, equation,...) through a "
 "function individually"
-msgstr ""
+msgstr "Her öğeyi bir fonksiyonla çalıştırır"
 
 #: ../../src/wxMaxima.cpp:8216
+#, fuzzy
 msgid ""
 "Runs each element of an object (list, matrix, equation,...) through an "
 "expression individually"
-msgstr ""
+msgstr "Her öğeyi bir fonksiyonla çalıştırır"
 
 #: ../../src/wxMaximaFrame.cpp:1691
 msgid "Runs each element through a function"
-msgstr ""
+msgstr "Her öğeyi bir fonksiyonla çalıştırır"
 
 #: ../../src/wxMaximaFrame.cpp:1694
+#, fuzzy
 msgid "Runs each element through an expression"
-msgstr ""
+msgstr "Her öğeyi bir fonksiyonla çalıştırır"
 
 #: ../../src/wxMaxima.cpp:9572
 msgid "Sample 1:"
-msgstr ""
+msgstr "Örnek 1:"
 
 #: ../../src/wxMaxima.cpp:9573
 msgid "Sample 2:"
-msgstr ""
+msgstr "Örnek 2:"
 
 #: ../../src/wxMaxima.cpp:9567
 msgid "Sample:"
-msgstr ""
+msgstr "Örnek:"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
 msgid "Save"
-msgstr ""
+msgstr "Kaydet"
 
 #: ../../src/Worksheet.cpp:1294
 msgid "Save Animation..."
-msgstr ""
+msgstr "Animasyonu Kaydet..."
 
 #: ../../src/wxMaxima.cpp:5672
 msgid "Save As"
-msgstr ""
+msgstr "Faklı Kaydet"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save As...\tShift+Ctrl+S"
-msgstr ""
+msgstr "Faklı Kaydet\tShift+Ctrl+S"
 
 #: ../../src/Worksheet.cpp:1291
 msgid "Save Image..."
-msgstr ""
+msgstr "Resmi Kaydet..."
 
 #: ../../src/wxMaxima.cpp:6440
 msgid "Save Selection to Image"
-msgstr ""
+msgstr "Seçileni Resim Olarak Kaydet"
 
 #: ../../src/wxMaximaFrame.cpp:675
 msgid "Save Selection to Image..."
-msgstr ""
+msgstr "Seçileni Resim Olarak Kaydet..."
 
 #: ../../src/wxMaxima.cpp:10184
 msgid "Save animation to file"
-msgstr ""
+msgstr "Animasyonu Dosyaya Kaydet"
 
 #: ../../src/wxMaxima.cpp:7203
 msgid "Save as lisp code"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1091
+#, fuzzy
 msgid "Save as lisp..."
-msgstr ""
+msgstr "Paket Yükle"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
 msgid "Save document"
-msgstr ""
+msgstr "Belgeyi Kaydet"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save document as"
-msgstr ""
+msgstr "Belgeyi Farklı Kaydet"
 
 #: ../../src/wxMaximaFrame.cpp:676
 msgid "Save selection from document to an image file"
-msgstr ""
+msgstr "Seçileni Bir Resim Dosyası Olarak Kaydet"
 
 #: ../../src/wxMaxima.cpp:10125
 msgid "Save selection to file"
-msgstr ""
+msgstr "Seçileni Dosyaya Kaydet"
 
 #: ../../src/wxMaximaFrame.cpp:573
 msgid "Saving failed."
-msgstr ""
+msgstr "Kaydetme başarısız."
 
 #: ../../src/WXMXformat.cpp:310
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
@@ -5950,25 +6404,37 @@ msgid ""
 "(*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|Portable anymap "
 "(*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"Ölçeklenebilir Vektör görüntüsü (* .svg) | * .svg | Sıkıştırılabilir "
+"Ölçeklenebilir Vektör Görüntüsü (* .svgz) | * .svgz | PNG resmi (* .png) | *"
+" .png | JPEG resmi (* .jpg) | * .jpg | GIF görüntüsü (* .gif) | * .gif | "
+"Windows bitmap (* .bmp) | * .bmp | Taşınabilir anymap (* .pnm) | * .pnm | "
+"Etiketli görüntü dosyası biçimi (* .tif) | * .tif | X pixmap (* .xpm) | * "
+".xpm"
 
 #: ../../src/wxMaxima.cpp:9533
 msgid "Scatterplot"
-msgstr ""
+msgstr "Dağılım Grafiği"
 
 #: ../../src/Autocomplete.cpp:125
+#, fuzzy
 msgid ""
 "Scheduling a background task that compiles a new list of autocompletable "
 "maxima commands."
 msgstr ""
+"Otomatik tamamlanabilir maxima komutlarının yeni bir listesini derleyen bir "
+"arka plan görevi başlatıyor."
 
 #: ../../src/Autocomplete.cpp:458
+#, fuzzy
 msgid ""
 "Scheduling a background task that scans for autocompletable file names."
 msgstr ""
+"Otomatik tamamlanabilir dosya adlarını tarayan bir arka plan görevi "
+"başlatıyor."
 
 #: ../../src/ToolBar.cpp:632
 msgid "Search button"
-msgstr ""
+msgstr "Arama butonu"
 
 #: ../../src/wxMaxima.cpp:7454
 msgid "Search first occurrence of part"
@@ -5980,15 +6446,16 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:273
 msgid "Section"
-msgstr ""
+msgstr "Bölüm"
 
 #: ../../src/Configuration.cpp:91
 msgid "Section cell (Heading 2)"
-msgstr ""
+msgstr "Bölüm hücresi (Başlık 2)"
 
 #: ../../src/wxMaxima.cpp:7218
+#, fuzzy
 msgid "Seek to position"
-msgstr ""
+msgstr "Padé Yaklaşımı"
 
 #: ../../src/BTextCtrl.cpp:45
 msgid "Seems like something is broken with a font."
@@ -5996,88 +6463,93 @@ msgstr ""
 
 #: ../../src/Autocomplete.cpp:350
 msgid "Seems like the package with the maxima share files isn't installed."
-msgstr ""
+msgstr "Görünüşe göre maxima paylaşım dosyalarına sahip paket kurulu değil."
 
 #: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
 msgid "Select All"
-msgstr ""
+msgstr "Tümünü Seç"
 
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select All\tCtrl+A"
-msgstr ""
+msgstr "Tümünü Seç\tCtrl+A"
 
 #: ../../src/ToolBar.cpp:629
 msgid "Select All button"
-msgstr ""
+msgstr "Hepsini seç butonu"
 
 #: ../../src/wxMaxima.cpp:9631
 msgid "Select Subsample"
-msgstr ""
+msgstr "Alt Örnek Seç"
 
 #: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select all"
-msgstr ""
+msgstr "Tümünü Seç"
 
 #: ../../src/wxMaxima.cpp:6971
 msgid "Select math display algorithm"
-msgstr ""
+msgstr "Matematik Gösterim Algoritmasını Seç"
 
 #: ../../src/Configuration.cpp:98
+#, fuzzy
 msgid "Selection color"
-msgstr ""
+msgstr "Seçim"
 
 #: ../../src/ToolBar.cpp:252
 msgid "Send all cells to maxima"
-msgstr ""
+msgstr "Tüm hücreleri Maxima'ya gönder"
 
 #: ../../src/ToolBar.cpp:249
 msgid "Send the current cell to maxima"
-msgstr ""
+msgstr "Geçerli hücreyi maxima'ya gönder"
 
 #: ../../src/wxMaxima.cpp:2810
 msgid "Sending Maxima a SIGINT signal."
-msgstr ""
+msgstr "Maxima'ya SIGINT sinyali gönderme."
 
 #: ../../src/StatusBar.cpp:220
 msgid "Sending a command to Maxima"
-msgstr ""
+msgstr "Maxima'ya bir komut gönderme"
 
 #: ../../src/wxMaxima.cpp:10598
+#, fuzzy
 msgid "Sending a new command to Maxima."
-msgstr ""
+msgstr "Maxima'ya bir komut gönderme"
 
 #: ../../src/wxMaxima.cpp:2792
 msgid "Sending an interrupt signal to Maxima."
-msgstr ""
+msgstr "Maxima'ya kesme sinyali gönderme."
 
 #: ../../src/wxMaxima.cpp:169
 msgid "Sending configuration data to maxima."
-msgstr ""
+msgstr "Yapılandırma verilerinin Maxima'ya gönderilmesi."
 
 #: ../../src/wxMaxima.cpp:4718
 msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
+"Maxima bilgisini 2B matematiğini XML olarak nasıl ifade edeceğinizi gönderme"
 
 #: ../../src/wxMaximaFrame.cpp:1533
+#, fuzzy
 msgid "Sequential Comparative Simplification"
-msgstr ""
+msgstr "&Karmaşık Sadeleştirme"
 
 #: ../../src/wxMaxima.cpp:9016
 msgid "Series"
-msgstr ""
+msgstr "Seriler"
 
 #: ../../src/wxMaximaFrame.cpp:1479
+#, fuzzy
 msgid "Series approximation"
-msgstr ""
+msgstr "Padé Yaklaşımı"
 
 #: ../../src/wxMaxima.cpp:2561
 msgid "Server started"
-msgstr ""
+msgstr "Sunucu Başladı"
 
 #: ../../src/wxMaximaFrame.cpp:1824
 msgid "Set &displayed Precision..."
-msgstr ""
+msgstr "Hassasiyet Ayarla ve görüntüle ..."
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Set Maxima option variable logexpand:all"
@@ -6093,130 +6565,141 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:822
 msgid "Set Zoom"
-msgstr ""
+msgstr "Yakınlaştır\\Uzaklaştır"
 
 #: ../../src/wxMaximaFrame.cpp:1819
 msgid "Set bigfloat &Precision..."
-msgstr ""
+msgstr "BüyükKayanSayı &Hassasiyeti Belirt..."
 
 #: ../../src/Worksheet.cpp:1306 ../../src/Worksheet.cpp:1479
+#, fuzzy
 msgid "Set image resolution"
-msgstr ""
+msgstr "Çözümleri yeniden kullanma\n"
 
 #: ../../src/wxMaximaFrame.cpp:1510
+#, fuzzy
 msgid "Set main variable..."
-msgstr ""
+msgstr "Bir Değişkeni Sil"
 
 #: ../../src/wxMaximaFrame.cpp:1773
 msgid "Set plot format"
-msgstr ""
+msgstr "Grafik formatını ayarla"
 
 #: ../../src/wxMaximaFrame.cpp:1101
+#, fuzzy
 msgid "Set position..."
-msgstr ""
+msgstr "Animasyonu Kaydet..."
 
 #: ../../src/wxMaximaFrame.cpp:1656
+#, fuzzy
 msgid "Set the \"algebraic\" flag"
-msgstr ""
+msgstr "Cebirsel Dizeyi (Flag) Çalıştır"
 
 #: ../../src/wxMaxima.cpp:8314
 msgid "Set the diagram title"
-msgstr ""
+msgstr "Diyagram başlığını ayarla"
 
 #: ../../src/wxMaximaFrame.cpp:1779
 msgid "Set the frame rate for animations."
-msgstr ""
+msgstr "Animasyonlar için çerçeve hızını ayarla."
 
 #: ../../src/wxMaxima.cpp:8377
 msgid "Set the grid density."
-msgstr ""
+msgstr "Izgara yoğunluğunu ayarlayın."
 
 #: ../../src/wxMaxima.cpp:8327
 msgid "Set the next plot's title. Empty = no title."
-msgstr ""
+msgstr "Bir sonraki arsanın başlığını ayarlayın. Boş = başlık yok."
 
 #: ../../src/wxMaximaFrame.cpp:1820
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can"
 " be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
+"Büyük Kayan sayı olarak tanımlanmış sayılarda hassasiyeti ayarlayın. Bu tür "
+"sayılar 1.5b12 ya da  bfloat(1.234) şeklinde üretilebilir."
 
 #: ../../src/wxMaximaFrame.cpp:811
 msgid "Set zoom to 100%"
-msgstr ""
+msgstr "%100 Yakınlık"
 
 #: ../../src/wxMaximaFrame.cpp:813
 msgid "Set zoom to 120%"
-msgstr ""
+msgstr "%120 Yakınlık"
 
 #: ../../src/wxMaximaFrame.cpp:815
 msgid "Set zoom to 150%"
-msgstr ""
+msgstr "%150 Yakınlık"
 
 #: ../../src/wxMaximaFrame.cpp:817
 msgid "Set zoom to 200%"
-msgstr ""
+msgstr "%200 Yakınlık"
 
 #: ../../src/wxMaximaFrame.cpp:819
 msgid "Set zoom to 300%"
-msgstr ""
+msgstr "%300 Yakınlık"
 
 #: ../../src/wxMaximaFrame.cpp:809
 msgid "Set zoom to 80%"
-msgstr ""
+msgstr "%80 Yakınlık"
 
 #: ../../src/wxMaxima.cpp:4731
 #, c-format
 msgid "Setting gnuplot_binary to %s"
-msgstr ""
+msgstr "Gnuplot_binary öğesini% s olarak ayarlama"
 
 #: ../../src/wxMaxima.cpp:4804
+#, fuzzy
 msgid "Setting prompt and help format"
-msgstr ""
+msgstr "Grafik formatını ayarla"
 
 #: ../../src/wxMaximaFrame.cpp:1292
 msgid "Setup atvalues for solving ODE with Laplace transformation"
-msgstr ""
+msgstr "ADD'yi Laplace dönüşümleri ile çözerken başlangıç değerlerini düzenle"
 
 #: ../../src/wxMaximaFrame.cpp:1661
 msgid "Setup modulus computation"
-msgstr ""
+msgstr "Modül Hesaplamasını Kur"
 
 #: ../../src/wxMaxima.cpp:9220
+#, fuzzy
 msgid "Setup the engineering format"
-msgstr ""
+msgstr "Mühendislik formatını ayarla..."
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "Setup the engineering format..."
-msgstr ""
+msgstr "Mühendislik formatını ayarla..."
 
 #: ../../src/wxMaxima.cpp:9576
 msgid "Shapiro-Wilk test for normality"
 msgstr ""
 
 #: ../../src/Worksheet.cpp:1543
+#, fuzzy
 msgid "Show \"%\" in special constants"
-msgstr ""
+msgstr "Özel Sabitler"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show &Tips..."
-msgstr ""
+msgstr "Yararlı Öneriler &Göster..."
 
 #: ../../src/Worksheet.cpp:1556
 msgid "Show * as multiplication dot"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:895
+#, fuzzy
 msgid "Show Template\tCtrl+Shift+Space"
-msgstr ""
+msgstr "Şablonu Göster\tCtrl+Shift+K"
 
 #: ../../src/wxMaximaFrame.cpp:753
+#, fuzzy
 msgid "Show XML representation"
-msgstr ""
+msgstr "Uzun ifadeleri göster:"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show a tip"
-msgstr ""
+msgstr "Bir Yararlı Bilgi Göster"
 
 #: ../../src/Worksheet.cpp:1607
 msgid "Show all + allow linebreaks in long numbers"
@@ -6224,63 +6707,66 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9475
 msgid "Show all commands similar to:"
-msgstr ""
+msgstr "'...:'ya benzer bütün komutları göster:"
 
 #: ../../src/wxMaxima.cpp:9468
 msgid "Show an example for the command:"
-msgstr ""
+msgstr "'...:' Komutu için bir örnek Göster:"
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "Show an example of usage"
-msgstr ""
+msgstr "Kullanımı için Örnek Ver"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "Show commands similar to"
-msgstr ""
+msgstr "'...:'ya benzer komutları Göster"
 
 #: ../../src/wxMaximaFrame.cpp:1020
 msgid "Show defined functions"
-msgstr ""
+msgstr "Tanımlanmış Fonksiyonları Göster"
 
 #: ../../src/wxMaximaFrame.cpp:1022
 msgid "Show defined variables"
-msgstr ""
+msgstr "Tanımlanmış Değişkenleri Göster"
 
 #: ../../src/wxMaximaFrame.cpp:1074
 msgid "Show definition of a function"
-msgstr ""
+msgstr "Bir Fonksiyonun Tanımını Göster"
 
 #: ../../src/wxMaximaFrame.cpp:740
 msgid "Show equations in their linear form"
-msgstr ""
+msgstr "Denklemleri doğrusal formlarında göster"
 
 #: ../../src/wxMaximaFrame.cpp:1073
+#, fuzzy
 msgid "Show function &Definition..."
-msgstr ""
+msgstr "Tanımı & göster..."
 
 #: ../../src/wxMaximaFrame.cpp:896
 msgid "Show function template"
-msgstr ""
+msgstr "Fonksiyon Şablonunu Göster"
 
 #: ../../src/Worksheet.cpp:1614
+#, fuzzy
 msgid "Show input labels"
-msgstr ""
+msgstr "Girdi Etiketleri"
 
 #: ../../src/wxMaximaFrame.cpp:750
+#, fuzzy
 msgid "Show lisp representation"
-msgstr ""
+msgstr "Uzun ifadeleri göster:"
 
 #: ../../src/Worksheet.cpp:1604
 msgid "Show max. 100 digits"
-msgstr ""
+msgstr "Maks. 100 basamak göster"
 
 #: ../../src/Worksheet.cpp:1602
 msgid "Show max. 20 digits"
-msgstr ""
+msgstr "Maks. 20 basamak göster"
 
 #: ../../src/Worksheet.cpp:1603
 msgid "Show max. 50 digits"
-msgstr ""
+msgstr "Maks. 50 basamak göster"
 
 #: ../../src/wxMaximaFrame.cpp:835
 msgid "Show or hide the wxMaxima logging window"
@@ -6288,108 +6774,116 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:612
 msgid "Show the \"New\" button?"
-msgstr ""
+msgstr "\"Yeni\" düğmesi gösterilsin mi?"
 
 #: ../../src/ToolBar.cpp:636
 msgid "Show the \"help\" button?"
-msgstr ""
+msgstr "\"Yardım\" düğmesi gösterilsin mi?"
 
 #: ../../src/ToolBar.cpp:633
 msgid "Show the \"search\" button?"
-msgstr ""
+msgstr "\"Ara\" düğmesi gösterilsin mi?"
 
 #: ../../src/ToolBar.cpp:630
 msgid "Show the \"select all\" button?"
-msgstr ""
+msgstr "\"Hepsini seç\" düğmesi gösterilsin mi?"
 
 #: ../../src/ToolBar.cpp:624
 msgid "Show the Copy, Cut and the Paste button?"
-msgstr ""
+msgstr "Kopyala, Kes ve Yapıştır düğmesi gösterilsin mi?"
 
 #: ../../src/wxMaxima.cpp:7033
+#, fuzzy
 msgid "Show the function's definition"
-msgstr ""
+msgstr "Fonksiyonun Tanımını Göster:"
 
 #: ../../src/ToolBar.cpp:618
 msgid "Show the open and the save button?"
-msgstr ""
+msgstr "Aç ve kaydet düğmesi gösterilsin mi?"
 
 #: ../../src/ToolBar.cpp:627
 msgid "Show the preferences button?"
-msgstr ""
+msgstr "Tercihler düğmesi gösterilsin mi?"
 
 #: ../../src/ToolBar.cpp:621
 msgid "Show the print button?"
-msgstr ""
+msgstr "Yazdır düğmesi gösterilsin mi?"
 
 #: ../../src/ToolBar.cpp:615
+#, fuzzy
 msgid "Show the undo and redo button?"
-msgstr ""
+msgstr "Aç ve kaydet düğmesi gösterilsin mi?"
 
 #: ../../src/wxMaximaFrame.cpp:1006 ../../src/wxMaximaFrame.cpp:1011
 msgid "Show used + to-be-freed memory"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1033
+#, fuzzy
 msgid "Show user definitions"
-msgstr ""
+msgstr "Fonksiyonun Tanımını Göster:"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Show wxMaxima help"
-msgstr ""
+msgstr "WxMaxima Yardımını Göster"
 
 #: ../../src/wxMaximaFrame.cpp:1825
 msgid "Shows how many digits of a numbers are displayed"
-msgstr ""
+msgstr "Bir sayının kaç basamağının görüntülendiğini gösterir"
 
 #: ../../src/wxMaximaFrame.cpp:732
 msgid "Sidebars"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1513
+#, fuzzy
 msgid "Simplify &Radicals..."
-msgstr ""
+msgstr "Kökleri &Sadeleştir"
 
 #: ../../src/Worksheet.cpp:1579
 msgid "Simplify Expression"
-msgstr ""
+msgstr "İfadeyi Sadeleştir"
 
 #: ../../src/wxMaximaFrame.cpp:1568
+#, fuzzy
 msgid "Simplify Logarithms"
-msgstr ""
+msgstr "Toplamı Sadeleştir"
 
 #: ../../src/wxMaximaFrame.cpp:1582
 msgid "Simplify an expression containing factorials"
-msgstr ""
+msgstr "Faktöryel İçeren İfadeyi Sadeleştir"
 
 #: ../../src/wxMaximaFrame.cpp:1539
+#, fuzzy
 msgid "Simplify equations"
-msgstr ""
+msgstr "Basit denklemler\n"
 
 #: ../../src/wxMaximaFrame.cpp:1514
 msgid "Simplify expression containing radicals"
-msgstr ""
+msgstr "Kökleri Olan İfadeyi Sadeleştir"
 
 #: ../../src/wxMaxima.cpp:8649
+#, fuzzy
 msgid "Simplify radicals"
-msgstr ""
+msgstr "Kökleri &Sadeleştir"
 
 #: ../../src/wxMaximaFrame.cpp:1512
 msgid "Simplify rational expression"
-msgstr ""
+msgstr "Rasyonel İfadeyi Sadeleştir"
 
 #: ../../src/wxMaximaFrame.cpp:1538
 msgid "Simplify sum() commands..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8636
+#, fuzzy
 msgid "Simplify sums"
-msgstr ""
+msgstr "Sadeleştir"
 
 #: ../../src/wxMaximaFrame.cpp:1592
 msgid "Simplify trigonometric expression"
-msgstr ""
+msgstr "Trigonometrik İfadeyi Sadeleştir"
 
 #: ../../src/wxMaximaFrame.cpp:1399
 msgid "Singular Values"
@@ -6404,105 +6898,113 @@ msgid "Singular values, left + right vectors"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1635
+#, fuzzy
 msgid "Smart Substitute..."
-msgstr ""
+msgstr "Yerine koy..."
 
 #: ../../src/wxMaxima.cpp:8730
+#, fuzzy
 msgid "Smart substitution"
-msgstr ""
+msgstr "Yerine koy"
 
 #: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
 #: ../../src/wxMaxima.cpp:7823
+#, fuzzy
 msgid "Solution of the ODE:"
-msgstr ""
+msgstr "Çözüm:"
 
 #: ../../src/wxMaxima.cpp:10017
 msgid "Solve"
-msgstr ""
+msgstr "Çöz"
 
 #: ../../src/wxMaximaFrame.cpp:1244
 msgid "Solve &Algebraic System..."
-msgstr ""
+msgstr "&Cebirsel Sistemi Çöz..."
 
 #: ../../src/wxMaximaFrame.cpp:1242
 msgid "Solve &Linear System..."
-msgstr ""
+msgstr "&Lineer sistemi Çöz..."
 
 #: ../../src/wxMaximaFrame.cpp:1266
 msgid "Solve &ODE..."
-msgstr ""
+msgstr "&ADD Çöz..."
 
 #: ../../src/wxMaximaFrame.cpp:1240
 msgid "Solve (to_poly)..."
-msgstr ""
+msgstr "Çöz (to_poly_solve)ile..."
 
 #: ../../src/wxMaxima.cpp:8045
 msgid "Solve A*x=b numerically"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1397
+#, fuzzy
 msgid "Solve Ax=b"
-msgstr ""
+msgstr "Çöz"
 
 #: ../../src/wxMaxima.cpp:7783
 msgid "Solve ODE"
-msgstr ""
+msgstr "ADD Çöz"
 
 #: ../../src/wxMaximaFrame.cpp:1287
 msgid "Solve ODE with Lapla&ce..."
-msgstr ""
+msgstr "ADDyi Laplace ile Çöz..."
 
 #: ../../src/wxMaximaFrame.cpp:1398
+#, fuzzy
 msgid "Solve a linear equation system using dgesv"
-msgstr ""
+msgstr "Lineer Denklem Sistemini Çöz"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
 msgid "Solve algebraic system"
-msgstr ""
+msgstr "Cebirsel Sistemi Çöz"
 
 #: ../../src/wxMaximaFrame.cpp:1245
 msgid "Solve algebraic system of equations"
-msgstr ""
+msgstr "Cebirsel Denklem Sistemini Çöz"
 
 #: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve boundary value problem for second degree ODE"
-msgstr ""
+msgstr "İkinci Derece ADD sınır Değer Problemini Çöz"
 
 #: ../../src/wxMaxima.cpp:7895
+#, fuzzy
 msgid "Solve differential equations using laplace()"
-msgstr ""
+msgstr "Diferansiyel denklemlerin çözümü"
 
 #: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
 msgid "Solve equation(s)"
-msgstr ""
+msgstr "Denklem(leri) Çöz"
 
 #: ../../src/wxMaximaFrame.cpp:1241
 msgid "Solve equation(s) with to_poly_solve"
-msgstr ""
+msgstr "Denklem(leri)'to_poly_solve'ile Çöz"
 
 #: ../../src/wxMaxima.cpp:7773
+#, fuzzy
 msgid "Solve equations numerically"
-msgstr ""
+msgstr "Denklem(leri) Çöz"
 
 #: ../../src/wxMaxima.cpp:7757
+#, fuzzy
 msgid "Solve equations to polynom"
-msgstr ""
+msgstr "Denklem(leri)'to_poly_solve'ile Çöz"
 
 #: ../../src/wxMaximaFrame.cpp:1271
 msgid "Solve initial value problem for first degree ODE"
-msgstr ""
+msgstr "Birinci derece ADD için Başlangıç Değer Problemini Çöz"
 
 #: ../../src/wxMaximaFrame.cpp:1275
 msgid "Solve initial value problem for second degree ODE"
-msgstr ""
+msgstr "İkinci derece ADD için Başlangıç Değer Problemini Çöz"
 
 #: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
 msgid "Solve linear system"
-msgstr ""
+msgstr "Lineer Sistemi Çöz"
 
 #: ../../src/wxMaximaFrame.cpp:1243
 msgid "Solve linear system of equations"
-msgstr ""
+msgstr "Lineer Denklem Sistemini Çöz"
 
 #: ../../src/wxMaximaFrame.cpp:1263
 msgid "Solve numerical, 1 Variable"
@@ -6510,39 +7012,43 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1267
 msgid "Solve ordinary differential equation of maximum degree 2"
-msgstr ""
+msgstr "En Yüksek İkinci Derece olan ADD yi Çöz"
 
 #: ../../src/wxMaximaFrame.cpp:1288
 msgid "Solve ordinary differential equations with Laplace transformation"
-msgstr ""
+msgstr "ADD leri Laplace Dönüşümü ile Çöz"
 
 #: ../../src/wxMaxima.cpp:7708
+#, fuzzy
 msgid "Solve polynomials numerically"
-msgstr ""
+msgstr "Denklem(leri) Çöz"
 
 #: ../../src/wxMaxima.cpp:7718
+#, fuzzy
 msgid "Solve polynomials numerically (bfloats)"
-msgstr ""
+msgstr "Denklem(leri) Çöz"
 
 #: ../../src/wxMaxima.cpp:7729
+#, fuzzy
 msgid "Solve polynomials numerically (real roots)"
-msgstr ""
+msgstr "Denklem(leri) Çöz"
 
 #: ../../src/wxMaximaFrame.cpp:1249
+#, fuzzy
 msgid "Solve symbolically"
-msgstr ""
+msgstr "Denklem(leri) Çöz"
 
 #: ../../src/Worksheet.cpp:1574
 msgid "Solve..."
-msgstr ""
+msgstr "Çöz..."
 
 #: ../../src/wxMaximaFrame.cpp:1916
 msgid "Solving differential equations"
-msgstr ""
+msgstr "Diferansiyel denklemlerin çözümü"
 
 #: ../../src/wxMaximaFrame.cpp:1904
 msgid "Solving equations with Maxima"
-msgstr ""
+msgstr "Denklemlerin Maxima'yla çözümü"
 
 #: ../../src/wxMaxima.cpp:7105
 #, c-format
@@ -6553,23 +7059,24 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1746
 msgid "Sort"
-msgstr ""
+msgstr "Sırala"
 
 #: ../../src/wxMaxima.cpp:8496
 msgid "Sort a list"
-msgstr ""
+msgstr "Bir dizin sırala"
 
 #: ../../src/wxMaxima.cpp:7459
 msgid "Sort all characters in string"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1179
+#, fuzzy
 msgid "Sort the characters..."
-msgstr ""
+msgstr "İçeriği Göster"
 
 #: ../../src/wxMaxima.cpp:8482
 msgid "Source list:"
-msgstr ""
+msgstr "Kaynak dizin:"
 
 #: ../../src/wxMaxima.cpp:7429
 msgid "Split"
@@ -6588,70 +7095,78 @@ msgid "Split string into tokens"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1171
+#, fuzzy
 msgid "Split..."
-msgstr ""
+msgstr "Kutu Diyagram..."
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Square"
-msgstr ""
+msgstr "Dörtköşe"
 
 #: ../../src/Configuration.cpp:86
+#, fuzzy
 msgid "Standard Text"
-msgstr ""
+msgstr "Standart eğriler\n"
 
 #: ../../src/Worksheet.cpp:1298
 msgid "Start Animation"
-msgstr ""
+msgstr "Animasyonu Başlat"
 
 #: ../../src/wxMaxima.cpp:7842
+#, fuzzy
 msgid "Start of t:"
-msgstr ""
+msgstr "X değerinin başlangıcı"
 
 #: ../../src/ToolBar.cpp:305
 msgid "Start or Stop animation"
-msgstr ""
+msgstr "Animasyonu Başlat yada Durdur"
 
 #: ../../src/ToolBar.cpp:306
 msgid ""
 "Start or stop the currently selected animation that has been created with "
 "the with_slider class of commands"
 msgstr ""
+"Seçtiğiniz with_slider komutlarıyla oluşturulan animasyonu Başlat ya da "
+"Durdur"
 
 #: ../../src/wxMaxima.cpp:386
 msgid "Starting Maxima process failed"
-msgstr ""
+msgstr "Maxima'yı başlatma işlemi hata ile sonuçlandı"
 
 #: ../../src/main.cpp:667
+#, fuzzy
 msgid "Starting a new wxMaxima process for a new window"
-msgstr ""
+msgstr "Maxima'yı başlatma işlemi hata ile sonuçlandı"
 
 #: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:5633
 msgid "Starting evaluation of the document"
-msgstr ""
+msgstr "Belgenin değerlendirilmesine başlama"
 
 #: ../../src/wxMaxima.cpp:2544
 msgid "Starting server failed"
-msgstr ""
+msgstr "Sunucu başlatımı hata ile sonuçlandı"
 
 #: ../../src/WXMXformat.cpp:64
 msgid "Starting to save the worksheet as .wxmx"
-msgstr ""
+msgstr "Çalışma sayfasını .wxmx olarak kaydetmeye başlama"
 
 #: ../../src/wxMaximaFrame.cpp:252
 msgid "Statistics"
-msgstr ""
+msgstr "İstatistik"
 
 #: ../../src/wxMaximaFrame.cpp:701
 msgid "Statistics\tAlt+Shift+S"
-msgstr ""
+msgstr "İstatistik\tAlt+Shift+S"
 
 #: ../../src/wxMaxima.cpp:7844
+#, fuzzy
 msgid "Step width:"
-msgstr ""
+msgstr "Etiket genişliği:"
 
 #: ../../src/wxMaximaFrame.cpp:794
+#, fuzzy
 msgid "Straight lines"
-msgstr ""
+msgstr "Örtüşme önleme çizgileri."
 
 #: ../../src/wxMaximaFrame.cpp:1106
 msgid "Stream"
@@ -6672,26 +7187,31 @@ msgid "Stream:"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1185
+#, fuzzy
 msgid "String"
-msgstr ""
+msgstr "Diziler"
 
 #: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
 #: ../../src/wxMaxima.cpp:7425
+#, fuzzy
 msgid "String #1:"
-msgstr ""
+msgstr "Diziler"
 
 #: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
 #: ../../src/wxMaxima.cpp:7426
+#, fuzzy
 msgid "String #2:"
-msgstr ""
+msgstr "Diziler"
 
 #: ../../src/wxMaximaFrame.cpp:1136
+#, fuzzy
 msgid "String Tests"
-msgstr ""
+msgstr "Diziler"
 
 #: ../../src/wxMaxima.cpp:7415
+#, fuzzy
 msgid "String length"
-msgstr ""
+msgstr "Diziler"
 
 #: ../../src/wxMaxima.cpp:7381
 msgid "String to list of char"
@@ -6702,8 +7222,9 @@ msgid "String to list of chars..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7496
+#, fuzzy
 msgid "String to octets"
-msgstr ""
+msgstr "Diziler"
 
 #: ../../src/wxMaximaFrame.cpp:1160
 msgid "String to octets..."
@@ -6720,8 +7241,9 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7465 ../../src/wxMaxima.cpp:7470
 #: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
 #: ../../src/wxMaxima.cpp:7497
+#, fuzzy
 msgid "String:"
-msgstr ""
+msgstr "Diziler"
 
 #: ../../src/wxMaxima.cpp:7197
 msgid "Struct :"
@@ -6737,11 +7259,11 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:274
 msgid "Subsection"
-msgstr ""
+msgstr "Altbölüm"
 
 #: ../../src/Configuration.cpp:90
 msgid "Subsection cell (Heading 3)"
-msgstr ""
+msgstr "Altbölüm hücresi (Başlık 3)"
 
 #: ../../src/wxMaximaFrame.cpp:1643
 msgid "Subst constant t into eq with diff(x,t)..."
@@ -6754,19 +7276,21 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
 #: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
 msgid "Substitute"
-msgstr ""
+msgstr "Yerine koy"
 
 #: ../../src/wxMaximaFrame.cpp:1193
+#, fuzzy
 msgid "Substitute all matches"
-msgstr ""
+msgstr "Yerine koy..."
 
 #: ../../src/wxMaximaFrame.cpp:1192
 msgid "Substitute first match"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1646
+#, fuzzy
 msgid "Substitute only in parts..."
-msgstr ""
+msgstr "Yerine koy..."
 
 #: ../../src/wxMaxima.cpp:8763
 msgid "Substitute only in specific parts"
@@ -6778,7 +7302,7 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
 msgid "Substitute..."
-msgstr ""
+msgstr "Yerine koy..."
 
 #: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
 msgid "Substitutes until the equation no more changes"
@@ -6814,15 +7338,16 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:275
 msgid "Subsubsection"
-msgstr ""
+msgstr "Alt+alt Bölüm"
 
 #: ../../src/Configuration.cpp:89
 msgid "Subsubsection cell (Heading 4)"
-msgstr ""
+msgstr "Altbölüm hücresi (Başlık 4)"
 
 #: ../../src/Worksheet.cpp:1831
+#, fuzzy
 msgid "Suggestion: "
-msgstr ""
+msgstr "Altbölüm"
 
 #: ../../src/Worksheet.cpp:2030
 msgid "Suitable as flag for ev()"
@@ -6830,7 +7355,7 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9049
 msgid "Sum"
-msgstr ""
+msgstr "Toplam"
 
 #: ../../src/wxMaximaFrame.cpp:1551
 msgid ""
@@ -6839,20 +7364,22 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:4090
+#, fuzzy
 msgid "Switched to lisp mode after receiving a lisp debug prompt!"
-msgstr ""
+msgstr "Bir lisp istemi aldıktan sonra lisp moduna geçildi!"
 
 #: ../../src/wxMaxima.cpp:4092
 msgid "Switched to lisp mode after receiving a lisp prompt!"
-msgstr ""
+msgstr "Bir lisp istemi aldıktan sonra lisp moduna geçildi!"
 
 #: ../../src/Worksheet.cpp:1971
+#, fuzzy
 msgid "Symbolic Constant"
-msgstr ""
+msgstr "Bir Sabit Seç"
 
 #: ../../src/wxMaximaFrame.cpp:705
 msgid "Symbols\tAlt+Shift+Y"
-msgstr ""
+msgstr "Semboller\tAlt+Shift+Y"
 
 #: ../../src/Worksheet.cpp:2006
 msgid "Symmetric function: f(x)=f(-x)"
@@ -6860,27 +7387,29 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:238
 msgid "Table of Contents"
-msgstr ""
+msgstr "İçerik Tablosu"
 
 #: ../../src/wxMaximaFrame.cpp:711
 msgid "Table of Contents\tAlt+Shift+T"
-msgstr ""
+msgstr "İçerik Tablosu \tAlt+Shift+T"
 
 #: ../../src/wxMaxima.cpp:8930
+#, fuzzy
 msgid "Taylor series"
-msgstr ""
+msgstr "Taylor Serileri:"
 
 #: ../../src/wxMaximaFrame.cpp:1474
+#, fuzzy
 msgid "Taylor series..."
-msgstr ""
+msgstr "Taylor Serileri:"
 
 #: ../../src/wxMaxima.cpp:8925
 msgid "Taylor series:"
-msgstr ""
+msgstr "Taylor Serileri:"
 
 #: ../../src/wxMaxima.cpp:4132
 msgid "Telling maxima about the new working directory."
-msgstr ""
+msgstr "Maxima'ya yeni çalışma dizini hakkında bilgi vermek."
 
 #: ../../src/wxMaxima.cpp:7907
 msgid "Tells maxima for an f(x), that f(x=t)=a"
@@ -6903,11 +7432,11 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:271
 msgid "Text"
-msgstr ""
+msgstr "Metin"
 
 #: ../../src/Configuration.cpp:93
 msgid "Text cell background"
-msgstr ""
+msgstr "Metin Hücresi Arka Planı"
 
 #: ../../src/wxMaxima.cpp:6541
 msgid "Text snippet"
@@ -6918,12 +7447,16 @@ msgid ""
 "The .xml file doesn't seem to be valid xml or isn't a content.xml extracted "
 "from a .wxmx zip archive"
 msgstr ""
+".xml dosyası geçerli değil ya da .xml olarak .wxmx zip arşivinde çıkarılan "
+"bir içerik değil"
 
 #: ../../src/wxMaxima.cpp:2734
 msgid ""
 "The Maxima process doesn't offer a shared memory segment we can send an "
 "interrupt signal to."
 msgstr ""
+"Maxima işlemi, kesme sinyali gönderebileceğimiz paylaşılan bir bellek "
+"segmenti sunmuyor."
 
 #: ../../src/MaximaManual.cpp:107
 msgid "The cache for the subjects the manual contains cannot be read."
@@ -6948,8 +7481,9 @@ msgid "The comma-separated contents of the struct fields"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7186
+#, fuzzy
 msgid "The comma-separated names of the struct fields"
-msgstr ""
+msgstr "Değişkenlerin listesini 'virgülle ayrılmış' olarak girin."
 
 #: ../../src/wxMaxima.cpp:7070
 msgid ""
@@ -6962,30 +7496,34 @@ msgid "The current Wizard"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:9592
+#, fuzzy
 msgid "The equation to fit the data to"
-msgstr ""
+msgstr "Denklemleri doğrusal formlarında göster"
 
 #: ../../src/wxMaxima.cpp:8447
 msgid "The function call whose arguments to extract"
-msgstr ""
+msgstr "Çıkarmak için argümanları olan işlev çağrısı"
 
 #: ../../src/wxMaximaFrame.cpp:1298
 msgid "The half of the equation that is to the left of the \"=\""
-msgstr ""
+msgstr "Denklemin \"=\" işaretinin solunda kalan yarısı"
 
 #: ../../src/wxMaximaFrame.cpp:1302
 msgid "The half of the equation that is to the right of the \"=\""
-msgstr ""
+msgstr "Denklemin \"=\" işaretinin sağında kalan yarısı"
 
 #: ../../src/MaximaManual.cpp:399
+#, fuzzy
 msgid "The help dir from the cache differs from the current one."
-msgstr ""
+msgstr "Geçerli çizim için eksenleri ayarla."
 
 #: ../../src/Image.cpp:985
 msgid ""
 "The image could not be displayed. It may be broken, in a wrong format or be the result of gnuplot not being able to write the image or not being able to understand what maxima wanted to plot.\n"
 "One example of the latter would be: Gnuplot refuses to plot entirely empty images"
 msgstr ""
+"Resim görüntülenemedi. Yanlış bir biçimde bozulabilir veya gnuplot'un görüntüyü yazamaması veya maxima'nın ne çizmek istediğini anlayamaması sonucu olabilir.\n"
+"İkincisinin bir örneği şöyle olabilir: Gnuplot tamamen boş görüntüleri çizmeyi reddediyor"
 
 #: ../../src/wxMaxima.cpp:9799 ../../src/wxMaxima.cpp:10158
 #, c-format
@@ -6993,8 +7531,9 @@ msgid "The image file \"%s\" cannot be found."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:718
+#, fuzzy
 msgid "The integrated help browser"
-msgstr ""
+msgstr "Hepsini seç butonu"
 
 #: ../../src/wxMaxima.cpp:9591
 msgid "The list of variables contained in each matrix row"
@@ -7005,12 +7544,14 @@ msgid "The main toolbar"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1882
+#, fuzzy
 msgid "The manual of Maxima"
-msgstr ""
+msgstr "Maxima çevrimdışı kılavuzu"
 
 #: ../../src/wxMaximaFrame.cpp:1881
+#, fuzzy
 msgid "The manual of wxMaxima"
-msgstr ""
+msgstr "WxMaxima çevrimdışı kılavuzu"
 
 #: ../../src/wxMaxima.cpp:7125
 msgid "The name of a function we don't want to be evaluated here"
@@ -7021,34 +7562,39 @@ msgid "The name of an expression that we don't want to be evaluated."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7199
+#, fuzzy
 msgid "The name of the field to read"
-msgstr ""
+msgstr "Çizilecek bir sonraki çizginin rengi"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "The name of the new struct type"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7198
+#, fuzzy
 msgid "The name of the struct"
-msgstr ""
+msgstr "Paramatrenin ismi"
 
 #: ../../src/wxMaxima.cpp:7191
 msgid "The name of the struct type"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8220
+#, fuzzy
 msgid "The name of the variable that shall contain the current element"
-msgstr ""
+msgstr "Geçerli kaynak öğesinin değeri değişkeninde saklanır."
 
 #: ../../src/wxMaxima.cpp:8468
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
-msgstr ""
+msgstr "\"İndeks sonu\" ndan \"İndeks Başlat\" a kadar  öğenin sayısı."
 
 #: ../../src/wxMaxima.cpp:8465 ../../src/wxMaxima.cpp:8478
 msgid ""
 "The rule that explains how to generate the value of a list item.\n"
 "Might be something like \"i\", \"i^2\" or \"sin(i)\""
 msgstr ""
+"Bir liste öğesinin değerini nasıl üretileceğini açıklayan kural.\n"
+"Böyle bir şey olabilir \"i\", \"i ^ 2\" veya \"sin (i)\""
 
 #: ../../src/wxMaxima.cpp:7785
 msgid ""
@@ -7078,31 +7624,38 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8481 ../../src/wxMaxima.cpp:8582
 msgid "The variable the value of the current source item is stored in."
-msgstr ""
+msgstr "Geçerli kaynak öğesinin değeri değişkeninde saklanır."
 
 #: ../../src/wxMaxima.cpp:9594
 msgid "The variables to search the optimum solution for"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:193
+#, fuzzy
 msgid "The worksheet"
-msgstr ""
+msgstr "Çalışma Yaprağı"
 
 #: ../../src/Worksheet.cpp:8122
 msgid "The worksheet containing maxima's input and output"
-msgstr ""
+msgstr "Maxima'nın giriş ve çıkışını içeren çalışma sayfası"
 
 #: ../../src/MathParser.cpp:629
 msgid ""
 "The xml data from maxima or from the .wxmx file was missing data here.\n"
 "If you find a way how to reproduce this problem please file a bug report against wxMaxima."
 msgstr ""
+"Maxima veya .wxmx dosyasındaki xml verileri burada veri eksikti.\n"
+"Bu sorunu nasıl üreteceğinizin bir yolunu bulursanız lütfen wxMaxima'ya karşı bir hata raporu hazırlayın."
 
 #: ../../src/wxMaxima.cpp:2143
+#, fuzzy
 msgid ""
 "There was an error in the XML maxima has generated.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"XML Oluşturulurken hata oluştu!\n"
+"\n"
+"Lütfen bunu hata olarak bildirin."
 
 #: ../../src/wxMaxima.cpp:3911
 msgid ""
@@ -7123,10 +7676,14 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:3257
+#, fuzzy
 msgid ""
 "There was an error in the XML that should describe the manual topics.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"XML Oluşturulurken hata oluştu!\n"
+"\n"
+"Lütfen bunu hata olarak bildirin."
 
 #: ../../src/wxMaxima.cpp:3202
 msgid ""
@@ -7167,55 +7724,57 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9013 ../../src/wxMaxima.cpp:10058
 msgid "Times:"
-msgstr ""
+msgstr "Kaç kez :"
 
 #: ../../src/ToolBar.cpp:272
 msgid "Title"
-msgstr ""
+msgstr "Başlık"
 
 #: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
-msgstr ""
+msgstr "Başlık (Alt ve üst yazı  x_ {10} veya x ^ {10})"
 
 #: ../../src/Configuration.cpp:92
 msgid "Title cell (Heading 1)"
-msgstr ""
+msgstr "Başlık Hücresi (Başlık 1)"
 
 #: ../../src/wxMaximaFrame.cpp:1794
 msgid "To &Bigfloat"
-msgstr ""
+msgstr "BüyükKayanSayı ya"
 
 #: ../../src/wxMaximaFrame.cpp:1791
 msgid "To &Float"
-msgstr ""
+msgstr "KayanSayıya"
 
 #: ../../src/Worksheet.cpp:1571
 msgid "To Float"
-msgstr ""
+msgstr "KayanSayıya"
 
 #: ../../src/wxMaximaFrame.cpp:1797
 msgid "To Numeri&c\tCtrl+Shift+N"
-msgstr ""
+msgstr "Numeri&k'e \tCtrl+Shift+N"
 
 #: ../../src/wxMaximaFrame.cpp:1803
+#, fuzzy
 msgid "To exact fraction"
-msgstr ""
+msgstr "Parçalı Kesirler"
 
 #: ../../src/wxMaximaFrame.cpp:1814
+#, fuzzy
 msgid "To exact number"
-msgstr ""
+msgstr "Tam sayılar\n"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "To:"
-msgstr ""
+msgstr "Son değer:"
 
 #: ../../src/wxMaximaFrame.cpp:825 ../../src/wxMaximaFrame.cpp:828
 msgid "Toggle full screen editing"
-msgstr ""
+msgstr "Tam Ekran Düzenlemesini Çalıştır"
 
 #: ../../src/ToolBar.cpp:265
 msgid "Toggle the visibility of code cells"
-msgstr ""
+msgstr "Kod hücrelerinin görünürlüğünü değiştirme"
 
 #: ../../src/wxMaximaFrame.cpp:1177
 msgid "Tokenize..."
@@ -7223,27 +7782,30 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1909
 msgid "Tolerance calculations with Maxima"
-msgstr ""
+msgstr "Maxima ile tolerans Hesaplamaları"
 
 #: ../../src/wxMaxima.cpp:8192
 msgid "Top end"
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1078
+#, fuzzy
 msgid "Trace a function..."
-msgstr ""
+msgstr "Bir Fonksiyonu Sil"
 
 #: ../../src/wxMaxima.cpp:7084
+#, fuzzy
 msgid "Trace function(s)"
-msgstr ""
+msgstr "Fonksiyon(ları) Sil:"
 
 #: ../../src/wxMaximaFrame.cpp:1184
+#, fuzzy
 msgid "Transformations"
-msgstr ""
+msgstr "Transpoze Matris"
 
 #: ../../src/wxMaximaFrame.cpp:1376
 msgid "Transpose a matrix"
-msgstr ""
+msgstr "Transpoze Matris"
 
 #: ../../src/wxMaxima.cpp:7832
 msgid ""
@@ -7253,15 +7815,17 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:10036
+#, fuzzy
 msgid ""
 "Tries to find a solution of the equation that lies between the two bounds."
-msgstr ""
+msgstr "Denklemin \"=\" işaretinin solunda kalan yarısı"
 
 #: ../../src/wxMaxima.cpp:7774
+#, fuzzy
 msgid ""
 "Tries to find a value of the variable that solves the equation between the "
 "two bonds"
-msgstr ""
+msgstr "Denklemin \"=\" işaretinin solunda kalan yarısı"
 
 #: ../../src/wxMaxima.cpp:7719
 msgid ""
@@ -7296,12 +7860,14 @@ msgid "Trim both ends..."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1182
+#, fuzzy
 msgid "Trim left..."
-msgstr ""
+msgstr "Limit..."
 
 #: ../../src/wxMaximaFrame.cpp:1183
+#, fuzzy
 msgid "Trim right..."
-msgstr ""
+msgstr "Limit..."
 
 #: ../../src/wxMaxima.cpp:7473
 msgid "Trim string left"
@@ -7334,34 +7900,37 @@ msgid "Trying to discard all output."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:4380
+#, fuzzy
 msgid "Trying to extract content.xml out of a broken .zip file."
-msgstr ""
+msgstr "%s eski geçici dosyasını kaldırmaya çalışılıyor"
 
 #: ../../src/wxMaxima.cpp:5519
 msgid "Trying to open a file with an empty name!"
-msgstr ""
+msgstr "Boş bir adla bir dosyayı açmaya çalışıyor!"
 
 #: ../../src/wxMaxima.cpp:5523
 #, c-format
 msgid "Trying to open the non-existing file %s"
-msgstr ""
+msgstr "%s olmayan dosyayı açmaya çalışıyor"
 
 #: ../../src/wxMaxima.cpp:4457
+#, fuzzy
 msgid "Trying to reconstruct the xml closing markers."
-msgstr ""
+msgstr "Maxima'yı yeniden başlatmaya çalışıyor."
 
 #: ../../src/wxMaxima.cpp:4376
+#, fuzzy
 msgid "Trying to recover a broken .wxmx file."
-msgstr ""
+msgstr "%s eski geçici dosyasını kaldırmaya çalışılıyor"
 
 #: ../../src/wxMaxima.cpp:6026
 #, c-format
 msgid "Trying to remove the old temp file %s"
-msgstr ""
+msgstr "%s eski geçici dosyasını kaldırmaya çalışılıyor"
 
 #: ../../src/wxMaxima.cpp:2507
 msgid "Trying to restart maxima."
-msgstr ""
+msgstr "Maxima'yı yeniden başlatmaya çalışıyor."
 
 #: ../../src/wxMaxima.cpp:2523
 #, c-format
@@ -7372,19 +7941,19 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1928
 msgid "Tutorials"
-msgstr ""
+msgstr "Ders Notları"
 
 #: ../../src/wxMaxima.cpp:9571
 msgid "Two sample t-test"
-msgstr ""
+msgstr "İki Örnek t-testi"
 
 #: ../../src/Worksheet.cpp:8013
 msgid "Type"
-msgstr ""
+msgstr "Tip"
 
 #: ../../src/wxMaxima.cpp:7180
 msgid "Type:"
-msgstr ""
+msgstr "Tip:"
 
 #: ../../src/wxMaxima.cpp:9429
 msgid "URL"
@@ -7396,21 +7965,24 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10479
 msgid "Un-closed parenthesis"
-msgstr ""
+msgstr "Kapanmamış parantezler"
 
 #: ../../src/wxMaxima.cpp:10467
 msgid "Un-closed parenthesis on encountering ; or $"
-msgstr ""
+msgstr "Kapatılmamış parantez"
 
 #: ../../src/wxMaxima.cpp:11160
 msgid ""
 "Unable to interpret the version info I got from http://wxMaxima-"
 "developers.github.io/wxmaxima/version.txt: "
 msgstr ""
+"'http://wxMaxima-developers.github.io/wxmaxima/version.txt' adresinden "
+"aldığım sürüm bilgileri yorumlanamıyor: "
 
 #: ../../src/wxMaximaFrame.cpp:1007
+#, fuzzy
 msgid "Undefine"
-msgstr ""
+msgstr "Tanımsız"
 
 #: ../../src/ToolBar.cpp:191
 msgid "Undo"
@@ -7418,59 +7990,61 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo\tCtrl+Z"
-msgstr ""
+msgstr "Geri Al\tCtrl+Z"
 
 #: ../../src/ToolBar.cpp:614
+#, fuzzy
 msgid "Undo and redo button"
-msgstr ""
+msgstr "Aç ve Kaydet Butonu"
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo last change"
-msgstr ""
+msgstr "Son Değişikliği Geri Al"
 
 #: ../../src/wxMaximaFrame.cpp:924
 msgid "Unfold All\tCtrl+Alt+]"
-msgstr ""
+msgstr "Hepsini Klasörden Çıkar\tCtrl+A]"
 
 #: ../../src/wxMaximaFrame.cpp:925
 msgid "Unfold all folded sections"
-msgstr ""
+msgstr "Klasörlenmiş bütün kısımları Klasörden Çıkar"
 
 #: ../../src/Worksheet.cpp:1893
 msgid "Unhide Heading 5"
-msgstr ""
+msgstr "Başlık 5 i Göster"
 
 #: ../../src/Worksheet.cpp:1904
 msgid "Unhide Heading 6"
-msgstr ""
+msgstr "Başlık 6 yı Göster"
 
 #: ../../src/Worksheet.cpp:1852
 msgid "Unhide Part"
-msgstr ""
+msgstr "Bölümü Göster"
 
 #: ../../src/Worksheet.cpp:1860
 msgid "Unhide Section"
-msgstr ""
+msgstr "Bölümü Göster"
 
 #: ../../src/Worksheet.cpp:1871
 msgid "Unhide Subsection"
-msgstr ""
+msgstr "Alt Kısmı Göster"
 
 #: ../../src/Worksheet.cpp:1882
 msgid "Unhide Subsubsection"
-msgstr ""
+msgstr "Alt+alt Kısmı Göster"
 
 #: ../../src/Worksheet.cpp:1912
 msgid "Unhide contents"
-msgstr ""
+msgstr "İçeriği Göster"
 
 #: ../../src/wxMaximaFrame.cpp:266
+#, fuzzy
 msgid "Unicode characters"
-msgstr ""
+msgstr "İçeriği Göster"
 
 #: ../../src/wxMaximaFrame.cpp:707
 msgid "Unicode chars\tAlt+Shift+U"
-msgstr ""
+msgstr "Unicode yazı karakterleri\tAlt+Shift+U"
 
 #: ../../src/wxMaximaFrame.cpp:1144
 msgid "Unicode code point to UTF8..."
@@ -7496,68 +8070,71 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:10418
 msgid "Unterminated comment."
-msgstr ""
+msgstr "Sonlandırılmamış yorum."
 
 #: ../../src/wxMaxima.cpp:10461
 msgid "Unterminated string."
-msgstr ""
+msgstr "Sonlandırılmamış dizin."
 
 #: ../../src/wxMaxima.cpp:4786
 msgid "Updating maxima's configuration"
-msgstr ""
+msgstr "Maxima yapılandırmasını güncelliyor"
 
 #: ../../src/wxMaxima.cpp:11150 ../../src/wxMaxima.cpp:11157
 #: ../../src/wxMaxima.cpp:11163
 msgid "Upgrade"
-msgstr ""
+msgstr "Yükselt"
 
 #: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
 msgid "Upper bound:"
-msgstr ""
+msgstr "Üst Sınır:"
 
 #: ../../src/wxMaximaFrame.cpp:792
+#, fuzzy
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
-msgstr ""
+msgstr "Matrisler için yuvarlak parantez kullanın"
 
 #: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
 msgid "Use a list"
-msgstr ""
+msgstr "Bir dizin kullan"
 
 #: ../../src/wxMaxima.cpp:8571
 msgid "Use a list as parameter list for a function"
-msgstr ""
+msgstr "Bir işlevin parametre dizini olarak bir dizin kullan"
 
 #: ../../src/wxMaximaFrame.cpp:1708
 msgid "Use list"
-msgstr ""
+msgstr "Dizin kullan"
 
 #: ../../src/wxMaximaFrame.cpp:1701
 msgid "Use list as the arguments of a function"
-msgstr ""
+msgstr "Dizini bir işlevin argümanları olarak kullanın"
 
 #: ../../src/wxMaximaFrame.cpp:786
 msgid "Use rounded parenthesis for matrices"
-msgstr ""
+msgstr "Matrisler için yuvarlak parantez kullanın"
 
 #: ../../src/wxMaximaFrame.cpp:789
 msgid "Use square parenthesis for matrices"
-msgstr ""
+msgstr "Matrisler için köşeli parantez kullanın"
 
 #: ../../src/wxMaximaFrame.cpp:1083
+#, fuzzy
 msgid "Use struct field..."
-msgstr ""
+msgstr "&Sürekli Kesirler"
 
 #: ../../src/wxMaximaFrame.cpp:795
+#, fuzzy
 msgid "Use vertical lines instead of parenthesis for matrices"
-msgstr ""
+msgstr "Matrisler için yuvarlak parantez kullanın"
 
 #: ../../src/Worksheet.cpp:1619
 msgid "User labels only"
-msgstr ""
+msgstr "Yalnızca kullanıcı etiketleri"
 
 #: ../../src/Configuration.cpp:81
 msgid "User-defined labels"
-msgstr ""
+msgstr "Kullanıcı tanımlı etiketler"
 
 #: ../../src/MaximaManual.cpp:483
 msgid ""
@@ -7569,8 +8146,9 @@ msgid "Using Maxima path from command line."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:4822
+#, fuzzy
 msgid "Using configured Maxima path."
-msgstr ""
+msgstr "'wxMaxima'yı' yapılandır"
 
 #: ../../src/wxMaxima.cpp:2961
 msgid ""
@@ -7592,25 +8170,28 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8755
+#, fuzzy
 msgid "Value at a given point"
-msgstr ""
+msgstr "Noktaya Değerlendir"
 
 #: ../../src/Worksheet.cpp:1987
 msgid "Value at a specific point"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7801
+#, fuzzy
 msgid "Value at that point:"
-msgstr ""
+msgstr "Noktaya Değerlendir"
 
 #: ../../src/wxMaxima.cpp:7812 ../../src/wxMaxima.cpp:7825
 #: ../../src/wxMaxima.cpp:7827
+#, fuzzy
 msgid "Value y at that point:"
-msgstr ""
+msgstr "Noktaya Değerlendir"
 
 #: ../../src/wxMaxima.cpp:7910
 msgid "Value:"
-msgstr ""
+msgstr "Değer:"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Var #1"
@@ -7622,29 +8203,32 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:6852 ../../src/wxMaxima.cpp:8183
 msgid "Variable"
-msgstr ""
+msgstr "Değişken"
 
 #: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
 #: ../../src/wxMaxima.cpp:8568
 msgid "Variable name"
-msgstr ""
+msgstr "Değişken adı"
 
 #: ../../src/wxMaximaFrame.cpp:1085
+#, fuzzy
 msgid "Variable name, not contents..."
-msgstr ""
+msgstr "X değeri için değişken"
 
 #: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
+#, fuzzy
 msgid "Variable name:"
-msgstr ""
+msgstr "Değişken adı"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
+#, fuzzy
 msgid "Variable(s)"
-msgstr ""
+msgstr "Değişken(ler):"
 
 #: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
 #: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
 msgid "Variable(s):"
-msgstr ""
+msgstr "Değişken(ler):"
 
 #: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
 #: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
@@ -7652,15 +8236,15 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
 #: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
 msgid "Variable:"
-msgstr ""
+msgstr "Değişken:"
 
 #: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
 msgid "Variables"
-msgstr ""
+msgstr "Değişken(ler)"
 
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
 msgid "Variables:"
-msgstr ""
+msgstr "Değişken(ler):"
 
 #: ../../src/WXMXformat.cpp:337
 msgid "Verified that we are able to read the whole .zip archive we produced."
@@ -7668,7 +8252,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:836
 msgid "View"
-msgstr ""
+msgstr "Görünüm"
 
 #: ../../src/Autocomplete.cpp:235
 msgid "Waiting for m_addFiles_backgroundThread to finish"
@@ -7683,18 +8267,20 @@ msgid "Waiting for the Manual anchors background task."
 msgstr ""
 
 #: ../../src/MaximaManual.cpp:562
+#, fuzzy
 msgid "Waiting for the thread that parses the maxima manual to finish"
-msgstr ""
+msgstr "Maxima kılavuzunun sunduğu anchor  listesini derleme"
 
 #: ../../src/MathParser.cpp:1229 ../../src/wxMaxima.cpp:3296
 #: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
 #: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
 msgid "Warning"
-msgstr ""
+msgstr "Uyarı"
 
 #: ../../src/wxMaximaFrame.cpp:1556
+#, fuzzy
 msgid "Warning:"
-msgstr ""
+msgstr "Uyarı"
 
 #: ../../src/Dirstructure.cpp:72
 #, c-format
@@ -7710,11 +8296,11 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5063
 msgid "Welcome to wxMaxima"
-msgstr ""
+msgstr "'wxMaxima'ya' Hoş Geldiniz"
 
 #: ../../src/wxMaxima.cpp:8583
 msgid "What to do:"
-msgstr ""
+msgstr "Ne yapalım:"
 
 #: ../../src/wxMaximaFrame.cpp:1058
 msgid "When to invoke the lisp compiler's debugger"
@@ -7729,10 +8315,13 @@ msgid "While loop..."
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:5673
+#, fuzzy
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38)"
 " (*.wxm)|*.wxm|All Files (*.*)|*"
 msgstr ""
+"Bütün belge (*.wxmx)|*.wxmx|load() komutu ile okunabilen girdi (Maxima> "
+"5.38) (*.wxm)|*.wxm"
 
 #: ../../src/wxMaxima.cpp:210
 msgid "Will try to generate a stack backtrace, if the program ever crashes"
@@ -7748,7 +8337,7 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:7191 ../../src/Worksheet.cpp:7279
 msgid "Wrapped search"
-msgstr ""
+msgstr "Kaydırlılan arama"
 
 #: ../../src/WXMXformat.cpp:282
 msgid "Wrote all image and gnuplot files to the zip archive"
@@ -7763,74 +8352,78 @@ msgid "Wrote the mimetype info"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:11147
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have version %s. The newest version source code is available for is %s.\n"
 "\n"
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
+"%s sürümünü kullanıyorsunuz. Şimdiki %s sürümüdür.\n"
+"\n"
+"wxMaxima web sayfasını ziyaret için OK i seçin."
 
 #: ../../src/wxMaxima.cpp:11202
 msgid "Your changes will be lost if you don't save them."
-msgstr ""
+msgstr "Kaydetmezseniz yaptığınız değişiklikler kaybolabilir."
 
 #: ../../src/wxMaxima.cpp:11156
 msgid "Your version of wxMaxima is up to date."
-msgstr ""
+msgstr "Kullandığınız wxMaxima günceldir."
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom &In\tCtrl++"
-msgstr ""
+msgstr "Yakınlaştır\tCtrl++"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom Ou&t\tCtrl+-"
-msgstr ""
+msgstr "Uzaklaştır\tCtrl+-"
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom in 10%"
-msgstr ""
+msgstr "%10 yakınlaştır"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom out 10%"
-msgstr ""
+msgstr "%10 uzaklaştır"
 
 #: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
 msgid "[ unsaved ]"
-msgstr ""
+msgstr "[Kaydedilmemiş]"
 
 #: ../../src/wxMaxima.cpp:10920
 msgid "[ unsaved* ]"
-msgstr ""
+msgstr "[Kaydedilmemiş*]"
 
 #: ../../src/Worksheet.cpp:5278
-#, c-format
+#, fuzzy, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" loading=\"lazy\" style=\"max-width:90%%;\">\n"
-msgstr ""
+msgstr "_%d.gif\"  alt=\"Animated Diagram\" loading=\"lazy\" style=\"max-width:90%%;\" />\n"
 
 #: ../../src/Worksheet.cpp:5484
-#, c-format
+#, fuzzy, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"lazy\">"
-msgstr ""
+msgstr "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"lazy\" />"
 
 #: ../../src/wxMaximaFrame.cpp:1690
 msgid "apply function to each element"
-msgstr ""
+msgstr "fonksiyonu her bir ögeye uygula"
 
 #: ../../src/wxMaximaFrame.cpp:739
 msgid "as 1D ASCII"
-msgstr ""
+msgstr "1D ASCII olarak"
 
 #: ../../src/wxMaximaFrame.cpp:742
 msgid "as ASCII Art"
-msgstr ""
+msgstr "'ASCII Art' olarak"
 
 #: ../../src/wxMaximaFrame.cpp:745
+#, fuzzy
 msgid "as ASCII+Unicode Art"
-msgstr ""
+msgstr "'ASCII Art' olarak"
 
 #: ../../src/wxMaximaFrame.cpp:1680
 msgid "as storage for actual values for variables"
-msgstr ""
+msgstr "değişkenler için gerçek değerler için depo olarak"
 
 #: ../../src/wxMaximaFrame.cpp:1139
 msgid "char to Ascii code..."
@@ -7842,51 +8435,56 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1064 ../../src/wxMaximaFrame.cpp:1702
 msgid "do for each element"
-msgstr ""
+msgstr "her bir öge için yap"
 
 #: ../../src/Worksheet.cpp:2027
+#, fuzzy
 msgid "ev() shall evaluate this automatically"
-msgstr ""
+msgstr "Çalışma sayfasını otomatik olarak kaydet"
 
 #: ../../src/wxMaxima.cpp:7130
+#, fuzzy
 msgid "expression:"
-msgstr ""
+msgstr "İfade:"
 
 #: ../../src/Worksheet.cpp:2025
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
+#, fuzzy
 msgid "filename:"
-msgstr ""
+msgstr "Değişken adı"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "from a list"
-msgstr ""
+msgstr "bir dizinden"
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "from a rule"
-msgstr ""
+msgstr "bir kuraldan"
 
 #: ../../src/wxMaximaFrame.cpp:1685
 msgid "from function arguments"
-msgstr ""
+msgstr "fonksiyon argümanlarından"
 
 #: ../../src/wxMaximaFrame.cpp:1669
 msgid "from individual elements"
-msgstr ""
+msgstr "tek tek ögelerden"
 
 #: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
+#, fuzzy
 msgid "function"
-msgstr ""
+msgstr "Fonksiyon"
 
 #: ../../src/wxMaximaFrame.cpp:747
 msgid "in 2D"
-msgstr ""
+msgstr "2B de"
 
 #: ../../src/wxMaxima.cpp:8554
+#, fuzzy
 msgid "list"
-msgstr ""
+msgstr "Dizin kullan"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "max(abs(A(i,j))) (complex)"
@@ -7897,13 +8495,15 @@ msgid "max(abs(A(i,j))) (real)"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8046
+#, fuzzy
 msgid "m×n Matrix A:"
-msgstr ""
+msgstr "Matris:"
 
 #: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533
+#, fuzzy
 msgid "n:"
-msgstr ""
+msgstr "n"
 
 #: ../../src/Worksheet.cpp:2000
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
@@ -7915,7 +8515,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1710
 msgid "nth"
-msgstr ""
+msgstr ".nci"
 
 #: ../../src/Worksheet.cpp:2021
 msgid "outative: f(2*x) = 2*f(x)"
@@ -7927,20 +8527,24 @@ msgid "part:"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:8942
+#, fuzzy
 msgid "point:"
-msgstr ""
+msgstr "Nokta:"
 
 #: ../../src/wxMaxima.cpp:7740
+#, fuzzy
 msgid "precision:"
-msgstr ""
+msgstr "OndalıkHassasiyet"
 
 #: ../../src/wxMaxima.cpp:7255
+#, fuzzy
 msgid "printf"
-msgstr ""
+msgstr "Yazdır"
 
 #: ../../src/wxMaximaFrame.cpp:1108
+#, fuzzy
 msgid "printf..."
-msgstr ""
+msgstr "Diferansiyel.."
 
 #: ../../src/wxMaxima.cpp:8650
 msgid ""
@@ -7956,29 +8560,37 @@ msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1111
+#, fuzzy
 msgid "readbyte..."
-msgstr ""
+msgstr "İntegralini Al..."
 
 #: ../../src/wxMaximaFrame.cpp:1110
+#, fuzzy
 msgid "readchar..."
-msgstr ""
+msgstr "Pasta dilimi..."
 
 #: ../../src/wxMaximaFrame.cpp:1109
+#, fuzzy
 msgid "readline..."
-msgstr ""
+msgstr "Varyans..."
 
 #: ../../src/wxMaxima.cpp:10018
+#, fuzzy
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables can be used to to tell solve() which variables to eliminate from the solution\n"
 "solve() searches for a global solution. If a problem has different solutions depending on the range its variables are in one way to successfully use solve() is to use solve() to eliminate variables one by one and to manually choose which of the solutions solve() found matches the current problem."
 msgstr ""
+"solve () yalnızca bir dizi denklemleri çözecektir; n bağımsız denklem için çözülecek n değişken varsa.\n"
+"Yalnızca bir sonuç değişkeni ilgi çekiyorsa, diğer sonuç değişkenleri, işi yapmak için ihtiyaç duydukları şeyleri çözümlemek için hangi değişkenlerin ilgili değişken için çözülebileceğini çözmek için solve () kullanılabilir ."
 
 #: ../../src/wxMaxima.cpp:7745
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables solve needs to do its work can be used to tell solve() which variables to eliminate in the solution for the interesting variable."
 msgstr ""
+"solve () yalnızca bir dizi denklemleri çözecektir; n bağımsız denklem için çözülecek n değişken varsa.\n"
+"Yalnızca bir sonuç değişkeni ilgi çekiyorsa, diğer sonuç değişkenleri, işi yapmak için ihtiyaç duydukları şeyleri çözümlemek için hangi değişkenlerin ilgili değişken için çözülebileceğini çözmek için solve () kullanılabilir ."
 
 #: ../../src/wxMaxima.cpp:7784
 msgid ""
@@ -7996,20 +8608,20 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:11190
 msgid "unsaved"
-msgstr ""
+msgstr "kaydedilmemiş"
 
 #: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
 #: ../../src/wxMaximaFrame.cpp:189
 msgid "untitled"
-msgstr ""
+msgstr "başlıksız"
 
 #: ../../src/wxMaximaFrame.cpp:1700
 msgid "use as function arguments"
-msgstr ""
+msgstr "fonksiyon argümanları olarak kullan"
 
 #: ../../src/wxMaximaFrame.cpp:1696
 msgid "use the actual values stored"
-msgstr ""
+msgstr "depolanan gerçek değerleri kullanın"
 
 #: ../../src/wxMaximaFrame.cpp:1112
 msgid "writebyte..."
@@ -8017,23 +8629,23 @@ msgstr ""
 
 #: ../../src/main.cpp:509
 msgid "wxMaxima"
-msgstr ""
+msgstr "wxMaxima"
 
 #: ../../src/main.cpp:516
-#, c-format
+#, fuzzy, c-format
 msgid "wxMaxima %ld"
-msgstr ""
+msgstr "wxMaxima %d"
 
 #: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
 #: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
 #: ../../src/wxMaximaFrame.cpp:185
-#, c-format
+#, fuzzy, c-format
 msgid "wxMaxima %s (%s) "
-msgstr ""
+msgstr "wxMaxima %s "
 
 #: ../../src/wxMaxima.cpp:4490
 msgid "wxMaxima cannot read the xml contents of "
-msgstr ""
+msgstr "wxMaxima xml içeriğini okuyamıyor "
 
 #: ../../src/wxMaxima.cpp:2546
 msgid ""
@@ -8045,16 +8657,16 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5285
 msgid "wxMaxima document"
-msgstr ""
+msgstr "wxMaxima Belgesi"
 
 #: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
 #: ../../src/wxMaxima.cpp:4230
 msgid "wxMaxima encountered an error loading "
-msgstr ""
+msgstr "wxMaxima bir yükleme hatası ile karşılaştı. "
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "wxMaxima help"
-msgstr ""
+msgstr "wxMaxima Yardımı"
 
 #: ../../src/Worksheet.cpp:1465 ../../src/Worksheet.cpp:1839
 msgid ""
@@ -8069,49 +8681,53 @@ msgid ""
 msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1896
+#, fuzzy
 msgid "wxMaxima shows help in a browser"
-msgstr ""
+msgstr "Dosya bulunamadı"
 
 #: ../../src/wxMaximaFrame.cpp:1894
+#, fuzzy
 msgid "wxMaxima shows help in the sidebar"
-msgstr ""
+msgstr "Dosya bulunamadı"
 
 #: ../../src/wxMaximaFrame.cpp:111
 #, c-format
 msgid "wxMaxima version %s"
-msgstr ""
+msgstr "wxMaxima sürümü %s"
 
 #: ../../src/wxMaximaFrame.cpp:1954
+#, fuzzy
 msgid "wxMaxima's ChangeLog"
-msgstr ""
+msgstr "wxMaxima Lisansı"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "wxMaxima's license"
-msgstr ""
+msgstr "wxMaxima Lisansı"
 
 #: ../../src/wxMaximaFrame.cpp:144
 msgid "wxWidgets is using GTK 2"
-msgstr ""
+msgstr "wxWidgets GTK 2 kullanıyor"
 
 #: ../../src/wxMaximaFrame.cpp:142
 msgid "wxWidgets is using GTK 3"
-msgstr ""
+msgstr "wxWidgets GTK 3 kullanıyor"
 
 #: ../../src/WXMXformat.cpp:367
 msgid "wxmx file saved"
-msgstr ""
+msgstr "wxmx dosyası kaydedildi"
 
 #: ../../src/wxMaxima.cpp:8375
 msgid "x direction [in multiples of the tick frequency]"
-msgstr ""
+msgstr "x yönü [tik frekansının katları]"
 
 #: ../../src/wxMaxima.cpp:4500 ../../src/wxMaxima.cpp:4643
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
+"dosyada bulunan xml, bir wxMaxima çalışma sayfası olmamasını talep ediyor. "
 
 #: ../../src/wxMaxima.cpp:8376
 msgid "y direction [in multiples of the tick frequency]"
-msgstr ""
+msgstr "y yönü [tik frekansının katları]"
 
 #: ../../src/wxMaxima.cpp:7789
 msgid "y:"
@@ -8605,8 +9221,9 @@ msgstr "'Maxima çıktısı ya da Maxima'dan soru"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Image cells."
-msgstr ""
+msgstr "Hücreleri birleştir"
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
@@ -8624,8 +9241,9 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: ../../info/wxmaxima.md:63
+#, fuzzy
 msgid "Page breaks."
-msgstr ""
+msgstr "Sayfa sonu"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:65
@@ -8978,8 +9596,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:134
+#, fuzzy
 msgid "##### Attention: Lookalike characters"
-msgstr ""
+msgstr "Uyarı: Benzer karakterler: "
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:138
@@ -11833,8 +12452,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:856
+#, fuzzy
 msgid "## Output rendering."
-msgstr ""
+msgstr "Diziler"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:858
@@ -12535,8 +13155,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:988
+#, fuzzy
 msgid "E.g. start wxMaxima with:"
-msgstr ""
+msgstr "Maxima'yı Yeniden Başlat"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:990

--- a/locales/wxMaxima/uk.po
+++ b/locales/wxMaxima/uk.po
@@ -28,12 +28,17 @@ msgid ""
 "\n"
 "Maxima is currently using %3.3f%% of all available CPUs."
 msgstr ""
+"\n"
+"\n"
+"Зараз Maxima використовує %3.3f%% з усіх доступних процесорів."
 
 #: ../../src/Image.cpp:690
 msgid ""
 "\n"
 "Image was loaded from a .wxmx file"
 msgstr ""
+"\n"
+"Зображення було завантажено з файла .wxmx"
 
 #: ../../src/wxMaxima.cpp:5153
 msgid ""
@@ -47,257 +52,260 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1559
 msgid " Wrong, if a is complex"
-msgstr ""
+msgstr " Помилка, якщо a є комплексним"
 
 #: ../../src/wxMaxima.cpp:7601
 msgid ""
 "\".\" = \"The current directory\"\n"
 "\"..\" = \"One directory up\""
 msgstr ""
+"«.» = «Поточний каталог»\n"
+"«..» = «На каталог вище»"
 
 #: ../../src/wxMaxima.cpp:7557 ../../src/wxMaxima.cpp:7563
 #: ../../src/wxMaxima.cpp:7568
 msgid "\"..\" means \"one directory up\"."
-msgstr ""
+msgstr "«..» означає «на один каталог вище»."
 
 #: ../../src/wxMaxima.cpp:5053
-#, c-format
+#, fuzzy, c-format
 msgid "%i cells in evaluation queue"
-msgstr ""
+msgstr "%i комірок у черзі обчислення"
 
 #: ../../src/Worksheet.cpp:330
 #, c-format
 msgid "%s image, %li×%li, %li ppi"
-msgstr ""
+msgstr "Зображення %s, %li×%li, %li т./д."
 
 #: ../../src/Autocomplete.cpp:319
 #, c-format
 msgid "%s: Can't interpret line: %s"
-msgstr ""
+msgstr "%s: не вдалося обробити рядок: %s"
 
 #: ../../src/wxMaximaFrame.cpp:1655
 msgid "&Algebraic Mode"
-msgstr ""
+msgstr "&Алгебраїчний режим"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "&Apropos..."
-msgstr ""
+msgstr "&Подібні команди…"
 
 #: ../../src/wxMaximaFrame.cpp:615
 msgid "&Batch File...\tCtrl+B"
-msgstr ""
+msgstr "&Пакетний файл…\tCtrl+B"
 
 #: ../../src/wxMaximaFrame.cpp:1278
 msgid "&Boundary Value Problem..."
-msgstr ""
+msgstr "&Крайова задача…"
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "&Bug Report"
-msgstr ""
+msgstr "&Надіслати звіт про ваду"
 
 #: ../../src/wxMaximaFrame.cpp:1505
 msgid "&Calculus"
-msgstr ""
+msgstr "&Аналіз"
 
 #: ../../src/wxMaximaFrame.cpp:1601
 msgid "&Canonical Form"
-msgstr ""
+msgstr "&Канонічна форма"
 
 #: ../../src/wxMaximaFrame.cpp:1358
 msgid "&Characteristic Polynomial..."
-msgstr ""
+msgstr "&Характеристичний поліном…"
 
 #: ../../src/wxMaximaFrame.cpp:990
 msgid "&Clear Memory"
-msgstr ""
+msgstr "С&порожнити пам'ять"
 
 #: ../../src/wxMaximaFrame.cpp:1583
 msgid "&Combine Factorials"
-msgstr ""
+msgstr "&Об'єднати факторіали"
 
 #: ../../src/wxMaximaFrame.cpp:1628
 msgid "&Complex Simplification"
-msgstr ""
+msgstr "&Комплексне спрощення"
 
 #: ../../src/wxMaximaFrame.cpp:1502
 msgid "&Continued Fraction"
-msgstr ""
+msgstr "&Неперервний дріб"
 
 #: ../../src/wxMaximaFrame.cpp:638
 msgid "&Copy\tCtrl+C"
-msgstr ""
+msgstr "&Копіювати\tCtrl+C"
 
 #: ../../src/wxMaximaFrame.cpp:1621
 msgid "&Demoivre"
-msgstr ""
+msgstr "У &тригонометричну форму"
 
 #: ../../src/wxMaximaFrame.cpp:1362
 msgid "&Determinant"
-msgstr ""
+msgstr "&Визначник"
 
 #: ../../src/wxMaximaFrame.cpp:1466
 msgid "&Differentiate..."
-msgstr ""
+msgstr "&Диференціювати…"
 
 #: ../../src/wxMaximaFrame.cpp:689
 msgid "&Edit"
-msgstr ""
+msgstr "З&міни"
 
 #: ../../src/wxMaximaFrame.cpp:1246
 msgid "&Eliminate Variable..."
-msgstr ""
+msgstr "З&нищити змінну…"
 
 #: ../../src/wxMaximaFrame.cpp:1318
 msgid "&Enter Matrix..."
-msgstr ""
+msgstr "&Ввести матрицю…"
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "&Example..."
-msgstr ""
+msgstr "П&риклад…"
 
 #: ../../src/wxMaximaFrame.cpp:1524
 msgid "&Expand Expression"
-msgstr ""
+msgstr "&Розкрити вираз"
 
 #: ../../src/wxMaximaFrame.cpp:1597
 msgid "&Expand Trigonometric"
-msgstr ""
+msgstr "&Розкрити тригонометричний вираз"
 
 #: ../../src/wxMaximaFrame.cpp:1626
 msgid "&Exponentialize"
-msgstr ""
+msgstr "У &експоненційну форму"
 
 #: ../../src/wxMaximaFrame.cpp:618
 msgid "&Export..."
-msgstr ""
+msgstr "&Експортувати…"
 
 #: ../../src/wxMaximaFrame.cpp:1516
 msgid "&Factor Expression"
-msgstr ""
+msgstr "Розкласти на &множники"
 
 #: ../../src/wxMaximaFrame.cpp:626
 msgid "&File"
-msgstr ""
+msgstr "&Файл"
 
 #: ../../src/wxMaximaFrame.cpp:1019
 msgid "&Functions"
-msgstr ""
+msgstr "&Функції"
 
 #: ../../src/wxMaximaFrame.cpp:1490
 msgid "&Greatest Common Divisor..."
-msgstr ""
+msgstr "Най&більший спільний дільник…"
 
 #: ../../src/wxMaximaFrame.cpp:1968
 msgid "&Help"
-msgstr ""
+msgstr "&Довідка"
 
 #: ../../src/wxMaximaFrame.cpp:1453
 msgid "&Integrate..."
-msgstr ""
+msgstr "&Інтегрувати…"
 
 #: ../../src/wxMaximaFrame.cpp:964
 msgid "&Interrupt\tCtrl+G"
-msgstr ""
+msgstr "П&ерервати\tCtrl+G"
 
 #: ../../src/wxMaximaFrame.cpp:1355
 msgid "&Invert Matrix"
-msgstr ""
+msgstr "&Обернена матриця"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "&License"
-msgstr ""
+msgstr "&Ліцензування"
 
 #: ../../src/wxMaximaFrame.cpp:1763
 msgid "&List"
-msgstr ""
+msgstr "С&писок"
 
 #: ../../src/wxMaximaFrame.cpp:610
 msgid "&Load Package...\tCtrl+L"
-msgstr ""
+msgstr "З&авантажити пакунок…\tCtrl+L"
 
 #: ../../src/wxMaximaFrame.cpp:1232
 msgid "&Maxima"
-msgstr ""
+msgstr "&Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "&Maxima help"
-msgstr ""
+msgstr "Дов&ідка з Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1660
 msgid "&Modulus Computation..."
-msgstr ""
+msgstr "Обчислення за &модулем…"
 
 #: ../../src/main.cpp:435
 msgid "&New\tCtrl+N"
-msgstr ""
+msgstr "С&творити\tCtrl+N"
 
 #: ../../src/wxMaximaFrame.cpp:1870
 msgid "&Numeric"
-msgstr ""
+msgstr "&Обчислення"
 
 #: ../../src/wxMaximaFrame.cpp:1785
 msgid "&Numeric Output"
-msgstr ""
+msgstr "Ч&ислове виведення"
 
 #: ../../src/main.cpp:436
 msgid "&Open\tCtrl+O"
-msgstr ""
+msgstr "&Відкрити\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "&Open...\tCtrl+O"
-msgstr ""
+msgstr "&Відкрити...\tCtrl+O"
 
 #: ../../src/wxMaximaFrame.cpp:1780
 msgid "&Plot"
-msgstr ""
+msgstr "&Креслення"
 
 #: ../../src/wxMaximaFrame.cpp:622
 msgid "&Print...\tCtrl+P"
-msgstr ""
+msgstr "На&друкувати\tCtrl+P"
 
 #: ../../src/wxMaximaFrame.cpp:1594
 msgid "&Reduce Trigonometric"
-msgstr ""
+msgstr "&Приведення тригонометричне"
 
 #: ../../src/wxMaximaFrame.cpp:974
+#, fuzzy
 msgid "&Restart Maxima\tCtrl+Alt+R"
-msgstr ""
+msgstr "Пе&резапустити Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:608
 msgid "&Save\tCtrl+S"
-msgstr ""
+msgstr "З&берегти\tCtrl+S"
 
 #: ../../src/wxMaximaFrame.cpp:1662
 msgid "&Simplify"
-msgstr ""
+msgstr "С&прощення"
 
 #: ../../src/wxMaximaFrame.cpp:1581
 msgid "&Simplify Factorials"
-msgstr ""
+msgstr "С&простити факторіали"
 
 #: ../../src/wxMaximaFrame.cpp:1591
 msgid "&Simplify Trigonometric"
-msgstr ""
+msgstr "Сп&ростити тригонометричний вираз"
 
 #: ../../src/wxMaximaFrame.cpp:1238
 msgid "&Solve..."
-msgstr ""
+msgstr "&Розв'язати…"
 
 #: ../../src/wxMaximaFrame.cpp:1035
 msgid "&Time Display"
-msgstr ""
+msgstr "Показ &часу"
 
 #: ../../src/wxMaximaFrame.cpp:1375
 msgid "&Transpose Matrix"
-msgstr ""
+msgstr "&Транспонувати матрицю"
 
 #: ../../src/wxMaximaFrame.cpp:1605
 msgid "&Trigonometric Simplification"
-msgstr ""
+msgstr "&Тригонометричне спрощення"
 
 #: ../../src/wxMaximaFrame.cpp:1021
 msgid "&Variables"
-msgstr ""
+msgstr "З&мінні"
 
 #: ../../src/wxMaxima.cpp:2443
 msgid "(Config tells to suppress the output of long cells)"
@@ -313,209 +321,211 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:9248
 msgid "(f(x),x,a,b)), Epsilon algorithm"
-msgstr ""
+msgstr "(f(x),x,a,b)), епсилон-алгоритм"
 
 #: ../../src/wxMaxima.cpp:9235
 msgid "(f(x),x,a,b)), Strategy of Aind"
-msgstr ""
+msgstr "(f(x),x,a,b)), стратегія Айнда"
 
 #: ../../src/wxMaxima.cpp:9258
 msgid "(f(x),x,a,b), (semi-) infinite interval"
-msgstr ""
+msgstr "(f(x),x,a,b), (напів-)нескінчений проміжок"
 
 #: ../../src/wxMaximaFrame.cpp:1841
 msgid "(f(x),x,a,b), Epsilon algorithm"
-msgstr ""
+msgstr "(f(x),x,a,b), епсилон-алгоритм"
 
 #: ../../src/wxMaximaFrame.cpp:1843
 msgid "(f(x),x,a,b), infinite interval"
-msgstr ""
+msgstr "(f(x),x,a,b), нескінчений проміжок"
 
 #: ../../src/wxMaximaFrame.cpp:1839
 msgid "(f(x),x,a,b), strategy of Aind"
-msgstr ""
+msgstr "(f(x),x,a,b), стратегія Айнда"
 
 #: ../../src/wxMaxima.cpp:9361 ../../src/wxMaximaFrame.cpp:1867
 msgid "(f(x),x,y) with singularities+discontinuities"
-msgstr ""
+msgstr "(f(x),x,y) із сингулярностями і розривами"
 
 #: ../../src/wxMaxima.cpp:2065
 msgid ""
 "... [suppressed additional lines as the output is longer than allowed in the"
 " wxMaxima configuration] "
 msgstr ""
+"... [придушено додаткові рядки, оскільки обсяг виведених даних перевищує "
+"дозволений у налаштуваннях wxMaxima] "
 
 #: ../../src/Worksheet.cpp:6666
 msgid ".wxm clipboard data with unusual header"
-msgstr ""
+msgstr "Дані буфера обміну .wxm із несподіваним заголовком"
 
 #: ../../src/wxMaxima.cpp:8047
 msgid "1×n Matrix b:"
-msgstr ""
+msgstr "Матриця b 1×n:"
 
 #: ../../src/wxMaximaFrame.cpp:1312
 msgid "2D Array to Matrix..."
-msgstr ""
+msgstr "Двовимірний масив у матрицю…"
 
 #: ../../src/wxMaximaFrame.cpp:743
 msgid "2D equations using ASCII Art"
-msgstr ""
+msgstr "Малюнки рівнянь з використанням символів ASCII"
 
 #: ../../src/wxMaximaFrame.cpp:746
 msgid "2D equations using ASCII Art with unicode characters, if available"
 msgstr ""
 
 #: ../../src/wxMaxima.cpp:5057
-#, c-format
+#, fuzzy, c-format
 msgid "; %i commands left in the current cell"
-msgstr ""
+msgstr "; у поточній комірці лишилося %i команд"
 
 #: ../../src/wxMaxima.cpp:10617
 msgid "A \":lisp\" as the first command might fail to send a \"finished\" signal."
-msgstr ""
+msgstr "Перша команда «:lisp» іноді не може надіслати сигнал «finished»."
 
 #: ../../src/wxMaxima.cpp:6585
 msgid "A Ctrl-F event"
-msgstr ""
+msgstr "Подія Ctrl-F"
 
 #: ../../src/Worksheet.cpp:1973
 msgid "A Scalar"
-msgstr ""
+msgstr "Число"
 
 #: ../../src/wxMaxima.cpp:6653
 #, c-format
 msgid "A find event, %s"
-msgstr ""
+msgstr "Подія пошуку, %s"
 
 #: ../../src/Worksheet.cpp:2012
 msgid "A function returning integers"
-msgstr ""
+msgstr "Функція, яка повертає цілі числа"
 
 #: ../../src/Worksheet.cpp:2014
 msgid "A function returning positive numbers"
-msgstr ""
+msgstr "Функція, яка повертає додатні числа"
 
 #: ../../src/Worksheet.cpp:1965
 msgid "A irrational variable"
-msgstr ""
+msgstr "Ірраціональна змінна"
 
 #: ../../src/Worksheet.cpp:2016
 msgid "A left-associative function"
-msgstr ""
+msgstr "Функція із лівою асоціативністю"
 
 #: ../../src/Worksheet.cpp:2019
 msgid "A linear function"
-msgstr ""
+msgstr "Лінійна функція"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "A matrix in which each row is a set of variables"
-msgstr ""
+msgstr "Матриця, у якій кожен рядок є набором змінних"
 
 #: ../../src/Worksheet.cpp:1963
 msgid "A rational variable"
-msgstr ""
+msgstr "Раціональна змінна"
 
 #: ../../src/Worksheet.cpp:2018
 msgid "A right-associative function"
-msgstr ""
+msgstr "Функція із правою асоціативністю"
 
 #: ../../src/wxMaximaFrame.cpp:1634
 msgid "A search-and-replace for equations"
-msgstr ""
+msgstr "Пошук із заміною для рівнянь"
 
 #: ../../src/wxMaximaFrame.cpp:1636
 msgid "A subst with basic maths knowledge"
-msgstr ""
+msgstr "Заміна із базовими знаннями з математики"
 
 #: ../../src/BTextCtrl.cpp:64
 msgid "A text control got the mouse focus"
-msgstr ""
+msgstr "Текстовий елемент отримав фокус миші"
 
 #: ../../src/wxMaximaFrame.cpp:1442
 msgid "A&pply function to each Matrix element..."
-msgstr ""
+msgstr "Заст&осувати функцію до кожного елемента матриці…"
 
 #: ../../src/wxMaximaFrame.cpp:1291
 msgid "A&t Value..."
-msgstr ""
+msgstr "Значення &у точці…"
 
 #: ../../src/Configuration.cpp:85
 msgid "ASCII maths"
-msgstr ""
+msgstr "математичні символи ASCII"
 
 #: ../../src/wxMaximaFrame.cpp:1963
 msgid "About"
-msgstr ""
+msgstr "Про програму"
 
 #: ../../src/wxMaximaFrame.cpp:1963 ../../src/wxMaximaFrame.cpp:1965
 msgid "About wxMaxima"
-msgstr ""
+msgstr "Про wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7837
 msgid "Accepts one expression or a list in the format [ode1,ode2,...]"
-msgstr ""
+msgstr "Приймає один вираз або список у форматі [ode1,ode2,...]"
 
 #: ../../src/wxMaxima.cpp:7841
 msgid "Accepts one variable or a list in the format [1,4,...]"
-msgstr ""
+msgstr "Приймає одну змінну або список у форматі [1,4,...]"
 
 #: ../../src/wxMaxima.cpp:7839
 msgid "Accepts one variable or a list in the format [var1,var2,...]"
-msgstr ""
+msgstr "Приймає одну змінну або список у форматі [змінна1,змінна2,...]"
 
 #: ../../src/wxMaximaFrame.cpp:1371
 msgid "Ad&joint Matrix"
-msgstr ""
+msgstr "Спр&яжена матриця"
 
 #: ../../src/wxMaximaFrame.cpp:1657
 msgid "Add Algebraic E&quality..."
-msgstr ""
+msgstr "Додати &алгебраїчну рівність…"
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add a directory to search path"
-msgstr ""
+msgstr "Додати каталог до шляху пошуку"
 
 #: ../../src/wxMaximaFrame.cpp:1752
 msgid ""
 "Add a new item to the beginning of the list. Useful for creating stacks."
-msgstr ""
+msgstr "Додати новий пункт на початку списку. Корисно для створення стосів."
 
 #: ../../src/wxMaxima.cpp:8602
 msgid "Add an element to the end of a list"
-msgstr ""
+msgstr "Додати елемент наприкінці списку"
 
 #: ../../src/wxMaxima.cpp:8597
 msgid "Add an element to the start of a list"
-msgstr ""
+msgstr "Додати елемент на початку списку"
 
 #: ../../src/wxMaxima.cpp:7625
 msgid "Add dir to path:"
-msgstr ""
+msgstr "Додати каталог до шляху:"
 
 #: ../../src/wxMaximaFrame.cpp:1658
 msgid "Add equality to the rational simplifier"
-msgstr ""
+msgstr "Додати рівність до спрощувача раціональних виразів"
 
 #: ../../src/wxMaximaFrame.cpp:1015
 msgid "Add to &Path..."
-msgstr ""
+msgstr "Додати до &шляху…"
 
 #: ../../src/Worksheet.cpp:1531 ../../src/Worksheet.cpp:1564
 #: ../../src/Worksheet.cpp:1704
 msgid "Add to watchlist"
-msgstr ""
+msgstr "Додати до списку спостереження"
 
 #: ../../src/wxMaximaFrame.cpp:1562
 msgid "Additionally: log(a*b)=log(a)+log(b)"
-msgstr ""
+msgstr "Додатково: log(a*b)=log(a)+log(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1566
 msgid "Additionally: log(a/b)=log(a)-log(b), a and b positive integers"
-msgstr ""
+msgstr "Додатково: log(a/b)=log(a)-log(b), a і b — додатні цілі числа"
 
 #: ../../src/Worksheet.cpp:1996
 msgid "Additive function: f(a+b)=f(a)+f(b)"
-msgstr ""
+msgstr "Адитивна функція: f(a+b)=f(a)+f(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1911
 msgid "Advanced 2d plotting"
@@ -523,29 +533,31 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1809
 msgid "Advanced guess (PSLQ algorithm)"
-msgstr ""
+msgstr "Удосконалене наближення (алгоритм PSLQ)"
 
 #: ../../src/wxMaximaFrame.cpp:1920
 msgid "Advanced variable names"
-msgstr ""
+msgstr "Розширені назви змінних"
 
 #: ../../src/ToolBar.cpp:321 ../../src/ToolBar.cpp:589
 msgid ""
 "After clicking on animations created with with_slider_draw() or similar this"
 " slider allows to change the current frame."
 msgstr ""
+"Після натискання анімацій, створених за допомогою with_slider_draw() або "
+"подібної функції, цей повзунок надає змогу змінити поточний кадр."
 
 #: ../../src/wxMaximaFrame.cpp:1028
 msgid "Aliases"
-msgstr ""
+msgstr "Замінники"
 
 #: ../../src/wxMaximaFrame.cpp:1714
 msgid "All but the 1st n elements"
-msgstr ""
+msgstr "Усі, окрім перших n елементів"
 
 #: ../../src/wxMaximaFrame.cpp:1716
 msgid "All but the last n elements"
-msgstr ""
+msgstr "Усі, окрім останніх n елементів"
 
 #: ../../src/main.cpp:594 ../../src/wxMaxima.cpp:6075
 msgid ""
@@ -554,93 +566,101 @@ msgid ""
 "*.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session "
 "(*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr ""
+"усі придатні типи (*.wxm, *.wxmx, *.mac, *.out, "
+"*.xml)|*.wxm;*.wxmx;*.mac;*.out;*.xml|документ wxMaxima (*.wxm, "
+"*.wxmx)|*.wxm;*.wxmx|сеанс Maxima (*.mac)|*.mac|сеанс Xmaxima "
+"(*.out)|*.out|xml з пошкодженого .wxmx (*.xml)|*.xml"
 
 #: ../../src/wxMaximaFrame.cpp:733
 msgid "All visible sidebars"
-msgstr ""
+msgstr "Усі видимі бічні панелі"
 
 #: ../../src/wxMaximaFrame.cpp:1650
 msgid "Allow to substitute operators"
-msgstr ""
+msgstr "Дозволити підставляння операторів"
 
 #: ../../src/wxMaxima.cpp:9040
 msgid ""
 "Allows to vary the parameters of a function until it fits experimental data."
 msgstr ""
+"Надає змогу варіювати параметри функції при апроксимації експериментальних "
+"даних."
 
 #: ../../src/wxMaximaFrame.cpp:763
 msgid "Always after underscores"
-msgstr ""
+msgstr "Завжди після символів підкреслювання"
 
 #: ../../src/wxMaximaFrame.cpp:764
 msgid "Always autosubscript after an underscore"
-msgstr ""
+msgstr "Завжди автоматичний нижній індекс після символу підкреслювання"
 
 #: ../../src/wxMaximaFrame.cpp:774
 msgid "Always display this variable with subscript"
-msgstr ""
+msgstr "Завжди показувати цю змінну із нижнім індексом"
 
 #: ../../src/Worksheet.cpp:1605
 msgid "Always show all digits"
-msgstr ""
+msgstr "Завжди показувати усі цифри"
 
 #: ../../src/wxMaxima.cpp:9241
 msgid ""
 "An integer between 1..6; Higher numbers work better for oscillating "
 "integrands"
 msgstr ""
+"Ціле число у межах від 1 до 6; більші значення краще працюють для "
+"підінтегральних функції із осциляцією"
 
 #: ../../src/MaximaManual.cpp:385
 msgid "Anchors file has no top node."
-msgstr ""
+msgstr "Файл прив'язок не містить вузла верхнього рівня."
 
 #: ../../src/wxMaximaFrame.cpp:791
 msgid "Angles"
-msgstr ""
+msgstr "Кути"
 
 #: ../../src/wxMaximaFrame.cpp:1775
 msgid "Animation autoplay"
-msgstr ""
+msgstr "Автовідтворення анімації"
 
 #: ../../src/wxMaximaFrame.cpp:1778
 msgid "Animation framerate..."
-msgstr ""
+msgstr "Частота кадрів анімації…"
 
 #: ../../src/Worksheet.cpp:2002
 msgid "Antisymmetric function: f(x)=-f(-x)"
-msgstr ""
+msgstr "Непарна функція: f(x)=-f(-x)"
 
 #: ../../src/wxMaximaFrame.cpp:1739
 msgid "Append"
-msgstr ""
+msgstr "Дописати"
 
 #: ../../src/wxMaximaFrame.cpp:1735
 msgid "Append a list"
-msgstr ""
+msgstr "Дописати список"
 
 #: ../../src/wxMaximaFrame.cpp:1736
 msgid "Append a list to an existing list"
-msgstr ""
+msgstr "Дописати список до наявного списку"
 
 #: ../../src/wxMaxima.cpp:8607
 msgid "Append a list to another list"
-msgstr ""
+msgstr "Дописати список до іншого списку"
 
 #: ../../src/wxMaximaFrame.cpp:1729
 msgid "Append an element"
-msgstr ""
+msgstr "Дописати елемент"
 
 #: ../../src/wxMaximaFrame.cpp:1734
 msgid "Append an element to the beginning an existing list"
-msgstr ""
+msgstr "Дописати елемент до наявного списку на початку"
 
 #: ../../src/wxMaximaFrame.cpp:1730
 msgid "Append an element to the end of an existing list"
-msgstr ""
+msgstr "Дописати елемент до наявного списку у кінці"
 
 #: ../../src/wxMaxima.cpp:8552
 msgid "Apply a function to each list element"
-msgstr ""
+msgstr "Застосувати функцію до усіх елементів списку"
 
 #: ../../src/wxMaximaFrame.cpp:1810
 #, c-format
@@ -648,120 +668,129 @@ msgid ""
 "Approximate by a fraction using log(), sqrt() and %pi, when needed. Only "
 "available in maxima > 5.46.0"
 msgstr ""
+"Наблизити дробом за допомогою log(), sqrt() і %pi, якщо потрібно. Можна "
+"скористатися лише у maxima > 5.46.0"
 
 #: ../../src/wxMaximaFrame.cpp:1806
 msgid "Approximate by nice fraction"
-msgstr ""
+msgstr "Наблизити добрим дробом"
 
 #: ../../src/wxMaxima.cpp:8931
 msgid ""
 "Approximates a expression around a point as a polynom\n"
 "The trailing \"...\" can be removed by using ratdisrep()"
 msgstr ""
+"Наблизити вираз поліномом в околі точки\n"
+"Кінцеве «...» можна вилучити за допомогою ratdisrep()"
 
 #: ../../src/wxMaxima.cpp:8939
 msgid "Approximates a expression as a polynom"
-msgstr ""
+msgstr "Наблизити вираз поліномом"
 
 #: ../../src/wxMaxima.cpp:9474
 msgid "Apropos"
-msgstr ""
+msgstr "Подібні команди"
 
 #: ../../src/wxMaxima.cpp:7317
 msgid "Are the chars equal, if case is ignored?"
-msgstr ""
+msgstr "Чи є ці символи однаковими, якщо не зважати на регістр?"
 
 #: ../../src/wxMaxima.cpp:7312
 msgid "Are the chars equal?"
-msgstr ""
+msgstr "Чи є символи рівними?"
 
 #: ../../src/wxMaxima.cpp:7349
 msgid "Are these strings equal if case is ignored?"
-msgstr ""
+msgstr "Чи є ці рядки однаковими, якщо не зважати на регістр символів?"
 
 #: ../../src/wxMaxima.cpp:7344
 msgid "Are these strings equal?"
-msgstr ""
+msgstr "Чи є ці рядки однаковими?"
 
 #: ../../src/wxMaxima.cpp:7259
 msgid "Arguments:"
-msgstr ""
+msgstr "Аргументи:"
 
 #: ../../src/wxMaxima.cpp:8189
 msgid "Array"
-msgstr ""
+msgstr "Масив"
 
 #: ../../src/wxMaximaFrame.cpp:1023
 msgid "Arrays"
-msgstr ""
+msgstr "Масиви"
 
 #: ../../src/wxMaxima.cpp:7308 ../../src/wxMaxima.cpp:7354
 msgid "Ascii code to char"
-msgstr ""
+msgstr "Код ASCII на символ"
 
 #: ../../src/wxMaximaFrame.cpp:1138
 msgid "Ascii code to char..."
-msgstr ""
+msgstr "Код ASCII на символ…"
 
 #: ../../src/wxMaxima.cpp:10063
 msgid "Assignment(s):"
-msgstr ""
+msgstr "Визначення:"
 
 #: ../../src/wxMaxima.cpp:10064
 msgid "Assignments of the format a=10,b=20"
-msgstr ""
+msgstr "Надання значення у форматі a=10,b=20"
 
 #: ../../src/wxMaxima.cpp:6851
 msgid "Assume a value range for a variable"
-msgstr ""
+msgstr "Припустити діапазон значень для змінної"
 
 #: ../../src/wxMaxima.cpp:8545
 msgid ""
 "Attention: Extracting a random list element isn't efficient for long "
 "lists.Iterating over lists using makelist() or for loops is way faster."
 msgstr ""
+"Увага! Для довгих списків видобування випадкового елемента зі списку є не "
+"ефективним. Набагато швидшим буде ітеративний перехід списками за допомогою "
+"makelist() або циклів for."
 
 #: ../../src/Worksheet.cpp:1618
 msgid "Automatic labels"
-msgstr ""
+msgstr "Автоматичні мітки"
 
 #: ../../src/wxMaximaFrame.cpp:952
 msgid "Automatically answer questions"
-msgstr ""
+msgstr "Автоматично відповідати на питання"
 
 #: ../../src/wxMaximaFrame.cpp:953
 msgid "Automatically fill in answers known from the last run"
 msgstr ""
+"Автоматично заповнювати відповіді, які відомі з часу попереднього запуску"
 
 #: ../../src/Worksheet.cpp:1464 ../../src/Worksheet.cpp:1838
 msgid "Automatically send known answers"
-msgstr ""
+msgstr "Автоматично надсилати відомі відповіді"
 
 #: ../../src/wxMaxima.cpp:6021
 #, c-format
 msgid "Autosaving as temp file %s"
-msgstr ""
+msgstr "Автоматичне збереження у форматі тимчасового файла %s"
 
 #: ../../src/wxMaxima.cpp:6033
 #, c-format
 msgid "Autosaving the .wxmx file as %s"
-msgstr ""
+msgstr "Автоматично зберігаємо файл .wxmx як %s"
 
 #: ../../src/wxMaximaFrame.cpp:781
 msgid "Autosubscript"
-msgstr ""
+msgstr "Автоматичне переведення у нижній індекс"
 
 #: ../../src/wxMaximaFrame.cpp:782
 msgid "Autosubscript chars after an underscore"
-msgstr ""
+msgstr "Автоматично переводити у нижній індекс символи після підкреслювання"
 
 #: ../../src/wxMaximaFrame.cpp:767
 msgid "Autosubscript numbers and text following single letters"
 msgstr ""
+"Автоматично переводити у нижні індекси числа і текст після одинарних літер"
 
 #: ../../src/wxMaxima.cpp:6529
 msgid "Autosubscript this variable"
-msgstr ""
+msgstr "Переводити цю змінну у нижній індекс автоматично"
 
 #: ../../src/MaximaManual.cpp:536
 msgid "Background task that compiles the Manual anchors scheduled."
@@ -769,83 +798,90 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1350
 msgid "Basic matrix operations"
-msgstr ""
+msgstr "Основні дії з матрицями"
 
 #: ../../src/wxMaxima.cpp:6210
 msgid "Batch File"
-msgstr ""
+msgstr "Пакетний файл"
 
 #: ../../src/wxMaxima.cpp:5318
 msgid "Both horizontal and vertical cursor active at the same time"
-msgstr ""
+msgstr "Активними є одночасно горизонтальний і вертикальний курсори"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Bottom end"
-msgstr ""
+msgstr "Нижній кінець"
 
 #: ../../src/wxMaxima.cpp:7817
 msgid "Boundary value problem"
-msgstr ""
+msgstr "Крайова задача"
 
 #: ../../src/wxMathml.cpp:101
 msgid ""
 "Bug: After removing the whitespace wxMathml.lisp is shorter than expected!"
 msgstr ""
+"Вада: після вилучення пробілів wxMathml.lisp виявився коротшим за "
+"очікуваний!"
 
 #: ../../src/Autocomplete.cpp:509
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
+"Вада: надіслано запит щодо автодоповнення для невідомого типу записів."
 
 #: ../../src/Worksheet.cpp:2992
 msgid "Bug: Cell left but not entered."
-msgstr ""
+msgstr "Вада: полишено комірку без введення даних."
 
 #: ../../src/Worksheet.cpp:6203
 msgid "Bug: Cell with negative y position!"
-msgstr ""
+msgstr "Вада: комірка із від'ємною координатою y!"
 
 #: ../../src/Worksheet.cpp:7723
 msgid ""
 "Bug: Encountered a heading I don't know how to move in one sectioning unit"
-msgstr ""
+msgstr "Вада: виявлено заголовок, який неможливо підняти на один щабель"
 
 #: ../../src/Worksheet.cpp:7766
 msgid ""
 "Bug: Encountered a heading I don't know how to move out one sectioning unit"
-msgstr ""
+msgstr "Вада: виявлено заголовок, який неможливо опустити на один щабель"
 
 #: ../../src/Worksheet.cpp:3112
 msgid "Bug: Got a question but no cell to answer it in"
-msgstr ""
+msgstr "Вада: маємо питання, але не маємо комірки для відповіді на нього"
 
 #: ../../src/Worksheet.cpp:6378
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of"
 " the worksheet."
 msgstr ""
+"Вада: отримано запит на зміну вмісту комірки над початком робочого аркуша."
 
 #: ../../src/Worksheet.cpp:6346
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
+"Вада: отримано запит на вилучення комірки над початком робочого аркуша."
 
 #: ../../src/Worksheet.cpp:6415
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
 msgstr ""
+"Вада: отримано запит спочатку на зміну вмісту комірки з наступним "
+"скасуванням її вилучення."
 
 #: ../../src/Worksheet.cpp:5578
 msgid "Bug: HTML output is no valid XML"
-msgstr ""
+msgstr "Вада: виведені дані HTML не є коректними даними XML"
 
 #: ../../src/Configuration.h:615
 msgid "Bug: Maximum number of digits that is to be displayed is too low!"
-msgstr ""
+msgstr "Вада: надто мала максимальна кількість цифр, які має бути показано!"
 
 #: ../../src/MathParser.cpp:523
 msgid "Bug: Missing contents"
-msgstr ""
+msgstr "Вада: немає вмісту"
 
 #: ../../src/Worksheet.cpp:2597 ../../src/Worksheet.cpp:2711
 #: ../../src/Worksheet.cpp:2753 ../../src/Worksheet.cpp:2787
@@ -853,135 +889,141 @@ msgstr ""
 #: ../../src/Worksheet.cpp:4442 ../../src/Worksheet.cpp:6650
 #: ../../src/Worksheet.cpp:6863
 msgid "Bug: The clipboard is already opened"
-msgstr ""
+msgstr "Вада: буфер обміну вже відкрито"
 
 #: ../../src/Worksheet.cpp:7763
 msgid "Bug: Trying to move a title out by one sectioning unit"
-msgstr ""
+msgstr "Вада: спроба пересунути заголовок через один рівень розділів"
 
 #: ../../src/Worksheet.cpp:6934
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
+"Вада: спроба пересунути горизонтальний курсор до місця усередині GroupCell."
 
 #: ../../src/Worksheet.h:247 ../../src/Worksheet.h:252
 msgid "Bug: Trying to record a cell contents change for undo without a cell."
 msgstr ""
+"Вада: спроба запису змін у вмісті комірок для скасовування без визначення "
+"комірки."
 
 #: ../../src/Worksheet.cpp:6417
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
+"Вада: дія зі скасування із одночасною зміною вмісту комірки і додаванням "
+"комірки."
 
 #: ../../src/Worksheet.cpp:6383
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
+"Вада: запит щодо скасування дій із коміркою поза межами робочого аркуша."
 
 #: ../../src/wxMaximaFrame.cpp:1948
 msgid "Build &Info"
-msgstr ""
+msgstr "Ві&домості щодо збирання"
 
 #: ../../src/wxMaxima.cpp:7275
 msgid "Byte:"
-msgstr ""
+msgstr "Байт:"
 
 #: ../../src/wxMaximaFrame.cpp:1458
 msgid "C&hange Variable in Integrate..."
-msgstr ""
+msgstr "З&амінити змінну інтегрування…"
 
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "C&onfigure"
-msgstr ""
+msgstr "&Налаштувати"
 
 #: ../../src/wxMaximaFrame.cpp:1482
 msgid "Calculate &Product..."
-msgstr ""
+msgstr "Обчислити &добуток…"
 
 #: ../../src/wxMaxima.cpp:8057
 msgid "Calculate Singular Value Decomposition of a matrix numerically"
-msgstr ""
+msgstr "Обчислити власний розклад матриці"
 
 #: ../../src/wxMaxima.cpp:8050
 msgid ""
 "Calculate Singular Value Decomposition, left and right singular vectors "
 "numerically"
-msgstr ""
+msgstr "Обчислити власний розклад, лівий і правий сингулярні вектори"
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate Su&m..."
-msgstr ""
+msgstr "Обчислити с&уму…"
 
 #: ../../src/wxMaximaFrame.cpp:1795
 msgid "Calculate bigfloat value of the last result"
-msgstr ""
+msgstr "Обчислити останній результат з підвищеною точністю"
 
 #: ../../src/wxMaximaFrame.cpp:1792
 msgid "Calculate float value of the last result"
-msgstr ""
+msgstr "Обчислити останній результат зі звичайною точністю"
 
 #: ../../src/wxMaxima.cpp:9550
 msgid "Calculate mean value"
-msgstr ""
+msgstr "Обчислити значення середнього"
 
 #: ../../src/wxMaxima.cpp:9554
 msgid "Calculate median value"
-msgstr ""
+msgstr "Обчислити значення медіани"
 
 #: ../../src/wxMaxima.cpp:8871
 msgid "Calculate modulus:"
-msgstr ""
+msgstr "Модуль обчислень:"
 
 #: ../../src/wxMaximaFrame.cpp:1798
 msgid "Calculate numeric value of the last result"
-msgstr ""
+msgstr "Визначити числове значення останнього результату"
 
 #: ../../src/wxMaximaFrame.cpp:1483
 msgid "Calculate products"
-msgstr ""
+msgstr "Обчислити добутки"
 
 #: ../../src/wxMaxima.cpp:9562
 msgid "Calculate standard deviation"
-msgstr ""
+msgstr "Обчислити стандартне відхилення"
 
 #: ../../src/wxMaximaFrame.cpp:1480
 msgid "Calculate sums"
-msgstr ""
+msgstr "Обчислити суми"
 
 #: ../../src/wxMaxima.cpp:8025 ../../src/wxMaxima.cpp:8035
 msgid "Calculate the eigenvalues and eigenvectors numerically"
-msgstr ""
+msgstr "Обчислити власні значення і власні вектори обчислювальними методами"
 
 #: ../../src/wxMaxima.cpp:8020 ../../src/wxMaxima.cpp:8030
 msgid "Calculate the eigenvalues of a matrix numerically"
-msgstr ""
+msgstr "Обчислити власні значення матриці обчислювальними методами"
 
 #: ../../src/wxMaxima.cpp:8078 ../../src/wxMaxima.cpp:8099
 msgid "Calculate the root of the sum of squares of matrix entries"
-msgstr ""
+msgstr "Обчислити корінь з суми квадратів елементів матриці"
 
 #: ../../src/wxMaxima.cpp:9558
 msgid "Calculate variation"
-msgstr ""
+msgstr "Обчислити варіацію"
 
 #: ../../src/wxMaxima.cpp:8949
 msgid "Calculates the fourier coefficients for the expression from -p to p"
-msgstr ""
+msgstr "Обчислює коефіцієнти Фур'є для виразу від -p до p"
 
 #: ../../src/Worksheet.cpp:1968
 msgid "Calls assume() in order to tell maxima about the variable's range"
-msgstr ""
+msgstr "Викликає assume() для визначення діапазону змінної у maxima"
 
 #: ../../src/Worksheet.cpp:2031
 msgid "Can be specified as flag in ev(exp, flag)"
-msgstr ""
+msgstr "Може бути вказано як прапорець у ev(вираз, прапорець)"
 
 #: ../../src/wxMaxima.cpp:11125
 msgid "Can not connect to the web server."
-msgstr ""
+msgstr "Не вдалося встановити з'єднання з вебсервером."
 
 #: ../../src/wxMaxima.cpp:11166
 msgid "Can not download version info."
-msgstr ""
+msgstr "Не вдалося отримати дані щодо версії."
 
 #: ../../src/wxMaxima.cpp:3016 ../../src/wxMaxima.cpp:4836
 msgid ""
@@ -989,149 +1031,157 @@ msgid ""
 " (it can be downloaded from https://maxima.sourceforge.io) or in wxMaxima's "
 "config dialogue the setting for Maxima's location is wrong."
 msgstr ""
+"Не вдалося запустити Maxima. Найімовірнішою причиною є те, що Maxima не "
+"встановлено (отримати пакунки можна з сайта https://maxima.sourceforge.io) "
+"або у вікні налаштовування wxMaxima встановлено помилковий каталог "
+"розташування Maxima."
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Cancel"
-msgstr ""
+msgstr "Скасувати"
 
 #: ../../src/wxMaxima.cpp:3292
 msgid "Cannot authenticate Maxima!"
-msgstr ""
+msgstr "Не вдалося розпізнати Maxima!"
 
 #: ../../src/wxMaxima.cpp:2677
 msgid ""
 "Cannot find a maxima binary and no binary chosen in the config dialogue."
 msgstr ""
+"Не вдалося знайти виконуваний файл maxima, а у діалоговому вікні "
+"налаштовування не вказано виконуваного файла."
 
 #: ../../src/Autocomplete.cpp:583
 #, c-format
 msgid "Cannot interpret template %s"
-msgstr ""
+msgstr "Не вдалося обробити шаблон %s"
 
 #: ../../src/wxMaxima.cpp:3082
 #, c-format
 msgid "Cannot interpret the numeric value of pid %s"
-msgstr ""
+msgstr "Не вдалося обробити числове значення pid %s"
 
 #: ../../src/wxMaxima.cpp:11066 ../../src/wxMaxima.cpp:11073
 #: ../../src/wxMaxima.cpp:11080
 #, c-format
 msgid "Cannot interpret version number component %s"
-msgstr ""
+msgstr "Не вдалося обробити компонент номера версії %s"
 
 #: ../../src/wxMaxima.cpp:2530
 msgid "Cannot set the communication address to localhost."
-msgstr ""
+msgstr "Не вдалося встановити адресу локального вузла для обміну даними."
 
 #: ../../src/wxMaxima.cpp:2532
-#, c-format
+#, fuzzy, c-format
 msgid "Cannot set the communication port to %i."
-msgstr ""
+msgstr "Не вдалося встановити порт обміну даними %i."
 
 #: ../../src/wxMaxima.cpp:3656 ../../src/wxMaxima.cpp:6359
 msgid "Cannot start gnuplot"
-msgstr ""
+msgstr "Не вдалося запустити gnuplot"
 
 #: ../../src/StatusBar.cpp:216 ../../src/wxMaxima.cpp:2662
 msgid "Cannot start the maxima binary"
-msgstr ""
+msgstr "Не вдалося запустити виконуваний файл maxima"
 
 #: ../../src/wxMaxima.cpp:9268
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
-msgstr ""
+msgstr "Головне значення за Коші f(x)/(x-c), скінченний проміжок"
 
 #: ../../src/wxMaximaFrame.cpp:1845
 msgid "Cauchy principal value, finite interval"
-msgstr ""
+msgstr "Головне значення за Коші, скінченний проміжок"
 
 #: ../../src/wxMaximaFrame.cpp:955
 msgid "Ce&ll"
-msgstr ""
+msgstr "&Комірка"
 
 #: ../../src/Configuration.cpp:96
 msgid "Cell bracket fill, Active"
-msgstr ""
+msgstr "Заповнення дужки комірки, активне"
 
 #: ../../src/Configuration.cpp:95
 msgid "Cell bracket fill, Inactive"
-msgstr ""
+msgstr "Заповнення дужки комірки, неактивне"
 
 #: ../../src/wxMaxima.cpp:10395
 msgid "Cell ends in a backslash"
-msgstr ""
+msgstr "Комірка закінчується зворотною похилою рискою"
 
 #: ../../src/wxMaximaFrame.cpp:1038
 msgid "Change &2d Display"
-msgstr ""
+msgstr "Змінити спосіб по&казу"
 
 #: ../../src/wxMaxima.cpp:10146
 msgid "Change Image"
-msgstr ""
+msgstr "Змінити зображення"
 
 #: ../../src/Worksheet.cpp:1324
 msgid "Change Image..."
-msgstr ""
+msgstr "Змінити зображення…"
 
 #: ../../src/wxMaximaFrame.cpp:1954
 msgid "Change Log"
-msgstr ""
+msgstr "Журнал змін"
 
 #: ../../src/wxMaxima.cpp:7555
 msgid "Change directory"
-msgstr ""
+msgstr "Змінити каталог"
 
 #: ../../src/wxMaximaFrame.cpp:1202
 msgid "Change directory..."
-msgstr ""
+msgstr "Змінити каталог…"
 
 #: ../../src/wxMaximaFrame.cpp:1039
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
+"Змінити алгоритм показу плоского зображення, що використовується для показу "
+"математичних виразів"
 
 #: ../../src/wxMaxima.cpp:8885
 msgid "Change variable"
-msgstr ""
+msgstr "Замінити змінну"
 
 #: ../../src/wxMaxima.cpp:8905
 msgid "Change variable and evaluate"
-msgstr ""
+msgstr "Замінити змінну і обчислити"
 
 #: ../../src/wxMaximaFrame.cpp:1459
 msgid "Change variable in integral or sum"
-msgstr ""
+msgstr "Замінити змінну в інтегралі або сумі"
 
 #: ../../src/wxMaximaFrame.cpp:1463
 msgid "Change variable in integral or sum and evaluate the result"
-msgstr ""
+msgstr "Замінити змінну в інтегралі або сумі і обчислити результат"
 
 #: ../../src/wxMaximaFrame.cpp:1026
 msgid "Changed option variables"
-msgstr ""
+msgstr "Замінити змінні параметра"
 
 #: ../../src/wxMaxima.cpp:10170
 #, c-format
 msgid "Changing image originally loaded from file %s to %s."
-msgstr ""
+msgstr "Заміна зображення, початково завантаженого з файла %s, на %s."
 
 #: ../../src/wxMaxima.cpp:7313 ../../src/wxMaxima.cpp:7318
 #: ../../src/wxMaxima.cpp:7323 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7334 ../../src/wxMaxima.cpp:7340
 msgid "Char #1:"
-msgstr ""
+msgstr "Символ 1:"
 
 #: ../../src/wxMaxima.cpp:7314 ../../src/wxMaxima.cpp:7319
 #: ../../src/wxMaxima.cpp:7324 ../../src/wxMaxima.cpp:7329
 #: ../../src/wxMaxima.cpp:7335 ../../src/wxMaxima.cpp:7340
 msgid "Char #2:"
-msgstr ""
+msgstr "Символ 2:"
 
 #: ../../src/wxMaximaFrame.cpp:1140
 msgid "Char to Unicode code point..."
-msgstr ""
+msgstr "Символ на позицію у таблиці Unicode…"
 
 #: ../../src/wxMaxima.cpp:7358 ../../src/wxMaxima.cpp:7362
 msgid "Char to unicode code point"
-msgstr ""
+msgstr "Символ на позицію у таблиці Unicode"
 
 #: ../../src/wxMaxima.cpp:7285 ../../src/wxMaxima.cpp:7289
 #: ../../src/wxMaxima.cpp:7293 ../../src/wxMaxima.cpp:7297
@@ -1139,324 +1189,346 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7359 ../../src/wxMaxima.cpp:7363
 #: ../../src/wxMaxima.cpp:7435
 msgid "Char:"
-msgstr ""
+msgstr "Символ:"
 
 #: ../../src/wxMaximaFrame.cpp:1131
 msgid "Character Tests"
-msgstr ""
+msgstr "Перевірки символів"
 
 #: ../../src/wxMaxima.cpp:8181
 msgid "Characteristic polynom"
-msgstr ""
+msgstr "Характеристичний поліном"
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Chars are strings that are one character long"
-msgstr ""
+msgstr "Символи — рядки, які складаються з одного символу"
 
 #: ../../src/wxMaximaFrame.cpp:1957
 msgid "Check for Updates"
-msgstr ""
+msgstr "Перевірити наявність оновлень"
 
 #: ../../src/wxMaximaFrame.cpp:1958
 msgid "Check if a newer version of wxMaxima is available."
-msgstr ""
+msgstr "Перевірити, чи не випущено новішу версію wxMaxima."
 
 #: ../../src/wxMaximaFrame.cpp:800
 msgid "Choose the parenthesis type for Matrices"
-msgstr ""
+msgstr "Виберіть тип дужок для матриць"
 
 #: ../../src/wxMaxima.cpp:9530 ../../src/wxMaxima.cpp:9535
 msgid "Classes:"
-msgstr ""
+msgstr "Класи:"
 
 #: ../../src/wxMaximaFrame.cpp:1378
 msgid "Classic matrix operations"
-msgstr ""
+msgstr "Класичні дії з матрицями"
 
 #: ../../src/wxMaximaFrame.cpp:998
+#, fuzzy
 msgid "Clear all aliases"
-msgstr ""
+msgstr "Спорожнити увесь журнал"
 
 #: ../../src/wxMaximaFrame.cpp:995
+#, fuzzy
 msgid "Clear all arrays"
-msgstr ""
+msgstr "Спорожнити увесь журнал"
 
 #: ../../src/wxMaximaFrame.cpp:992
+#, fuzzy
 msgid "Clear all dependencies"
-msgstr ""
+msgstr "Залежності"
 
 #: ../../src/wxMaximaFrame.cpp:994
+#, fuzzy
 msgid "Clear all functions"
-msgstr ""
+msgstr "Зібрати функцію"
 
 #: ../../src/wxMaximaFrame.cpp:1001
+#, fuzzy
 msgid "Clear all gradefs"
-msgstr ""
+msgstr "Спорожнити увесь журнал"
 
 #: ../../src/wxMaximaFrame.cpp:1000
+#, fuzzy
 msgid "Clear all labels"
-msgstr ""
+msgstr "Спорожнити увесь журнал"
 
 #: ../../src/wxMaximaFrame.cpp:1004
+#, fuzzy
 msgid "Clear all let rule packages"
-msgstr ""
+msgstr "Список let-правил користувача"
 
 #: ../../src/wxMaximaFrame.cpp:1003
+#, fuzzy
 msgid "Clear all macros"
-msgstr ""
+msgstr "Спорожнити увесь журнал"
 
 #: ../../src/wxMaximaFrame.cpp:1002
+#, fuzzy
 msgid "Clear all props"
-msgstr ""
+msgstr "Спорожнити увесь журнал"
 
 #: ../../src/wxMaximaFrame.cpp:997
+#, fuzzy
 msgid "Clear all rules"
-msgstr ""
+msgstr "Спорожнити увесь журнал"
 
 #: ../../src/wxMaximaFrame.cpp:999
+#, fuzzy
 msgid "Clear all structures"
-msgstr ""
+msgstr "Спорожнити увесь журнал"
 
 #: ../../src/wxMaximaFrame.cpp:993
+#, fuzzy
 msgid "Clear all variables"
-msgstr ""
+msgstr "Вилучити змінну"
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close\tCtrl+W"
-msgstr ""
+msgstr "Закрити\tCtrl+W"
 
 #: ../../src/wxMaxima.cpp:7235
 msgid "Close Stream"
-msgstr ""
+msgstr "Закрити потік"
 
 #: ../../src/wxMaximaFrame.cpp:606
 msgid "Close window"
-msgstr ""
+msgstr "Закрити вікно"
 
 #: ../../src/wxMaximaFrame.cpp:1105
 msgid "Close..."
-msgstr ""
+msgstr "Закрити…"
 
 #: ../../src/WXMXformat.cpp:301
 msgid "Closed the zip archive"
-msgstr ""
+msgstr "Закрито архів zip"
 
 #: ../../src/Configuration.cpp:77
 msgid "Code Default (Maxima input)"
-msgstr ""
+msgstr "Типовий для коду (вхідні дані Maxima)"
 
 #: ../../src/Configuration.cpp:103
 msgid "Code highlighting: Comments"
-msgstr ""
+msgstr "Підсвічування коду: коментарі"
 
 #: ../../src/Configuration.cpp:108
 msgid "Code highlighting: End of line markers"
-msgstr ""
+msgstr "Підсвічування коду: позначки кінця рядка"
 
 #: ../../src/Configuration.cpp:102
 msgid "Code highlighting: Functions"
-msgstr ""
+msgstr "Підсвічування коду: функції"
 
 #: ../../src/Configuration.cpp:107
 msgid "Code highlighting: Lisp"
-msgstr ""
+msgstr "Підсвічування коду: Lisp"
 
 #: ../../src/Configuration.cpp:104
 msgid "Code highlighting: Numbers"
-msgstr ""
+msgstr "Підсвічування коду: числа"
 
 #: ../../src/Configuration.cpp:106
 msgid "Code highlighting: Operators"
-msgstr ""
+msgstr "Підсвічування коду: оператори"
 
 #: ../../src/Configuration.cpp:105
 msgid "Code highlighting: Strings"
-msgstr ""
+msgstr "Підсвічування коду: рядки"
 
 #: ../../src/Configuration.cpp:101
 msgid "Code highlighting: Variables"
-msgstr ""
+msgstr "Підсвічування коду: змінні"
 
 #: ../../src/wxMaxima.cpp:7309 ../../src/wxMaxima.cpp:7355
 msgid "Code number:"
-msgstr ""
+msgstr "Кодовий номер:"
 
 #: ../../src/wxMaxima.cpp:7367 ../../src/wxMaxima.cpp:7373
 msgid "Codepoint number:"
-msgstr ""
+msgstr "Номер позиції у таблиці:"
 
 #: ../../src/wxMaxima.cpp:9590
 msgid "Col. names:"
-msgstr ""
+msgstr "Назви стовпців:"
 
 #: ../../src/Configuration.cpp:100
 msgid "Color of Outdated cells"
-msgstr ""
+msgstr "Колір застарілих комірок"
 
 #: ../../src/Configuration.cpp:99
 msgid "Color of text equal to selection"
-msgstr ""
+msgstr "Колір тексту, що збігається із позначеним"
 
 #: ../../src/wxMaxima.cpp:7962
 msgid "Column number:"
-msgstr ""
+msgstr "Номер стовпчика:"
 
 #: ../../src/wxMaxima.cpp:7978
 msgid "Column numbers:"
-msgstr ""
+msgstr "Номери стовпчиків:"
 
 #: ../../src/wxMaxima.cpp:8202
+#, fuzzy
 msgid "Columns"
-msgstr ""
+msgstr "Номери стовпчиків:"
 
 #: ../../src/wxMaximaFrame.cpp:1584
 msgid "Combine factorials in an expression"
-msgstr ""
+msgstr "Об'єднати факторіали у один вираз"
 
 #: ../../src/wxMaxima.cpp:10454
 msgid "Comma directly followed by a closing parenthesis"
-msgstr ""
+msgstr "За комою одразу вказано завершальну дужку"
 
 #: ../../src/wxMaxima.cpp:7259
 msgid "Comma-separated arguments"
-msgstr ""
+msgstr "Аргументи, відокремлені комами"
 
 #: ../../src/wxMaxima.cpp:7057 ../../src/wxMaxima.cpp:7066
 msgid "Comma-separated commands"
-msgstr ""
+msgstr "Команди, відокремлені комами"
 
 #: ../../src/wxMaxima.cpp:8458
 msgid "Comma-separated elements"
-msgstr ""
+msgstr "Елементи, відокремлені комами"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 #: ../../src/wxMaxima.cpp:10031
 msgid "Comma-separated equations"
-msgstr ""
+msgstr "Рівняння, відокремлені комами"
 
 #: ../../src/wxMaxima.cpp:8727 ../../src/wxMaxima.cpp:8735
 #: ../../src/wxMaxima.cpp:8743 ../../src/wxMaxima.cpp:8751
 #: ../../src/wxMaxima.cpp:8760 ../../src/wxMaxima.cpp:8768
 msgid "Comma-separated expressions"
-msgstr ""
+msgstr "Вирази, відокремлені комами"
 
 #: ../../src/wxMaxima.cpp:7215
 msgid "Comma-separated expressions that shall be converted to a string"
 msgstr ""
+"Список виразів, відокремлених комами, які має бути перетворено на рядок"
 
 #: ../../src/wxMaxima.cpp:7100 ../../src/wxMaxima.cpp:7114
 msgid "Comma-separated expressions."
-msgstr ""
+msgstr "Список виразів, відокремлених комами."
 
 #: ../../src/wxMaxima.cpp:7073 ../../src/wxMaxima.cpp:7168
 msgid "Comma-separated function names"
-msgstr ""
+msgstr "Список назв функцій, відокремлених комами"
 
 #: ../../src/wxMaxima.cpp:7086
 msgid "Comma-separated function names."
-msgstr ""
+msgstr "Список назв функцій, відокремлених комами."
 
 #: ../../src/wxMaxima.cpp:8560 ../../src/wxMaxima.cpp:8567
 #: ../../src/wxMaxima.cpp:8573 ../../src/wxMaxima.cpp:8580
 msgid "Comma-separated list entry in the format val1=1,val2=2"
 msgstr ""
+"Запис відокремлених комами значень пункту списку у форматі "
+"значення1=1,значення2=2"
 
 #: ../../src/wxMaxima.cpp:7205
 msgid "Comma-separated names of the elements that shall be written"
-msgstr ""
+msgstr "Список назв елементів, відокремлених комами, які має бути записано"
 
 #: ../../src/wxMaxima.cpp:7099
 msgid "Comma-separated names the parameters will be referenced by later."
-msgstr ""
+msgstr "Відокремлені комами назви параметрів, які буде використано пізніше."
 
 #: ../../src/wxMaxima.cpp:7488 ../../src/wxMaxima.cpp:7493
 msgid "Comma-separated numbers from 0 to 255"
-msgstr ""
+msgstr "Числа від 0 до 255, відокремлені комами"
 
 #: ../../src/wxMaxima.cpp:8770
 msgid "Comma-separated numbers of the terms to substitute in"
-msgstr ""
+msgstr "Відокремлені комами числами члени, до яких слід виконати підставляння"
 
 #: ../../src/wxMaxima.cpp:7137 ../../src/wxMaxima.cpp:7150
 msgid ""
 "Comma-separated parameter names. A parameter in square brackets [] will be "
 "filled with the list of any additional arguments the function gets."
 msgstr ""
+"Список назв параметрів, які відокремлено комами. Параметр у квадратних "
+"дужках, [], буде заповнено списком будь-яких додаткових аргументів, які "
+"функція отримує."
 
 #: ../../src/wxMaxima.cpp:7054
 msgid "Comma-separated variable names, can be initialized by the \":\" operator."
 msgstr ""
+"Список назв змінних, відокремлених комами, можна ініціалізувати оператором "
+"«:»."
 
 #: ../../src/wxMaxima.cpp:7753 ../../src/wxMaxima.cpp:7767
 #: ../../src/wxMaxima.cpp:8719 ../../src/wxMaxima.cpp:8785
 #: ../../src/wxMaxima.cpp:10032
 msgid "Comma-separated variables"
-msgstr ""
+msgstr "Змінні, відокремлені комами"
 
 #: ../../src/wxMaxima.cpp:9469
 msgid "Command:"
-msgstr ""
+msgstr "Команда:"
 
 #: ../../src/Worksheet.cpp:1692
 msgid "Comment Selection"
-msgstr ""
+msgstr "Закоментувати позначене"
 
 #: ../../src/wxMaximaFrame.cpp:681
 msgid "Comment out the currently selected text"
-msgstr ""
+msgstr "Закоментувати поточний позначений фрагмент тексту"
 
 #: ../../src/wxMaximaFrame.cpp:680
 msgid "Comment selection\tCtrl+/"
-msgstr ""
+msgstr "Закоментувати позначене\tCtrl+/"
 
 #: ../../src/Worksheet.cpp:2004
 msgid "Commutative function"
-msgstr ""
+msgstr "Комутативна функція"
 
 #: ../../src/wxMaximaFrame.cpp:1396
 msgid "Compile a QR decomposition using dgeqrf"
-msgstr ""
+msgstr "Зібрати QR-розклад за допомогою dgeqrf"
 
 #: ../../src/wxMaxima.cpp:7162
 msgid "Compile a function"
-msgstr ""
+msgstr "Зібрати функцію"
 
 #: ../../src/wxMaximaFrame.cpp:1188
+#, fuzzy
 msgid "Compile a regular expression"
-msgstr ""
+msgstr "Зібрати формальний вираз"
 
 #: ../../src/wxMaximaFrame.cpp:1385
 msgid "Compile eigenvalues using dgeev"
-msgstr ""
+msgstr "Зібрати eigenvalues за допомогою dgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1388
 msgid "Compile eigenvalues using zgeev"
-msgstr ""
+msgstr "Зібрати eigenvalues за допомогою zgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1391
 msgid "Compile eigenvalues+eigenvectors using dgeev"
-msgstr ""
+msgstr "Зібрати eigenvalues+eigenvectors за допомогою dgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1394
 msgid "Compile eigenvalues+eigenvectors using zgeev"
-msgstr ""
+msgstr "Зібрати eigenvalues+eigenvectors за допомогою zgeev"
 
 #: ../../src/wxMaximaFrame.cpp:1076
 msgid "Compile function..."
-msgstr ""
+msgstr "Зібрати функцію…"
 
 #: ../../src/wxMaxima.cpp:7511
 msgid "Compile regex"
-msgstr ""
+msgstr "Зібрати формальний вираз"
 
 #: ../../src/wxMathml.cpp:53
 msgid "Compiler-Bug? wxMathml.lisp is shorter than expected!"
-msgstr ""
+msgstr "Вада компілятора? wxMathml.lisp є коротшим за очікуваний!"
 
 #: ../../src/wxMaxima.cpp:2234
 #, c-format
 msgid "Compiling %s"
-msgstr ""
+msgstr "Компілюємо %s"
 
 #: ../../src/wxMaxima.cpp:7163
 msgid ""
@@ -1464,440 +1536,460 @@ msgid ""
 " the function parameters are made known to the function before it is "
 "compiled. Else the generated code has to be hideously generic."
 msgstr ""
+"Збирання функції може надати суттєвий приріст у швидкості виконання, якщо "
+"типи параметрів функції стають відомими функції до її збирання. В інших "
+"випадках створений код буде аж надто загальним."
 
 #: ../../src/wxMaximaFrame.cpp:892
 msgid "Complete Word\tCtrl+Space"
-msgstr ""
+msgstr "Завершити слово\tCtrl+Space"
 
 #: ../../src/wxMaximaFrame.cpp:893
 msgid "Complete word"
-msgstr ""
+msgstr "Завершити слово"
 
 #: ../../src/ToolBar.cpp:230
 msgid "Completely stop maxima and restart it"
-msgstr ""
+msgstr "Повністю зупинити і перезапустити maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1503
 msgid "Compute continued fraction of a value"
-msgstr ""
+msgstr "Обчислити значення неперервного дробу"
 
 #: ../../src/wxMaximaFrame.cpp:1372
 msgid "Compute the adjoint matrix"
-msgstr ""
+msgstr "Обчислити спряжену матрицю"
 
 #: ../../src/wxMaximaFrame.cpp:1359
 msgid "Compute the characteristic polynomial of a matrix"
-msgstr ""
+msgstr "Обчислити характеристичний поліном матриці"
 
 #: ../../src/wxMaximaFrame.cpp:1363
 msgid "Compute the determinant of a matrix"
-msgstr ""
+msgstr "Обчислити визначник матриці"
 
 #: ../../src/wxMaximaFrame.cpp:1491
 msgid "Compute the greatest common divisor"
-msgstr ""
+msgstr "Обчислити найбільший спільний дільник"
 
 #: ../../src/wxMaximaFrame.cpp:1356
 msgid "Compute the inverse of a matrix"
-msgstr ""
+msgstr "Обчислити обернену матрицю"
 
 #: ../../src/wxMaximaFrame.cpp:1494
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
+"Обчислити найменше спільне кратне (віддайте команду load(functs) перед "
+"використанням)"
 
 #: ../../src/wxMaximaFrame.cpp:1374
 msgid "Compute the rank of a matrix"
-msgstr ""
+msgstr "Обчислити ранг матриці"
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Condition:"
-msgstr ""
+msgstr "Умова:"
 
 #: ../../src/ToolBar.cpp:200 ../../src/wxMaximaFrame.cpp:685
 #: ../../src/wxMaximaFrame.cpp:687
 msgid "Configure wxMaxima"
-msgstr ""
+msgstr "Налаштувати wxMaxima"
 
 #: ../../src/wxMaxima.cpp:2504
 msgid "Connection attempt, but connection failed."
-msgstr ""
+msgstr "Спроба встановити з'єднання, яка виявилася невдалою."
 
 #: ../../src/wxMaxima.cpp:2459
 msgid "Connection to Maxima lost."
-msgstr ""
+msgstr "Втрачено з'єднання із Maxima."
 
 #: ../../src/wxMaxima.cpp:7921
 msgid "Construct a fraction"
-msgstr ""
+msgstr "Побудувати функцію"
 
 #: ../../src/wxMaximaFrame.cpp:1305
 msgid "Construct fraction..."
-msgstr ""
+msgstr "Побудувати дріб…"
 
 #: ../../src/wxMaxima.cpp:7158
 msgid "Contents:"
-msgstr ""
+msgstr "Зміст:"
 
 #: ../../src/wxMaximaFrame.cpp:1877
 msgid "Context-sensitive &Help\tCtrl+?"
-msgstr ""
+msgstr "&Контекстна довідка\tCtrl+?"
 
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Context-sensitive &Help\tF1"
-msgstr ""
+msgstr "&Контекстна довідка\tF1"
 
 #: ../../src/wxMaximaFrame.cpp:1542
 msgid "Contract Logarithms"
-msgstr ""
+msgstr "Об'єднати логарифми"
 
 #: ../../src/wxMaximaFrame.cpp:1161
 msgid "Conversions"
-msgstr ""
+msgstr "Перетворення"
 
 #: ../../src/wxMaximaFrame.cpp:1229
 msgid "Convert"
-msgstr ""
+msgstr "Перетворити"
 
 #: ../../src/wxMaximaFrame.cpp:1230
 msgid "Convert + Write to file"
-msgstr ""
+msgstr "Перетворити + записати до файла"
 
 #: ../../src/wxMaximaFrame.cpp:1434
 msgid "Convert Column to list..."
-msgstr ""
+msgstr "Перетворити стовпчик у список…"
 
 #: ../../src/wxMaximaFrame.cpp:1430
 msgid "Convert Row to list..."
-msgstr ""
+msgstr "Перетворити рядок у список…"
 
 #: ../../src/wxMaximaFrame.cpp:1044
 msgid "Convert a command to maxima code"
-msgstr ""
+msgstr "Перетворити команду на код maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1321
 msgid "Convert a list of lists to a matrix"
-msgstr ""
+msgstr "Перетворити список списків у матрицю"
 
 #: ../../src/wxMaximaFrame.cpp:1574
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr ""
+"Перетворити біноміальні коефіцієнти, бета- і гамма-функції у факторіали"
 
 #: ../../src/wxMaximaFrame.cpp:1578
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
+"Перетворити біноміальні коефіцієнти, факторіали й бета-функції у гама-"
+"функції"
 
 #: ../../src/wxMaximaFrame.cpp:1613
 msgid "Convert complex expression to polar form"
-msgstr ""
+msgstr "Перетворити комплексний вираз у тригонометричну форму"
 
 #: ../../src/wxMaximaFrame.cpp:1610
 msgid "Convert complex expression to rect form"
-msgstr ""
+msgstr "Перетворювати комплексний вираз у алгебраїчну форму"
 
 #: ../../src/wxMaximaFrame.cpp:1622
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
+"Перетворити експоненційну функцію уявного аргументу у тригонометричну форму"
 
 #: ../../src/wxMaxima.cpp:7411
 msgid "Convert string to lowercase"
-msgstr ""
+msgstr "Перетворити символи рядка до нижнього регістру"
 
 #: ../../src/wxMaxima.cpp:7543
 msgid "Convert string to matching regex"
-msgstr ""
+msgstr "Перетворити рядок до відповідного формального виразу"
 
 #: ../../src/wxMaximaFrame.cpp:1543
 msgid "Convert sum of logarithms to logarithm of product"
-msgstr ""
+msgstr "Перетворити суму логарифмів у логарифм добутку"
 
 #: ../../src/wxMaximaFrame.cpp:1573
 msgid "Convert to &Factorials"
-msgstr ""
+msgstr "Перетворити у &факторіали"
 
 #: ../../src/wxMaximaFrame.cpp:1577
 msgid "Convert to &Gamma"
-msgstr ""
+msgstr "Перетворити у &гамма-функцію"
 
 #: ../../src/wxMaximaFrame.cpp:1612
 msgid "Convert to &Polarform"
-msgstr ""
+msgstr "Перетворювати у тригонометричну форму"
 
 #: ../../src/wxMaximaFrame.cpp:1609
 msgid "Convert to &Rectform"
-msgstr ""
+msgstr "Перетворювати у &алгебраїчну форму"
 
 #: ../../src/wxMaximaFrame.cpp:1166
 msgid "Convert to downcase..."
-msgstr ""
+msgstr "Перетворити на нижній регістр…"
 
 #: ../../src/wxMaxima.cpp:7016
 msgid "Convert to programming language"
-msgstr ""
+msgstr "Перетворити на код мови програмування"
 
 #: ../../src/wxMaxima.cpp:7022
 msgid "Convert to programming language file"
-msgstr ""
+msgstr "Перетворити на файл мови програмування"
 
 #: ../../src/wxMaximaFrame.cpp:1602
 msgid "Convert trigonometric expression to canonical quasilinear form"
-msgstr ""
+msgstr "Перетворити тригонометричний вираз в канонічну квазілінійну форму"
 
 #: ../../src/wxMaximaFrame.cpp:1627
 msgid "Convert trigonometric functions to exponential form"
-msgstr ""
+msgstr "Перетворювати тригонометричні функції у експоненційну форму"
 
 #: ../../src/wxMaximaFrame.cpp:1762
 msgid "Converts a matrix to a list of lists"
-msgstr ""
+msgstr "Перетворює матрицю на список списків"
 
 #: ../../src/wxMaximaFrame.cpp:1760
 msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
-msgstr ""
+msgstr "Перетворює вкладений список, наприклад [[1,2],[3,4]], у матрицю"
 
 #: ../../src/ToolBar.cpp:209 ../../src/Worksheet.cpp:1290
 #: ../../src/Worksheet.cpp:1359 ../../src/Worksheet.cpp:1498
 #: ../../src/Worksheet.cpp:1684
 msgid "Copy"
-msgstr ""
+msgstr "Копіювати"
 
 #: ../../src/Worksheet.cpp:1296 ../../src/Worksheet.cpp:1375
 #: ../../src/Worksheet.cpp:1514
 msgid "Copy Animation"
-msgstr ""
+msgstr "Копіювати анімацію"
 
 #: ../../src/wxMaximaFrame.cpp:887
 msgid "Copy Previous Input\tCtrl+I"
-msgstr ""
+msgstr "Копіювати попередню введену команду\tCtrl+I"
 
 #: ../../src/wxMaximaFrame.cpp:890
 msgid "Copy Previous Output\tCtrl+U"
-msgstr ""
+msgstr "Копіювати попередній результат\tCtrl+U"
 
 #: ../../src/wxMaxima.cpp:7992
 msgid "Copy a matrix"
-msgstr ""
+msgstr "Копіювати матрицю"
 
 #: ../../src/Worksheet.cpp:1380 ../../src/Worksheet.cpp:1519
 #: ../../src/wxMaximaFrame.cpp:663
 msgid "Copy as EMF"
-msgstr ""
+msgstr "Копіювати як EMF"
 
 #: ../../src/Worksheet.cpp:1370 ../../src/Worksheet.cpp:1509
 #: ../../src/wxMaximaFrame.cpp:652
 msgid "Copy as Image"
-msgstr ""
+msgstr "Копіювати як зображення"
 
 #: ../../src/Worksheet.cpp:1362 ../../src/Worksheet.cpp:1501
 #: ../../src/wxMaximaFrame.cpp:645
 msgid "Copy as LaTeX"
-msgstr ""
+msgstr "Копіювати як LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:648
 msgid "Copy as MathML"
-msgstr ""
+msgstr "Копіювати як MathML"
 
 #: ../../src/Worksheet.cpp:1368 ../../src/Worksheet.cpp:1506
 msgid "Copy as MathML (e.g. to word processor)"
-msgstr ""
+msgstr "Копіювати як MathML (наприклад для текстових процесорів)"
 
 #: ../../src/Worksheet.cpp:1383 ../../src/Worksheet.cpp:1522
 #: ../../src/wxMaximaFrame.cpp:658
 msgid "Copy as RTF"
-msgstr ""
+msgstr "Копіювати як RTF"
 
 #: ../../src/Worksheet.cpp:1377 ../../src/Worksheet.cpp:1516
 #: ../../src/wxMaximaFrame.cpp:655
 msgid "Copy as SVG"
-msgstr ""
+msgstr "Копіювати як SVG"
 
 #: ../../src/wxMaximaFrame.cpp:640
 msgid "Copy as Text\tCtrl+Shift+C"
-msgstr ""
+msgstr "Копіювати як текст\tCtrl+Shift+C"
 
 #: ../../src/Worksheet.cpp:1364 ../../src/Worksheet.cpp:1503
 msgid "Copy as plain text"
-msgstr ""
+msgstr "Копіювати як звичайний текст"
 
 #: ../../src/wxMaxima.cpp:7576
 msgid "Copy file"
-msgstr ""
+msgstr "Копіювання файла"
 
 #: ../../src/wxMaximaFrame.cpp:1214
 msgid "Copy file..."
-msgstr ""
+msgstr "Копіювати файл…"
 
 #: ../../src/Worksheet.cpp:1360 ../../src/Worksheet.cpp:1499
 #: ../../src/wxMaximaFrame.cpp:643
 msgid "Copy for Octave/Matlab"
-msgstr ""
+msgstr "Копіювати для Octave/Matlab"
 
 #: ../../src/ToolBar.cpp:209 ../../src/wxMaximaFrame.cpp:638
 msgid "Copy selection"
-msgstr ""
+msgstr "Копіювати позначене"
 
 #: ../../src/wxMaximaFrame.cpp:664
 msgid "Copy selection from document as an Enhanced Metafile"
-msgstr ""
+msgstr "Скопіювати позначений фрагмент документа як дані EMF"
 
 #: ../../src/wxMaximaFrame.cpp:656
 msgid "Copy selection from document as an SVG image"
-msgstr ""
+msgstr "Копіювати позначений фрагмент документа як зображення SVG"
 
 #: ../../src/wxMaximaFrame.cpp:653
 msgid "Copy selection from document as an image"
-msgstr ""
+msgstr "Копіювати позначений фрагмент документа як зображення"
 
 #: ../../src/wxMaximaFrame.cpp:659
 msgid ""
 "Copy selection from document as rtf that a word processor might understand"
 msgstr ""
+"Скопіювати позначений фрагмент з документа у форматі rtf, який можна "
+"використати у текстовому процесорі Word"
 
 #: ../../src/wxMaximaFrame.cpp:641
 msgid "Copy selection from document as text"
-msgstr ""
+msgstr "Копіювати позначений фрагмент документа як текст"
 
 #: ../../src/wxMaximaFrame.cpp:646
 msgid "Copy selection from document in LaTeX format"
-msgstr ""
+msgstr "Копіювати позначений фрагмент документа у форматі LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:644
 msgid "Copy selection from document in Matlab format"
-msgstr ""
+msgstr "Скопіювати позначене з документа у форматі Matlab"
 
 #: ../../src/wxMaximaFrame.cpp:649
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
+"Скопіювати позначений фрагмент з документа у форматі MathML, який "
+"використовується для показу рівнянь у багатьох текстових процесорах"
 
 #: ../../src/wxMaxima.cpp:7403
 msgid "Copy string"
-msgstr ""
+msgstr "Копіювати рядок"
 
 #: ../../src/wxMaximaFrame.cpp:1165
 msgid "Copy string..."
-msgstr ""
+msgstr "Копіювати рядок…"
 
 #: ../../src/ToolBar.cpp:623
 msgid "Copy, Cut and Paste button"
-msgstr ""
+msgstr "Кнопка копіювання, вирізання та вставлення"
 
 #: ../../src/WXMXformat.cpp:295
 msgid "Could not create the backup file during saving => aborting."
 msgstr ""
+"Не вдалося створити файл резервної копії під час зберігання => перериваємо "
+"обробку."
 
 #: ../../src/wxMaxima.cpp:3294 ../../src/wxMaxima.cpp:3306
 msgid ""
 "Could not make sure that we talk to the maxima we started => discarding all "
 "data it sends."
 msgstr ""
+"Не вдалося переконатися, що ведеться обмін даними із запущеною нами maxima "
+"=> відкидаємо усі дані, які вона надсилає."
 
 #: ../../src/wxMaxima.cpp:2783
 msgid ""
 "Could not map view of the file needed in order to send an interrupt signal "
 "to maxima."
 msgstr ""
+"Не вдалося прив'язати перегляд файла, потрібний для надсилання сигналу "
+"переривання до maxima."
 
 #: ../../src/wxMaxima.cpp:2763 ../../src/wxMaxima.cpp:2805
 msgid "Could not send an interrupt signal to maxima."
-msgstr ""
+msgstr "Не вдалося надіслати сигнал переривання до maxima."
 
 #: ../../src/WXMXformat.cpp:287
 msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
+"Не вдалося записати вміст файла під час зберігання => перериваємо обробку."
 
 #: ../../src/wxMaximaFrame.cpp:1325
 msgid "Create Matrix"
-msgstr ""
+msgstr "Створити матрицю"
 
 #: ../../src/wxMaximaFrame.cpp:1688
 msgid "Create a list"
-msgstr ""
+msgstr "Створити список"
 
 #: ../../src/wxMaxima.cpp:8487
 msgid "Create a list as a storage for the values of variables"
-msgstr ""
+msgstr "Створити список як сховище значень змінних"
 
 #: ../../src/wxMaxima.cpp:8463 ../../src/wxMaxima.cpp:8476
 msgid "Create a list from a rule"
-msgstr ""
+msgstr "Створити список на основі правила"
 
 #: ../../src/wxMaximaFrame.cpp:1670
 msgid "Create a list from comma-separated elements"
-msgstr ""
+msgstr "Створити список на основі елементів, відокремлених комами"
 
 #: ../../src/wxMaximaFrame.cpp:888
 msgid "Create a new cell with previous input"
-msgstr ""
+msgstr "Створити нову комірку з попередньою введеною командою"
 
 #: ../../src/wxMaximaFrame.cpp:891
 msgid "Create a new cell with previous output"
-msgstr ""
+msgstr "Створити нову комірку з попереднім результатом обчислень"
 
 #: ../../src/wxMaximaFrame.cpp:1348
 msgid "Create copy, not clone..."
-msgstr ""
+msgstr "Створити копію, а не клон…"
 
 #: ../../src/wxMaxima.cpp:7561
 msgid "Create directory"
-msgstr ""
+msgstr "Створити каталог"
 
 #: ../../src/wxMaximaFrame.cpp:1203
 msgid "Create directory..."
-msgstr ""
+msgstr "Створити каталог…"
 
 #: ../../src/wxMaxima.cpp:7419
 msgid "Create empty string"
-msgstr ""
+msgstr "Створити порожній рядок"
 
 #: ../../src/wxMaximaFrame.cpp:1168
 msgid "Create empty string..."
-msgstr ""
+msgstr "Створити порожній рядок…"
 
 #: ../../src/wxMaximaFrame.cpp:1687
 msgid "Create list"
-msgstr ""
+msgstr "Створити список"
 
 #: ../../src/wxMaxima.cpp:8457
 msgid "Create list from comma-separated elements"
-msgstr ""
+msgstr "Створити список на основі елементів, відокремлених комами"
 
 #: ../../src/wxMaximaFrame.cpp:1082
 msgid "Create struct..."
-msgstr ""
+msgstr "Створити структуру…"
 
 #: ../../src/WXMXformat.cpp:80
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
-msgstr ""
+msgstr "Створено архів .zip (з технічного погляду файл .wxmx є файлом .zip)"
 
 #: ../../src/wxMaximaFrame.cpp:1349
 msgid "Creates an independent matrix with the same contents"
-msgstr ""
+msgstr "Створити незалежну матрицю із тим самим вмістом"
 
 #: ../../src/Configuration.cpp:97
 msgid "Cursor color"
-msgstr ""
+msgstr "Колір курсора"
 
 #: ../../src/ToolBar.cpp:208 ../../src/Worksheet.cpp:1683
 msgid "Cut"
-msgstr ""
+msgstr "Вирізати"
 
 #: ../../src/wxMaximaFrame.cpp:636
 msgid "Cut\tCtrl+X"
-msgstr ""
+msgstr "Вирізати\tCtrl+X"
 
 #: ../../src/ToolBar.cpp:208 ../../src/wxMaximaFrame.cpp:636
 msgid "Cut selection"
-msgstr ""
+msgstr "Вирізати позначене"
 
 #: ../../src/wxMaxima.cpp:9589 ../../src/wxMaxima.cpp:9629
 msgid "Data Matrix:"
-msgstr ""
+msgstr "Матриця даних:"
 
 #: ../../src/wxMaxima.cpp:9599
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
-msgstr ""
+msgstr "Файл даних (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
 #: ../../src/wxMaxima.cpp:9529 ../../src/wxMaxima.cpp:9534
 #: ../../src/wxMaxima.cpp:9539 ../../src/wxMaxima.cpp:9543
@@ -1906,158 +1998,160 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9563 ../../src/wxMaxima.cpp:9577
 #: ../../src/wxMaxima.cpp:9582 ../../src/wxMaxima.cpp:10030
 msgid "Data:"
-msgstr ""
+msgstr "Дані:"
 
 #: ../../src/wxMaximaFrame.cpp:1057
 msgid "Debugger trigger"
-msgstr ""
+msgstr "Критерій запуску засобу діагностики"
 
 #: ../../src/wxMaximaFrame.cpp:779
 msgid "Declare Text to always be displayed as subscript"
-msgstr ""
+msgstr "Оголосити, що текст завжди буде показано як нижній індекс"
 
 #: ../../src/wxMaxima.cpp:7069
 msgid "Declare a function local to a Program"
-msgstr ""
+msgstr "Оголосити функцію локальною до програми"
 
 #: ../../src/wxMaxima.cpp:6539
 msgid "Declare a text snippet to always be displayed as subscript"
 msgstr ""
+"Оголосити, що фрагмент тексту має бути завжди показано як нижній індекс"
 
 #: ../../src/Worksheet.cpp:2044
 #, c-format
 msgid "Declare facts about %s"
-msgstr ""
+msgstr "Оголосити властивості %s"
 
 #: ../../src/wxMaxima.cpp:8800
 msgid "Declare main variable:"
-msgstr ""
+msgstr "Оголосити основну змінну:"
 
 #: ../../src/wxMaxima.cpp:7171
 msgid "Declare the type of a function parameter"
-msgstr ""
+msgstr "Оголосити тип параметра функції"
 
 #: ../../src/Worksheet.cpp:2038
 msgid "Declare these chars as ordinary letters"
-msgstr ""
+msgstr "Оголосити ці символи звичайними літерами"
 
 #: ../../src/wxMaximaFrame.cpp:1500 ../../src/wxMaximaFrame.cpp:1536
 msgid "Decompose rational function to partial fractions"
-msgstr ""
+msgstr "Розкласти раціональну функцію на прості дроби"
 
 #: ../../src/Worksheet.cpp:2010
 msgid "Decreasing function f(x)<x"
-msgstr ""
+msgstr "Спадна функція f(x)<x"
 
 #: ../../src/wxMaxima.cpp:7134
 msgid "Define a function"
-msgstr ""
+msgstr "Визначити функцію"
 
 #: ../../src/wxMaxima.cpp:7147
 msgid "Define a macro"
-msgstr ""
+msgstr "Визначити макрос"
 
 #: ../../src/wxMaxima.cpp:7189
 msgid "Define a structure"
-msgstr ""
+msgstr "Визначити структуру"
 
 #: ../../src/wxMaxima.cpp:7183
 msgid "Define a structure type"
-msgstr ""
+msgstr "Визначити тип структури"
 
 #: ../../src/wxMaxima.cpp:7156
 msgid "Define a variable"
-msgstr ""
+msgstr "Визначити змінну"
 
 #: ../../src/wxMaximaFrame.cpp:1072
 msgid "Define function..."
-msgstr ""
+msgstr "Визначити функцію…"
 
 #: ../../src/wxMaximaFrame.cpp:1079
 msgid "Define macro..."
-msgstr ""
+msgstr "Визначити макрос…"
 
 #: ../../src/wxMaximaFrame.cpp:1077
 msgid "Define parameter type..."
-msgstr ""
+msgstr "Визначити тип параметра…"
 
 #: ../../src/wxMaximaFrame.cpp:1081
 msgid "Define struct..."
-msgstr ""
+msgstr "Визначити структуру…"
 
 #: ../../src/wxMaximaFrame.cpp:1080
 msgid "Define variable..."
-msgstr ""
+msgstr "Визначити змінну…"
 
 #: ../../src/wxMaximaFrame.cpp:1776
 msgid ""
 "Defines if an animation is automatically started or only by clicking on it."
 msgstr ""
+"Визначає, слід запускати анімацію автоматично чи лише після натискання."
 
 #: ../../src/wxMaxima.cpp:8935
 msgid "Degree:"
-msgstr ""
+msgstr "Порядок:"
 
 #: ../../src/wxMaximaFrame.cpp:985
 msgid "Delete F&unction..."
-msgstr ""
+msgstr "Вилучити ф&ункцію…"
 
 #: ../../src/Worksheet.cpp:1386 ../../src/Worksheet.cpp:1525
 msgid "Delete Selection"
-msgstr ""
+msgstr "Вилучити позначене"
 
 #: ../../src/wxMaximaFrame.cpp:987
 msgid "Delete V&ariable..."
-msgstr ""
+msgstr "Вилучити змі&нну…"
 
 #: ../../src/wxMaximaFrame.cpp:986
 msgid "Delete a function"
-msgstr ""
+msgstr "Вилучити функцію"
 
 #: ../../src/wxMaximaFrame.cpp:988
 msgid "Delete a variable"
-msgstr ""
+msgstr "Вилучити змінну"
 
 #: ../../src/wxMaximaFrame.cpp:982
 msgid "Delete all objects with a given name"
-msgstr ""
+msgstr "Вилучити усі об'єкти із вказаною назвою"
 
 #: ../../src/wxMaximaFrame.cpp:991
 msgid "Delete all values from memory"
-msgstr ""
+msgstr "Вилучити з пам'яті всі значення"
 
 #: ../../src/wxMaxima.cpp:7588
 msgid "Delete file"
-msgstr ""
+msgstr "Вилучити файл"
 
 #: ../../src/wxMaximaFrame.cpp:1216
 msgid "Delete file..."
-msgstr ""
+msgstr "Вилучити файл…"
 
 #: ../../src/wxMaxima.cpp:7683
 msgid "Delete function(s)"
-msgstr ""
+msgstr "Вилучити функції"
 
 #: ../../src/wxMaxima.cpp:7679
 msgid "Delete named object(s)"
-msgstr ""
+msgstr "Вилучити іменовані об'єкти"
 
 #: ../../src/wxMaximaFrame.cpp:981
 msgid "Delete named object..."
-msgstr ""
+msgstr "Вилучити іменований об'єкт…"
 
 #: ../../src/wxMaxima.cpp:7674
 msgid "Delete variable(s)"
-msgstr ""
+msgstr "Вилучити змінні"
 
 #: ../../src/wxMaxima.cpp:7430
 msgid "Delimiter:"
-msgstr ""
+msgstr "Роздільник:"
 
 #: ../../src/Worksheet.cpp:1347 ../../src/Worksheet.cpp:1785
-#, c-format
+#, fuzzy, c-format
 msgid "Demo for \"%s\""
-msgstr ""
+msgstr "Довідка щодо «%s»"
 
 #: ../../src/wxMaximaFrame.cpp:1930
 msgid "Demos"
@@ -2065,65 +2159,67 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8927
 msgid "Denom. deg:"
-msgstr ""
+msgstr "Степінь знаменника:"
 
 #: ../../src/wxMaxima.cpp:7923
 msgid "Denominator:"
-msgstr ""
+msgstr "Знаменник:"
 
 #: ../../src/wxMaximaFrame.cpp:1030
 msgid "Dependencies"
-msgstr ""
+msgstr "Залежності"
 
 #: ../../src/wxMaxima.cpp:7813
 msgid "Derivate of y at that point:"
-msgstr ""
+msgstr "Похідна y у цій точці:"
 
 #: ../../src/wxMaximaFrame.cpp:1497
 msgid "Di&vide Polynomials..."
-msgstr ""
+msgstr "&Ділення поліномів…"
 
 #: ../../src/MaximaManual.cpp:517
 msgid "Didn't find the maxima HTML manual."
-msgstr ""
+msgstr "Не вдалося знайти підручник з maxima у форматі HTML."
 
 #: ../../src/wxMaxima.cpp:4907
 msgid ""
 "Didn't get a help browser launch program command line, but can request the "
 "system's default help browser."
 msgstr ""
+"Не отримано рядка команди для запуску програми навігатора довідкою, але "
+"можна надіслати запит до типового навігатора довідкою системи."
 
 #: ../../src/wxMaxima.cpp:9010 ../../src/wxMaxima.cpp:10055
 msgid "Differentiate"
-msgstr ""
+msgstr "Продиференціювати"
 
 #: ../../src/wxMaximaFrame.cpp:1467
 msgid "Differentiate expression"
-msgstr ""
+msgstr "Продиференціювати вираз"
 
 #: ../../src/Worksheet.cpp:1590
 msgid "Differentiate..."
-msgstr ""
+msgstr "Продиференціювати…"
 
 #: ../../src/wxMaxima.cpp:9010
 msgid "Differentiates an expression n times"
-msgstr ""
+msgstr "Продиференціювати вираз n разів"
 
 #: ../../src/wxMaxima.cpp:10055
 msgid "Differentiates the expression n times"
-msgstr ""
+msgstr "Продиференціювати вираз n разів"
 
 #: ../../src/wxMaximaFrame.cpp:1212
 msgid "Directory operations"
-msgstr ""
+msgstr "Дії з каталогами"
 
 #: ../../src/wxMaximaFrame.cpp:1041
 msgid "Display Te&X Form"
-msgstr ""
+msgstr "В&ивести у форматі TeX"
 
 #: ../../src/wxMaxima.cpp:6972
 msgid "Display algorithm"
-msgstr ""
+msgstr "Спосіб виведення"
 
 #: ../../src/wxMaximaFrame.cpp:751
 msgid "Display an expression as maxima's internal lisp representation"
@@ -2135,7 +2231,7 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:758
 msgid "Display equations"
-msgstr ""
+msgstr "Показ рівнянь"
 
 #: ../../src/wxMaxima.cpp:6508
 msgid "Display expression in maxima's internal representation"
@@ -2147,161 +2243,166 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1042
 msgid "Display last result in TeX form"
-msgstr ""
+msgstr "Показати останній результат у форматі TeX"
 
 #: ../../src/ToolBar.cpp:360
 #, c-format
 msgid "Display resolution according to wxWidgets: %li x %li ppi"
-msgstr ""
+msgstr "Роздільність показу за даними wxWidgets: %li x %li точок на дюйм"
 
 #: ../../src/wxMaximaFrame.cpp:802
 msgid "Display string quotation marks"
-msgstr ""
+msgstr "Показати позначки лапок у рядку"
 
 #: ../../src/wxMaximaFrame.cpp:1036
 msgid "Display time used for evaluation"
-msgstr ""
+msgstr "Показати час, витрачений на обчислення"
 
 #: ../../src/wxMaxima.cpp:9206
 msgid "Displayed Precision"
-msgstr ""
+msgstr "Точність показу"
 
 #: ../../src/wxMaximaFrame.cpp:1913
 msgid "Displaying 3d curves"
-msgstr ""
+msgstr "Показ просторових кривих"
 
 #: ../../src/wxMaximaFrame.cpp:1462
 msgid "Dito, and evaluate the result..."
-msgstr ""
+msgstr "Те саме, і обчислити результат…"
 
 #: ../../src/wxMaximaFrame.cpp:1445
 msgid "Dito, but affect all clones of the Matrix..."
-msgstr ""
+msgstr "Те саме, але із обробкою усіх клонів матриці…"
 
 #: ../../src/wxMaximaFrame.cpp:1255
 msgid "Dito, but as fraction (real only)..."
-msgstr ""
+msgstr "Те саме, але як дріб (лише дійсні)…"
 
 #: ../../src/wxMaximaFrame.cpp:1532
 msgid "Dito, including denominator"
-msgstr ""
+msgstr "Те саме, включно із знаменником"
 
 #: ../../src/Worksheet.cpp:1715 ../../src/wxMaximaFrame.cpp:944
 msgid "Divide Cell"
-msgstr ""
+msgstr "Ділити комірку"
 
 #: ../../src/wxMaximaFrame.cpp:1498
 msgid "Divide numbers or polynomials"
-msgstr ""
+msgstr "Ділити числа або поліноми"
 
 #: ../../src/wxMaxima.cpp:8578
 msgid "Do for each list element"
-msgstr ""
+msgstr "Застосувати до кожного елемента списку"
 
 #: ../../src/wxMaxima.cpp:11197
 #, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
-msgstr ""
+msgstr "Хочете зберегти зміни, які було внесено до документа «%s»?"
 
 #: ../../src/wxMaximaFrame.cpp:724
 msgid "Dock all Sidebars"
-msgstr ""
+msgstr "Пришпилити усі бічні панелі"
 
 #: ../../src/Configuration.cpp:94
 msgid "Document background"
-msgstr ""
+msgstr "Тло документа"
 
 #: ../../src/wxMaxima.cpp:4611
 msgid ""
 "Document was saved using a newer version of wxMaxima so it may not load "
 "correctly. Please update your wxMaxima."
 msgstr ""
+"Документ було збережено за допомогою новішої версії wxMaxima, отже дані може"
+" бути завантажено з помилками. Будь ласка, оновіть вашу версію wxMaxima."
 
 #: ../../src/wxMaxima.cpp:4603
 msgid ""
 "Document was saved using a newer version of wxMaxima. Please update your "
 "wxMaxima."
 msgstr ""
+"Документ було збережено за допомогою новішої версії wxMaxima. Будь ласка, "
+"оновіть вашу версію wxMaxima."
 
 #: ../../src/wxMaximaFrame.cpp:770
 msgid "Don't autosubscript after an underscore"
 msgstr ""
+"Не переводити автоматично у нижній індекс символи після підкреслювання"
 
 #: ../../src/wxMaximaFrame.cpp:1086
 msgid "Don't evaluate Expression..."
-msgstr ""
+msgstr "Не обчислювати вираз…"
 
 #: ../../src/wxMaxima.cpp:7117
 msgid "Don't evaluate one command"
-msgstr ""
+msgstr "Не обчислювати одну команду"
 
 #: ../../src/wxMaxima.cpp:7129
 msgid "Don't evaluate one whole expression"
-msgstr ""
+msgstr "Не обчислювати увесь вираз"
 
 #: ../../src/Worksheet.cpp:1931 ../../src/Worksheet.cpp:2064
 msgid "Don't mark cells that contain tooltips in yellow"
-msgstr ""
+msgstr "Не позначати комірки, які містять підказки, жовтим"
 
 #: ../../src/Worksheet.cpp:1938 ../../src/Worksheet.cpp:2070
 msgid "Don't mark this message text in yellow"
-msgstr ""
+msgstr "Не позначати текст цього повідомлення жовтим"
 
 #: ../../src/wxMaxima.cpp:11203
 msgid "Don't save"
-msgstr ""
+msgstr "Не зберігати"
 
 #: ../../src/Worksheet.cpp:1620
 msgid "Don't show labels"
-msgstr ""
+msgstr "Не показувати мітки"
 
 #: ../../src/Worksheet.cpp:1979
 msgid "Don't use if unassigned"
-msgstr ""
+msgstr "Не використовувати, якщо не має значення"
 
 #: ../../src/wxMaximaFrame.cpp:797
 msgid "Don't use parenthesis for matrices"
-msgstr ""
+msgstr "Не використовувати дужки для матриць"
 
 #: ../../src/wxMaxima.cpp:8525
 msgid "Drop the first n list elements"
-msgstr ""
+msgstr "Скиньте перші n елементів списку"
 
 #: ../../src/wxMaxima.cpp:8531 ../../src/wxMaxima.cpp:8537
 msgid "Drop the last n list elements"
-msgstr ""
+msgstr "Скиньте останні n елементів списку"
 
 #: ../../src/wxMaximaFrame.cpp:1306
 msgid "E&quations"
-msgstr ""
+msgstr "&Рівняння"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "E&xit\tCtrl+Q"
-msgstr ""
+msgstr "Ви&йти\tCtrl+Q"
 
 #: ../../src/wxMaximaFrame.cpp:1368
 msgid "Eige&nvectors"
-msgstr ""
+msgstr "В&ласні вектори"
 
 #: ../../src/wxMaximaFrame.cpp:1365
 msgid "Eigen&values"
-msgstr ""
+msgstr "Вл&асні значення"
 
 #: ../../src/wxMaximaFrame.cpp:1387
 msgid "Eigenvalues (complex)"
-msgstr ""
+msgstr "Власні значення (комплексні)"
 
 #: ../../src/wxMaximaFrame.cpp:1384
 msgid "Eigenvalues (real)"
-msgstr ""
+msgstr "Власні значення (дійсні)"
 
 #: ../../src/wxMaximaFrame.cpp:1393
 msgid "Eigenvalues, left+right eigenvectors (complex)"
-msgstr ""
+msgstr "Власні значення, лівий+правий власні вектори (комплексні)"
 
 #: ../../src/wxMaximaFrame.cpp:1390
 msgid "Eigenvalues, left+right eigenvectors (real)"
-msgstr ""
+msgstr "Власні значення, лівий+правий власні вектори (дійсні)"
 
 #: ../../src/wxMaxima.cpp:8584
 msgid ""
@@ -2309,130 +2410,132 @@ msgid ""
 "parenthesis. In the latter case the result of the last expression in the "
 "parenthesis is used."
 msgstr ""
+"Одинарний вираз або список відокремлених комами виразів у дужках. У "
+"останньому випадку буде використано результат останнього виразу у дужках."
 
 #: ../../src/wxMaxima.cpp:8593
 msgid "Element"
-msgstr ""
+msgstr "Елемент"
 
 #: ../../src/wxMaxima.cpp:8549
 msgid "Element number"
-msgstr ""
+msgstr "Номер елемента"
 
 #: ../../src/wxMaxima.cpp:8005
 msgid ""
 "Element-by-element Product of matrices of the same size (Hadamard product)"
-msgstr ""
+msgstr "Поелементний добуток матриць однакового розміру (добуток Адамара)"
 
 #: ../../src/wxMaxima.cpp:8012
 msgid "Element-by-element exponentiation of two matrices"
-msgstr ""
+msgstr "Поелементне піднесення до степеня для двох матриць"
 
 #: ../../src/wxMaximaFrame.cpp:1342
 msgid "Element-by-element multiplication"
-msgstr ""
+msgstr "Поелементне множення"
 
 #: ../../src/wxMaxima.cpp:8510
 msgid "Element:"
-msgstr ""
+msgstr "Елемент:"
 
 #: ../../src/wxMaxima.cpp:7204
 msgid "Elements:"
-msgstr ""
+msgstr "Елементи:"
 
 #: ../../src/wxMaxima.cpp:7847
 msgid "Eliminate a variable"
-msgstr ""
+msgstr "Знищити змінну"
 
 #: ../../src/wxMaximaFrame.cpp:1247
 msgid "Eliminate a variable from a system of equations"
-msgstr ""
+msgstr "Виключити змінну із системи рівнянь"
 
 #: ../../src/wxMaxima.cpp:10651
 msgid "Empty command => re-triggering evaluation"
-msgstr ""
+msgstr "Порожня команда => повторно започатковуємо обробку"
 
 #: ../../src/wxMaxima.cpp:9225
 msgid "Enable:"
-msgstr ""
+msgstr "Увімкнути:"
 
 #: ../../src/MathParser.cpp:99
 #, c-format
 msgid "Encountered an unknown XML tag: <%s>"
-msgstr ""
+msgstr "Виявлено невідомий теґ XML: <%s>"
 
 #: ../../src/wxMaxima.cpp:2476
 msgid "Encountered an unknown socket event."
-msgstr ""
+msgstr "Сталася невідома подія із сокетом."
 
 #: ../../src/wxMaxima.cpp:7843
 msgid "End of t:"
-msgstr ""
+msgstr "Кінець за t:"
 
 #: ../../src/wxMaxima.cpp:4097
 msgid "Ended lisp mode after receiving a maxima prompt!"
-msgstr ""
+msgstr "Роботу у режимі lisp завершено після отримання запиту maxima!"
 
 #: ../../src/wxMaximaFrame.cpp:1828
 msgid "Engineering format (12.1e6 etc.)"
-msgstr ""
+msgstr "Науковий формат (12.1e6 тощо)"
 
 #: ../../src/wxMaximaFrame.cpp:1319
 msgid "Enter a matrix"
-msgstr ""
+msgstr "Введення матриці"
 
 #: ../../src/wxMaxima.cpp:8866
 msgid "Enter an equation for rational simplification:"
-msgstr ""
+msgstr "Введіть рівняння для раціонального спрощення:"
 
 #: ../../src/wxMaxima.cpp:8169
 msgid "Enter matrix"
-msgstr ""
+msgstr "Введіть матрицю"
 
 #: ../../src/wxMaxima.cpp:9095
 msgid "Enter new animation frame rate [Hz, integer]:"
-msgstr ""
+msgstr "Введіть нову частоту кадрів анімації [Гц, ціле число]:"
 
 #: ../../src/wxMaxima.cpp:9201
 msgid "Enter new precision for bigfloats:"
-msgstr ""
+msgstr "Вкажіть нову підвищену точність:"
 
 #: ../../src/wxMaxima.cpp:7922
 msgid "Enumerator:"
-msgstr ""
+msgstr "Чисельник:"
 
 #: ../../src/wxMaximaFrame.cpp:1220
 msgid "Environment variables"
-msgstr ""
+msgstr "Змінні середовища"
 
 #: ../../src/wxMaxima.cpp:9045
 msgid "Epsilon:"
-msgstr ""
+msgstr "ε:"
 
 #: ../../src/wxMaximaFrame.cpp:1124 ../../src/wxMaximaFrame.cpp:1135
 msgid "Equal, ignoring case?..."
-msgstr ""
+msgstr "Рівні, якщо не зважати на регістр?…"
 
 #: ../../src/wxMaximaFrame.cpp:1133
 msgid "Equal?..."
-msgstr ""
+msgstr "Рівні?…"
 
 #: ../../src/wxMaxima.cpp:8561
 msgid "Equation"
-msgstr ""
+msgstr "Рівняння"
 
 #: ../../src/wxMaxima.cpp:7751 ../../src/wxMaxima.cpp:7765
 msgid "Equation(s)"
-msgstr ""
+msgstr "Рівняння"
 
 #: ../../src/wxMaxima.cpp:7848 ../../src/wxMaxima.cpp:7900
 msgid "Equation(s):"
-msgstr ""
+msgstr "Рівняння:"
 
 #: ../../src/wxMaxima.cpp:7776 ../../src/wxMaxima.cpp:7788
 #: ../../src/wxMaxima.cpp:8899 ../../src/wxMaxima.cpp:8919
 #: ../../src/wxMaxima.cpp:9592 ../../src/wxMaxima.cpp:10039
 msgid "Equation:"
-msgstr ""
+msgstr "Рівняння:"
 
 #: ../../src/WXMXformat.cpp:258 ../../src/WXMXformat.cpp:288
 #: ../../src/WXMXformat.cpp:296 ../../src/WXMXformat.cpp:311
@@ -2444,22 +2547,22 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:4645 ../../src/wxMaxima.cpp:11125
 #: ../../src/wxMaxima.cpp:11166
 msgid "Error"
-msgstr ""
+msgstr "Помилка"
 
 #: ../../src/wxMaxima.cpp:2456
 msgid "Error writing to Maxima"
-msgstr ""
+msgstr "Помилка під час спроби записати дані до Maxima"
 
 #: ../../src/wxMaxima.cpp:6164 ../../src/wxMaxima.cpp:6176
 #: ../../src/wxMaxima.cpp:6187 ../../src/wxMaxima.cpp:7858
 #: ../../src/wxMaxima.cpp:7880 ../../src/wxMaxima.cpp:8163
 msgid "Error!"
-msgstr ""
+msgstr "Помилка!"
 
 #: ../../src/Image.cpp:696
 #, c-format
 msgid "Error: Cannot render %s."
-msgstr ""
+msgstr "Помилка: не вдалося обробити %s."
 
 #: ../../src/Image.cpp:699
 #, c-format
@@ -2467,10 +2570,12 @@ msgid ""
 "Error: Cannot render %s:\n"
 "%s"
 msgstr ""
+"Помилка: не вдалося обробити %s\n"
+"%s"
 
 #: ../../src/Image.cpp:704
 msgid "Error: Cannot render the image."
-msgstr ""
+msgstr "Помилка: не вдалося обробити зображення."
 
 #: ../../src/Image.cpp:706
 #, c-format
@@ -2478,248 +2583,254 @@ msgid ""
 "Error: Cannot render the image:\n"
 "%s"
 msgstr ""
+"Помилка: не вдалося обробити зображення:\n"
+"%s"
 
 #: ../../src/wxMaxima.cpp:7544
 msgid ""
 "Escapes all special characters in a string. The result is a regex that "
 "matches this string exactly."
 msgstr ""
+"Екранує усі спеціальні символи у рядку. Результатом буде формальний вираз, "
+"який точно відповідає цьому рядку."
 
 #: ../../src/wxMaximaFrame.cpp:1652
 msgid "Evaluate &Noun Forms..."
-msgstr ""
+msgstr "Обчислити нео&бчислювані (noun) форми…"
 
 #: ../../src/wxMaximaFrame.cpp:856
 msgid "Evaluate All Cells\tCtrl+Shift+R"
-msgstr ""
+msgstr "Обчислити усі комірки\tCtrl+Shift+R"
 
 #: ../../src/wxMaximaFrame.cpp:851
 msgid "Evaluate All Visible Cells\tCtrl+R"
-msgstr ""
+msgstr "Обчислити усі видимі комірки\tCtrl+R"
 
 #: ../../src/Worksheet.cpp:1395
+#, fuzzy
 msgid "Evaluate Cell"
-msgstr ""
+msgstr "Обчислити комірки"
 
 #: ../../src/Worksheet.cpp:1398 ../../src/wxMaximaFrame.cpp:844
 msgid "Evaluate Cell(s)"
-msgstr ""
+msgstr "Обчислити комірки"
 
 #: ../../src/Worksheet.cpp:1391 ../../src/Worksheet.cpp:1674
 msgid "Evaluate Cells Above"
-msgstr ""
+msgstr "Обчислити комірки вище"
 
 #: ../../src/wxMaximaFrame.cpp:866
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
-msgstr ""
+msgstr "Обчислити комірку вище\tCtrl+Shift+P"
 
 #: ../../src/Worksheet.cpp:1402 ../../src/Worksheet.cpp:1676
 #: ../../src/wxMaximaFrame.cpp:876
 msgid "Evaluate Cells Below"
-msgstr ""
+msgstr "Обчислити комірки нижче"
 
 #: ../../src/Worksheet.cpp:1451 ../../src/Worksheet.cpp:1756
 #: ../../src/Worksheet.cpp:1890
 msgid "Evaluate Heading 5\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Обчислити заголовок 5\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1457 ../../src/Worksheet.cpp:1761
 #: ../../src/Worksheet.cpp:1901
 msgid "Evaluate Heading 6\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Обчислити заголовок 6\tShift+Ctrl+Enter"
 
 #: ../../src/wxMaxima.cpp:8626
 msgid "Evaluate Nouns"
-msgstr ""
+msgstr "Обчислити необчислювані (noun) форми"
 
 #: ../../src/Worksheet.cpp:1425 ../../src/Worksheet.cpp:1736
 msgid "Evaluate Part\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Обчислити частину\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1431 ../../src/Worksheet.cpp:1741
 msgid "Evaluate Section\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Обчислити розділ\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1445 ../../src/Worksheet.cpp:1751
 #: ../../src/Worksheet.cpp:1879
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Обчислити підпідрозділ\tShift+Ctrl+Enter"
 
 #: ../../src/Worksheet.cpp:1438 ../../src/Worksheet.cpp:1746
 #: ../../src/Worksheet.cpp:1868
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
-msgstr ""
+msgstr "Обчислити підрозділ\tShift+Ctrl+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:845
 msgid "Evaluate active or selected cell(s)"
-msgstr ""
+msgstr "Виконати обчислення у активних або позначених комірках"
 
 #: ../../src/ToolBar.cpp:251
 msgid "Evaluate all"
-msgstr ""
+msgstr "Обчислити всі"
 
 #: ../../src/wxMaximaFrame.cpp:857
 msgid "Evaluate all cells in the document"
-msgstr ""
+msgstr "Виконати обчислення у всіх комірках документа"
 
 #: ../../src/wxMaximaFrame.cpp:1653
 msgid "Evaluate all noun forms in expression"
-msgstr ""
+msgstr "Обчислити всі необчислювані (noun) форми у виразі"
 
 #: ../../src/wxMaximaFrame.cpp:852
 msgid "Evaluate all visible cells in the document"
-msgstr ""
+msgstr "Виконати обчислення у всіх видимих комірках документа"
 
 #: ../../src/ToolBar.cpp:248
 msgid "Evaluate current cell"
-msgstr ""
+msgstr "Обчислити поточну комірку"
 
 #: ../../src/wxMaxima.cpp:7395
 msgid "Evaluate string"
-msgstr ""
+msgstr "Обчислити рядок"
 
 #: ../../src/wxMaximaFrame.cpp:1151
 msgid "Evaluate string..."
-msgstr ""
+msgstr "Обчислити рядок…"
 
 #: ../../src/ToolBar.cpp:256
 msgid "Evaluate the file from its beginning to the cell above the cursor"
-msgstr ""
+msgstr "Виконати у файлі обчислення від початку до комірки під курсором"
 
 #: ../../src/ToolBar.cpp:259
 msgid "Evaluate the file from the cursor to its end"
-msgstr ""
+msgstr "Виконати обчислення всіх команд у файлі від курсора до кінця файла"
 
 #: ../../src/ToolBar.cpp:258
 msgid "Evaluate the rest"
-msgstr ""
+msgstr "Обчислити решту"
 
 #: ../../src/ToolBar.cpp:255
 msgid "Evaluate to point"
-msgstr ""
+msgstr "Обчислити до пункту"
 
 #: ../../src/wxMaxima.cpp:10518
 msgid "Evaluation ended, since evaluation queue is empty."
-msgstr ""
+msgstr "Обробку завершено, оскільки черга обробки є порожньою."
 
 #: ../../src/Worksheet.cpp:1957
 msgid "Even number"
-msgstr ""
+msgstr "Парне число"
 
 #: ../../src/wxMaximaFrame.cpp:1703
 msgid "Execute a command for each element of the list"
-msgstr ""
+msgstr "Виконати команду для кожного з елементів у списку"
 
 #: ../../src/main.cpp:438
 msgid "Exit"
-msgstr ""
+msgstr "Вийти"
 
 #: ../../src/wxMaximaFrame.cpp:625
 msgid "Exit wxMaxima"
-msgstr ""
+msgstr "Вийти з wxMaxima"
 
 #: ../../src/Worksheet.cpp:1583
 msgid "Expand Expression"
-msgstr ""
+msgstr "Розкрити вираз"
 
 #: ../../src/wxMaximaFrame.cpp:1525
 msgid "Expand an expression"
-msgstr ""
+msgstr "Розкрити вираз"
 
 #: ../../src/wxMaximaFrame.cpp:1531
 msgid "Expand for given variables"
-msgstr ""
+msgstr "Розгорнути для заданих змінних"
 
 #: ../../src/wxMaxima.cpp:8781
 msgid "Expand for variable(s) including denominator:"
-msgstr ""
+msgstr "Розгорнути для змінних, включно із знаменником:"
 
 #: ../../src/wxMaxima.cpp:8716
 msgid "Expand for variable(s):"
-msgstr ""
+msgstr "Розгорнути для змінних:"
 
 #: ../../src/wxMaximaFrame.cpp:1545
 msgid "Expand log in previous expression"
-msgstr ""
+msgstr "Розгорнути логарифм у попередньому виразі"
 
 #: ../../src/wxMaximaFrame.cpp:1598
 msgid "Expand trigonometric expression"
-msgstr ""
+msgstr "Розкрити тригонометричний вираз"
 
 #: ../../src/wxMaximaFrame.cpp:1788
 msgid "Expect numbers harder to be complex"
-msgstr ""
+msgstr "Наполегливіше шукати комплексні числа"
 
 #: ../../src/wxMaximaFrame.cpp:1789
 msgid "Expect variables to contain complex numbers"
-msgstr ""
+msgstr "Очікувати на змінні, які містять комплексні числа"
 
 #: ../../src/wxMaxima.cpp:6121
 msgid "Export"
-msgstr ""
+msgstr "Експорт"
 
 #: ../../src/wxMaximaFrame.cpp:1705
 msgid "Export List to csv file..."
-msgstr ""
+msgstr "Експортувати список до файла CSV…"
 
 #: ../../src/wxMaximaFrame.cpp:1706
 msgid "Export a list to a csv file"
-msgstr ""
+msgstr "Експортувати список до файла CSV"
 
 #: ../../src/wxMaximaFrame.cpp:1332
 msgid "Export a matrix to a csv file"
-msgstr ""
+msgstr "Експортувати матрицю до файла CSV"
 
 #: ../../src/wxMaximaFrame.cpp:619
 msgid "Export document to a HTML or LaTeX file"
-msgstr ""
+msgstr "Експортувати документ до файла HTML або файла LaTeX"
 
 #: ../../src/wxMaximaFrame.cpp:579
 msgid "Export failed."
-msgstr ""
+msgstr "Помилка під час експортування."
 
 #: ../../src/wxMaximaFrame.cpp:567
 msgid "Export successful."
-msgstr ""
+msgstr "Успішно експортовано."
 
 #: ../../src/wxMaxima.cpp:6187
 msgid "Exporting to HTML failed!"
-msgstr ""
+msgstr "Спроба експортування даних до HTML завершилася невдало!"
 
 #: ../../src/wxMaxima.cpp:6164
 msgid "Exporting to TeX failed!"
-msgstr ""
+msgstr "Спроба експортування даних до TeX завершилася невдало!"
 
 #: ../../src/wxMaxima.cpp:6175
 msgid "Exporting to maxima batch file failed!"
-msgstr ""
+msgstr "Не вдалося експортувати до файла пакетної обробки maxima!"
 
 #: ../../src/wxMaximaFrame.cpp:561
 msgid "Exporting..."
-msgstr ""
+msgstr "Експортування…"
 
 #: ../../src/wxMaxima.cpp:6510 ../../src/wxMaxima.cpp:6516
 #: ../../src/wxMaxima.cpp:8218 ../../src/wxMaxima.cpp:8633
 #: ../../src/wxMaxima.cpp:8638 ../../src/wxMaxima.cpp:8658
 #: ../../src/wxMaxima.cpp:10065
 msgid "Expression"
-msgstr ""
+msgstr "Вираз"
 
 #: ../../src/wxMaxima.cpp:7019 ../../src/wxMaxima.cpp:7025
 msgid "Expression or a list of comma-separated expressions"
-msgstr ""
+msgstr "Вираз або список виразів, які відокремлено комами"
 
 #: ../../src/wxMaximaFrame.cpp:1088
 msgid "Expression to string..."
-msgstr ""
+msgstr "Вираз у рядок…"
 
 #: ../../src/wxMaxima.cpp:7113
 msgid "Expression whose output is to be used as maxima's input."
 msgstr ""
+"Вираз, результат обчислення якого слід використати як вхідні дані maxima."
 
 #: ../../src/wxMaxima.cpp:7214
 msgid "Expression(s):"
-msgstr ""
+msgstr "Вираз(и):"
 
 #: ../../src/wxMaxima.cpp:8933 ../../src/wxMaxima.cpp:8941
 #: ../../src/wxMaxima.cpp:8952 ../../src/wxMaxima.cpp:8976
@@ -2728,385 +2839,388 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9062
 #: ../../src/wxMaxima.cpp:10056
 msgid "Expression:"
-msgstr ""
+msgstr "Вираз:"
 
 #: ../../src/wxMaximaFrame.cpp:1423
 msgid "Extract Column..."
-msgstr ""
+msgstr "Видобути стовпчик…"
 
 #: ../../src/wxMaximaFrame.cpp:1726
 msgid "Extract Elements"
-msgstr ""
+msgstr "Видобути елементи"
 
 #: ../../src/wxMaximaFrame.cpp:1421
 msgid "Extract Row..."
-msgstr ""
+msgstr "Видобути рядок…"
 
 #: ../../src/wxMaximaFrame.cpp:1424
 msgid "Extract a column from the matrix"
-msgstr ""
+msgstr "Видобути стовпчик з матриці"
 
 #: ../../src/wxMaximaFrame.cpp:1435
 msgid "Extract a column from the matrix and convert it to a list"
-msgstr ""
+msgstr "Видобути стовпчик з матриці і перетворити його у список"
 
 #: ../../src/wxMaxima.cpp:7960
 msgid "Extract a matrix column"
-msgstr ""
+msgstr "Видобути стовпчик з матриці"
 
 #: ../../src/wxMaxima.cpp:7970
 msgid "Extract a matrix column as a list"
-msgstr ""
+msgstr "Видобути стовпчик з матриці як список"
 
 #: ../../src/wxMaximaFrame.cpp:1313
 msgid "Extract a matrix from a 2-dimensional array"
-msgstr ""
+msgstr "Видобути матрицю з двовимірного масиву"
 
 #: ../../src/wxMaxima.cpp:7955
 msgid "Extract a matrix row"
-msgstr ""
+msgstr "Видобути рядок з матриці"
 
 #: ../../src/wxMaxima.cpp:7965
 msgid "Extract a matrix row as a list"
-msgstr ""
+msgstr "Видобути рядок з матриці як список"
 
 #: ../../src/wxMaximaFrame.cpp:1422
 msgid "Extract a row from the matrix"
-msgstr ""
+msgstr "Видобути рядок з матриці"
 
 #: ../../src/wxMaximaFrame.cpp:1431
 msgid "Extract a row from the matrix and convert it to a list"
-msgstr ""
+msgstr "Видобути рядок з матриці і перетворити його у список"
 
 #: ../../src/wxMaxima.cpp:8564
 msgid "Extract a variable's value from a list of variable values"
-msgstr ""
+msgstr "Видобути значення змінної зі списку значень змінної"
 
 #: ../../src/wxMaximaFrame.cpp:1723
 msgid "Extract an actual value for a variable"
-msgstr ""
+msgstr "Видобути справжнє значення змінної"
 
 #: ../../src/wxMaximaFrame.cpp:1163
 msgid "Extract char..."
-msgstr ""
+msgstr "Видобути символ…"
 
 #: ../../src/wxMaximaFrame.cpp:1207
 msgid "Extract dir from path..."
-msgstr ""
+msgstr "Видобути каталог зі шляху…"
 
 #: ../../src/wxMaxima.cpp:7605
 msgid "Extract directory part"
-msgstr ""
+msgstr "Видобути частину з каталогом"
 
 #: ../../src/wxMaxima.cpp:7617
 msgid "Extract file type extension"
-msgstr ""
+msgstr "Видобути суфікс назв типу файлів"
 
 #: ../../src/wxMaximaFrame.cpp:1209
 msgid "Extract filename from path..."
-msgstr ""
+msgstr "Видобути назву файла зі шляху…"
 
 #: ../../src/wxMaxima.cpp:7611
 msgid "Extract filename part"
-msgstr ""
+msgstr "Видобути частину із назвою файла"
 
 #: ../../src/wxMaximaFrame.cpp:1211
 msgid "Extract filetype from path..."
-msgstr ""
+msgstr "Видобути тип файла зі шляху…"
 
 #: ../../src/wxMaxima.cpp:8445
 msgid "Extract function arguments"
-msgstr ""
+msgstr "Видобути аргументи функцій"
 
 #: ../../src/wxMaximaFrame.cpp:1727
 msgid "Extract list Elements"
-msgstr ""
+msgstr "Видобути елементи списку"
 
 #: ../../src/wxMaxima.cpp:8187
 msgid "Extract matrix from 2D array"
-msgstr ""
+msgstr "Видобути матрицю з двовимірного масиву"
 
 #: ../../src/wxMaximaFrame.cpp:1686
 msgid "Extract the argument list from a function call"
-msgstr ""
+msgstr "Видобути список аргументів з виклику функції"
 
 #: ../../src/wxMaxima.cpp:8538
 msgid "Extract the last n elements from a list"
-msgstr ""
+msgstr "Видобути останні n елементів зі списку"
 
 #: ../../src/wxMaxima.cpp:7376
 msgid "Extract the nth char of a string"
-msgstr ""
+msgstr "Видобути n-й символ рядка"
 
 #: ../../src/wxMaxima.cpp:8544
 msgid "Extract the nth list elements"
-msgstr ""
+msgstr "Видобути елементи n-го списку"
 
 #: ../../src/wxMaximaFrame.cpp:1724
 msgid "Extract the value for one variable assigned in a list"
-msgstr ""
+msgstr "Видобути значення для однієї змінної на основі списку"
 
 #: ../../src/wxMaximaFrame.cpp:1439
 msgid "Extract, append or delete rows or columns"
-msgstr ""
+msgstr "Видобування, дописування або вилучення рядків чи стовпчиків"
 
 #: ../../src/wxMaxima.cpp:8188
 msgid "Extracts a rectangle from a 2D array and converts it to a matrix"
 msgstr ""
+"Видобуває прямокутник з двовимірного масиву і перетворює його на матрицю"
 
 #: ../../src/wxMaximaFrame.cpp:1521
 msgid "Factor Complex"
-msgstr ""
+msgstr "Розкласти на комплексні множники"
 
 #: ../../src/Worksheet.cpp:1581
 msgid "Factor Expression"
-msgstr ""
+msgstr "Розкласти на множники вираз"
 
 #: ../../src/wxMaximaFrame.cpp:1519
 msgid "Factor Expression including subexpressions"
-msgstr ""
+msgstr "Розкласти на множники вираз, разом із підвиразами"
 
 #: ../../src/wxMaximaFrame.cpp:1517 ../../src/wxMaximaFrame.cpp:1520
 msgid "Factor an expression"
-msgstr ""
+msgstr "Розкласти вираз на множники"
 
 #: ../../src/wxMaximaFrame.cpp:1522
 msgid "Factor an expression in Gaussian numbers"
-msgstr ""
+msgstr "Розкласти на елементарні гаусові множники"
 
 #: ../../src/wxMaximaFrame.cpp:1587
 msgid "Factorials and &Gamma"
-msgstr ""
+msgstr "Факторіали і &гамма-функція"
 
 #: ../../src/Image.cpp:137
 #, c-format
 msgid "Failed to delete gnuplot data file %s"
-msgstr ""
+msgstr "Не вдалося вилучити файл даних gnuplot %s"
 
 #: ../../src/Image.cpp:121 ../../src/Image.cpp:128
 #, c-format
 msgid "Failed to delete gnuplot file %s"
-msgstr ""
+msgstr "Не вдалося вилучити файл gnuplot %s"
 
 #: ../../src/wxMaxima.cpp:2667
+#, fuzzy
 msgid "Failed to start Maxima"
-msgstr ""
+msgstr "Перезапустити Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1418
 msgid "Fast fortran routines that perform numerical tasks"
-msgstr ""
+msgstr "Швидкі підпрограми fortran, які виконують обчислювальні завдання"
 
 #: ../../src/wxMaximaFrame.cpp:1922
 msgid "Fast list access"
-msgstr ""
+msgstr "Швидкий доступ до списку"
 
 #: ../../src/wxMaxima.cpp:2553
 msgid "Fatal error"
-msgstr ""
+msgstr "Критична помилка"
 
 #: ../../src/wxMaxima.cpp:7191
 msgid "Field contents:"
-msgstr ""
+msgstr "Вміст поля:"
 
 #: ../../src/wxMaxima.cpp:7198
 msgid "Field name:"
-msgstr ""
+msgstr "Назва поля:"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "Fields:"
-msgstr ""
+msgstr "Поля:"
 
 #: ../../src/main.cpp:439
 msgid "File"
-msgstr ""
+msgstr "Файл"
 
 #: ../../src/wxMaximaFrame.cpp:1333
 msgid "File I/O"
-msgstr ""
+msgstr "Введення-виведення до файла"
 
 #: ../../src/wxMaxima.cpp:4165 ../../src/wxMaxima.cpp:4224
 #: ../../src/wxMaxima.cpp:4493 ../../src/wxMaxima.cpp:4504
 #: ../../src/wxMaxima.cpp:4606 ../../src/wxMaxima.cpp:4636
 #: ../../src/wxMaxima.cpp:4647 ../../src/wxMaxima.cpp:5641
 msgid "File could not be opened"
-msgstr ""
+msgstr "Не вдалося відкрити файл"
 
 #: ../../src/wxMaxima.cpp:7241 ../../src/wxMaxima.cpp:7246
 #: ../../src/wxMaxima.cpp:7251
 msgid "File name:"
-msgstr ""
+msgstr "Назва файла:"
 
 #: ../../src/wxMaxima.cpp:10225 ../../src/wxMaxima.cpp:10268
 msgid "File not found"
-msgstr ""
+msgstr "Файл не знайдено"
 
 #: ../../src/wxMaxima.cpp:5631
 msgid "File opened"
-msgstr ""
+msgstr "Файл відкрито"
 
 #: ../../src/wxMaximaFrame.cpp:1217
 msgid "File operations"
-msgstr ""
+msgstr "Дії із файлами"
 
 #: ../../src/wxMaxima.cpp:10224 ../../src/wxMaxima.cpp:10267
 msgid "File you tried to open does not exist."
-msgstr ""
+msgstr "Файла, який ви намагалися відкрити, не існує."
 
 #: ../../src/wxMaximaFrame.cpp:1221
+#, fuzzy
 msgid "File/directory functions"
-msgstr ""
+msgstr "Дії з каталогами"
 
 #: ../../src/wxMaxima.cpp:7027
 msgid "Filename or a list of comma-separated file names"
-msgstr ""
+msgstr "Назва файла або список назв файлів, відокремлених комами"
 
 #: ../../src/ToolBar.cpp:222
 msgid "Find"
-msgstr ""
+msgstr "Знайти"
 
 #: ../../src/wxMaximaFrame.cpp:670
 msgid "Find\tCtrl+F"
-msgstr ""
+msgstr "Знайти\tCtrl+F"
 
 #: ../../src/wxMaximaFrame.cpp:1468
 msgid "Find &Limit..."
-msgstr ""
+msgstr "Знайти &границю…"
 
 #: ../../src/wxMaximaFrame.cpp:1470
 msgid "Find Minimum..."
-msgstr ""
+msgstr "Знайти мінімум…"
 
 #: ../../src/Worksheet.cpp:1576
 msgid "Find Root..."
-msgstr ""
+msgstr "Знайти корінь…"
 
 #: ../../src/wxMaximaFrame.cpp:1471
 msgid "Find a (unconstrained) minimum of an expression"
-msgstr ""
+msgstr "Знайти (абсолютний) мінімум виразу"
 
 #: ../../src/wxMaximaFrame.cpp:1804
 msgid "Find a fraction that represents this float exactly"
-msgstr ""
+msgstr "Знайти дріб, який точно збігається з цим десятковим дробом"
 
 #: ../../src/wxMaximaFrame.cpp:1469
 msgid "Find a limit of an expression"
-msgstr ""
+msgstr "Знайти границю виразу"
 
 #: ../../src/wxMaximaFrame.cpp:1807
 msgid "Find a nice fraction that is similar to this float"
-msgstr ""
+msgstr "Знайти добрий дріб, який є близьким до цього десяткового дробу"
 
 #: ../../src/wxMaximaFrame.cpp:1283
 msgid "Find a numerical solution for a first degree ODE"
-msgstr ""
+msgstr "Знайти обчислювальний розв'язок для ЗДР першого порядку"
 
 #: ../../src/wxMaximaFrame.cpp:1252
 msgid "Find a root of an equation on an interval"
-msgstr ""
+msgstr "Знайти корінь рівняння на інтервалі"
 
 #: ../../src/wxMaximaFrame.cpp:1259
 msgid "Find all roots of a polynomial"
-msgstr ""
+msgstr "Знайти всі корені полінома"
 
 #: ../../src/wxMaximaFrame.cpp:1262
 msgid "Find all roots of a polynomial (bfloat)"
-msgstr ""
+msgstr "Знайти всі корені полінома (підв. точність)"
 
 #: ../../src/wxMaxima.cpp:6589
 msgid "Find and Replace"
-msgstr ""
+msgstr "Знайти і замінити"
 
 #: ../../src/ToolBar.cpp:222 ../../src/wxMaximaFrame.cpp:670
 msgid "Find and replace"
-msgstr ""
+msgstr "Знайти і замінити"
 
 #: ../../src/wxMaxima.cpp:7434
 msgid "Find char in string"
-msgstr ""
+msgstr "Знайти символ у рядку"
 
 #: ../../src/wxMaximaFrame.cpp:1172
 msgid "Find char in string..."
-msgstr ""
+msgstr "Знайти символ у рядку…"
 
 #: ../../src/wxMaximaFrame.cpp:1534
 msgid "Find common denominator"
-msgstr ""
+msgstr "Знайти спільний знаменник"
 
 #: ../../src/wxMaximaFrame.cpp:1366
 msgid "Find eigenvalues of a matrix"
-msgstr ""
+msgstr "Знайти власні значення матриці"
 
 #: ../../src/wxMaximaFrame.cpp:1369
 msgid "Find eigenvectors of a matrix"
-msgstr ""
+msgstr "Знайти власні вектори матриці"
 
 #: ../../src/wxMaxima.cpp:7424
 msgid "Find first difference"
-msgstr ""
+msgstr "Знайти першу різницю"
 
 #: ../../src/wxMaximaFrame.cpp:1170
 msgid "Find first difference..."
-msgstr ""
+msgstr "Знайти першу різницю…"
 
 #: ../../src/wxMaximaFrame.cpp:1256
 msgid "Find fractions that real roots of a polynomial and "
-msgstr ""
+msgstr "Знайти дроби, які є дійсними коренями полінома і "
 
 #: ../../src/wxMaxima.cpp:9039
 msgid "Find minimum"
-msgstr ""
+msgstr "Знайти мінімум"
 
 #: ../../src/wxMaximaFrame.cpp:1251
 msgid "Find numerical solution..."
-msgstr ""
+msgstr "Знайти обчислювальний розв'язок…"
 
 #: ../../src/wxMaxima.cpp:10035
 msgid "Find root (solve numerically)"
-msgstr ""
+msgstr "Знайти корінь (обчислювальним методом)"
 
 #: ../../src/wxMaxima.cpp:8062 ../../src/wxMaxima.cpp:8083
 msgid "Find the maximum absolute value of a matrix entry"
-msgstr ""
+msgstr "Знайти максимальне значення за модулем запису матриці"
 
 #: ../../src/wxMaxima.cpp:8068 ../../src/wxMaxima.cpp:8089
 msgid "Find the maximum sum of the absolute values of a matrix column"
-msgstr ""
+msgstr "Знайти максимальну суму значень за модулем у стовпчику матриці"
 
 #: ../../src/wxMaxima.cpp:8073 ../../src/wxMaxima.cpp:8094
 msgid "Find the maximum sum of the absolute values of a matrix row"
-msgstr ""
+msgstr "Знайти максимальну суму значень за модулем у рядку матриці"
 
 #: ../../src/wxMaximaFrame.cpp:1832
 msgid "Fine-tune the display of engineering-format numbers"
-msgstr ""
+msgstr "Скоригувати показ чисел у науковому форматі"
 
 #: ../../src/wxMaximaFrame.cpp:1712
 msgid "First"
-msgstr ""
+msgstr "Перший"
 
 #: ../../src/wxMaximaFrame.cpp:1918
 msgid "Fitting curves to measurement data"
-msgstr ""
+msgstr "Криві апроксимації для даних вимірювань"
 
 #: ../../src/wxMaxima.cpp:7227
 msgid "Flush stream"
-msgstr ""
+msgstr "Витерти потік"
 
 #: ../../src/wxMaximaFrame.cpp:1103
 msgid "Flush..."
-msgstr ""
+msgstr "Витерти…"
 
 #: ../../src/wxMaximaFrame.cpp:922
 msgid "Fold All\tCtrl+Alt+["
-msgstr ""
+msgstr "Згорнути все\tCtrl+Alt+["
 
 #: ../../src/wxMaximaFrame.cpp:923
 msgid "Fold all sections"
-msgstr ""
+msgstr "Згорнути усі розділи"
 
 #: ../../src/ToolBar.cpp:240
 msgid "Follow"
-msgstr ""
+msgstr "Перейти"
 
 #: ../../src/ToolBar.cpp:285
 msgid ""
@@ -3121,55 +3235,68 @@ msgid ""
 "   Ctrl+6: Heading5 cell\n"
 "   Ctrl+7: Heading6 cell\n"
 msgstr ""
+"Для пришвидшення створення комірок передбачено такі комбінації клавіш:\n"
+"\n"
+"   Ctrl+0: Комірка з рівнянням\n"
+"   Ctrl+1: Комірка з текстом\n"
+"   Ctrl+2: Комірка із заголовком\n"
+"   Ctrl+3: Комірка розділу\n"
+"   Ctrl+4: Комірка підрозділу\n"
+"   Ctrl+5: Комірка підпідрозділу\n"
+"   Ctrl+6: Комірка heading5\n"
+"   Ctrl+7: Комірка heading6\n"
 
 #: ../../src/wxMaxima.cpp:7038
 msgid "For loop"
-msgstr ""
+msgstr "Цикл for"
 
 #: ../../src/wxMaximaFrame.cpp:1062
 msgid "For loop..."
-msgstr ""
+msgstr "Цикл for…"
 
 #: ../../src/Worksheet.cpp:237 ../../src/wxMaxima.cpp:11217
 msgid "Forwarding the keyboard focus to a text control"
-msgstr ""
+msgstr "Переспрямовуємо фокус клавіатури на текстовий елемент"
 
 #: ../../src/wxMaxima.cpp:11220
 msgid "Forwarding the keyboard focus to the worksheet"
-msgstr ""
+msgstr "Переспрямовуємо фокус клавіатури на робочий аркуш"
 
 #: ../../src/MaximaManual.cpp:452
 #, c-format
 msgid ""
 "Found %li anchors, URLs (individual files): %li, URLs (singlepage): %li"
 msgstr ""
+"Знайдено %li прив'язок, адрес (окремих файлів): %li, адрес (singlepage): %li"
 
 #: ../../src/MaximaManual.cpp:313
 #, c-format
 msgid "Found only %li keywords in maxima's manual. Not caching them to disc."
 msgstr ""
+"У підручнику з Maxima знайдено лише %li ключових слів. Не кешуємо їх на "
+"диск."
 
 #: ../../src/MaximaManual.cpp:513
 #, c-format
 msgid "Found the maxima HTML manual in the folder %s."
-msgstr ""
+msgstr "Виявлено підручник з maxima у форматі HTML у теці %s."
 
 #: ../../src/wxMaxima.cpp:8948
 msgid "Fourier coefficients"
-msgstr ""
+msgstr "Коефіцієнти Фур'є"
 
 #: ../../src/wxMaximaFrame.cpp:1476
 msgid "Fourier coefficients..."
-msgstr ""
+msgstr "Коефіцієнти Фур'є…"
 
 #: ../../src/ToolBar.cpp:137
-#, c-format
+#, fuzzy, c-format
 msgid "Frame %li of %li"
-msgstr ""
+msgstr "Кадр %i з %i"
 
 #: ../../src/wxMaxima.cpp:9097
 msgid "Frame rate"
-msgstr ""
+msgstr "Частота кадрів"
 
 #: ../../src/wxMaximaFrame.cpp:1005 ../../src/wxMaximaFrame.cpp:1009
 msgid "Free all unused items now"
@@ -3177,67 +3304,68 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1413
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
-msgstr ""
+msgstr "Норма Фробеніуса sqrt(sum((A(i,j))^2)) (комплексна)"
 
 #: ../../src/wxMaximaFrame.cpp:1411
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (real)"
-msgstr ""
+msgstr "Норма Фробеніуса sqrt(sum((A(i,j))^2)) (дійсна)"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "From:"
-msgstr ""
+msgstr "Від:"
 
 #: ../../src/wxMaximaFrame.cpp:827
+#, fuzzy
 msgid "Full Screen\tAlt+Enter"
-msgstr ""
+msgstr "На весь екран\tAlt+Enter"
 
 #: ../../src/wxMaximaFrame.cpp:824
 msgid "Full Screen\tF11"
-msgstr ""
+msgstr "На весь екран\tF11"
 
 #: ../../src/wxMaxima.cpp:7140
 msgid "Function contents:"
-msgstr ""
+msgstr "Вміст функції:"
 
 #: ../../src/wxMaxima.cpp:7908
 msgid "Function f(x):"
-msgstr ""
+msgstr "Функція f(x):"
 
 #: ../../src/wxMaxima.cpp:8572
 msgid "Function name"
-msgstr ""
+msgstr "Назва функції"
 
 #: ../../src/wxMaxima.cpp:7167
 msgid "Function name(s):"
-msgstr ""
+msgstr "Назви функцій:"
 
 #: ../../src/wxMaxima.cpp:7135 ../../src/wxMaxima.cpp:7684
 msgid "Function name:"
-msgstr ""
+msgstr "Назва функції:"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Function:"
-msgstr ""
+msgstr "Функція:"
 
 #: ../../src/wxMaximaFrame.cpp:1630
 msgid "Functions for complex simplification"
-msgstr ""
+msgstr "Функції для спрощення комплексних чисел"
 
 #: ../../src/wxMaximaFrame.cpp:1588
 msgid "Functions for simplifying factorials and gamma function"
-msgstr ""
+msgstr "Функції для спрощення факторіалів і гамма-функцій"
 
 #: ../../src/wxMaximaFrame.cpp:1606
 msgid "Functions for simplifying trigonometric expressions"
-msgstr ""
+msgstr "Функції для спрощення тригонометричних виразів"
 
 #: ../../src/wxMaxima.cpp:8965 ../../src/wxMaxima.cpp:8970
 msgid "GCD"
-msgstr ""
+msgstr "НСД"
 
 #: ../../src/wxMaxima.cpp:10186
 msgid "GIF image (*.gif)|*.gif"
-msgstr ""
+msgstr "зображення GIF (*.gif)|*.gif"
 
 #: ../../src/Worksheet.cpp:103
 msgid ""
@@ -3245,169 +3373,182 @@ msgid ""
 " hotkeys to be broken, see for example "
 "https://trac.wxwidgets.org/ticket/18462."
 msgstr ""
+"GTK_IM_MODULE встановлено у значення «xim». Слід очікувати огидне блимання і"
+" непрацездатність клавіатурних скорочень, див. "
+"https://trac.wxwidgets.org/ticket/18462."
 
 #: ../../src/wxMaximaFrame.cpp:295
 msgid "General Math"
-msgstr ""
+msgstr "Математика"
 
 #: ../../src/wxMaximaFrame.cpp:699
 msgid "General Math\tAlt+Shift+M"
-msgstr ""
+msgstr "Математика\tAlt+Shift+M"
 
 #: ../../src/wxMaximaFrame.cpp:1316
 msgid "Generate Matrix from Expression..."
-msgstr ""
+msgstr "Створити матрицю за виразом…"
 
 #: ../../src/wxMaximaFrame.cpp:1317
 msgid "Generate a matrix from a lambda expression"
-msgstr ""
+msgstr "Створити матрицю на основі лямбда-виразу"
 
 #: ../../src/wxMaximaFrame.cpp:1675
 msgid "Generate a new list using a lists' elements"
-msgstr ""
+msgstr "Створити новий список на основі елементів списку"
 
 #: ../../src/wxMaximaFrame.cpp:1681
 msgid ""
 "Generate a storage for variable values that can be introduced into equations"
 " at any time"
 msgstr ""
+"Створити сховище значень змінних, яке можна буде будь-коли вставити до "
+"рівнянь"
 
 #: ../../src/wxMaximaFrame.cpp:1672
 msgid "Generate list elements using a rule"
-msgstr ""
+msgstr "Створити елементи списку на основі правила"
 
 #: ../../src/wxMaxima.cpp:8196
 msgid "Generate matrix from a rule"
-msgstr ""
+msgstr "Створити матрицю з файла"
 
 #: ../../src/wxMaximaFrame.cpp:1094
 msgid "Generate unused symbol name"
-msgstr ""
+msgstr "Створити невикористану назву символу"
 
 #: ../../src/WXMXformat.cpp:231
 msgid "Generated the XML representation of the document"
-msgstr ""
+msgstr "Створено представлення XML документа"
 
 #: ../../src/wxMaxima.cpp:8197
+#, fuzzy
 msgid ""
 "Generates a matrix and fills each element with the result of the expression "
 "\"Rule\"."
 msgstr ""
+"Створити прямокутну матрицю і заповнити її результатом обчислення виразу "
+"«Правило»"
 
 #: ../../src/wxMaximaFrame.cpp:1619
 msgid "Get &Imaginary Part"
-msgstr ""
+msgstr "Знайти у&явну частину"
 
 #: ../../src/wxMaximaFrame.cpp:1485
 msgid "Get Laplace transformation of an expression"
-msgstr ""
+msgstr "Обчислити перетворення Лапласа від виразу"
 
 #: ../../src/wxMaximaFrame.cpp:1615
 msgid "Get Real P&art"
-msgstr ""
+msgstr "Знайти &дійсну частину"
 
 #: ../../src/wxMaximaFrame.cpp:1201
 msgid "Get current directory"
-msgstr ""
+msgstr "Отримати поточний каталог"
 
 #: ../../src/wxMaximaFrame.cpp:1489
 msgid "Get inverse Laplace transformation of an expression"
-msgstr ""
+msgstr "Обчислити обернене перетворення Лапласа від виразу"
 
 #: ../../src/wxMaxima.cpp:7223
 msgid "Get position in stream"
-msgstr ""
+msgstr "Отримати позицію у потоці"
 
 #: ../../src/wxMaximaFrame.cpp:1102
 msgid "Get position..."
-msgstr ""
+msgstr "Отримати позицію…"
 
 #: ../../src/wxMaximaFrame.cpp:1620
 msgid "Get the imaginary part of complex expression"
-msgstr ""
+msgstr "Знайти уявну частину комплексного виразу"
 
 #: ../../src/wxMaximaFrame.cpp:1616
 msgid "Get the real part of complex expression"
-msgstr ""
+msgstr "Знайти дійсну частину комплексного виразу"
 
 #: ../../src/wxMaxima.cpp:3609
-#, c-format
+#, fuzzy, c-format
 msgid "Gnuplot (command line) found at: %s"
-msgstr ""
+msgstr "Gnuplot можна знайти на %s"
 
 #: ../../src/wxMaxima.cpp:3607
 #, c-format
 msgid "Gnuplot found at: %s"
-msgstr ""
+msgstr "Gnuplot знайдено у %s"
 
 #: ../../src/wxMaxima.cpp:2974
 msgid "Gnuplot has closed."
-msgstr ""
+msgstr "Gnuplot закрито."
 
 #: ../../src/wxMaxima.cpp:3598 ../../src/wxMaxima.cpp:3603
 #, c-format
 msgid "Gnuplot not found, using the default: %s"
-msgstr ""
+msgstr "Gnuplot не знайдено, використовуємо типовий: %s"
 
 #: ../../src/wxMaxima.cpp:9428 ../../src/wxMaximaFrame.cpp:1887
 msgid "Go to URL"
-msgstr ""
+msgstr "Перейти до адреси"
 
 #: ../../src/wxMaxima.cpp:3989
 msgid "Got a new input prompt!"
-msgstr ""
+msgstr "Отримано новий запит щодо введення!"
 
 #: ../../src/Worksheet.cpp:6354
 msgid ""
 "Got a request to undo an action that involves a delete which isn't possible "
 "at this moment."
 msgstr ""
+"Отримано запит на скасування дії, до якої включено вилучення, яке зараз не "
+"можна виконати."
 
 #: ../../src/wxMaximaFrame.cpp:1031
 msgid "Gradefs"
-msgstr ""
+msgstr "Gradefs"
 
 #: ../../src/Worksheet.cpp:1967
 msgid "Greater or less than a value"
-msgstr ""
+msgstr "Більше або менше за значення"
 
 #: ../../src/wxMaximaFrame.cpp:1130
 msgid "Greater, ignoring case?..."
-msgstr ""
+msgstr "Є більшим, якщо ігнорувати регістр…"
 
 #: ../../src/wxMaximaFrame.cpp:260
 msgid "Greek Letters"
-msgstr ""
+msgstr "Грецькі літери"
 
 #: ../../src/wxMaximaFrame.cpp:703
 msgid "Greek Letters\tAlt+Shift+G"
-msgstr ""
+msgstr "Грецькі літери\tAlt+Shift+G"
 
 #: ../../src/wxMaximaFrame.cpp:1815
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
+"Вгадати точне число, яке могло б бути представлено цим десятковим дробом"
 
 #: ../../src/wxMaxima.cpp:6123
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file "
 "(*.tex)|*.tex"
 msgstr ""
+"файл HTML (*.html)|*.html|пакетний файл maxima (*.mac)|*.mac|файл LaTeX "
+"(*.tex)|*.tex"
 
 #: ../../src/wxMaximaFrame.cpp:1341
 msgid "Hadamard (element-by-element) product..."
-msgstr ""
+msgstr "Добуток Адамара (поелементний)…"
 
 #: ../../src/wxMaxima.cpp:8004
 msgid "Hadamard Product"
-msgstr ""
+msgstr "Добуток Адамара"
 
 #: ../../src/wxMaxima.cpp:8011
 msgid "Hadamard exponent"
-msgstr ""
+msgstr "Степінь Адамара"
 
 #: ../../src/wxMaximaFrame.cpp:1345
 msgid "Hadamard exponent..."
-msgstr ""
+msgstr "Степінь Адамара…"
 
 #: ../../src/MaximaManual.cpp:260
 #, c-format
@@ -3415,119 +3556,122 @@ msgid ""
 "Have only %li keyword anchors at the end of parsing the maxima manual => Not"
 " caching the result of using the built-in keyword list"
 msgstr ""
+"Маємо лише %li прив'язок ключових слів наприкінці обробки підручника з "
+"maxima => не кешуємо результат використання вбудованого списку ключових слів"
 
 #: ../../src/Configuration.cpp:88 ../../src/ToolBar.cpp:276
 msgid "Heading 5"
-msgstr ""
+msgstr "Заголовок 5"
 
 #: ../../src/Configuration.cpp:87 ../../src/ToolBar.cpp:277
 msgid "Heading 6"
-msgstr ""
+msgstr "Заголовок 6"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:330
 msgid "Help"
-msgstr ""
+msgstr "Довідка"
 
 #: ../../src/ToolBar.cpp:635
 msgid "Help button"
-msgstr ""
+msgstr "Кнопка довідки"
 
 #: ../../src/Worksheet.cpp:1340 ../../src/Worksheet.cpp:1778
 #, c-format
 msgid "Help on \"%s\""
-msgstr ""
+msgstr "Довідка щодо «%s»"
 
 #: ../../src/wxMaximaFrame.cpp:729
 msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr ""
+msgstr "Приховати усі панелі інструментів\tAlt+Shift+-"
 
 #: ../../src/ToolBar.cpp:264
 msgid "Hide Code"
-msgstr ""
+msgstr "Приховати код"
 
 #: ../../src/wxMaximaFrame.cpp:727
 msgid "Hide Code Cells\tAlt+Ctrl+H"
-msgstr ""
+msgstr "Приховати комірки з кодом\tAlt+Ctrl+H"
 
 #: ../../src/Worksheet.cpp:1896
 msgid "Hide Heading 5"
-msgstr ""
+msgstr "Приховати заголовок 5"
 
 #: ../../src/Worksheet.cpp:1907
 msgid "Hide Heading 6"
-msgstr ""
+msgstr "Приховати заголовок 6"
 
 #: ../../src/Worksheet.cpp:1855
 msgid "Hide Part"
-msgstr ""
+msgstr "Приховати частину"
 
 #: ../../src/Worksheet.cpp:1863
 msgid "Hide Section"
-msgstr ""
+msgstr "Приховати розділ"
 
 #: ../../src/Worksheet.cpp:1874
 msgid "Hide Subsection"
-msgstr ""
+msgstr "Приховати підрозділ"
 
 #: ../../src/Worksheet.cpp:1885
 msgid "Hide Subsubsection"
-msgstr ""
+msgstr "Приховати підпідрозділ"
 
 #: ../../src/wxMaximaFrame.cpp:730
 msgid "Hide all panes"
-msgstr ""
+msgstr "Приховати усі панелі"
 
 #: ../../src/Worksheet.cpp:1491
+#, fuzzy
 msgid "Hide cell brackets"
-msgstr ""
+msgstr "Дужка активної комірки"
 
 #: ../../src/Worksheet.cpp:1915
 msgid "Hide contents"
-msgstr ""
+msgstr "Приховати вміст"
 
 #: ../../src/Worksheet.cpp:1552
 msgid "Hide multiplication dots"
-msgstr ""
+msgstr "Приховувати крапки множення"
 
 #: ../../src/Worksheet.cpp:1930 ../../src/Worksheet.cpp:2063
 msgid "Hide yellow tooltip marker for this cell"
-msgstr ""
+msgstr "Приховати жовту позначку підказок для цієї комірки"
 
 #: ../../src/Worksheet.cpp:1937 ../../src/Worksheet.cpp:2069
 msgid "Hide yellow tooltip marker for this message type"
-msgstr ""
+msgstr "Приховати жовту позначку підказок для цього типу повідомлень"
 
 #: ../../src/Configuration.cpp:82
 msgid "Highlight (box)"
-msgstr ""
+msgstr "Підсвітити (box)"
 
 #: ../../src/wxMaxima.cpp:9528
 msgid "Histogram"
-msgstr ""
+msgstr "Гістограма"
 
 #: ../../src/wxMaximaFrame.cpp:232
 msgid "History"
-msgstr ""
+msgstr "Журнал"
 
 #: ../../src/wxMaximaFrame.cpp:709
 msgid "History\tAlt+Shift+I"
-msgstr ""
+msgstr "Журнал\tAlt+Shift+I"
 
 #: ../../src/wxMaximaFrame.cpp:1526
 msgid "Horner's rule"
-msgstr ""
+msgstr "Правило Горнера"
 
 #: ../../src/wxMaxima.cpp:9207
 msgid "How many digits to show:"
-msgstr ""
+msgstr "Скільки цифр показувати:"
 
 #: ../../src/wxMaximaFrame.cpp:759
 msgid "How to display new equations"
-msgstr ""
+msgstr "Як показувати нові рівняння"
 
 #: ../../src/wxMaximaFrame.cpp:1113
 msgid "I/O"
-msgstr ""
+msgstr "В/В"
 
 #: ../../src/wxMaxima.cpp:7062
 msgid ""
@@ -3535,6 +3679,9 @@ msgid ""
 "between parenthesis. The result of the last operation is the return value of"
 " the program."
 msgstr ""
+"Якщо програма не потребує локальних мінних, maxima надає змогу брати команди"
+" у дужки. Результат виконання останньої дії буде повернутим значенням "
+"програми."
 
 #: ../../src/wxMaxima.cpp:7172
 msgid ""
@@ -3543,6 +3690,10 @@ msgid ""
 "\n"
 "array, boolean, integer, fixnum (machine-length integer), float (machine-size floating-point numbers), real or any (which is useful for declaring arrays of any)"
 msgstr ""
+"Якщо тип параметра функції є відомим, при збиранні код функції може бути значно оптимізовано.\n"
+"Відомі типи:\n"
+"\n"
+"array, boolean, integer, fixnum (ціле число із архітектурною довжиною), float (архітектурного розміру числа із рухомою крапкою), real або any (корисно для оголошення масивів довільного типу)"
 
 #: ../../src/MathParser.cpp:890
 msgid ""
@@ -3552,231 +3703,239 @@ msgstr ""
 
 #: ../../src/MaximaManual.cpp:403
 msgid "Ignoring the cache version for the manual anchors."
-msgstr ""
+msgstr "Ігноруємо версію кешу для прив'язок у підручнику."
 
 #: ../../src/Image.cpp:79
 msgid "Image data had zero length!"
-msgstr ""
+msgstr "Дані зображення мають нульову довжину!"
 
 #: ../../src/wxMaxima.cpp:10147 ../../src/wxMaxima.cpp:10855
 msgid ""
 "Image files (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, "
 "*.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
 msgstr ""
+"файли зображень (*.png, *.jpg, *.bmp, *.xpm, *.gif, *.svg, "
+"*.svgz)|*.png;*.jpg;*.bmp;*.xpm;*.gif;*.svg;*.svgz"
 
 #: ../../src/Worksheet.cpp:5509
 msgid "ImageCell without image."
-msgstr ""
+msgstr "ImageCell без зображення."
 
 #: ../../src/MathParser.cpp:347
 msgid "Importing compressed gnuplot sources for an animation"
-msgstr ""
+msgstr "Імпортуємо стиснений початковий код gnuplot для анімації"
 
 #: ../../src/MathParser.cpp:334
 msgid "Importing uncompressed gnuplot sources for an animation"
-msgstr ""
+msgstr "Імпортуємо розпакований початковий код gnuplot для анімації"
 
 #: ../../src/wxMaxima.cpp:7993
 msgid ""
 "In order to save memory the \":\" operator does clone the matrix, not copy it:\n"
 "If you change an element of one matrix the same element will change in all of its clones. copymatrix() instead generates a copy of a matrix: A new matrix that, if changed in any way, won't change the original."
 msgstr ""
+"З метою заощадження пам'яті «:» виконує клонування матриці, а не її копіювання:\n"
+"Якщо ви зміните елемент однієї матриці, той самий елемент зміниться в усіх її клонах. Натомість, copymatrix() створює копію матриці — нову матрицю, яка, якщо до неї внести зміни у будь-який спосіб, не змінюватиметься разом із початковою матрицею."
 
 #: ../../src/wxMaxima.cpp:7404
 msgid ""
 "In order to save memory the : operator doesn't create an individual copy of "
 "the string, but a clone that changes when the original string changes."
 msgstr ""
+"Для заощадження пам'яті оператор «:» не створює окремою копії рядка, а "
+"створює клон, який змінюється разом із початковим рядком."
 
 #: ../../src/wxMaxima.cpp:9629
 msgid "Include columns:"
-msgstr ""
+msgstr "Включити такі стовпці:"
 
 #: ../../src/Worksheet.cpp:2008
 msgid "Increasing function f(x)>x"
-msgstr ""
+msgstr "Функція, що зростає, f(x)>x"
 
 #: ../../src/wxMaxima.cpp:8470
 msgid "Index End:"
-msgstr ""
+msgstr "Кінцевий індекс:"
 
 #: ../../src/wxMaxima.cpp:8470
 msgid "Index Start:"
-msgstr ""
+msgstr "Початковий індекс:"
 
 #: ../../src/wxMaxima.cpp:8471
 msgid "Index Step:"
-msgstr ""
+msgstr "Крок індексу:"
 
 #: ../../src/wxMaxima.cpp:8467 ../../src/wxMaxima.cpp:8480
 msgid "Index variable:"
-msgstr ""
+msgstr "Індекс змінної:"
 
 #: ../../src/wxMaximaFrame.cpp:1949
 msgid "Info about Maxima build"
-msgstr ""
+msgstr "Дані щодо збирання Maxima"
 
 #: ../../src/Worksheet.cpp:2046
 msgid "Inform maxima about facts you know for this symbol"
-msgstr ""
+msgstr "Інформувати maxima про відомі властивості цього символу"
 
 #: ../../src/Worksheet.cpp:1988
 msgid ""
 "Inform maxima about the value of the function at a specific point, e.G. for "
 "declaring initial conditions"
 msgstr ""
+"Інформувати maxima про значення функції у певній точці, наприклад, "
+"оголошення початкових умов"
 
 #: ../../src/wxMaxima.cpp:7793 ../../src/wxMaxima.cpp:7804
 msgid "Initial Condition"
-msgstr ""
+msgstr "Початкова умова"
 
 #: ../../src/wxMaximaFrame.cpp:1270
 msgid "Initial Value Problem (&1)..."
-msgstr ""
+msgstr "Задача Коші (&1)…"
 
 #: ../../src/wxMaximaFrame.cpp:1274
 msgid "Initial Value Problem (&2)..."
-msgstr ""
+msgstr "Задача Коші (&2)…"
 
 #: ../../src/wxMaxima.cpp:9044
 msgid "Initial estimates:"
-msgstr ""
+msgstr "Початкові наближення:"
 
 #: ../../src/wxMaxima.cpp:7840
 msgid "Initial x:"
-msgstr ""
+msgstr "Початкове x:"
 
 #: ../../src/Configuration.cpp:78
 msgid "Input labels"
-msgstr ""
+msgstr "Мітки введення"
 
 #: ../../src/wxMaximaFrame.cpp:314
 msgid "Insert"
-msgstr ""
+msgstr "Вставити"
 
 #: ../../src/wxMaximaFrame.cpp:905
 msgid "Insert &Section Cell\tCtrl+3"
-msgstr ""
+msgstr "Вставити комірку &розділу\tCtrl+3"
 
 #: ../../src/wxMaximaFrame.cpp:901
 msgid "Insert &Text Cell\tCtrl+1"
-msgstr ""
+msgstr "Вставити комірку &тексту\tCtrl+1"
 
 #: ../../src/wxMaximaFrame.cpp:713
 msgid "Insert Cell\tAlt+Shift+C"
-msgstr ""
+msgstr "Вставити комірку\tAlt+Shift+C"
 
 #: ../../src/Worksheet.cpp:1669
 msgid "Insert Heading5 Cell"
-msgstr ""
+msgstr "Вставити комірку Heading5"
 
 #: ../../src/Worksheet.cpp:1671
 msgid "Insert Heading6 Cell"
-msgstr ""
+msgstr "Вставити комірку Heading6"
 
 #: ../../src/wxMaxima.cpp:10854
 msgid "Insert Image"
-msgstr ""
+msgstr "Вставити зображення"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert Image..."
-msgstr ""
+msgstr "Вставити зображення…"
 
 #: ../../src/wxMaximaFrame.cpp:899
 msgid "Insert Input &Cell\tCtrl+0"
-msgstr ""
+msgstr "Вставити комірку &введення\tCtrl+0"
 
 #: ../../src/wxMaximaFrame.cpp:919
 msgid "Insert Page Break"
-msgstr ""
+msgstr "Вставити розрив сторінки"
 
 #: ../../src/wxMaximaFrame.cpp:907
 msgid "Insert S&ubsection Cell\tCtrl+4"
-msgstr ""
+msgstr "Вставити комірку п&ідрозділу\tCtrl+4"
 
 #: ../../src/wxMaximaFrame.cpp:910
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
-msgstr ""
+msgstr "Вставити комірку підпі&дрозділу\tCtrl+5"
 
 #: ../../src/Worksheet.cpp:1662
 msgid "Insert Section Cell"
-msgstr ""
+msgstr "Вставити комірку розділу"
 
 #: ../../src/Worksheet.cpp:1664
 msgid "Insert Subsection Cell"
-msgstr ""
+msgstr "Вставити комірку підрозділу"
 
 #: ../../src/Worksheet.cpp:1667
 msgid "Insert Subsubsection Cell"
-msgstr ""
+msgstr "Вставити комірку підпідрозділу"
 
 #: ../../src/wxMaximaFrame.cpp:903
 msgid "Insert T&itle Cell\tCtrl+2"
-msgstr ""
+msgstr "Вставити комірку з&аголовка\tCtrl+2"
 
 #: ../../src/Worksheet.cpp:1658
 msgid "Insert Text Cell"
-msgstr ""
+msgstr "Вставити текстову комірку (коментар)"
 
 #: ../../src/Worksheet.cpp:1660
 msgid "Insert Title Cell"
-msgstr ""
+msgstr "Вставити комірку заголовка"
 
 #: ../../src/wxMaximaFrame.cpp:913
 msgid "Insert a new heading5 cell"
-msgstr ""
+msgstr "Вставити нову комірку heading5"
 
 #: ../../src/wxMaximaFrame.cpp:915
 msgid "Insert a new heading6 cell"
-msgstr ""
+msgstr "Вставити нову комірку heading6"
 
 #: ../../src/wxMaximaFrame.cpp:900
 msgid "Insert a new input cell"
-msgstr ""
+msgstr "Вставити нову комірку введення команди"
 
 #: ../../src/wxMaximaFrame.cpp:906
 msgid "Insert a new section cell"
-msgstr ""
+msgstr "Вставити нову комірку розділу"
 
 #: ../../src/wxMaximaFrame.cpp:908
 msgid "Insert a new subsection cell"
-msgstr ""
+msgstr "Вставити нову комірку підрозділу"
 
 #: ../../src/wxMaximaFrame.cpp:911
 msgid "Insert a new subsubsection cell"
-msgstr ""
+msgstr "Вставити нову комірку підпідрозділу"
 
 #: ../../src/wxMaximaFrame.cpp:902
 msgid "Insert a new text cell"
-msgstr ""
+msgstr "Вставити нову текстову комірку"
 
 #: ../../src/wxMaximaFrame.cpp:904
 msgid "Insert a new title cell"
-msgstr ""
+msgstr "Вставити нову комірку заголовка"
 
 #: ../../src/wxMaximaFrame.cpp:920
 msgid "Insert a page break"
-msgstr ""
+msgstr "Вставити розрив сторінки"
 
 #: ../../src/wxMaximaFrame.cpp:1164
 msgid "Insert char..."
-msgstr ""
+msgstr "Вставити символ…"
 
 #: ../../src/wxMaximaFrame.cpp:912
 msgid "Insert heading5 Cell\tCtrl+6"
-msgstr ""
+msgstr "Вставити комірку heading5\tCtrl+6"
 
 #: ../../src/wxMaximaFrame.cpp:914
 msgid "Insert heading6 Cell\tCtrl+7"
-msgstr ""
+msgstr "Вставити комірку heading6\tCtrl+7"
 
 #: ../../src/wxMaximaFrame.cpp:917
 msgid "Insert image"
-msgstr ""
+msgstr "Вставити зображення"
 
 #: ../../src/wxMaximaFrame.cpp:916
 msgid "Insert textbased cell"
-msgstr ""
+msgstr "Вставити комірку на основі тексту"
 
 #: ../../src/wxMaxima.cpp:3566
 msgid "Instructed to prefer gnuplot over wgnuplot"
@@ -3788,214 +3947,216 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8898 ../../src/wxMaxima.cpp:8919
 msgid "Integral/Sum:"
-msgstr ""
+msgstr "Інтеграл або сума:"
 
 #: ../../src/wxMaxima.cpp:8986 ../../src/wxMaxima.cpp:10044
 msgid "Integrate"
-msgstr ""
+msgstr "Проінтегрувати"
 
 #: ../../src/wxMaxima.cpp:8980
 msgid "Integrate (risch)"
-msgstr ""
+msgstr "Проінтегрувати (Ріш)"
 
 #: ../../src/wxMaximaFrame.cpp:1454
 msgid "Integrate expression"
-msgstr ""
+msgstr "Проінтегрувати вираз"
 
 #: ../../src/wxMaximaFrame.cpp:1456
 msgid "Integrate expression with Risch algorithm"
-msgstr ""
+msgstr "Проінтегрувати вираз за допомогою алгоритму Ріша"
 
 #: ../../src/wxMaximaFrame.cpp:1869
 msgid "Integrate numerically"
-msgstr ""
+msgstr "Проінтегрувати обчислювальними методами"
 
 #: ../../src/Worksheet.cpp:1588
 msgid "Integrate..."
-msgstr ""
+msgstr "Проінтегрувати…"
 
 #: ../../src/wxMaximaFrame.cpp:1737
 msgid "Interleave"
-msgstr ""
+msgstr "Накладання"
 
 #: ../../src/wxMaximaFrame.cpp:1738
 msgid "Interleave the values of two lists"
-msgstr ""
+msgstr "Накладання значень двох списків"
 
 #: ../../src/wxMaxima.cpp:8612
 msgid "Interleave two lists"
-msgstr ""
+msgstr "Накласти два списки"
 
 #: ../../src/wxMaximaFrame.cpp:1087
 msgid "Interpret like input..."
-msgstr ""
+msgstr "Обробити як вхідні дані…"
 
 #: ../../src/wxMaxima.cpp:7104
 msgid "Interpret maxima's output as input"
-msgstr ""
+msgstr "Обробити виведені maxima дані як вхідні дані"
 
 #: ../../src/wxMaxima.cpp:7502
 msgid "Interpret string as maxima code"
-msgstr ""
+msgstr "Обробити рядок як код maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1089
 msgid "Interpret string..."
-msgstr ""
+msgstr "Інтерпретувати рядок…"
 
 #: ../../src/ToolBar.cpp:231
 msgid "Interrupt"
-msgstr ""
+msgstr "Перервати"
 
 #: ../../src/wxMaximaFrame.cpp:965
 msgid "Interrupt current computation"
-msgstr ""
+msgstr "Перервати поточні обчислення"
 
 #: ../../src/ToolBar.cpp:232
 msgid ""
 "Interrupt current computation. To completely restart maxima press the button"
 " left to this one."
 msgstr ""
+"Перервати поточні обчислення. Щоб повністю перезапустити maxima, натисніть "
+"кнопку, розташовану ліворуч від цієї."
 
 #: ../../src/wxMaxima.cpp:2766
 #, c-format
 msgid "Interrupting maxima: %s"
-msgstr ""
+msgstr "Перериваємо роботу maxima: %s"
 
 #: ../../src/wxMaxima.cpp:8557
 msgid "Introduce a list of actual values into an equation"
-msgstr ""
+msgstr "Вставити список значень до рівняння"
 
 #: ../../src/wxMaximaFrame.cpp:1697
 msgid "Introduce the actual values for variables stored in the list"
-msgstr ""
+msgstr "Вставити значення змінних, збережені у списку"
 
 #: ../../src/wxMaxima.cpp:10062
 msgid "Introduces one or more assignments into an expression"
-msgstr ""
+msgstr "Впроваджує одне або декілька встановлень значень у виразі"
 
 #: ../../src/wxMaxima.cpp:9003
 msgid "Inverse Laplace"
-msgstr ""
+msgstr "Обернене перетворення Лапласа"
 
 #: ../../src/wxMaximaFrame.cpp:1488
 msgid "Inverse Laplace T&ransform..."
-msgstr ""
+msgstr "Обернене п&еретворення Лапласа…"
 
 #: ../../src/wxMaximaFrame.cpp:832
 msgid "Invert worksheet brightness"
-msgstr ""
+msgstr "Інвертувати яскравість робочого аркуша"
 
 #: ../../src/wxMaxima.cpp:7338
 msgid "Is Char 1 greater than Char2, if case is ignored?"
-msgstr ""
+msgstr "Чи є символ 1 більшим за символ 2, якщо ігнорувати регістр?"
 
 #: ../../src/wxMaxima.cpp:7333
 msgid "Is Char 1 greater than Char2?"
-msgstr ""
+msgstr "Чи є символ 1 більшим за символ 2?"
 
 #: ../../src/wxMaxima.cpp:7327
 msgid "Is Char 1 less than Char2, if case is ignored?"
-msgstr ""
+msgstr "Чи є символ 1 меншим за символ 2, якщо ігнорувати регістр?"
 
 #: ../../src/wxMaxima.cpp:7322
 msgid "Is Char 1 less than Char2?"
-msgstr ""
+msgstr "Чи є символ 1 меншим за символ 2?"
 
 #: ../../src/wxMaxima.cpp:7280
 msgid "Is a char?"
-msgstr ""
+msgstr "Чи є символом?"
 
 #: ../../src/wxMaximaFrame.cpp:1115
 msgid "Is a char?..."
-msgstr ""
+msgstr "Чи є символом…"
 
 #: ../../src/Worksheet.cpp:1952
 msgid "Is a complex variable"
-msgstr ""
+msgstr "Є комплексною змінною"
 
 #: ../../src/wxMaxima.cpp:7292
 msgid "Is a digit?"
-msgstr ""
+msgstr "Є цифрою?"
 
 #: ../../src/wxMaximaFrame.cpp:1118
 msgid "Is a digit?..."
-msgstr ""
+msgstr "Є цифрою…"
 
 #: ../../src/wxMaxima.cpp:7304
 msgid "Is a lowercase char?"
-msgstr ""
+msgstr "Є символом нижнього регістру?"
 
 #: ../../src/wxMaxima.cpp:7296
 msgid "Is a printable char?"
-msgstr ""
+msgstr "Є друкованим символом?"
 
 #: ../../src/Worksheet.cpp:1949
 msgid "Is a real variable"
-msgstr ""
+msgstr "Є дійсною змінною"
 
 #: ../../src/wxMaxima.cpp:7300
 msgid "Is a uppercase char?"
-msgstr ""
+msgstr "Чи є символом верхнього регістру?"
 
 #: ../../src/wxMaximaFrame.cpp:1116
 msgid "Is alphabetic?..."
-msgstr ""
+msgstr "Чи є літерою…"
 
 #: ../../src/wxMaximaFrame.cpp:1117
 msgid "Is alphanumeric?..."
-msgstr ""
+msgstr "Чи є літерою або цифрою…"
 
 #: ../../src/wxMaxima.cpp:7284
 msgid "Is an alphabetic char?"
-msgstr ""
+msgstr "Чи є літерою абетки…"
 
 #: ../../src/wxMaxima.cpp:7288
 msgid "Is an alphanumeric char?"
-msgstr ""
+msgstr "Чи є літерою або цифрою?"
 
 #: ../../src/Worksheet.cpp:1991
 msgid "Is an even function"
-msgstr ""
+msgstr "Є непарною функцією"
 
 #: ../../src/Worksheet.cpp:1955
 msgid "Is an imaginary variable"
-msgstr ""
+msgstr "Є уявною змінною"
 
 #: ../../src/Worksheet.cpp:1960
 msgid "Is an integer variable"
-msgstr ""
+msgstr "Є цілим значенням"
 
 #: ../../src/Worksheet.cpp:1993
 msgid "Is an odd function"
-msgstr ""
+msgstr "Є непарною функцією"
 
 #: ../../src/wxMaximaFrame.cpp:1122
 msgid "Is equal?..."
-msgstr ""
+msgstr "Чи є рівним…"
 
 #: ../../src/wxMaximaFrame.cpp:1128
 msgid "Is greater?..."
-msgstr ""
+msgstr "Є більшим…"
 
 #: ../../src/wxMaximaFrame.cpp:1125
 msgid "Is lower?..."
-msgstr ""
+msgstr "Є нижнім…"
 
 #: ../../src/wxMaximaFrame.cpp:1121
 msgid "Is lowercase?..."
-msgstr ""
+msgstr "Є нижнім регістром…"
 
 #: ../../src/Worksheet.cpp:1962
 msgid "Is no integer variable"
-msgstr ""
+msgstr "Не є цілим значенням"
 
 #: ../../src/wxMaximaFrame.cpp:1119
 msgid "Is printable?..."
-msgstr ""
+msgstr "Є друкованим…"
 
 #: ../../src/wxMaximaFrame.cpp:1120
 msgid "Is uppercase?..."
-msgstr ""
+msgstr "Є верхнім регістром…"
 
 #: ../../src/Worksheet.cpp:6256
 msgid "Issuing the active cell's undo function"
@@ -4007,47 +4168,47 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:8598 ../../src/wxMaxima.cpp:8604
 msgid "Item"
-msgstr ""
+msgstr "Пункт"
 
 #: ../../src/wxMaxima.cpp:8581
 msgid "Iterator name:"
-msgstr ""
+msgstr "Назва ітератора:"
 
 #: ../../src/wxMaximaFrame.cpp:1048
 msgid "Jump to first error"
-msgstr ""
+msgstr "Перейти до першої помилки"
 
 #: ../../src/wxMaximaFrame.cpp:1049
 msgid "Jump to the first cell Maxima has reported an error in."
-msgstr ""
+msgstr "Перейти до першої комірки, щодо якої Maxima повідомлено про помилку."
 
 #: ../../src/wxMaxima.cpp:8960
 msgid "LCM"
-msgstr ""
+msgstr "НСК"
 
 #: ../../src/wxMaximaFrame.cpp:1407
 msgid "L[1] Norm (complex)"
-msgstr ""
+msgstr "Норма L[1] (комплексна)"
 
 #: ../../src/wxMaximaFrame.cpp:1406
 msgid "L[1] Norm (real)"
-msgstr ""
+msgstr "Норма L[1] (дійсна)"
 
 #: ../../src/wxMaximaFrame.cpp:1409
 msgid "L[inf] Norm (complex)"
-msgstr ""
+msgstr "Норма L[inf] (комплексна)"
 
 #: ../../src/wxMaximaFrame.cpp:1408
 msgid "L[inf] Norm (real)"
-msgstr ""
+msgstr "Норма L[inf] (дійсна)"
 
 #: ../../src/wxMaximaFrame.cpp:1025
 msgid "Labels"
-msgstr ""
+msgstr "Мітки"
 
 #: ../../src/wxMaxima.cpp:7090
 msgid "Lambda"
-msgstr ""
+msgstr "Λ"
 
 #: ../../src/wxMaxima.cpp:7091
 msgid ""
@@ -4055,102 +4216,105 @@ msgid ""
 "This is useful if you want to use a function only once, perhaps as a parameter to another function and don't need it to be named.\n"
 "Also you can fill a variable with a lambda() construct, effectively generating a function pointer: A variable that can be used as a function, and filled with a different function, if needed."
 msgstr ""
+"Лямбда створює функцію, але не надає їй назви.\n"
+"Це корисно, якщо вам потрібна функція лише на раз, наприклад, як параметр іншої функції, і цій функції не потрібна назва.\n"
+"Крім того, ви можете заповнити змінну конструкцією lambda(), насправді створивши вказівник на функцію — змінну, якою можна буде скористатися як функцією і яку можна буде заповнити іншою функцією, якщо у цьому виникне потреба."
 
 #: ../../src/wxMaxima.cpp:8997
 msgid "Laplace"
-msgstr ""
+msgstr "Перетворення Лапласа"
 
 #: ../../src/wxMaximaFrame.cpp:1484
 msgid "Laplace &Transform..."
-msgstr ""
+msgstr "&Перетворення Лапласа…"
 
 #: ../../src/wxMaximaFrame.cpp:1718
 msgid "Last"
-msgstr ""
+msgstr "Останній"
 
 #: ../../src/wxMaxima.cpp:3006
 #, c-format
 msgid "Last message from maxima's stderr: %s"
-msgstr ""
+msgstr "Останнє повідомлення зі stderr maxima: %s"
 
 #: ../../src/wxMaxima.cpp:2993
 #, c-format
 msgid "Last message from maxima's stdout: %s"
-msgstr ""
+msgstr "Останнє повідомлення зі stdout maxima: %s"
 
 #: ../../src/wxMaximaFrame.cpp:1720
 msgid "Last n"
-msgstr ""
+msgstr "Останні n"
 
 #: ../../src/wxMaxima.cpp:10400
 msgid "Last non-whitespace is a question mark"
-msgstr ""
+msgstr "Останнім непробільним символом є знак питання"
 
 #: ../../src/wxMaxima.cpp:4899
 #, c-format
 msgid "Launching the system's default help browser as %s."
-msgstr ""
+msgstr "Запускаємо типовий навігатор довідкою системи як %s."
 
 #: ../../src/wxMaxima.cpp:4909
 msgid "Launching the system's default help browser failed."
-msgstr ""
+msgstr "Не вдалося запустити типову програму для перегляду довідки у системі."
 
 #: ../../src/wxMaximaFrame.cpp:1493
 msgid "Least Common Multiple..."
-msgstr ""
+msgstr "Найменше спільне кратне…"
 
 #: ../../src/wxMaxima.cpp:9587
 msgid "Least Squares Fit"
-msgstr ""
+msgstr "Наближення за методом найменших квадратів"
 
 #: ../../src/wxMaxima.cpp:7982 ../../src/wxMaxima.cpp:7987
 #: ../../src/wxMaxima.cpp:8007 ../../src/wxMaxima.cpp:8013
 msgid "Left Matrix:"
-msgstr ""
+msgstr "Ліва матриця:"
 
 #: ../../src/wxMaxima.cpp:8191
 msgid "Left end"
-msgstr ""
+msgstr "Лівий кінець"
 
 #: ../../src/wxMaximaFrame.cpp:1297
 msgid "Left side to the \"=\""
-msgstr ""
+msgstr "Ліва частина рівності до «=»"
 
 #: ../../src/wxMaximaFrame.cpp:1741
 msgid "Length"
-msgstr ""
+msgstr "Довжина"
 
 #: ../../src/wxMaximaFrame.cpp:1104 ../../src/wxMaximaFrame.cpp:1167
 msgid "Length..."
-msgstr ""
+msgstr "Довжина…"
 
 #: ../../src/wxMaxima.cpp:7421
 msgid "Length:"
-msgstr ""
+msgstr "Довжина:"
 
 #: ../../src/wxMaximaFrame.cpp:1032
 msgid "Letrules"
-msgstr ""
+msgstr "Letrules"
 
 #: ../../src/Worksheet.cpp:1976
 msgid "Likely to be the main variable"
-msgstr ""
+msgstr "Ймовірно, є основною змінною"
 
 #: ../../src/wxMaxima.cpp:9028
 msgid "Limit"
-msgstr ""
+msgstr "Границя"
 
 #: ../../src/wxMaxima.cpp:7256
 msgid "Lisp format string:"
-msgstr ""
+msgstr "Рядок форматування lisp:"
 
 #: ../../src/wxMaxima.cpp:7258
 msgid "Lisp format strings are more powerful than c++ format strings"
-msgstr ""
+msgstr "Рядки форматування lisp є потужнішими за рядки форматування c++"
 
 #: ../../src/wxMaxima.cpp:5066
 msgid "Lisp mode."
-msgstr ""
+msgstr "Режим lisp."
 
 #: ../../src/wxMaximaFrame.cpp:1010 ../../src/wxMaximaFrame.cpp:1012
 msgid "Lisp normally frees memory only when it has time or runs out of space"
@@ -4159,171 +4323,174 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:3691
 #, c-format
 msgid "Lisp version: %s"
-msgstr ""
+msgstr "Версія Lisp: %s"
 
 #: ../../src/wxMaxima.cpp:8435 ../../src/wxMaxima.cpp:8539
 #: ../../src/wxMaxima.cpp:8548 ../../src/wxMaxima.cpp:8565
 #: ../../src/wxMaxima.cpp:8574 ../../src/wxMaxima.cpp:8594
 #: ../../src/wxMaxima.cpp:8599 ../../src/wxMaxima.cpp:8603
 msgid "List"
-msgstr ""
+msgstr "Список"
 
 #: ../../src/wxMaxima.cpp:8608 ../../src/wxMaxima.cpp:8613
 msgid "List #1"
-msgstr ""
+msgstr "Список 1"
 
 #: ../../src/wxMaxima.cpp:8609 ../../src/wxMaxima.cpp:8614
 msgid "List #2"
-msgstr ""
+msgstr "Список 2"
 
 #: ../../src/wxMaximaFrame.cpp:1200
 msgid "List directory"
-msgstr ""
+msgstr "Вивести список каталогу"
 
 #: ../../src/wxMaximaFrame.cpp:1205
 msgid "List directory..."
-msgstr ""
+msgstr "Вивести список каталогу…"
 
 #: ../../src/wxMaxima.cpp:7385 ../../src/wxMaxima.cpp:7389
 msgid "List of char to String"
-msgstr ""
+msgstr "Список символів у рядок"
 
 #: ../../src/wxMaximaFrame.cpp:1150
 msgid "List of chars to string..."
-msgstr ""
+msgstr "Список символів у рядок…"
 
 #: ../../src/wxMaxima.cpp:7386
 msgid "List of chars:"
-msgstr ""
+msgstr "Список символів:"
 
 #: ../../src/wxMaxima.cpp:8559
 msgid "List with values"
-msgstr ""
+msgstr "Список зі значеннями"
 
 #: ../../src/wxMaxima.cpp:8509 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533 ../../src/wxMaxima.cpp:8579
 msgid "List:"
-msgstr ""
+msgstr "Список:"
 
 #: ../../src/wxMaxima.cpp:6200
 msgid "Load Package"
-msgstr ""
+msgstr "Завантажити пакунок"
 
 #: ../../src/wxMaximaFrame.cpp:613
 msgid "Load Recent Package"
-msgstr ""
+msgstr "Завантажити нещодавній пакунок"
 
 #: ../../src/wxMaximaFrame.cpp:616
 msgid "Load a Maxima file using the batch command"
-msgstr ""
+msgstr "Завантажити файл програми Maxima за допомогою команди batch"
 
 #: ../../src/wxMaximaFrame.cpp:611
 msgid "Load a Maxima package file"
-msgstr ""
+msgstr "Завантажити файл пакунка Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1678
 msgid "Load a list from a csv file"
-msgstr ""
+msgstr "Завантажити список з файла CSV"
 
 #: ../../src/wxMaximaFrame.cpp:1324 ../../src/wxMaximaFrame.cpp:1330
 msgid "Load a matrix from a csv file"
-msgstr ""
+msgstr "Завантажити матрицю з файла CSV"
 
 #: ../../src/wxMaximaFrame.cpp:1381 ../../src/wxMaximaFrame.cpp:1382
 msgid "Load lapack"
-msgstr ""
+msgstr "Завантажити lapack"
 
 #: ../../src/wxMaxima.cpp:7208
 msgid "Load lisp code"
-msgstr ""
+msgstr "Завантажити код lisp"
 
 #: ../../src/wxMaximaFrame.cpp:1092
 msgid "Load lisp..."
-msgstr ""
+msgstr "Завантажити lisp…"
 
 #: ../../src/wxMaximaFrame.cpp:1198
+#, fuzzy
 msgid "Load the file/dir operations (operatingsystem)"
-msgstr ""
+msgstr "Завантажити операції з файлами/каталогами"
 
 #: ../../src/wxMaximaFrame.cpp:1187
+#, fuzzy
 msgid "Load the regular expression package (sregex)"
-msgstr ""
+msgstr "Завантажити процесор формальних виразів"
 
 #: ../../src/wxMaximaFrame.cpp:1224
+#, fuzzy
 msgid "Load the translation generator (gentran)"
-msgstr ""
+msgstr "Завантажити генератор перекладів"
 
 #: ../../src/wxMaxima.cpp:8219
 msgid "Loop variable"
-msgstr ""
+msgstr "Змінна циклу"
 
 #: ../../src/wxMaxima.cpp:7778 ../../src/wxMaxima.cpp:10040
 msgid "Lower bound:"
-msgstr ""
+msgstr "Нижня межа:"
 
 #: ../../src/wxMaximaFrame.cpp:1127
 msgid "Lower, ignoring case?..."
-msgstr ""
+msgstr "Менше, якщо враховувати регістр…"
 
 #: ../../src/wxMaximaFrame.cpp:1448
 msgid "M&atrix"
-msgstr ""
+msgstr "М&атриця"
 
 #: ../../src/wxMaxima.cpp:7153
 msgid "Macro contents:"
-msgstr ""
+msgstr "Вміст макроса:"
 
 #: ../../src/wxMaxima.cpp:7148
 msgid "Macro name:"
-msgstr ""
+msgstr "Назва макроса:"
 
 #: ../../src/wxMaximaFrame.cpp:1024
 msgid "Macros"
-msgstr ""
+msgstr "Макроси"
 
 #: ../../src/wxMaximaFrame.cpp:697
 msgid "Main Toolbar\tAlt+Shift+B"
-msgstr ""
+msgstr "Головна панель інструментів\tAlt+Shift+B"
 
 #: ../../src/wxMaxima.cpp:7906
 msgid "Make a function value at a specific point known"
-msgstr ""
+msgstr "Відоме значення функції у вказаній точці"
 
 #: ../../src/Worksheet.cpp:2028
 msgid "Make an eventual ev() evaluate this"
-msgstr ""
+msgstr "Обчислити наприкінці за допомогою ev()"
 
 #: ../../src/wxMaximaFrame.cpp:1070
 msgid "Make function local..."
-msgstr ""
+msgstr "Зробити функцію локальною…"
 
 #: ../../src/wxMaxima.cpp:8207
 msgid "Map"
-msgstr ""
+msgstr "Відобразити"
 
 #: ../../src/wxMaxima.cpp:8215
 msgid "Map an expression"
-msgstr ""
+msgstr "Відобразити виразом"
 
 #: ../../src/wxMaximaFrame.cpp:1443
 msgid "Map function to a matrix"
-msgstr ""
+msgstr "Відобразити функцію на матрицю"
 
 #: ../../src/wxMaximaFrame.cpp:1446
 msgid "Map function to a matrix, affecting all of its clones"
-msgstr ""
+msgstr "Відобразити функцію у матрицю з врахуванням усіх її клонів"
 
 #: ../../src/Configuration.cpp:109
 msgid "Math Default"
-msgstr ""
+msgstr "Типовий математичний"
 
 #: ../../src/wxMaximaFrame.cpp:286
 msgid "Mathematical Symbols"
-msgstr ""
+msgstr "Математичні символи"
 
 #: ../../src/ToolBar.cpp:270
 msgid "Maths"
-msgstr ""
+msgstr "Формули"
 
 #: ../../src/wxMaxima.cpp:7945 ../../src/wxMaxima.cpp:8022
 #: ../../src/wxMaxima.cpp:8027 ../../src/wxMaxima.cpp:8032
@@ -4335,54 +4502,54 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8096 ../../src/wxMaxima.cpp:8101
 #: ../../src/wxMaxima.cpp:8152 ../../src/wxMaxima.cpp:8182
 msgid "Matrix"
-msgstr ""
+msgstr "Матриця"
 
 #: ../../src/wxMaxima.cpp:7986
 msgid "Matrix Exponent"
-msgstr ""
+msgstr "Степінь матриці"
 
 #: ../../src/wxMaximaFrame.cpp:1339
 msgid "Matrix exponent..."
-msgstr ""
+msgstr "Степінь матриці…"
 
 #: ../../src/wxMaximaFrame.cpp:1329
 msgid "Matrix from csv file"
-msgstr ""
+msgstr "Матриця з файла CSV"
 
 #: ../../src/wxMaximaFrame.cpp:1323
 msgid "Matrix from csv file..."
-msgstr ""
+msgstr "Матриця з файла CSV…"
 
 #: ../../src/wxMaxima.cpp:8137
 msgid "Matrix map"
-msgstr ""
+msgstr "Застосувати до матриці"
 
 #: ../../src/wxMaxima.cpp:9630
 msgid "Matrix name:"
-msgstr ""
+msgstr "Назва матриці:"
 
 #: ../../src/wxMaximaFrame.cpp:798
 msgid "Matrix parenthesis"
-msgstr ""
+msgstr "Дужки матриці"
 
 #: ../../src/wxMaximaFrame.cpp:1331
 msgid "Matrix to csv file"
-msgstr ""
+msgstr "Матриця до файла CSV"
 
 #: ../../src/wxMaximaFrame.cpp:1334
 msgid "Matrix to file or Matrix from file"
-msgstr ""
+msgstr "Матриця у файл або матриця з файла"
 
 #: ../../src/wxMaximaFrame.cpp:1761
 msgid "Matrix to nested List"
-msgstr ""
+msgstr "Матрицю у вкладений список"
 
 #: ../../src/wxMaxima.cpp:7956 ../../src/wxMaxima.cpp:7961
 #: ../../src/wxMaxima.cpp:7966 ../../src/wxMaxima.cpp:7971
 #: ../../src/wxMaxima.cpp:7976 ../../src/wxMaxima.cpp:8000
 #: ../../src/wxMaxima.cpp:8136
 msgid "Matrix:"
-msgstr ""
+msgstr "Матриця:"
 
 #: ../../src/wxMaxima.cpp:8627
 msgid ""
@@ -4391,189 +4558,196 @@ msgid ""
 "\n"
 "This command tells maxima that the nouns in this expression shall now be evaluated, too."
 msgstr ""
+"Maxima уможливлює визначення функцій як необчислюваних («nouns»). Це означає, що maxima, якщо такі трапляться, не обчислюватиме їхнє значення автоматично.\n"
+"Серед способів визначення функції як необчислюваної є оголошення із початковим ' та взяття функції у дужки, '().\n"
+"\n"
+"Ця команда вказує maxima, що необчислювані функції у цьому виразі слід обчислити."
 
 #: ../../src/wxMaxima.cpp:3473
 #, c-format
 msgid "Maxima architecture: %s"
-msgstr ""
+msgstr "Архітектура Maxima: %s"
 
 #: ../../src/StatusBar.cpp:252
 msgid "Maxima asks a question"
-msgstr ""
+msgstr "У Maxima є питання"
 
 #: ../../src/wxMaxima.cpp:4066
 msgid "Maxima asks a question!"
-msgstr ""
+msgstr "У Maxima є питання!"
 
 #: ../../src/wxMaxima.cpp:7118
 msgid ""
 "Maxima automatically simplifies expressions it gets as input and then tries to evaluate their value. The ' operator tells maxima that we want a command to be in noun form, which means: stand here as is, and unevaluated.\n"
 "The ' operator can be undone by using the '' operator."
 msgstr ""
+"Maxima автоматично спрощує вирази, які отримує на вході, а потім намагається обчислити їхнє значення. Оператор «'» вказує maxima на те, що нам потрібна команда у необчислюваній формі, що означає таке: залишити як є і не обчислювати.\n"
+"Дію оператора «'» можна скасувати за допомогою оператора «''»."
 
 #: ../../src/wxMaxima.cpp:3304
 msgid "Maxima didn't attempt to authenticate!"
-msgstr ""
+msgstr "Maxima не виконала спроби розпізнавання!"
 
 #: ../../src/Configuration.cpp:84
 msgid "Maxima errors"
-msgstr ""
+msgstr "Помилки Maxima"
 
 #: ../../src/wxMaxima.cpp:3289
 msgid "Maxima has authenticated!"
-msgstr ""
+msgstr "Maxima розпізнано!"
 
 #: ../../src/wxMaxima.cpp:10533
 msgid "Maxima has finished calculating."
-msgstr ""
+msgstr "Maxima завершила обчислення."
 
 #: ../../src/wxMaxima.cpp:5832
 msgid "Maxima has issued an error!"
-msgstr ""
+msgstr "Maxima повідомлено про помилку!"
 
 #: ../../src/wxMaxima.cpp:3696
 #, c-format
 msgid "Maxima has loaded the file %s."
-msgstr ""
+msgstr "Maxima завантажено файл %s."
 
 #: ../../src/wxMaxima.cpp:3382
 msgid "Maxima has sent a new variable value."
-msgstr ""
+msgstr "Maxima надіслано нове значення змінної."
 
 #: ../../src/MaximaManual.cpp:552
 msgid "Maxima help file not found!"
-msgstr ""
+msgstr "Не знайдено файла довідки Maxima!"
 
 #: ../../src/wxMaximaFrame.cpp:1043
 msgid "Maxima input"
-msgstr ""
+msgstr "Команда Maxima"
 
 #: ../../src/StatusBar.cpp:236
 msgid "Maxima is calculating"
-msgstr ""
+msgstr "Maxima виконує обчислення"
 
 #: ../../src/wxMaxima.cpp:5068
 msgid "Maxima is ready for input."
-msgstr ""
+msgstr "Maxima готова до введення команд."
 
 #: ../../src/Dirstructure.cpp:144
 #, c-format
 msgid "Maxima not found as %s"
-msgstr ""
+msgstr "Maxima не знайдено як %s"
 
 #: ../../src/wxMaxima.cpp:6211
 msgid "Maxima package (*.mac)|*.mac"
-msgstr ""
+msgstr "пакунок Maxima (*.mac)|*.mac"
 
 #: ../../src/wxMaxima.cpp:6202
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
-msgstr ""
+msgstr "пакунок Maxima (*.mac)|*.mac|пакунок Lisp (*.lisp)|*.lisp|усі файли|*"
 
 #: ../../src/wxMaxima.cpp:3012
 msgid "Maxima process terminated unexpectedly."
-msgstr ""
+msgstr "Процес Maxima несподівано перервав роботу."
 
 #: ../../src/Configuration.cpp:79
 msgid "Maxima question labels"
-msgstr ""
+msgstr "Мітки питань Maxima"
 
 #: ../../src/wxMaxima.cpp:3380
 msgid "Maxima sends a new set of auto-completable symbols."
-msgstr ""
+msgstr "Maxima надсилає новий набір автоматично заповнюваних символів."
 
 #: ../../src/wxMaxima.cpp:3908
 msgid "Maxima sends us a new set of variables for the watch list."
-msgstr ""
+msgstr "Maxima надсилає новий набір змінних для списку спостереження."
 
 #: ../../src/wxMaximaFrame.cpp:1944
 msgid "Maxima shows help in a browser"
-msgstr ""
+msgstr "Maxima показує довідку у браузері"
 
 #: ../../src/wxMaximaFrame.cpp:1940
 msgid "Maxima shows help in a sidebar"
-msgstr ""
+msgstr "Maxima показує довідку на бічній панелі"
 
 #: ../../src/wxMaximaFrame.cpp:1935
 msgid "Maxima shows help in the console"
-msgstr ""
+msgstr "Maxima показує довідку у консолі"
 
 #: ../../src/StatusBar.cpp:232
 msgid "Maxima started. Waiting for authentication..."
-msgstr ""
+msgstr "Запущено Maxima. Очікуємо на розпізнавання…"
 
 #: ../../src/StatusBar.cpp:212
 msgid "Maxima started. Waiting for connection..."
-msgstr ""
+msgstr "Maxima запущено. Очікуємо на встановлення з'єднання…"
 
 #: ../../src/StatusBar.cpp:228
 msgid "Maxima started. Waiting for initial prompt..."
-msgstr ""
+msgstr "Maxima запущено. Очікуємо на початковий запит…"
 
 #: ../../src/wxMaximaFrame.cpp:1231
+#, fuzzy
 msgid "Maxima to other language"
-msgstr ""
+msgstr "maxima до іншої мови"
 
 #: ../../src/wxMaxima.cpp:7213
 msgid "Maxima to string"
-msgstr ""
+msgstr "Maxima у рядок"
 
 #: ../../src/wxMaxima.cpp:3397
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima user configuration is located in directory %s"
-msgstr ""
+msgstr "Налаштування користувача Maxima зберігаються у каталозі %s"
 
 #: ../../src/wxMaxima.cpp:3443
 #, c-format
 msgid "Maxima uses temp directory %s"
-msgstr ""
+msgstr "Maxima використовує тимчасовий каталог %s"
 
 #: ../../src/wxMaxima.cpp:3469
 #, c-format
 msgid "Maxima version: %s"
-msgstr ""
+msgstr "Версія Maxima: %s"
 
 #: ../../src/MaximaManual.cpp:390
 #, c-format
 msgid "Maxima version: %s, Anchors cache version"
-msgstr ""
+msgstr "Версія Maxima: %s, прив'язує версію кешу"
 
 #: ../../src/wxMaximaFrame.cpp:1925
 msgid "Maxima vs. Programming languages"
-msgstr ""
+msgstr "Maxima і мови програмування"
 
 #: ../../src/Configuration.cpp:83
 msgid "Maxima warnings"
-msgstr ""
+msgstr "Попередження Maxima"
 
 #: ../../src/wxMaxima.cpp:3687
 #, c-format
 msgid "Maxima was compiled using %s"
-msgstr ""
+msgstr "Maxima було зібрано з використанням %s"
 
 #: ../../src/wxMaxima.cpp:3487
 #, c-format
 msgid "Maxima's HTML manuals are in directory %s"
-msgstr ""
+msgstr "Підручники з Maxima у форматі HTML зберігаються у каталозі %s"
 
 #: ../../src/wxMaxima.cpp:3099
 #, c-format
 msgid "Maxima's PID is %li"
-msgstr ""
+msgstr "Ідентифікатор процесу Maxima — %li"
 
 #: ../../src/wxMaxima.cpp:3681
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's demo files are located in directory %s"
-msgstr ""
+msgstr "Спільні файли Maxima зберігаються у каталозі %s"
 
 #: ../../src/wxMaxima.cpp:3478
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's manual is located in directory %s"
-msgstr ""
+msgstr "Підручник з Maxima зберігається у каталозі %s"
 
 #: ../../src/wxMaxima.cpp:3670
-#, c-format
+#, fuzzy, c-format
 msgid "Maxima's share files are located in directory %s"
-msgstr ""
+msgstr "Спільні файли Maxima зберігаються у каталозі %s"
 
 #: ../../src/StatusBar.cpp:66
 msgid ""
@@ -4585,6 +4759,14 @@ msgid ""
 "not only intercepts connections from the outside, but also to intercept "
 "connections between two programs that run on the same computer."
 msgstr ""
+"Maxima, програма, яка виконує обчислення, і wxMaxima, програма, яка показує "
+"робочий аркуш, працюють у різних процесах системи. Це означає, що навіть "
+"якщо роботу maxima буде завершено у аварійному режимі, wxMaxima (а отже і "
+"робочий аркуш) не постраждають. Обмін даними між програмами відбувається за "
+"допомогою сокета у локальній мережі. Цього разу такий сокет не вдалося "
+"створити через роботу брандмауера, який налаштовано не лише на перехоплення "
+"з'єднань іззовні, але і на перехоплення з'єднань між програмами, які "
+"працюють на одному комп'ютері."
 
 #: ../../src/StatusBar.cpp:75
 msgid ""
@@ -4599,480 +4781,503 @@ msgid ""
 "might be that maxima cannot be found (see wxMaxima's Configuration dialogue "
 "for a way to specify maxima's location) or isn't in a working order."
 msgstr ""
+"Maxima, програма, яка виконує обчислення, і wxMaxima, програма, яка показує "
+"робочий аркуш, працюють у різних процесах системи. Це означає, що навіть "
+"якщо роботу maxima буде завершено у аварійному режимі, wxMaxima (а отже і "
+"робочий аркуш) не постраждають. Зараз ці дві програми не з'єднано одна з "
+"одною. Це, ймовірно, означає, що maxima усе ще запускається, або що maxima "
+"не вдалося запустити. Крім того, проблему може бути спричинено роботою "
+"брандмауера, який налаштовано не лише на перехоплення з'єднань іззовні, але "
+"і на перехоплення з'єднань між програмами, які працюють на одному "
+"комп'ютері. Ще однією причиною неможливості запуску maxima може бути те, що "
+"виконуваний файл maxima не вдалося знайти (див. діалогове вікно "
+"налаштовування wxMaxima, де можна вказати розташування виконуваного файла "
+"maxima) або цей файл непридатний до запуску."
 
 #: ../../src/StatusBar.cpp:61
 msgid ""
 "Maxima, the program that does the actual mathematics is started as a separate process. This has the advantage that an eventual crash of maxima cannot harm wxMaxima, which displays the worksheet.\n"
 "This icon indicates if data is transferred between maxima and wxMaxima."
 msgstr ""
+"Maxima, програму, яка виконує обчислення, запущено у окремому процесі. Перевагою такої схеми запуску є те, що аварійне завершення роботи maxima не зашкодить даним у програмі wxMaxima, яка показує робочий аркуш.\n"
+"Ця піктограма є індикатором передавання даних між maxima і wxMaxima."
 
 #: ../../src/wxMaxima.cpp:9228
 msgid "Maximum absolute value printed without exponent"
 msgstr ""
+"Максимальне абсолютне значення, яке можна показувати без суфікса степеня 10"
 
 #: ../../src/wxMaxima.cpp:9230
 msgid "Maximum number of digits to be displayed:"
-msgstr ""
+msgstr "Максимальна показана кількість цифр:"
 
 #: ../../src/wxMaxima.cpp:9568
 msgid "Mean:"
-msgstr ""
+msgstr "Середнє:"
 
 #: ../../src/wxMaximaFrame.cpp:1924
 msgid "Memoizing"
-msgstr ""
+msgstr "Мемоізація"
 
 #: ../../src/wxMaximaFrame.cpp:1013
+#, fuzzy
 msgid "Memory"
-msgstr ""
+msgstr "С&порожнити пам'ять"
 
 #: ../../src/Worksheet.cpp:1409 ../../src/wxMaximaFrame.cpp:935
 msgid "Merge Cells"
-msgstr ""
+msgstr "Об'єднати комірки"
 
 #: ../../src/wxMaxima.cpp:5780
 msgid "Message from the stdout of Maxima: "
-msgstr ""
+msgstr "Повідомлення зі stdout Maxima: "
 
 #: ../../src/wxMaximaFrame.cpp:1326
 msgid "Methods of generating a matrix"
-msgstr ""
+msgstr "Способи породження матриці"
 
 #: ../../src/Worksheet.cpp:6866
 #, c-format
 msgid "Middle-click clipboard data: %s"
-msgstr ""
+msgstr "Дані буфера клацання середньою кнопкою: %s"
 
 #: ../../src/wxMaxima.cpp:9226
 msgid "Minimum absolute value printed without exponent:"
 msgstr ""
+"Мінімальне абсолютне значення, яке можна показувати без суфікса степеня 10:"
 
 #: ../../src/wxMaxima.cpp:10449 ../../src/wxMaxima.cpp:10451
 msgid "Mismatched parenthesis"
-msgstr ""
+msgstr "Незбалансована дужка"
 
 #: ../../src/wxMaximaFrame.cpp:1352
 msgid "Multiplication, exponent and similar"
-msgstr ""
+msgstr "Множення, піднесення до степеня і подібне"
 
 #: ../../src/Worksheet.cpp:1998
 msgid "Multiplicative function: f(a*b)=f(a)*f(b)"
-msgstr ""
+msgstr "Мультиплікативна функція: f(a*b)=f(a)*f(b)"
 
 #: ../../src/wxMaximaFrame.cpp:1338
 msgid "Multiply matrices..."
-msgstr ""
+msgstr "Перемножити матриці…"
 
 #: ../../src/wxMaxima.cpp:7981
 msgid "Multiply two matrices"
-msgstr ""
+msgstr "Перемножити дві матриці"
 
 #: ../../src/wxMaxima.cpp:9581
 msgid "Multivariate linear regression"
-msgstr ""
+msgstr "Багатовимірна лінійна регресія"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Name of t:"
-msgstr ""
+msgstr "Назва t:"
 
 #: ../../src/wxMaxima.cpp:7838
 msgid "Name of x:"
-msgstr ""
+msgstr "Назва x:"
 
 #: ../../src/wxMaximaFrame.cpp:1320 ../../src/wxMaximaFrame.cpp:1759
 msgid "Nested list to Matrix"
-msgstr ""
+msgstr "Вкладений список у матрицю"
 
 #: ../../src/wxMaximaFrame.cpp:769 ../../src/wxMaximaFrame.cpp:1053
 msgid "Never"
-msgstr ""
+msgstr "Ніколи"
 
 #: ../../src/wxMaxima.cpp:6534
 msgid "Never autosubscript this variable"
-msgstr ""
+msgstr "Ніколи не переводити цю змінну у нижній індекс автоматично"
 
 #: ../../src/wxMaximaFrame.cpp:776
 msgid "Never display this variable with subscript"
-msgstr ""
+msgstr "Ніколи не показувати цю змінну із нижнім індексом"
 
 #: ../../src/Worksheet.cpp:1469 ../../src/Worksheet.cpp:1843
 msgid "Never offer known answers"
-msgstr ""
+msgstr "Ніколи не пропонувати відомі відповіді"
 
 #: ../../src/ToolBar.cpp:174
 msgid "New"
-msgstr ""
+msgstr "Створити"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "New\tCtrl+N"
-msgstr ""
+msgstr "Створити\tCtrl+N"
 
 #: ../../src/ToolBar.cpp:611
 msgid "New button"
-msgstr ""
+msgstr "Нова кнопка"
 
 #: ../../src/wxMaxima.cpp:2483
 msgid "New connection attempt whilst already connected."
-msgstr ""
+msgstr "Спроба нового з'єднання, коли з'єднання вже встановлено."
 
 #: ../../src/wxMaxima.cpp:2491
+#, fuzzy
 msgid ""
 "New connection attempt, but no currently no socket maxima could connect to."
-msgstr ""
+msgstr "Нова спроба з'єднання, але зараз немає запущеного процесу maxima."
 
 #: ../../src/wxMaxima.cpp:2487
 msgid "New connection attempt, but no currently running maxima process."
-msgstr ""
+msgstr "Нова спроба з'єднання, але зараз немає запущеного процесу maxima."
 
 #: ../../src/ToolBar.cpp:174
 msgid "New document"
-msgstr ""
+msgstr "Новий документ"
 
 #: ../../src/wxMaxima.cpp:3899
 #, c-format
 msgid "New maxima Operators detected: %s"
-msgstr ""
+msgstr "Виявлено нові оператори maxima: %s"
 
 #: ../../src/wxMaxima.cpp:7390
 msgid "New part:"
-msgstr ""
+msgstr "Нова частина:"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8920
 #: ../../src/wxMaxima.cpp:9000 ../../src/wxMaxima.cpp:9005
 msgid "New variable:"
-msgstr ""
+msgstr "Нова змінна:"
 
 #: ../../src/wxMaximaFrame.cpp:929
 msgid "Next Command\tAlt+Down"
-msgstr ""
+msgstr "Наступна команда\tAlt+Down"
 
 #: ../../src/wxMaximaFrame.cpp:748
 msgid "Nice Graphical Equations"
-msgstr ""
+msgstr "Чудові графічні рівняння"
 
 #: ../../src/wxMaximaFrame.cpp:1550
 msgid "No"
-msgstr ""
+msgstr "Ні"
 
 #: ../../src/Worksheet.cpp:1972
 msgid "No Array"
-msgstr ""
+msgstr "Не масив"
 
 #: ../../src/Worksheet.cpp:1974
 msgid "No Scalar"
-msgstr ""
+msgstr "Не число"
 
 #: ../../src/wxMaxima.cpp:10482
 msgid "No dollar ($) or semicolon (;) at the end of command"
-msgstr ""
+msgstr "Наприкінці команди немає символу долара ($) або крапки з комою (;)"
 
 #: ../../src/MaximaManual.cpp:406
 msgid "No entries in the caches for the subjects the manual contains."
-msgstr ""
+msgstr "У кеші немає записів для тем, які містяться у підручнику."
 
 #: ../../src/MaximaManual.cpp:101
 msgid ""
 "No file with the subjects the manual contained in the last wxMaxima run."
 msgstr ""
+"Немає файла з темами, які містяться у підручнику, з останнього запуску "
+"wxMaxima."
 
 #: ../../src/Image.cpp:495
 msgid "No gnuplot data!"
-msgstr ""
+msgstr "Немає даних gnuplot!"
 
 #: ../../src/Image.cpp:530
 msgid "No gnuplot source!"
-msgstr ""
+msgstr "Немає початкового коду gnuplot!"
 
 #: ../../src/wxMaxima.cpp:6662 ../../src/wxMaxima.cpp:6668
 #: ../../src/wxMaxima.cpp:6687 ../../src/wxMaxima.cpp:6697
 msgid "No matches found!"
-msgstr ""
+msgstr "Не знайдено відповідників."
 
 #: ../../src/wxMaxima.cpp:3240
 msgid "No topics found in topic flag"
-msgstr ""
+msgstr "Для прапорця теми не знайдено жодної теми"
 
 #: ../../src/wxMaxima.cpp:3227
 msgid "No topics found in topic tag"
-msgstr ""
+msgstr "Для мітки теми не знайдено жодної теми"
 
 #: ../../src/wxMaximaFrame.cpp:797
 msgid "None"
-msgstr ""
+msgstr "Немає"
 
 #: ../../src/wxMaxima.cpp:8163
 msgid "Not a valid matrix dimension!"
-msgstr ""
+msgstr "Некоректна розмірність матриці."
 
 #: ../../src/wxMaxima.cpp:7858 ../../src/wxMaxima.cpp:7880
 msgid "Not a valid number of equations!"
-msgstr ""
+msgstr "Некоректна кількість рівнянь."
 
 #: ../../src/StatusBar.cpp:256
 msgid "Not connected to Maxima"
-msgstr ""
+msgstr "Не з'єднано з Maxima"
 
 #: ../../src/wxMaxima.cpp:10496
 msgid "Not triggering evaluation as maxima is still busy!"
-msgstr ""
+msgstr "Не запускаємо обробку, оскільки maxima усе ще зайнято!"
 
 #: ../../src/wxMaxima.cpp:10503
 msgid "Not triggering evaluation as maxima still asks a question!"
 msgstr ""
+"Не запускаємо обробку, оскільки maxima усе ще не отримала відповіді на "
+"питання!"
 
 #: ../../src/wxMaxima.cpp:10511
 msgid "Not triggering evaluation as there is no working maxima process"
-msgstr ""
+msgstr "Не запускаємо обробку, оскільки немає працездатного процесу maxima"
 
 #: ../../src/wxMaxima.cpp:8926
 msgid "Num. deg:"
-msgstr ""
+msgstr "Степінь чисельника:"
 
 #: ../../src/wxMaxima.cpp:8540
 msgid "Number of elements"
-msgstr ""
+msgstr "Кількість елементів"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7874
 msgid "Number of equations:"
-msgstr ""
+msgstr "Кількість рівнянь:"
 
 #: ../../src/wxMaxima.cpp:7481
 msgid "Number to octets"
-msgstr ""
+msgstr "Число у вісімкові"
 
 #: ../../src/wxMaximaFrame.cpp:1154
 msgid "Number to octets..."
-msgstr ""
+msgstr "Число у вісімкові…"
 
 #: ../../src/wxMaximaFrame.cpp:1906
 msgid "Number types"
-msgstr ""
+msgstr "Типи чисел"
 
 #: ../../src/wxMaxima.cpp:7482
 msgid "Number:"
-msgstr ""
+msgstr "Число:"
 
 #: ../../src/wxMaximaFrame.cpp:1786
 msgid "Numeric output"
-msgstr ""
+msgstr "Числове виведення"
 
 #: ../../src/wxMaxima.cpp:8040
 msgid "Numerical QR decomposition of a matrix"
-msgstr ""
+msgstr "Числовий QR-розклад матриці"
 
 #: ../../src/wxMaximaFrame.cpp:1417
 msgid "Numerical operations (lapack)"
-msgstr ""
+msgstr "Обчислювальні дії (lapack)"
 
 #: ../../src/wxMaxima.cpp:7831
 msgid "Numerical solution for 1st degree ODE"
-msgstr ""
+msgstr "Обчислювальний розв'язок ЗДР 1-го порядку"
 
 #: ../../src/wxMaximaFrame.cpp:1282
 msgid "Numerical solution..."
-msgstr ""
+msgstr "Обчислювальний розв'язок…"
 
 #: ../../src/wxMaximaFrame.cpp:1261
+#, fuzzy
 msgid "Numerical solutions of polynomial (bfloat)..."
-msgstr ""
+msgstr "Обчислювальні розв'язки поліноміального рівняння…"
 
 #: ../../src/wxMaximaFrame.cpp:1258
 msgid "Numerical solutions of polynomial..."
-msgstr ""
+msgstr "Обчислювальні розв'язки поліноміального рівняння…"
 
 #: ../../src/wxMaxima.cpp:9802 ../../src/wxMaxima.cpp:10161
 msgid "OK"
-msgstr ""
+msgstr "Гаразд"
 
 #: ../../src/wxMaximaFrame.cpp:122
-#, c-format
+#, fuzzy, c-format
 msgid "OS: %s Version %li.%li"
-msgstr ""
+msgstr "ОС: %s версія %i.%i"
 
 #: ../../src/wxMaxima.cpp:8211 ../../src/wxMaxima.cpp:8221
 msgid "Object composed of elements"
-msgstr ""
+msgstr "Об'єкт, який складено з елементів"
 
 #: ../../src/wxMaxima.cpp:7680
 msgid "Object name:"
-msgstr ""
+msgstr "Назва об'єкта:"
 
 #: ../../src/wxMaxima.cpp:7281
 msgid "Object:"
-msgstr ""
+msgstr "Об'єкт:"
 
 #: ../../src/wxMaxima.cpp:7486
 msgid "Octets to Number"
-msgstr ""
+msgstr "Вісімкові до числа"
 
 #: ../../src/wxMaxima.cpp:7491
 msgid "Octets to String"
-msgstr ""
+msgstr "Вісімкові до рядка"
 
 #: ../../src/wxMaximaFrame.cpp:1156
 msgid "Octets to number..."
-msgstr ""
+msgstr "Вісімкові до числа…"
 
 #: ../../src/wxMaximaFrame.cpp:1158
 msgid "Octets to string..."
-msgstr ""
+msgstr "Вісімкові до рядка…"
 
 #: ../../src/wxMaxima.cpp:7487 ../../src/wxMaxima.cpp:7492
 msgid "Octets:"
-msgstr ""
+msgstr "Вісімкові:"
 
 #: ../../src/Worksheet.cpp:1958
 msgid "Odd number"
-msgstr ""
+msgstr "Непарне число"
 
 #: ../../src/wxMaxima.cpp:8900 ../../src/wxMaxima.cpp:8921
 #: ../../src/wxMaxima.cpp:8999 ../../src/wxMaxima.cpp:9005
 msgid "Old variable:"
-msgstr ""
+msgstr "Попередня змінна:"
 
 #: ../../src/wxMaximaFrame.cpp:1055
 msgid "On all errors"
-msgstr ""
+msgstr "При усіх помилках"
 
 #: ../../src/wxMaximaFrame.cpp:1054
 msgid "On lisp errors"
-msgstr ""
+msgstr "При помилках lisp"
 
 #: ../../src/wxMaxima.cpp:9566
 msgid "One sample t-test"
-msgstr ""
+msgstr "Одновибіркова t-перевірка"
 
 #: ../../src/wxMaximaFrame.cpp:1927
 msgid "Online tutorials"
-msgstr ""
+msgstr "Навчальні матеріали у інтернеті"
 
 #: ../../src/wxMaximaFrame.cpp:766
 msgid "Only Integers and single letters"
-msgstr ""
+msgstr "Лише цілі числа і окремі літери"
 
 #: ../../src/ToolBar.cpp:176 ../../src/main.cpp:593
 #: ../../src/wxMaxima.cpp:6074
 msgid "Open"
-msgstr ""
+msgstr "Відкрити"
 
 #: ../../src/wxMaximaFrame.cpp:598
 msgid "Open a document"
-msgstr ""
+msgstr "Відкрити документ"
 
 #: ../../src/wxMaximaFrame.cpp:597
 msgid "Open a new window"
-msgstr ""
+msgstr "Відкрити нове вікно"
 
 #: ../../src/ToolBar.cpp:617
 msgid "Open and save button"
-msgstr ""
+msgstr "Кнопки відкриття і збереження"
 
 #: ../../src/ToolBar.cpp:176
 msgid "Open document"
-msgstr ""
+msgstr "Відкрити документ"
 
 #: ../../src/wxMaxima.cpp:7239
 msgid "Open for appending"
-msgstr ""
+msgstr "Відкрити для дописування"
 
 #: ../../src/wxMaximaFrame.cpp:1099
 msgid "Open for appending..."
-msgstr ""
+msgstr "Відкрити для дописування…"
 
 #: ../../src/wxMaxima.cpp:7244
 msgid "Open for reading"
-msgstr ""
+msgstr "Відкрити для читання"
 
 #: ../../src/wxMaximaFrame.cpp:1098
 msgid "Open for reading..."
-msgstr ""
+msgstr "Відкрити для читання…"
 
 #: ../../src/wxMaxima.cpp:7249
 msgid "Open for writing"
-msgstr ""
+msgstr "Відкрити для запису"
 
 #: ../../src/wxMaximaFrame.cpp:1100
 msgid "Open for writing..."
-msgstr ""
+msgstr "Відкрити для запису…"
 
 #: ../../src/wxMaxima.cpp:9598
 msgid "Open matrix"
-msgstr ""
+msgstr "Відкрити матрицю"
 
 #: ../../src/wxMaximaFrame.cpp:600
 msgid "Open recent"
-msgstr ""
+msgstr "Відкрити недавні"
 
 #: ../../src/wxMaxima.cpp:4309
 msgid "Opening a wxmx file"
-msgstr ""
+msgstr "Відкриваємо файл wxmx"
 
 #: ../../src/wxMaxima.cpp:4153 ../../src/wxMaxima.cpp:4214
 #: ../../src/wxMaxima.cpp:4313 ../../src/wxMaxima.cpp:4622
 msgid "Opening file"
-msgstr ""
+msgstr "Відкриваємо файл"
 
 #: ../../src/wxMaxima.cpp:5030
 #, c-format
 msgid "Opening help file %s"
-msgstr ""
+msgstr "Відкриваємо файл довідки %s"
 
 #: ../../src/wxMaximaFrame.cpp:1530
 msgid "Optimize for CPU time"
-msgstr ""
+msgstr "Оптимізувати за часом процесора"
 
 #: ../../src/wxMaximaFrame.cpp:1529
 msgid "Optimize for memory"
-msgstr ""
+msgstr "Оптимізувати за пам'яттю"
 
 #: ../../src/ToolBar.cpp:199
 msgid "Options"
-msgstr ""
+msgstr "Параметри"
 
 #: ../../src/wxMaximaFrame.cpp:1225
 msgid "Output C"
-msgstr ""
+msgstr "Вивести до C"
 
 #: ../../src/wxMaximaFrame.cpp:1226
 msgid "Output Fortran"
-msgstr ""
+msgstr "Вивести до Fortran"
 
 #: ../../src/wxMaximaFrame.cpp:1228
 msgid "Output Rational Fortran"
-msgstr ""
+msgstr "Вивести до Rational Fortran"
 
 #: ../../src/Configuration.cpp:80
 msgid "Output labels"
-msgstr ""
+msgstr "Мітки результатів"
 
 #: ../../src/Configuration.cpp:73
 msgid "Output: Function names"
-msgstr ""
+msgstr "Виведення: назви функцій"
 
 #: ../../src/Configuration.cpp:75
 msgid "Output: Latin names as greek symbols"
-msgstr ""
+msgstr "Виведення: назви латиницею як символи грецькою"
 
 #: ../../src/Configuration.cpp:72
 msgid "Output: Numbers and Digits"
-msgstr ""
+msgstr "Виведення: числа і цифри"
 
 #: ../../src/Configuration.cpp:71
 msgid "Output: Operators"
-msgstr ""
+msgstr "Виведення: оператори"
 
 #: ../../src/Configuration.cpp:74
 #, c-format
 msgid "Output: Special constants (%e,%i)"
-msgstr ""
+msgstr "Виведення: особливі сталі (%e,%i)"
 
 #: ../../src/Configuration.cpp:76
 msgid "Output: Strings"
-msgstr ""
+msgstr "Виведення: рядки"
 
 #: ../../src/Configuration.cpp:70
 msgid "Output: Variable names"
-msgstr ""
+msgstr "Виведення: назви змінних"
 
 #: ../../src/wxMaxima.cpp:6442
 msgid ""
@@ -5081,6 +5286,10 @@ msgid ""
 "(*.bmp)|*.bmp|Portable anymap (*.pnm)|*.pnm|Tagged image file format "
 "(*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"зображення PNG (*png)|*png|зображення JPEG (*jpg)|*jpg|зображення GIF "
+"(*gif)|*.gif|масштабована векторна графіка (*.svg)|*.svg|растрове зображення"
+" Windows (*.bmp)|*.bmp|портативний anymap (*.pnm)|*.pnm|формат файлів "
+"зображень із мітками (*.tif)|*.tif|растрова карта X (*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:10117
 msgid ""
@@ -5088,321 +5297,331 @@ msgid ""
 "(*.bmp)|*.bmp|GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged "
 "image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"зображення PNG (*png)|*.png|зображення JPEG (*.jpg)|*.jpg|Windows bitmap "
+"(*.bmp)|*.bmp|зображення GIF (*.gif)|*.gif|Portable anymap "
+"(*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:8924
 msgid "Pade approximation"
-msgstr ""
+msgstr "Апроксимація Паде"
 
 #: ../../src/wxMaximaFrame.cpp:1478
 msgid "Pade approximation of a Taylor series"
-msgstr ""
+msgstr "Паде-апроксимація ряду Тейлора"
 
 #: ../../src/wxMaximaFrame.cpp:1637
 msgid "Parallel Substitute..."
-msgstr ""
+msgstr "Паралельне підставляння…"
 
 #: ../../src/wxMaxima.cpp:8738
 msgid "Parallel substitution"
-msgstr ""
+msgstr "Паралельне підставляння"
 
 #: ../../src/wxMaxima.cpp:7179
 msgid "Parameter name:"
-msgstr ""
+msgstr "Назва параметра:"
 
 #: ../../src/wxMaxima.cpp:7136 ../../src/wxMaxima.cpp:7149
 msgid "Parameter(s):"
-msgstr ""
+msgstr "Параметри:"
 
 #: ../../src/wxMaxima.cpp:7399
 msgid "Parse string"
-msgstr ""
+msgstr "Обробити рядок"
 
 #: ../../src/wxMaximaFrame.cpp:1152
 msgid "Parse string only..."
-msgstr ""
+msgstr "Обробити лише рядок…"
 
 #: ../../src/StatusBar.cpp:240
 msgid "Parsing output"
-msgstr ""
+msgstr "Аналіз результату"
 
 #: ../../src/wxMaxima.cpp:7464
 msgid "Part:"
-msgstr ""
+msgstr "Частина:"
 
 #: ../../src/wxMaximaFrame.cpp:1499 ../../src/wxMaximaFrame.cpp:1535
 msgid "Partial &Fractions..."
-msgstr ""
+msgstr "Прості &дроби…"
 
 #: ../../src/wxMaxima.cpp:8975
 msgid "Partial Fractions"
-msgstr ""
+msgstr "Прості дроби"
 
 #: ../../src/wxMaxima.cpp:4702
 msgid "Parts of the document will not be loaded correctly!"
-msgstr ""
+msgstr "Частину документа не вдалося завантажити!"
 
 #: ../../src/ToolBar.cpp:210 ../../src/Worksheet.cpp:1654
 #: ../../src/Worksheet.cpp:1685
 msgid "Paste"
-msgstr ""
+msgstr "Вставити"
 
 #: ../../src/wxMaximaFrame.cpp:667
 msgid "Paste\tCtrl+V"
-msgstr ""
+msgstr "Вставити\tCtrl+V"
 
 #: ../../src/ToolBar.cpp:211
 msgid "Paste from clipboard"
-msgstr ""
+msgstr "Вставити з буфера"
 
 #: ../../src/wxMaximaFrame.cpp:668
 msgid "Paste text from clipboard"
-msgstr ""
+msgstr "Вставити текст із буфера обміну даними"
 
 #: ../../src/wxMaxima.cpp:4841
 msgid "Please configure wxMaxima with 'Edit->Configure'."
-msgstr ""
+msgstr "Налаштуйте wxMaxima за допомогою пункту меню «Зміни → Налаштувати»."
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot &2d..."
-msgstr ""
+msgstr "&Двовимірний графік…"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot &3d..."
-msgstr ""
+msgstr "&Тривимірний графік…"
 
 #: ../../src/wxMaximaFrame.cpp:1772
 msgid "Plot &Format..."
-msgstr ""
+msgstr "&Формат графіка…"
 
 #: ../../src/wxMaxima.cpp:9101 ../../src/wxMaxima.cpp:10068
 msgid "Plot 2D"
-msgstr ""
+msgstr "Двовимірний графік"
 
 #: ../../src/Worksheet.cpp:1593
 msgid "Plot 2D..."
-msgstr ""
+msgstr "Двовимірний графік…"
 
 #: ../../src/wxMaxima.cpp:9078 ../../src/wxMaxima.cpp:10079
 msgid "Plot 3D"
-msgstr ""
+msgstr "Тривимірний графік"
 
 #: ../../src/Worksheet.cpp:1595
 msgid "Plot 3D..."
-msgstr ""
+msgstr "Тривимірний графік…"
 
 #: ../../src/wxMaxima.cpp:9538
 msgid "Plot as bars"
-msgstr ""
+msgstr "Намалювати як стовпчики"
 
 #: ../../src/wxMaxima.cpp:9542
 msgid "Plot as error bars"
-msgstr ""
+msgstr "Намалювати як стовпчики похибок"
 
 #: ../../src/wxMaxima.cpp:9546
 msgid "Plot as pie chart"
-msgstr ""
+msgstr "Намалювати як кругову діаграму"
 
 #: ../../src/wxMaxima.cpp:9112
 msgid "Plot format"
-msgstr ""
+msgstr "Формат графіка"
 
 #: ../../src/wxMaximaFrame.cpp:1768
 msgid "Plot in 2 dimensions"
-msgstr ""
+msgstr "Двовимірний графік"
 
 #: ../../src/wxMaximaFrame.cpp:1770
 msgid "Plot in 3 dimensions"
-msgstr ""
+msgstr "Тривимірний графік"
 
 #: ../../src/wxMaximaFrame.cpp:320 ../../src/wxMaximaFrame.cpp:714
 msgid "Plot using Draw"
-msgstr ""
+msgstr "Накреслити за допомогою Draw"
 
 #: ../../src/wxMaxima.cpp:7824
 msgid "Point #1 with known value:"
-msgstr ""
+msgstr "Точка 1 з відомим значенням:"
 
 #: ../../src/wxMaxima.cpp:7826
 msgid "Point #2 with known value:"
-msgstr ""
+msgstr "Точка 2 з відомим значенням:"
 
 #: ../../src/wxMaxima.cpp:7800 ../../src/wxMaxima.cpp:7811
 msgid "Point the value is known at:"
-msgstr ""
+msgstr "Точка, у якій відоме значення:"
 
 #: ../../src/wxMaxima.cpp:7909 ../../src/wxMaxima.cpp:8935
 msgid "Point:"
-msgstr ""
+msgstr "Точка:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 1:"
-msgstr ""
+msgstr "Поліном 1:"
 
 #: ../../src/wxMaxima.cpp:8961 ../../src/wxMaxima.cpp:8966
 #: ../../src/wxMaxima.cpp:8971
 msgid "Polynomial 2:"
-msgstr ""
+msgstr "Поліном 2:"
 
 #: ../../src/wxMaxima.cpp:7713 ../../src/wxMaxima.cpp:7724
 #: ../../src/wxMaxima.cpp:7739
 msgid "Polynomial:"
-msgstr ""
+msgstr "Поліном:"
 
 #: ../../src/wxMaximaFrame.cpp:1754
 msgid "Pop"
-msgstr ""
+msgstr "Виштовхнути"
 
 #: ../../src/Worksheet.cpp:1331 ../../src/Worksheet.cpp:1485
 msgid "Popout interactively"
-msgstr ""
+msgstr "Інтерактивна поява"
 
 #: ../../src/wxMaximaFrame.cpp:1189
 msgid "Position of a match"
-msgstr ""
+msgstr "Позиція відповідника"
 
 #: ../../src/wxMaxima.cpp:7220 ../../src/wxMaxima.cpp:7391
 msgid "Position:"
-msgstr ""
+msgstr "Позиція:"
 
 #: ../../src/wxMaxima.cpp:8939
 msgid "Power series"
-msgstr ""
+msgstr "Степеневий ряд"
 
 #: ../../src/wxMaximaFrame.cpp:1475
 msgid "Power series..."
-msgstr ""
+msgstr "Степеневий ряд…"
 
 #: ../../src/wxMaxima.cpp:9202
 msgid "Precision"
-msgstr ""
+msgstr "Точність"
 
 #: ../../src/Worksheet.cpp:1616
 msgid "Prefer user labels"
-msgstr ""
+msgstr "Пріоритет міток користувача"
 
 #: ../../src/main.cpp:437
 msgid "Preferences"
-msgstr ""
+msgstr "Налаштування"
 
 #: ../../src/ToolBar.cpp:626
 msgid "Preferences button"
-msgstr ""
+msgstr "Кнопка налаштувань"
 
 #: ../../src/wxMaximaFrame.cpp:685
 msgid "Preferences...\tCtrl+,"
-msgstr ""
+msgstr "Параметри…\tCtrl+,"
 
 #: ../../src/wxMaximaFrame.cpp:1733
 msgid "Prepend an element"
-msgstr ""
+msgstr "Дописати елемент на початку"
 
 #: ../../src/wxMaximaFrame.cpp:927
 msgid "Previous Command\tAlt+Up"
-msgstr ""
+msgstr "Попередня команда\tAlt+Up"
 
 #: ../../src/ToolBar.cpp:184
 msgid "Print"
-msgstr ""
+msgstr "Надрукувати"
 
 #: ../../src/ToolBar.cpp:620
 msgid "Print button"
-msgstr ""
+msgstr "Кнопка друку"
 
 #: ../../src/Worksheet.cpp:1493
+#, fuzzy
 msgid "Print cell brackets"
-msgstr ""
+msgstr "Дужка активної комірки"
 
 #: ../../src/ToolBar.cpp:184 ../../src/wxMaximaFrame.cpp:622
 msgid "Print document"
-msgstr ""
+msgstr "Надрукувати документ"
 
 #: ../../src/wxMaximaFrame.cpp:1829
 msgid "Print floating-point numbers with exponents dividable by 3"
 msgstr ""
+"Друкувати числа з рухомою крапкою із степенями десяти, які діляться на 3"
 
 #: ../../src/WXMXformat.cpp:255
 msgid ""
 "Produced invalid XML. The erroneous XML data has therefore not been saved "
 "but has been put on the clipboard in order to allow to debug it."
 msgstr ""
+"Створено некоректний код XML. Через це помилкові дані XML не збережено, а "
+"записано до буфера обміну даними з метою уможливлення діагностики причин "
+"помилки."
 
 #: ../../src/wxMaxima.cpp:9061
 msgid "Product"
-msgstr ""
+msgstr "Добуток"
 
 #: ../../src/wxMaximaFrame.cpp:1095
 msgid "Program"
-msgstr ""
+msgstr "Програма"
 
 #: ../../src/wxMaxima.cpp:7061
 msgid "Program (no local variables)"
-msgstr ""
+msgstr "Програма (без локальних змінних)"
 
 #: ../../src/wxMaxima.cpp:7052
 msgid "Program block"
-msgstr ""
+msgstr "Блок програми"
 
 #: ../../src/wxMaximaFrame.cpp:1066
 msgid "Program block with local variables..."
-msgstr ""
+msgstr "Блок програми із локальними змінними…"
 
 #: ../../src/wxMaximaFrame.cpp:1068
 msgid "Program block, no local variables..."
-msgstr ""
+msgstr "Блок програми без локальних змінних…"
 
 #: ../../src/wxMaximaFrame.cpp:1751
 msgid "Push"
-msgstr ""
+msgstr "Надіслати"
 
 #: ../../src/wxMaxima.cpp:8508
 msgid "Push an element to a list"
-msgstr ""
+msgstr "Вставити елемент до списку"
 
 #: ../../src/wxMaximaFrame.cpp:1395
 msgid "QR decomposition"
-msgstr ""
+msgstr "QR-розклад"
 
 #: ../../src/wxMaxima.cpp:3621
 msgid "Querying gnuplot which graphics drivers it supports."
 msgstr ""
+"Опитуємо gnuplot щодо графічних драйверів, підтримку яких передбачено."
 
 #: ../../src/wxMaxima.cpp:8953
 msgid "Range radius:"
-msgstr ""
+msgstr "Радіус діапазона:"
 
 #: ../../src/wxMaximaFrame.cpp:1374
 msgid "Rank"
-msgstr ""
+msgstr "Ранг"
 
 #: ../../src/wxMaximaFrame.cpp:246 ../../src/wxMaximaFrame.cpp:722
 msgid "Raw XML monitor"
-msgstr ""
+msgstr "Монітор коду XML"
 
 #: ../../src/wxMaximaFrame.cpp:2117
 #, c-format
 msgid "Re-Reading the config from %s."
-msgstr ""
+msgstr "Повторно читаємо файл налаштувань з %s."
 
 #: ../../src/wxMaximaFrame.cpp:2114
 msgid "Re-Reading the config from the default location."
-msgstr ""
+msgstr "Повторно читаємо файл налаштувань з типового місця."
 
 #: ../../src/wxMaximaFrame.cpp:867
 msgid "Re-evaluate all cells above the one the cursor is in"
-msgstr ""
+msgstr "Виконати обчислення у всіх комірках над коміркою, де перебуває курсор"
 
 #: ../../src/wxMaximaFrame.cpp:877
 msgid "Re-evaluate all cells below the one the cursor is in"
-msgstr ""
+msgstr "Виконати обчислення у всіх комірках під коміркою, де перебуває курсор"
 
 #: ../../src/main.cpp:366
 msgid "Re-opening STDERR failed."
 msgstr ""
 
 #: ../../src/main.cpp:367
+#, fuzzy
 msgid "Re-opening STDIN failed."
-msgstr ""
+msgstr "Відкриваємо файл"
 
 #: ../../src/main.cpp:365
 msgid "Re-opening STDOUT failed."
@@ -5413,535 +5632,551 @@ msgid ""
 "Re-using a compiled regex is faster that using the same regex string "
 "multiple times."
 msgstr ""
+"Повторне використання зібраного формального виразу є швидшим за використання"
+" одного рядка формального виразу декілька разів."
 
 #: ../../src/Worksheet.cpp:6668
 msgid "Read .wxm data from clipboard"
-msgstr ""
+msgstr "Прочитати дані .wxm з буфера обміну даними"
 
 #: ../../src/wxMaxima.cpp:7599
 msgid "Read Directory"
-msgstr ""
+msgstr "Прочитати каталог"
 
 #: ../../src/wxMaximaFrame.cpp:1677
 msgid "Read List from csv file..."
-msgstr ""
+msgstr "Прочитати список з файла CSV…"
 
 #: ../../src/wxMaxima.cpp:7196
 msgid "Read a structure field"
-msgstr ""
+msgstr "Прочитати поле структури"
 
 #: ../../src/wxMaxima.cpp:7270 ../../src/wxMaxima.cpp:7274
 msgid "Read byte"
-msgstr ""
+msgstr "Прочитати байт"
 
 #: ../../src/wxMaxima.cpp:7266
 msgid "Read char"
-msgstr ""
+msgstr "Прочитати символ"
 
 #: ../../src/wxMaxima.cpp:7593
 msgid "Read environment variable"
-msgstr ""
+msgstr "Прочитати змінну середовища"
 
 #: ../../src/wxMaximaFrame.cpp:1219
 msgid "Read environment variable..."
-msgstr ""
+msgstr "Прочитати змінну середовища…"
 
 #: ../../src/wxMaxima.cpp:7262
 msgid "Read line"
-msgstr ""
+msgstr "Прочитати рядок"
 
 #: ../../src/MaximaManual.cpp:113
 #, c-format
 msgid "Read the entries the maxima manual offers from %s"
-msgstr ""
+msgstr "Прочитати записи підручника з maxima щодо %s"
 
 #: ../../src/StatusBar.cpp:245
 msgid "Reading Maxima output"
-msgstr ""
+msgstr "Читаємо результат обчислень Maxima"
 
 #: ../../src/StatusBar.cpp:247
 #, c-format
 msgid "Reading Maxima output: %li bytes"
-msgstr ""
+msgstr "Читаємо результат обчислень Maxima: %li байтів"
 
 #: ../../src/wxMathml.cpp:55
 #, c-format
 msgid "Reading the Lisp part of wxMaxima from the file %s"
-msgstr ""
+msgstr "Читання частини коду Lisp wxMaxima з файла %s"
 
 #: ../../src/wxMathml.cpp:43
 msgid "Reading the Lisp part of wxMaxima from the included header file."
-msgstr ""
+msgstr "Читання частини коду Lisp wxMaxima з включеного файла заголовка."
 
 #: ../../src/wxMaximaFrame.cpp:148
 #, c-format
 msgid "Reading the config from %s."
-msgstr ""
+msgstr "Читаємо файл налаштувань з %s."
 
 #: ../../src/wxMaximaFrame.cpp:151
 msgid "Reading the config from the default location."
-msgstr ""
+msgstr "Читаємо файл налаштувань з типового місця."
 
 #: ../../src/StatusBar.cpp:224
 msgid "Ready for user input"
-msgstr ""
+msgstr "Готова до введення команди"
 
 #: ../../src/Worksheet.cpp:960
 msgid "Recalculated the whole worksheet at once => Updating its size"
-msgstr ""
+msgstr "Переобчислено одразу увесь робочий аркуш => оновлюємо його розмір"
 
 #: ../../src/Worksheet.cpp:946
 msgid "Recalculation hit the end of the worksheet => Updating its size"
 msgstr ""
+"Повторне обчислення досягло кінця робочого аркуша => переобчислюємо його "
+"розмір"
 
 #: ../../src/wxMaximaFrame.cpp:930
 msgid "Recall next command from history"
-msgstr ""
+msgstr "Нагадати наступну команду з журналу"
 
 #: ../../src/wxMaximaFrame.cpp:928
 msgid "Recall previous command from history"
-msgstr ""
+msgstr "Нагадати попередню команду з журналу"
 
 #: ../../src/wxMaxima.cpp:3235
 #, c-format
 msgid "Received manual topic request: %s"
-msgstr ""
+msgstr "Отримано запит щодо теми підручника: %s"
 
 #: ../../src/wxMaxima.cpp:3097
 #, c-format
 msgid "Received maxima's first prompt: %s"
-msgstr ""
+msgstr "Отримано перший запит maxima: %s"
 
 #: ../../src/wxMaximaFrame.cpp:603
 msgid "Recover unsaved"
-msgstr ""
+msgstr "Відновити незбережене"
 
 #: ../../src/wxMaximaFrame.cpp:1640
 msgid "Recursive Substitute..."
-msgstr ""
+msgstr "Рекурсивно підставити…"
 
 #: ../../src/wxMaxima.cpp:8746
 msgid "Recursive substitution"
-msgstr ""
+msgstr "Рекурсивне підставляння"
 
 #: ../../src/ToolBar.cpp:192
 msgid "Redo"
-msgstr ""
+msgstr "Повторити"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo\tCtrl+Y"
-msgstr ""
+msgstr "Повторити\tCtrl+Y"
 
 #: ../../src/wxMaximaFrame.cpp:633
 msgid "Redo last change"
-msgstr ""
+msgstr "Повторити останню зміну"
 
 #: ../../src/wxMaximaFrame.cpp:1595
 msgid "Reduce trigonometric expression"
-msgstr ""
+msgstr "Привести тригонометричний вираз"
 
 #: ../../src/wxMaxima.cpp:2366 ../../src/wxMaxima.cpp:10630
 msgid "Refusing to send cell to maxima: "
-msgstr ""
+msgstr "Відмовлено у надсиланні комірки до maxima: "
 
 #: ../../src/wxMaxima.cpp:7523
 msgid "Regex match"
-msgstr ""
+msgstr "Відповідність форм. виразу"
 
 #: ../../src/wxMaxima.cpp:7518
 msgid "Regex match position"
-msgstr ""
+msgstr "Позиція відповідності формального виразу"
 
 #: ../../src/wxMaximaFrame.cpp:1195
+#, fuzzy
 msgid "Regular expression that matches a string"
-msgstr ""
+msgstr "Формальний вираз, який відповідає рядку"
 
 #: ../../src/wxMaximaFrame.cpp:1196
+#, fuzzy
 msgid "Regular expressions"
-msgstr ""
+msgstr "Проінтегрувати вираз"
 
 #: ../../src/Worksheet.cpp:1314
 msgid "Reload Image"
-msgstr ""
+msgstr "Перезавантажити зображення"
 
 #: ../../src/Worksheet.cpp:1320
 #, c-format
 msgid "Reload Image \"%s\""
-msgstr ""
+msgstr "Перезавантажити зображення «%s»"
 
 #: ../../src/wxMaxima.cpp:9809
 #, c-format
 msgid "Reloading image file %s."
-msgstr ""
+msgstr "Перезавантажуємо файл зображення %s."
 
 #: ../../src/wxMaximaFrame.cpp:883
 msgid "Remove All Output"
-msgstr ""
+msgstr "Вилучити всі результати"
 
 #: ../../src/wxMaximaFrame.cpp:1426
 msgid "Remove Rows or Columns..."
-msgstr ""
+msgstr "Вилучити рядки або стовпчики…"
 
 #: ../../src/wxMaximaFrame.cpp:1748
 msgid ""
 "Remove all list elements that appear twice in a row. Normally used in "
 "conjunction with sort."
 msgstr ""
+"Вилучити усі елементи списку, які трапляються у ньому декілька разів. "
+"Зазвичай, використовується разом із упорядковуванням."
 
 #: ../../src/wxMaximaFrame.cpp:1174
 msgid "Remove all occurrences of a word..."
-msgstr ""
+msgstr "Вилучити усі відповідники слова…"
 
 #: ../../src/wxMaxima.cpp:7439
 msgid "Remove all occurrences of part"
-msgstr ""
+msgstr "Вилучити усі відповідники частини"
 
 #: ../../src/wxMaxima.cpp:8592
 msgid "Remove an element from a list"
-msgstr ""
+msgstr "Вилучити елемент зі списку"
 
 #: ../../src/wxMaxima.cpp:7566
 msgid "Remove directory"
-msgstr ""
+msgstr "Вилучити каталог"
 
 #: ../../src/wxMaximaFrame.cpp:1204
 msgid "Remove directory..."
-msgstr ""
+msgstr "Вилучити каталог…"
 
 #: ../../src/wxMaximaFrame.cpp:1747
 msgid "Remove duplicates"
-msgstr ""
+msgstr "Вилучити дублікати"
 
 #: ../../src/wxMaximaFrame.cpp:1176
 msgid "Remove first occurrence of a word..."
-msgstr ""
+msgstr "Вилучити перший відповідник слова…"
 
 #: ../../src/wxMaxima.cpp:7444
 msgid "Remove first occurrence of part"
-msgstr ""
+msgstr "Вилучити перший відповідник частини"
 
 #: ../../src/wxMaximaFrame.cpp:884
 msgid "Remove output from input cells"
-msgstr ""
+msgstr "Вилучити всі виведені дані з комірок для введення даних"
 
 #: ../../src/wxMaxima.cpp:7975
 msgid "Remove rows and/or columns"
-msgstr ""
+msgstr "Вилучити рядки і/або стовпчики"
 
 #: ../../src/wxMaximaFrame.cpp:1427
 msgid "Remove rows and/or columns from the matrix"
-msgstr ""
+msgstr "Вилучити рядки і/або стовпчики з матриці"
 
 #: ../../src/wxMaxima.cpp:7582
 msgid "Rename file"
-msgstr ""
+msgstr "Перейменувати файл"
 
 #: ../../src/wxMaximaFrame.cpp:1215
 msgid "Rename file..."
-msgstr ""
+msgstr "Перейменувати файл…"
 
 #: ../../src/wxMaximaFrame.cpp:1527
 msgid "Reorganize an expression using horner's rule"
-msgstr ""
+msgstr "Переупорядкувати вираз за допомогою правила Горнера"
 
 #: ../../src/wxMaximaFrame.cpp:1346
 msgid "Repetitive element-by-element multiplication"
-msgstr ""
+msgstr "Повторне поелементне множення"
 
 #: ../../src/wxMaxima.cpp:7538
 msgid "Replace all regex matches"
-msgstr ""
+msgstr "Замінити усі відповідники формального виразу"
 
 #: ../../src/wxMaxima.cpp:7533
 msgid "Replace first regex match"
-msgstr ""
+msgstr "Замінити перший відповідник формального виразу"
 
 #: ../../src/wxMaxima.cpp:7463
 msgid "Replace the first occurrence of Part"
-msgstr ""
+msgstr "Замінити перший відповідник частини"
 
 #: ../../src/wxMaximaFrame.cpp:1180
 msgid "Replace..."
-msgstr ""
+msgstr "Замінити…"
 
 #: ../../src/wxMaxima.cpp:6719
 #, c-format
 msgid "Replaced %li occurrences."
-msgstr ""
+msgstr "Замінено %li відповідників."
 
 #: ../../src/wxMaximaFrame.cpp:1950
 msgid "Report bug"
-msgstr ""
+msgstr "Повідомити про ваду"
 
 #: ../../src/wxMaximaFrame.cpp:996
+#, fuzzy
 msgid "Reset option variables"
-msgstr ""
+msgstr "Замінити змінні параметра"
 
 #: ../../src/ToolBar.cpp:229 ../../src/wxMaximaFrame.cpp:974
 msgid "Restart Maxima"
-msgstr ""
+msgstr "Перезапустити Maxima"
 
 #: ../../src/Worksheet.cpp:1304 ../../src/Worksheet.cpp:1477
 msgid "Restrict Maximum size"
-msgstr ""
+msgstr "Обмежити максимальний розмір"
 
 #: ../../src/wxMaxima.cpp:10031
 msgid "Result variables:"
-msgstr ""
+msgstr "Змінні результату:"
 
 #: ../../src/wxMaxima.cpp:8135
 msgid "Resulting Matrix name (may be empty):"
-msgstr ""
+msgstr "Назва матриці результатів (може бути порожньою):"
 
 #: ../../src/wxMaximaFrame.cpp:1190
 msgid "Return a match"
-msgstr ""
+msgstr "Повернути відповідник"
 
 #: ../../src/wxMaxima.cpp:7077
 msgid "Return from a block or loop"
-msgstr ""
+msgstr "Повернутися з блоку або циклу"
 
 #: ../../src/wxMaximaFrame.cpp:1069
 msgid "Return from current block/loop..."
-msgstr ""
+msgstr "Повернутися з поточного блоку або циклу…"
 
 #: ../../src/wxMaximaFrame.cpp:1755
 msgid ""
 "Return the first item of the list and remove it from the list. Useful for "
 "creating stacks."
 msgstr ""
+"Повернути перший пункт зі списку і вилучити його зі списку. Корисно для "
+"створення стосів."
 
 #: ../../src/wxMaxima.cpp:8526
 msgid "Return the list without its first n elements"
-msgstr ""
+msgstr "Повернути список без його перших n елементів"
 
 #: ../../src/wxMaxima.cpp:8532
 msgid "Return the list without its last n elements"
-msgstr ""
+msgstr "Повернути список без його останніх n елементів"
 
 #: ../../src/ToolBar.cpp:241
 msgid "Return to the cell that is currently being evaluated"
-msgstr ""
+msgstr "Повернутися до комірки, у якій виконуються обчислення"
 
 #: ../../src/wxMaximaFrame.cpp:1711
 msgid "Returns an arbitrary list item"
-msgstr ""
+msgstr "Повертає довільний пункт у списку"
 
 #: ../../src/wxMaximaFrame.cpp:1713
 msgid "Returns the first item of the list"
-msgstr ""
+msgstr "Повертає перший пункт у списку"
 
 #: ../../src/wxMaximaFrame.cpp:1719
 msgid "Returns the last item of the list"
-msgstr ""
+msgstr "Повертає останній пункт у списку"
 
 #: ../../src/wxMaximaFrame.cpp:1721
 msgid "Returns the last n items of the list"
-msgstr ""
+msgstr "Повертає n останніх пунктів у списку"
 
 #: ../../src/wxMaximaFrame.cpp:1742
 msgid "Returns the length of the list"
-msgstr ""
+msgstr "Повертає довжину списку"
 
 #: ../../src/wxMaximaFrame.cpp:1715
 msgid "Returns the list without its first n elements"
-msgstr ""
+msgstr "Повертає список без його перших n елементів"
 
 #: ../../src/wxMaximaFrame.cpp:1717
 msgid "Returns the list without its last n elements"
-msgstr ""
+msgstr "Повертає список без його останніх n елементів"
 
 #: ../../src/wxMaximaFrame.cpp:1743
 msgid "Reverse"
-msgstr ""
+msgstr "Обернути"
 
 #: ../../src/wxMaximaFrame.cpp:1744
 msgid "Reverse the order of the list items"
-msgstr ""
+msgstr "Зворотний порядок пунктів у списку"
 
 #: ../../src/wxMaxima.cpp:7983 ../../src/wxMaxima.cpp:7988
 #: ../../src/wxMaxima.cpp:8008 ../../src/wxMaxima.cpp:8014
 msgid "Right Matrix:"
-msgstr ""
+msgstr "Права матриця:"
 
 #: ../../src/wxMaxima.cpp:8190
 msgid "Right end"
-msgstr ""
+msgstr "Правий кінець"
 
 #: ../../src/wxMaximaFrame.cpp:1301
 msgid "Right side to the \"=\""
-msgstr ""
+msgstr "Права частина рівності до «=»"
 
 #: ../../src/wxMaximaFrame.cpp:1455
 msgid "Risch Integration..."
-msgstr ""
+msgstr "Інтегрування за Рішем…"
 
 #: ../../src/wxMaximaFrame.cpp:785
 msgid "Rounded"
-msgstr ""
+msgstr "Круглі"
 
 #: ../../src/wxMaximaFrame.cpp:1437
 msgid "Row and column operations"
-msgstr ""
+msgstr "Дії з рядками і стовпчиками"
 
 #: ../../src/wxMaxima.cpp:7957 ../../src/wxMaxima.cpp:7967
 #: ../../src/wxMaxima.cpp:7972
 msgid "Row number:"
-msgstr ""
+msgstr "Номер рядка:"
 
 #: ../../src/wxMaxima.cpp:7977
 msgid "Row numbers:"
-msgstr ""
+msgstr "Номери рядків:"
 
 #: ../../src/wxMaxima.cpp:8203
+#, fuzzy
 msgid "Rows"
-msgstr ""
+msgstr "Рядків:"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Rule"
-msgstr ""
+msgstr "Правило"
 
 #: ../../src/wxMaxima.cpp:8464 ../../src/wxMaxima.cpp:8477
 msgid "Rule:"
-msgstr ""
+msgstr "Правило:"
 
 #: ../../src/wxMaximaFrame.cpp:1027
 msgid "Rules"
-msgstr ""
+msgstr "Правила"
 
 #: ../../src/wxMaximaFrame.cpp:1693
 msgid "Run each element through an expression"
-msgstr ""
+msgstr "Пропустити кожен елемент крізь вираз"
 
 #: ../../src/wxMaxima.cpp:6355
 #, c-format
 msgid "Running %s on the file %s: "
-msgstr ""
+msgstr "Запускаємо %s для файла %s: "
 
 #: ../../src/wxMaxima.cpp:2633
 #, c-format
 msgid "Running maxima as: %s"
-msgstr ""
+msgstr "Запускаємо maxima як: %s"
 
 #: ../../src/wxMaximaFrame.cpp:130
 msgid "Running on DirectFB"
-msgstr ""
+msgstr "Працюємо на основі DirectFB"
 
 #: ../../src/wxMaximaFrame.cpp:114
 msgid "Running on MS Windows"
-msgstr ""
+msgstr "Працюємо у MS Windows"
 
 #: ../../src/wxMaximaFrame.cpp:116
 msgid "Running on MS Windows using DirectDraw"
-msgstr ""
+msgstr "Працюємо у MS Windows з використанням DirectDraw"
 
 #: ../../src/wxMaximaFrame.cpp:136
 msgid "Running on Mac OS"
-msgstr ""
+msgstr "Працюємо у Mac OS"
 
 #: ../../src/wxMaximaFrame.cpp:127
 msgid "Running on Motif"
-msgstr ""
+msgstr "Працюємо з Motif"
 
 #: ../../src/wxMaximaFrame.cpp:133
 msgid "Running on the universal wxWidgets port"
-msgstr ""
+msgstr "Працюємо із універсальним портом wxWidgets"
 
 #: ../../src/wxMaxima.cpp:8208
 msgid ""
 "Runs each element of an object (list, matrix, equation,...) through a "
 "function individually"
 msgstr ""
+"Пропускає кожен елемент об'єкта (списку, матриці, рівняння,...) крізь "
+"функцію окремо"
 
 #: ../../src/wxMaxima.cpp:8216
 msgid ""
 "Runs each element of an object (list, matrix, equation,...) through an "
 "expression individually"
 msgstr ""
+"Пропускає кожен елемент об'єкта (списку, матриці, рівняння,...) крізь вираз "
+"окремо"
 
 #: ../../src/wxMaximaFrame.cpp:1691
 msgid "Runs each element through a function"
-msgstr ""
+msgstr "Пропустити крізь функцію кожен пункт"
 
 #: ../../src/wxMaximaFrame.cpp:1694
 msgid "Runs each element through an expression"
-msgstr ""
+msgstr "Пропускає кожен елемент крізь вираз"
 
 #: ../../src/wxMaxima.cpp:9572
 msgid "Sample 1:"
-msgstr ""
+msgstr "Вибірка 1:"
 
 #: ../../src/wxMaxima.cpp:9573
 msgid "Sample 2:"
-msgstr ""
+msgstr "Вибірка 2:"
 
 #: ../../src/wxMaxima.cpp:9567
 msgid "Sample:"
-msgstr ""
+msgstr "Вибірка:"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaxima.cpp:11203
 msgid "Save"
-msgstr ""
+msgstr "Зберегти"
 
 #: ../../src/Worksheet.cpp:1294
 msgid "Save Animation..."
-msgstr ""
+msgstr "Зберегти анімацію…"
 
 #: ../../src/wxMaxima.cpp:5672
 msgid "Save As"
-msgstr ""
+msgstr "Зберегти як"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save As...\tShift+Ctrl+S"
-msgstr ""
+msgstr "Зберегти як\tShift+Ctrl+S"
 
 #: ../../src/Worksheet.cpp:1291
 msgid "Save Image..."
-msgstr ""
+msgstr "Зберегти зображення…"
 
 #: ../../src/wxMaxima.cpp:6440
 msgid "Save Selection to Image"
-msgstr ""
+msgstr "Зберегти позначене як зображення"
 
 #: ../../src/wxMaximaFrame.cpp:675
 msgid "Save Selection to Image..."
-msgstr ""
+msgstr "Зберегти позначене як зображення…"
 
 #: ../../src/wxMaxima.cpp:10184
 msgid "Save animation to file"
-msgstr ""
+msgstr "Зберегти анімацію до файла"
 
 #: ../../src/wxMaxima.cpp:7203
 msgid "Save as lisp code"
-msgstr ""
+msgstr "Зберегти як код lisp"
 
 #: ../../src/wxMaximaFrame.cpp:1091
 msgid "Save as lisp..."
-msgstr ""
+msgstr "Зберегти як lisp…"
 
 #: ../../src/ToolBar.cpp:177 ../../src/wxMaximaFrame.cpp:608
 msgid "Save document"
-msgstr ""
+msgstr "Зберегти документ"
 
 #: ../../src/wxMaximaFrame.cpp:609
 msgid "Save document as"
-msgstr ""
+msgstr "Зберегти документ як"
 
 #: ../../src/wxMaximaFrame.cpp:676
 msgid "Save selection from document to an image file"
-msgstr ""
+msgstr "Зберегти позначене у документі до файла зображення"
 
 #: ../../src/wxMaxima.cpp:10125
 msgid "Save selection to file"
-msgstr ""
+msgstr "Зберегти позначене до файла"
 
 #: ../../src/wxMaximaFrame.cpp:573
 msgid "Saving failed."
-msgstr ""
+msgstr "Спроба збереження зазнала невдачі."
 
 #: ../../src/WXMXformat.cpp:310
 msgid "Saving succeeded, but the resulting files has disappeared ?!?."
-msgstr ""
+msgstr "Дані успішно збережено, але файли-результати зникли ?!?."
 
 #: ../../src/wxMaxima.cpp:10107
 msgid ""
@@ -5950,337 +6185,355 @@ msgid ""
 "(*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|Portable anymap "
 "(*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
+"зображення масштабованої векторної графіки (*.svg)|*.svg|зображення "
+"стисненої векторної графіки (*.svgz)|*.svgz|зображення PNG "
+"(*.png)|*.png|зображення JPEG (*.jpg)|*.jpg|зображення GIF "
+"(*.gif)|*.gif|растрове зображення Windows (*.bmp)|*.bmp|портативна "
+"універсальна карта (*.pnm)|*.pnm|формат файлів з мітками "
+"(*.tif)|*.tif|растрова карта X (*.xpm)|*.xpm"
 
 #: ../../src/wxMaxima.cpp:9533
 msgid "Scatterplot"
-msgstr ""
+msgstr "Точкова діаграма"
 
 #: ../../src/Autocomplete.cpp:125
 msgid ""
 "Scheduling a background task that compiles a new list of autocompletable "
 "maxima commands."
 msgstr ""
+"Плануємо фонове завдання, яке збирає новий список автоматичного доповнення "
+"для команд maxima."
 
 #: ../../src/Autocomplete.cpp:458
 msgid ""
 "Scheduling a background task that scans for autocompletable file names."
 msgstr ""
+"Плануємо фонове завдання сканування назв файлів для автоматичного "
+"доповнення."
 
 #: ../../src/ToolBar.cpp:632
 msgid "Search button"
-msgstr ""
+msgstr "Кнопка пошуку"
 
 #: ../../src/wxMaxima.cpp:7454
 msgid "Search first occurrence of part"
-msgstr ""
+msgstr "Шукати перший відповідник частини"
 
 #: ../../src/wxMaximaFrame.cpp:1178
 msgid "Search..."
-msgstr ""
+msgstr "Шукати…"
 
 #: ../../src/ToolBar.cpp:273
 msgid "Section"
-msgstr ""
+msgstr "Розділ"
 
 #: ../../src/Configuration.cpp:91
 msgid "Section cell (Heading 2)"
-msgstr ""
+msgstr "Комірка розділу (Заголовок 2)"
 
 #: ../../src/wxMaxima.cpp:7218
 msgid "Seek to position"
-msgstr ""
+msgstr "Перейти до позиції"
 
 #: ../../src/BTextCtrl.cpp:45
 msgid "Seems like something is broken with a font."
-msgstr ""
+msgstr "Здається, маємо якісь проблеми із шрифтом."
 
 #: ../../src/Autocomplete.cpp:350
 msgid "Seems like the package with the maxima share files isn't installed."
 msgstr ""
+"Здається, пакунок із файлами спільного використання maxima не встановлено."
 
 #: ../../src/Worksheet.cpp:1655 ../../src/Worksheet.cpp:1687
 msgid "Select All"
-msgstr ""
+msgstr "Позначити все"
 
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select All\tCtrl+A"
-msgstr ""
+msgstr "Позначити все\tCtrl+A"
 
 #: ../../src/ToolBar.cpp:629
 msgid "Select All button"
-msgstr ""
+msgstr "Кнопка «Позначити все»"
 
 #: ../../src/wxMaxima.cpp:9631
 msgid "Select Subsample"
-msgstr ""
+msgstr "Виберіть підвибірку"
 
 #: ../../src/ToolBar.cpp:214 ../../src/ToolBar.cpp:215
 #: ../../src/wxMaximaFrame.cpp:673
 msgid "Select all"
-msgstr ""
+msgstr "Позначити все"
 
 #: ../../src/wxMaxima.cpp:6971
 msgid "Select math display algorithm"
-msgstr ""
+msgstr "Виберіть спосіб показу математичних формул"
 
 #: ../../src/Configuration.cpp:98
 msgid "Selection color"
-msgstr ""
+msgstr "Колір позначення"
 
 #: ../../src/ToolBar.cpp:252
 msgid "Send all cells to maxima"
-msgstr ""
+msgstr "Надіслати усі комірки до maxima"
 
 #: ../../src/ToolBar.cpp:249
 msgid "Send the current cell to maxima"
-msgstr ""
+msgstr "Надіслати поточну комірку до maxima"
 
 #: ../../src/wxMaxima.cpp:2810
 msgid "Sending Maxima a SIGINT signal."
-msgstr ""
+msgstr "Надсилаємо Maxima сигнал SIGINT."
 
 #: ../../src/StatusBar.cpp:220
 msgid "Sending a command to Maxima"
-msgstr ""
+msgstr "Надсилаємо команду до Maxima"
 
 #: ../../src/wxMaxima.cpp:10598
 msgid "Sending a new command to Maxima."
-msgstr ""
+msgstr "Надсилаємо нову команду до Maxima."
 
 #: ../../src/wxMaxima.cpp:2792
 msgid "Sending an interrupt signal to Maxima."
-msgstr ""
+msgstr "Надсилаємо сигнал переривання Maxima."
 
 #: ../../src/wxMaxima.cpp:169
 msgid "Sending configuration data to maxima."
-msgstr ""
+msgstr "Надсилаємо дані налаштувань до maxima."
 
 #: ../../src/wxMaxima.cpp:4718
 msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
+"Надсилаємо maxima дані щодо того, як виразити двовимірні математичні формули"
+" у форматі XML"
 
 #: ../../src/wxMaximaFrame.cpp:1533
 msgid "Sequential Comparative Simplification"
-msgstr ""
+msgstr "Послідовне порівняльне спрощення"
 
 #: ../../src/wxMaxima.cpp:9016
 msgid "Series"
-msgstr ""
+msgstr "Ряд"
 
 #: ../../src/wxMaximaFrame.cpp:1479
 msgid "Series approximation"
-msgstr ""
+msgstr "Апроксимація рядом"
 
 #: ../../src/wxMaxima.cpp:2561
 msgid "Server started"
-msgstr ""
+msgstr "Сервер запущено"
 
 #: ../../src/wxMaximaFrame.cpp:1824
 msgid "Set &displayed Precision..."
-msgstr ""
+msgstr "Встановити &точність показу…"
 
 #: ../../src/wxMaximaFrame.cpp:1563
 msgid "Set Maxima option variable logexpand:all"
-msgstr ""
+msgstr "Встановити для змінної Maxima logexpand:all"
 
 #: ../../src/wxMaximaFrame.cpp:1567
 msgid "Set Maxima option variable logexpand:super"
-msgstr ""
+msgstr "Встановити для змінної Maxima logexpand:super"
 
 #: ../../src/wxMaximaFrame.cpp:1560
 msgid "Set Maxima option variable logexpand:true"
-msgstr ""
+msgstr "Встановити для змінної Maxima logexpand:true"
 
 #: ../../src/wxMaximaFrame.cpp:822
 msgid "Set Zoom"
-msgstr ""
+msgstr "Встановити масштаб"
 
 #: ../../src/wxMaximaFrame.cpp:1819
 msgid "Set bigfloat &Precision..."
-msgstr ""
+msgstr "Встановити підвищену то&чність обчислень…"
 
 #: ../../src/Worksheet.cpp:1306 ../../src/Worksheet.cpp:1479
 msgid "Set image resolution"
-msgstr ""
+msgstr "Встановити роздільну здатність зображення"
 
 #: ../../src/wxMaximaFrame.cpp:1510
 msgid "Set main variable..."
-msgstr ""
+msgstr "Встановити основну змінну…"
 
 #: ../../src/wxMaximaFrame.cpp:1773
 msgid "Set plot format"
-msgstr ""
+msgstr "Встановити формат графіка"
 
 #: ../../src/wxMaximaFrame.cpp:1101
 msgid "Set position..."
-msgstr ""
+msgstr "Встановити позицію…"
 
 #: ../../src/wxMaximaFrame.cpp:1656
 msgid "Set the \"algebraic\" flag"
-msgstr ""
+msgstr "Встановити «алгебраїчний» прапорець"
 
 #: ../../src/wxMaxima.cpp:8314
 msgid "Set the diagram title"
-msgstr ""
+msgstr "Встановити заголовок діаграми"
 
 #: ../../src/wxMaximaFrame.cpp:1779
 msgid "Set the frame rate for animations."
-msgstr ""
+msgstr "Встановити частоту кадрів для анімацій."
 
 #: ../../src/wxMaxima.cpp:8377
 msgid "Set the grid density."
-msgstr ""
+msgstr "Встановити щільність сітки."
 
 #: ../../src/wxMaxima.cpp:8327
 msgid "Set the next plot's title. Empty = no title."
-msgstr ""
+msgstr "Встановити заголовок наступного креслення. Порожній = без заголовка."
 
 #: ../../src/wxMaximaFrame.cpp:1820
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can"
 " be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
+"Встановити точність для чисел, які визначаються типом bigfloat. Такі числа "
+"можна вказати за допомогою такого коду: 1.5b12 або bfloat(1.234)"
 
 #: ../../src/wxMaximaFrame.cpp:811
 msgid "Set zoom to 100%"
-msgstr ""
+msgstr "Встановити масштаб у 100%"
 
 #: ../../src/wxMaximaFrame.cpp:813
 msgid "Set zoom to 120%"
-msgstr ""
+msgstr "Встановити масштаб у 120%"
 
 #: ../../src/wxMaximaFrame.cpp:815
 msgid "Set zoom to 150%"
-msgstr ""
+msgstr "Встановити масштаб у 150%"
 
 #: ../../src/wxMaximaFrame.cpp:817
 msgid "Set zoom to 200%"
-msgstr ""
+msgstr "Встановити масштаб у 200%"
 
 #: ../../src/wxMaximaFrame.cpp:819
 msgid "Set zoom to 300%"
-msgstr ""
+msgstr "Встановити масштаб у 300%"
 
 #: ../../src/wxMaximaFrame.cpp:809
 msgid "Set zoom to 80%"
-msgstr ""
+msgstr "Встановити масштаб у 80%"
 
 #: ../../src/wxMaxima.cpp:4731
 #, c-format
 msgid "Setting gnuplot_binary to %s"
-msgstr ""
+msgstr "Встановлюємо для gnuplot_binary значення %s"
 
 #: ../../src/wxMaxima.cpp:4804
 msgid "Setting prompt and help format"
-msgstr ""
+msgstr "Встановлення форматів запиту і довідки"
 
 #: ../../src/wxMaximaFrame.cpp:1292
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
+"Встановити значення для розвя'зання ЗДР за допомогою перетворення Лапласа"
 
 #: ../../src/wxMaximaFrame.cpp:1661
 msgid "Setup modulus computation"
-msgstr ""
+msgstr "Встановити обчислення за модулем"
 
 #: ../../src/wxMaxima.cpp:9220
 msgid "Setup the engineering format"
-msgstr ""
+msgstr "Налаштувати науковий формат"
 
 #: ../../src/wxMaximaFrame.cpp:1831
 msgid "Setup the engineering format..."
-msgstr ""
+msgstr "Налаштувати науковий формат…"
 
 #: ../../src/wxMaxima.cpp:9576
 msgid "Shapiro-Wilk test for normality"
-msgstr ""
+msgstr "Перевірка нормальності Шапіро-Вілка"
 
 #: ../../src/Worksheet.cpp:1543
 msgid "Show \"%\" in special constants"
-msgstr ""
+msgstr "Показувати «%» у спеціальних сталих"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show &Tips..."
-msgstr ""
+msgstr "Показати п&ідказку…"
 
 #: ../../src/Worksheet.cpp:1556
 msgid "Show * as multiplication dot"
-msgstr ""
+msgstr "Показувати * як знак множення"
 
 #: ../../src/wxMaximaFrame.cpp:895
 msgid "Show Template\tCtrl+Shift+Space"
-msgstr ""
+msgstr "Показати шаблон\tCtrl+Shift+Space"
 
 #: ../../src/wxMaximaFrame.cpp:753
+#, fuzzy
 msgid "Show XML representation"
-msgstr ""
+msgstr "Показувати довгі вирази:"
 
 #: ../../src/wxMaximaFrame.cpp:1889
 msgid "Show a tip"
-msgstr ""
+msgstr "Показати підказку"
 
 #: ../../src/Worksheet.cpp:1607
 msgid "Show all + allow linebreaks in long numbers"
-msgstr ""
+msgstr "Показати все + дозволити розривати рядки із довгими числами"
 
 #: ../../src/wxMaxima.cpp:9475
 msgid "Show all commands similar to:"
-msgstr ""
+msgstr "Показати всі команди, подібні до:"
 
 #: ../../src/wxMaxima.cpp:9468
 msgid "Show an example for the command:"
-msgstr ""
+msgstr "Показати приклад для команди:"
 
 #: ../../src/wxMaximaFrame.cpp:1883
 msgid "Show an example of usage"
-msgstr ""
+msgstr "Показати приклад використання"
 
 #: ../../src/wxMaximaFrame.cpp:1884
 msgid "Show commands similar to"
-msgstr ""
+msgstr "Показати команди, подібні до"
 
 #: ../../src/wxMaximaFrame.cpp:1020
 msgid "Show defined functions"
-msgstr ""
+msgstr "Показати визначені функції"
 
 #: ../../src/wxMaximaFrame.cpp:1022
 msgid "Show defined variables"
-msgstr ""
+msgstr "Показати визначені змінні"
 
 #: ../../src/wxMaximaFrame.cpp:1074
 msgid "Show definition of a function"
-msgstr ""
+msgstr "Показати визначення функції"
 
 #: ../../src/wxMaximaFrame.cpp:740
 msgid "Show equations in their linear form"
-msgstr ""
+msgstr "Показувати рівняння у лінійній формі"
 
 #: ../../src/wxMaximaFrame.cpp:1073
 msgid "Show function &Definition..."
-msgstr ""
+msgstr "Показати ви&значення функції…"
 
 #: ../../src/wxMaximaFrame.cpp:896
 msgid "Show function template"
-msgstr ""
+msgstr "Показати шаблон функції"
 
 #: ../../src/Worksheet.cpp:1614
 msgid "Show input labels"
-msgstr ""
+msgstr "Показувати мітки вхідних даних"
 
 #: ../../src/wxMaximaFrame.cpp:750
+#, fuzzy
 msgid "Show lisp representation"
-msgstr ""
+msgstr "Показувати довгі вирази:"
 
 #: ../../src/Worksheet.cpp:1604
 msgid "Show max. 100 digits"
-msgstr ""
+msgstr "Показувати не більше 100 цифр"
 
 #: ../../src/Worksheet.cpp:1602
 msgid "Show max. 20 digits"
-msgstr ""
+msgstr "Показувати не більше 20 цифр"
 
 #: ../../src/Worksheet.cpp:1603
 msgid "Show max. 50 digits"
-msgstr ""
+msgstr "Показувати не більше 50 цифр"
 
 #: ../../src/wxMaximaFrame.cpp:835
 msgid "Show or hide the wxMaxima logging window"
@@ -6288,43 +6541,43 @@ msgstr ""
 
 #: ../../src/ToolBar.cpp:612
 msgid "Show the \"New\" button?"
-msgstr ""
+msgstr "Показувати кнопку «Створити»?"
 
 #: ../../src/ToolBar.cpp:636
 msgid "Show the \"help\" button?"
-msgstr ""
+msgstr "Показувати кнопку «Довідка»?"
 
 #: ../../src/ToolBar.cpp:633
 msgid "Show the \"search\" button?"
-msgstr ""
+msgstr "Показувати кнопку «Пошук»"
 
 #: ../../src/ToolBar.cpp:630
 msgid "Show the \"select all\" button?"
-msgstr ""
+msgstr "Показувати кнопку «Позначити все»?"
 
 #: ../../src/ToolBar.cpp:624
 msgid "Show the Copy, Cut and the Paste button?"
-msgstr ""
+msgstr "Показувати кнопки копіювання, вирізання та вставлення?"
 
 #: ../../src/wxMaxima.cpp:7033
 msgid "Show the function's definition"
-msgstr ""
+msgstr "Показати визначення функції"
 
 #: ../../src/ToolBar.cpp:618
 msgid "Show the open and the save button?"
-msgstr ""
+msgstr "Показувати кнопки відкриття і збереження?"
 
 #: ../../src/ToolBar.cpp:627
 msgid "Show the preferences button?"
-msgstr ""
+msgstr "Показувати кнопку налаштувань?"
 
 #: ../../src/ToolBar.cpp:621
 msgid "Show the print button?"
-msgstr ""
+msgstr "Показувати кнопку друку?"
 
 #: ../../src/ToolBar.cpp:615
 msgid "Show the undo and redo button?"
-msgstr ""
+msgstr "Показувати кнопки скасування і повторення?"
 
 #: ../../src/wxMaximaFrame.cpp:1006 ../../src/wxMaximaFrame.cpp:1011
 msgid "Show used + to-be-freed memory"
@@ -6332,334 +6585,343 @@ msgstr ""
 
 #: ../../src/wxMaximaFrame.cpp:1033
 msgid "Show user definitions"
-msgstr ""
+msgstr "Показати визначення користувача"
 
 #: ../../src/ToolBar.cpp:328 ../../src/wxMaximaFrame.cpp:1877
 #: ../../src/wxMaximaFrame.cpp:1879
 msgid "Show wxMaxima help"
-msgstr ""
+msgstr "Показати довідку з wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1825
 msgid "Shows how many digits of a numbers are displayed"
-msgstr ""
+msgstr "Показує, скільки цифр буде показано у числах"
 
 #: ../../src/wxMaximaFrame.cpp:732
 msgid "Sidebars"
-msgstr ""
+msgstr "Бічні панелі"
 
 #: ../../src/wxMaximaFrame.cpp:1513
 msgid "Simplify &Radicals..."
-msgstr ""
+msgstr "Спростити &радикали…"
 
 #: ../../src/Worksheet.cpp:1579
 msgid "Simplify Expression"
-msgstr ""
+msgstr "Спростити вираз"
 
 #: ../../src/wxMaximaFrame.cpp:1568
 msgid "Simplify Logarithms"
-msgstr ""
+msgstr "Спростити логарифми"
 
 #: ../../src/wxMaximaFrame.cpp:1582
 msgid "Simplify an expression containing factorials"
-msgstr ""
+msgstr "Спростити вираз, що містить факторіали"
 
 #: ../../src/wxMaximaFrame.cpp:1539
 msgid "Simplify equations"
-msgstr ""
+msgstr "Спростити рівняння"
 
 #: ../../src/wxMaximaFrame.cpp:1514
 msgid "Simplify expression containing radicals"
-msgstr ""
+msgstr "Спростити вираз, що містить радикали"
 
 #: ../../src/wxMaxima.cpp:8649
 msgid "Simplify radicals"
-msgstr ""
+msgstr "Спростити радикали"
 
 #: ../../src/wxMaximaFrame.cpp:1512
 msgid "Simplify rational expression"
-msgstr ""
+msgstr "Спростити раціональний вираз"
 
 #: ../../src/wxMaximaFrame.cpp:1538
 msgid "Simplify sum() commands..."
-msgstr ""
+msgstr "Спростити команди sum()…"
 
 #: ../../src/wxMaxima.cpp:8636
 msgid "Simplify sums"
-msgstr ""
+msgstr "Спростити суми"
 
 #: ../../src/wxMaximaFrame.cpp:1592
 msgid "Simplify trigonometric expression"
-msgstr ""
+msgstr "Спростити тригонометричний вираз"
 
 #: ../../src/wxMaximaFrame.cpp:1399
 msgid "Singular Values"
-msgstr ""
+msgstr "Особливі значення)"
 
 #: ../../src/wxMaximaFrame.cpp:1400 ../../src/wxMaximaFrame.cpp:1403
 msgid "Singular values using dgesvd"
-msgstr ""
+msgstr "Особливі значення за допомогою dgesvd"
 
 #: ../../src/wxMaximaFrame.cpp:1402
 msgid "Singular values, left + right vectors"
-msgstr ""
+msgstr "Особливі значення, лівий + правий вектори"
 
 #: ../../src/wxMaximaFrame.cpp:1635
 msgid "Smart Substitute..."
-msgstr ""
+msgstr "Кмітливе підставляння…"
 
 #: ../../src/wxMaxima.cpp:8730
 msgid "Smart substitution"
-msgstr ""
+msgstr "Кмітливе підставляння"
 
 #: ../../src/wxMaxima.cpp:7799 ../../src/wxMaxima.cpp:7810
 #: ../../src/wxMaxima.cpp:7823
 msgid "Solution of the ODE:"
-msgstr ""
+msgstr "Розв'язок ЗДР:"
 
 #: ../../src/wxMaxima.cpp:10017
 msgid "Solve"
-msgstr ""
+msgstr "Розв'язати"
 
 #: ../../src/wxMaximaFrame.cpp:1244
 msgid "Solve &Algebraic System..."
-msgstr ""
+msgstr "Розв'язати систему &алгебраїчних рівнянь…"
 
 #: ../../src/wxMaximaFrame.cpp:1242
 msgid "Solve &Linear System..."
-msgstr ""
+msgstr "Розв'язати систему &лінійних рівнянь…"
 
 #: ../../src/wxMaximaFrame.cpp:1266
 msgid "Solve &ODE..."
-msgstr ""
+msgstr "Розв'язати &ЗДР…"
 
 #: ../../src/wxMaximaFrame.cpp:1240
 msgid "Solve (to_poly)..."
-msgstr ""
+msgstr "Розв'язати (to_poly)…"
 
 #: ../../src/wxMaxima.cpp:8045
 msgid "Solve A*x=b numerically"
-msgstr ""
+msgstr "Розв'язати A*x=b обчислювальними методами"
 
 #: ../../src/wxMaximaFrame.cpp:1397
 msgid "Solve Ax=b"
-msgstr ""
+msgstr "Розв'язати Ax=b"
 
 #: ../../src/wxMaxima.cpp:7783
 msgid "Solve ODE"
-msgstr ""
+msgstr "Розв'язати ЗДР"
 
 #: ../../src/wxMaximaFrame.cpp:1287
 msgid "Solve ODE with Lapla&ce..."
-msgstr ""
+msgstr "Розв'язати ЗДР за допомогою перетворення &Лапласа…"
 
 #: ../../src/wxMaximaFrame.cpp:1398
 msgid "Solve a linear equation system using dgesv"
-msgstr ""
+msgstr "Розв'язати систему лінійних рівнянь за допомогою dgesv"
 
 #: ../../src/wxMaxima.cpp:7852 ../../src/wxMaxima.cpp:7863
 msgid "Solve algebraic system"
-msgstr ""
+msgstr "Розв'язати систему алгебраїчних рівнянь"
 
 #: ../../src/wxMaximaFrame.cpp:1245
 msgid "Solve algebraic system of equations"
-msgstr ""
+msgstr "Розв'язати систему алгебраїчних рівнянь"
 
 #: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve boundary value problem for second degree ODE"
-msgstr ""
+msgstr "Розв'язати крайову задачу для ЗДР другого порядку"
 
 #: ../../src/wxMaxima.cpp:7895
 msgid "Solve differential equations using laplace()"
-msgstr ""
+msgstr "Розв'язати диференціальні рівняння за допомогою laplace()"
 
 #: ../../src/wxMaxima.cpp:7744 ../../src/wxMaximaFrame.cpp:1238
 msgid "Solve equation(s)"
-msgstr ""
+msgstr "Розв'язати рівняння"
 
 #: ../../src/wxMaximaFrame.cpp:1241
 msgid "Solve equation(s) with to_poly_solve"
-msgstr ""
+msgstr "Розв'язати рівняння за допомогою to_poly_solve"
 
 #: ../../src/wxMaxima.cpp:7773
+#, fuzzy
 msgid "Solve equations numerically"
-msgstr ""
+msgstr "Розв'язати поліноміальне рівняння обчислювальними методами"
 
 #: ../../src/wxMaxima.cpp:7757
 msgid "Solve equations to polynom"
-msgstr ""
+msgstr "Розв'язати рівняння для поліномів"
 
 #: ../../src/wxMaximaFrame.cpp:1271
 msgid "Solve initial value problem for first degree ODE"
-msgstr ""
+msgstr "Розв'язати задачу Коші для ЗДР першого порядку"
 
 #: ../../src/wxMaximaFrame.cpp:1275
 msgid "Solve initial value problem for second degree ODE"
-msgstr ""
+msgstr "Розв'язати задачу Коші для ЗДР другого порядку"
 
 #: ../../src/wxMaxima.cpp:7874 ../../src/wxMaxima.cpp:7884
 msgid "Solve linear system"
-msgstr ""
+msgstr "Розв'язати систему лінійних рівнянь"
 
 #: ../../src/wxMaximaFrame.cpp:1243
 msgid "Solve linear system of equations"
-msgstr ""
+msgstr "Розв'язати систему лінійних рівнянь"
 
 #: ../../src/wxMaximaFrame.cpp:1263
 msgid "Solve numerical, 1 Variable"
-msgstr ""
+msgstr "Числове розв'язання, 1 змінна"
 
 #: ../../src/wxMaximaFrame.cpp:1267
 msgid "Solve ordinary differential equation of maximum degree 2"
-msgstr ""
+msgstr "Розв'язати звичайне диференціальне рівняння не вище другого порядку"
 
 #: ../../src/wxMaximaFrame.cpp:1288
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
+"Розв'язати звичайне диференціальне рівняння за допомогою перетворення "
+"Лапласа"
 
 #: ../../src/wxMaxima.cpp:7708
 msgid "Solve polynomials numerically"
-msgstr ""
+msgstr "Розв'язати поліноміальне рівняння обчислювальними методами"
 
 #: ../../src/wxMaxima.cpp:7718
 msgid "Solve polynomials numerically (bfloats)"
-msgstr ""
+msgstr "Розв'язати поліноміальне рівняння обчислювальними методами (bfloats)"
 
 #: ../../src/wxMaxima.cpp:7729
 msgid "Solve polynomials numerically (real roots)"
 msgstr ""
+"Розв'язати поліноміальне рівняння обчислювальними методами (дійсні корені)"
 
 #: ../../src/wxMaximaFrame.cpp:1249
 msgid "Solve symbolically"
-msgstr ""
+msgstr "Розв'язати символічно"
 
 #: ../../src/Worksheet.cpp:1574
 msgid "Solve..."
-msgstr ""
+msgstr "Розв'язати…"
 
 #: ../../src/wxMaximaFrame.cpp:1916
 msgid "Solving differential equations"
-msgstr ""
+msgstr "Розв'язування диференціальних рівнянь"
 
 #: ../../src/wxMaximaFrame.cpp:1904
 msgid "Solving equations with Maxima"
-msgstr ""
+msgstr "Розв'язування рівнянь з Maxima"
 
 #: ../../src/wxMaxima.cpp:7105
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Sometimes one wants maxima to loose the information that a function name was used with the ' operator in order to make maxima not evaluate it. In other places one wants % to mean \"the last expression at the time this function was created\", not \"the last expression now\".\n"
 "In both cases the '' operator will do what is requested."
 msgstr ""
+"Іноді потрібно, щоб maxima втратила відомості про те, що назву функції було використано з оператором «'», щоб maxima не виконувала її обчислення. В інших місцях може виникнути потреба, щоб «%» означало «останній вираз на момент, коли цю функцію було створено», а не «останній вираз зараз».\n"
+"В обох випадках оператор «''» виконає відповідне завдання."
 
 #: ../../src/wxMaximaFrame.cpp:1746
 msgid "Sort"
-msgstr ""
+msgstr "Упорядкувати"
 
 #: ../../src/wxMaxima.cpp:8496
 msgid "Sort a list"
-msgstr ""
+msgstr "Упорядкувати список"
 
 #: ../../src/wxMaxima.cpp:7459
 msgid "Sort all characters in string"
-msgstr ""
+msgstr "Упорядкувати усі символи у рядку"
 
 #: ../../src/wxMaximaFrame.cpp:1179
 msgid "Sort the characters..."
-msgstr ""
+msgstr "Упорядкувати символи…"
 
 #: ../../src/wxMaxima.cpp:8482
 msgid "Source list:"
-msgstr ""
+msgstr "Початковий список:"
 
 #: ../../src/wxMaxima.cpp:7429
 msgid "Split"
-msgstr ""
+msgstr "Розділити"
 
 #: ../../src/wxMaximaFrame.cpp:1191
 msgid "Split on match"
-msgstr ""
+msgstr "Поділити на відповіднику"
 
 #: ../../src/wxMaxima.cpp:7528
 msgid "Split on regex match"
-msgstr ""
+msgstr "Поділити на відповіднику формального виразу"
 
 #: ../../src/wxMaxima.cpp:7449
 msgid "Split string into tokens"
-msgstr ""
+msgstr "Поділити рядок на жетони"
 
 #: ../../src/wxMaximaFrame.cpp:1171
 msgid "Split..."
-msgstr ""
+msgstr "Розділити…"
 
 #: ../../src/wxMaximaFrame.cpp:788
 msgid "Square"
-msgstr ""
+msgstr "Квадратні"
 
 #: ../../src/Configuration.cpp:86
 msgid "Standard Text"
-msgstr ""
+msgstr "Стандартний текст"
 
 #: ../../src/Worksheet.cpp:1298
 msgid "Start Animation"
-msgstr ""
+msgstr "Почати анімацію"
 
 #: ../../src/wxMaxima.cpp:7842
 msgid "Start of t:"
-msgstr ""
+msgstr "Початок для t:"
 
 #: ../../src/ToolBar.cpp:305
 msgid "Start or Stop animation"
-msgstr ""
+msgstr "Почати або зупинити анімацію"
 
 #: ../../src/ToolBar.cpp:306
 msgid ""
 "Start or stop the currently selected animation that has been created with "
 "the with_slider class of commands"
 msgstr ""
+"Розпочати або зупинити поточну позначену анімацію, яку було створено за "
+"допомогою класу команд with_slider"
 
 #: ../../src/wxMaxima.cpp:386
 msgid "Starting Maxima process failed"
-msgstr ""
+msgstr "Спроба запустити процес Maxima завершилася невдало"
 
 #: ../../src/main.cpp:667
+#, fuzzy
 msgid "Starting a new wxMaxima process for a new window"
-msgstr ""
+msgstr "Запускаємо новий процес wxMaxima як %s"
 
 #: ../../src/wxMaxima.cpp:3105 ../../src/wxMaxima.cpp:5633
 msgid "Starting evaluation of the document"
-msgstr ""
+msgstr "Починаємо обробку документа"
 
 #: ../../src/wxMaxima.cpp:2544
 msgid "Starting server failed"
-msgstr ""
+msgstr "Не вдалося запустити сервер"
 
 #: ../../src/WXMXformat.cpp:64
 msgid "Starting to save the worksheet as .wxmx"
-msgstr ""
+msgstr "Розпочинаємо збереження робочого аркуша у форматі .wxmx"
 
 #: ../../src/wxMaximaFrame.cpp:252
 msgid "Statistics"
-msgstr ""
+msgstr "Статистика"
 
 #: ../../src/wxMaximaFrame.cpp:701
 msgid "Statistics\tAlt+Shift+S"
-msgstr ""
+msgstr "Статистика\tAlt+Shift+S"
 
 #: ../../src/wxMaxima.cpp:7844
 msgid "Step width:"
-msgstr ""
+msgstr "Ширина кроку:"
 
 #: ../../src/wxMaximaFrame.cpp:794
 msgid "Straight lines"
-msgstr ""
+msgstr "Прямі лінії"
 
 #: ../../src/wxMaximaFrame.cpp:1106
 msgid "Stream"
-msgstr ""
+msgstr "Потік"
 
 #: ../../src/wxMaxima.cpp:7231
 msgid "Stream length"
-msgstr ""
+msgstr "Довжина потоку"
 
 #: ../../src/wxMaxima.cpp:7219 ../../src/wxMaxima.cpp:7224
 #: ../../src/wxMaxima.cpp:7228 ../../src/wxMaxima.cpp:7232
@@ -6669,45 +6931,45 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7267 ../../src/wxMaxima.cpp:7271
 #: ../../src/wxMaxima.cpp:7276
 msgid "Stream:"
-msgstr ""
+msgstr "Потік:"
 
 #: ../../src/wxMaximaFrame.cpp:1185
 msgid "String"
-msgstr ""
+msgstr "Рядок"
 
 #: ../../src/wxMaxima.cpp:7345 ../../src/wxMaxima.cpp:7350
 #: ../../src/wxMaxima.cpp:7425
 msgid "String #1:"
-msgstr ""
+msgstr "Рядок 1:"
 
 #: ../../src/wxMaxima.cpp:7346 ../../src/wxMaxima.cpp:7351
 #: ../../src/wxMaxima.cpp:7426
 msgid "String #2:"
-msgstr ""
+msgstr "Рядок 2:"
 
 #: ../../src/wxMaximaFrame.cpp:1136
 msgid "String Tests"
-msgstr ""
+msgstr "Перевірки рядків"
 
 #: ../../src/wxMaxima.cpp:7415
 msgid "String length"
-msgstr ""
+msgstr "Довжина рядка"
 
 #: ../../src/wxMaxima.cpp:7381
 msgid "String to list of char"
-msgstr ""
+msgstr "Рядок у списку символів"
 
 #: ../../src/wxMaximaFrame.cpp:1148
 msgid "String to list of chars..."
-msgstr ""
+msgstr "Рядок у списку символів…"
 
 #: ../../src/wxMaxima.cpp:7496
 msgid "String to octets"
-msgstr ""
+msgstr "Рядок у вісімкові"
 
 #: ../../src/wxMaximaFrame.cpp:1160
 msgid "String to octets..."
-msgstr ""
+msgstr "Рядок у вісімкові..."
 
 #: ../../src/wxMaxima.cpp:7377 ../../src/wxMaxima.cpp:7382
 #: ../../src/wxMaxima.cpp:7391 ../../src/wxMaxima.cpp:7396
@@ -6721,74 +6983,76 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:7474 ../../src/wxMaxima.cpp:7478
 #: ../../src/wxMaxima.cpp:7497
 msgid "String:"
-msgstr ""
+msgstr "Рядок:"
 
 #: ../../src/wxMaxima.cpp:7197
 msgid "Struct :"
-msgstr ""
+msgstr "Структура:"
 
 #: ../../src/wxMaxima.cpp:7184 ../../src/wxMaxima.cpp:7190
 msgid "Struct type name:"
-msgstr ""
+msgstr "Назва типу структури:"
 
 #: ../../src/wxMaximaFrame.cpp:1029
 msgid "Structs"
-msgstr ""
+msgstr "Структури"
 
 #: ../../src/ToolBar.cpp:274
 msgid "Subsection"
-msgstr ""
+msgstr "Підрозділ"
 
 #: ../../src/Configuration.cpp:90
 msgid "Subsection cell (Heading 3)"
-msgstr ""
+msgstr "Комірка підрозділу (Заголовок 3)"
 
 #: ../../src/wxMaximaFrame.cpp:1643
 msgid "Subst constant t into eq with diff(x,t)..."
-msgstr ""
+msgstr "Підставити стале t до рівняння з diff(x,t)..."
 
 #: ../../src/wxMaxima.cpp:8724
 msgid "Subst is a better string-search-and-replace for expressions."
-msgstr ""
+msgstr "Subst є кращим методом пошуку і заміни рядка для виразів."
 
 #: ../../src/wxMaxima.cpp:7688 ../../src/wxMaxima.cpp:8723
 #: ../../src/wxMaxima.cpp:10061 ../../src/wxMaximaFrame.cpp:1651
 msgid "Substitute"
-msgstr ""
+msgstr "Підставити"
 
 #: ../../src/wxMaximaFrame.cpp:1193
 msgid "Substitute all matches"
-msgstr ""
+msgstr "Підставити в усі відповідники"
 
 #: ../../src/wxMaximaFrame.cpp:1192
 msgid "Substitute first match"
-msgstr ""
+msgstr "Підставити у перший відповідник"
 
 #: ../../src/wxMaximaFrame.cpp:1646
 msgid "Substitute only in parts..."
-msgstr ""
+msgstr "Підставити лише у частинах…"
 
 #: ../../src/wxMaxima.cpp:8763
 msgid "Substitute only in specific parts"
-msgstr ""
+msgstr "Підставити лише у вказані частини"
 
 #: ../../src/wxMaximaFrame.cpp:1647
 msgid "Substitute only in the elements n_1, n_2,..."
-msgstr ""
+msgstr "Підставити лише до елементів n_1, n_2,..."
 
 #: ../../src/Worksheet.cpp:1585 ../../src/wxMaximaFrame.cpp:1633
 msgid "Substitute..."
-msgstr ""
+msgstr "Підставити…"
 
 #: ../../src/wxMaximaFrame.cpp:1641 ../../src/wxMaximaFrame.cpp:1644
 msgid "Substitutes until the equation no more changes"
-msgstr ""
+msgstr "Підставляє, аж доки рівняння не перестає змінюватися"
 
 #: ../../src/wxMaxima.cpp:8747
 msgid ""
 "Substitutes up to lrats_max_iter times, or until the expression stops "
 "changing when substituting."
 msgstr ""
+"Виконує підставляння аж до lrats_max_iter разів або до того кроку, коли "
+"вираз перестане змінюватися після підставляння."
 
 #: ../../src/wxMaxima.cpp:8756
 #, c-format
@@ -6796,190 +7060,210 @@ msgid ""
 "Substitutes, but makes sure that if substituting t=0 in diff(x,t) the result"
 " isn't 0 (as t no more changes), but %at(diff(x,t),t=0)."
 msgstr ""
+"Виконує підставляння, але забезпечує такий режим роботи, що підставляння t=0"
+" до diff(x,t) даватиме не 0 (оскільки t не змінюється), а "
+"%at(diff(x,t),t=0)."
 
 #: ../../src/wxMaxima.cpp:8739
 msgid ""
 "Substitutes, but makes sure that nothing is substituted into the other "
 "substituents."
 msgstr ""
+"Підставити, але переконатися, що нічого не буде підставлено у підставлені "
+"фрагменти"
 
 #: ../../src/wxMaximaFrame.cpp:1638
 msgid "Substitutes, but not in the other substituents"
-msgstr ""
+msgstr "Підставити, але без підставляння до інших підставлених фрагментів"
 
 #: ../../src/wxMaxima.cpp:8764
 msgid ""
 "Substitutes, but only in the n_1th, n_2th and so on term of the equation."
 msgstr ""
+"Виконати підставляння, але лише до n_1-ої, n_2-ої та інших частин рівняння."
 
 #: ../../src/ToolBar.cpp:275
 msgid "Subsubsection"
-msgstr ""
+msgstr "Підпідрозділ"
 
 #: ../../src/Configuration.cpp:89
 msgid "Subsubsection cell (Heading 4)"
-msgstr ""
+msgstr "Комірка підпідрозділу (Заголовок 4)"
 
 #: ../../src/Worksheet.cpp:1831
+#, fuzzy
 msgid "Suggestion: "
-msgstr ""
+msgstr "Підрозділ"
 
 #: ../../src/Worksheet.cpp:2030
 msgid "Suitable as flag for ev()"
-msgstr ""
+msgstr "Є придатним, як прапорець, для ev()"
 
 #: ../../src/wxMaxima.cpp:9049
 msgid "Sum"
-msgstr ""
+msgstr "Сума"
 
 #: ../../src/wxMaximaFrame.cpp:1551
 msgid ""
 "Switch off simplifications of log(). Set Maxima option variable "
 "logexpand:false"
 msgstr ""
+"Вимкнути спрощення log(). Встановити для змінної Maxima logexpand:false"
 
 #: ../../src/wxMaxima.cpp:4090
 msgid "Switched to lisp mode after receiving a lisp debug prompt!"
 msgstr ""
+"Перемкнулися до режиму lisp після отримання діагностичного запиту lisp!"
 
 #: ../../src/wxMaxima.cpp:4092
 msgid "Switched to lisp mode after receiving a lisp prompt!"
-msgstr ""
+msgstr "Перемкнулися до режиму lisp після отримання запиту lisp!"
 
 #: ../../src/Worksheet.cpp:1971
 msgid "Symbolic Constant"
-msgstr ""
+msgstr "Символічна стала"
 
 #: ../../src/wxMaximaFrame.cpp:705
 msgid "Symbols\tAlt+Shift+Y"
-msgstr ""
+msgstr "Символи\tAlt+Shift+Y"
 
 #: ../../src/Worksheet.cpp:2006
 msgid "Symmetric function: f(x)=f(-x)"
-msgstr ""
+msgstr "Парна функція: f(x)=f(-x)"
 
 #: ../../src/wxMaximaFrame.cpp:238
 msgid "Table of Contents"
-msgstr ""
+msgstr "Зміст"
 
 #: ../../src/wxMaximaFrame.cpp:711
 msgid "Table of Contents\tAlt+Shift+T"
-msgstr ""
+msgstr "Зміст\tAlt+Shift+T"
 
 #: ../../src/wxMaxima.cpp:8930
 msgid "Taylor series"
-msgstr ""
+msgstr "Ряд Тейлора"
 
 #: ../../src/wxMaximaFrame.cpp:1474
 msgid "Taylor series..."
-msgstr ""
+msgstr "Ряд Тейлора…"
 
 #: ../../src/wxMaxima.cpp:8925
 msgid "Taylor series:"
-msgstr ""
+msgstr "Ряд Тейлора:"
 
 #: ../../src/wxMaxima.cpp:4132
 msgid "Telling maxima about the new working directory."
-msgstr ""
+msgstr "Повідомляємо maxima про новий робочий каталог."
 
 #: ../../src/wxMaxima.cpp:7907
 msgid "Tells maxima for an f(x), that f(x=t)=a"
-msgstr ""
+msgstr "Повідомляє maxima щодо f(x), що f(x=t)=a"
 
 #: ../../src/wxMaximaFrame.cpp:1945
 msgid ""
 "Tells maxima to show the help for ?, ?? and describe() in a separate browser"
 " window"
 msgstr ""
+"Наказує maxima показувати довідку для команд ?, ?? і describe() в окремому "
+"вікні браузера"
 
 #: ../../src/wxMaximaFrame.cpp:1941
 msgid ""
 "Tells maxima to show the help for ?, ?? and describe() in a wxMaxima sidebar"
 msgstr ""
+"Наказує maxima показувати довідку для команд ?, ?? і describe() на бічній "
+"панелі wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1936
 msgid "Tells maxima to show the help for ?, ?? and describe() on the console"
 msgstr ""
+"Наказує maxima показувати довідку для команд ?, ?? і describe() у консолі"
 
 #: ../../src/ToolBar.cpp:271
 msgid "Text"
-msgstr ""
+msgstr "Текст"
 
 #: ../../src/Configuration.cpp:93
 msgid "Text cell background"
-msgstr ""
+msgstr "Тло текстової комірки"
 
 #: ../../src/wxMaxima.cpp:6541
 msgid "Text snippet"
-msgstr ""
+msgstr "Фрагмент тексту"
 
 #: ../../src/wxMaxima.cpp:4632
 msgid ""
 "The .xml file doesn't seem to be valid xml or isn't a content.xml extracted "
 "from a .wxmx zip archive"
 msgstr ""
+"Здається, файл .xml не є коректним файлом xml або не є файлом content.xml, "
+"який видобуто з архіву zip .wxmx"
 
 #: ../../src/wxMaxima.cpp:2734
 msgid ""
 "The Maxima process doesn't offer a shared memory segment we can send an "
 "interrupt signal to."
 msgstr ""
+"У процесі Maxima не передбачено сегмента спільної пам'яті, до якого ми могли"
+" б надіслати сигнал переривання."
 
 #: ../../src/MaximaManual.cpp:107
 msgid "The cache for the subjects the manual contains cannot be read."
-msgstr ""
+msgstr "Кеш тем, які містяться у підручнику, є непридатним до читання."
 
 #: ../../src/MaximaManual.cpp:378
 msgid "The cache for the subjects the manual contains has no head node."
-msgstr ""
+msgstr "Кеш тем, які містяться у підручнику, не містить вузла заголовка."
 
 #: ../../src/MaximaManual.cpp:396
 msgid ""
 "The cache for the subjects the manual contains is from a different Maxima "
 "version."
-msgstr ""
+msgstr "Кеш тем, які містяться у підручнику, належить до іншої версії Maxima."
 
 #: ../../src/wxMaximaFrame.cpp:1379
 msgid "The classic operations one typically uses matrices for"
-msgstr ""
+msgstr "Класичні дії, для яких типово використовують матриці"
 
 #: ../../src/wxMaxima.cpp:7193
 msgid "The comma-separated contents of the struct fields"
-msgstr ""
+msgstr "Список вмісту полів структури, відокремлених комами"
 
 #: ../../src/wxMaxima.cpp:7186
 msgid "The comma-separated names of the struct fields"
-msgstr ""
+msgstr "Список назв полів структури, відокремлених комами"
 
 #: ../../src/wxMaxima.cpp:7070
 msgid ""
 "The command local() allows to tell maxima which functions to make local to "
 "the current program when defined."
 msgstr ""
+"За допомогою команди local() можна повідомити maxima, які функції слід "
+"зробити локальними щодо поточної програми при визначенні."
 
 #: ../../src/wxMaximaFrame.cpp:303
 msgid "The current Wizard"
-msgstr ""
+msgstr "Поточний майстер"
 
 #: ../../src/wxMaxima.cpp:9592
 msgid "The equation to fit the data to"
-msgstr ""
+msgstr "Рівняння, за яким слід апроксимувати дані"
 
 #: ../../src/wxMaxima.cpp:8447
 msgid "The function call whose arguments to extract"
-msgstr ""
+msgstr "Виклик функції, чиї аргументи слід видобути"
 
 #: ../../src/wxMaximaFrame.cpp:1298
 msgid "The half of the equation that is to the left of the \"=\""
-msgstr ""
+msgstr "Частина рівняння ліворуч від символу «=»"
 
 #: ../../src/wxMaximaFrame.cpp:1302
 msgid "The half of the equation that is to the right of the \"=\""
-msgstr ""
+msgstr "Частина рівняння праворуч від символу «=»"
 
 #: ../../src/MaximaManual.cpp:399
 msgid "The help dir from the cache differs from the current one."
-msgstr ""
+msgstr "Каталог довідки з кешу відрізняється від поточного каталогу."
 
 #: ../../src/Image.cpp:985
 msgid ""
@@ -6990,65 +7274,67 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:9799 ../../src/wxMaxima.cpp:10158
 #, c-format
 msgid "The image file \"%s\" cannot be found."
-msgstr ""
+msgstr "Не вдалося знайти файл зображення «%s»."
 
 #: ../../src/wxMaximaFrame.cpp:718
 msgid "The integrated help browser"
-msgstr ""
+msgstr "Інтегрований переглядач довідки"
 
 #: ../../src/wxMaxima.cpp:9591
 msgid "The list of variables contained in each matrix row"
-msgstr ""
+msgstr "Список змінних, що містяться у кожному з рядків матриці"
 
 #: ../../src/wxMaximaFrame.cpp:214
 msgid "The main toolbar"
-msgstr ""
+msgstr "Основна панель інструментів"
 
 #: ../../src/wxMaximaFrame.cpp:1882
 msgid "The manual of Maxima"
-msgstr ""
+msgstr "Підручник з Maxima"
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "The manual of wxMaxima"
-msgstr ""
+msgstr "Підручник з wxMaxima"
 
 #: ../../src/wxMaxima.cpp:7125
 msgid "The name of a function we don't want to be evaluated here"
-msgstr ""
+msgstr "Назва функції, яку не слід тут обчислювати"
 
 #: ../../src/wxMaxima.cpp:7131
 msgid "The name of an expression that we don't want to be evaluated."
-msgstr ""
+msgstr "Назва виразу, який не слід обчислювати."
 
 #: ../../src/wxMaxima.cpp:7199
 msgid "The name of the field to read"
-msgstr ""
+msgstr "Назва поля для читання"
 
 #: ../../src/wxMaxima.cpp:7185
 msgid "The name of the new struct type"
-msgstr ""
+msgstr "Назва типу нової структури"
 
 #: ../../src/wxMaxima.cpp:7198
 msgid "The name of the struct"
-msgstr ""
+msgstr "Назва структури"
 
 #: ../../src/wxMaxima.cpp:7191
 msgid "The name of the struct type"
-msgstr ""
+msgstr "Назва типу структури"
 
 #: ../../src/wxMaxima.cpp:8220
 msgid "The name of the variable that shall contain the current element"
-msgstr ""
+msgstr "Назва змінної, у якій міститиметься поточний елемент"
 
 #: ../../src/wxMaxima.cpp:8468
 msgid "The number of the item which is stepped from \"Index Start\" to \"Index End\"."
-msgstr ""
+msgstr "Номер пункту за кроками від «Початковий індекс» до «Кінцевий індекс»."
 
 #: ../../src/wxMaxima.cpp:8465 ../../src/wxMaxima.cpp:8478
 msgid ""
 "The rule that explains how to generate the value of a list item.\n"
 "Might be something like \"i\", \"i^2\" or \"sin(i)\""
 msgstr ""
+"Правило, яке визначає, як створювати значення пункту списку.\n"
+"Може бути подібним до «i», «i^2» або «sin(i)»."
 
 #: ../../src/wxMaxima.cpp:7785
 msgid ""
@@ -7056,18 +7342,24 @@ msgid ""
 "The actual height of that curve is defined by the initial condition or "
 "boundary values, later on."
 msgstr ""
+"Загальний розв'язок ЗДР описує загальну форму інтегральної кривої. Позиція "
+"інтегральної кривої визначається початковими або крайовими умовами пізніше."
 
 #: ../../src/wxMaxima.cpp:7818
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's result is known at two points this function fills in the correct values for the  constants"
 msgstr ""
+"Загальний розв'язок ЗДР визначає форму, але не позицію розв'язку.\n"
+"Якщо відомий результат розв'язання ЗДР у двох точках, ця функція встановлює належні значення сталих"
 
 #: ../../src/wxMaxima.cpp:7794 ../../src/wxMaxima.cpp:7805
 msgid ""
 "The solution of an ODE tells the shape, but not the height of the solution.\n"
 "If the ODE's state is known at a point this function fills in the correct values for the constants"
 msgstr ""
+"Загальний розв'язок ЗДР визначає форму, але не позицію розв'язку.\n"
+"Якщо відомий стан ЗДР у точці, ця функція встановлює належні значення сталих"
 
 #: ../../src/wxMaxima.cpp:7896
 msgid ""
@@ -7075,22 +7367,25 @@ msgid ""
 "   U(t)=1/2*U(t)+3*diff(U(t),t)\n"
 "for this to work; Initial conditions can be specified using atvalue()."
 msgstr ""
+"Щоб це спрацювало, змінну розв'язання слід подавати у формі\n"
+"   U(t)=1/2*U(t)+3*diff(U(t),t)\n"
+"Початкові умови можна вказати за допомогою atvalue()."
 
 #: ../../src/wxMaxima.cpp:8481 ../../src/wxMaxima.cpp:8582
 msgid "The variable the value of the current source item is stored in."
-msgstr ""
+msgstr "Змінна, до якої слід зберегти значення поточного пункту джерела."
 
 #: ../../src/wxMaxima.cpp:9594
 msgid "The variables to search the optimum solution for"
-msgstr ""
+msgstr "Змінна, для якої слід шукати оптимальний розв'язок"
 
 #: ../../src/wxMaximaFrame.cpp:193
 msgid "The worksheet"
-msgstr ""
+msgstr "Робочий аркуш"
 
 #: ../../src/Worksheet.cpp:8122
 msgid "The worksheet containing maxima's input and output"
-msgstr ""
+msgstr "Робочий аркуш, який містить вхідні і вихідні дані maxima"
 
 #: ../../src/MathParser.cpp:629
 msgid ""
@@ -7103,36 +7398,48 @@ msgid ""
 "There was an error in the XML maxima has generated.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"У XML була помилка, яку створено maxima.\n"
+"Будь ласка, повідомте про цю ваду розробникам проєкту wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3911
 msgid ""
 "There was an error in the XML that should contain a list of watch variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"У XML була помилка, яка має містити список змінних, за якими велося спостереження.\n"
+"Будь ласка, повідомте про цю ваду розробникам проєкту wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3869
 msgid ""
 "There was an error in the XML that should contain the list of operators.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"У XML була помилка, яка має містити список операторів.\n"
+"Будь ласка, повідомте про цю ваду розробникам проєкту wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3321
 msgid ""
 "There was an error in the XML that should describe the contents of some variables.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"У XML була помилка, яка має описувати вміст деяких змінних.\n"
+"Будь ласка, повідомте про цю ваду розробникам проєкту wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3257
 msgid ""
 "There was an error in the XML that should describe the manual topics.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"У XML була помилка, яка має описувати теми підручника.\n"
+"Будь ласка, повідомте про цю ваду розробникам проєкту wxMaxima."
 
 #: ../../src/wxMaxima.cpp:3202
 msgid ""
 "There was an error in the XML that should describe the status bar message.\n"
 "Please report this as a bug to the wxMaxima project."
 msgstr ""
+"У XML була помилка, яка має описувати повідомлення у рядку стану.\n"
+"Будь ласка, повідомте про цю ваду розробникам проєкту wxMaxima."
 
 #: ../../src/MaximaManual.cpp:363
 msgid ""
@@ -7140,110 +7447,116 @@ msgid ""
 "It caches the list of subjects maxima's manual offers and is automatically\n"
 "overwritten if maxima's version changes or the file cannot be read"
 msgstr ""
+"Цей файл було створено за допомогою wxMaxima.\n"
+"У ньому зберігається кеш тем, які містяться у підручнику з maxima. Його буде автоматично\n"
+"перезаписано, якщо версію maxima буде змінено або файл не вдасться прочитати"
 
 #: ../../src/Worksheet.cpp:1992
 msgid "This function will return even integers"
-msgstr ""
+msgstr "Ця функція повертає парні цілі числа"
 
 #: ../../src/Worksheet.cpp:1994
 msgid "This function will return odd integers"
-msgstr ""
+msgstr "Ця функція повертає непарні цілі числа"
 
 #: ../../src/Worksheet.cpp:1950
 msgid "This symbol has no imaginary part"
-msgstr ""
+msgstr "Цей символ не має уявної частини"
 
 #: ../../src/Worksheet.cpp:1956
 msgid "This symbol has no real part"
-msgstr ""
+msgstr "Цей символ не має дійсної частини"
 
 #: ../../src/Worksheet.cpp:1953
 msgid "This symbol might have both real and imaginary part"
-msgstr ""
+msgstr "Цей символ може мати дійсну і уявну частини"
 
 #: ../../src/Worksheet.cpp:1980
 msgid "Throw an error if this symbol is used before assigning it any contents"
 msgstr ""
+"Вивести повідомлення про помилку, якщо цей символ використано до "
+"встановлення його значення за допомогою якоїсь сталої"
 
 #: ../../src/wxMaxima.cpp:9013 ../../src/wxMaxima.cpp:10058
 msgid "Times:"
-msgstr ""
+msgstr "Порядок:"
 
 #: ../../src/ToolBar.cpp:272
 msgid "Title"
-msgstr ""
+msgstr "Заголовок"
 
 #: ../../src/wxMaxima.cpp:8315 ../../src/wxMaxima.cpp:8328
 msgid "Title (Sub- and superscripts as x_{10} or x^{10})"
 msgstr ""
+"Заголовок (можна використовувати нижні і верхні індекси: x_{10} або x^{10})"
 
 #: ../../src/Configuration.cpp:92
 msgid "Title cell (Heading 1)"
-msgstr ""
+msgstr "Комірка заголовка (Заголовок 1)"
 
 #: ../../src/wxMaximaFrame.cpp:1794
 msgid "To &Bigfloat"
-msgstr ""
+msgstr "У число &підвищеної точності з рухомою крапкою"
 
 #: ../../src/wxMaximaFrame.cpp:1791
 msgid "To &Float"
-msgstr ""
+msgstr "У число з &рухомою крапкою"
 
 #: ../../src/Worksheet.cpp:1571
 msgid "To Float"
-msgstr ""
+msgstr "У число з рухомою крапкою"
 
 #: ../../src/wxMaximaFrame.cpp:1797
 msgid "To Numeri&c\tCtrl+Shift+N"
-msgstr ""
+msgstr "У &число\tCtrl+Shift+N"
 
 #: ../../src/wxMaximaFrame.cpp:1803
 msgid "To exact fraction"
-msgstr ""
+msgstr "У точний дріб"
 
 #: ../../src/wxMaximaFrame.cpp:1814
 msgid "To exact number"
-msgstr ""
+msgstr "У точне число"
 
 #: ../../src/wxMaxima.cpp:9064
 msgid "To:"
-msgstr ""
+msgstr "До:"
 
 #: ../../src/wxMaximaFrame.cpp:825 ../../src/wxMaximaFrame.cpp:828
 msgid "Toggle full screen editing"
-msgstr ""
+msgstr "Увімкнути або вимкнути режим повноекранного редагування"
 
 #: ../../src/ToolBar.cpp:265
 msgid "Toggle the visibility of code cells"
-msgstr ""
+msgstr "Увімкнути або вимкнути видимість комірок з кодом"
 
 #: ../../src/wxMaximaFrame.cpp:1177
 msgid "Tokenize..."
-msgstr ""
+msgstr "Проставити мітки…"
 
 #: ../../src/wxMaximaFrame.cpp:1909
 msgid "Tolerance calculations with Maxima"
-msgstr ""
+msgstr "Обчислення припустимого відхилення за допомогою Maxima"
 
 #: ../../src/wxMaxima.cpp:8192
 msgid "Top end"
-msgstr ""
+msgstr "Верхній кінець"
 
 #: ../../src/wxMaximaFrame.cpp:1078
 msgid "Trace a function..."
-msgstr ""
+msgstr "Трасувати функцію…"
 
 #: ../../src/wxMaxima.cpp:7084
 msgid "Trace function(s)"
-msgstr ""
+msgstr "Трасувати функції"
 
 #: ../../src/wxMaximaFrame.cpp:1184
 msgid "Transformations"
-msgstr ""
+msgstr "Перетворення"
 
 #: ../../src/wxMaximaFrame.cpp:1376
 msgid "Transpose a matrix"
-msgstr ""
+msgstr "Транспонувати матрицю"
 
 #: ../../src/wxMaxima.cpp:7832
 msgid ""
@@ -7251,17 +7564,23 @@ msgid ""
 " equation of the format depends(x,t);diff(x,t)=(something containing x and "
 "t)"
 msgstr ""
+"Спробувати знайти обчислювальний розв'язок для звичайного диференціального "
+"рівняння першого порядку (або іншими словами рівняння у форматі "
+"depends(x,t);diff(x,t)=(щось, що містить x і t)"
 
 #: ../../src/wxMaxima.cpp:10036
 msgid ""
 "Tries to find a solution of the equation that lies between the two bounds."
-msgstr ""
+msgstr "Спробувати знайти розв'язок рівняння, який лежить у вказаних межах."
 
 #: ../../src/wxMaxima.cpp:7774
+#, fuzzy
 msgid ""
 "Tries to find a value of the variable that solves the equation between the "
 "two bonds"
 msgstr ""
+"Намагається знайти між двома межами значення змінної, яке перетворює "
+"рівняння у тотожність"
 
 #: ../../src/wxMaxima.cpp:7719
 msgid ""
@@ -7270,6 +7589,10 @@ msgid ""
 "\n"
 "    bfallroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
+"Спробувати знайти усі розв'язки поліноміального рівняння за допомогою обчислювальних методів і bfloats.\n"
+"Здатна виявити розв'язки у неполіноміальних рівняння, якщо вираз перед цим наближено поліномом:\n"
+"\n"
+"    bfallroots(ratdisrep(taylor(вираз,0,30)));"
 
 #: ../../src/wxMaxima.cpp:7709
 msgid ""
@@ -7278,9 +7601,13 @@ msgid ""
 "\n"
 "    allroots(ratdisrep(taylor(expression,0,30)));"
 msgstr ""
+"Спробувати знайти усі розв'язки поліноміального рівняння за допомогою обчислювальних методів.\n"
+"Здатна виявити розв'язки у неполіноміальних рівняння, якщо вираз перед цим наближено поліномом:\n"
+"\n"
+"    bfallroots(ratdisrep(taylor(вираз,0,30)));"
 
 #: ../../src/wxMaxima.cpp:7730
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Tries to find exact fractions that match the numerical solutions of a polynomial.\n"
 "Is not able to deal with solutions with a imaginary part. Numerical constants like %pi% need to be eliminated using float() or similar\n"
@@ -7290,361 +7617,380 @@ msgid ""
 "\n"
 "See also guess_exact_value()"
 msgstr ""
+"Спробувати знайти точні дроби, які відповідають розв'язкам поліноміального рівняння.\n"
+"Не може працювати із розв'язками, які містять уявну частину. Числові сталі, подібні до %pi%, слід вилучити за допомогою float() або подібної функції.\n"
+"Здатна виявити розв'язки у неполіноміальних рівняння, якщо вираз перед цим наближено поліномом:\n"
+"\n"
+"    realroots(ratdisrep(taylor(expression,0,30)));\n"
+"\n"
+"Див. також guess_exact_value()"
 
 #: ../../src/wxMaximaFrame.cpp:1181
 msgid "Trim both ends..."
-msgstr ""
+msgstr "Обрізати з обох кінців…"
 
 #: ../../src/wxMaximaFrame.cpp:1182
 msgid "Trim left..."
-msgstr ""
+msgstr "Обрізати ліворуч…"
 
 #: ../../src/wxMaximaFrame.cpp:1183
 msgid "Trim right..."
-msgstr ""
+msgstr "Обрізати праворуч…"
 
 #: ../../src/wxMaxima.cpp:7473
 msgid "Trim string left"
-msgstr ""
+msgstr "Обрізати рядок ліворуч"
 
 #: ../../src/wxMaxima.cpp:7469
 msgid "Trim string on both ends"
-msgstr ""
+msgstr "Обрізати рядок з обох боків"
 
 #: ../../src/wxMaxima.cpp:7477
 msgid "Trim string right"
-msgstr ""
+msgstr "Обрізати рядок праворуч"
 
 #: ../../src/wxMaximaFrame.cpp:1511
 msgid "Try to guess which form is &simple"
-msgstr ""
+msgstr "Спробувати вгадати, яка форма є &простою"
 
 #: ../../src/wxMaxima.cpp:8637
 msgid "Try to simplify sums that result from sum() commands."
-msgstr ""
+msgstr "Спробувати спростити суми, які є результатом команд sum()."
 
 #: ../../src/MaximaManual.cpp:369
 #, c-format
 msgid ""
 "Trying to cache the list of subjects the manual contains in the file %s."
 msgstr ""
+"Намагаємося створити кеш списку тем, які містяться у файлі підручника %s."
 
 #: ../../src/wxMaxima.cpp:4423
 msgid "Trying to discard all output."
-msgstr ""
+msgstr "Намагаємося відкинути усі виведені дані."
 
 #: ../../src/wxMaxima.cpp:4380
 msgid "Trying to extract content.xml out of a broken .zip file."
-msgstr ""
+msgstr "Намагаємося видобути content.xml з пошкодженого файл .zip."
 
 #: ../../src/wxMaxima.cpp:5519
 msgid "Trying to open a file with an empty name!"
-msgstr ""
+msgstr "Спроба відкрити файл із порожньою назвою!"
 
 #: ../../src/wxMaxima.cpp:5523
 #, c-format
 msgid "Trying to open the non-existing file %s"
-msgstr ""
+msgstr "Спроба відкрити файл %s, якого не існує"
 
 #: ../../src/wxMaxima.cpp:4457
 msgid "Trying to reconstruct the xml closing markers."
-msgstr ""
+msgstr "Намагаємося відтворити завершальні позначки xml."
 
 #: ../../src/wxMaxima.cpp:4376
 msgid "Trying to recover a broken .wxmx file."
-msgstr ""
+msgstr "Намагаємося відновити пошкоджений файл .wxmx."
 
 #: ../../src/wxMaxima.cpp:6026
 #, c-format
 msgid "Trying to remove the old temp file %s"
-msgstr ""
+msgstr "Намагаємося вилучити застарілий тимчасовий файл %s"
 
 #: ../../src/wxMaxima.cpp:2507
 msgid "Trying to restart maxima."
-msgstr ""
+msgstr "Намагаємося перезапустити maxima."
 
 #: ../../src/wxMaxima.cpp:2523
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "Trying to start the socket a Maxima on the local machine can connect to on "
 "port %i"
 msgstr ""
+"Намагаємося відкрити сокет, із яким може встановити з'єднання maxima на "
+"локальному комп'ютері, на порту %i"
 
 #: ../../src/wxMaximaFrame.cpp:1928
 msgid "Tutorials"
-msgstr ""
+msgstr "Підручники"
 
 #: ../../src/wxMaxima.cpp:9571
 msgid "Two sample t-test"
-msgstr ""
+msgstr "Двовибіркова t-перевірка"
 
 #: ../../src/Worksheet.cpp:8013
 msgid "Type"
-msgstr ""
+msgstr "Тип"
 
 #: ../../src/wxMaxima.cpp:7180
 msgid "Type:"
-msgstr ""
+msgstr "Тип:"
 
 #: ../../src/wxMaxima.cpp:9429
 msgid "URL"
-msgstr ""
+msgstr "Адреса"
 
 #: ../../src/wxMaximaFrame.cpp:1146
 msgid "UTF8 to Unicode code point..."
-msgstr ""
+msgstr "UTF8 до позиції у таблиці Unicode…"
 
 #: ../../src/wxMaxima.cpp:10479
 msgid "Un-closed parenthesis"
-msgstr ""
+msgstr "Незакрита дужка"
 
 #: ../../src/wxMaxima.cpp:10467
 msgid "Un-closed parenthesis on encountering ; or $"
-msgstr ""
+msgstr "Незакрита дужка до символу ; або $"
 
 #: ../../src/wxMaxima.cpp:11160
 msgid ""
 "Unable to interpret the version info I got from http://wxMaxima-"
 "developers.github.io/wxmaxima/version.txt: "
 msgstr ""
+"Не вдалося визначити дані щодо версій з http://wxMaxima-"
+"developers.github.io/wxmaxima/version.txt: "
 
 #: ../../src/wxMaximaFrame.cpp:1007
+#, fuzzy
 msgid "Undefine"
-msgstr ""
+msgstr "Не визначено"
 
 #: ../../src/ToolBar.cpp:191
 msgid "Undo"
-msgstr ""
+msgstr "Скасувати"
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo\tCtrl+Z"
-msgstr ""
+msgstr "Вернути\tCtrl+Z"
 
 #: ../../src/ToolBar.cpp:614
 msgid "Undo and redo button"
-msgstr ""
+msgstr "Кнопки скасування і повторення дій"
 
 #: ../../src/wxMaximaFrame.cpp:631
 msgid "Undo last change"
-msgstr ""
+msgstr "Скасувати останню зміну"
 
 #: ../../src/wxMaximaFrame.cpp:924
 msgid "Unfold All\tCtrl+Alt+]"
-msgstr ""
+msgstr "Розгорнути всі\tCtrl+Alt+]"
 
 #: ../../src/wxMaximaFrame.cpp:925
 msgid "Unfold all folded sections"
-msgstr ""
+msgstr "Розгорнути всі згорнути розділи"
 
 #: ../../src/Worksheet.cpp:1893
 msgid "Unhide Heading 5"
-msgstr ""
+msgstr "Скасувати приховування заголовка 5"
 
 #: ../../src/Worksheet.cpp:1904
 msgid "Unhide Heading 6"
-msgstr ""
+msgstr "Скасувати приховування заголовка 6"
 
 #: ../../src/Worksheet.cpp:1852
 msgid "Unhide Part"
-msgstr ""
+msgstr "Скасувати приховування частини"
 
 #: ../../src/Worksheet.cpp:1860
 msgid "Unhide Section"
-msgstr ""
+msgstr "Скасувати приховування розділу"
 
 #: ../../src/Worksheet.cpp:1871
 msgid "Unhide Subsection"
-msgstr ""
+msgstr "Скасувати приховування підрозділу"
 
 #: ../../src/Worksheet.cpp:1882
 msgid "Unhide Subsubsection"
-msgstr ""
+msgstr "Скасувати приховування підпідрозділ"
 
 #: ../../src/Worksheet.cpp:1912
 msgid "Unhide contents"
-msgstr ""
+msgstr "Скасувати приховування змісту"
 
 #: ../../src/wxMaximaFrame.cpp:266
 msgid "Unicode characters"
-msgstr ""
+msgstr "Символи Unicode"
 
 #: ../../src/wxMaximaFrame.cpp:707
 msgid "Unicode chars\tAlt+Shift+U"
-msgstr ""
+msgstr "Символи Юнікод\tAlt+Shift+U"
 
 #: ../../src/wxMaximaFrame.cpp:1144
 msgid "Unicode code point to UTF8..."
-msgstr ""
+msgstr "Позицію таблиці Unicode до UTF8…"
 
 #: ../../src/wxMaxima.cpp:7366
 msgid "Unicode code point to char"
-msgstr ""
+msgstr "Позицію таблиці Unicode до символу"
 
 #: ../../src/wxMaximaFrame.cpp:1142
 msgid "Unicode code point to char..."
-msgstr ""
+msgstr "Позицію таблиці Unicode до символу…"
 
 #: ../../src/wxMaxima.cpp:7371
 msgid "Unicode code point to utf8 numbers"
-msgstr ""
+msgstr "Позицію таблиці Unicode до чисел utf8"
 
 #: ../../src/wxMaxima.cpp:7078
 msgid ""
 "Unlike in other programming language return() only exits from the current "
 "loop or block(), not from the whole function."
 msgstr ""
+"На відміну від return() в інших мовах програмування, виводить із поточного "
+"циклу або block(), а не з усієї функції."
 
 #: ../../src/wxMaxima.cpp:10418
 msgid "Unterminated comment."
-msgstr ""
+msgstr "Незавершений коментар."
 
 #: ../../src/wxMaxima.cpp:10461
 msgid "Unterminated string."
-msgstr ""
+msgstr "Незавершений рядок."
 
 #: ../../src/wxMaxima.cpp:4786
 msgid "Updating maxima's configuration"
-msgstr ""
+msgstr "Оновлюємо налаштування maxima"
 
 #: ../../src/wxMaxima.cpp:11150 ../../src/wxMaxima.cpp:11157
 #: ../../src/wxMaxima.cpp:11163
 msgid "Upgrade"
-msgstr ""
+msgstr "Оновити"
 
 #: ../../src/wxMaxima.cpp:7779 ../../src/wxMaxima.cpp:10041
 msgid "Upper bound:"
-msgstr ""
+msgstr "Верхня межа:"
 
 #: ../../src/wxMaximaFrame.cpp:792
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
-msgstr ""
+msgstr "Використовувати кутові дужки для матриць"
 
 #: ../../src/wxMaximaFrame.cpp:1708 ../../src/wxMaximaFrame.cpp:1739
 msgid "Use a list"
-msgstr ""
+msgstr "Використати список"
 
 #: ../../src/wxMaxima.cpp:8571
 msgid "Use a list as parameter list for a function"
-msgstr ""
+msgstr "Використати список як список параметрів функції"
 
 #: ../../src/wxMaximaFrame.cpp:1708
 msgid "Use list"
-msgstr ""
+msgstr "Використовувати список"
 
 #: ../../src/wxMaximaFrame.cpp:1701
 msgid "Use list as the arguments of a function"
-msgstr ""
+msgstr "Використовувати список як аргументи функції"
 
 #: ../../src/wxMaximaFrame.cpp:786
 msgid "Use rounded parenthesis for matrices"
-msgstr ""
+msgstr "Використовувати круглі дужки для матриць"
 
 #: ../../src/wxMaximaFrame.cpp:789
 msgid "Use square parenthesis for matrices"
-msgstr ""
+msgstr "Використовувати квадратні дужки для матриць"
 
 #: ../../src/wxMaximaFrame.cpp:1083
 msgid "Use struct field..."
-msgstr ""
+msgstr "Скористатися поле структури…"
 
 #: ../../src/wxMaximaFrame.cpp:795
 msgid "Use vertical lines instead of parenthesis for matrices"
-msgstr ""
+msgstr "Використовувати вертикальні лінії замість дужок для матриць"
 
 #: ../../src/Worksheet.cpp:1619
 msgid "User labels only"
-msgstr ""
+msgstr "Лише мітки користувача"
 
 #: ../../src/Configuration.cpp:81
 msgid "User-defined labels"
-msgstr ""
+msgstr "Визначені користувачем мітки"
 
 #: ../../src/MaximaManual.cpp:483
 msgid ""
 "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
 msgstr ""
+"Використання файл довідки Maxima з файла налаштувань wxMaxima "
+"(helpFile=...))"
 
 #: ../../src/wxMaxima.cpp:4825
 msgid "Using Maxima path from command line."
-msgstr ""
+msgstr "Використовуємо шлях до Maxima з командного рядка."
 
 #: ../../src/wxMaxima.cpp:4822
 msgid "Using configured Maxima path."
-msgstr ""
+msgstr "Використовуємо налаштований шлях до Maxima."
 
 #: ../../src/wxMaxima.cpp:2961
 msgid ""
 "Using gnuplot's antialiassing-less png driver for embedded plots as pngcairo"
 " could not be found"
 msgstr ""
+"Використовуємо драйвер png gnuplot без згладжування для вбудованих креслень,"
+" оскільки не вдалося знайти pngcairo"
 
 #: ../../src/wxMaxima.cpp:2956
 msgid "Using gnuplot's pngcairo driver for embedded plots"
-msgstr ""
+msgstr "Використовуємо для вбудованих графіків драйвер pngcairo gnuplot"
 
 #: ../../src/MaximaManual.cpp:88
 msgid "Using the built-in list of manual anchors."
-msgstr ""
+msgstr "Використовуємо вбудований список визначених вручну прив'язок."
 
 #: ../../src/WXMXformat.cpp:266
 msgid ""
 "Validated that the XML representation of the document actually is valid XML"
-msgstr ""
+msgstr "Перевірено, що представлення XML документа є коректним кодом XML"
 
 #: ../../src/wxMaxima.cpp:8755
 msgid "Value at a given point"
-msgstr ""
+msgstr "Значення у вказаній точці"
 
 #: ../../src/Worksheet.cpp:1987
 msgid "Value at a specific point"
-msgstr ""
+msgstr "Значення у вказаній точці"
 
 #: ../../src/wxMaxima.cpp:7801
 msgid "Value at that point:"
-msgstr ""
+msgstr "Значення у цій точці:"
 
 #: ../../src/wxMaxima.cpp:7812 ../../src/wxMaxima.cpp:7825
 #: ../../src/wxMaxima.cpp:7827
 msgid "Value y at that point:"
-msgstr ""
+msgstr "Значення y у цій точці:"
 
 #: ../../src/wxMaxima.cpp:7910
 msgid "Value:"
-msgstr ""
+msgstr "Значення:"
 
 #: ../../src/wxMaxima.cpp:8201
 msgid "Var #1"
-msgstr ""
+msgstr "Змінна 1"
 
 #: ../../src/wxMaxima.cpp:8202
 msgid "Var #2"
-msgstr ""
+msgstr "Змінна 2"
 
 #: ../../src/wxMaxima.cpp:6852 ../../src/wxMaxima.cpp:8183
 msgid "Variable"
-msgstr ""
+msgstr "Змінна"
 
 #: ../../src/wxMaxima.cpp:6530 ../../src/wxMaxima.cpp:6536
 #: ../../src/wxMaxima.cpp:8568
 msgid "Variable name"
-msgstr ""
+msgstr "Назва змінної"
 
 #: ../../src/wxMaximaFrame.cpp:1085
 msgid "Variable name, not contents..."
-msgstr ""
+msgstr "Назва змінної, а не вміст…"
 
 #: ../../src/wxMaxima.cpp:7157 ../../src/wxMaxima.cpp:7675
 msgid "Variable name:"
-msgstr ""
+msgstr "Назва змінної:"
 
 #: ../../src/wxMaxima.cpp:7752 ../../src/wxMaxima.cpp:7766
 msgid "Variable(s)"
-msgstr ""
+msgstr "Змінні"
 
 #: ../../src/wxMaxima.cpp:7849 ../../src/wxMaxima.cpp:7901
 #: ../../src/wxMaxima.cpp:9012 ../../src/wxMaxima.cpp:10057
 msgid "Variable(s):"
-msgstr ""
+msgstr "Змінні:"
 
 #: ../../src/wxMaxima.cpp:7714 ../../src/wxMaxima.cpp:7725
 #: ../../src/wxMaxima.cpp:7777 ../../src/wxMaxima.cpp:8934
@@ -7652,23 +7998,23 @@ msgstr ""
 #: ../../src/wxMaxima.cpp:8977 ../../src/wxMaxima.cpp:8982
 #: ../../src/wxMaxima.cpp:9063 ../../src/wxMaxima.cpp:10039
 msgid "Variable:"
-msgstr ""
+msgstr "Змінна:"
 
 #: ../../src/wxMaximaFrame.cpp:277 ../../src/wxMaximaFrame.cpp:720
 msgid "Variables"
-msgstr ""
+msgstr "Змінні"
 
 #: ../../src/wxMaxima.cpp:9043 ../../src/wxMaxima.cpp:9593
 msgid "Variables:"
-msgstr ""
+msgstr "Змінні:"
 
 #: ../../src/WXMXformat.cpp:337
 msgid "Verified that we are able to read the whole .zip archive we produced."
-msgstr ""
+msgstr "Перевірено, що ми можемо прочитати увесь створений архів .zip."
 
 #: ../../src/wxMaximaFrame.cpp:836
 msgid "View"
-msgstr ""
+msgstr "Перегляд"
 
 #: ../../src/Autocomplete.cpp:235
 msgid "Waiting for m_addFiles_backgroundThread to finish"
@@ -7685,16 +8031,17 @@ msgstr ""
 #: ../../src/MaximaManual.cpp:562
 msgid "Waiting for the thread that parses the maxima manual to finish"
 msgstr ""
+"Очікуємо на завершення потоку обробки, який обробляє підручник з maxima"
 
 #: ../../src/MathParser.cpp:1229 ../../src/wxMaxima.cpp:3296
 #: ../../src/wxMaxima.cpp:3308 ../../src/wxMaxima.cpp:4613
 #: ../../src/wxMaxima.cpp:4703 ../../src/wxMaxima.cpp:4840
 msgid "Warning"
-msgstr ""
+msgstr "Попередження"
 
 #: ../../src/wxMaximaFrame.cpp:1556
 msgid "Warning:"
-msgstr ""
+msgstr "Попередження:"
 
 #: ../../src/Dirstructure.cpp:72
 #, c-format
@@ -7702,37 +8049,43 @@ msgid ""
 "Warning: Cannot create %s, the directory maxima keeps configuration, user packages and caches in.\n"
 "Make sure that your system's home directory is set up correctly"
 msgstr ""
+"Попередження: не вдалося створити %s, каталог, у якому maxima зберігає налаштування, пакунки користувача та кеш.\n"
+"Переконайтеся, що домашній каталог вашої системи налаштовано належним чином"
 
 #: ../../src/wxMaximaFrame.cpp:1546
 msgid ""
 "Warning: No test if the argument of the log is complex, positive or negative"
 msgstr ""
+"Попередження: немає перевірки того, є аргумент логарифма комплексним, "
+"додатним чи від'ємним"
 
 #: ../../src/wxMaxima.cpp:5063
 msgid "Welcome to wxMaxima"
-msgstr ""
+msgstr "Ласкаво просимо до wxMaxima"
 
 #: ../../src/wxMaxima.cpp:8583
 msgid "What to do:"
-msgstr ""
+msgstr "Що робити:"
 
 #: ../../src/wxMaximaFrame.cpp:1058
 msgid "When to invoke the lisp compiler's debugger"
-msgstr ""
+msgstr "Коли слід викликати засіб діагностики компілятора lisp"
 
 #: ../../src/wxMaxima.cpp:7046
 msgid "While loop"
-msgstr ""
+msgstr "Цикл while"
 
 #: ../../src/wxMaximaFrame.cpp:1063
 msgid "While loop..."
-msgstr ""
+msgstr "Цикл while…"
 
 #: ../../src/wxMaxima.cpp:5673
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38)"
 " (*.wxm)|*.wxm|All Files (*.*)|*"
 msgstr ""
+"увесь документ (*.wxmx)|*.wxmx|введені команди, придатні до читання load() "
+"(maxima > 5.38) (*.wxm)|*.wxm|усі файли (*.*)|*"
 
 #: ../../src/wxMaxima.cpp:210
 msgid "Will try to generate a stack backtrace, if the program ever crashes"
@@ -7740,207 +8093,211 @@ msgstr ""
 
 #: ../../src/Worksheet.cpp:6920
 msgid "Worksheet got activated"
-msgstr ""
+msgstr "Робочий аркуш активовано"
 
 #: ../../src/Worksheet.cpp:6840
 msgid "Worksheet got the mouse focus"
-msgstr ""
+msgstr "Робочий аркуш отримав фокус миші"
 
 #: ../../src/Worksheet.cpp:7191 ../../src/Worksheet.cpp:7279
 msgid "Wrapped search"
-msgstr ""
+msgstr "Циклічний пошук"
 
 #: ../../src/WXMXformat.cpp:282
 msgid "Wrote all image and gnuplot files to the zip archive"
-msgstr ""
+msgstr "Записано усі зображення та файли gnuplot до архіву zip"
 
 #: ../../src/WXMXformat.cpp:272
 msgid "Wrote the XML representation of the document to the zip archive"
-msgstr ""
+msgstr "Записано до архіву zip XML-представлення документа"
 
 #: ../../src/WXMXformat.cpp:116
 msgid "Wrote the mimetype info"
-msgstr ""
+msgstr "Записано дані щодо типу MIME"
 
 #: ../../src/wxMaxima.cpp:11147
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "You have version %s. The newest version source code is available for is %s.\n"
 "\n"
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
+"Ви користуєтеся версією %s. Актуальною версією є %s.\n"
+"\n"
+"Натисніть кнопку «Гаразд», щоб відвідати сторінку wxMaxima у інтернеті."
 
 #: ../../src/wxMaxima.cpp:11202
 msgid "Your changes will be lost if you don't save them."
-msgstr ""
+msgstr "Внесені вами зміни буде втрачено, якщо ви не збережете їх."
 
 #: ../../src/wxMaxima.cpp:11156
 msgid "Your version of wxMaxima is up to date."
-msgstr ""
+msgstr "Ваша версія wxMaxima є актуальною."
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom &In\tCtrl++"
-msgstr ""
+msgstr "З&більшити\tCtrl++"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom Ou&t\tCtrl+-"
-msgstr ""
+msgstr "З&меншити\tCtrl+-"
 
 #: ../../src/wxMaximaFrame.cpp:805
 msgid "Zoom in 10%"
-msgstr ""
+msgstr "Збільшити на 10%"
 
 #: ../../src/wxMaximaFrame.cpp:806
 msgid "Zoom out 10%"
-msgstr ""
+msgstr "Зменшити на 10%"
 
 #: ../../src/wxMaxima.cpp:10915 ../../src/wxMaximaFrame.cpp:187
 msgid "[ unsaved ]"
-msgstr ""
+msgstr "[ не збережено ]"
 
 #: ../../src/wxMaxima.cpp:10920
 msgid "[ unsaved* ]"
-msgstr ""
+msgstr "[ не збережено* ]"
 
 #: ../../src/Worksheet.cpp:5278
-#, c-format
+#, fuzzy, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" loading=\"lazy\" style=\"max-width:90%%;\">\n"
-msgstr ""
+msgstr "_%d.gif\"  alt=\"Анімована діаграма\" loading=\"lazy\" style=\"max-width:90%%;\" />\n"
 
 #: ../../src/Worksheet.cpp:5484
-#, c-format
+#, fuzzy, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" loading=\"lazy\">"
-msgstr ""
+msgstr "_%d.gif\" alt=\"Анімована діаграма\" style=\"max-width:90%%;\" loading=\"lazy\" />"
 
 #: ../../src/wxMaximaFrame.cpp:1690
 msgid "apply function to each element"
-msgstr ""
+msgstr "застосувати функцію до кожного елемента"
 
 #: ../../src/wxMaximaFrame.cpp:739
 msgid "as 1D ASCII"
-msgstr ""
+msgstr "як одновимірний ASCII"
 
 #: ../../src/wxMaximaFrame.cpp:742
 msgid "as ASCII Art"
-msgstr ""
+msgstr "як рисунок ASCII"
 
 #: ../../src/wxMaximaFrame.cpp:745
+#, fuzzy
 msgid "as ASCII+Unicode Art"
-msgstr ""
+msgstr "як рисунок ASCII"
 
 #: ../../src/wxMaximaFrame.cpp:1680
 msgid "as storage for actual values for variables"
-msgstr ""
+msgstr "як сховище поточних даних змінних"
 
 #: ../../src/wxMaximaFrame.cpp:1139
 msgid "char to Ascii code..."
-msgstr ""
+msgstr "Символ до коду ASCII…"
 
 #: ../../src/wxMaxima.cpp:7836
 msgid "diff(x,t)="
-msgstr ""
+msgstr "diff(x,t)="
 
 #: ../../src/wxMaximaFrame.cpp:1064 ../../src/wxMaximaFrame.cpp:1702
 msgid "do for each element"
-msgstr ""
+msgstr "застосувати до усіх елементів"
 
 #: ../../src/Worksheet.cpp:2027
 msgid "ev() shall evaluate this automatically"
-msgstr ""
+msgstr "ev() буде обчислювати це автоматично"
 
 #: ../../src/wxMaxima.cpp:7130
 msgid "expression:"
-msgstr ""
+msgstr "вираз:"
 
 #: ../../src/Worksheet.cpp:2025
 msgid "f(x) stays f(x) even if the value of f(x) is computable"
-msgstr ""
+msgstr "f(x) лишається f(x), навіть якщо значення f(x) можна обчислити"
 
 #: ../../src/wxMaxima.cpp:7204 ../../src/wxMaxima.cpp:7209
 msgid "filename:"
-msgstr ""
+msgstr "назва файла:"
 
 #: ../../src/wxMaximaFrame.cpp:1674
 msgid "from a list"
-msgstr ""
+msgstr "зі списку"
 
 #: ../../src/wxMaximaFrame.cpp:1671
 msgid "from a rule"
-msgstr ""
+msgstr "на основі правила"
 
 #: ../../src/wxMaximaFrame.cpp:1685
 msgid "from function arguments"
-msgstr ""
+msgstr "з аргументів функції"
 
 #: ../../src/wxMaximaFrame.cpp:1669
 msgid "from individual elements"
-msgstr ""
+msgstr "з окремих елементів"
 
 #: ../../src/wxMaxima.cpp:8210 ../../src/wxMaxima.cpp:8553
 msgid "function"
-msgstr ""
+msgstr "функція"
 
 #: ../../src/wxMaximaFrame.cpp:747
 msgid "in 2D"
-msgstr ""
+msgstr "2 виміри"
 
 #: ../../src/wxMaxima.cpp:8554
 msgid "list"
-msgstr ""
+msgstr "список"
 
 #: ../../src/wxMaximaFrame.cpp:1405
 msgid "max(abs(A(i,j))) (complex)"
-msgstr ""
+msgstr "max(abs(A(i,j))) (комплексне)"
 
 #: ../../src/wxMaximaFrame.cpp:1404
 msgid "max(abs(A(i,j))) (real)"
-msgstr ""
+msgstr "max(abs(A(i,j))) (дійсне)"
 
 #: ../../src/wxMaxima.cpp:8046
 msgid "m×n Matrix A:"
-msgstr ""
+msgstr "Матриця A m×n:"
 
 #: ../../src/wxMaxima.cpp:7378 ../../src/wxMaxima.cpp:8527
 #: ../../src/wxMaxima.cpp:8533
 msgid "n:"
-msgstr ""
+msgstr "n:"
 
 #: ../../src/Worksheet.cpp:2000
 msgid "nary: f(x, f(y,z)) = foo(x,y,z)"
-msgstr ""
+msgstr "Унарна: f(x, f(y,z)) = foo(x,y,z)"
 
 #: ../../src/Worksheet.cpp:2024
 msgid "noun: Not evaluated by default"
-msgstr ""
+msgstr "слово: типово не обчислюється"
 
 #: ../../src/wxMaximaFrame.cpp:1710
 msgid "nth"
-msgstr ""
+msgstr "n-й"
 
 #: ../../src/Worksheet.cpp:2021
 msgid "outative: f(2*x) = 2*f(x)"
-msgstr ""
+msgstr "Однорідна: f(2*x) = 2*f(x)"
 
 #: ../../src/wxMaxima.cpp:7440 ../../src/wxMaxima.cpp:7445
 #: ../../src/wxMaxima.cpp:7455
 msgid "part:"
-msgstr ""
+msgstr "частина:"
 
 #: ../../src/wxMaxima.cpp:8942
 msgid "point:"
-msgstr ""
+msgstr "точка:"
 
 #: ../../src/wxMaxima.cpp:7740
 msgid "precision:"
-msgstr ""
+msgstr "точність:"
 
 #: ../../src/wxMaxima.cpp:7255
 msgid "printf"
-msgstr ""
+msgstr "printf"
 
 #: ../../src/wxMaximaFrame.cpp:1108
 msgid "printf..."
-msgstr ""
+msgstr "printf..."
 
 #: ../../src/wxMaxima.cpp:8650
 msgid ""
@@ -7950,22 +8307,29 @@ msgid ""
 " makes sense for the problem that resulted in the Expression that is to be "
 "simplified."
 msgstr ""
+"radcan() є потужним інструментом для спрощення тригонометричних функцій, але"
+" потребує обережного користування: якщо у функції декілька гілок, radcan "
+"використовує ту, яку програма вважає найкращою, а не обов'язково ту, яка має"
+" сенс у задачі, результатом розв'язування якої став вираз, який слід "
+"спростити."
 
 #: ../../src/wxMaxima.cpp:8731
+#, fuzzy
 msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
+"ratsubst працює як subst, але використовує базову математику, якщо потрібно."
 
 #: ../../src/wxMaximaFrame.cpp:1111
 msgid "readbyte..."
-msgstr ""
+msgstr "readbyte…"
 
 #: ../../src/wxMaximaFrame.cpp:1110
 msgid "readchar..."
-msgstr ""
+msgstr "readchar…"
 
 #: ../../src/wxMaximaFrame.cpp:1109
 msgid "readline..."
-msgstr ""
+msgstr "readline…"
 
 #: ../../src/wxMaxima.cpp:10018
 msgid ""
@@ -7973,67 +8337,74 @@ msgid ""
 "If only one result variable is of interest the other result variables can be used to to tell solve() which variables to eliminate from the solution\n"
 "solve() searches for a global solution. If a problem has different solutions depending on the range its variables are in one way to successfully use solve() is to use solve() to eliminate variables one by one and to manually choose which of the solutions solve() found matches the current problem."
 msgstr ""
+"solve() може розв'язати список рівнянь, лише якщо у ньому n незалежних рівнянь для n невідомих змінних.\n"
+"Якщо вас цікавить значення лише однієї змінної, можна скористатися заміною інших змінних на вирази через потрібну вам змінну так, щоб solve() змогла виключити з рівнянь усі зайві змінні.\n"
+"solve() шукає загальний розв'язок. Якщо у задачі є різні розв'язки, залежно від діапазону її змінних, єдиним способом успішно скористатися solve() є використання solve() для виключення змінних одна за одною і ручний вибір того знайденого solve() розв'язку, який відповідає задачі."
 
 #: ../../src/wxMaxima.cpp:7745
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables solve needs to do its work can be used to tell solve() which variables to eliminate in the solution for the interesting variable."
 msgstr ""
+"solve() може розв'язати список рівнянь, лише якщо у ньому n незалежних рівнянь для n невідомих змінних.\n"
+"Якщо вас цікавить значення лише однієї змінної, можна скористатися заміною інших змінних на вирази через потрібну вам змінну так, щоб solve() змогла виключити з рівнянь усі зайві змінні."
 
 #: ../../src/wxMaxima.cpp:7784
 msgid ""
 "solves an equation of the form\n"
 "    'diff(y,t) = -y;"
 msgstr ""
+"розв'язує рівняння у формі\n"
+"    'diff(y,t) = -y;"
 
 #: ../../src/wxMaxima.cpp:7789
 msgid "t:"
-msgstr ""
+msgstr "t:"
 
 #: ../../src/wxMaximaFrame.cpp:1075
 msgid "unnamed function (lambda)..."
-msgstr ""
+msgstr "неіменована функція (лямбда)…"
 
 #: ../../src/wxMaxima.cpp:11190
 msgid "unsaved"
-msgstr ""
+msgstr "не збережено"
 
 #: ../../src/wxMaxima.cpp:5667 ../../src/wxMaxima.cpp:6114
 #: ../../src/wxMaximaFrame.cpp:189
 msgid "untitled"
-msgstr ""
+msgstr "без назви"
 
 #: ../../src/wxMaximaFrame.cpp:1700
 msgid "use as function arguments"
-msgstr ""
+msgstr "використати як аргументи функції"
 
 #: ../../src/wxMaximaFrame.cpp:1696
 msgid "use the actual values stored"
-msgstr ""
+msgstr "використовувати збережені справжні значення"
 
 #: ../../src/wxMaximaFrame.cpp:1112
 msgid "writebyte..."
-msgstr ""
+msgstr "writebyte…"
 
 #: ../../src/main.cpp:509
 msgid "wxMaxima"
-msgstr ""
+msgstr "wxMaxima"
 
 #: ../../src/main.cpp:516
-#, c-format
+#, fuzzy, c-format
 msgid "wxMaxima %ld"
-msgstr ""
+msgstr "wxMaxima %d"
 
 #: ../../src/wxMaxima.cpp:10913 ../../src/wxMaxima.cpp:10918
 #: ../../src/wxMaxima.cpp:10929 ../../src/wxMaxima.cpp:10934
 #: ../../src/wxMaximaFrame.cpp:185
 #, c-format
 msgid "wxMaxima %s (%s) "
-msgstr ""
+msgstr "wxMaxima %s (%s) "
 
 #: ../../src/wxMaxima.cpp:4490
 msgid "wxMaxima cannot read the xml contents of "
-msgstr ""
+msgstr "wxMaxima не вдалося прочитати вміст xml "
 
 #: ../../src/wxMaxima.cpp:2546
 msgid ""
@@ -8045,77 +8416,83 @@ msgstr ""
 
 #: ../../src/wxMaxima.cpp:5285
 msgid "wxMaxima document"
-msgstr ""
+msgstr "Документ wxMaxima"
 
 #: ../../src/wxMaxima.cpp:4162 ../../src/wxMaxima.cpp:4221
 #: ../../src/wxMaxima.cpp:4230
 msgid "wxMaxima encountered an error loading "
-msgstr ""
+msgstr "Під час спроби завантаження wxMaxima сталася помилка "
 
 #: ../../src/wxMaximaFrame.cpp:1881
 msgid "wxMaxima help"
-msgstr ""
+msgstr "Довідка з wxMaxima"
 
 #: ../../src/Worksheet.cpp:1465 ../../src/Worksheet.cpp:1839
 msgid ""
 "wxMaxima remembers answers from the last run and is able to automatically "
 "send them to maxima, if requested"
 msgstr ""
+"wxMaxima запам'ятовує відповіді з останнього запуску і може автоматично "
+"надсилати їх до Maxima, якщо надійде запит"
 
 #: ../../src/Worksheet.cpp:1470 ../../src/Worksheet.cpp:1844
 msgid ""
 "wxMaxima remembers answers from the last run and is able to offer them as "
 "the default answer"
 msgstr ""
+"wxMaxima запам'ятовує відповіді з останнього запуску і може пропонувати їх "
+"як типові відповіді"
 
 #: ../../src/wxMaximaFrame.cpp:1896
 msgid "wxMaxima shows help in a browser"
-msgstr ""
+msgstr "wxMaxima показує довідку у навігаторі"
 
 #: ../../src/wxMaximaFrame.cpp:1894
 msgid "wxMaxima shows help in the sidebar"
-msgstr ""
+msgstr "wxMaxima показує довідку на бічній панелі"
 
 #: ../../src/wxMaximaFrame.cpp:111
 #, c-format
 msgid "wxMaxima version %s"
-msgstr ""
+msgstr "Версія wxMaxima %s"
 
 #: ../../src/wxMaximaFrame.cpp:1954
 msgid "wxMaxima's ChangeLog"
-msgstr ""
+msgstr "Журнал змін wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:1952
 msgid "wxMaxima's license"
-msgstr ""
+msgstr "Ліцензування wxMaxima"
 
 #: ../../src/wxMaximaFrame.cpp:144
 msgid "wxWidgets is using GTK 2"
-msgstr ""
+msgstr "wxWidgets використовують GTK 2"
 
 #: ../../src/wxMaximaFrame.cpp:142
 msgid "wxWidgets is using GTK 3"
-msgstr ""
+msgstr "wxWidgets використовують GTK 3"
 
 #: ../../src/WXMXformat.cpp:367
 msgid "wxmx file saved"
-msgstr ""
+msgstr "Збережено файл wxmx"
 
 #: ../../src/wxMaxima.cpp:8375
 msgid "x direction [in multiples of the tick frequency]"
-msgstr ""
+msgstr "напрям x [у одиницях частоти поділок]"
 
 #: ../../src/wxMaxima.cpp:4500 ../../src/wxMaxima.cpp:4643
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
+"xml, що міститься у файлі, вказує на те, що ці дані не є робочим аркушем "
+"wxMaxima. "
 
 #: ../../src/wxMaxima.cpp:8376
 msgid "y direction [in multiples of the tick frequency]"
-msgstr ""
+msgstr "напрям y [у одиницях частоти поділок]"
 
 #: ../../src/wxMaxima.cpp:7789
 msgid "y:"
-msgstr ""
+msgstr "y:"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:2
@@ -11937,8 +12314,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:856
+#, fuzzy
 msgid "## Output rendering."
-msgstr ""
+msgstr "Виведення: рядки"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:858
@@ -12623,8 +13001,9 @@ msgstr ""
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:988
+#, fuzzy
 msgid "E.g. start wxMaxima with:"
-msgstr ""
+msgstr "Перезапустити Maxima"
 
 #. type: Plain text
 #: ../../info/wxmaxima.md:990


### PR DESCRIPTION
## Summary

On 2026-08-02, Crowdin's first sync of this project overwrote every Crowdin-managed language's `locales/wxMaxima/<lang>.po` with an essentially blank one. Its translation memory had never been seeded from the existing (in some cases decades-old) human translations, so the sync pushed its own empty state over them.

Confirmed directly from git history, before → after the wipe commits (all titled `New translations wxmaxima.pot (<Language>)`, all landing within the same minute):

| lang | before | after |
|---|---|---|
| fr | 1898/1898 (100%) — Michel Gosse | 0 |
| ru | 1898/1898 (100%) | 0 |
| hu | 1884/1898 (99%) | 0 |
| es | 1861/1898 (98%) | 0 |
| uk | 1806/1898 (95%) | 0 |
| it | 1685/1898 (89%) | 0 |
| de | 1668/1898 (88%) — Harald Geyer / Gunter Königsmann | 0 |
| tr | 903 + 501 fuzzy | 0 |
| ar/cs/da/el/fi/ja/kab | 30–497 translated each | 0 |

This predates and is independent of the recent translation-pipeline restructuring and PR #2187's merge-conflict resolution — neither of those caused or fixed it, since both were only working from the already-wiped state.

## What this PR does

For each affected language:
1. Extract the last pre-wipe `locales/wxMaxima/<lang>.po` from git history.
2. `msgmerge` it against the current (post-restructuring) `wxMaxima.pot`, so old translations line up with today's msgids (exact matches carry over cleanly; near-misses are marked fuzzy for reconfirmation, standard gettext behavior).
3. Fold the result into today's combined `.po` files, filling **only** entries that are still genuinely blank — nothing already translated (via the manual-content merge or Crowdin's post-wipe re-sync) is overwritten.

Every file re-validated with `msgfmt --check`.

## Follow-up needed (not part of this PR)

Crowdin's own translation memory is still empty for these strings. Unless it's re-seeded from this recovered content on Crowdin's side, the next sync will wipe it again.

## Test plan

- [x] `msgfmt --check --statistics` passes on all 15 recovered `.po` files
- [x] Spot-checked previously-known-good entries (manual-content headings, already-translated strings) are unchanged
- [x] `git diff` scoped to exactly the 15 `locales/wxMaxima/*.po` files, no other content touched

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_