### PR TITLE
Stop wrapping box() in spurious extra parentheses (GH #1948)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # Current development version
 
+- Display (GH #1948): `box()` draws its own border around its argument, so
+  it never needed the extra pair of parentheses `wxMathML.lisp`'s generic
+  precedence-based paren-insertion logic could still wrap around it, e.g.
+  `a*box(b)*c` showing spurious parens around `box(b)`. Fixed by giving
+  `box()` (and its labelled form, `box(expr, label)`) a precedence higher
+  than any real operator's, so it never needs disambiguating -- except for
+  the one case where it doesn't actually draw a border at all: `box(expr,
+  highlight)` only colors its content, and correctly keeps the
+  disambiguating parentheses it already had, since a bare color change
+  doesn't visually delimit its own extent.
 - Code cell syntax highlighting (GH #898): an identifier split across two
   physical lines by an escaped newline (`\` immediately followed by a line
   break -- confirmed against a real Maxima that this contributes nothing to

--- a/src/wxMathML.lisp
+++ b/src/wxMathML.lisp
@@ -593,6 +593,31 @@ Submit bug reports by following the 'New issue' link on that page."))
 		     y (cdr y)
 		     l nil))))))
 
+;; GH #1948: box()'s displayed precedence depends on whether it actually
+;; draws a border (always self-delimiting, so it should never need parens,
+;; see the high wxxml-lbp/rbp below) or is being used purely to color its
+;; content red without a border (boxname "highlight" -- see
+;; MathParser::ParseHighlightTag on the C++ side, which skips creating a
+;; BoxCell for that specific boxname and just applies a color instead). A
+;; bare color change doesn't visually delimit its own extent the way an
+;; actual border does, so that variant still needs the old, low precedence.
+;; Both variants of the *labelled* form (box(expr, boxname), including the
+;; "highlight" boxname) share the very same mlabox head symbol -- the
+;; unlabelled form box(expr) is mbox instead -- differing only in this
+;; argument, so a plain per-symbol wxxml-lbp/rbp property can't tell them
+;; apart. These wrappers can, since (unlike wxxml-lbp/rbp) they see the
+;; whole form, not just its head symbol.
+(defun wxxml-form-is-highlight-only-box (x)
+  (and (member (caar x) '(mbox mlabox))
+       (caddr x)
+       (equal (wxxml-mstring (caddr x)) "highlight")))
+
+(defun wxxml-form-lbp (x)
+  (if (wxxml-form-is-highlight-only-box x) 10. (wxxml-lbp (caar x))))
+
+(defun wxxml-form-rbp (x)
+  (if (wxxml-form-is-highlight-only-box x) 10. (wxxml-rbp (caar x))))
+
 ;; Converts a sexp element to XML
 ;;
 ;; Most objects are assigned properties to, that tell this function how to
@@ -602,8 +627,8 @@ Submit bug reports by following the 'New issue' link on that page."))
   (cond ((atom x) (wxxml-atom x l r))
 	((not (listp (car x)))
 	 (wxxml (cons '(mlist simp) x) l r lop rop))
-	((or (<= (wxxml-lbp (caar x)) (wxxml-rbp lop))
-	     (> (wxxml-lbp rop) (wxxml-rbp (caar x))))
+	((or (<= (wxxml-form-lbp x) (wxxml-rbp lop))
+	     (> (wxxml-lbp rop) (wxxml-form-rbp x)))
 	 (wxxml-paren x l r))
 	;; special check needed because macsyma notates arrays peculiarly
 	((member 'array (cdar x) :test #'eq) (wxxml-array x l r))
@@ -750,9 +775,31 @@ Submit bug reports by following the 'New issue' link on that page."))
 (wx-defprop mbox wxxml-mbox wxxml)
 (wx-defprop mlabox wxxml-mbox wxxml)
 
-(wx-defprop mbox 10. wxxml-rbp)
-(wx-defprop mbox 10. wxxml-lbp)
+;; GH #1948: box() draws its own border around its argument (see
+;; wxxml-mbox below, dispatched via the "wxxml" property above) and is
+;; therefore always self-delimiting, exactly like a matched-delimiter
+;; construct (a matrix, absolute value, ...) -- it should never need an
+;; extra pair of parentheses no matter what operator surrounds it. But the
+;; generic paren-insertion check in wxxml (wxxml-lbp/wxxml-rbp comparison)
+;; runs *before* the "wxxml" property dispatch, so a low precedence here
+;; still wraps the box in a redundant, wrong-looking pair of parentheses,
+;; e.g. "a*box(b)*c" (120 for mtimes). 250 clears every real operator's
+;; precedence in this file with headroom, including mquote's 201 (the
+;; highest otherwise in use, using a plain "<=" comparison so an exact tie
+;; would still parenthesize). mlabox (box(expr, boxname), the labelled
+;; form -- see wxxml-mbox below, which handles both) gets the same
+;; treatment; wxxml-form-lbp/rbp above override both back down to the old
+;; low precedence for the "highlight" boxname specifically.
+(wx-defprop mbox 250. wxxml-rbp)
+(wx-defprop mbox 250. wxxml-lbp)
 
+(wx-defprop mlabox 250. wxxml-rbp)
+(wx-defprop mlabox 250. wxxml-lbp)
+
+;; mlabbox (double b) does not appear to be an internal representation any
+;; live Maxima code path actually produces (box(expr, boxname) is mlabox,
+;; single b, above) -- left untouched since there's nothing to verify this
+;; against.
 (wx-defprop mlabbox 10. wxxml-rbp)
 (wx-defprop mlabbox 10. wxxml-lbp)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -178,6 +178,24 @@ add_test(
     COMMAND "${CMAKE_CURRENT_BINARY_DIR}/check-wxMathML.sh" "1+1;" "<math><lbl altCopy=\"%o1\">(%o1) </lbl><mn>2</mn></math>"
 )
 
+# GH #1948: box() draws its own border (the <hl> tag), so it must never be
+# wrapped in an extra, redundant pair of parentheses no matter what operator
+# surrounds it -- this pins that "a*box(b)*c" renders with no <p>/wxxml-paren
+# element between box's own <mrow> and its <hl> content.
+add_test(
+    NAME check-wxMathML.lisp_box_no_extra_parens
+    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/check-wxMathML.sh" "a*box(b)*c;" "</hl></mrow><h>\\*</h><mi"
+)
+
+# GH #1948, the fringe case: box(expr, highlight) doesn't draw a border at
+# all (see MathParser::ParseHighlightTag) -- it only colors its content --
+# so unlike an ordinary box it still needs the parentheses above to visually
+# delimit its extent. This must keep getting them even after the fix above.
+add_test(
+    NAME check-wxMathML.lisp_highlight_box_keeps_parens
+    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/check-wxMathML.sh" "a*box(b,highlight)*c;" "<p lisp=\"wxxml-paren\"><mrow><hl boxname=\"highlight\">"
+)
+
 # Syntax-check every wizard/menu command template (the "#n#" CommandWiz rules in
 # src/wxMaxima.cpp) through Maxima's parser, so a malformed generated command --
 # e.g. an unbalanced parenthesis -- fails the build instead of only being found


### PR DESCRIPTION
## Summary

#1948 is still reproducible: `a*box(b)*c` displays with unnecessary parentheses around `box(b)`.

Root cause: `box()` draws its own border (`wxxml-mbox`'s `<hl>` tag), but `wxMathML.lisp` declared its display precedence (`wxxml-lbp`/`wxxml-rbp`) as `10.` — far below multiplication's `120.` — and the generic precedence-based paren-insertion check in `wxxml` runs *before* it ever looks at what `box()` itself draws. Since `box()` is always self-delimiting (like a matrix or absolute value), it should never need that extra pair of parens no matter what operator surrounds it. Fixed by raising `mbox`'s (and its labelled form `mlabox`'s — `box(expr, label)`) precedence to `250.`, clearing every real operator in the file with headroom.

One fringe case needed real care, caught before it shipped: `box(expr, highlight)` doesn't draw a border at all — see `MathParser::ParseHighlightTag` on the C++ side, which skips creating a `BoxCell` for that specific `boxname` and just colors the content red instead. A bare color change doesn't visually delimit its own extent the way a real border does, so *that* variant still needs the old, low precedence — dropping its parens would make `a*box(b,highlight)*c` genuinely ambiguous-looking. Both variants share the exact same head symbol (`mbox`/`mlabox`), differing only in this argument, so a plain per-symbol `wxxml-lbp`/`wxxml-rbp` property can't tell them apart. Added `wxxml-form-lbp`/`wxxml-form-rbp`, which can, since they see the whole form (not just its head symbol) and fall back to the old precedence specifically when the boxname is `"highlight"`.

## Verification

Confirmed against a real Maxima + `wxMathML.lisp` (not guessed) before and after, across: `box()` bare, in a product, `^2`, `+y`, `/y`, inside `diff()`, and `box(x, label)` with a string/number/symbol label — for both the ordinary case (no more spurious parens) and the `highlight` case (parens correctly preserved).

- New `check-wxMathML.lisp_box_no_extra_parens` and `check-wxMathML.lisp_highlight_box_keeps_parens` regression tests, following the existing `check-wxMathML.sh` pattern.
- Ran both new tests plus the existing `boxCells` integration smoke test against a full build: 5/5 pass.

Fixes #1948.

## Test plan

- [x] `check-wxMathML.lisp_box_no_extra_parens` passes (no `<p>`/`wxxml-paren` around a plain `box()`)
- [x] `check-wxMathML.lisp_highlight_box_keeps_parens` passes (parens preserved for the highlight-only variant)
- [x] Existing `boxCells` integration test still passes
- [x] Verified against a real Maxima before writing the fix, not guessed

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_