### PR TITLE
GH #2196: fail loudly, not silently, on the observed drop signature

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # Current development version
 
+- `EvaluationQueue` now catches (in `--batch` mode) rather than silently
+  proceeding on the failure mode behind GH #2196: a cell's text at the
+  moment it becomes the queue's current cell no longer necessarily matching
+  what was captured when the cell was queued -- the observed signature of a
+  statement (e.g. the `assume(...)` in the original report) never reaching
+  Maxima at all. The exact mechanism is still unknown, so this can't fix the
+  underlying bug, but it makes its effect loud instead of silent: a mismatch
+  now halts the batch run with a clear error naming both texts, the same way
+  an unmatched-parenthesis refusal already does, instead of quietly sending
+  (or skipping) the wrong thing. Not checked in interactive use, where a
+  cell's text can legitimately differ from what was queued if the user
+  edited it before its turn came up.
 - Translations: added a reverse sync (`locales/wxMaxima/split_manual_po.cmake`,
   wired into `update-locale-manual-in-source`) that pulls a language's
   manual-content translations back out of the combined

--- a/src/EvaluationQueue.cpp
+++ b/src/EvaluationQueue.cpp
@@ -48,15 +48,21 @@ void EvaluationQueue::Clear() {
   m_pendingConfig = nullptr;
   m_cellConsumedChars = 0;
   m_workingGroupChanged = false;
+  m_integrityFailure = false;
+  m_integrityFailureEnqueuedText.Clear();
+  m_integrityFailureCurrentText.Clear();
 }
 
 bool EvaluationQueue::IsInQueue(GroupCell *gr) const {
-  return std::find(m_queue.begin(), m_queue.end(), gr) != m_queue.end();
+  return std::find_if(m_queue.begin(), m_queue.end(),
+                       [gr](const QueuedCell &qc) { return qc.cell == gr; }) !=
+         m_queue.end();
 }
 
 void EvaluationQueue::Remove(GroupCell *gr) {
   bool removeFirst = IsLastInQueue(gr);
-  auto pos = std::find(m_queue.begin(), m_queue.end(), gr);
+  auto pos = std::find_if(m_queue.begin(), m_queue.end(),
+                           [gr](const QueuedCell &qc) { return qc.cell == gr; });
   if (pos != m_queue.end())
     m_queue.erase(pos);
   m_size = m_queue.size();
@@ -66,7 +72,7 @@ void EvaluationQueue::Remove(GroupCell *gr) {
     m_pendingConfig = nullptr;
     m_cellConsumedChars = 0;
     if (!m_queue.empty())
-      AddTokens(GetCell());
+      AddTokens();
   }
 }
 
@@ -78,12 +84,16 @@ void EvaluationQueue::AddToQueue(GroupCell *gr) {
       gr->GetEditable() == NULL) // don't add cells which can't be evaluated
     return;
 
-  if (m_queue.empty()) {
-    AddTokens(gr);
+  const bool wasEmpty = m_queue.empty();
+  m_size++;
+  // Snapshot the cell's text now, at the moment it's queued -- AddTokens()
+  // re-reads it once this cell becomes current and compares the two (see
+  // GH #2196 and m_integrityFailure).
+  m_queue.push_back({CellPtr<GroupCell>(gr), gr->GetEditable()->ToString(true)});
+  if (wasEmpty) {
+    AddTokens();
     m_workingGroupChanged = true;
   }
-  m_size++;
-  m_queue.push_back(CellPtr<GroupCell>(gr));
 }
 
 /**
@@ -120,19 +130,42 @@ void EvaluationQueue::RemoveFirst() {
 
   m_queue.erase(m_queue.begin());
   m_size--;
-  AddTokens(GetCell());
+  AddTokens();
   m_workingGroupChanged = true;
 }
 
-void EvaluationQueue::AddTokens(const GroupCell *cell) {
+void EvaluationQueue::AddTokens() {
   m_commands.clear();
   m_pendingText.Clear();
   m_pendingConfig = nullptr;
   m_cellConsumedChars = 0;
-  if (cell == NULL)
+  m_integrityFailure = false;
+  m_integrityFailureEnqueuedText.Clear();
+  m_integrityFailureCurrentText.Clear();
+  if (m_queue.empty())
+    return;
+  GroupCell *const cell = m_queue.front().cell;
+  if (cell == nullptr || cell->GetEditable() == nullptr)
     return;
   m_pendingConfig = cell->GetEditable()->GetConfiguration();
   m_pendingText = cell->GetEditable()->ToString(true);
+  // GH #2196: the first statement of a multi-statement cell has been
+  // observed to silently vanish somewhere between a cell being queued and
+  // becoming current, with no error and nothing sent to Maxima. The root
+  // cause is still unknown (a live tcpdump capture confirmed the drop, but
+  // repeated live instrumentation to catch the mechanism itself failed --
+  // see AGENTS.md). This comparison can't fix the unknown cause, but it can
+  // catch its one observable effect: if the cell's text now differs from
+  // what was captured when it was queued, that mismatch itself is the bug
+  // signature. Recorded here regardless of caller; MaximaEvaluator decides
+  // whether it matters (batch mode has no interactive user who could have
+  // legitimately edited a not-yet-reached queued cell in the meantime, so
+  // there a mismatch can only be this bug).
+  if (m_pendingText != m_queue.front().textAtEnqueue) {
+    m_integrityFailure = true;
+    m_integrityFailureEnqueuedText = m_queue.front().textAtEnqueue;
+    m_integrityFailureCurrentText = m_pendingText;
+  }
   ProduceNextCommand();
 }
 
@@ -311,7 +344,7 @@ GroupCell *EvaluationQueue::GetCell() {
   if (m_queue.empty())
     return NULL;
   else
-    return m_queue.front();
+    return m_queue.front().cell;
 }
 
 wxString EvaluationQueue::GetCommand() {

--- a/src/EvaluationQueue.h
+++ b/src/EvaluationQueue.h
@@ -95,11 +95,32 @@ private:
   std::size_t m_size;
   //! The label the user has assigned to the current command.
   wxString m_userLabel;
-  //! The groupCells in the evaluation Queue.
-  std::vector<CellPtr<GroupCell>> m_queue;
 
-  //! Starts tokenizing a cell: remembers its text and produces its first command.
-  void AddTokens(const GroupCell *cell);
+  //! A cell in the queue, together with the text it had when it was queued
+  //! (see m_integrityFailure below).
+  struct QueuedCell {
+    CellPtr<GroupCell> cell;
+    wxString textAtEnqueue;
+  };
+  //! The groupCells in the evaluation Queue.
+  std::vector<QueuedCell> m_queue;
+
+  //! Set by AddTokens() when the cell that just became current has different
+  //! text now than what was captured when it was added to the queue (see
+  //! GH #2196: this is the signature of a statement being silently dropped,
+  //! not something that can happen legitimately in --batch mode, where there
+  //! is no interactive user who could have edited a not-yet-reached queued
+  //! cell in the meantime). Purely informational here -- EvaluationQueue
+  //! itself always proceeds with the freshly-read text either way, exactly
+  //! as it did before this check existed; it is the caller's job to decide
+  //! whether the mismatch matters (see MaximaEvaluator::TriggerEvaluation()).
+  bool m_integrityFailure = false;
+  wxString m_integrityFailureEnqueuedText;
+  wxString m_integrityFailureCurrentText;
+
+  //! Starts tokenizing the queue's current (front) cell: remembers its text
+  //! and produces its first command.
+  void AddTokens();
   //! Tokenizes the next single command out of m_pendingText, in the mode current
   //! now, appending a ";" if it is the cell's last command and we are in maxima
   //! (not lisp) mode.
@@ -139,7 +160,7 @@ public:
   //! Is GroupCell gr part of the evaluation queue?
   bool IsLastInQueue(GroupCell const *gr)
     {
-      return !m_queue.empty() && (gr == m_queue.front());
+      return !m_queue.empty() && (gr == m_queue.front().cell);
     }
 
   //! Is GroupCell gr part of the evaluation queue?
@@ -171,6 +192,20 @@ public:
 
   //! Return the next command that needs to be evaluated.
   wxString GetCommand();
+
+  //! Did the cell that just became current (see GetCell()) have different
+  //! text than what was captured when it was added to the queue? See
+  //! m_integrityFailure -- this is purely a diagnostic signal, it does not
+  //! change what GetCommand() returns.
+  bool HasIntegrityFailure() const { return m_integrityFailure; }
+  //! The cell's text as it was when AddToQueue() was called, valid only
+  //! while HasIntegrityFailure() is true for the current cell.
+  const wxString &GetIntegrityFailureEnqueuedText() const
+    { return m_integrityFailureEnqueuedText; }
+  //! The cell's text as AddTokens() actually read it, valid only while
+  //! HasIntegrityFailure() is true for the current cell.
+  const wxString &GetIntegrityFailureCurrentText() const
+    { return m_integrityFailureCurrentText; }
 
   //! Get the size of the queue [in cells]
   int Size() const { return m_size; }

--- a/src/MaximaEvaluator.cpp
+++ b/src/MaximaEvaluator.cpp
@@ -357,6 +357,37 @@ void MaximaEvaluator::TriggerEvaluation() {
     return; // empty queue
   }
 
+  // GH #2196: the cell that just became current has different text now than
+  // when it was queued -- the signature of a statement being silently
+  // dropped (a live tcpdump capture confirmed this happens; the exact
+  // mechanism is still unknown, see AGENTS.md). Only treated as a hard
+  // error in --batch mode: there, nothing legitimate could have changed a
+  // not-yet-reached queued cell's text (no interactive user to edit it), so
+  // a mismatch there can only be this bug. In interactive use the same
+  // mismatch is ordinary and expected -- a user editing a cell before its
+  // turn comes up -- so it is intentionally not checked there; whatever the
+  // cell now reads is simply what gets evaluated, same as always.
+  if (m_wxMaxima.m_exitAfterEval &&
+      m_wxMaxima.GetWorksheet()->GetEvaluationQueue().HasIntegrityFailure()) {
+    auto &evaluationQueue = m_wxMaxima.GetWorksheet()->GetEvaluationQueue();
+    m_wxMaxima.GetWorksheet()->GetErrorList().Add(tmp);
+    m_wxMaxima.StatusMaximaBusy(StatusBar::MaximaStatus::maximaerror);
+    auto cell = std::make_unique<TextCell>(
+        tmp, &m_wxMaxima.m_configuration,
+        _("Refusing to evaluate cell: its text changed between being "
+          "queued and being evaluated (see GH #2196).\nQueued as: ") +
+            evaluationQueue.GetIntegrityFailureEnqueuedText() +
+            _("\nNow reads: ") +
+            evaluationQueue.GetIntegrityFailureCurrentText() + wxS("\n"));
+    cell->SetType(MC_TYPE_ERROR);
+    tmp->SetOutput(std::move(cell));
+    evaluationQueue.Clear();
+    m_wxMaxima.GetWorksheet()->SetWorkingGroup(nullptr);
+    m_wxMaxima.GetWorksheet()->RequestRedraw();
+    AbortOnError();
+    return;
+  }
+
   // Add a semicolon at the end of the cell, if needed.
   if (tmp->AddEnding())
     m_wxMaxima.GetWorksheet()->GetEvaluationQueue().AddEnding();

--- a/test/unit_tests/test_EvalQueueCommands.cpp
+++ b/test/unit_tests/test_EvalQueueCommands.cpp
@@ -316,6 +316,66 @@ SCENARIO("to_lisp() then lisp forms in one cell is driven per-command by the "
   }
 }
 
+SCENARIO("to_lisp() as a lone cell's only command still gets terminated when "
+         "the PREVIOUS cell ended in lisp mode and switched back",
+         "[redesign]") {
+  // A specific, remembered detail about GH #2196: the one thing ever seen to
+  // be lost was possibly just a to_lisp() command's own trailing ";", not
+  // the whole statement. Auto-terminating the last command of a cell only
+  // happens "if not in lisp mode" (ProduceNextCommand()'s !haveBoundary
+  // branch) - if that check ever saw a stale InLispMode()==true for a
+  // command that is actually still a plain maxima statement (to_lisp()
+  // itself hasn't run yet, so tokenizing it should always happen in maxima
+  // mode), the ";" would silently never be appended. Cell 0 ends with
+  // (to-maxima) (leaves lisp mode); cell 1 starts with a bare to_lisp() (no
+  // ";" typed) as its ONLY command - by the time cell 1 is tokenized,
+  // InLispMode() must already be back to false.
+  Reset();
+  EvaluationQueue q;
+  GroupCell *c0 = MakeCodeCell(wxS("to_lisp();\n(setq $x 3)\n(to-maxima)"));
+  GroupCell *c1 = MakeCodeCell(wxS("to_lisp()"));
+  q.AddToQueue(c0);
+  q.AddToQueue(c1);
+  PromptReaction prompt = [](const wxString &cmd) {
+    if (cmd.Contains(wxS("to_lisp")))
+      g_cfg->InLispMode(true);
+    if (cmd.Contains(wxS("to-maxima")))
+      g_cfg->InLispMode(false);
+  };
+  auto cmds = DriveQueue(q, prompt);
+  THEN("cell 1's to_lisp() still arrives, terminated") {
+    REQUIRE(cmds.size() >= 4);
+    REQUIRE(cmds.back() == wxS("to_lisp();"));
+  }
+}
+
+SCENARIO("to_lisp() as the FIRST of two commands in a cell reached by "
+         "advancing from the previous cell",
+         "[redesign]") {
+  // Same concern as above, but via RemoveFirst()'s cell-to-cell advance path
+  // (AddTokens() called from inside RemoveFirst(), not from AddToQueue())
+  // rather than being the queue's initial cell - the exact boundary GH #2196
+  // was actually observed at.
+  Reset();
+  EvaluationQueue q;
+  GroupCell *c0 = MakeCodeCell(wxS("first;"));
+  GroupCell *c1 = MakeCodeCell(wxS("to_lisp();\n(setq $x 3)\n(to-maxima)"));
+  q.AddToQueue(c0);
+  q.AddToQueue(c1);
+  PromptReaction prompt = [](const wxString &cmd) {
+    if (cmd.Contains(wxS("to_lisp")))
+      g_cfg->InLispMode(true);
+    if (cmd.Contains(wxS("to-maxima")))
+      g_cfg->InLispMode(false);
+  };
+  auto cmds = DriveQueue(q, prompt);
+  THEN("to_lisp() survives the cell-boundary advance, terminated") {
+    REQUIRE(cmds.size() >= 4);
+    REQUIRE(cmds[0] == wxS("first;"));
+    REQUIRE(cmds[1] == wxS("to_lisp();"));
+  }
+}
+
 class TestApp : public wxApp {
 public:
   bool OnInit() override { return true; }


### PR DESCRIPTION
## Summary

GH #2196's actual mechanism is still unknown after extensive live-tracing (see the issue and `AGENTS.md`) — it's a genuinely narrow race that even light instrumentation reliably suppresses. This doesn't fix the cause, but makes its one known observable effect impossible to miss: a statement (e.g. the `assume(...)` in the original report) silently never reaching Maxima.

- `EvaluationQueue::AddToQueue()` now captures each cell's text at the moment it's queued.
- `EvaluationQueue::AddTokens()` compares that snapshot against what it actually reads when the cell becomes current, exposing the result via `HasIntegrityFailure()`/`GetIntegrityFailureEnqueuedText()`/`GetIntegrityFailureCurrentText()`. This is purely informational at the `EvaluationQueue` level — it always proceeds with the freshly-read text either way, unchanged from before.
- `MaximaEvaluator::TriggerEvaluation()` now checks that flag, but **only in `--batch` mode** (`m_exitAfterEval`): there, no interactive user could have legitimately edited a not-yet-reached queued cell, so a mismatch can only be this bug. It's handled exactly like the existing unmatched-parenthesis refusal — halt loudly with both texts shown (`GetErrorList()`, an `MC_TYPE_ERROR` cell, `AbortOnError()`) — instead of silently sending or silently skipping the wrong text.
- Interactive use is intentionally left unchecked: a queued cell's text differing from its enqueue-time snapshot there is the ordinary, expected result of a user editing it before its turn comes up, not a bug.

## Also included

Two new deterministic `EvaluationQueue` unit tests probing a specific remembered detail about this bug: whether a `to_lisp()` cell's own auto-appended terminator could be lost specifically at a lisp-mode transition straddling a cell boundary. Both pass cleanly — this doesn't rule out the live race, but does rule out a simple, deterministic ordering bug in the current tokenization logic for that shape.

## Test plan

- [x] `ctest --test-dir build -L unittest` — 41/41 pass (includes the two new scenarios)
- [x] `ctest --test-dir build -R "tutorial_10Minutes|commandSequenceIntegrity|lisp_mode"` — all pass on a normal (non-buggy) run, confirming no false positives from the new check
- [x] Manually verified the new check compiles and links cleanly, and doesn't change behavior on any passing run

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_