### PR TITLE
Don't parenthesize a plain sum()/product() summand (GH #1536)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -660,6 +660,44 @@ tried without rebuilding.
   holding, worth checking for before assuming "existing tests pass" means
   "no behavior changed."
 
+- **`SumCell`'s always-on parentheses (GH #1536), and why the fix needed
+  both wxMathML.lisp and C++:** `sum(k,k,1,n)` used to always display as
+  `Σ (k)`, even though Maxima's own terminal printer shows a bare `k` --
+  `SumCell`'s constructor (`src/cells/SumCell.cpp`) unconditionally wrapped
+  the summand in its own `ParenCell` (`m_paren`), regardless of what the
+  summand actually was. The tempting "just use the existing operator-
+  precedence machinery" fix doesn't quite apply here: `%sum`/`%product` have
+  no `lbp`/`rbp` registered at all in real Maxima (confirmed live:
+  `(get '%sum 'lbp)` is `NIL`), so Maxima's own printer can't be using
+  generic precedence comparison for this either -- it must special-case it,
+  and the same real distinction it makes (parenthesize a compound summand
+  like `k+k^2`, not a bare one like `k`) is exactly `mplusp` on the actual
+  Maxima expression, which is what `wxxml-sum` (`wxMathML.lisp`) now checks.
+  This deliberately avoids inventing a new binding-power value for `sum` --
+  the maintainer has flagged doing that as risky in the past (wxMaxima's own
+  operator precedences drifting out of sync with Maxima's, GH #1536's
+  comment thread), so `mplusp` (an existing Maxima predicate on the real
+  parsed expression) is used instead of a numeric precedence comparison.
+  That decision alone isn't sufficient, though: it has to reach `SumCell`'s
+  2D on-screen layout, which is computed entirely in C++
+  (`Recalculate()`/`Draw()`), and `ParenCell`'s own `m_print` flag -- which
+  looked like the obvious existing mechanism to reuse -- turned out to only
+  suppress parentheses in `ToString()`/`ToTeX()`/`ToMathML()` (text/export
+  formats); `Recalculate()`/`Draw()`/`SetCurrentPoint()` don't check it at
+  all and always reserve/draw the paren glyphs regardless. So the Lisp-side
+  decision is carried across the wire as a `needsparen` attribute on `<sm>`,
+  which `MathParser::ParseSumTag` reads and feeds into `SumCell::NeedsParen()`
+  -- a new setter that drives the *already-existing* `m_displayParen`/
+  `DisplayedBase()` mechanism (previously only toggled by `BreakUp()`/
+  `Unbreak()` for the broken-into-lines case) via a new persistent
+  `m_baseNeedsParen` field, rather than inventing a second, competing
+  wrapping mechanism. Confirmed end-to-end with a live Xvfb screenshot
+  (`sum(k,k,1,n)` bare, `sum(k+k^2,k,1,n)` parenthesized, and
+  `sum(k,k,1,n)+L` -- which motivated the original always-parenthesize
+  decision -- correctly getting *outer* parens around the whole sum from
+  the unrelated, already-existing `%sum` `rbp` registration, not extra
+  parens around the summand).
+
 ## Layout & Compatibility
 
 - **Mathematical Cell Padding:** Use `MC_TEXT_PADDING` (in `Configuration.h`) for text-based cells. **Exception:** `DigitCell` does not include padding to ensure visual consistency in broken-up numbers.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # Current development version
 
+- `sum()`/`product()`/`lsum` (GH #1536) no longer wrap a plain summand in
+  spurious parentheses: `sum(k,k,1,n)` now displays the sum sign over a bare
+  `k`, matching Maxima's own terminal output, instead of always showing
+  `(k)`. A genuinely compound summand, like `sum(k+k^2,k,1,n)`, still gets
+  the parentheses, since dropping them there really could be misread as
+  extending past the sum sign. The decision is made in `wxxml-sum`
+  (`wxMathML.lisp`) from the real Maxima expression (`mplusp`) rather than
+  an invented operator precedence -- Maxima's own printer has no `lbp`/`rbp`
+  registered for `sum`/`product` either, so it can't be using generic
+  precedence comparison for this -- and is carried across the wire to
+  `SumCell` (which still needed a small, targeted change of its own: its 2D
+  on-screen layout is computed in C++, and turned out not to be reachable
+  through `ParenCell`'s existing "print" flag, which only suppresses
+  parentheses in text/TeX/MathML export, not in the interactive display).
 - Folding/unfolding a section (or the whole document, via "Fold All"/
   "Unfold All") is now recorded in the undo buffer (GH #266), a 2013 feature
   request: Ctrl+Z after an accidental fold, or after "Fold All" collapses a

--- a/src/MathParser.cpp
+++ b/src/MathParser.cpp
@@ -187,6 +187,7 @@ MathParser::MathParser(Configuration *cfg, const wxString &zipfile) {
       wxS("listdelim"),
       wxS("set"),
       wxS("roundedParens"),
+      wxS("needsparen"),
       wxS("noneParens"),
       wxS("bracketParens"),
       wxS("straightParens"),
@@ -1163,6 +1164,15 @@ std::unique_ptr<Cell> MathParser::ParseSumTag(wxXmlNode *node, int depth) {
   sum->SetHighlight(highlight);
   sum->SetType(m_ParserStyle);
   sum->SetStyle(TS_VARIABLE);
+  // GH #1536: wxxml-sum (wxMathML.lisp) already decided, from the real
+  // Maxima expression, whether the summand needs disambiguating parens
+  // (default true so an <sm> tag from before this attribute existed, e.g.
+  // an old cached wxMathML.lisp or a document saved by an older wxMaxima,
+  // keeps the previous always-parenthesize behavior). ProductCell is a
+  // SumCell, so this cast is valid for both branches above.
+  bool needsParen =
+    node->GetAttribute(wxS("needsparen"), wxS("true")) != wxS("false");
+  static_cast<SumCell *>(sum.get())->NeedsParen(needsParen);
   ParseCommonAttrs(node, sum);
   return sum;
 }

--- a/src/cells/SumCell.cpp
+++ b/src/cells/SumCell.cpp
@@ -321,9 +321,11 @@ wxString SumCell::ToXML() const {
   wxString type = GetXMLType();
   wxString flags = GetXMLFlags();
 
-  return wxS("<sm type=\"") + type + "\"" + flags + wxS("><r>") +
-    m_under->ListToXML() + _T("</r><r>") + m_over->ListToXML() +
-    _T("</r><r>") + Base()->ListToXML() + _T("</r></sm>");
+  return wxS("<sm type=\"") + type + wxS("\" needsparen=\"") +
+    (m_baseNeedsParen ? wxS("true") : wxS("false")) + wxS("\"") + flags +
+    wxS("><r>") + m_under->ListToXML() + _T("</r><r>") +
+    m_over->ListToXML() + _T("</r><r>") + Base()->ListToXML() +
+    _T("</r></sm>");
 }
 
 wxString SumCell::ToMathML() const {
@@ -353,7 +355,7 @@ wxString SumCell::ToMathML() const {
 }
 
 void SumCell::Unbreak() const {
-  m_displayParen = true;
+  m_displayParen = m_baseNeedsParen;
   Cell::Unbreak();
 }
 

--- a/src/cells/SumCell.h
+++ b/src/cells/SumCell.h
@@ -92,6 +92,18 @@ public:
   wxString ToXML() const override;
 
   void SetAltCopyText(const wxString &text) override { m_altCopyText = text; }
+
+  /*! Whether the summand genuinely needs the disambiguating parentheses
+    around it (GH #1536), e.g. because it is a sum of terms like "k+k^2"
+    that could otherwise be misread as extending past the sum sign into
+    whatever follows it -- a bare summand like "k" doesn't. Must be set
+    right after construction, before the first layout pass; defaults to
+    true (the old, always-parenthesize behavior) if never called.
+  */
+  void NeedsParen(bool needsParen) {
+    m_baseNeedsParen = needsParen;
+    m_displayParen = needsParen;
+  }
   const wxString &GetAltCopyText() const override { return m_altCopyText; }
 
   bool BreakUp() const override;
@@ -156,7 +168,7 @@ protected:
   Cell *Base() const;
   Cell *Over() const {return m_over.get();}
   Cell *Under() const {return m_under.get();}
-  
+
 private:
   std::unique_ptr<Cell> MakeStart(Cell *under) const;
   void MakeBreakUpCells();
@@ -187,8 +199,20 @@ private:
 
 //** Bitfield objects (1 bytes)
 //**
-  //! Display m_paren if true, or Base() if false
+  /*! Display m_paren if true, or Base() if false.
+
+    Unlike m_baseNeedsParen this is transient view state, forced to false
+    whenever BreakUp() linearizes the cell (the linear form never shows a
+    sum sign to disambiguate against, so it never needs the parens either,
+    regardless of m_baseNeedsParen) and restored from m_baseNeedsParen by
+    Unbreak().
+  */
   mutable bool m_displayParen : 1 = true;
+  /*! Whether the summand structurally needs the disambiguating parentheses
+    (GH #1536) -- see NeedsParen(). Persists across BreakUp()/Unbreak(),
+    unlike m_displayParen.
+  */
+  bool m_baseNeedsParen : 1 = true;
 };
 
 #endif // SUMCELL_H

--- a/src/wxMathML.lisp
+++ b/src/wxMathML.lisp
@@ -1166,8 +1166,26 @@ Submit bug reports by following the 'New issue' link on that page."))
 
 ;; easily extended to union, intersect, otherops
 
+;; GH #1536: a bare summand ("k") doesn't need visual disambiguation from
+;; whatever follows the whole sum/product, but a compound one ("k+k^2")
+;; could otherwise be misread as extending past the sum sign into it --
+;; e.g. "sum k + L" is genuinely ambiguous about whether L is part of the
+;; sum. Maxima's own printer has no lbp/rbp registered for %sum/%product at
+;; all (confirmed: (get '%sum 'lbp) is NIL), so it can't be using generic
+;; operator-precedence comparison for this either -- mplusp (a direct,
+;; already-existing Maxima predicate on the real expression, not an
+;; invented precedence value) is the same structural distinction Maxima's
+;; own 2D ASCII printer visibly makes for this exact construct. This is
+;; carried across the wire as the needsparen attribute since the decision
+;; of whether to show parens has to reach SumCell's 2D on-screen layout in
+;; wxWidgets/C++, which ParenCell's own "print" flag cannot do (it only
+;; suppresses parens in text/TeX/MathML export, not in Recalculate()/Draw()).
+(defun wxxml-sum-needsparen (x)
+  (if (mplusp (cadr x)) "true" "false"))
+
 (defun wxxml-lproduct(x l r)
-  (let ((op "<sm type=\"lprod\"><mrow>")
+  (let* ((op (concatenate 'string "<sm type=\"lprod\" needsparen=\""
+			   (wxxml-sum-needsparen x) "\"><mrow>"))
 	;; gotta be one of those above
 	(s1 (wxxml (cadr x) nil nil 'mparen rop));; summand
 	(index ;; "index = lowerlimit"
@@ -1178,7 +1196,8 @@ Submit bug reports by following the 'New issue' link on that page."))
 		    ,@s1 "</mrow></sm>") r)))
 
 (defun wxxml-lsum(x l r)
-  (let ((op "<sm type=\"lsum\"><mrow>")
+  (let* ((op (concatenate 'string "<sm type=\"lsum\" needsparen=\""
+			   (wxxml-sum-needsparen x) "\"><mrow>"))
 	;; gotta be one of those above
 	(s1 (wxxml (cadr x) nil nil 'mparen rop));; summand
 	(index ;; "index = lowerlimit"
@@ -1189,10 +1208,11 @@ Submit bug reports by following the 'New issue' link on that page."))
 		    ,@s1 "</mrow></sm>") r)))
 
 (defun wxxml-sum(x l r)
-  (let ((op (if (or (eq (caar x) '%sum)
-		    (eq (caar x) '$sum))
-		"<sm><mrow>"
-		"<sm type=\"prod\"><mrow>"))
+  (let* ((prodp (not (or (eq (caar x) '%sum) (eq (caar x) '$sum))))
+	 (op (concatenate 'string "<sm"
+			   (if prodp " type=\"prod\"" "")
+			   " needsparen=\"" (wxxml-sum-needsparen x)
+			   "\"><mrow>"))
 	(s1 (wxxml (cadr x) nil nil 'mparen rop));; summand
 	(index ;; "index = lowerlimit"
 	 (wxxml `((mequal simp) ,(caddr x) ,(cadddr x))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -196,6 +196,20 @@ add_test(
     COMMAND "${CMAKE_CURRENT_BINARY_DIR}/check-wxMathML.sh" "a*box(b,highlight)*c;" "<p lisp=\"wxxml-paren\"><mrow><hl boxname=\"highlight\">"
 )
 
+# GH #1536: a bare summand doesn't need the disambiguating parentheses
+# SumCell used to always draw around it -- only a compound one (here a sum
+# of terms, "k+k^2") does. wxxml-sum (wxMathML.lisp) decides this from the
+# real Maxima expression (mplusp) and hands the decision to SumCell via the
+# needsparen attribute on <sm>; these two pin that attribute for both cases.
+add_test(
+    NAME check-wxMathML.lisp_sum_bare_summand_no_parens
+    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/check-wxMathML.sh" "'sum(k,k,1,n);" "<sm needsparen=\"false\">"
+)
+add_test(
+    NAME check-wxMathML.lisp_sum_compound_summand_needs_parens
+    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/check-wxMathML.sh" "'sum(k+k^2,k,1,n);" "<sm needsparen=\"true\">"
+)
+
 # GH #1672: wx-cd (the function wxMaxima uses to keep Maxima's working
 # directory in sync with the worksheet's) used to fail to cd into a
 # directory whose name contains characters outside the OS's active


### PR DESCRIPTION
Fixes #1536.

`sum(k,k,1,n)` always displayed as a sum sign over `(k)`, even though Maxima's own terminal printer shows a bare `k` — `SumCell`'s constructor unconditionally wrapped the summand in its own `ParenCell` regardless of what it actually was.

## Why not just use operator precedence?

That was my first instinct too, but it doesn't quite hold up: `%sum`/`%product` have **no** `lbp`/`rbp` registered in real Maxima at all (confirmed live: `(get '%sum 'lbp)` → `NIL`), so Maxima's own printer can't be basing this particular decision on generic precedence comparison either — it must special-case it. The maintainer has also flagged inventing new wxMaxima-side binding powers as risky in the issue thread (they can drift out of sync with Maxima's own), so this avoids that entirely: `wxxml-sum` (`wxMathML.lisp`) checks `mplusp` directly on the real Maxima expression — parenthesize a compound summand like `k+k^2`, not a bare one like `k` — which is exactly the distinction Maxima's own 2D printer already makes for this construct, and matches what the issue cites Android Maxima doing.

## Why C++ still needed a (small) change

That Lisp-side decision still has to reach `SumCell`'s 2D on-screen layout, which is computed entirely in C++ (`Recalculate()`/`Draw()`). `ParenCell`'s own `print` flag looked like the obvious existing mechanism to reuse, but it turned out to only suppress parentheses in `ToString()`/`ToTeX()`/`ToMathML()` (text/export formats) — `Recalculate()`/`Draw()`/`SetCurrentPoint()` don't check it at all and always reserve/draw the paren glyphs regardless. So the Lisp-side decision is carried across the wire as a `needsparen` attribute on `<sm>`, read by `MathParser::ParseSumTag` and fed into a new `SumCell::NeedsParen()` setter — which drives the **already-existing** `m_displayParen`/`DisplayedBase()` mechanism (previously only toggled by `BreakUp()`/`Unbreak()` for the broken-into-lines case) via a new persistent `m_baseNeedsParen` field, rather than inventing a second, competing wrapping mechanism.

## Testing

- Verified end-to-end with a live Xvfb screenshot: `sum(k,k,1,n)` now shows bare, `sum(k+k^2,k,1,n)` still shows parenthesized, and `sum(k,k,1,n)+L` — the case that motivated the original always-parenthesize behavior — correctly gets parentheses around the *whole* sum instead (from the separate, already-existing `%sum` `rbp` registration), so the original ambiguity concern stays resolved.
- Added two `check-wxMathML.lisp_*` regression tests pinning the `needsparen` attribute for both the bare and compound cases.
- Full unit test suite (43/43) and the existing `sumCells`/`productCells` batch tests all still pass.
- Full local build succeeds.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_