### PR TITLE
Fix compile_cygwin.yml checking out main instead of the triggering ref

### DIFF
--- a/.github/workflows/compile_cygwin.yml
+++ b/.github/workflows/compile_cygwin.yml
@@ -15,7 +15,12 @@ jobs:
         with:
           packages: cmake git libwx_baseu3.0-devel libwx_gtk3u3.0-devel gcc-core gcc-g++ make gettext-devel
       - name: Checkout_git
-        run: git clone --depth 20 https://github.com/wxMaxima-developers/wxmaxima.git
+        uses: actions/checkout@v7
+        with:
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 15
+          path: wxmaxima
       - name: configure
         run: |
              mkdir build

--- a/.github/workflows/compile_cygwin.yml
+++ b/.github/workflows/compile_cygwin.yml
@@ -10,10 +10,12 @@ jobs:
   setup_cygwin:
     runs-on: windows-latest
     steps:
-      - name: setup_cygwin
-        uses: cygwin/cygwin-install-action@v6
-        with:
-          packages: cmake git libwx_baseu3.0-devel libwx_gtk3u3.0-devel gcc-core gcc-g++ make gettext-devel
+      # Runs before setup_cygwin on purpose: cygwin-install-action puts its own
+      # git.exe ahead of the native one on PATH, and that git refuses this
+      # checkout with "detected dubious ownership" (a safe.directory check that
+      # Cygwin's POSIX ownership emulation trips on Windows runners) -- checking
+      # out first, while the runner's native git is still the one on PATH,
+      # avoids the whole problem instead of adding a safe.directory exception.
       - name: Checkout_git
         uses: actions/checkout@v7
         with:
@@ -21,6 +23,10 @@ jobs:
           # a pull request then we can checkout the head.
           fetch-depth: 15
           path: wxmaxima
+      - name: setup_cygwin
+        uses: cygwin/cygwin-install-action@v6
+        with:
+          packages: cmake git libwx_baseu3.0-devel libwx_gtk3u3.0-devel gcc-core gcc-g++ make gettext-devel
       - name: configure
         run: |
              mkdir build


### PR DESCRIPTION
## Summary

Found while investigating why `compile_cygwin` stayed red on #2201 even after the actual fix landed:

`compile_cygwin.yml`'s checkout step was a plain `git clone https://github.com/.../wxmaxima.git` with no ref argument — that always clones `main`'s current HEAD, regardless of which branch or PR actually triggered the run. Confirmed live: a cygwin run whose own `head_sha` metadata pointed at #2201's fix commit still compiled the *pre-fix* source, because the clone never checked out that commit at all.

This means `compile_cygwin` has never actually validated a feature branch or PR before merge — it only ever re-tests whatever's currently on `main`, under whatever ref happened to trigger it. A real, misleading CI signal: a red cygwin run on a PR doesn't necessarily mean the PR broke anything, and a green one doesn't necessarily mean it didn't.

## Fix

Switched to `actions/checkout@v7` (what every other `push`-triggered workflow in this repo already uses) with `path: wxmaxima` — matching the directory layout the manual clone produced, so the existing `cd build && cmake ../wxmaxima` step still resolves correctly — and the same `fetch-depth: 15` the other Linux/Windows compile workflows use for the same "might be a PR" reason.

## Audit

Checked every other `push`/`pull_request`-triggered workflow in `.github/workflows/` for the same pattern:
- All already use `actions/checkout` correctly.
- `build_maxima_snap.yml`'s manual `git clone` is a different, correct case — it clones Maxima's own upstream source on a weekly schedule, not wxMaxima's code, and is explicitly commented as intentional.
- `doxygen-gh-pages.yml` has no checkout step because its third-party action handles that internally, and it's scoped to pushes on `main` only anyway (never claims to validate a PR).

`compile_cygwin.yml` was the only instance of this bug.

## Test plan

- [x] YAML syntax validated
- [x] Directory layout traced against the actual pre-fix CI log paths (`/cygdrive/d/a/wxmaxima/wxmaxima/wxmaxima/src/...`) to confirm `path: wxmaxima` reproduces the same structure
- [ ] Will confirm cygwin actually builds the correct ref once this PR's own CI runs

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_