### PR TITLE
Document the macOS Gatekeeper quarantine issue in SUPPORT.md

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -15,6 +15,31 @@ menu, file loading/saving, …), it is a **wxMaxima** issue.
 If unsure just report the problem to the wxMaxima project so its members will find
 out where the problem lies.
 
+**Note:** this quick test can be misleading for the macOS quarantine issue below --
+a plain terminal session doesn't need the local socket wxMaxima uses to talk to
+Maxima, so `maxima` can look completely fine there even when wxMaxima cannot
+reach it at all.
+
+## Known issues
+
+### macOS: wxMaxima never evaluates anything (stuck on "Reading Maxima output")
+
+The GUI opens and is responsive, but every cell just sits in the evaluation
+queue forever, with the status bar stuck on "Reading Maxima output" (see
+[#1761](https://github.com/wxMaxima-developers/wxmaxima/issues/1761)). This is
+usually **macOS Gatekeeper quarantining the `maxima` binary** -- a binary
+installed via Homebrew, MacPorts, or downloaded directly can be flagged
+`com.apple.quarantine`, which then silently blocks the local socket connection
+wxMaxima uses to talk to it. Fix it from a Terminal:
+
+```sh
+xattr -dr com.apple.quarantine /path/to/maxima
+```
+
+If the exact binary path is unclear, running it against the whole install
+prefix also works, e.g. `$(brew --prefix)` for Homebrew or `/opt/local` for
+MacPorts.
+
 ## The wxMaxima GUI (this project)
 
 - **Questions, ideas, general discussion** →


### PR DESCRIPTION
## Summary

Per your comment on #1761: this symptom (GUI responsive, but every cell stuck forever in the evaluation queue on "Reading Maxima output", no error) is macOS Gatekeeper quarantining the `maxima` binary, which then silently blocks the local socket wxMaxima uses to talk to it.

Added a "Known issues" section to `SUPPORT.md` covering this, with the `xattr -dr com.apple.quarantine` fix. Also flagged an important gotcha in the existing "quick test" section right above it: running `maxima` directly in a plain terminal (the standard "is it wxMaxima or Maxima" triage step) doesn't open that socket at all, so it can look completely healthy there even when wxMaxima can't reach it — this test would otherwise misdirect someone hitting this exact bug toward filing it as a "Maxima" issue.

This is the first of what we discussed as a 3-tier documentation approach (SUPPORT.md, the project homepage's macOS install section, and eventually an in-app detection dialog once the actual symptom/timing can be verified on real hardware — none of us have a Mac to test that heuristic against, so it's deliberately not attempted here). A separate PR will follow for the homepage (`download.html`, on the `gh-pages` branch).

## Test plan

- [x] Markdown renders correctly (checked locally)
- [x] Cross-references #1761
- N/A — documentation-only change, no code affected

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_