### PR TITLE
Fix Persian language constant breaking compile_2204 and compile_cygwin

### DIFF
--- a/src/dialogs/ConfigDialogue.cpp
+++ b/src/dialogs/ConfigDialogue.cpp
@@ -215,7 +215,7 @@ ConfigDialogue::ConfigDialogue(wxWindow *parent)
   m_languages[_("Malay")] = wxLANGUAGE_MALAY;
   m_languages[_("Nepali")] = wxLANGUAGE_NEPALI;
   m_languages[_("Norwegian")] = wxLANGUAGE_NORWEGIAN_BOKMAL;
-  m_languages[_("Persian")] = wxLANGUAGE_PERSIAN_IRAN;
+  m_languages[_("Persian")] = wxLANGUAGE_FARSI;
   m_languages[_("Polish")] = wxLANGUAGE_POLISH;
   m_languages[_("Portuguese")] = wxLANGUAGE_PORTUGUESE;
   m_languages[_("Portuguese (Brazilian)")] = wxLANGUAGE_PORTUGUESE_BRAZILIAN;


### PR DESCRIPTION
## Summary

`compile_2204` and `compile_cygwin` went red after #2200 merged:

```
error: 'wxLANGUAGE_PERSIAN_IRAN' was not declared in this scope; did you mean 'wxLANGUAGE_UKRAINIAN'?
```

`wxLANGUAGE_PERSIAN_IRAN` was only introduced alongside wxWidgets' later fine-grained regional locale list. Checked directly against both header versions:
- wxWidgets 3.0.5 (`compile_2204`, Cygwin): only has `wxLANGUAGE_FARSI` — no `PERSIAN` or `PERSIAN_IRAN` at all.
- wxWidgets 3.2.4 (installed locally, matches most other CI jobs): has `wxLANGUAGE_FARSI` and `wxLANGUAGE_PERSIAN_IRAN`, but not bare `wxLANGUAGE_PERSIAN` (that one only exists in current wxWidgets master/dev).

`wxLANGUAGE_FARSI` is the one name present unchanged across all of them, and is documented in current wxWidgets master as the legacy alias for Persian. Switched to it.

## Test plan

- [x] Full local build (`ninja -C build wxmaxima`) succeeds with wxWidgets 3.2.4
- [x] Verified `wxLANGUAGE_FARSI` present in both wxWidgets 3.0.5's and 3.2.4's `include/wx/language.h` directly from source

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_