### PR TITLE
Snap: always use the internal help pane for the local manual

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # Current development version
 
+- Snap: opening the local manual (Help > wxMaxima help, F1, ...) with "use
+  external browser" selected in Options no longer silently fails under
+  strict confinement. The portal-routed external browser may itself be a
+  strictly confined snap (Firefox/Chromium are commonly installed that way
+  by default) and cannot see another snap's private files at all, so it
+  could never actually open the `file://` URI it was handed. The local
+  manual now always uses the internal help pane (which reads the file
+  in-process, unaffected by confinement) when running inside a snap,
+  regardless of the external-browser preference; external `http(s)://`
+  links (website, online manual) are unaffected either way, since fetching
+  those never depended on filesystem access across the confinement
+  boundary.
 - `EvaluationQueue` now catches (in `--batch` mode) rather than silently
   proceeding on the failure mode behind GH #2196: a cell's text at the
   moment it becomes the queue's current cell no longer necessarily matching

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -1626,7 +1626,27 @@ void wxMaxima::ShowTip(bool force) {
 
 void wxMaxima::LaunchHelpBrowser(wxString uri) {
 #ifdef USE_WEBVIEW
-  if (m_configuration.InternalHelpBrowser()) {
+  // A file:// URI (the local manual) inside a confined snap is a special
+  // case: even once the portal successfully reaches the host's default
+  // browser (see the SNAP branch below), that browser still has to read the
+  // file itself off its own filesystem view. If it is ALSO a strictly
+  // confined snap -- Firefox and Chromium are commonly installed as snaps by
+  // default -- it cannot see another snap's private files at all, with no
+  // interface connecting them, so the manual fails to load with no clear
+  // reason why. The internal help pane reads the file in-process instead, so
+  // it isn't affected: use it unconditionally for a local file under
+  // confinement, regardless of the "use external browser" preference.
+  // Remote (http/https) links are unaffected either way -- the browser just
+  // fetches those over the network -- so this only narrows the local-manual
+  // case, not "visit website"-style external links.
+  // wxURI::BuildURI() (used to construct the manual's URI) normalizes an
+  // empty-authority "file://" + absolute path down to "file:/path" (one
+  // slash, not two) -- confirmed live: a plain uri.StartsWith("file://")
+  // check silently never matched. Parse the scheme properly instead of
+  // string-matching the serialized form.
+  bool forceInternal = wxGetEnv(wxS("SNAP"), nullptr) &&
+    (wxURI(uri).GetScheme() == wxS("file"));
+  if (m_configuration.InternalHelpBrowser() || forceInternal) {
     m_helpPane->SetURL(uri);
     wxMaximaFrame::ShowPane(EventIDs::menu_pane_help);
   } else


### PR DESCRIPTION
## Summary

- Under strict snap confinement, choosing "use external browser" in Options could silently fail to show the local manual. `LaunchHelpBrowser()`'s existing `SNAP` branch already routes external opens through the XDG portal so the host's default browser can be *launched* at all — but that browser then has to read the `file://` URI itself, off its own filesystem view. Firefox and Chromium are commonly installed as snaps by default, and a strictly confined browser snap cannot see another snap's private files at all (no interface connects them), so the manual would fail to load with no clear indication why.
- The internal help pane reads the file in-process, unaffected by confinement, and the snap already stages the webview library it needs (`libwxgtk-webview3.2-1t64`). Use it unconditionally for a local (`file://`) manual URI while running inside a snap, regardless of the user's external-browser preference.
- External `http(s)://` links (website, online manual redirect) are untouched — fetching those never depended on filesystem access across the confinement boundary, only the local manual did. No new attack surface (no local server, no new listener) — this narrows an existing, already-used code path rather than adding one.

## How this was actually verified

This sandbox's default wxWidgets install lacked webview support (`WXM_DISABLE_WEBVIEW` auto-detected on), so the `USE_WEBVIEW`-gated fix couldn't be exercised at all until installing `libwxgtk-webview3.2-dev` and rebuilding. With that done, drove the app live under Xvfb (`xdotool`) with `useInternalHelpBrowser=0` set via `--ini` and `F1` pressed:
- Without `SNAP` set: takes the external path as before (unchanged behavior, confirmed via the log's "Failed to open URL ... in default browser" error, expected since no real browser exists in this sandbox).
- With `SNAP=1` set: takes the internal path instead, with no such error.

This process also caught a real bug in the first version of the check: `uri.StartsWith("file://")` silently never matched, because `wxURI::BuildURI()` (used to construct the manual's URI) normalizes an empty-authority `file://` + absolute path down to `file:/path` (one slash, not two). Fixed to parse the scheme via `wxURI::GetScheme()` instead of string-matching the serialized form.

## Test plan

- [x] Full build with webview enabled, unit tests, and a sample of GUI batch tests (`imageCells`, `tutorial_10Minutes`, `commandSequenceIntegrity`, `boxes`, `unicode`, `weirdLabels`, `formerCrashes`, `autosave`) — all pass
- [x] Live-verified both branches of the new condition under Xvfb (see above)
- [x] `NEWS.md` updated

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_