### PR TITLE
Log why --exit-on-error aborted, not just that it did

### DIFF
--- a/src/MaximaEvaluator.cpp
+++ b/src/MaximaEvaluator.cpp
@@ -195,6 +195,24 @@ bool MaximaEvaluator::AbortOnError() {
   }
 
   if (m_wxMaxima.ExitOnErrorArmed()) {
+    // Without this, a CI log for a --exit-on-error run that aborted here
+    // shows nothing but a normal-looking shutdown sequence (Kill Maxima,
+    // Performance Statistics, ...) with no indication an error happened at
+    // all or which cell caused it -- the failing cell's actual error text
+    // lives only in a TextCell in the worksheet, which nothing prints to
+    // --logtostderr/stderr. Log the cell that was current when we aborted
+    // (its input, and its output if the error already produced one) so the
+    // reason survives into the CI log instead of only the exit code.
+    GroupCell *const errorGroup = m_wxMaxima.GetWorksheet()->GetWorkingGroup(true);
+    wxString errorText;
+    if (errorGroup) {
+      if (errorGroup->GetEditable())
+        errorText = errorGroup->GetEditable()->ToString(true);
+      if (errorGroup->GetLabel())
+        errorText += wxS(" -> ") + errorGroup->GetLabel()->ToString();
+    }
+    wxLogMessage(_("Aborting due to --exit-on-error (exit code 1). Cell: %s"),
+                errorText);
     wxMaxima::m_exitCode = 1;
     m_wxMaxima.Close();
   }


### PR DESCRIPTION
## Summary

Investigating the `lisp_mode` CI failure on #2213 confirmed exactly what you flagged: with `CTEST_OUTPUT_ON_FAILURE=1` we do get the failing test's own captured output, but for a `--exit-on-error` abort it currently gives no indication anything went wrong. The full captured log for that failing run ends with a completely normal-looking shutdown sequence (`Kill Maxima`, `Performance Statistics`, ...) — indistinguishable from a passing run's tail.

The root cause: when `MaximaEvaluator::AbortOnError()` closes the app because of `--exit-on-error`, the only trace of *why* is a `TextCell` rendered into the worksheet's error output — nothing calls `wxLogMessage()`, so nothing reaches `--logtostderr`/stderr, so nothing reaches the CI log. This applies to every `--exit-on-error` abort, including the GH #2196 integrity-failure path (a statement silently dropped from the evaluation queue), whose descriptive "Queued as: ... Now reads: ..." message was similarly invisible.

Fixed by logging the cell that was current when aborting (its input, plus its output if the error already produced one) right before closing. Verified this correctly reaches the GH #2196 path too: `SetWorkingGroup(nullptr)` runs before `AbortOnError()`, but `GetWorkingGroup(true)`'s `resortToLast` fallback still finds the right cell via `m_lastWorkingGroup`, which is only updated on a non-null `Set` (i.e. it isn't cleared to null by the just-happened `SetWorkingGroup(nullptr)`).

This doesn't yet explain the actual `lisp_mode` failure — that CI log's captured output showed something different again (an unusually low number of "Sending a new command to Maxima" events for a 22-cell document) and I haven't reproduced that specific pattern locally yet. But regardless of root cause, this closes the diagnostic gap: the *next* time any `--exit-on-error` test fails in CI, its log will say which cell and why.

## Verification

- Normal `--exit-on-error` run (no error): no new log lines, confirmed no false positives.
- Deliberate `error("FAIL: ...")` cell with `--exit-on-error`: now logs `Aborting due to --exit-on-error (exit code 1). Cell: error("FAIL: ...")$ -> FAIL: ...`.
- Full unit test suite (`ctest -L unittest`, 42 tests) passes, no regressions.
- Isolated fresh-checkout build of just this change compiles cleanly.

## Test plan

- [x] Normal run stays silent (no spurious log lines)
- [x] Deliberate error() produces the expected diagnostic line
- [x] Full unit test suite (42/42) passes
- [x] Clean build from a fresh `main` checkout

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_