### PR TITLE
GH #2196: rule out two queue-advance theories, document sandbox tracing limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,51 @@ working without extra checks.
   question) that differs depending on whether the dropped statement ran.
   A cell without such a canary would just silently produce a
   different-but-plausible-looking answer.
+  - **This sandbox cannot run `rr` or eBPF uprobes, and gdb hardware
+    watchpoints insert but then fail on resume -- confirmed live, not
+    assumed.** `rr record` fails immediately (`Unable to open performance
+    counter with 'perf_event_open'`): `/sys/bus/event_source/devices/` has
+    no `cpu` entry (only `breakpoint`/`msr`/`power`/`software`/`tracepoint`/
+    `uprobe`), so there is no hardware PMU exposed to the container at all --
+    not a `perf_event_paranoid` permission issue, a missing device. `rr`
+    needs that PMU for its retired-conditional-branch counting; there is no
+    workaround, this is a hard environment limit. `bpftrace`'s `BEGIN`
+    probe fires fine (plain BPF program loading works), but a `uprobe:`
+    probe on the built `wxmaxima` binary silently reports "No probes to
+    attach" -- uprobe attachment itself is blocked even though the kernel
+    lists it as a source. Oddest of all: `gdb`'s hardware watchpoints
+    (`watch this->m_commands` on a live, multi-threaded `wxmaxima`) report
+    success and show no error at the moment they're set, faking out a quick
+    check -- but the FIRST subsequent `continue` fails with "Could not
+    insert hardware watchpoint" / "Could not insert hardware breakpoints:
+    You may have requested too many hardware breakpoints/watchpoints",
+    reproduced 3/3 with a minimal `watch` + `continue` script and 0/3
+    failures with the identical `watch` alone (no `continue`) -- so the
+    debug registers can be written once but not reprogrammed across the
+    process's threads when the kernel actually tries to arm them for
+    execution. Software breakpoints (plain `break`/`tbreak`) work
+    completely normally, including hitting, `commands` blocks, and
+    `continue` across hundreds of hits -- only the *hardware*-assisted
+    paths (perf counters, uprobes, debug-register resume) are affected,
+    consistent with a sandboxing layer that fakes/no-ops specific
+    hardware-facility syscalls rather than a resource exhaustion or a
+    generic ptrace restriction (plain ptrace, software breakpoints, and
+    even setting-not-resuming a hardware watchpoint all work). **On real
+    (non-sandboxed) hardware, `rr record` + `rr replay` is almost
+    certainly the right tool for this bug** -- it would let a natural
+    reproduction under `rr record` (much lower overhead than gdb
+    breakpoints or logging, since it only needs to log nondeterministic
+    inputs, not trap on every call) be replayed deterministically
+    afterward, with arbitrarily heavy breakpoints/watchpoints during
+    *replay* costing nothing towards reproducing the original race. Try
+    that first outside this sandbox before repeating any of the above.
+  - A gdb software-breakpoint hunt (`EvaluationQueue.cpp:124`, right after
+    `AddTokens(GetCell())` on every cell-to-cell advance, logging
+    `m_commands[0]` and continuing automatically) was run against
+    `commandSequenceIntegrity.wxm` as the most targeted live attempt so
+    far, checking every run's advance log for a gap in the expected
+    1,3,5,...,299 sequence. See the follow-up note below (or GH #2196
+    directly) for whether it caught anything.
 
 ## Architecture & GUI
 

--- a/test/unit_tests/test_EvalQueueCommands.cpp
+++ b/test/unit_tests/test_EvalQueueCommands.cpp
@@ -153,6 +153,55 @@ SCENARIO("Commands are drawn from the cells in queue order") {
   }
 }
 
+SCENARIO("The first statement of a multi-statement cell survives a queue "
+         "advance from the previous cell") {
+  // GH #2196: every existing multi-statement scenario above only exercises a
+  // cell reached via AddToQueue() (which calls AddTokens() directly). A cell
+  // reached instead via RemoveFirst()'s "current cell drained, advance to the
+  // next one" path takes a different code path to populate its first command
+  // (the do-while loop in RemoveFirst() itself, not AddTokens() called
+  // directly) - this pins that path also correctly produces every statement,
+  // in particular the first one, instead of silently skipping it.
+  Reset();
+  EvaluationQueue q;
+  GroupCell *c0 = MakeCodeCell(wxS("first;"));
+  GroupCell *c1 = MakeCodeCell(wxS("assume(a > 0)$ integrate(1/(x^2+a),x); forget(a > 0)$"));
+  q.AddToQueue(c0);
+  q.AddToQueue(c1);
+  auto cmds = DriveQueue(q);
+  THEN("every statement of the second cell arrives, in order, none dropped") {
+    REQUIRE(cmds.size() == 4);
+    REQUIRE(cmds[0] == wxS("first;"));
+    REQUIRE(cmds[1] == wxS("assume(a > 0)$"));
+    REQUIRE(cmds[2] == wxS("integrate(1/(x^2+a),x);"));
+    REQUIRE(cmds[3] == wxS("forget(a > 0)$"));
+  }
+}
+
+SCENARIO("The first statement of a multi-statement cell survives advancing "
+         "through an empty-command cell") {
+  // Same GH #2196 concern, but via RemoveFirst()'s do-while loop actually
+  // iterating more than once (skipping the commented-out cell) before it
+  // finds a runnable command - a different path through the same function
+  // than a plain one-hop advance.
+  Reset();
+  EvaluationQueue q;
+  GroupCell *c0 = MakeCodeCell(wxS("first;"));
+  GroupCell *commented = MakeCodeCell(wxS("/* nothing to do */"));
+  GroupCell *c2 = MakeCodeCell(wxS("assume(a > 0)$ integrate(1/(x^2+a),x); forget(a > 0)$"));
+  q.AddToQueue(c0);
+  q.AddToQueue(commented);
+  q.AddToQueue(c2);
+  auto cmds = DriveQueue(q);
+  THEN("every statement of the third cell arrives, in order, none dropped") {
+    REQUIRE(cmds.size() == 4);
+    REQUIRE(cmds[0] == wxS("first;"));
+    REQUIRE(cmds[1] == wxS("assume(a > 0)$"));
+    REQUIRE(cmds[2] == wxS("integrate(1/(x^2+a),x);"));
+    REQUIRE(cmds[3] == wxS("forget(a > 0)$"));
+  }
+}
+
 SCENARIO("A cell without a runnable command still becomes the working cell once") {
   // A cell whose input is commented out entirely produces no command, but it
   // must not be skipped silently while the queue advances: the evaluator has


### PR DESCRIPTION
## Summary

Not a fix for GH #2196 — that bug is still open. This is the real, incremental progress from a deep investigation session, kept because it's independently valuable:

- **Two new `EvaluationQueue` unit tests** covering the exact code path GH #2196's dropped `assume(a > 0)$` goes through: advancing from a finished cell into a new multi-statement cell, both directly and through an intervening empty-command (commented-out) cell. Every existing multi-statement test only exercised a cell reached via `AddToQueue()` (which calls `AddTokens()` directly) — none tested the `RemoveFirst()` "advance to the next cell" path specifically. Both new tests pass cleanly, which rules out "the queue-advance logic has a deterministic string-processing bug for this transition shape" as an explanation. The bug depends on the live async environment (real Maxima prompt timing, thread interaction, or the question/auto-answer flow) in a way this synchronous, no-Maxima-needed harness can't reproduce.
- **Documented this sandbox's tracing-tool limits**, confirmed live rather than assumed:
  - `rr record` fails immediately — no hardware PMU exposed to the container (`/sys/bus/event_source/devices/` has no `cpu` entry), not a permissions issue.
  - `bpftrace` uprobes fail to attach to the built binary (`bpftrace`'s own `BEGIN` probe works fine, so it's specifically uprobe attachment that's blocked).
  - `gdb` hardware watchpoints report success when *set* on a live, multi-threaded `wxmaxima`, but fail on the very next `continue` ("Could not insert hardware watchpoint") — reproduced 3/3 with a minimal repro, 0/3 failures with `watch` alone (no `continue`). Software breakpoints work completely normally.
  - On real (non-sandboxed) hardware, `rr record` + `rr replay` is almost certainly the right tool for this bug, since replay lets breakpoints/watchpoints cost nothing towards reproducing the original race.

## Test plan

- [x] Both new scenarios pass in `test_EvalQueueCommands`
- [x] Full existing test suite in that binary still passes (11 scenarios total)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_