### PR TITLE
Attribute gnuplot's license in builds that bundle it (snap)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,8 @@ set(WXM_SANITIZE "" CACHE STRING
     "Comma-separated list of sanitizers to compile with, e.g. \"address,undefined\" (GCC/Clang only).")
 option(WXM_FUZZ
     "Build the coverage-guided libFuzzer parser fuzz targets (requires a Clang compiler). See test/fuzz/." OFF)
+option(WXM_BUNDLES_GNUPLOT
+    "This build bundles its own gnuplot binary instead of relying on a separately installed one (e.g. the snap, which stages gnuplot via the maxima snap so it works under strict confinement). Appends gnuplot's own license notice to THIRD-PARTY-NOTICES.txt, since it is then being distributed, not merely recommended." OFF)
 
 if(DEFINED MACOSX_VERSION_MIN)
     set(CMAKE_OSX_DEPLOYMENT_TARGET ${MACOSX_VERSION_MIN} CACHE STRING FORCE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Current development version
 
+- Snap packaging: the snap stages gnuplot via the `maxima` snap so plotting
+  works under strict confinement, which means it distributes gnuplot's own
+  binary rather than merely recommending a separately-installed one.
+  gnuplot's license notice now travels with any build configured with
+  `-DWXM_BUNDLES_GNUPLOT=ON` (currently just the snap), appended to
+  `THIRD-PARTY-NOTICES.txt` (see `THIRD-PARTY-NOTICES-Gnuplot.txt`) and
+  therefore reachable from the app's own Help > License dialog. Regular
+  builds, which only recommend a system gnuplot, are unaffected.
 - `EvaluationQueue` now catches (in `--batch` mode) rather than silently
   proceeding on the failure mode behind GH #2196: a cell's text at the
   moment it becomes the queue's current cell no longer necessarily matching

--- a/THIRD-PARTY-NOTICES-Gnuplot.txt
+++ b/THIRD-PARTY-NOTICES-Gnuplot.txt
@@ -1,0 +1,49 @@
+-------------------------------------------------------------------------------
+gnuplot
+-------------------------------------------------------------------------------
+
+wxMaxima (and Maxima itself) use gnuplot to render 2D/3D plots. This build
+bundles a gnuplot binary rather than relying on one already installed on the
+system, so gnuplot's own license terms apply to what is being distributed
+here, not just recommended as a separate dependency.
+
+The program was obtained from the following website:
+https://gnuplot.sourceforge.net/
+
+With the following license (covering the bulk of gnuplot's own source code):
+
+Copyright 1986-1993, 1998, 2004 Thomas Williams, Colin Kelley
+
+Permission to use, copy, and distribute this software and its documentation
+for any purpose with or without fee is hereby granted, provided that the
+above copyright notice appear in all copies and that both that copyright
+notice and this permission notice appear in supporting documentation.
+
+Permission to modify the software is granted, but not the right to
+distribute the complete modified source code. Modifications are to be
+distributed as patches to the released version. Permission to distribute
+binaries produced by compiling modified sources is granted, provided you
+  1. distribute the corresponding source modifications from the released
+     version in the form of a patch file along with the binaries,
+  2. add special version identification to distinguish your version in
+     addition to the base release version number,
+  3. provide your name and address as the primary contact for the support
+     of your modified version, and
+  4. retain our contact information in regard to use of the base software.
+Permission to distribute the released version of the source code along
+with corresponding source modifications in the form of a patch file is
+granted with same provisions 2 through 4 for binary distributions.
+
+This software is provided "as is" without express or implied warranty to
+the extent permitted by applicable law.
+
+-----------------------------------------------------------------------------
+
+gnuplot itself bundles a handful of files under other, separate license
+terms (for example the wxWidgets terminal driver under BSD-4-clause or
+GPL-2, Adobe's AGLFN font-metrics data, and an X Consortium-style license on
+one header) -- unchanged from upstream. The exact set depends on the
+gnuplot build actually bundled; its own copyright/license file (typically
+installed as /usr/share/doc/gnuplot*/copyright on a Debian-derived build)
+is the authoritative, itemized source and should travel along with the
+binary wherever it is bundled.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,6 +43,11 @@ parts:
     plugin: cmake
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
+      # This snap stages gnuplot via the maxima snap below (strict confinement
+      # can't just exec a host gnuplot binary), so it is being distributed, not
+      # merely recommended -- gnuplot's own license notice needs to travel
+      # with it. See THIRD-PARTY-NOTICES-Gnuplot.txt.
+      - -DWXM_BUNDLES_GNUPLOT=ON
     source: https://github.com/wxMaxima-developers/wxmaxima.git
     # core24 == Ubuntu 24.04 (noble), which ships wxWidgets 3.2 (not 3.0) and
     # applied the 64-bit time_t transition, so the runtime libraries carry the

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -659,6 +659,14 @@ if(WIN32 AND USE_WEBVIEW)
     file(READ "${CMAKE_SOURCE_DIR}/THIRD-PARTY-NOTICES-Webview.txt" webview_license)
     file(APPEND "${CMAKE_BINARY_DIR}/THIRD-PARTY-NOTICES.txt" "${webview_license}")
 endif()
+
+# gnuplot is bundled (not just recommended) only by builds that pass
+# -DWXM_BUNDLES_GNUPLOT=ON, e.g. the snap (see snap/snapcraft.yaml), which
+# stages gnuplot via the maxima snap so it works under strict confinement.
+if(WXM_BUNDLES_GNUPLOT)
+    file(READ "${CMAKE_SOURCE_DIR}/THIRD-PARTY-NOTICES-Gnuplot.txt" gnuplot_license)
+    file(APPEND "${CMAKE_BINARY_DIR}/THIRD-PARTY-NOTICES.txt" "${gnuplot_license}")
+endif()
 add_custom_command(
         OUTPUT ${CMAKE_BINARY_DIR}/wxm_thirdparty_notices.h
         COMMAND ${CMAKE_COMMAND} ARGS


### PR DESCRIPTION
## Summary

- The snap stages gnuplot via the `maxima` snap (`stage-snaps: [maxima]`) rather than relying on a system-installed one, since strict confinement can't just exec an arbitrary host binary. That means the snap *distributes* gnuplot's binary, not merely recommends it as a dependency — gnuplot's own license terms (non-GPL, permissive but attribution-requiring, despite the name) apply to that distribution.
- Adds `THIRD-PARTY-NOTICES-Gnuplot.txt` with gnuplot's license text (copied verbatim from its Debian packaging's `copyright` file), appended to `THIRD-PARTY-NOTICES.txt` — and therefore reachable from the app's own Help > License dialog — by any build configured with the new `-DWXM_BUNDLES_GNUPLOT=ON` option.
- Mirrors the existing `WIN32 AND USE_WEBVIEW` pattern already used for the MS Edge WebView2 notice (`THIRD-PARTY-NOTICES-Webview.txt`), so it follows established project convention rather than introducing a new mechanism.
- Wired into `snap/snapcraft.yaml`'s `cmake-parameters`. Regular builds, which only *recommend* a separately-installed system gnuplot rather than bundling one, are unaffected — the option defaults `OFF`.

## Test plan

- [x] Built with `-DWXM_BUNDLES_GNUPLOT=ON` in a throwaway build dir: `THIRD-PARTY-NOTICES.txt` correctly gains the gnuplot section
- [x] Default build (option unset): `THIRD-PARTY-NOTICES.txt` unchanged, no gnuplot mention
- [x] Full default build succeeds cleanly

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_