### PR TITLE
Un-silence tutorial_10Minutes as a GH #2196 canary

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # Current development version
 
+- Test fixtures: removed the recorded auto-answer PR #2195 added for
+  `tutorial_10Minutes`'s `assume(a > 0)$ integrate(...); forget(a > 0)$`
+  cell. That auto-answer stopped the test from flaking, but it also silently
+  swallows the actual symptom of the still-open bug GH #2196 (the cell's
+  `assume(a > 0)$` statement occasionally never reaches Maxima at all) --
+  with the recorded answer in place, a drop just gets auto-answered instead
+  of halting the batch run, so this test could no longer detect it. Removing
+  it restores `tutorial_10Minutes` as a working (if occasionally flaky)
+  canary for GH #2196, alongside the deterministic `commandSequenceIntegrity`
+  regression test. The other question/answer pair earlier in the same file
+  (the tutorial's own intentional demonstration of the interactive-question
+  feature) is unrelated and untouched.
 - Translations: added a reverse sync (`locales/wxMaxima/split_manual_po.cmake`,
   wired into `update-locale-manual-in-source`) that pulls a language's
   manual-content translations back out of the combined

--- a/test/automatic_test_files/10MinuteTutorial.wxm
+++ b/test/automatic_test_files/10MinuteTutorial.wxm
@@ -169,25 +169,6 @@ assume(a > 0)$
 integrate( 1 / (x^2 + a), x);
 forget(a > 0)$
 /* [wxMaxima: input   end   ] */
-/* [wxMaxima: question  start ] */
-<math><st>Is </st><mi>a</mi><st> positive or negative?</st></math>
-/* [wxMaxima: question  end   ] */
-/* [wxMaxima: answer  start ] */
-p;
-/* [wxMaxima: answer  end   ] */
-/* [wxMaxima: question  start ] */
-<math><st>Is </st><mi lisp="*var-tag*">a</mi><st> positive or negative?</st></math>
-/* [wxMaxima: question  end   ] */
-/* [wxMaxima: answer  start ] */
-p;
-/* [wxMaxima: answer  end   ] */
-/* [wxMaxima: question  start ] */
-<math><mrow lisp="mtext"><mrow lisp="mtext"><st>Is </st><mi>a</mi><st> positive or negative?</st></mrow></mrow></math>
-/* [wxMaxima: question  end   ] */
-/* [wxMaxima: answer  start ] */
-p;
-/* [wxMaxima: answer  end   ] */
-/* [wxMaxima: autoanswer    ] */
 
 
 /* [wxMaxima: comment start ]


### PR DESCRIPTION
## Summary

- PR #2195 recorded an auto-answer for `tutorial_10Minutes`'s `assume(a > 0)$ integrate(1/(x^2+a),x); forget(a > 0)$` cell's rare "Is a positive or negative?" question, to stop the test from flaking.
- That fixed the test's own flakiness, but it also masks the actual symptom of the still-open bug **#2196**: when `assume(a > 0)$` is silently dropped and never reaches Maxima, `integrate()` asks that question — and with a recorded answer now in place, the question gets silently auto-answered instead of halting the batch run with `"no scripted answer available"`. So the test can no longer detect the bug it originally caught.
- This removes that recorded auto-answer (only for this cell — the tutorial's own intentional demonstration of the interactive-question feature, earlier in the same file, is untouched), restoring the original repro vector documented in #2196.

## Why

`tutorial_10Minutes` will occasionally flake again (historically ~1-in-20 to 1-in-30) until #2196's actual root cause is fixed. That's an intentional, accepted tradeoff — the deterministic `commandSequenceIntegrity` regression test (added since #2195) stays as a second, non-flaky detector, but restoring this original canary gives a second independent repro vector while the root cause is still being chased.

## Test plan

- [x] `ctest --test-dir build -R "tutorial_10Minutes|commandSequenceIntegrity"` passes on a normal (non-buggy) run
- [x] Confirmed the removed block is only the auto-answer for the `assume`/`integrate`/`forget` cell, not the tutorial's other, intentional question/answer demonstration earlier in the file

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_