### PR TITLE
Record fold/unfold in the worksheet's undo buffer (GH #266)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -612,6 +612,54 @@ tried without rebuilding.
   untransformed `m_text`) instead of `ToTeX()`, not just the one place a new
   case is added.
 
+- **`TreeUndoAction`'s discriminant model, and adding a fourth action kind
+  (GH #266, fold/unfold undo):** `TreeUndoAction` (`src/TreeUndoAction.h`) is
+  a single, non-polymorphic struct, not an `Action`/`Undo()`/`Redo()` class
+  hierarchy -- `Worksheet::TreeUndo()` (`Worksheet.cpp`) tells apart the
+  three original action kinds (text change, cell insertion, cell deletion)
+  by which of `m_newCellsEnd`/`m_oldCells`/neither is set, not by a type
+  tag. Adding fold/unfold as a fourth kind followed the same style rather
+  than introducing polymorphism for a fourth fixed case: a `std::optional<
+  FoldDirection>` field (`FoldDirection::Folded`/`Unfolded`), checked in
+  `TreeUndo()`'s dispatch *before* the existing `m_oldCells`-vs-text-change
+  fallback (a `std::nullopt` field, like the others, defaults via the
+  member's own default constructor -- no explicit initializer needed in the
+  three original constructors). Undoing a fold/unfold just applies the
+  opposite direction to the same cell (`m_start`), which is naturally
+  reversible/re-doable through the same generic replay loop the other three
+  kinds already use (`Worksheet::TreeUndo()`'s do-while + swapped-stacks
+  trick already makes redo "undo, but backwards" for free).
+  **Two things worth getting right if you touch this again:**
+  1. `GroupCell::Fold()`/`Unfold()` (`GroupCell.cpp`) are the low-level
+     primitives (`CellList::TearOut`/`SpliceInAfter`, same as `DeleteRegion`/
+     `InsertGroupCells` use) and do **not** themselves record undo -- only
+     `WorksheetDocument::Fold()`/`Unfold()`/`ToggleFold()`/`FoldAll()`/
+     `UnfoldAll()` do, since only `WorksheetDocument` owns the
+     `TreeUndoManager`. Anywhere that needs a fold/unfold NOT to be
+     independently undoable (the automatic auto-unfold in `RevealHidden()`,
+     and the "make room" auto-unfold in `Worksheet.cpp`'s new-cell-insertion
+     logic when the h-caret sits inside a folded ancestor) must keep calling
+     the raw `GroupCell::Fold()`/`Unfold()` directly, not the
+     `WorksheetDocument`-level wrappers, or it'll silently start occupying
+     an undo slot it shouldn't.
+  2. `TreeUndoManager::AppendAction()`'s ordering is easy to get backwards:
+     since actions are pushed with `emplace_front` (newest at the front),
+     marking an entry's `m_partOfAtomicAction = true` means "when the entry
+     pushed *after* me gets undone, keep going and undo me too" -- so to
+     chain N actions (e.g. every cell "Fold All" actually folded) into one
+     atomic Ctrl+Z, call `AppendAction()` after each push *except the
+     last-pushed one* (see `WorksheetDocument::RecordFoldUndo()`), not after
+     the first.
+  A pre-existing unit test (`test/unit_tests/test_TreeUndo.cpp`,
+  "Undoing an insertion whose cell was folded away...") had to switch from
+  `g_ws->ToggleFold()` to the raw `section->Fold()` once folding became
+  independently undoable: it was relying on folding *not* pushing its own
+  undo action so that a single `TreeUndo()` call would reach past it to the
+  insertion underneath -- exactly the kind of test that silently encodes an
+  old architectural assumption and breaks the moment that assumption stops
+  holding, worth checking for before assuming "existing tests pass" means
+  "no behavior changed."
+
 ## Layout & Compatibility
 
 - **Mathematical Cell Padding:** Use `MC_TEXT_PADDING` (in `Configuration.h`) for text-based cells. **Exception:** `DigitCell` does not include padding to ensure visual consistency in broken-up numbers.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # Current development version
 
+- Folding/unfolding a section (or the whole document, via "Fold All"/
+  "Unfold All") is now recorded in the undo buffer (GH #266), a 2013 feature
+  request: Ctrl+Z after an accidental fold, or after "Fold All" collapses a
+  document you didn't mean to collapse, restores exactly the fold state that
+  was there before. A single-cell fold/unfold undoes with one Ctrl+Z; "Fold
+  All"/"Unfold All" (which can fold many cells at once, only the ones that
+  weren't already in that state) undoes and redoes all of them together as
+  one atomic step, so it doesn't unfold sections that were already folded
+  before "Fold All" ran. Implemented by giving `TreeUndoAction` a fourth,
+  explicit fold/unfold case alongside its existing text-change/insertion/
+  deletion ones, rather than reusing those for something semantically
+  different (a fold keeps its subtree alive and logically part of the
+  document, unlike a real deletion).
 - "Can set maxima's working directory but cannot change it during the
   maxima session" (GH #1672): this warning, printed by `wx-cd` whenever it
   fails to keep Maxima's working directory in sync with the worksheet's,

--- a/src/MaximaCommandMenus.cpp
+++ b/src/MaximaCommandMenus.cpp
@@ -3124,7 +3124,7 @@ void MaximaCommandMenus::PopupMenu(wxCommandEvent &event) {
         // This "if" is pure paranoia. But - since the costs of an "if" are low...
         GroupCell *group = m_wxMaxima.GetWorksheet()->GetActiveCell()->GetGroup();
         if (group->IsFoldable())
-          group->Fold();
+          m_wxMaxima.GetWorksheet()->Fold(group);
         else
           group->Hide(true);
         m_wxMaxima.GetWorksheet()->UpdateTableOfContents();
@@ -3225,7 +3225,7 @@ void MaximaCommandMenus::PopupMenu(wxCommandEvent &event) {
   else if(event.GetId() == EventIDs::popid_unfold){
       GroupCell *group = m_wxMaxima.GetWorksheet()->GetActiveCell()->GetGroup();
       if (group->IsFoldable())
-        group->Unfold();
+        m_wxMaxima.GetWorksheet()->Unfold(group);
       else
         group->Hide(false);
       m_wxMaxima.GetWorksheet()->UpdateTableOfContents();
@@ -3237,7 +3237,7 @@ void MaximaCommandMenus::PopupMenu(wxCommandEvent &event) {
       if ((m_wxMaxima.GetWorksheet()->GetTree()) &&
           (m_wxMaxima.GetWorksheet()->GetTree()->Contains(
                                             m_wxMaxima.m_tableOfContents->RightClickedOn()))) {
-        m_wxMaxima.m_tableOfContents->RightClickedOn()->Fold();
+        m_wxMaxima.GetWorksheet()->Fold(m_wxMaxima.m_tableOfContents->RightClickedOn());
         m_wxMaxima.GetWorksheet()->RequestRecalculation();
         m_wxMaxima.GetWorksheet()->RequestRedraw();
         m_wxMaxima.GetWorksheet()->UpdateTableOfContents();
@@ -3251,7 +3251,7 @@ void MaximaCommandMenus::PopupMenu(wxCommandEvent &event) {
       if ((m_wxMaxima.GetWorksheet()->GetTree()) &&
           (m_wxMaxima.GetWorksheet()->GetTree()->Contains(
                                             m_wxMaxima.m_tableOfContents->RightClickedOn()))) {
-        m_wxMaxima.m_tableOfContents->RightClickedOn()->Unfold();
+        m_wxMaxima.GetWorksheet()->Unfold(m_wxMaxima.m_tableOfContents->RightClickedOn());
         m_wxMaxima.GetWorksheet()->RequestRecalculation();
         m_wxMaxima.GetWorksheet()->RequestRedraw();
         m_wxMaxima.GetWorksheet()->UpdateTableOfContents();

--- a/src/TreeUndoAction.h
+++ b/src/TreeUndoAction.h
@@ -36,6 +36,7 @@
 #include <wx/string.h>
 #include <list>
 #include <memory>
+#include <optional>
 
 /*! The description of one action for the undo (or redo) command.
   This object is immutable - the undo/redo buffer cannot be modified.
@@ -58,6 +59,18 @@ public:
   TreeUndoAction(GroupCell *start, GroupCell *end, GroupCell *oldCells) :
     m_start(start), m_newCellsEnd(end), m_oldCells(oldCells)
     {
+    }
+
+  //! Which way a fold/unfold undo action (see m_fold) goes.
+  enum class FoldDirection {
+    Folded,  //!< This action folded start's subtree; undoing it unfolds it.
+    Unfolded //!< This action unfolded start's subtree; undoing it folds it.
+  };
+
+  TreeUndoAction(GroupCell *start, FoldDirection direction) :
+    m_start(start), m_fold(direction)
+    {
+      wxASSERT_MSG(start, _("Bug: Trying to record a fold/unfold for undo without a cell."));
     }
 
   /*! True = This undo action is only part of an atomic undo action.
@@ -114,6 +127,14 @@ public:
     If this field's value is NULL no cells have to be added to undo this action.
   */
   std::unique_ptr<GroupCell> m_oldCells;
+
+  /*! Set only for fold/unfold actions (see FoldDirection): whether this
+    action folded or unfolded the subtree that starts right after m_start.
+
+    std::nullopt for every other action kind (text change, cell addition,
+    cell deletion).
+  */
+  const std::optional<FoldDirection> m_fold;
 };
 
 //! The type of the list of tree actions that can be undone

--- a/src/cells/GroupCell.cpp
+++ b/src/cells/GroupCell.cpp
@@ -1971,30 +1971,34 @@ GroupCell *GroupCell::Unfold() {
   return dynamic_cast<GroupCell *>(splicedIn.lastSpliced);
 }
 
-GroupCell *GroupCell::FoldAll() {
+GroupCell *GroupCell::FoldAll(std::vector<GroupCell *> *affected) {
   GroupCell *result = NULL;
   for (auto &tmp : OnList(this)) {
     if (tmp.IsFoldable() && !tmp.m_hiddenTree) {
       tmp.Fold();
       result = &tmp;
+      if (affected)
+        affected->push_back(&tmp);
     }
     if (tmp.m_hiddenTree != NULL)
-      tmp.m_hiddenTree->FoldAll();
+      tmp.m_hiddenTree->FoldAll(affected);
   }
   return result;
 }
 
 // unfolds recursively its contents
 // if (all) then also calls it on it's m_next
-GroupCell *GroupCell::UnfoldAll() {
+GroupCell *GroupCell::UnfoldAll(std::vector<GroupCell *> *affected) {
   GroupCell *result = NULL;
   for (auto &tmp : OnList(this)) {
     if (tmp.IsFoldable() && (tmp.m_hiddenTree != NULL)) {
       tmp.Unfold();
       result = &tmp;
+      if (affected)
+        affected->push_back(&tmp);
     }
     if (tmp.m_hiddenTree != NULL)
-      tmp.m_hiddenTree->UnfoldAll();
+      tmp.m_hiddenTree->UnfoldAll(affected);
   }
   return result;
 }

--- a/src/cells/GroupCell.h
+++ b/src/cells/GroupCell.h
@@ -412,15 +412,21 @@ public:
 
   /*! Fold all cells
 
+    \param affected If non-null, every cell actually folded by this call is
+                     appended here, in the order it was folded -- the
+                     caller can use this to record one undo action per cell.
     \return the cell's address if folding was successful, else NULL
   */
-  GroupCell *FoldAll();
+  GroupCell *FoldAll(std::vector<GroupCell *> *affected = nullptr);
 
   /*! Unfold all cells
 
+    \param affected If non-null, every cell actually unfolded by this call
+                     is appended here, in the order it was unfolded -- the
+                     caller can use this to record one undo action per cell.
     \return the last unfolded cell's address if unfolding was successful, else NULL
   */
-  GroupCell *UnfoldAll();
+  GroupCell *UnfoldAll(std::vector<GroupCell *> *affected = nullptr);
 
   /*! Document structure: Can this cell type be part of the contents of comparedTo?
 

--- a/src/worksheet/Worksheet.cpp
+++ b/src/worksheet/Worksheet.cpp
@@ -4312,6 +4312,35 @@ bool Worksheet::TreeUndoCellAddition(UndoActions *sourcelist,
   return true;
 }
 
+bool Worksheet::TreeUndoFold(UndoActions *sourcelist,
+                             UndoActions *undoForThisOperation) {
+  const TreeUndoAction &action = sourcelist->front();
+  GroupCell *cell = action.m_start.get();
+  if (!cell)
+    // The cell this action folded/unfolded no longer exists (e.g. it was
+    // later deleted) -- nothing to undo.
+    return false;
+
+  TreeUndoAction::FoldDirection direction = *action.m_fold;
+
+  // Record the opposite direction, so this undo step can itself be redone.
+  undoForThisOperation->emplace_front(
+    cell, direction == TreeUndoAction::FoldDirection::Folded
+            ? TreeUndoAction::FoldDirection::Unfolded
+            : TreeUndoAction::FoldDirection::Folded);
+
+  if (direction == TreeUndoAction::FoldDirection::Folded)
+    cell->Unfold();
+  else
+    cell->Fold();
+
+  FoldOccurred();
+  UpdateTableOfContents();
+  RequestRecalculation();
+  RequestRedraw();
+  return true;
+}
+
 bool Worksheet::TreeUndoTextChange(UndoActions *sourcelist,
                                    UndoActions *undoForThisOperation) {
   const TreeUndoAction &action = sourcelist->front();
@@ -4383,6 +4412,8 @@ bool Worksheet::TreeUndo(UndoActions *sourcelist,
     const TreeUndoAction &actn = sourcelist->front();
     if (actn.m_newCellsEnd)
       TreeUndoCellAddition(sourcelist, undoForThisOperation);
+    else if (actn.m_fold)
+      TreeUndoFold(sourcelist, undoForThisOperation);
     else {
       if (actn.m_oldCells)
         TreeUndoCellDeletion(sourcelist, undoForThisOperation);

--- a/src/worksheet/Worksheet.h
+++ b/src/worksheet/Worksheet.h
@@ -310,6 +310,10 @@ public:
 
     Called from TreeUndo().*/
   bool TreeUndoCellAddition(UndoActions *sourcelist, UndoActions *undoForThisOperation);
+  /*! Undo a fold or unfold (GH #266)
+
+    Called from TreeUndo().*/
+  bool TreeUndoFold(UndoActions *sourcelist, UndoActions *undoForThisOperation);
 
   //! Undo a tree operation.
   bool TreeUndo()
@@ -1447,6 +1451,12 @@ public:
   void FoldOccurred();
 
   // methods for folding
+  //! Fold a cell (see WorksheetDocument::Fold())
+  GroupCell *Fold(GroupCell *which) { return m_document.Fold(which); }
+
+  //! Unfold a cell (see WorksheetDocument::Unfold())
+  GroupCell *Unfold(GroupCell *which) { return m_document.Unfold(which); }
+
   //! Fold or unfold a cell
   GroupCell *ToggleFold(GroupCell *which) { return m_document.ToggleFold(which); }
 

--- a/src/worksheet/WorksheetDocument.cpp
+++ b/src/worksheet/WorksheetDocument.cpp
@@ -243,42 +243,92 @@ WorksheetDocument::UndoTextChange(const TreeUndoAction &action,
   return TextUndoResult::Applied;
 }
 
+void WorksheetDocument::RecordFoldUndo(const std::vector<GroupCell *> &affected,
+                                       TreeUndoAction::FoldDirection direction) {
+  if (affected.empty())
+    return;
+
+  m_treeUndo.ClearRedoActionList();
+  // Pushed newest-first (emplace_front), so the LAST entry pushed here (the
+  // first cell FoldAll()/UnfoldAll() actually touched) ends up as the atomic
+  // group's un-marked tail -- see TreeUndoManager::AppendAction().
+  for (std::size_t i = 0; i < affected.size(); ++i) {
+    m_treeUndo.UndoStack().emplace_front(affected[i], direction);
+    if (i + 1 < affected.size())
+      m_treeUndo.AppendAction();
+  }
+}
+
+GroupCell *WorksheetDocument::Fold(GroupCell *which) {
+  if (!which || !which->IsFoldable() || which->GetHiddenTree())
+    return {};
+
+  GroupCell *result = which->Fold();
+
+  if (result) { // something has folded
+    OutputChanged();
+    m_treeUndo.ClearRedoActionList();
+    m_treeUndo.UndoStack().emplace_front(which, TreeUndoAction::FoldDirection::Folded);
+  }
+
+  return result;
+}
+
+GroupCell *WorksheetDocument::Unfold(GroupCell *which) {
+  if (!which || !which->IsFoldable() || !which->GetHiddenTree())
+    return {};
+
+  GroupCell *result = which->Unfold();
+
+  if (result) { // something has unfolded
+    OutputChanged();
+    m_treeUndo.ClearRedoActionList();
+    m_treeUndo.UndoStack().emplace_front(which, TreeUndoAction::FoldDirection::Unfolded);
+  }
+
+  return result;
+}
+
 GroupCell *WorksheetDocument::ToggleFold(GroupCell *which) {
   if (!which || !which->IsFoldable())
     return {};
 
-  GroupCell *result = which->GetHiddenTree() ? which->Unfold() : which->Fold();
-
-  if (result) // something has folded/unfolded
-    OutputChanged();
-
-  return result;
+  return which->GetHiddenTree() ? Unfold(which) : Fold(which);
 }
 
 GroupCell *WorksheetDocument::ToggleFoldAll(GroupCell *which) {
   if (!which || !which->IsFoldable())
     return {};
 
+  bool wasFolded = which->GetHiddenTree() != nullptr;
+  std::vector<GroupCell *> affected;
   GroupCell *result =
-    which->GetHiddenTree() ? which->UnfoldAll() : which->FoldAll();
+    wasFolded ? which->UnfoldAll(&affected) : which->FoldAll(&affected);
 
-  if (result) // something has folded/unfolded
+  if (result) { // something has folded/unfolded
     OutputChanged();
+    RecordFoldUndo(affected, wasFolded ? TreeUndoAction::FoldDirection::Unfolded
+                                       : TreeUndoAction::FoldDirection::Folded);
+  }
 
   return result;
 }
 
 void WorksheetDocument::FoldAll() {
   if (m_tree) {
-    m_tree->FoldAll();
+    std::vector<GroupCell *> affected;
+    m_tree->FoldAll(&affected);
     OutputChanged();
+    RecordFoldUndo(affected, TreeUndoAction::FoldDirection::Folded);
   }
 }
 
 void WorksheetDocument::UnfoldAll() {
   if (m_tree) {
-    m_tree->UnfoldAll();
+    std::vector<GroupCell *> affected;
+    m_tree->UnfoldAll(&affected);
     OutputChanged();
+    RecordFoldUndo(affected, TreeUndoAction::FoldDirection::Unfolded);
   }
 }
 

--- a/src/worksheet/WorksheetDocument.h
+++ b/src/worksheet/WorksheetDocument.h
@@ -48,6 +48,7 @@
 #include "cells/CellPtr.h"
 #include "cells/GroupCell.h"
 #include <memory>
+#include <vector>
 #include <wx/string.h>
 
 class WorksheetDocumentView;
@@ -127,6 +128,15 @@ public:
   //! Renumber all sectioning cells (titles, sections, ...) from the top.
   void NumberSections() const;
 
+  /*! Fold \p which; see GroupCell::Fold(). Returns the cell if it was
+    actually folded, null if \p which is null, not foldable, or already
+    folded. Records an undo action (GH #266) and clears the redo list; the
+    caller still has to schedule a recalculation - every existing caller
+    already does.
+  */
+  GroupCell *Fold(GroupCell *which);
+  //! Unfold \p which; see GroupCell::Unfold(). Mirrors Fold().
+  GroupCell *Unfold(GroupCell *which);
   /*! Fold or unfold \p which, whichever it currently isn't; see
     GroupCell::Fold()/Unfold(). Returns the cell if something actually
     changed, null if \p which is null or not foldable. The caller still has
@@ -234,6 +244,13 @@ public:
   }
 
 private:
+  /*! Record one undo action per cell in \p affected, all as a single atomic
+    group (see TreeUndoManager::AppendAction()), all going the same
+    \p direction, and clear the redo list. No-op if \p affected is empty.
+  */
+  void RecordFoldUndo(const std::vector<GroupCell *> &affected,
+                      TreeUndoAction::FoldDirection direction);
+
   //! The cells scheduled to be sent to Maxima, in evaluation order.
   EvaluationQueue m_evaluationQueue;
   //! Undo/redo history of edits to the cell-tree structure.

--- a/test/unit_tests/test_TreeUndo.cpp
+++ b/test/unit_tests/test_TreeUndo.cpp
@@ -232,7 +232,12 @@ SCENARIO("Folding survives an unrelated deletion and its undo") {
     REQUIRE(section->GetHiddenTree() != nullptr);
     REQUIRE(section->GetHiddenTree()->GetEditable()->GetValue() == wxS("child:2$"));
     REQUIRE(CellCount() == 2); // only [code, section] are visible now
-    g_ws->TreeUndo_ClearBuffers(); // folding itself is not an undoable action
+    // Folding is itself undoable (GH #266) and just pushed its own action;
+    // discard it so the deletion below is the only action on the stack --
+    // this scenario is specifically about the deletion's undo leaving an
+    // unrelated, already-settled fold alone, not about the fold's own undo
+    // (see "Folding a section is undoable and redoable" for that).
+    g_ws->TreeUndo_ClearBuffers();
 
     WHEN("an unrelated cell above the fold is deleted and the delete is undone") {
       g_ws->DeleteRegion(top, top);
@@ -304,8 +309,15 @@ SCENARIO("Undoing an insertion whose cell was folded away reveals and removes it
     REQUIRE(g_ws->CanUndo());
 
     // Fold the section: the freshly-inserted child moves into the hidden tree,
-    // so the pending undo action now points at a hidden cell.
-    REQUIRE(g_ws->ToggleFold(section) == section);
+    // so the pending undo action now points at a hidden cell. Folding via the
+    // raw GroupCell::Fold() (not g_ws->ToggleFold()) is deliberate: since
+    // folding became undoable in its own right (GH #266), going through
+    // ToggleFold() here would push a second undo action in front of the
+    // insertion we actually want to test, so the first TreeUndo() below would
+    // undo the fold instead. This scenario is specifically about
+    // TreeUndoCellAddition's RevealHidden() branch, not about fold's own
+    // undo (see "Folding a section is undoable and redoable" for that).
+    REQUIRE(section->Fold() == section);
     REQUIRE(section->GetHiddenTree() == child);
     REQUIRE(CellCount() == 1);
 
@@ -318,6 +330,126 @@ SCENARIO("Undoing an insertion whose cell was folded away reveals and removes it
         REQUIRE(only->GetGroupType() == GC_TYPE_SECTION);
         CHECK(only->GetHiddenTree() == nullptr); // unfolded during the undo
         CHECK(only->GetNext() == nullptr);        // the inserted cell was removed
+      }
+    }
+  }
+}
+
+SCENARIO("Folding a section is undoable and redoable (GH #266)") {
+  GIVEN("a worksheet [code, section, code] with the section unfolded") {
+    g_ws->ClearDocument();
+    AppendCell(GC_TYPE_CODE, wxS("top:1$"));
+    GroupCell *section = AppendCell(GC_TYPE_SECTION, wxS("A section"));
+    AppendCell(GC_TYPE_CODE, wxS("child:2$"));
+    g_ws->TreeUndo_ClearBuffers();
+    REQUIRE(CellCount() == 3);
+
+    WHEN("the section is folded") {
+      REQUIRE(g_ws->ToggleFold(section) == section);
+      REQUIRE(section->GetHiddenTree() != nullptr);
+      REQUIRE(CellCount() == 2);
+
+      THEN("undo unfolds it again; redo folds it back") {
+        REQUIRE(g_ws->CanUndo());
+        REQUIRE(g_ws->TreeUndo());
+        CHECK(section->GetHiddenTree() == nullptr);
+        CHECK(CellCount() == 3);
+
+        REQUIRE(g_ws->TreeRedo());
+        CHECK(section->GetHiddenTree() != nullptr);
+        CHECK(CellCount() == 2);
+      }
+    }
+  }
+}
+
+SCENARIO("Unfolding a section is undoable and redoable (GH #266)") {
+  GIVEN("a worksheet [code, section] with the section folded over a child") {
+    g_ws->ClearDocument();
+    AppendCell(GC_TYPE_CODE, wxS("top:1$"));
+    GroupCell *section = AppendCell(GC_TYPE_SECTION, wxS("A section"));
+    AppendCell(GC_TYPE_CODE, wxS("child:2$"));
+    g_ws->TreeUndo_ClearBuffers();
+
+    REQUIRE(g_ws->ToggleFold(section) == section);
+    REQUIRE(section->GetHiddenTree() != nullptr);
+    g_ws->TreeUndo_ClearBuffers();
+
+    WHEN("the section is unfolded") {
+      REQUIRE(g_ws->ToggleFold(section) != nullptr);
+      REQUIRE(section->GetHiddenTree() == nullptr);
+      REQUIRE(CellCount() == 3);
+
+      THEN("undo folds it again; redo unfolds it back") {
+        REQUIRE(g_ws->TreeUndo());
+        CHECK(section->GetHiddenTree() != nullptr);
+        CHECK(CellCount() == 2);
+
+        REQUIRE(g_ws->TreeRedo());
+        CHECK(section->GetHiddenTree() == nullptr);
+        CHECK(CellCount() == 3);
+      }
+    }
+  }
+}
+
+SCENARIO("Folding and a later unrelated edit are two separate undo steps") {
+  GIVEN("a worksheet [code, section, code] with the section unfolded") {
+    g_ws->ClearDocument();
+    GroupCell *top = AppendCell(GC_TYPE_CODE, wxS("top:1$"));
+    GroupCell *section = AppendCell(GC_TYPE_SECTION, wxS("A section"));
+    AppendCell(GC_TYPE_CODE, wxS("child:2$"));
+    g_ws->TreeUndo_ClearBuffers();
+
+    WHEN("the section is folded, then an unrelated cell is inserted") {
+      REQUIRE(g_ws->ToggleFold(section) == section);
+      REQUIRE(CellCount() == 2);
+      g_ws->InsertGroupCells(
+        std::make_unique<GroupCell>(g_cfg, GC_TYPE_CODE, wxS("extra:3$")), top);
+      REQUIRE(CellCount() == 3);
+
+      THEN("the first undo only reverts the insertion; the fold survives") {
+        REQUIRE(g_ws->TreeUndo());
+        CHECK(CellCount() == 2);
+        CHECK(section->GetHiddenTree() != nullptr);
+
+        AND_THEN("a second undo reverts the fold too") {
+          REQUIRE(g_ws->TreeUndo());
+          CHECK(section->GetHiddenTree() == nullptr);
+          CHECK(CellCount() == 3);
+        }
+      }
+    }
+  }
+}
+
+SCENARIO("Fold All folds every foldable cell as one atomic undo step (GH #266)") {
+  GIVEN("a worksheet with two sections, each with a child") {
+    g_ws->ClearDocument();
+    GroupCell *sec1 = AppendCell(GC_TYPE_SECTION, wxS("Section 1"));
+    AppendCell(GC_TYPE_CODE, wxS("a:1$"));
+    GroupCell *sec2 = AppendCell(GC_TYPE_SECTION, wxS("Section 2"));
+    AppendCell(GC_TYPE_CODE, wxS("b:2$"));
+    g_ws->TreeUndo_ClearBuffers();
+    REQUIRE(CellCount() == 4);
+
+    WHEN("Fold All is invoked") {
+      g_ws->FoldAll();
+
+      THEN("both sections fold, and a single undo reverts both at once") {
+        REQUIRE(sec1->GetHiddenTree() != nullptr);
+        REQUIRE(sec2->GetHiddenTree() != nullptr);
+        REQUIRE(CellCount() == 2);
+
+        REQUIRE(g_ws->TreeUndo());
+        CHECK(sec1->GetHiddenTree() == nullptr);
+        CHECK(sec2->GetHiddenTree() == nullptr);
+        CHECK(CellCount() == 4);
+
+        REQUIRE(g_ws->TreeRedo());
+        CHECK(sec1->GetHiddenTree() != nullptr);
+        CHECK(sec2->GetHiddenTree() != nullptr);
+        CHECK(CellCount() == 2);
       }
     }
   }


### PR DESCRIPTION
Fixes #266.

Folding or unfolding a section (or "Fold All"/"Unfold All" on the whole document) previously left no trace in the undo buffer, so an accidental fold — or a "Fold All" run when you didn't mean to collapse the document — could only be reverted by reloading the file. This was requested in #266 back in 2013.

## Approach

`TreeUndoAction` (`src/TreeUndoAction.h`) is a single, non-polymorphic struct, not an `Action`/`Undo()`/`Redo()` hierarchy — `Worksheet::TreeUndo()` tells apart its existing three action kinds (text change, cell insertion, cell deletion) by which of a couple of optional fields is set, not by a type tag. Fold/unfold becomes a fourth explicit case the same way: an `std::optional<FoldDirection>` field, checked in the dispatch before the existing fallback. Undoing a fold/unfold just applies the opposite direction to the same cell, which is naturally redoable through the same generic replay loop the other three kinds already use (no separate redo logic needed).

`GroupCell::Fold()`/`Unfold()` themselves stay undo-agnostic — they're the low-level tree-surgery primitives (the same `CellList::TearOut`/`SpliceInAfter` calls `DeleteRegion`/`InsertGroupCells` already use). Only `WorksheetDocument`, which owns the `TreeUndoManager`, records the undo action, via two new single-direction `Fold()`/`Unfold()` methods plus the existing `ToggleFold()`/`ToggleFoldAll()`/`FoldAll()`/`UnfoldAll()`.

"Fold All"/"Unfold All" can touch many cells in one call (only the ones not already in the target state), so `GroupCell::FoldAll()`/`UnfoldAll()` gained an optional out-vector of every cell they actually folded/unfolded, letting `WorksheetDocument` record one action per cell, chained into a single atomic undo/redo step — so undoing a "Fold All" never over-reverts a section that was already folded before it ran.

A few call sites fold/unfold as an implicit side effect rather than a deliberate user action — `RevealHidden()`'s auto-unfold-to-reveal, and the auto-unfold when inserting a new cell under a folded ancestor — and keep calling the raw `GroupCell` methods directly, so they don't spend an undo slot of their own.

## Testing

- Added unit test coverage in `test_TreeUndo.cpp`: folding/unfolding a section is undoable and redoable, a fold stays a separate undo step from a later unrelated edit, and "Fold All" undoes/redoes as one atomic step across multiple cells.
- One pre-existing test relied on folding *not* being independently undoable (so a single `TreeUndo()` call would reach past it to an older insertion underneath) — updated to fold via the raw `GroupCell::Fold()` instead, since that's what it's actually testing (see the AGENTS.md note added in this PR).
- Full unit test suite passes locally (43/43 under `ctest -L unittest`).
- Full local build succeeds.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_