### PR TITLE
Fix syntax highlighting of an identifier split by an escaped newline

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # Current development version
 
+- Code cell syntax highlighting (GH #898): an identifier split across two
+  physical lines by an escaped newline (`\` immediately followed by a line
+  break -- confirmed against a real Maxima that this contributes nothing to
+  the resolved name at all, e.g. `fo\<newline>obar` is plainly `foobar`,
+  unlike an ordinary escaped character such as `a\,b`, which resolves to the
+  symbol `a,b`) used to be highlighted as two unrelated tokens: the half
+  before the line break wasn't classified at all (falling through the
+  function/variable/operator/keyword lookups entirely), and the half after
+  it started over as if it were a brand new, independent identifier. Both
+  halves are now resolved and styled as the one logical name Maxima
+  actually sees.
 - Table of contents sidebar: dragging a chapter/section entry to reorder it
   (GH #1524) now actually works -- it was wired up (drag image, scroll-while-
   dragging, the reordered-preview rendering) but never functional, since

--- a/src/MaximaTokenizer.cpp
+++ b/src/MaximaTokenizer.cpp
@@ -290,7 +290,22 @@ MaximaTokenizer::MaximaTokenizer(const wxString &commands,
     }
     // Handle keywords
     if (IsAlpha(Ch) || (Ch == '\\') || (Ch == '?')) {
+      // GH #898: an escaped newline ("\<newline>") inside an identifier is
+      // invisible to Maxima -- it just continues the same name onto the next
+      // physical line -- so it must not end the token for classification
+      // purposes, or the half before it and the half after it get styled as
+      // two unrelated tokens (the half before not even being classified at
+      // all, since it used to skip straight past the lookups below). But a
+      // newline still has to become its own isolated token when rendered
+      // (see "Tab Characters in EditorCell" in AGENTS.md: the editor's line
+      // splitting relies on every newline being isolated like that), so
+      // `token` keeps accumulating across escaped newlines as one logical
+      // name -- recording where each one falls in `newlineOffsets` -- and
+      // gets spliced back into multiple same-styled pieces with a real
+      // newline token between them once the whole name (and therefore its
+      // style) is known.
       wxString token;
+      std::vector<size_t> newlineOffsets;
       if (Ch == '?') {
         token += Ch;
         ++it;
@@ -305,12 +320,8 @@ MaximaTokenizer::MaximaTokenizer(const wxString &commands,
             Ch = *it;
             if (Ch != wxS('\n'))
               token += Ch;
-            else {
-              m_tokens.emplace_back(token);
-              token.Clear();
-
-              break;
-            }
+            else
+              newlineOffsets.push_back(token.Length());
           }
         }
         if (it < commands.end())
@@ -321,25 +332,48 @@ MaximaTokenizer::MaximaTokenizer(const wxString &commands,
       // sent (EvaluationQueue::ProduceNextCommand), so once to_lisp() has run and
       // maxima has printed its MAXIMA> prompt the following commands are
       // tokenized via the InLispMode() branch near the top of this function.
-      if (m_hardcodedFunctions.find(token) != m_hardcodedFunctions.end())
-        m_tokens.emplace_back(token, TS_CODE_FUNCTION);
-      else if (m_configuration->IsOperator(token))
-        m_tokens.emplace_back(token, TS_CODE_OPERATOR);
+      //
+      // The lookups below need the actual resolved Maxima symbol name, not
+      // the rendered text: confirmed against a real Maxima that an escaped
+      // newline contributes nothing to the name at all (fo\<newline>obar
+      // resolves to plain foobar), unlike an ordinary escaped character
+      // (a\,b resolves to the symbol a,b -- the backslash drops but the
+      // escaped character stays part of the name, same as `token` already
+      // renders it). So build `name` like `token`, except each escaped
+      // newline's trailing backslash (the last character of the segment
+      // ending at that offset) is dropped instead of carried over.
+      wxString name;
+      {
+        size_t prev = 0;
+        for (size_t offset : newlineOffsets) {
+          name += token.Mid(prev, offset - prev - 1);
+          prev = offset;
+        }
+        name += token.Mid(prev);
+      }
+      TextStyle style;
+      if (m_hardcodedFunctions.find(name) != m_hardcodedFunctions.end())
+        style = TS_CODE_FUNCTION;
+      else if (m_configuration->IsOperator(name))
+        style = TS_CODE_OPERATOR;
       else {
         // Let's look what the next char looks like
         wxString::const_iterator it3(it);
         while ((it3 < commands.end()) && ((*it3 == ' ') || (*it3 == '\t') ||
                                           (*it3 == '\n') || (*it3 == '\r')))
           ++it3;
-        if (it3 >= commands.end())
-          m_tokens.emplace_back(token, TS_CODE_VARIABLE);
-        else {
-          if (*it3 == '(')
-            m_tokens.emplace_back(token, TS_CODE_FUNCTION);
-          else
-            m_tokens.emplace_back(token, TS_CODE_VARIABLE);
-        }
+        style = ((it3 < commands.end()) && (*it3 == '('))
+          ? TS_CODE_FUNCTION : TS_CODE_VARIABLE;
       }
+      size_t prevOffset = 0;
+      for (size_t offset : newlineOffsets) {
+        if (offset > prevOffset)
+          m_tokens.emplace_back(token.Mid(prevOffset, offset - prevOffset), style);
+        m_tokens.emplace_back(wxUniChar('\n'));
+        prevOffset = offset;
+      }
+      if ((prevOffset < token.Length()) || newlineOffsets.empty())
+        m_tokens.emplace_back(token.Mid(prevOffset), style);
       continue;
     }
     if ((Ch == '$') || (Ch == ';')) {

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -342,6 +342,19 @@ if(TARGET wxmTestApp)
     add_test(NAME WorksheetContextMenu
         COMMAND ${WXM_TEST_LAUNCHER} "$<TARGET_FILE:test_WorksheetContextMenu>")
 
+    # Pins MaximaTokenizer's handling of an identifier split by an escaped
+    # newline (GH #898): both halves must stay one logical name for
+    # function/variable/operator/keyword classification, even though a
+    # newline still has to render as its own isolated token.
+    add_executable(test_MaximaTokenizer
+        test_MaximaTokenizer.cpp groupcell_test_stubs.cpp ${WXM_TEST_SETUP}
+        $<TARGET_OBJECTS:wxmTestApp>)
+    target_compile_features(test_MaximaTokenizer PUBLIC cxx_std_20)
+    target_link_libraries(test_MaximaTokenizer PRIVATE
+        ${wxWidgets_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${WXM_TESTAPP_EXTRA_LIBS})
+    add_test(NAME MaximaTokenizer
+        COMMAND ${WXM_TEST_LAUNCHER} "$<TARGET_FILE:test_MaximaTokenizer>")
+
     # Pins the worksheet's two-cursor model (h-caret between cells XOR editor
     # cursor inside a cell; neither while cells are selected) ahead of the
     # WorksheetCursor extraction.

--- a/test/unit_tests/test_MaximaTokenizer.cpp
+++ b/test/unit_tests/test_MaximaTokenizer.cpp
@@ -1,0 +1,152 @@
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+//
+//  Copyright (C) 2026 Gunter Königsmann <wxMaxima@physikbuch.de>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+//  SPDX-License-Identifier: GPL-2.0+
+
+/*! \file
+  Regression tests for GH #898: an identifier split by an escaped newline
+  ("\<newline>") used to be tokenized (and therefore syntax-highlighted) as
+  two unrelated halves -- the first not even classified at all (it fell
+  through the function/variable/operator/keyword lookups entirely), the
+  second starting over as if it were a brand new, independent identifier.
+
+  Confirmed against a real Maxima that an escaped newline contributes
+  nothing to the resolved symbol name at all (fo\<newline>obar resolves to
+  the plain identifier foobar), unlike an ordinary escaped character
+  (a\,b resolves to the symbol a,b -- the backslash drops but the escaped
+  character stays part of the name). The fix keeps collecting one logical
+  name across any number of escaped newlines for classification, while
+  still emitting a newline as its own isolated token when rendering (the
+  editor's line splitting depends on that -- see "Tab Characters in
+  EditorCell" in AGENTS.md).
+*/
+
+#include <wx/app.h>
+#include <wx/bitmap.h>
+#include <wx/dcmemory.h>
+#include <wx/log.h>
+
+#include "Configuration.h"
+#include "MaximaTokenizer.h"
+
+#include <cstdlib>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+#define CATCH_CONFIG_RUNNER
+#include <catch2/catch.hpp>
+
+namespace {
+wxBitmap *g_bmp = nullptr;
+wxMemoryDC *g_dc = nullptr;
+Configuration *g_cfg = nullptr;
+} // namespace
+
+static MaximaTokenizer::TokenList Tokenize(const wxString &commands) {
+  return MaximaTokenizer(commands, g_cfg).PopTokens();
+}
+
+SCENARIO("A plain identifier (no escapes) tokenizes as a single styled token") {
+  auto tokens = Tokenize(wxS("foobar:"));
+  REQUIRE(tokens.size() >= 1);
+  REQUIRE(tokens[0].GetText() == wxS("foobar"));
+  REQUIRE(tokens[0].GetTextStyle() == TS_CODE_VARIABLE);
+}
+
+SCENARIO("An identifier split by an escaped newline stays one logical, consistently-styled name") {
+  // "fo\<newline>obar: 42;" -- confirmed against a real Maxima to resolve to
+  // the plain identifier foobar.
+  auto tokens = Tokenize(wxS("fo\\\nobar:"));
+
+  THEN("it is rendered as two segments joined by an isolated newline token") {
+    REQUIRE(tokens.size() >= 3);
+    REQUIRE(tokens[0].GetText() == wxS("fo\\"));
+    REQUIRE(tokens[1].GetText() == wxS("\n"));
+    REQUIRE(tokens[2].GetText() == wxS("obar"));
+  }
+  THEN("both halves share the same style, resolved from the whole name") {
+    // Before the fix, the first half fell through every classification
+    // lookup untouched (default style) while the second half was
+    // classified independently -- here both must agree, and match what a
+    // plain "foobar:" would get (TS_CODE_VARIABLE, see the scenario above).
+    REQUIRE(tokens[0].GetTextStyle() == TS_CODE_VARIABLE);
+    REQUIRE(tokens[2].GetTextStyle() == TS_CODE_VARIABLE);
+  }
+}
+
+SCENARIO("A hardcoded keyword split by an escaped newline is still recognized as one") {
+  // "th\<newline>en" resolves to the plain keyword "then".
+  auto tokens = Tokenize(wxS("th\\\nen"));
+  REQUIRE(tokens.size() >= 3);
+  REQUIRE(tokens[0].GetText() == wxS("th\\"));
+  REQUIRE(tokens[1].GetText() == wxS("\n"));
+  REQUIRE(tokens[2].GetText() == wxS("en"));
+  REQUIRE(tokens[0].GetTextStyle() == TS_CODE_FUNCTION);
+  REQUIRE(tokens[2].GetTextStyle() == TS_CODE_FUNCTION);
+}
+
+SCENARIO("A function name split by an escaped newline is still recognized as a function call") {
+  // Classification peeks at the character right after the whole name ends;
+  // an escaped newline must not confuse that either.
+  auto tokens = Tokenize(wxS("fo\\\nobar(x)"));
+  REQUIRE(tokens.size() >= 3);
+  REQUIRE(tokens[0].GetText() == wxS("fo\\"));
+  REQUIRE(tokens[1].GetText() == wxS("\n"));
+  REQUIRE(tokens[2].GetText() == wxS("obar"));
+  REQUIRE(tokens[0].GetTextStyle() == TS_CODE_FUNCTION);
+  REQUIRE(tokens[2].GetTextStyle() == TS_CODE_FUNCTION);
+}
+
+SCENARIO("An ordinary escaped character in an identifier is unaffected by the fix") {
+  // a\,b resolves to the symbol a,b (confirmed against a real Maxima) and
+  // has always rendered with the backslash still visible, as a single,
+  // unsplit token -- this scenario pins that this still works exactly as
+  // before the GH #898 fix.
+  auto tokens = Tokenize(wxS("a\\,b:"));
+  REQUIRE(tokens.size() >= 1);
+  REQUIRE(tokens[0].GetText() == wxS("a\\,b"));
+  REQUIRE(tokens[0].GetTextStyle() == TS_CODE_VARIABLE);
+}
+
+class TestApp : public wxApp {
+public:
+  bool OnInit() override { return true; }
+};
+wxDECLARE_APP(TestApp);
+
+int main(int argc, char **argv) {
+  wxLog::EnableLogging(false);
+  wxApp::SetInstance(new TestApp());
+  wxEntryStart(argc, argv);
+  wxTheApp->CallOnInit();
+  wxInitAllImageHandlers();
+
+  g_bmp = new wxBitmap(800, 600);
+  g_dc = new wxMemoryDC();
+  g_dc->SelectObject(*g_bmp);
+  g_cfg = new Configuration(g_dc);
+  g_cfg->SetZoomFactor(1.0);
+  g_cfg->SetCanvasSize(wxSize(800, 600));
+
+  const int result = Catch::Session().run(argc, argv);
+
+  wxEntryCleanup();
+  return result;
+}


### PR DESCRIPTION
## Summary

#898 is still reproducible: an identifier split across two physical lines by an escaped newline (`\` immediately followed by a line break) gets syntax-highlighted as two unrelated tokens instead of one consistently-styled name.

Root cause, in `MaximaTokenizer`'s identifier-collecting loop: when it hit an escaped newline, it pushed whatever it had collected so far as an **unstyled** token (skipping the function/variable/operator/keyword classification entirely — that lookup only runs after the loop exits normally) and `break`s out. The remaining characters after the line break then get tokenized completely from scratch in the next pass, as if they were a brand new, unrelated identifier.

Confirmed the correct semantics against a real Maxima first, rather than guessing:
- `fo\<newline>obar: 42;` followed by `foobar;` — both evaluate to 42. An escaped newline contributes *nothing* to the resolved symbol name.
- `a\,b: 99;` resolves to the symbol literally named `a,b` — for an ordinary escaped character, the backslash drops but the escaped character stays part of the name (matching wxMaxima's existing, unrelated-to-this-bug rendering of that case).

Fixed by collecting the identifier as one logical name across any number of escaped newlines (for classification), while still emitting a real newline as its own isolated token when rendering — `AGENTS.md`'s "Tab Characters in EditorCell" note documents that the editor's line-splitting logic depends on every newline being its own isolated token, so the fix can't just merge the newline into a bigger token. Both rendered segments share the one style resolved from the whole name.

## Verification

- New `test_MaximaTokenizer.cpp` (GUI-free, no live Maxima) pins: a plain identifier, an identifier split by an escaped newline (both a `TS_CODE_VARIABLE` case and a `TS_CODE_FUNCTION`-by-trailing-`(` case), a hardcoded keyword (`then`) split the same way, and the ordinary-escaped-character case staying unaffected.
- Confirmed the resolved-name semantics against a real Maxima (see above) before writing the fix, not guessed.
- Full unit test suite (`ctest -L unittest`, 42 tests) passes, no regressions.
- Verified on a completely fresh `main` checkout (isolated build dir), not just the working tree.

Fixes #898.

## Test plan

- [x] New `test_MaximaTokenizer` (5 scenarios, 24 assertions) passes
- [x] Full unit test suite (42/42) passes
- [x] Verified against a real Maxima that the fix's assumed name-resolution semantics are correct
- [x] Clean build from a fresh `main` checkout

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_