### PR TITLE
Fix two 32-bit-only bugs found by GH #2208, and run tests on 32-bit CI

### DIFF
--- a/.github/workflows/compile_ubuntu_32bit.yml
+++ b/.github/workflows/compile_ubuntu_32bit.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
              sudo dpkg --add-architecture i386
              sudo apt-get update
-             sudo apt-get install g++-i686-linux-gnu cmake gettext libwxgtk3.2-dev:i386 libwxgtk-webview3.2-dev:i386 wx3.2-headers pandoc make po4a
+             sudo apt-get install g++-i686-linux-gnu cmake gettext libwxgtk3.2-dev:i386 libwxgtk-webview3.2-dev:i386 wx3.2-headers pandoc make po4a xvfb at-spi2-core dbus
       - name: configure
         run: |
              export CXX="i686-linux-gnu-g++"
@@ -32,10 +32,33 @@ jobs:
              export LANG=en_US.UTF-8
              mkdir build
              cd build
-             cmake ..
+             cmake -DWXM_UNIT_TESTS=YES ..
              cd ..
       - name: compile
         run: |
              cd build
              cmake --build .
+             cd ..
+      - name: Run unit tests
+        # GH #2208: this build's test/ subdirectory was never actually built,
+        # let alone run - so two real 32-bit-only bugs (CellPtr's cmpObjects()
+        # doing raw pointer subtraction, and EditorCell::FindNext()/its Tab-key
+        # handler comparing a wxString::find() result against wxNOT_FOUND
+        # through a signed 64-bit variable -- both undefined behavior /
+        # incorrect-by-construction patterns that only happen to produce the
+        # right answer when size_t is itself 64 bits wide) sat undetected
+        # until a Debian rebuild caught them. The "unittest" label selects the
+        # self-contained C++ unit tests (test/unit_tests/*), which need
+        # neither Maxima nor a real desktop - see test/unit_tests/CMakeLists.txt
+        # and compile_windows.yml's own "Run unit tests" step for the same
+        # pattern on another platform that cannot run the full Maxima-driven
+        # integration suite. Unlike Windows, though, most of these tests still
+        # instantiate real GTK widgets, so -- like compile_ubuntu.yml's own
+        # run_tests step -- they need a real (virtual) X server: xvfb-run
+        # supplies that, and dbus-run-session avoids each GTK process
+        # otherwise stalling ~25s waiting out the AT-SPI accessibility
+        # bridge's D-Bus timeout at startup.
+        run: |
+             cd build
+             GDK_BACKEND=x11 dbus-run-session -- xvfb-run -a ctest -L unittest --output-on-failure
              cd ..

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,32 @@
 # Current development version
 
+- Fixed two 32-bit-only bugs (GH #2208), found because CI never actually ran
+  the test suite on a 32-bit build -- it only compiled it:
+  - `CellPtr`'s ordering comparison (`cmpObjects()`, backing `operator<`)
+    subtracted two unrelated `Observed*` pointers directly. That is
+    undefined behavior, and in practice, on a 32-bit address space, it
+    could silently overflow and produce the wrong sign (a null pointer no
+    longer compared as less than a real one) -- a 64-bit build's much
+    sparser address space essentially never triggers it. Fixed by comparing
+    the addresses as unsigned integers instead, which is well-defined on
+    any architecture. Verified against the exact addresses from the bug
+    report, and by cross-compiling and running the real `test_CellPtr` unit
+    test as an i386 binary.
+  - `EditorCell::FindNext()` (worksheet search) and its Tab-key indent
+    handler both stored a `wxString::find()`/`rfind()` result -- `size_t`,
+    whose "not found" value is `wxString::npos` -- into a signed 64-bit
+    variable and compared it against `wxNOT_FOUND` (`-1`). On a 64-bit
+    build `size_t` is also 64 bits wide, so `npos`'s bit pattern
+    reinterprets as `-1` and the comparison happens to work; on a 32-bit
+    build `size_t` is 32 bits, so `npos` zero-extends into a large positive
+    number instead, making every failed search look like a match at a huge
+    offset -- corrupting the worksheet's search/selection state. Fixed by
+    keeping both in `size_t`/`wxString::npos` terms throughout. Found by
+    running the real `test_WorksheetFind` unit test as an i386 binary.
+  CI now also actually runs the unit test suite (`ctest -L unittest`) on
+  the 32-bit build, under a virtual X server, which previously only
+  compiled the tests and never ran any of them -- the gap that let both of
+  these bugs go undetected until a Debian rebuild caught them.
 - Snap: opening the local manual (Help > wxMaxima help, F1, ...) with "use
   external browser" selected in Options no longer silently fails under
   strict confinement. The portal-routed external browser may itself be a

--- a/src/cells/CellPtr.h
+++ b/src/cells/CellPtr.h
@@ -450,6 +450,15 @@ protected:
 
   void base_reset(Observed *obj = nullptr) noexcept;
 
+  //! A total order over two (possibly unrelated) addresses, usable with
+  //! < 0 / == 0 / > 0. Compares them as unsigned integers rather than via
+  //! pointer subtraction: see the GH #2208 comment on cmpObjects() below.
+  static int CmpAddresses(const void *a, const void *b) noexcept {
+    const auto ia = reinterpret_cast<uintptr_t>(a);
+    const auto ib = reinterpret_cast<uintptr_t>(b);
+    return (ia > ib) - (ia < ib);
+  }
+
 public:
   template <typename U>
   static bool constexpr is_pointer() {
@@ -465,10 +474,24 @@ public:
   auto cmpPointers(const CellPtrBase &o) const noexcept { return m_ptr.GetImpl() - o.m_ptr.GetImpl(); }
 
   //! This is the spaceship operator acting on pointed-to objects
-  auto cmpObjects(const CellPtrBase &o) const noexcept { return base_get() - o.base_get(); }
+  //!
+  //! GH #2208: this used to be a plain `base_get() - o.base_get()` pointer
+  //! subtraction. That is undefined behavior for two pointers into unrelated
+  //! objects, and in practice, on 32-bit architectures, it can silently
+  //! produce the wrong sign: a signed ptrdiff_t subtraction of two addresses
+  //! spread widely across the (much smaller) 32-bit address space can
+  //! overflow and wrap around, which a 64-bit build's much sparser address
+  //! space essentially never triggers. Comparing the two addresses as
+  //! unsigned integers instead is well-defined on any architecture and gives
+  //! the total order operator< (used via cmpObjects() < 0) actually needs.
+  auto cmpObjects(const CellPtrBase &o) const noexcept {
+    return CmpAddresses(base_get(), o.base_get());
+  }
 
   //! This is the spaceship operator acting on pointed-to objects
-  auto cmpObjects(const Observed *o) const noexcept { return base_get() - o; }
+  auto cmpObjects(const Observed *o) const noexcept {
+    return CmpAddresses(base_get(), o);
+  }
 
   static size_t GetLiveInstanceCount() noexcept { return m_instanceCount; }
 

--- a/src/cells/EditorCell.cpp
+++ b/src/cells/EditorCell.cpp
@@ -2018,11 +2018,15 @@ bool EditorCell::HandleSpecialKey(wxKeyEvent &event) {
 
             auto start = SelectionLeft();
             auto end   = SelectionRight();
-            long long newLineIndex = std::min(m_text.find(wxS('\n'), start),
-                                           m_text.find(wxS('\r'), start));
+            // GH #2208: see the matching comment in FindNext() -- keep this
+            // in size_t/wxString::npos terms rather than converting to a
+            // signed type and comparing against wxNOT_FOUND, which only
+            // happens to work on a 64-bit build.
+            size_t newLineIndex = std::min(m_text.find(wxS('\n'), start),
+                                            m_text.find(wxS('\r'), start));
 
-            if (((newLineIndex != wxNOT_FOUND) && (static_cast<size_t>(newLineIndex) < end)) ||
-                (m_text.SubString(static_cast<size_t>(newLineIndex), start).Trim() == wxEmptyString)) {
+            if (((newLineIndex != wxString::npos) && (newLineIndex < end)) ||
+                (m_text.SubString(newLineIndex, start).Trim() == wxEmptyString)) {
               start = BeginningOfLine(start);
               size_t p = start;
 
@@ -4176,17 +4180,24 @@ bool EditorCell::FindNext(wxString str, const bool &down,
       CursorPosition(m_text.Length());
     }
   }
-  long long strStart = wxNOT_FOUND;
+  // GH #2208: wxString::find()/rfind() return size_t, whose "not found"
+  // value is wxString::npos (size_t(-1)), not wxNOT_FOUND -- assigning it to
+  // a signed 64-bit variable and comparing against wxNOT_FOUND (-1) only
+  // works by accident on a 64-bit build, where size_t is also 64 bits wide
+  // and the bit pattern reinterprets as -1. On a 32-bit build size_t is
+  // 32 bits, so npos zero-extends to a large positive number instead,
+  // making a failed search silently look like a match at a huge offset.
+  size_t strStart = wxString::npos;
   if (down)
     strStart = text.find(str, start);
   else
     strStart = text.rfind(str, start);
 
-  if (strStart != wxNOT_FOUND) {
+  if (strStart != wxString::npos) {
     if (down)
-      SetSelection(static_cast<size_t>(strStart), static_cast<size_t>(strStart) + str.Length());
+      SetSelection(strStart, strStart + str.Length());
     else
-      SetSelection(static_cast<size_t>(strStart) + str.Length(), static_cast<size_t>(strStart));
+      SetSelection(strStart + str.Length(), strStart);
     return true;
   }
   else


### PR DESCRIPTION
## Summary

Benoit was right in #2208: we never ran the test suite on CI for the 32-bit build — `compile_ubuntu_32bit.yml` only compiled it. That gap let two real 32-bit-only bugs go undetected until a Debian rebuild caught them.

- **`CellPtr::cmpObjects()`** (`src/cells/CellPtr.h`), which backs `operator<`'s total order over cell addresses, subtracted two unrelated `Observed*` pointers directly. Pointer subtraction between unrelated objects is undefined behavior, and in practice it can silently produce the wrong sign once the address space is only 32 bits wide — a 64-bit build's much sparser address space essentially never triggers it. This is the bug #2208 literally reported. Fixed by comparing the addresses as unsigned integers instead.
- **`EditorCell::FindNext()`** (worksheet search) and its Tab-key indent handler both stored a `wxString::find()`/`rfind()` result — `size_t`, whose "not found" value is `wxString::npos` — into a signed 64-bit variable and compared it against `wxNOT_FOUND` (`-1`). On a 64-bit build `size_t` is also 64 bits wide, so `npos`'s bit pattern happens to reinterpret as `-1` and the comparison works by accident; on a 32-bit build `size_t` is 32 bits, so `npos` zero-extends into a large positive number instead, making every failed search look like a match at a huge offset and corrupting the worksheet's search/selection state. Found only because I ran the real `test_WorksheetFind` unit test as an i386 binary and saw it fail. Fixed by keeping both in `size_t`/`wxString::npos` terms throughout.

`compile_ubuntu_32bit.yml` now actually runs the unit test suite (`ctest -L unittest`) on the 32-bit build. Most of these tests instantiate real GTK widgets, so (like the other Linux CI jobs) the step needs a virtual X server — added `xvfb`/`dbus`/`at-spi2-core` to the installed packages and wrapped the `ctest` invocation with `GDK_BACKEND=x11 dbus-run-session -- xvfb-run -a`, mirroring `compile_ubuntu.yml`'s own `run_tests` step.

## Verification

- Cross-compiled the project for i386 in a sandbox (`CXX=i686-linux-gnu-g++`), confirmed `test_CellPtr` failed exactly as in the bug report before the fix, and passed after.
- Ran the *entire* unit test suite (`ctest -L unittest`, 41 tests) as real i386 binaries under a virtual X server — all failed before the `EditorCell::FindNext()` fix (`WorksheetFind`) and all 41 pass after, using the exact command now in the CI workflow (`GDK_BACKEND=x11 dbus-run-session -- xvfb-run -a ctest -L unittest --output-on-failure`).
- Ran the same full unit test suite on a regular 64-bit Debug build to confirm no regression: 41/41 pass.
- Validated the workflow YAML with `python3 -c "import yaml; yaml.safe_load(...)"`.

Fixes #2208.

## Test plan

- [x] i386 cross-build: `test_CellPtr` fails pre-fix, passes post-fix
- [x] i386 cross-build: full `ctest -L unittest` (41/41) passes post-fix, using the exact CI command
- [x] 64-bit Debug build: full `ctest -L unittest` (41/41) passes, no regression
- [x] `compile_ubuntu_32bit.yml` YAML syntax validated

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_