### PR TITLE
Fix TOC sidebar drag-and-drop reordering (GH #1524)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,31 @@
 # Current development version
 
+- Table of contents sidebar: dragging a chapter/section entry to reorder it
+  (GH #1524) now actually works -- it was wired up (drag image, scroll-while-
+  dragging, the reordered-preview rendering) but never functional, since
+  three separate bugs each broke it in a different way:
+  - `Worksheet::TOCdnd()`, which performs the actual reorder, required a
+    worksheet selection to already exist before doing anything -- but
+    nothing sets one up before this function itself builds one from the
+    dragged cell a few lines later. In ordinary use (no unrelated selection
+    active when a TOC drag starts) this made every drop a silent no-op.
+  - Dropping at or near the end of the list snapped back to a position near
+    the drag's own start instead of the end, because the "clamp an
+    out-of-range drop position" logic in both `OnMouseMotion()` and
+    `OnMouseUp()` clamped to the wrong value.
+  - Dragging a heading that has its own sub-heading (e.g. a section with a
+    subsection) could silently strip the sub-heading (and its content) back
+    off during the move, landing it elsewhere in the document instead of
+    following its parent: the selection-extension logic compared each next
+    cell's rank against whatever cell the selection currently ended on
+    rather than against the originally-dragged heading's rank, so once the
+    selection had absorbed the dragged heading's own plain-content cell, a
+    sub-heading right after it was compared against that content cell
+    instead and always judged "not part of this chapter".
+  Verified end-to-end in a live session: dragging a section with a nested
+  subsection and its own content cells to a new position now moves the
+  whole chapter together, with correct renumbering and a table of contents
+  that stays in sync with the document afterwards.
 - Release automation (GH #1192): tagged releases now also attach a
   `.tar.xz` source archive plus a `.sha256` checksum file, built with
   `git archive` from the tagged commit rather than reusing GitHub's own

--- a/src/sidebars/TableOfContents.cpp
+++ b/src/sidebars/TableOfContents.cpp
@@ -96,10 +96,18 @@ void TableOfContents::OnMouseMotion(wxMouseEvent &event) {
     int flags;
     m_dragCurrentPos =
       m_displayedItems->HitTest(event.GetPosition(), flags, NULL);
+    // Dropping at or beyond the last valid slot (there are
+    // GetItemCount() - m_numberOfCaptionsDragged "other" items left once the
+    // dragged block is removed) means "move to the end of the list" -- clamp
+    // to that boundary itself, not to m_numberOfCaptionsDragged - 1 (a
+    // position near the *start* of the list, which used to make "drop near
+    // the end" silently snap back next to the drag's own start and look like
+    // a no-op -- GH #1524).
     if ((m_dragCurrentPos >= 0) &&
         (static_cast<std::size_t>(m_dragCurrentPos) >=
          m_displayedItems->GetItemCount() - m_numberOfCaptionsDragged))
-      m_dragCurrentPos = m_numberOfCaptionsDragged - 1;
+      m_dragCurrentPos =
+        m_displayedItems->GetItemCount() - m_numberOfCaptionsDragged;
     if (m_dragFeedback_Last != m_dragCurrentPos) {
       m_dragImage->Hide();
       UpdateDisplay();
@@ -191,10 +199,12 @@ void TableOfContents::OnMouseUp(wxMouseEvent &evt) {
   }
   int flags;
   m_dragStop = m_displayedItems->HitTest(evt.GetPosition(), flags, NULL);
+  // See the matching comment in OnMouseMotion(): clamp to the boundary itself
+  // ("move to the end"), not to a fixed position near the drag's own start.
   if ((m_dragStop >= 0) &&
       (static_cast<std::size_t>(m_dragStop) >=
        m_displayedItems->GetItemCount() - m_numberOfCaptionsDragged))
-    m_dragStop = m_numberOfCaptionsDragged - 1;
+    m_dragStop = m_displayedItems->GetItemCount() - m_numberOfCaptionsDragged;
   if ((m_dragStart >= 0) && (m_dragStop >= 0) && (m_dragStart != m_dragStop)) {
     const wxWindow *mainWin = this;
     while (mainWin->GetParent() != NULL)
@@ -204,6 +214,15 @@ void TableOfContents::OnMouseUp(wxMouseEvent &evt) {
     tocEv->SetId(EventIDs::popid_tocdnd);
     mainWin->GetEventHandler()->QueueEvent(tocEv);
   }
+  // The drag is over: forget its state so that UpdateDisplay() (here and on
+  // every later call, e.g. from UpdateTableOfContents()) goes back to
+  // rendering the real tree order instead of getting stuck replaying this
+  // drag's reordered preview forever -- these used to only get reset in
+  // OnMouseCaptureLost(), never on a normal drop (GH #1524).
+  m_dragStart = -1;
+  m_dragStop = -1;
+  m_dragCurrentPos = -1;
+  m_dragFeedback_Last = -1;
   UpdateDisplay();
   evt.Skip();
 }

--- a/src/sidebars/TableOfContents.cpp
+++ b/src/sidebars/TableOfContents.cpp
@@ -91,23 +91,24 @@ void TableOfContents::OnTimer(wxTimerEvent &event) {
   }
 }
 
+long TableOfContents::ClampDropIndex(long hitIndex, int itemCount,
+                                     std::size_t numberOfCaptionsDragged) {
+  if ((hitIndex >= 0) &&
+      (static_cast<std::size_t>(hitIndex) >=
+       static_cast<std::size_t>(itemCount) - numberOfCaptionsDragged))
+    return static_cast<long>(itemCount) -
+      static_cast<long>(numberOfCaptionsDragged);
+  return hitIndex;
+}
+
 void TableOfContents::OnMouseMotion(wxMouseEvent &event) {
   if (m_dragImage != NULL) {
     int flags;
     m_dragCurrentPos =
       m_displayedItems->HitTest(event.GetPosition(), flags, NULL);
-    // Dropping at or beyond the last valid slot (there are
-    // GetItemCount() - m_numberOfCaptionsDragged "other" items left once the
-    // dragged block is removed) means "move to the end of the list" -- clamp
-    // to that boundary itself, not to m_numberOfCaptionsDragged - 1 (a
-    // position near the *start* of the list, which used to make "drop near
-    // the end" silently snap back next to the drag's own start and look like
-    // a no-op -- GH #1524).
-    if ((m_dragCurrentPos >= 0) &&
-        (static_cast<std::size_t>(m_dragCurrentPos) >=
-         m_displayedItems->GetItemCount() - m_numberOfCaptionsDragged))
-      m_dragCurrentPos =
-        m_displayedItems->GetItemCount() - m_numberOfCaptionsDragged;
+    m_dragCurrentPos = ClampDropIndex(m_dragCurrentPos,
+                                      m_displayedItems->GetItemCount(),
+                                      m_numberOfCaptionsDragged);
     if (m_dragFeedback_Last != m_dragCurrentPos) {
       m_dragImage->Hide();
       UpdateDisplay();
@@ -199,12 +200,8 @@ void TableOfContents::OnMouseUp(wxMouseEvent &evt) {
   }
   int flags;
   m_dragStop = m_displayedItems->HitTest(evt.GetPosition(), flags, NULL);
-  // See the matching comment in OnMouseMotion(): clamp to the boundary itself
-  // ("move to the end"), not to a fixed position near the drag's own start.
-  if ((m_dragStop >= 0) &&
-      (static_cast<std::size_t>(m_dragStop) >=
-       m_displayedItems->GetItemCount() - m_numberOfCaptionsDragged))
-    m_dragStop = m_displayedItems->GetItemCount() - m_numberOfCaptionsDragged;
+  m_dragStop = ClampDropIndex(m_dragStop, m_displayedItems->GetItemCount(),
+                              m_numberOfCaptionsDragged);
   if ((m_dragStart >= 0) && (m_dragStop >= 0) && (m_dragStart != m_dragStop)) {
     const wxWindow *mainWin = this;
     while (mainWin->GetParent() != NULL)

--- a/src/sidebars/TableOfContents.h
+++ b/src/sidebars/TableOfContents.h
@@ -80,6 +80,21 @@ public:
 
   GroupCell *DNDStart() {return m_dndStartCell;}
   GroupCell *DNDEnd() {return m_dndEndCell;}
+
+  /*! Clamp a hit-tested drop position to a valid target.
+
+    hitIndex is tested against the *pre-drop* item count: once the dragged
+    block of numberOfCaptionsDragged items is removed, only
+    itemCount - numberOfCaptionsDragged "other" items are left, so dropping
+    at or past that many means "move to the end of the list" -- clamp to
+    that boundary itself. (A negative hitIndex, meaning HitTest() found no
+    item there, passes through unchanged.) Shared by OnMouseMotion() and
+    OnMouseUp(), and exposed as a pure function so it can be unit-tested
+    without needing to synthesize real mouse events -- see
+    test_TableOfContentsDnD.cpp.
+  */
+  static long ClampDropIndex(long hitIndex, int itemCount,
+                             std::size_t numberOfCaptionsDragged);
 protected:
   void OnSize(wxSizeEvent &event);
   void OnDragStart(wxListEvent &evt);

--- a/src/worksheet/Worksheet.cpp
+++ b/src/worksheet/Worksheet.cpp
@@ -3620,8 +3620,13 @@ std::unique_ptr<Cell> Worksheet::CopySelection(bool asData) const {
 }
 
 void Worksheet::TOCdnd(GroupCell *dndStart, GroupCell *dndEnd) {
-  if((GetDocumentCellPointers().GetSelectionStart() == nullptr) || (GetDocumentCellPointers().GetSelectionEnd() == nullptr))
-    return;
+  // GH #1524: this used to also require a pre-existing worksheet selection
+  // (GetSelectionStart()/GetSelectionEnd() both non-null) before doing
+  // anything -- but nothing above builds that selection; it's this function
+  // itself that establishes one a few lines below, from dndStart. Since a
+  // TOC-driven drag is normally started with no unrelated selection active
+  // in the worksheet, that guard made the entire feature a silent no-op in
+  // ordinary use.
   if (!dndStart)
     return;
 
@@ -3632,18 +3637,26 @@ void Worksheet::TOCdnd(GroupCell *dndStart, GroupCell *dndEnd) {
   if (dndEnd && !GetTree()->Contains(dndEnd))
     return;
 
-  // Select the region that is to be moved
+  // Select the region that is to be moved: the dragged heading plus
+  // everything "lesser" than it -- sub-headings and their own content --
+  // stopping at the next heading of equal or higher rank (see
+  // GroupCell::IsLesserGCType()). Always compare against dndStart's own
+  // type, never a shifting one: comparing against whatever cell
+  // SelectionEnd currently sits on (as this used to) meant that once
+  // SelectionEnd had advanced onto dndStart's own plain-content cell, a
+  // sub-heading right after it got compared against that content cell's
+  // type instead of dndStart's -- IsLesserGCType() has no ordering relation
+  // to a non-heading type, so the comparison always came out false and
+  // silently cut the sub-heading (and its own content) loose from the
+  // chapter being moved (GH #1524). This mirrors the (correct) reference
+  // TableOfContents::OnDragStart() already uses for its own, separate
+  // "how many TOC entries are being dragged" count.
+  const GroupType dndStartType = dndStart->GetGroupType();
   GetDocumentCellPointers().SetSelectionStart(dndStart);
   GetDocumentCellPointers().SetSelectionEnd(GetDocumentCellPointers().GetSelectionStart());
-  if (GetDocumentCellPointers().GetSelectionEnd()->GetNext())
-    GetDocumentCellPointers().SetSelectionEnd(GetDocumentCellPointers().GetSelectionEnd()->GetNext());
-  while ((GetDocumentCellPointers().GetSelectionEnd()) &&
-         ((GetDocumentCellPointers().GetSelectionEnd()->GetNext() != NULL) &&
-          (dynamic_cast<GroupCell *>(GetDocumentCellPointers().GetSelectionEnd()->GetNext()) &&
-           dynamic_cast<GroupCell *>(GetDocumentCellPointers().GetSelectionEnd().get()) &&
-           (dynamic_cast<GroupCell *>(GetDocumentCellPointers().GetSelectionEnd()->GetNext())
-            ->IsLesserGCType(dynamic_cast<GroupCell *>(GetDocumentCellPointers().GetSelectionEnd().get())
-                             ->GetGroupType())))))
+  while (GetDocumentCellPointers().GetSelectionEnd()->GetNext() &&
+         dynamic_cast<GroupCell *>(GetDocumentCellPointers().GetSelectionEnd()->GetNext())
+           ->IsLesserGCType(dndStartType))
     GetDocumentCellPointers().SetSelectionEnd(GetDocumentCellPointers().GetSelectionEnd()->GetNext());
 
   // Copy the region we want to move

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -366,6 +366,21 @@ if(TARGET wxmTestApp)
     add_test(NAME WorksheetFind
         COMMAND ${WXM_TEST_LAUNCHER} "$<TARGET_FILE:test_WorksheetFind>")
 
+    # Pins Worksheet::TOCdnd() (the table of contents sidebar's drag-and-drop
+    # reorder, GH #1524) and TableOfContents::ClampDropIndex(): a chapter
+    # moves as a whole (taking its own content and nested sub-headings with
+    # it), with no pre-existing worksheet selection required, and dropping
+    # near the end of the list lands at the end rather than snapping back
+    # near the drag's own start.
+    add_executable(test_TableOfContentsDnD
+        test_TableOfContentsDnD.cpp groupcell_test_stubs.cpp ${WXM_TEST_SETUP}
+        $<TARGET_OBJECTS:wxmTestApp>)
+    target_compile_features(test_TableOfContentsDnD PUBLIC cxx_std_20)
+    target_link_libraries(test_TableOfContentsDnD PRIVATE
+        ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${WXM_TESTAPP_EXTRA_LIBS})
+    add_test(NAME TableOfContentsDnD
+        COMMAND ${WXM_TEST_LAUNCHER} "$<TARGET_FILE:test_TableOfContentsDnD>")
+
     # Pins Worksheet::AnonymizeCodeCells() (GH #1339): non-builtin
     # variable/function names in the selected code cells get replaced with a
     # random, collision-free, reproducible-within-the-run name, while Maxima

--- a/test/unit_tests/test_TableOfContentsDnD.cpp
+++ b/test/unit_tests/test_TableOfContentsDnD.cpp
@@ -1,0 +1,235 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+//
+//  Copyright (C) 2026 Gunter Königsmann <wxMaxima@physikbuch.de>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+/*! \file
+  Regression tests for the table of contents sidebar's drag-and-drop reorder
+  (GH #1524).
+
+  The feature was wired up (drag image, scroll-while-dragging, reordered-
+  preview rendering) well before it was ever exercised end-to-end, and two
+  independent bugs in Worksheet::TOCdnd() -- the function that performs the
+  actual reorder -- made it either a no-op or silently data-corrupting:
+
+  - TOCdnd() used to require a pre-existing worksheet selection before doing
+    anything, even though it builds its own selection from dndStart a few
+    lines later. A TOC-driven drag normally starts with no such selection
+    active, so every drop was silently swallowed.
+  - TOCdnd()'s selection-extension loop used to compare each next cell's
+    heading rank against whatever cell the selection currently ended on (a
+    moving target) instead of the originally dragged heading's rank. Once
+    the selection had absorbed the dragged heading's own content cell, a
+    sub-heading right after it was compared against that content cell's
+    rank instead and always judged "not part of this chapter", leaving it
+    (and its own content) behind during the move.
+
+  A third bug lived in TableOfContents' own mouse handlers: dropping at or
+  near the end of the list clamped to a position near the drag's own start
+  instead of the end. That logic is pinned here too, extracted into the
+  pure ClampDropIndex() helper so it needs no simulated mouse events at all.
+*/
+
+#include <wx/app.h>
+#include <wx/bitmap.h>
+#include <wx/dcmemory.h>
+#include <wx/frame.h>
+#include <wx/log.h>
+
+#include "Configuration.h"
+#include "worksheet/Worksheet.h"
+#include "sidebars/TableOfContents.h"
+#include "cells/EditorCell.h"
+#include "cells/GroupCell.h"
+
+#include <vector>
+
+#include <cstdlib>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+#define CATCH_CONFIG_RUNNER
+#include <catch2/catch.hpp>
+
+namespace {
+wxBitmap *g_bmp = nullptr;
+wxMemoryDC *g_dc = nullptr;
+Configuration *g_cfg = nullptr;
+Worksheet *g_ws = nullptr;
+wxFrame *g_frame = nullptr;
+} // namespace
+
+//! Appends a heading with one code cell of content after *after, and
+//! advances *after past that content cell.
+static void AppendHeading(GroupType type, const wxString &title,
+                          const wxString &code, GroupCell **after) {
+  auto heading = std::make_unique<GroupCell>(g_cfg, type, title);
+  GroupCell *headingCell = g_ws->InsertGroupCells(std::move(heading), *after);
+  *after = g_ws->InsertGroupCells(
+    std::make_unique<GroupCell>(g_cfg, GC_TYPE_CODE, code), headingCell);
+}
+
+//! The first group cell whose editable text is exactly title.
+static GroupCell *FindHeading(const wxString &title) {
+  for (GroupCell *g = g_ws->GetTree(); g; g = g->GetNext())
+    if (g->GetEditable() && g->GetEditable()->ToString(true) == title)
+      return g;
+  return nullptr;
+}
+
+//! A fresh document: Title, SectionA (+content), SubsectionA1 (+content),
+//! SectionB (+content), SectionC (+content) -- the same shape used to find
+//! and confirm the fix for GH #1524 in a live session.
+static void BuildDocument() {
+  g_ws->ClearDocument();
+  GroupCell *pos = g_ws->InsertGroupCells(
+    std::make_unique<GroupCell>(g_cfg, GC_TYPE_TITLE, wxS("Test Document")),
+    nullptr);
+  AppendHeading(GC_TYPE_SECTION, wxS("SectionA"), wxS("a: 1;"), &pos);
+  AppendHeading(GC_TYPE_SUBSECTION, wxS("SubsectionA1"), wxS("a1: 11;"), &pos);
+  AppendHeading(GC_TYPE_SECTION, wxS("SectionB"), wxS("b: 2;"), &pos);
+  AppendHeading(GC_TYPE_SECTION, wxS("SectionC"), wxS("c: 3;"), &pos);
+  g_ws->SetActiveCell(nullptr);
+  g_ws->ClearSelection();
+  g_ws->RecalculateIfNeeded();
+}
+
+//! The document's group cells, in order, by their editable text -- compact
+//! enough to compare the whole tree shape in one assertion.
+static std::vector<wxString> DocumentOrder() {
+  std::vector<wxString> result;
+  for (GroupCell *g = g_ws->GetTree(); g; g = g->GetNext())
+    result.push_back(g->GetEditable() ? g->GetEditable()->ToString(true)
+                                      : wxString());
+  return result;
+}
+
+SCENARIO("TOCdnd moves a chapter with no pre-existing worksheet selection") {
+  BuildDocument();
+  REQUIRE(g_ws->GetSelectionStart() == nullptr);
+  REQUIRE(g_ws->GetSelectionEnd() == nullptr);
+
+  GroupCell *sectionB = FindHeading(wxS("SectionB"));
+  GroupCell *sectionC = FindHeading(wxS("SectionC"));
+  REQUIRE(sectionB != nullptr);
+  REQUIRE(sectionC != nullptr);
+
+  // Move SectionB (+ its own content) to after SectionC's content, i.e. to
+  // the very end of the document.
+  g_ws->TOCdnd(sectionB, sectionC->GetNext());
+  g_ws->RecalculateIfNeeded();
+
+  THEN("the section actually moved") {
+    REQUIRE(DocumentOrder() == std::vector<wxString>{
+      wxS("Test Document"), wxS("SectionA"), wxS("a: 1;"),
+      wxS("SubsectionA1"), wxS("a1: 11;"),
+      wxS("SectionC"), wxS("c: 3;"),
+      wxS("SectionB"), wxS("b: 2;")});
+  }
+}
+
+SCENARIO("TOCdnd keeps a nested sub-heading attached to its parent when moving") {
+  BuildDocument();
+  GroupCell *sectionA = FindHeading(wxS("SectionA"));
+  GroupCell *sectionC = FindHeading(wxS("SectionC"));
+  REQUIRE(sectionA != nullptr);
+  REQUIRE(sectionC != nullptr);
+
+  // Move SectionA to the very end. It should take its own content cell and
+  // its nested SubsectionA1 (+ that subsection's own content) along with it.
+  g_ws->TOCdnd(sectionA, sectionC->GetNext());
+  g_ws->RecalculateIfNeeded();
+
+  THEN("SectionA, its content and its subsection all move together, in order") {
+    REQUIRE(DocumentOrder() == std::vector<wxString>{
+      wxS("Test Document"),
+      wxS("SectionB"), wxS("b: 2;"),
+      wxS("SectionC"), wxS("c: 3;"),
+      wxS("SectionA"), wxS("a: 1;"),
+      wxS("SubsectionA1"), wxS("a1: 11;")});
+  }
+}
+
+SCENARIO("TOCdnd moves a chapter to the very top of the document") {
+  BuildDocument();
+  GroupCell *sectionC = FindHeading(wxS("SectionC"));
+  REQUIRE(sectionC != nullptr);
+
+  // dndEnd == nullptr means "insert at the top of the document" (see
+  // Worksheet::InsertGroupCells()'s own doc comment).
+  g_ws->TOCdnd(sectionC, nullptr);
+  g_ws->RecalculateIfNeeded();
+
+  THEN("SectionC (+ its content) now leads the document, ahead of the title") {
+    REQUIRE(DocumentOrder() == std::vector<wxString>{
+      wxS("SectionC"), wxS("c: 3;"),
+      wxS("Test Document"),
+      wxS("SectionA"), wxS("a: 1;"),
+      wxS("SubsectionA1"), wxS("a1: 11;"),
+      wxS("SectionB"), wxS("b: 2;")});
+  }
+}
+
+SCENARIO("ClampDropIndex clamps an out-of-range drop to the end of the list, not the start") {
+  // 5 displayed items, dragging 2 of them (a chapter heading + one nested
+  // sub-heading) -- 3 "other" items are left once the dragged block is
+  // removed, so slot 3 is the last valid drop target (append at the end).
+  CHECK(TableOfContents::ClampDropIndex(0, 5, 2) == 0);
+  CHECK(TableOfContents::ClampDropIndex(2, 5, 2) == 2);
+  CHECK(TableOfContents::ClampDropIndex(3, 5, 2) == 3);
+  // At or past the last valid slot clamps to that slot itself, not to
+  // numberOfCaptionsDragged - 1 (a position near the *start* of the list --
+  // the bug that made "drop near the end" silently no-op, GH #1524).
+  CHECK(TableOfContents::ClampDropIndex(4, 5, 2) == 3);
+  CHECK(TableOfContents::ClampDropIndex(100, 5, 2) == 3);
+  // A "no item hit" result (HitTest() returning a negative flag) passes
+  // through unchanged.
+  CHECK(TableOfContents::ClampDropIndex(-1, 5, 2) == -1);
+}
+
+class TestApp : public wxApp {
+public:
+  bool OnInit() override { return true; }
+};
+wxDECLARE_APP(TestApp);
+
+int main(int argc, char **argv) {
+  wxLog::EnableLogging(false);
+  wxApp::SetInstance(new TestApp());
+  wxEntryStart(argc, argv);
+  wxTheApp->CallOnInit();
+  wxInitAllImageHandlers();
+
+  g_bmp = new wxBitmap(800, 600);
+  g_dc = new wxMemoryDC();
+  g_dc->SelectObject(*g_bmp);
+  g_cfg = new Configuration(g_dc);
+  g_cfg->SetZoomFactor(1.0);
+  g_cfg->SetCanvasSize(wxSize(800, 600));
+  g_frame = new wxFrame(nullptr, wxID_ANY, wxS("test"));
+  g_ws = new Worksheet(g_frame, wxID_ANY, g_cfg, wxDefaultPosition, wxDefaultSize,
+                       /*reactToEvents=*/false);
+  g_cfg->SetWorkSheet(g_ws);
+
+  const int result = Catch::Session().run(argc, argv);
+
+  wxEntryCleanup();
+  return result;
+}


### PR DESCRIPTION
## Summary

You asked me to look into #1524 ("in theory this should be implemented, but I never tested it"). It turns out the whole mechanism was already there — drag image, scroll-while-dragging near the list edges, live reordered-preview rendering while dragging, the popup-menu event wiring to `Worksheet::TOCdnd()` — but the feature never actually worked in practice, for three independent reasons found by testing it live in an Xvfb session:

1. **`Worksheet::TOCdnd()` required a pre-existing worksheet selection before doing anything**, via a guard at the top of the function (`GetSelectionStart()/GetSelectionEnd()` both non-null). But nothing sets up that selection beforehand — the function itself builds one from the dragged cell a few lines later. Since a TOC-driven drag normally starts with no unrelated selection active in the worksheet, this guard made every drop a silent no-op. This alone explains "should work in theory" — the code downstream of this guard looks entirely reasonable, it just never got a chance to run.

2. **Dropping at or near the end of the list snapped back to a position near the drag's own start instead of the end.** Both `TableOfContents::OnMouseMotion()` (live preview) and `OnMouseUp()` (the actual drop) clamp an out-of-range drop index, but clamped to `m_numberOfCaptionsDragged - 1` (a position near the *start* of the list) instead of `GetItemCount() - m_numberOfCaptionsDragged` (the correct end-of-list boundary).

3. **Dragging a heading with a nested sub-heading could strip the sub-heading (and its content) off during the move.** `TOCdnd()`'s selection-extension loop decides how far the "chapter" extends by comparing each next cell's rank against whatever cell the selection currently ends on — but that's a moving target. Once the selection had absorbed the dragged heading's own content cell, a sub-heading right after it got compared against that *content cell's* rank instead of the original heading's rank, and `IsLesserGCType()` has no ordering relation to a non-heading type, so the comparison always came out false. `TableOfContents::OnDragStart()` already gets this right (always compares against the original dragged cell's type) — `TOCdnd()` now does the same.

I also fixed a fourth, more cosmetic bug while testing: `OnMouseUp()` never reset the drag-position bookkeeping (`m_dragStart`/`m_dragStop`/`m_dragCurrentPos`) after a drop, so the sidebar kept rendering the last drag's reordered preview forever afterward, regardless of what the document tree actually looked like, until some other trigger happened to reset it via `OnMouseCaptureLost()`.

## Verification

Built and ran the app live under Xvfb with a test document (Title, SectionA with a nested SubsectionA1 and its own content, SectionB, SectionC) and drove the TOC sidebar drag-and-drop with synthetic mouse events:

- Before the fixes: dragging did nothing to the document at all (bug 1), and even after fixing that, dropping near the end still did nothing (bug 2), and dropping in the middle split SubsectionA1 off from SectionA into a structurally broken position (bug 3).
- After all three fixes: dragging "SectionA" (with its nested "SubsectionA1" and both cells' content) to the end of the document correctly produces `SectionB, SectionC, SectionA > SubsectionA1`, with correct renumbering (1, 2, 3, 3.1) and the TOC sidebar staying in sync with the document afterward.
- Ran the full unit test suite (`ctest -L unittest`, 41 tests) before and after: 41/41 pass, no regressions. (There's no existing automated test harness for the TOC sidebar's drag-and-drop specifically — happy to add one as a follow-up if wanted.)

Fixes #1524.

## Test plan

- [x] Live Xvfb session: drag a section with a nested subsection + content to the end of the document; document and TOC sidebar both end up correctly reordered and renumbered
- [x] Live Xvfb session: confirm the sidebar no longer gets stuck showing a stale drag-preview order after a drop
- [x] Full unit test suite (41/41) passes before and after, no regressions

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_