### PR TITLE
Gnuplot popout warnings + don't unfold folded cells on error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -803,6 +803,39 @@ tried without rebuilding.
   the unrelated, already-existing `%sum` `rbp` registration, not extra
   parens around the summand).
 
+- **"Don't unfold cells just because their folded tree is being evaluated"
+  (GH #1952):** `Worksheet::ScrollToError()` -- called automatically by
+  `MaximaEvaluator::CheckForErrors()` whenever `AbortOnError()` is on (the
+  default) and a cell errors -- used to call `errorCell->RevealHidden()`
+  unconditionally. If the errored cell was folded away, that silently
+  unfolded the *entire* enclosing section just to point at it, defeating the
+  whole reason many users fold a calculation down to one line in the first
+  place: to keep the worksheet readable while it evaluates, errors included.
+  Confirmed live in a real Xvfb session (a folded section containing
+  `a:1$ error("...")$ a+1$`, evaluated via "Evaluate All Cells"): the section
+  sprang open the instant the `error()` cell ran, on unmodified `main`.
+  Fixed by walking up `GroupCell::GetHiddenTreeParent()` (returns non-null
+  exactly when a cell sits in someone's torn-out `m_hiddenTree` -- see the
+  `Fold()`/`Unfold()`/`CellList::TearOut` notes elsewhere in this section)
+  to the outermost cell that *is* part of the visible tree, and -- only if
+  that ancestor differs from the error cell itself, i.e. the cell actually
+  is hidden -- targeting that ancestor (`SetHCaret`+`ScrollToCaret`) instead
+  of calling `RevealHidden()`/touching `errorCell`'s own (still-hidden,
+  un-renderable) `EditorCell` at all. The ordinary (not-folded) case falls
+  through to the original code completely unchanged. Deliberately left
+  `Worksheet::OpenQuestionCaret()`'s own `RevealHidden()` call alone: unlike
+  an error, an interactive Maxima question genuinely blocks the evaluation
+  queue until the user answers it, so there is no way to let the user
+  respond without unfolding down to the cell that's asking. Regression-
+  tested in `test/unit_tests/test_TreeUndo.cpp` (`SCENARIO("An error inside
+  a folded section does not unfold it (GH #1952)")`) by folding a section,
+  calling the *public* `ErrorList::Add()` directly to simulate what
+  `MaximaEvaluator` does on a real error (no live Maxima needed), then
+  asserting `ScrollToError()` leaves `GetHiddenTree()`/`GetHiddenTreeParent()`
+  untouched and lands the h-caret on the header -- confirmed to actually
+  catch the regression by reverting the fix and watching the new assertions
+  fail against the old code before restoring it.
+
 ## Layout & Compatibility
 
 - **Mathematical Cell Padding:** Use `MC_TEXT_PADDING` (in `Configuration.h`) for text-based cells. **Exception:** `DigitCell` does not include padding to ensure visual consistency in broken-up numbers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,62 @@ a local TCP socket.
   - `Maxima` (`src/Maxima.cpp`): Owns the TCP socket to the Maxima process and emits `EVT_MAXIMA` events carrying incoming data.
   - `Variablespane`: Manages the list of defined variables and their values.
   - `AutoComplete`: Handles the autocomplete logic for commands, variables, and files.
+- **`wxLogMessage`/`wxLogWarning`/`wxLogError` are NOT reliably visible to the
+  user in this app -- don't reach for them when something needs to actually
+  be seen.** `main.cpp` installs a `wxLogWindow` with `passToOld=false`
+  (both branches of its `#if (DEBUG==1)`), which means every `wxLogXXX` call
+  goes *only* to that custom log window and nowhere else -- not to wx's
+  stock `wxLogGui` popups, which is what raises the "but wxLogError usually
+  shows something" intuition. The log window itself is constructed with
+  `show=false` in a normal (non-`DEBUG`) build, i.e. hidden until the user
+  explicitly picks View -> Toggle Log Window or passes `--logtostderr`.
+  Confirmed live while building the gnuplot-popout-warning feature below: a
+  real `wxLogWarning()` call reached the log window's backing store (visible
+  once the window was forced to raise) but the window itself never mapped
+  on screen on its own, even for a Warning-level message -- a user running
+  a normal release build would never see it. When a message genuinely needs
+  to reach the user, use `LoggingMessageBox`/`LoggingMessageDialog`
+  (`src/dialogs/LoggingMessageDialog.h`) instead: it logs the same way
+  `wxLogMessage` does *and* shows a real modal dialog, and it already
+  honors `LoggingMessageDialog::IsNonInteractive()` so batch/test runs
+  don't block on it. This is already the established pattern (~40 call
+  sites across `wxMaxima.cpp`, `MaximaFileIO.cpp`, `MaximaCommandMenus.cpp`,
+  `WXMXformat.cpp`, ...) -- `wxLogXXX` alone is for the debug-messages
+  sidebar, not for anything the user is expected to act on.
+- **Gnuplot "Pop out interactively" now warns about gnuplot errors/warnings
+  (GH #1973):** the popout handler (`MaximaCommandMenus.cpp`,
+  `popid_popup_gnuplot`) launches a *second*, independent gnuplot process
+  alongside the real interactive one, running the identical script with
+  `set term unknown` instead of a real terminal so it needs no display and
+  exits immediately once the script finishes executing.
+  `MaximaProcessManager::OnGnuplotPopoutCheckClose` (`wxEVT_END_PROCESS` for
+  `EventIDs::gnuplot_popout_check_id`) reads back its stdout+stderr and, if
+  anything survives filtering, shows it via `LoggingMessageBox`. The real
+  interactive process (`m_gnuplotProcess`) is deliberately **never**
+  `Redirect()`ed: doing so would replace its console's actual stdin/stdout
+  with pipes wx owns, silently breaking the "type further gnuplot commands
+  into the popped-out console" feature the manual documents (Windows'
+  `wgnuplot.exe` specifically) -- since `set term unknown` needs no console
+  at all, redirecting *that* one is free of this tradeoff. **Filtering
+  gotcha, confirmed against a real gnuplot 6.0, not assumed:** `set term
+  unknown` makes gnuplot print `WARNING: Plotting with 'unknown'
+  terminal.\nNo output will be generated. Please select a terminal with
+  'set terminal'.` to stderr on *every single* `plot`/`replot` statement,
+  even for a script with nothing else wrong with it -- these two lines are
+  a side effect of the diagnostic's own terminal choice, not a finding
+  about the user's script, and must be filtered out (matched by substring,
+  not exact string, since gnuplot's exact wording could vary by version) or
+  every popout would raise a spurious warning. Verified end-to-end in a
+  live Xvfb session with a real Maxima+gnuplot: a `wxdraw2d` with a bad
+  `user_preamble` (`set y2tics out` with no y2 data, reproducing the
+  original bug report) raises a "Warning" dialog quoting gnuplot's actual
+  `"...gnuplot" line NN: warning: y2 axis range undefined or overflow,
+  resetting to [0:0]"` message, while the same plot without the bad
+  preamble raises nothing -- and the real interactive popout window (a
+  separate, still-running, reparented-to-init process once its short-lived
+  wx-tracked launcher process exits -- a pre-existing, unrelated forking
+  detail of how gnuplot/`--persist` behaves under X11) keeps working
+  exactly as before in both cases.
 - **The draw list is computed, not stored (2026-08, closes GH #1445):** `Cell`
   used to carry a `mutable CellPtr<Cell> m_nextToDraw` member -- a second
   always-present `CellPtr` on *every* cell, threaded by hand via a virtual

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # Current development version
 
+- "Pop out interactively" (the plot image's right-click menu) now tells you
+  when gnuplot had trouble with the plot, instead of silently leaving you
+  with an unexplained window (GH #1973). A second, hidden gnuplot process
+  runs the same script headlessly (`set term unknown`, so it needs no
+  display) purely to catch anything gnuplot prints while preparing the plot;
+  if it printed something, a "Warning" dialog shows it verbatim. The
+  interactive popout itself is untouched -- it still gets its own real
+  console/window exactly as before, so typing further gnuplot commands into
+  it still works.
 - macOS: translation files should now actually make it into the app bundle
   (GH #1711). Two separate bugs meant the `.mo` files never reached
   `Contents/Resources/locale/<lang>/LC_MESSAGES/`, where wxMaxima looks for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Current development version
 
+- Evaluating a folded section no longer unfolds it just because an error
+  happened somewhere inside (GH #1952). Folding a time-consuming or
+  no-longer-relevant calculation down to one line, so the worksheet stays
+  readable while everything still gets evaluated, was defeated if a single
+  error deep inside the fold unconditionally sprang it back open -- the
+  worksheet now lands on the fold's own (visible) header instead, leaving
+  the fold itself untouched.
 - "Pop out interactively" (the plot image's right-click menu) now tells you
   when gnuplot had trouble with the plot, instead of silently leaving you
   with an unexplained window (GH #1973). A second, hidden gnuplot process

--- a/locales/wxMaxima/wxMaxima.pot
+++ b/locales/wxMaxima/wxMaxima.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-07 00:07+0000\n"
+"POT-Creation-Date: 2026-08-10 03:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,7 +51,7 @@ msgid ""
 "Now reads: "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1979
+#: ../../src/wxMaxima.cpp:1981
 msgid ""
 "\n"
 "Use the menu \"View->Toggle log window\" to show/hide a log window with all debug messages."
@@ -209,14 +209,14 @@ msgstr ""
 msgid " times"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4413
+#: ../../src/MaximaCommandMenus.cpp:4473
 msgid ""
 "\".\" = \"The current directory\"\n"
 "\"..\" = \"One directory up\""
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4369 ../../src/MaximaCommandMenus.cpp:4375
-#: ../../src/MaximaCommandMenus.cpp:4380
+#: ../../src/MaximaCommandMenus.cpp:4429 ../../src/MaximaCommandMenus.cpp:4435
+#: ../../src/MaximaCommandMenus.cpp:4440
 msgid "\"..\" means \"one directory up\"."
 msgstr ""
 
@@ -244,7 +244,7 @@ msgstr ""
 msgid "%d differences"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1829
+#: ../../src/wxMaxima.cpp:1831
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
@@ -264,7 +264,7 @@ msgstr ""
 msgid "%s: Can't interpret line: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2857
+#: ../../src/wxMaxima.cpp:2859
 #, c-format
 msgid ""
 "%sCould not write the setting for:%s\n"
@@ -531,7 +531,7 @@ msgstr ""
 msgid "(Animation)"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:769
+#: ../../src/MaximaProcessManager.cpp:771
 msgid "(Config tells to suppress the output of long cells)"
 msgstr ""
 
@@ -609,7 +609,7 @@ msgstr ""
 msgid "... [suppressed additional lines as the output is longer than allowed in the wxMaxima configuration] "
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:4647
+#: ../../src/worksheet/Worksheet.cpp:4657
 msgid ".wxm clipboard data with unusual header"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "3D"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1833
+#: ../../src/wxMaxima.cpp:1835
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
@@ -662,7 +662,7 @@ msgstr ""
 msgid "A 'horizontal cursor' was introduced in wxMaxima 0.8.0. It looks like a horizontal line between cells. It indicates where a new cell will appear if you type or paste text or execute a menu command."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3039
+#: ../../src/MaximaCommandMenus.cpp:3099
 msgid "A Ctrl-F event"
 msgstr ""
 
@@ -680,7 +680,7 @@ msgid ""
 "Most probable cause: A missing comma between two list items."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2640
+#: ../../src/wxMaxima.cpp:2642
 #, c-format
 msgid "A find event, %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Add an element to the start of a list"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4437
+#: ../../src/MaximaCommandMenus.cpp:4497
 msgid "Add dir to path:"
 msgstr ""
 
@@ -1084,7 +1084,7 @@ msgstr ""
 msgid "Announce Maxima's output as MathML"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:5457 ../../src/wxMaximaFrame.cpp:1989
+#: ../../src/worksheet/Worksheet.cpp:5467 ../../src/wxMaximaFrame.cpp:1989
 msgid "Anonymize Code for Bug Report"
 msgstr ""
 
@@ -1155,23 +1155,23 @@ msgstr ""
 msgid "Arabic"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4129
+#: ../../src/MaximaCommandMenus.cpp:4189
 msgid "Are the chars equal, if case is ignored?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4124
+#: ../../src/MaximaCommandMenus.cpp:4184
 msgid "Are the chars equal?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4161
+#: ../../src/MaximaCommandMenus.cpp:4221
 msgid "Are these strings equal if case is ignored?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4156
+#: ../../src/MaximaCommandMenus.cpp:4216
 msgid "Are these strings equal?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4071
+#: ../../src/MaximaCommandMenus.cpp:4131
 msgid "Arguments:"
 msgstr ""
 
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Ascending by magnitude (numeric only)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4120 ../../src/MaximaCommandMenus.cpp:4166
+#: ../../src/MaximaCommandMenus.cpp:4180 ../../src/MaximaCommandMenus.cpp:4226
 msgid "Ascii code to char"
 msgstr ""
 
@@ -1210,11 +1210,11 @@ msgstr ""
 msgid "Asking the user for the location of a working maxima binary"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3492
+#: ../../src/MaximaCommandMenus.cpp:3552
 msgid "Assignment(s):"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3493
+#: ../../src/MaximaCommandMenus.cpp:3553
 msgid "Assignments of the format a=10,b=20"
 msgstr ""
 
@@ -1292,7 +1292,7 @@ msgstr ""
 msgid "Autosubscript numbers and text following single letters"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:2989
+#: ../../src/MaximaCommandMenus.cpp:3049
 msgid "Autosubscript this variable"
 msgstr ""
 
@@ -1332,12 +1332,12 @@ msgstr ""
 msgid "Batch File"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2077
+#: ../../src/wxMaxima.cpp:2079
 #, c-format
 msgid "Batch mode: %d image(s) could not be loaded at all."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2082
+#: ../../src/wxMaxima.cpp:2084
 #, c-format
 msgid "Batch mode: %d image(s) failed to decode/render (--debug)."
 msgstr ""
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Bold"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2259
+#: ../../src/wxMaxima.cpp:2261
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
@@ -1422,23 +1422,23 @@ msgstr ""
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:4183
+#: ../../src/worksheet/Worksheet.cpp:4193
 msgid "Bug: Cell with negative y position!"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:5895
+#: ../../src/worksheet/Worksheet.cpp:5905
 msgid "Bug: Encountered a heading I don't know how to move in one sectioning unit"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:5942
+#: ../../src/worksheet/Worksheet.cpp:5952
 msgid "Bug: Encountered a heading I don't know how to move out one sectioning unit"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:2234
+#: ../../src/worksheet/Worksheet.cpp:2244
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:4283
+#: ../../src/worksheet/Worksheet.cpp:4293
 msgid "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
@@ -1469,15 +1469,15 @@ msgstr ""
 #: ../../src/cells/AnimationCell.cpp:543 ../../src/cells/EditorCell.cpp:2968
 #: ../../src/cells/ImgCell.cpp:353 ../../src/graphical_io/BitmapOut.cpp:161
 #: ../../src/graphical_io/OutCommon.cpp:264
-#: ../../src/worksheet/Worksheet.cpp:1754
-#: ../../src/worksheet/Worksheet.cpp:1891
-#: ../../src/worksheet/Worksheet.cpp:1933
-#: ../../src/worksheet/Worksheet.cpp:1967
-#: ../../src/worksheet/Worksheet.cpp:1996
-#: ../../src/worksheet/Worksheet.cpp:2008
-#: ../../src/worksheet/Worksheet.cpp:3502
-#: ../../src/worksheet/Worksheet.cpp:4631
-#: ../../src/worksheet/Worksheet.cpp:4856
+#: ../../src/worksheet/Worksheet.cpp:1764
+#: ../../src/worksheet/Worksheet.cpp:1901
+#: ../../src/worksheet/Worksheet.cpp:1943
+#: ../../src/worksheet/Worksheet.cpp:1977
+#: ../../src/worksheet/Worksheet.cpp:2006
+#: ../../src/worksheet/Worksheet.cpp:2018
+#: ../../src/worksheet/Worksheet.cpp:3512
+#: ../../src/worksheet/Worksheet.cpp:4641
+#: ../../src/worksheet/Worksheet.cpp:4866
 msgid "Bug: The clipboard is already opened"
 msgstr ""
 
@@ -1497,11 +1497,11 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:5939
+#: ../../src/worksheet/Worksheet.cpp:5949
 msgid "Bug: Trying to move a title out by one sectioning unit"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:4915
+#: ../../src/worksheet/Worksheet.cpp:4925
 msgid "Bug: Trying to move the horizontally-drawn cursor to a place inside a GroupCell."
 msgstr ""
 
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "By default, Shift-Enter is used to evaluate commands, while Enter is used for multiline input. This behaviour can be changed in 'Edit->Configure' dialog by checking 'Enter evaluates cells'. This switches the roles of these two key commands."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4087
+#: ../../src/MaximaCommandMenus.cpp:4147
 msgid "Byte:"
 msgstr ""
 
@@ -1651,16 +1651,16 @@ msgstr ""
 msgid "Can be specified as flag in ev(exp, flag)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3436
+#: ../../src/wxMaxima.cpp:3438
 msgid "Can not connect to the web server."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3382 ../../src/wxMaxima.cpp:3418
-#: ../../src/wxMaxima.cpp:3470
+#: ../../src/wxMaxima.cpp:3384 ../../src/wxMaxima.cpp:3420
+#: ../../src/wxMaxima.cpp:3472
 msgid "Can not download version info."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:575 ../../src/wxMaxima.cpp:1579
+#: ../../src/MaximaProcessManager.cpp:577 ../../src/wxMaxima.cpp:1581
 msgid "Can not start Maxima. The most probable cause is that Maxima isn't installed (it can be downloaded from https://maxima.sourceforge.io) or in wxMaxima's config dialogue the setting for Maxima's location is wrong."
 msgstr ""
 
@@ -1698,7 +1698,7 @@ msgstr ""
 #: ../../src/wizards/SeriesWiz.cpp:52 ../../src/wizards/SubstituteWiz.cpp:42
 #: ../../src/wizards/SubstituteWiz.cpp:44 ../../src/wizards/SumWiz.cpp:48
 #: ../../src/wizards/SumWiz.cpp:50 ../../src/wizards/SystemWiz.cpp:39
-#: ../../src/wizards/SystemWiz.cpp:41 ../../src/wxMaxima.cpp:3507
+#: ../../src/wizards/SystemWiz.cpp:41 ../../src/wxMaxima.cpp:3509
 msgid "Cancel"
 msgstr ""
 
@@ -1706,7 +1706,7 @@ msgstr ""
 msgid "Cannot authenticate Maxima!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1281
+#: ../../src/wxMaxima.cpp:1283
 #, c-format
 msgid "Cannot cache the list of known symbols to %s"
 msgstr ""
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "Cannot create a font based on %s. Falling back to a default font."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:368
+#: ../../src/MaximaProcessManager.cpp:370
 msgid "Cannot find a maxima binary and no binary chosen in the config dialogue."
 msgstr ""
 
@@ -1730,8 +1730,8 @@ msgstr ""
 msgid "Cannot interpret the numeric value of pid %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3345 ../../src/wxMaxima.cpp:3352
-#: ../../src/wxMaxima.cpp:3359
+#: ../../src/wxMaxima.cpp:3347 ../../src/wxMaxima.cpp:3354
+#: ../../src/wxMaxima.cpp:3361
 #, c-format
 msgid "Cannot interpret version number component %s"
 msgstr ""
@@ -1763,20 +1763,24 @@ msgstr ""
 msgid "Cannot save the list of subjects manual contains to the file %s."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:189
+#: ../../src/MaximaProcessManager.cpp:191
 msgid "Cannot set the communication address to localhost."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:191
+#: ../../src/MaximaProcessManager.cpp:193
 #, c-format
 msgid "Cannot set the communication port to %i."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:2785 ../../src/MaximaResponseReader.cpp:880
+#: ../../src/MaximaCommandMenus.cpp:2795 ../../src/MaximaResponseReader.cpp:880
 msgid "Cannot start gnuplot"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:339 ../../src/StatusBar.cpp:254
+#: ../../src/MaximaCommandMenus.cpp:2844
+msgid "Cannot start the headless gnuplot warnings check"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:341 ../../src/StatusBar.cpp:254
 msgid "Cannot start the maxima binary"
 msgstr ""
 
@@ -1808,7 +1812,7 @@ msgstr ""
 msgid "Cell bracket fill, Inactive"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3080
+#: ../../src/wxMaxima.cpp:3082
 msgid "Cell ends in a backslash"
 msgstr ""
 
@@ -1821,7 +1825,7 @@ msgstr ""
 msgid "Change &2d Display"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3581
+#: ../../src/MaximaCommandMenus.cpp:3641
 msgid "Change Image"
 msgstr ""
 
@@ -1833,7 +1837,7 @@ msgstr ""
 msgid "Change Log"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4367
+#: ../../src/MaximaCommandMenus.cpp:4427
 msgid "Change directory"
 msgstr ""
 
@@ -1877,20 +1881,20 @@ msgstr ""
 msgid "Changed option variables"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3639
+#: ../../src/MaximaCommandMenus.cpp:3699
 #, c-format
 msgid "Changing image originally loaded from file %s to %s."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4125 ../../src/MaximaCommandMenus.cpp:4130
-#: ../../src/MaximaCommandMenus.cpp:4135 ../../src/MaximaCommandMenus.cpp:4141
-#: ../../src/MaximaCommandMenus.cpp:4146 ../../src/MaximaCommandMenus.cpp:4152
+#: ../../src/MaximaCommandMenus.cpp:4185 ../../src/MaximaCommandMenus.cpp:4190
+#: ../../src/MaximaCommandMenus.cpp:4195 ../../src/MaximaCommandMenus.cpp:4201
+#: ../../src/MaximaCommandMenus.cpp:4206 ../../src/MaximaCommandMenus.cpp:4212
 msgid "Char #1:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4126 ../../src/MaximaCommandMenus.cpp:4131
-#: ../../src/MaximaCommandMenus.cpp:4136 ../../src/MaximaCommandMenus.cpp:4141
-#: ../../src/MaximaCommandMenus.cpp:4147 ../../src/MaximaCommandMenus.cpp:4152
+#: ../../src/MaximaCommandMenus.cpp:4186 ../../src/MaximaCommandMenus.cpp:4191
+#: ../../src/MaximaCommandMenus.cpp:4196 ../../src/MaximaCommandMenus.cpp:4201
+#: ../../src/MaximaCommandMenus.cpp:4207 ../../src/MaximaCommandMenus.cpp:4212
 msgid "Char #2:"
 msgstr ""
 
@@ -1898,15 +1902,15 @@ msgstr ""
 msgid "Char to Unicode code point..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4170 ../../src/MaximaCommandMenus.cpp:4174
+#: ../../src/MaximaCommandMenus.cpp:4230 ../../src/MaximaCommandMenus.cpp:4234
 msgid "Char to unicode code point"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4097 ../../src/MaximaCommandMenus.cpp:4101
-#: ../../src/MaximaCommandMenus.cpp:4105 ../../src/MaximaCommandMenus.cpp:4109
-#: ../../src/MaximaCommandMenus.cpp:4113 ../../src/MaximaCommandMenus.cpp:4117
-#: ../../src/MaximaCommandMenus.cpp:4171 ../../src/MaximaCommandMenus.cpp:4175
-#: ../../src/MaximaCommandMenus.cpp:4247
+#: ../../src/MaximaCommandMenus.cpp:4157 ../../src/MaximaCommandMenus.cpp:4161
+#: ../../src/MaximaCommandMenus.cpp:4165 ../../src/MaximaCommandMenus.cpp:4169
+#: ../../src/MaximaCommandMenus.cpp:4173 ../../src/MaximaCommandMenus.cpp:4177
+#: ../../src/MaximaCommandMenus.cpp:4231 ../../src/MaximaCommandMenus.cpp:4235
+#: ../../src/MaximaCommandMenus.cpp:4307
 msgid "Char:"
 msgstr ""
 
@@ -1918,7 +1922,7 @@ msgstr ""
 msgid "Characteristic polynom"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4092
+#: ../../src/MaximaCommandMenus.cpp:4152
 msgid "Chars are strings that are one character long"
 msgstr ""
 
@@ -2056,7 +2060,7 @@ msgstr ""
 msgid "Close\tCtrl+W"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4047
+#: ../../src/MaximaCommandMenus.cpp:4107
 msgid "Close Stream"
 msgstr ""
 
@@ -2108,11 +2112,11 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4121 ../../src/MaximaCommandMenus.cpp:4167
+#: ../../src/MaximaCommandMenus.cpp:4181 ../../src/MaximaCommandMenus.cpp:4227
 msgid "Code number:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4179 ../../src/MaximaCommandMenus.cpp:4185
+#: ../../src/MaximaCommandMenus.cpp:4239 ../../src/MaximaCommandMenus.cpp:4245
 msgid "Codepoint number:"
 msgstr ""
 
@@ -2152,7 +2156,7 @@ msgstr ""
 msgid "Comma"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3139
+#: ../../src/wxMaxima.cpp:3141
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -2164,11 +2168,11 @@ msgstr ""
 msgid "Comma separated y coordinates"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4071
+#: ../../src/MaximaCommandMenus.cpp:4131
 msgid "Comma-separated arguments"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3869 ../../src/MaximaCommandMenus.cpp:3878
+#: ../../src/MaximaCommandMenus.cpp:3929 ../../src/MaximaCommandMenus.cpp:3938
 msgid "Comma-separated commands"
 msgstr ""
 
@@ -2177,7 +2181,7 @@ msgid "Comma-separated elements"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:933 ../../src/MaximaCommandMenus.cpp:947
-#: ../../src/MaximaCommandMenus.cpp:3460
+#: ../../src/MaximaCommandMenus.cpp:3520
 msgid "Comma-separated equations"
 msgstr ""
 
@@ -2187,19 +2191,19 @@ msgstr ""
 msgid "Comma-separated expressions"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4027
+#: ../../src/MaximaCommandMenus.cpp:4087
 msgid "Comma-separated expressions that shall be converted to a string"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3912 ../../src/MaximaCommandMenus.cpp:3926
+#: ../../src/MaximaCommandMenus.cpp:3972 ../../src/MaximaCommandMenus.cpp:3986
 msgid "Comma-separated expressions."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3885 ../../src/MaximaCommandMenus.cpp:3980
+#: ../../src/MaximaCommandMenus.cpp:3945 ../../src/MaximaCommandMenus.cpp:4040
 msgid "Comma-separated function names"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3898
+#: ../../src/MaximaCommandMenus.cpp:3958
 msgid "Comma-separated function names."
 msgstr ""
 
@@ -2208,19 +2212,19 @@ msgstr ""
 msgid "Comma-separated list entry in the format val1=1,val2=2"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4017
+#: ../../src/MaximaCommandMenus.cpp:4077
 msgid "Comma-separated names of the elements that shall be written"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3911
+#: ../../src/MaximaCommandMenus.cpp:3971
 msgid "Comma-separated names the parameters will be referenced by later."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4300 ../../src/MaximaCommandMenus.cpp:4305
+#: ../../src/MaximaCommandMenus.cpp:4360 ../../src/MaximaCommandMenus.cpp:4365
 msgid "Comma-separated numbers from 0 to 255"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3949 ../../src/MaximaCommandMenus.cpp:3962
+#: ../../src/MaximaCommandMenus.cpp:4009 ../../src/MaximaCommandMenus.cpp:4022
 msgid "Comma-separated parameter names. A parameter in square brackets [] will be filled with the list of any additional arguments the function gets."
 msgstr ""
 
@@ -2228,13 +2232,13 @@ msgstr ""
 msgid "Comma-separated part numbers selecting the subexpression to replace (as in part())"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3866
+#: ../../src/MaximaCommandMenus.cpp:3926
 msgid "Comma-separated variable names, can be initialized by the \":\" operator."
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:711 ../../src/MaximaCommandMenus.cpp:792
 #: ../../src/MaximaCommandMenus.cpp:934 ../../src/MaximaCommandMenus.cpp:948
-#: ../../src/MaximaCommandMenus.cpp:3461
+#: ../../src/MaximaCommandMenus.cpp:3521
 msgid "Comma-separated variables"
 msgstr ""
 
@@ -2282,7 +2286,7 @@ msgstr ""
 msgid "Compile a QR decomposition using dgeqrf"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3974
+#: ../../src/MaximaCommandMenus.cpp:4034
 msgid "Compile a function"
 msgstr ""
 
@@ -2310,7 +2314,7 @@ msgstr ""
 msgid "Compile function..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4323
+#: ../../src/MaximaCommandMenus.cpp:4383
 msgid "Compile regex"
 msgstr ""
 
@@ -2323,7 +2327,7 @@ msgstr ""
 msgid "Compiling %s"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3975
+#: ../../src/MaximaCommandMenus.cpp:4035
 msgid "Compiling a function can generate a considerable speed boost if the types of the function parameters are made known to the function before it is compiled. Else the generated code has to be hideously generic."
 msgstr ""
 
@@ -2408,11 +2412,11 @@ msgstr ""
 msgid "Connect the dots"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:163
+#: ../../src/MaximaProcessManager.cpp:165
 msgid "Connection attempt, but connection failed."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:790
+#: ../../src/MaximaProcessManager.cpp:792
 msgid "Connection to Maxima lost."
 msgstr ""
 
@@ -2434,7 +2438,7 @@ msgstr ""
 msgid "Contents"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3970
+#: ../../src/MaximaCommandMenus.cpp:4030
 msgid "Contents:"
 msgstr ""
 
@@ -2522,11 +2526,11 @@ msgstr ""
 msgid "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4223
+#: ../../src/MaximaCommandMenus.cpp:4283
 msgid "Convert string to lowercase"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4355
+#: ../../src/MaximaCommandMenus.cpp:4415
 msgid "Convert string to matching regex"
 msgstr ""
 
@@ -2582,11 +2586,11 @@ msgstr ""
 msgid "Convert to downcase..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3828
+#: ../../src/MaximaCommandMenus.cpp:3888
 msgid "Convert to programming language"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3834
+#: ../../src/MaximaCommandMenus.cpp:3894
 msgid "Convert to programming language file"
 msgstr ""
 
@@ -2689,7 +2693,7 @@ msgstr ""
 msgid "Copy as plain text"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4388
+#: ../../src/MaximaCommandMenus.cpp:4448
 msgid "Copy file"
 msgstr ""
 
@@ -2747,7 +2751,7 @@ msgstr ""
 msgid "Copy selection from document in a MathML format many word processors can display as 2d equation"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4215
+#: ../../src/MaximaCommandMenus.cpp:4275
 msgid "Copy string"
 msgstr ""
 
@@ -2791,7 +2795,7 @@ msgstr ""
 msgid "Could not make sure that we talk to the maxima we started => discarding all data it sends."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:891
+#: ../../src/MaximaProcessManager.cpp:893
 msgid "Could not map view of the file needed in order to send an interrupt signal to maxima."
 msgstr ""
 
@@ -2799,8 +2803,8 @@ msgstr ""
 msgid "Could not parse the SVG image data."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:871
-#: ../../src/MaximaProcessManager.cpp:914
+#: ../../src/MaximaProcessManager.cpp:873
+#: ../../src/MaximaProcessManager.cpp:916
 msgid "Could not send an interrupt signal to maxima."
 msgstr ""
 
@@ -2844,7 +2848,7 @@ msgstr ""
 msgid "Create copy, not clone..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4373
+#: ../../src/MaximaCommandMenus.cpp:4433
 msgid "Create directory"
 msgstr ""
 
@@ -2852,7 +2856,7 @@ msgstr ""
 msgid "Create directory..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4231
+#: ../../src/MaximaCommandMenus.cpp:4291
 msgid "Create empty string"
 msgstr ""
 
@@ -2892,7 +2896,7 @@ msgstr ""
 msgid "Csv files (*.csv)|*.csv|Text files (*.txt)|*.txt|All|*"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:6115
+#: ../../src/worksheet/Worksheet.cpp:6125
 msgid "Cursor"
 msgstr ""
 
@@ -2943,7 +2947,7 @@ msgstr ""
 #: ../../src/MaximaCommandMenus.cpp:1785 ../../src/MaximaCommandMenus.cpp:1789
 #: ../../src/MaximaCommandMenus.cpp:1793 ../../src/MaximaCommandMenus.cpp:1797
 #: ../../src/MaximaCommandMenus.cpp:1801 ../../src/MaximaCommandMenus.cpp:1815
-#: ../../src/MaximaCommandMenus.cpp:1822 ../../src/MaximaCommandMenus.cpp:3459
+#: ../../src/MaximaCommandMenus.cpp:1822 ../../src/MaximaCommandMenus.cpp:3519
 msgid "Data:"
 msgstr ""
 
@@ -2955,11 +2959,11 @@ msgstr ""
 msgid "Declare Text to always be displayed as subscript"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3881
+#: ../../src/MaximaCommandMenus.cpp:3941
 msgid "Declare a function local to a Program"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:2999
+#: ../../src/MaximaCommandMenus.cpp:3059
 msgid "Declare a text snippet to always be displayed as subscript"
 msgstr ""
 
@@ -2972,7 +2976,7 @@ msgstr ""
 msgid "Declare main variable:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3983
+#: ../../src/MaximaCommandMenus.cpp:4043
 msgid "Declare the type of a function parameter"
 msgstr ""
 
@@ -3000,23 +3004,23 @@ msgstr ""
 msgid "Default port for communication with wxMaxima:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3946
+#: ../../src/MaximaCommandMenus.cpp:4006
 msgid "Define a function"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3959
+#: ../../src/MaximaCommandMenus.cpp:4019
 msgid "Define a macro"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4001
+#: ../../src/MaximaCommandMenus.cpp:4061
 msgid "Define a structure"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3995
+#: ../../src/MaximaCommandMenus.cpp:4055
 msgid "Define a structure type"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3968
+#: ../../src/MaximaCommandMenus.cpp:4028
 msgid "Define a variable"
 msgstr ""
 
@@ -3081,7 +3085,7 @@ msgstr ""
 msgid "Delete all values from memory"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4400
+#: ../../src/MaximaCommandMenus.cpp:4460
 msgid "Delete file"
 msgstr ""
 
@@ -3089,11 +3093,11 @@ msgstr ""
 msgid "Delete file..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4495
+#: ../../src/MaximaCommandMenus.cpp:4555
 msgid "Delete function(s)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4491
+#: ../../src/MaximaCommandMenus.cpp:4551
 msgid "Delete named object(s)"
 msgstr ""
 
@@ -3101,11 +3105,11 @@ msgstr ""
 msgid "Delete named object..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4486
+#: ../../src/MaximaCommandMenus.cpp:4546
 msgid "Delete variable(s)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4242
+#: ../../src/MaximaCommandMenus.cpp:4302
 msgid "Delimiter:"
 msgstr ""
 
@@ -3194,7 +3198,7 @@ msgstr ""
 msgid "Didn't find the maxima HTML manual."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1683
+#: ../../src/wxMaxima.cpp:1685
 msgid "Didn't get a help browser launch program command line, but can request the system's default help browser."
 msgstr ""
 
@@ -3211,7 +3215,7 @@ msgstr ""
 msgid "Difference %d / %d"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:264 ../../src/MaximaCommandMenus.cpp:3484
+#: ../../src/MaximaCommandMenus.cpp:264 ../../src/MaximaCommandMenus.cpp:3544
 msgid "Differentiate"
 msgstr ""
 
@@ -3227,7 +3231,7 @@ msgstr ""
 msgid "Differentiates an expression n times"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3484
+#: ../../src/MaximaCommandMenus.cpp:3544
 msgid "Differentiates the expression n times"
 msgstr ""
 
@@ -3255,7 +3259,7 @@ msgstr ""
 msgid "Display Te&X Form"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3784
+#: ../../src/MaximaCommandMenus.cpp:3844
 msgid "Display algorithm"
 msgstr ""
 
@@ -3279,11 +3283,11 @@ msgstr ""
 msgid "Display equations"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:2968
+#: ../../src/MaximaCommandMenus.cpp:3028
 msgid "Display expression in maxima's internal representation"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:2974
+#: ../../src/MaximaCommandMenus.cpp:3034
 msgid "Display expression in wxMaxima's internal representation"
 msgstr ""
 
@@ -3349,7 +3353,7 @@ msgstr ""
 msgid "Do for each list element"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3501
+#: ../../src/wxMaxima.cpp:3503
 #, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr ""
@@ -3386,11 +3390,11 @@ msgstr ""
 msgid "Don't evaluate Expression..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3929
+#: ../../src/MaximaCommandMenus.cpp:3989
 msgid "Don't evaluate one command"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3941
+#: ../../src/MaximaCommandMenus.cpp:4001
 msgid "Don't evaluate one whole expression"
 msgstr ""
 
@@ -3404,7 +3408,7 @@ msgstr ""
 msgid "Don't mark this message text in yellow"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3507
+#: ../../src/wxMaxima.cpp:3509
 msgid "Don't save"
 msgstr ""
 
@@ -3526,7 +3530,7 @@ msgstr ""
 msgid "Element:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4016
+#: ../../src/MaximaCommandMenus.cpp:4076
 msgid "Elements:"
 msgstr ""
 
@@ -3551,7 +3555,7 @@ msgstr ""
 msgid "Encountered an unknown XML tag: <%s>"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:135
+#: ../../src/MaximaProcessManager.cpp:137
 msgid "Encountered an unknown socket event."
 msgstr ""
 
@@ -3691,7 +3695,7 @@ msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:150 ../../src/MaximaCommandMenus.cpp:170
 #: ../../src/MaximaCommandMenus.cpp:957 ../../src/MaximaCommandMenus.cpp:969
-#: ../../src/MaximaCommandMenus.cpp:1832 ../../src/MaximaCommandMenus.cpp:3468
+#: ../../src/MaximaCommandMenus.cpp:1832 ../../src/MaximaCommandMenus.cpp:3528
 msgid "Equation:"
 msgstr ""
 
@@ -3703,17 +3707,17 @@ msgstr ""
 #: ../../src/MaximaFileIO.cpp:130 ../../src/MaximaFileIO.cpp:399
 #: ../../src/MaximaFileIO.cpp:410 ../../src/MaximaFileIO.cpp:528
 #: ../../src/MaximaFileIO.cpp:557 ../../src/MaximaFileIO.cpp:568
-#: ../../src/MaximaProcessManager.cpp:579 ../../src/WXMXformat.cpp:260
+#: ../../src/MaximaProcessManager.cpp:581 ../../src/WXMXformat.cpp:260
 #: ../../src/WXMXformat.cpp:290 ../../src/WXMXformat.cpp:298
 #: ../../src/WXMXformat.cpp:313 ../../src/WXMXformat.cpp:334
 #: ../../src/WXMXformat.cpp:364 ../../src/dialogs/BinaryNameCtrl.cpp:78
-#: ../../src/main.cpp:725 ../../src/wxMaxima.cpp:3382
-#: ../../src/wxMaxima.cpp:3418 ../../src/wxMaxima.cpp:3436
-#: ../../src/wxMaxima.cpp:3470
+#: ../../src/main.cpp:725 ../../src/wxMaxima.cpp:3384
+#: ../../src/wxMaxima.cpp:3420 ../../src/wxMaxima.cpp:3438
+#: ../../src/wxMaxima.cpp:3472
 msgid "Error"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:787
+#: ../../src/MaximaProcessManager.cpp:789
 msgid "Error writing to Maxima"
 msgstr ""
 
@@ -3747,7 +3751,7 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4356
+#: ../../src/MaximaCommandMenus.cpp:4416
 msgid "Escapes all special characters in a string. The result is a regex that matches this string exactly."
 msgstr ""
 
@@ -3857,7 +3861,7 @@ msgstr ""
 msgid "Evaluate current cell"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4207
+#: ../../src/MaximaCommandMenus.cpp:4267
 msgid "Evaluate string"
 msgstr ""
 
@@ -4010,7 +4014,7 @@ msgstr ""
 msgid "Export successful."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3408
+#: ../../src/MaximaCommandMenus.cpp:3468
 msgid "Export the selected output(s) to this folder"
 msgstr ""
 
@@ -4022,12 +4026,12 @@ msgstr ""
 msgid "Export visible commands to a .mac file"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3417
+#: ../../src/MaximaCommandMenus.cpp:3477
 #, c-format
 msgid "Exported %d output image(s) to %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2198 ../../src/wxMaxima.cpp:2240
+#: ../../src/wxMaxima.cpp:2200 ../../src/wxMaxima.cpp:2242
 #, c-format
 msgid "Exported the worksheet to %s"
 msgstr ""
@@ -4058,13 +4062,13 @@ msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:625 ../../src/MaximaCommandMenus.cpp:630
 #: ../../src/MaximaCommandMenus.cpp:650 ../../src/MaximaCommandMenus.cpp:1408
-#: ../../src/MaximaCommandMenus.cpp:2970 ../../src/MaximaCommandMenus.cpp:2976
-#: ../../src/MaximaCommandMenus.cpp:3494 ../../src/sidebars/DrawSidebar.cpp:54
+#: ../../src/MaximaCommandMenus.cpp:3030 ../../src/MaximaCommandMenus.cpp:3036
+#: ../../src/MaximaCommandMenus.cpp:3554 ../../src/sidebars/DrawSidebar.cpp:54
 #: ../../src/wizards/Plot3dWiz.cpp:32
 msgid "Expression"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3831 ../../src/MaximaCommandMenus.cpp:3837
+#: ../../src/MaximaCommandMenus.cpp:3891 ../../src/MaximaCommandMenus.cpp:3897
 msgid "Expression or a list of comma-separated expressions"
 msgstr ""
 
@@ -4088,11 +4092,11 @@ msgstr ""
 msgid "Expression to string..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3925
+#: ../../src/MaximaCommandMenus.cpp:3985
 msgid "Expression whose output is to be used as maxima's input."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4026 ../../src/wizards/Plot2dWiz.cpp:39
+#: ../../src/MaximaCommandMenus.cpp:4086 ../../src/wizards/Plot2dWiz.cpp:39
 msgid "Expression(s):"
 msgstr ""
 
@@ -4101,7 +4105,7 @@ msgstr ""
 #: ../../src/MaximaCommandMenus.cpp:235 ../../src/MaximaCommandMenus.cpp:252
 #: ../../src/MaximaCommandMenus.cpp:258 ../../src/MaximaCommandMenus.cpp:265
 #: ../../src/MaximaCommandMenus.cpp:297 ../../src/MaximaCommandMenus.cpp:316
-#: ../../src/MaximaCommandMenus.cpp:3485 ../../src/wizards/IntegrateWiz.cpp:33
+#: ../../src/MaximaCommandMenus.cpp:3545 ../../src/wizards/IntegrateWiz.cpp:33
 #: ../../src/wizards/LimitWiz.cpp:29 ../../src/wizards/SeriesWiz.cpp:30
 #: ../../src/wizards/SubstituteWiz.cpp:29 ../../src/wizards/SumWiz.cpp:31
 msgid "Expression:"
@@ -4171,11 +4175,11 @@ msgstr ""
 msgid "Extract dir from path..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4417
+#: ../../src/MaximaCommandMenus.cpp:4477
 msgid "Extract directory part"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4429
+#: ../../src/MaximaCommandMenus.cpp:4489
 msgid "Extract file type extension"
 msgstr ""
 
@@ -4183,7 +4187,7 @@ msgstr ""
 msgid "Extract filename from path..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4423
+#: ../../src/MaximaCommandMenus.cpp:4483
 msgid "Extract filename part"
 msgstr ""
 
@@ -4215,7 +4219,7 @@ msgstr ""
 msgid "Extract the last n list elements"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4188
+#: ../../src/MaximaCommandMenus.cpp:4248
 msgid "Extract the nth char of a string"
 msgstr ""
 
@@ -4273,11 +4277,11 @@ msgstr ""
 msgid "Failed to delete gnuplot file %s"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:350
+#: ../../src/MaximaProcessManager.cpp:352
 msgid "Failed to start Maxima"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:626
+#: ../../src/MaximaProcessManager.cpp:628
 msgid "Failed to write to Maxima's stdin (LDB)."
 msgstr ""
 
@@ -4289,7 +4293,7 @@ msgstr ""
 msgid "Fast list access"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:216
+#: ../../src/MaximaProcessManager.cpp:218
 msgid "Fatal error"
 msgstr ""
 
@@ -4297,15 +4301,15 @@ msgstr ""
 msgid "Field Separator"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4003
+#: ../../src/MaximaCommandMenus.cpp:4063
 msgid "Field contents:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4010
+#: ../../src/MaximaCommandMenus.cpp:4070
 msgid "Field name:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3997
+#: ../../src/MaximaCommandMenus.cpp:4057
 msgid "Fields:"
 msgstr ""
 
@@ -4329,12 +4333,12 @@ msgstr ""
 msgid "File could not be opened"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4053 ../../src/MaximaCommandMenus.cpp:4058
-#: ../../src/MaximaCommandMenus.cpp:4063
+#: ../../src/MaximaCommandMenus.cpp:4113 ../../src/MaximaCommandMenus.cpp:4118
+#: ../../src/MaximaCommandMenus.cpp:4123
 msgid "File name:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2993 ../../src/wxMaxima.cpp:3036
+#: ../../src/wxMaxima.cpp:2995 ../../src/wxMaxima.cpp:3038
 msgid "File not found"
 msgstr ""
 
@@ -4346,7 +4350,7 @@ msgstr ""
 msgid "File operations"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2992 ../../src/wxMaxima.cpp:3035
+#: ../../src/wxMaxima.cpp:2994 ../../src/wxMaxima.cpp:3037
 msgid "File you tried to open does not exist."
 msgstr ""
 
@@ -4358,7 +4362,7 @@ msgstr ""
 msgid "Filename"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3839
+#: ../../src/MaximaCommandMenus.cpp:3899
 msgid "Filename or a list of comma-separated file names"
 msgstr ""
 
@@ -4418,7 +4422,7 @@ msgstr ""
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3043
+#: ../../src/MaximaCommandMenus.cpp:3103
 msgid "Find and Replace"
 msgstr ""
 
@@ -4427,7 +4431,7 @@ msgstr ""
 msgid "Find and replace"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4246
+#: ../../src/MaximaCommandMenus.cpp:4306
 msgid "Find char in string"
 msgstr ""
 
@@ -4447,7 +4451,7 @@ msgstr ""
 msgid "Find eigenvectors of a matrix"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4236
+#: ../../src/MaximaCommandMenus.cpp:4296
 msgid "Find first difference"
 msgstr ""
 
@@ -4467,7 +4471,7 @@ msgstr ""
 msgid "Find numerical solution..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3464
+#: ../../src/MaximaCommandMenus.cpp:3524
 msgid "Find root (solve numerically)"
 msgstr ""
 
@@ -4512,7 +4516,7 @@ msgstr ""
 msgid "Fixed font in text controls"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4039
+#: ../../src/MaximaCommandMenus.cpp:4099
 msgid "Flush stream"
 msgstr ""
 
@@ -4574,7 +4578,7 @@ msgid ""
 "   Ctrl+7: Heading6 cell\n"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3850
+#: ../../src/MaximaCommandMenus.cpp:3910
 msgid "For loop"
 msgstr ""
 
@@ -4586,11 +4590,11 @@ msgstr ""
 msgid "Format:"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3521
+#: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3523
 msgid "Forwarding the keyboard focus to a text control"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3524
+#: ../../src/wxMaxima.cpp:3526
 msgid "Forwarding the keyboard focus to the worksheet"
 msgstr ""
 
@@ -4678,7 +4682,7 @@ msgstr ""
 msgid "Full-window repaints:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3952
+#: ../../src/MaximaCommandMenus.cpp:4012
 msgid "Function contents:"
 msgstr ""
 
@@ -4690,11 +4694,11 @@ msgstr ""
 msgid "Function name"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3979
+#: ../../src/MaximaCommandMenus.cpp:4039
 msgid "Function name(s):"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3947 ../../src/MaximaCommandMenus.cpp:4496
+#: ../../src/MaximaCommandMenus.cpp:4007 ../../src/MaximaCommandMenus.cpp:4556
 msgid "Function name:"
 msgstr ""
 
@@ -4718,11 +4722,11 @@ msgstr ""
 msgid "GCD"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3655
+#: ../../src/MaximaCommandMenus.cpp:3715
 msgid "GIF image (*.gif)|*.gif"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3555
+#: ../../src/MaximaCommandMenus.cpp:3615
 msgid "GIF image (*.gif)|*.gif|Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
 
@@ -4810,7 +4814,7 @@ msgstr ""
 msgid "Get inverse Laplace transformation of an expression"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4035
+#: ../../src/MaximaCommandMenus.cpp:4095
 msgid "Get position in stream"
 msgstr ""
 
@@ -4826,7 +4830,7 @@ msgstr ""
 msgid "Get the real part of complex expression"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:1109
+#: ../../src/MaximaProcessManager.cpp:1220
 #, c-format
 msgid "Gnuplot (command line) found at: %s"
 msgstr ""
@@ -4835,19 +4839,26 @@ msgstr ""
 msgid "Gnuplot flavour"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:1107
+#: ../../src/MaximaProcessManager.cpp:1218
 #, c-format
 msgid "Gnuplot found at: %s"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:992
+#: ../../src/MaximaProcessManager.cpp:994
 msgid "Gnuplot has closed."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:1098
-#: ../../src/MaximaProcessManager.cpp:1103
+#: ../../src/MaximaProcessManager.cpp:1209
+#: ../../src/MaximaProcessManager.cpp:1214
 #, c-format
 msgid "Gnuplot not found, using the default: %s"
+msgstr ""
+
+#: ../../src/MaximaProcessManager.cpp:1097
+#, c-format
+msgid ""
+"Gnuplot reported the following while preparing the popped-out plot:\n"
+"%s"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:2071 ../../src/wxMaximaFrame.cpp:1924
@@ -4858,7 +4869,7 @@ msgstr ""
 msgid "Got a new input prompt!"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:4296
+#: ../../src/worksheet/Worksheet.cpp:4306
 msgid "Got a request to undo an action that involves a delete which isn't possible at this moment."
 msgstr ""
 
@@ -5111,7 +5122,7 @@ msgstr ""
 msgid "Identical to"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3874
+#: ../../src/MaximaCommandMenus.cpp:3934
 msgid "If a program doesn't need local variables, Maxima allows putting the commands between parentheses. The result of the last operation is the return value of the program."
 msgstr ""
 
@@ -5167,7 +5178,7 @@ msgstr ""
 msgid "If the thing maxima complains about actually looks like a polynomial you can try running it through ratdisrep() in order to fix that problem."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3984
+#: ../../src/MaximaCommandMenus.cpp:4044
 msgid ""
 "If the type of a function parameter is known when compiling a function the code can vastly be optimized.\n"
 "Known types:\n"
@@ -5230,8 +5241,8 @@ msgstr ""
 msgid "Image data had zero length!"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:2564 ../../src/MaximaCommandMenus.cpp:2873
-#: ../../src/MaximaCommandMenus.cpp:3582
+#: ../../src/MaximaCommandMenus.cpp:2564 ../../src/MaximaCommandMenus.cpp:2933
+#: ../../src/MaximaCommandMenus.cpp:3642
 msgid "Image files ("
 msgstr ""
 
@@ -5270,7 +5281,7 @@ msgid ""
 "If you change an element of one matrix the same element will change in all of its clones. copymatrix() instead generates a copy of a matrix: A new matrix that, if changed in any way, won't change the original."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4216
+#: ../../src/MaximaCommandMenus.cpp:4276
 msgid "In order to save memory the : operator doesn't create an individual copy of the string, but a clone that changes when the original string changes."
 msgstr ""
 
@@ -5522,7 +5533,7 @@ msgstr ""
 msgid "Insert a page break"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4201
+#: ../../src/MaximaCommandMenus.cpp:4261
 msgid "Insert a string into another"
 msgstr ""
 
@@ -5546,7 +5557,7 @@ msgstr ""
 msgid "Insert textbased cell"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:6121
+#: ../../src/worksheet/Worksheet.cpp:6131
 msgid "Insertion point between cells"
 msgstr ""
 
@@ -5554,11 +5565,11 @@ msgstr ""
 msgid "Instantiating the HTML manual browser"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:1066
+#: ../../src/MaximaProcessManager.cpp:1177
 msgid "Instructed to prefer gnuplot over wgnuplot"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:1054
+#: ../../src/MaximaProcessManager.cpp:1165
 msgid "Instructed to prefer wgnuplot over gnuplot"
 msgstr ""
 
@@ -5574,7 +5585,7 @@ msgstr ""
 msgid "Integral/Sum:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:240 ../../src/MaximaCommandMenus.cpp:3473
+#: ../../src/MaximaCommandMenus.cpp:240 ../../src/MaximaCommandMenus.cpp:3533
 #: ../../src/wizards/IntegrateWiz.cpp:73
 msgid "Integrate"
 msgstr ""
@@ -5632,11 +5643,11 @@ msgstr ""
 msgid "Interpret like input..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3916
+#: ../../src/MaximaCommandMenus.cpp:3976
 msgid "Interpret maxima's output as input"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4314
+#: ../../src/MaximaCommandMenus.cpp:4374
 msgid "Interpret string as maxima code"
 msgstr ""
 
@@ -5656,7 +5667,7 @@ msgstr ""
 msgid "Interrupt current computation. To completely restart maxima press the button left to this one."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:874
+#: ../../src/MaximaProcessManager.cpp:876
 #, c-format
 msgid "Interrupting maxima: %s"
 msgstr ""
@@ -5669,7 +5680,7 @@ msgstr ""
 msgid "Introduce the actual values for variables stored in the list"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3491
+#: ../../src/MaximaCommandMenus.cpp:3551
 msgid "Introduces one or more assignments into an expression"
 msgstr ""
 
@@ -5694,23 +5705,23 @@ msgstr ""
 msgid "Iota"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4150
+#: ../../src/MaximaCommandMenus.cpp:4210
 msgid "Is Char 1 greater than Char2, if case is ignored?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4145
+#: ../../src/MaximaCommandMenus.cpp:4205
 msgid "Is Char 1 greater than Char2?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4139
+#: ../../src/MaximaCommandMenus.cpp:4199
 msgid "Is Char 1 less than Char2, if case is ignored?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4134
+#: ../../src/MaximaCommandMenus.cpp:4194
 msgid "Is Char 1 less than Char2?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4092
+#: ../../src/MaximaCommandMenus.cpp:4152
 msgid "Is a char?"
 msgstr ""
 
@@ -5722,7 +5733,7 @@ msgstr ""
 msgid "Is a complex variable"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4104
+#: ../../src/MaximaCommandMenus.cpp:4164
 msgid "Is a digit?"
 msgstr ""
 
@@ -5730,11 +5741,11 @@ msgstr ""
 msgid "Is a digit?..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4116
+#: ../../src/MaximaCommandMenus.cpp:4176
 msgid "Is a lowercase char?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4108
+#: ../../src/MaximaCommandMenus.cpp:4168
 msgid "Is a printable char?"
 msgstr ""
 
@@ -5742,7 +5753,7 @@ msgstr ""
 msgid "Is a real variable"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4112
+#: ../../src/MaximaCommandMenus.cpp:4172
 msgid "Is a uppercase char?"
 msgstr ""
 
@@ -5754,11 +5765,11 @@ msgstr ""
 msgid "Is alphanumeric?..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4096
+#: ../../src/MaximaCommandMenus.cpp:4156
 msgid "Is an alphabetic char?"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4100
+#: ../../src/MaximaCommandMenus.cpp:4160
 msgid "Is an alphanumeric char?"
 msgstr ""
 
@@ -5810,11 +5821,11 @@ msgstr ""
 msgid "Issue a notification if maxima finishes calculating while the wxMaxima window isn't in focus."
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:4237
+#: ../../src/worksheet/Worksheet.cpp:4247
 msgid "Issuing the active cell's undo function"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:4241
+#: ../../src/worksheet/Worksheet.cpp:4251
 msgid "Issuing the worksheet's undo function"
 msgstr ""
 
@@ -5935,12 +5946,12 @@ msgstr ""
 msgid "Labels"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3902
+#: ../../src/MaximaCommandMenus.cpp:3962
 #: ../../src/sidebars/GreekSidebar.cpp:188
 msgid "Lambda"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3903
+#: ../../src/MaximaCommandMenus.cpp:3963
 msgid ""
 "Lambda generates a function, but doesn't give it a name.\n"
 "This is useful if you want to use a function only once, perhaps as a parameter to another function and don't need it to be named.\n"
@@ -5967,12 +5978,12 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:555
+#: ../../src/MaximaProcessManager.cpp:557
 #, c-format
 msgid "Last message from maxima's stderr: %s"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:542
+#: ../../src/MaximaProcessManager.cpp:544
 #, c-format
 msgid "Last message from maxima's stdout: %s"
 msgstr ""
@@ -5981,7 +5992,7 @@ msgstr ""
 msgid "Last n"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3085
+#: ../../src/wxMaxima.cpp:3087
 msgid "Last non-whitespace is a question mark"
 msgstr ""
 
@@ -5989,12 +6000,12 @@ msgstr ""
 msgid "Latvian"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1673
+#: ../../src/wxMaxima.cpp:1675
 #, c-format
 msgid "Launching the system's default help browser as %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1664 ../../src/wxMaxima.cpp:1685
+#: ../../src/wxMaxima.cpp:1666 ../../src/wxMaxima.cpp:1687
 msgid "Launching the system's default help browser failed."
 msgstr ""
 
@@ -6039,7 +6050,7 @@ msgstr ""
 msgid "Length..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4233
+#: ../../src/MaximaCommandMenus.cpp:4293
 msgid "Length:"
 msgstr ""
 
@@ -6080,15 +6091,15 @@ msgstr ""
 msgid "Linear Regression..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4068
+#: ../../src/MaximaCommandMenus.cpp:4128
 msgid "Lisp format string:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4070
+#: ../../src/MaximaCommandMenus.cpp:4130
 msgid "Lisp format strings are more powerful than c++ format strings"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1872
+#: ../../src/wxMaxima.cpp:1874
 msgid "Lisp mode."
 msgstr ""
 
@@ -6136,7 +6147,7 @@ msgstr ""
 msgid "List of changed options"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4197
+#: ../../src/MaximaCommandMenus.cpp:4257
 msgid "List of char to String"
 msgstr ""
 
@@ -6144,7 +6155,7 @@ msgstr ""
 msgid "List of chars to string..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4198
+#: ../../src/MaximaCommandMenus.cpp:4258
 msgid "List of chars:"
 msgstr ""
 
@@ -6241,7 +6252,7 @@ msgstr ""
 msgid "Load lapack"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4020
+#: ../../src/MaximaCommandMenus.cpp:4080
 msgid "Load lisp code"
 msgstr ""
 
@@ -6273,7 +6284,7 @@ msgstr ""
 msgid "Loop variable"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:959 ../../src/MaximaCommandMenus.cpp:3469
+#: ../../src/MaximaCommandMenus.cpp:959 ../../src/MaximaCommandMenus.cpp:3529
 msgid "Lower bound:"
 msgstr ""
 
@@ -6289,11 +6300,11 @@ msgstr ""
 msgid "MAXIMA RESPONSE:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3965
+#: ../../src/MaximaCommandMenus.cpp:4025
 msgid "Macro contents:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3960
+#: ../../src/MaximaCommandMenus.cpp:4020
 msgid "Macro name:"
 msgstr ""
 
@@ -6491,7 +6502,7 @@ msgstr ""
 msgid "Maxima assigns each command/equation an automatic label (which looks like %i1 or %o1). If a command begins with a descriptive name followed by a : wxMaxima will call the descriptive name a \"user-defined label\" instead. This selection now allows telling wxMaxima whether to show only automatic labels, automatic labels if there aren't user-defined ones or no label at all until a user-defined label can be found by wxMaxima's heuristics. If automatic labels are suppressed extra vertical space is added between equations in order to ease discerning which line starts a new equation and which one only continues the one from the last line."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3930
+#: ../../src/MaximaCommandMenus.cpp:3990
 msgid ""
 "Maxima automatically simplifies expressions it gets as input and then tries to evaluate their value. The ' operator tells maxima that we want a command to be in noun form, which means: stand here as is, and unevaluated.\n"
 "The ' operator can be undone by using the '' operator."
@@ -6565,7 +6576,7 @@ msgstr ""
 msgid "Maxima is calculating"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1874
+#: ../../src/wxMaxima.cpp:1876
 msgid "Maxima is ready for input."
 msgstr ""
 
@@ -6582,7 +6593,7 @@ msgstr ""
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:567
+#: ../../src/MaximaProcessManager.cpp:569
 msgid "Maxima process terminated unexpectedly."
 msgstr ""
 
@@ -6654,7 +6665,7 @@ msgstr ""
 msgid "Maxima to other language"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4025
+#: ../../src/MaximaCommandMenus.cpp:4085
 msgid "Maxima to string"
 msgstr ""
 
@@ -6874,7 +6885,7 @@ msgstr ""
 msgid "Methods of generating a matrix"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:4859
+#: ../../src/worksheet/Worksheet.cpp:4869
 #, c-format
 msgid "Middle-click clipboard data: %s"
 msgstr ""
@@ -6901,7 +6912,7 @@ msgstr ""
 msgid "Misc settings"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3134 ../../src/wxMaxima.cpp:3136
+#: ../../src/wxMaxima.cpp:3136 ../../src/wxMaxima.cpp:3138
 msgid "Mismatched parenthesis"
 msgstr ""
 
@@ -6989,7 +7000,7 @@ msgstr ""
 msgid "Never"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:2994
+#: ../../src/MaximaCommandMenus.cpp:3054
 msgid "Never autosubscript this variable"
 msgstr ""
 
@@ -7014,15 +7025,15 @@ msgstr ""
 msgid "New button"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:142
+#: ../../src/MaximaProcessManager.cpp:144
 msgid "New connection attempt whilst already connected."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:150
+#: ../../src/MaximaProcessManager.cpp:152
 msgid "New connection attempt, but no currently no socket maxima could connect to."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:146
+#: ../../src/MaximaProcessManager.cpp:148
 msgid "New connection attempt, but no currently running maxima process."
 msgstr ""
 
@@ -7039,7 +7050,7 @@ msgstr ""
 msgid "New maxima Operators detected: %s"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4202
+#: ../../src/MaximaCommandMenus.cpp:4262
 msgid "New part:"
 msgstr ""
 
@@ -7077,7 +7088,7 @@ msgstr ""
 msgid "No Scalar"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:5456
+#: ../../src/worksheet/Worksheet.cpp:5466
 msgid "No cells are selected. Anonymize the code in the whole document?"
 msgstr ""
 
@@ -7089,7 +7100,7 @@ msgstr ""
 msgid "No differences"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3167
+#: ../../src/wxMaxima.cpp:3169
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
@@ -7113,8 +7124,8 @@ msgstr ""
 msgid "No image to export"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2651 ../../src/wxMaxima.cpp:2659
-#: ../../src/wxMaxima.cpp:2680 ../../src/wxMaxima.cpp:2692
+#: ../../src/wxMaxima.cpp:2653 ../../src/wxMaxima.cpp:2661
+#: ../../src/wxMaxima.cpp:2682 ../../src/wxMaxima.cpp:2694
 msgid "No matches found!"
 msgstr ""
 
@@ -7215,7 +7226,7 @@ msgstr ""
 msgid "Number of equations:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4293
+#: ../../src/MaximaCommandMenus.cpp:4353
 msgid "Number to octets"
 msgstr ""
 
@@ -7227,7 +7238,7 @@ msgstr ""
 msgid "Number types"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4294
+#: ../../src/MaximaCommandMenus.cpp:4354
 msgid "Number:"
 msgstr ""
 
@@ -7259,7 +7270,7 @@ msgstr ""
 msgid "Numerical solutions of polynomial..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3205 ../../src/MaximaCommandMenus.cpp:3630
+#: ../../src/MaximaCommandMenus.cpp:3265 ../../src/MaximaCommandMenus.cpp:3690
 #: ../../src/dialogs/ChangeLogDialog.cpp:131
 #: ../../src/dialogs/LicenseDialog.cpp:90
 #: ../../src/dialogs/MaxSizeChooser.cpp:44
@@ -7310,19 +7321,19 @@ msgstr ""
 msgid "Object composed of elements"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4492
+#: ../../src/MaximaCommandMenus.cpp:4552
 msgid "Object name:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4093
+#: ../../src/MaximaCommandMenus.cpp:4153
 msgid "Object:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4298
+#: ../../src/MaximaCommandMenus.cpp:4358
 msgid "Octets to Number"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4303
+#: ../../src/MaximaCommandMenus.cpp:4363
 msgid "Octets to String"
 msgstr ""
 
@@ -7334,7 +7345,7 @@ msgstr ""
 msgid "Octets to string..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4299 ../../src/MaximaCommandMenus.cpp:4304
+#: ../../src/MaximaCommandMenus.cpp:4359 ../../src/MaximaCommandMenus.cpp:4364
 msgid "Octets:"
 msgstr ""
 
@@ -7416,7 +7427,7 @@ msgstr ""
 msgid "Open document"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4051
+#: ../../src/MaximaCommandMenus.cpp:4111
 msgid "Open for appending"
 msgstr ""
 
@@ -7424,7 +7435,7 @@ msgstr ""
 msgid "Open for appending..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4056
+#: ../../src/MaximaCommandMenus.cpp:4116
 msgid "Open for reading"
 msgstr ""
 
@@ -7432,7 +7443,7 @@ msgstr ""
 msgid "Open for reading..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4061
+#: ../../src/MaximaCommandMenus.cpp:4121
 msgid "Open for writing"
 msgstr ""
 
@@ -7457,7 +7468,7 @@ msgstr ""
 msgid "Opening file"
 msgstr ""
 
-#: ../../src/sidebars/HelpBrowser.cpp:175 ../../src/wxMaxima.cpp:1806
+#: ../../src/sidebars/HelpBrowser.cpp:175 ../../src/wxMaxima.cpp:1808
 #, c-format
 msgid "Opening help file %s"
 msgstr ""
@@ -7536,7 +7547,7 @@ msgstr ""
 msgid "Overlay scrollbars (slow: repaints the worksheet while they fade)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3549
+#: ../../src/MaximaCommandMenus.cpp:3609
 msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*.bmp|"
 msgstr ""
 
@@ -7568,11 +7579,11 @@ msgstr ""
 msgid "Parallel to"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3991
+#: ../../src/MaximaCommandMenus.cpp:4051
 msgid "Parameter name:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3948 ../../src/MaximaCommandMenus.cpp:3961
+#: ../../src/MaximaCommandMenus.cpp:4008 ../../src/MaximaCommandMenus.cpp:4021
 msgid "Parameter(s):"
 msgstr ""
 
@@ -7584,7 +7595,7 @@ msgstr ""
 msgid "Parametric plot"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4211
+#: ../../src/MaximaCommandMenus.cpp:4271
 msgid "Parse string"
 msgstr ""
 
@@ -7596,7 +7607,7 @@ msgstr ""
 msgid "Parsing output"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4276
+#: ../../src/MaximaCommandMenus.cpp:4336
 msgid "Part:"
 msgstr ""
 
@@ -7654,7 +7665,7 @@ msgstr ""
 msgid "Piechart..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1585
+#: ../../src/wxMaxima.cpp:1587
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr ""
 
@@ -7678,7 +7689,7 @@ msgstr ""
 msgid "Plot &Format..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:107 ../../src/MaximaCommandMenus.cpp:3497
+#: ../../src/MaximaCommandMenus.cpp:107 ../../src/MaximaCommandMenus.cpp:3557
 #: ../../src/wizards/Plot2dWiz.cpp:108 ../../src/wizards/Plot2dWiz.cpp:428
 #: ../../src/wizards/Plot2dWiz.cpp:441
 msgid "Plot 2D"
@@ -7689,7 +7700,7 @@ msgstr ""
 msgid "Plot 2D..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:85 ../../src/MaximaCommandMenus.cpp:3508
+#: ../../src/MaximaCommandMenus.cpp:85 ../../src/MaximaCommandMenus.cpp:3568
 #: ../../src/wizards/Plot3dWiz.cpp:103
 msgid "Plot 3D"
 msgstr ""
@@ -7798,7 +7809,7 @@ msgstr ""
 msgid "Popout interactively"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3545
+#: ../../src/MaximaCommandMenus.cpp:3605
 msgid "Portable anymap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X pixmap (*.xpm)|*.xpm"
 msgstr ""
 
@@ -7814,7 +7825,7 @@ msgstr ""
 msgid "Position of a match"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4032 ../../src/MaximaCommandMenus.cpp:4203
+#: ../../src/MaximaCommandMenus.cpp:4092 ../../src/MaximaCommandMenus.cpp:4263
 msgid "Position:"
 msgstr ""
 
@@ -7983,11 +7994,11 @@ msgstr ""
 msgid "Program"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3873
+#: ../../src/MaximaCommandMenus.cpp:3933
 msgid "Program (no local variables)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3864
+#: ../../src/MaximaCommandMenus.cpp:3924
 msgid "Program block"
 msgstr ""
 
@@ -8068,20 +8079,20 @@ msgstr ""
 msgid "Re-opening STDOUT failed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2887
+#: ../../src/wxMaxima.cpp:2889
 #, c-format
 msgid "Re-pointed the .wxmx file association at %s"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4324
+#: ../../src/MaximaCommandMenus.cpp:4384
 msgid "Re-using a compiled regex is faster that using the same regex string multiple times."
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:4649
+#: ../../src/worksheet/Worksheet.cpp:4659
 msgid "Read .wxm data from clipboard"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4411
+#: ../../src/MaximaCommandMenus.cpp:4471
 msgid "Read Directory"
 msgstr ""
 
@@ -8089,15 +8100,15 @@ msgstr ""
 msgid "Read Matrix..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4008
+#: ../../src/MaximaCommandMenus.cpp:4068
 msgid "Read a structure field"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4082 ../../src/MaximaCommandMenus.cpp:4086
+#: ../../src/MaximaCommandMenus.cpp:4142 ../../src/MaximaCommandMenus.cpp:4146
 msgid "Read byte"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4078
+#: ../../src/MaximaCommandMenus.cpp:4138
 msgid "Read char"
 msgstr ""
 
@@ -8105,7 +8116,7 @@ msgstr ""
 msgid "Read config to file"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4405
+#: ../../src/MaximaCommandMenus.cpp:4465
 msgid "Read environment variable"
 msgstr ""
 
@@ -8113,7 +8124,7 @@ msgstr ""
 msgid "Read environment variable..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4074
+#: ../../src/MaximaCommandMenus.cpp:4134
 msgid "Read line"
 msgstr ""
 
@@ -8268,11 +8279,11 @@ msgstr ""
 msgid "Regex"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4335
+#: ../../src/MaximaCommandMenus.cpp:4395
 msgid "Regex match"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4330
+#: ../../src/MaximaCommandMenus.cpp:4390
 msgid "Regex match position"
 msgstr ""
 
@@ -8305,7 +8316,7 @@ msgstr ""
 msgid "Reload the style settings from disc"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3212
+#: ../../src/MaximaCommandMenus.cpp:3272
 #, c-format
 msgid "Reloading image file %s."
 msgstr ""
@@ -8346,7 +8357,7 @@ msgstr ""
 msgid "Remove all occurrences of a word..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4251
+#: ../../src/MaximaCommandMenus.cpp:4311
 msgid "Remove all occurrences of part"
 msgstr ""
 
@@ -8362,7 +8373,7 @@ msgstr ""
 msgid "Remove columns from a matrix"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4378
+#: ../../src/MaximaCommandMenus.cpp:4438
 msgid "Remove directory"
 msgstr ""
 
@@ -8378,7 +8389,7 @@ msgstr ""
 msgid "Remove first occurrence of a word..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4256
+#: ../../src/MaximaCommandMenus.cpp:4316
 msgid "Remove first occurrence of part"
 msgstr ""
 
@@ -8398,7 +8409,7 @@ msgstr ""
 msgid "Remove rows from the a matrix"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4394
+#: ../../src/MaximaCommandMenus.cpp:4454
 msgid "Rename file"
 msgstr ""
 
@@ -8418,11 +8429,11 @@ msgstr ""
 msgid "Replace All"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4350
+#: ../../src/MaximaCommandMenus.cpp:4410
 msgid "Replace all regex matches"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4345
+#: ../../src/MaximaCommandMenus.cpp:4405
 msgid "Replace first regex match"
 msgstr ""
 
@@ -8430,7 +8441,7 @@ msgstr ""
 msgid "Replace non-builtin variable and function names in the selected code cells (or the whole document) with random names, so a worksheet can be shared without revealing its original names"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4275
+#: ../../src/MaximaCommandMenus.cpp:4335
 msgid "Replace the first occurrence of Part"
 msgstr ""
 
@@ -8438,7 +8449,7 @@ msgstr ""
 msgid "Replace..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2718
+#: ../../src/wxMaxima.cpp:2720
 #, c-format
 msgid "Replaced %li occurrences."
 msgstr ""
@@ -8482,7 +8493,7 @@ msgstr ""
 msgid "Restrict Maximum size"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3460
+#: ../../src/MaximaCommandMenus.cpp:3520
 msgid "Result variables:"
 msgstr ""
 
@@ -8494,7 +8505,7 @@ msgstr ""
 msgid "Return a match"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3889
+#: ../../src/MaximaCommandMenus.cpp:3949
 msgid "Return from a block or loop"
 msgstr ""
 
@@ -8655,12 +8666,12 @@ msgstr ""
 msgid "Run each element through an expression"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:2780
+#: ../../src/MaximaCommandMenus.cpp:2790
 #, c-format
 msgid "Running %s on the file %s: "
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:295
+#: ../../src/MaximaProcessManager.cpp:297
 #, c-format
 msgid "Running maxima as: %s"
 msgstr ""
@@ -8754,7 +8765,7 @@ msgid "Samples on a line:"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
-#: ../../src/dialogs/ConfigDialogue.cpp:2163 ../../src/wxMaxima.cpp:3507
+#: ../../src/dialogs/ConfigDialogue.cpp:2163 ../../src/wxMaxima.cpp:3509
 msgid "Save"
 msgstr ""
 
@@ -8774,7 +8785,7 @@ msgstr ""
 msgid "Save Image..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:2866
+#: ../../src/MaximaCommandMenus.cpp:2926
 msgid "Save Selection to Image"
 msgstr ""
 
@@ -8782,11 +8793,11 @@ msgstr ""
 msgid "Save Selection to Image..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3653
+#: ../../src/MaximaCommandMenus.cpp:3713
 msgid "Save animation to file"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4015
+#: ../../src/MaximaCommandMenus.cpp:4075
 msgid "Save as lisp code"
 msgstr ""
 
@@ -8815,7 +8826,7 @@ msgstr ""
 msgid "Save selection from document to an image file"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3560
+#: ../../src/MaximaCommandMenus.cpp:3620
 msgid "Save selection to file"
 msgstr ""
 
@@ -8843,7 +8854,7 @@ msgstr ""
 msgid "Scalable Vector Graphics (svg)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3536
+#: ../../src/MaximaCommandMenus.cpp:3596
 msgid "Scalable Vector image (*.svg)|*.svg|Compressed Scalable Vector Image (*.svgz)|*.svgz|PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|GIF image (*.gif)|*.gif|Windows bitmap (*.bmp)|*.bmp|"
 msgstr ""
 
@@ -8875,7 +8886,7 @@ msgstr ""
 msgid "Search button"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4266
+#: ../../src/MaximaCommandMenus.cpp:4326
 msgid "Search first occurrence of part"
 msgstr ""
 
@@ -8903,7 +8914,7 @@ msgstr ""
 msgid "See also the speed <-> accuracy button."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4030
+#: ../../src/MaximaCommandMenus.cpp:4090
 msgid "Seek to position"
 msgstr ""
 
@@ -8959,7 +8970,7 @@ msgstr ""
 msgid "Select csv file to read"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3783
+#: ../../src/MaximaCommandMenus.cpp:3843
 msgid "Select math display algorithm"
 msgstr ""
 
@@ -8983,7 +8994,7 @@ msgstr ""
 msgid "Send the current cell to maxima"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:919
+#: ../../src/MaximaProcessManager.cpp:921
 msgid "Sending Maxima a SIGINT signal."
 msgstr ""
 
@@ -8995,7 +9006,7 @@ msgstr ""
 msgid "Sending a new command to Maxima."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:900
+#: ../../src/MaximaProcessManager.cpp:902
 msgid "Sending an interrupt signal to Maxima."
 msgstr ""
 
@@ -9023,7 +9034,7 @@ msgstr ""
 msgid "Series approximation"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:225
+#: ../../src/MaximaProcessManager.cpp:227
 msgid "Server started"
 msgstr ""
 
@@ -9326,7 +9337,7 @@ msgstr ""
 msgid "Show the differences between 2 or 3 files"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3845
+#: ../../src/MaximaCommandMenus.cpp:3905
 msgid "Show the function's definition"
 msgstr ""
 
@@ -9504,7 +9515,7 @@ msgstr ""
 msgid "Solution:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3446
+#: ../../src/MaximaCommandMenus.cpp:3506
 msgid "Solve"
 msgstr ""
 
@@ -9637,7 +9648,7 @@ msgstr ""
 msgid "Solving equations with Maxima"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3917
+#: ../../src/MaximaCommandMenus.cpp:3977
 #, c-format
 msgid ""
 "Sometimes one wants maxima to loose the information that a function name was used with the ' operator in order to make maxima not evaluate it. In other places one wants % to mean \"the last expression at the time this function was created\", not \"the last expression now\".\n"
@@ -9656,7 +9667,7 @@ msgstr ""
 msgid "Sort a list"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4271
+#: ../../src/MaximaCommandMenus.cpp:4331
 msgid "Sort all characters in string"
 msgstr ""
 
@@ -9681,7 +9692,7 @@ msgstr ""
 msgid "Speed versus accuracy"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4241
+#: ../../src/MaximaCommandMenus.cpp:4301
 msgid "Split"
 msgstr ""
 
@@ -9689,11 +9700,11 @@ msgstr ""
 msgid "Split on match"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4340
+#: ../../src/MaximaCommandMenus.cpp:4400
 msgid "Split on regex match"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4261
+#: ../../src/MaximaCommandMenus.cpp:4321
 msgid "Split string into tokens"
 msgstr ""
 
@@ -9761,11 +9772,11 @@ msgstr ""
 msgid "Starting a new wxMaxima process for a new window"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1856 ../../src/wxMaxima.cpp:1882
+#: ../../src/wxMaxima.cpp:1858 ../../src/wxMaxima.cpp:1884
 msgid "Starting evaluation of the document"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:203
+#: ../../src/MaximaProcessManager.cpp:205
 msgid "Starting server failed"
 msgstr ""
 
@@ -9802,17 +9813,17 @@ msgstr ""
 msgid "Stream"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4043
+#: ../../src/MaximaCommandMenus.cpp:4103
 msgid "Stream length"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4031 ../../src/MaximaCommandMenus.cpp:4036
-#: ../../src/MaximaCommandMenus.cpp:4040 ../../src/MaximaCommandMenus.cpp:4044
-#: ../../src/MaximaCommandMenus.cpp:4048 ../../src/MaximaCommandMenus.cpp:4052
-#: ../../src/MaximaCommandMenus.cpp:4057 ../../src/MaximaCommandMenus.cpp:4062
-#: ../../src/MaximaCommandMenus.cpp:4068 ../../src/MaximaCommandMenus.cpp:4075
-#: ../../src/MaximaCommandMenus.cpp:4079 ../../src/MaximaCommandMenus.cpp:4083
-#: ../../src/MaximaCommandMenus.cpp:4088
+#: ../../src/MaximaCommandMenus.cpp:4091 ../../src/MaximaCommandMenus.cpp:4096
+#: ../../src/MaximaCommandMenus.cpp:4100 ../../src/MaximaCommandMenus.cpp:4104
+#: ../../src/MaximaCommandMenus.cpp:4108 ../../src/MaximaCommandMenus.cpp:4112
+#: ../../src/MaximaCommandMenus.cpp:4117 ../../src/MaximaCommandMenus.cpp:4122
+#: ../../src/MaximaCommandMenus.cpp:4128 ../../src/MaximaCommandMenus.cpp:4135
+#: ../../src/MaximaCommandMenus.cpp:4139 ../../src/MaximaCommandMenus.cpp:4143
+#: ../../src/MaximaCommandMenus.cpp:4148
 msgid "Stream:"
 msgstr ""
 
@@ -9824,13 +9835,13 @@ msgstr ""
 msgid "String"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4157 ../../src/MaximaCommandMenus.cpp:4162
-#: ../../src/MaximaCommandMenus.cpp:4237
+#: ../../src/MaximaCommandMenus.cpp:4217 ../../src/MaximaCommandMenus.cpp:4222
+#: ../../src/MaximaCommandMenus.cpp:4297
 msgid "String #1:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4158 ../../src/MaximaCommandMenus.cpp:4163
-#: ../../src/MaximaCommandMenus.cpp:4238
+#: ../../src/MaximaCommandMenus.cpp:4218 ../../src/MaximaCommandMenus.cpp:4223
+#: ../../src/MaximaCommandMenus.cpp:4298
 msgid "String #2:"
 msgstr ""
 
@@ -9838,11 +9849,11 @@ msgstr ""
 msgid "String Tests"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4227
+#: ../../src/MaximaCommandMenus.cpp:4287
 msgid "String length"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4193
+#: ../../src/MaximaCommandMenus.cpp:4253
 msgid "String to list of char"
 msgstr ""
 
@@ -9850,7 +9861,7 @@ msgstr ""
 msgid "String to list of chars..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4308
+#: ../../src/MaximaCommandMenus.cpp:4368
 msgid "String to octets"
 msgstr ""
 
@@ -9858,25 +9869,25 @@ msgstr ""
 msgid "String to octets..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4189 ../../src/MaximaCommandMenus.cpp:4194
-#: ../../src/MaximaCommandMenus.cpp:4203 ../../src/MaximaCommandMenus.cpp:4208
-#: ../../src/MaximaCommandMenus.cpp:4212 ../../src/MaximaCommandMenus.cpp:4219
-#: ../../src/MaximaCommandMenus.cpp:4224 ../../src/MaximaCommandMenus.cpp:4228
-#: ../../src/MaximaCommandMenus.cpp:4232 ../../src/MaximaCommandMenus.cpp:4242
-#: ../../src/MaximaCommandMenus.cpp:4248 ../../src/MaximaCommandMenus.cpp:4253
-#: ../../src/MaximaCommandMenus.cpp:4258 ../../src/MaximaCommandMenus.cpp:4262
-#: ../../src/MaximaCommandMenus.cpp:4268 ../../src/MaximaCommandMenus.cpp:4272
-#: ../../src/MaximaCommandMenus.cpp:4277 ../../src/MaximaCommandMenus.cpp:4282
-#: ../../src/MaximaCommandMenus.cpp:4286 ../../src/MaximaCommandMenus.cpp:4290
-#: ../../src/MaximaCommandMenus.cpp:4309
+#: ../../src/MaximaCommandMenus.cpp:4249 ../../src/MaximaCommandMenus.cpp:4254
+#: ../../src/MaximaCommandMenus.cpp:4263 ../../src/MaximaCommandMenus.cpp:4268
+#: ../../src/MaximaCommandMenus.cpp:4272 ../../src/MaximaCommandMenus.cpp:4279
+#: ../../src/MaximaCommandMenus.cpp:4284 ../../src/MaximaCommandMenus.cpp:4288
+#: ../../src/MaximaCommandMenus.cpp:4292 ../../src/MaximaCommandMenus.cpp:4302
+#: ../../src/MaximaCommandMenus.cpp:4308 ../../src/MaximaCommandMenus.cpp:4313
+#: ../../src/MaximaCommandMenus.cpp:4318 ../../src/MaximaCommandMenus.cpp:4322
+#: ../../src/MaximaCommandMenus.cpp:4328 ../../src/MaximaCommandMenus.cpp:4332
+#: ../../src/MaximaCommandMenus.cpp:4337 ../../src/MaximaCommandMenus.cpp:4342
+#: ../../src/MaximaCommandMenus.cpp:4346 ../../src/MaximaCommandMenus.cpp:4350
+#: ../../src/MaximaCommandMenus.cpp:4369
 msgid "String:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4009
+#: ../../src/MaximaCommandMenus.cpp:4069
 msgid "Struct :"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3996 ../../src/MaximaCommandMenus.cpp:4002
+#: ../../src/MaximaCommandMenus.cpp:4056 ../../src/MaximaCommandMenus.cpp:4062
 msgid "Struct type name:"
 msgstr ""
 
@@ -9916,8 +9927,8 @@ msgstr ""
 msgid "Subst..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3490
-#: ../../src/MaximaCommandMenus.cpp:4500 ../../src/wizards/SubstituteWiz.cpp:53
+#: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3550
+#: ../../src/MaximaCommandMenus.cpp:4560 ../../src/wizards/SubstituteWiz.cpp:53
 #: ../../src/wxMaximaFrame.cpp:1688
 msgid "Substitute"
 msgstr ""
@@ -10069,7 +10080,7 @@ msgstr ""
 msgid "Taylor series:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1486
+#: ../../src/wxMaxima.cpp:1488
 msgid "Telling maxima about the new working directory."
 msgstr ""
 
@@ -10113,7 +10124,7 @@ msgstr ""
 msgid "Text cells can hold citations that as marked as such by beginning a line with \" > \". The number of spaces in front of the \">\" determines the indentation level, as it does with bullet lists."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3001
+#: ../../src/MaximaCommandMenus.cpp:3061
 msgid "Text snippet"
 msgstr ""
 
@@ -10130,7 +10141,7 @@ msgstr ""
 msgid "The .xml file doesn't seem to be valid xml or isn't a content.xml extracted from a .wxmx zip archive"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:842
+#: ../../src/MaximaProcessManager.cpp:844
 msgid "The Maxima process doesn't offer a shared memory segment we can send an interrupt signal to."
 msgstr ""
 
@@ -10170,15 +10181,15 @@ msgstr ""
 msgid "The color of the next line to draw"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4005
+#: ../../src/MaximaCommandMenus.cpp:4065
 msgid "The comma-separated contents of the struct fields"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3998
+#: ../../src/MaximaCommandMenus.cpp:4058
 msgid "The comma-separated names of the struct fields"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3882
+#: ../../src/MaximaCommandMenus.cpp:3942
 msgid "The command local() allows telling Maxima which functions to make local to the current program when defined."
 msgstr ""
 
@@ -10278,7 +10289,7 @@ msgid ""
 "One example of the latter would be: Gnuplot refuses to plot entirely empty images"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3202 ../../src/MaximaCommandMenus.cpp:3627
+#: ../../src/MaximaCommandMenus.cpp:3262 ../../src/MaximaCommandMenus.cpp:3687
 #, c-format
 msgid "The image file \"%s\" cannot be found."
 msgstr ""
@@ -10327,27 +10338,27 @@ msgstr ""
 msgid "The maximum size for this image. Values <= 0 mean: Unspecified."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3937
+#: ../../src/MaximaCommandMenus.cpp:3997
 msgid "The name of a function we don't want to be evaluated here"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3943
+#: ../../src/MaximaCommandMenus.cpp:4003
 msgid "The name of an expression that we don't want to be evaluated."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4011
+#: ../../src/MaximaCommandMenus.cpp:4071
 msgid "The name of the field to read"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3997
+#: ../../src/MaximaCommandMenus.cpp:4057
 msgid "The name of the new struct type"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4010
+#: ../../src/MaximaCommandMenus.cpp:4070
 msgid "The name of the struct"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4003
+#: ../../src/MaximaCommandMenus.cpp:4063
 msgid "The name of the struct type"
 msgstr ""
 
@@ -10413,7 +10424,7 @@ msgstr ""
 msgid "The second argument of at() isn't an equation or a list of equations. Most probably it was lacking an \"=\"."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3421
+#: ../../src/MaximaCommandMenus.cpp:3481
 msgid "The selection contains no output that could be exported."
 msgstr ""
 
@@ -10460,7 +10471,7 @@ msgstr ""
 msgid "The worksheet"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:6361
+#: ../../src/worksheet/Worksheet.cpp:6371
 msgid "The worksheet containing maxima's input and output"
 msgstr ""
 
@@ -10599,7 +10610,7 @@ msgstr ""
 msgid "Time [in Minutes] between autosaves"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:267 ../../src/MaximaCommandMenus.cpp:3487
+#: ../../src/MaximaCommandMenus.cpp:267 ../../src/MaximaCommandMenus.cpp:3547
 msgid "Times:"
 msgstr ""
 
@@ -10710,7 +10721,7 @@ msgstr ""
 msgid "Top end"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2860
+#: ../../src/wxMaxima.cpp:2862
 msgid "Tortoise diff tool"
 msgstr ""
 
@@ -10718,7 +10729,7 @@ msgstr ""
 msgid "Trace a function..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3896
+#: ../../src/MaximaCommandMenus.cpp:3956
 msgid "Trace function(s)"
 msgstr ""
 
@@ -10734,7 +10745,7 @@ msgstr ""
 msgid "Tries to find a numerical solution for a 1st order ODE (or in other words: a equation of the format depends(x,t);diff(x,t)=(something containing x and t)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3465
+#: ../../src/MaximaCommandMenus.cpp:3525
 msgid "Tries to find a solution of the equation that lies between the two bounds."
 msgstr ""
 
@@ -10782,15 +10793,15 @@ msgstr ""
 msgid "Trim right..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4285
+#: ../../src/MaximaCommandMenus.cpp:4345
 msgid "Trim string left"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4281
+#: ../../src/MaximaCommandMenus.cpp:4341
 msgid "Trim string on both ends"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4289
+#: ../../src/MaximaCommandMenus.cpp:4349
 msgid "Trim string right"
 msgstr ""
 
@@ -10837,11 +10848,11 @@ msgstr ""
 msgid "Trying to remove the old temp file %s"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:166
+#: ../../src/MaximaProcessManager.cpp:168
 msgid "Trying to restart maxima."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:182
+#: ../../src/MaximaProcessManager.cpp:184
 #, c-format
 msgid "Trying to start the socket a Maxima on the local machine can connect to on port %i"
 msgstr ""
@@ -10858,7 +10869,7 @@ msgstr ""
 msgid "Two sample t-test"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:6239
+#: ../../src/worksheet/Worksheet.cpp:6249
 msgid "Type"
 msgstr ""
 
@@ -10866,7 +10877,7 @@ msgstr ""
 msgid "Type in text"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3992 ../../src/wizards/MatWiz.cpp:158
+#: ../../src/MaximaCommandMenus.cpp:4052 ../../src/wizards/MatWiz.cpp:158
 msgid "Type:"
 msgstr ""
 
@@ -10886,20 +10897,20 @@ msgstr ""
 msgid "Ukrainian"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3164
+#: ../../src/wxMaxima.cpp:3166
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3152
+#: ../../src/wxMaxima.cpp:3154
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3466
+#: ../../src/wxMaxima.cpp:3468
 #, c-format
 msgid "Unable to interpret the version info I got from %s: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3412
+#: ../../src/wxMaxima.cpp:3414
 #, c-format
 msgid "Unable to interpret the version info I got: %s"
 msgstr ""
@@ -10994,7 +11005,7 @@ msgstr ""
 msgid "Unicode code point to UTF8..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4178
+#: ../../src/MaximaCommandMenus.cpp:4238
 msgid "Unicode code point to char"
 msgstr ""
 
@@ -11002,7 +11013,7 @@ msgstr ""
 msgid "Unicode code point to char..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4183
+#: ../../src/MaximaCommandMenus.cpp:4243
 msgid "Unicode code point to utf8 numbers"
 msgstr ""
 
@@ -11010,15 +11021,15 @@ msgstr ""
 msgid "Unicode symbols:"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3890
+#: ../../src/MaximaCommandMenus.cpp:3950
 msgid "Unlike in other programming language return() only exits from the current loop or block(), not from the whole function."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3103
+#: ../../src/wxMaxima.cpp:3105
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3146
+#: ../../src/wxMaxima.cpp:3148
 msgid "Unterminated string."
 msgstr ""
 
@@ -11034,9 +11045,9 @@ msgstr ""
 msgid "Updating maxima's configuration"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3405 ../../src/wxMaxima.cpp:3410
-#: ../../src/wxMaxima.cpp:3412 ../../src/wxMaxima.cpp:3459
-#: ../../src/wxMaxima.cpp:3464 ../../src/wxMaxima.cpp:3467
+#: ../../src/wxMaxima.cpp:3407 ../../src/wxMaxima.cpp:3412
+#: ../../src/wxMaxima.cpp:3414 ../../src/wxMaxima.cpp:3461
+#: ../../src/wxMaxima.cpp:3466 ../../src/wxMaxima.cpp:3469
 msgid "Upgrade"
 msgstr ""
 
@@ -11045,7 +11056,7 @@ msgstr ""
 msgid "Upper bound on the number of cycles. Must be greater than or equal to 3."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:960 ../../src/MaximaCommandMenus.cpp:3470
+#: ../../src/MaximaCommandMenus.cpp:960 ../../src/MaximaCommandMenus.cpp:3530
 msgid "Upper bound:"
 msgstr ""
 
@@ -11148,19 +11159,19 @@ msgstr ""
 msgid "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1564
+#: ../../src/wxMaxima.cpp:1566
 msgid "Using Maxima path from command line."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1561
+#: ../../src/wxMaxima.cpp:1563
 msgid "Using configured Maxima path."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:974
+#: ../../src/MaximaProcessManager.cpp:976
 msgid "Using gnuplot's antialiassing-less png driver for embedded plots as pngcairo could not be found"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:969
+#: ../../src/MaximaProcessManager.cpp:971
 msgid "Using gnuplot's pngcairo driver for embedded plots"
 msgstr ""
 
@@ -11232,8 +11243,8 @@ msgstr ""
 msgid "Variable for the z value"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:1586 ../../src/MaximaCommandMenus.cpp:2990
-#: ../../src/MaximaCommandMenus.cpp:2996
+#: ../../src/MaximaCommandMenus.cpp:1586 ../../src/MaximaCommandMenus.cpp:3050
+#: ../../src/MaximaCommandMenus.cpp:3056
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:48
 msgid "Variable name"
 msgstr ""
@@ -11242,7 +11253,7 @@ msgstr ""
 msgid "Variable name, not contents..."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3969 ../../src/MaximaCommandMenus.cpp:4487
+#: ../../src/MaximaCommandMenus.cpp:4029 ../../src/MaximaCommandMenus.cpp:4547
 msgid "Variable name:"
 msgstr ""
 
@@ -11251,14 +11262,14 @@ msgid "Variable(s)"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:266 ../../src/MaximaCommandMenus.cpp:1030
-#: ../../src/MaximaCommandMenus.cpp:1082 ../../src/MaximaCommandMenus.cpp:3486
+#: ../../src/MaximaCommandMenus.cpp:1082 ../../src/MaximaCommandMenus.cpp:3546
 msgid "Variable(s):"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:185 ../../src/MaximaCommandMenus.cpp:195
 #: ../../src/MaximaCommandMenus.cpp:206 ../../src/MaximaCommandMenus.cpp:231
 #: ../../src/MaximaCommandMenus.cpp:236 ../../src/MaximaCommandMenus.cpp:317
-#: ../../src/MaximaCommandMenus.cpp:958 ../../src/MaximaCommandMenus.cpp:3468
+#: ../../src/MaximaCommandMenus.cpp:958 ../../src/MaximaCommandMenus.cpp:3528
 #: ../../src/wizards/IntegrateWiz.cpp:36 ../../src/wizards/LimitWiz.cpp:32
 #: ../../src/wizards/Plot2dWiz.cpp:45 ../../src/wizards/Plot2dWiz.cpp:55
 #: ../../src/wizards/Plot2dWiz.cpp:496 ../../src/wizards/Plot3dWiz.cpp:34
@@ -11309,7 +11320,8 @@ msgid "Warn if an inactive window is idle"
 msgstr ""
 
 #: ../../src/MathParser.cpp:1343 ../../src/MaximaFileIO.cpp:536
-#: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1583
+#: ../../src/MaximaProcessManager.cpp:1100
+#: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1585
 msgid "Warning"
 msgstr ""
 
@@ -11339,11 +11351,11 @@ msgid ""
 "Please enter the path to the program again."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3543 ../../src/MaximaCommandMenus.cpp:3553
+#: ../../src/MaximaCommandMenus.cpp:3603 ../../src/MaximaCommandMenus.cpp:3613
 msgid "WebP (*.webp)|*.webp|"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1869
+#: ../../src/wxMaxima.cpp:1871
 msgid "Welcome to wxMaxima"
 msgstr ""
 
@@ -11359,7 +11371,7 @@ msgstr ""
 msgid "When to invoke the lisp compiler's debugger"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3858
+#: ../../src/MaximaCommandMenus.cpp:3918
 msgid "While loop"
 msgstr ""
 
@@ -11388,11 +11400,11 @@ msgstr ""
 msgid "Worksheet export of type \"%s\" is not supported yet."
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:4901
+#: ../../src/worksheet/Worksheet.cpp:4911
 msgid "Worksheet got activated"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:4833
+#: ../../src/worksheet/Worksheet.cpp:4843
 msgid "Worksheet got the mouse focus"
 msgstr ""
 
@@ -11404,7 +11416,7 @@ msgstr ""
 msgid "Wrap equations exported by the \"copy as LaTeX\" feature between \\[ and \\] as equation markers"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:5190
+#: ../../src/worksheet/Worksheet.cpp:5200
 msgid "Wrapped search"
 msgstr ""
 
@@ -11473,7 +11485,7 @@ msgstr ""
 msgid "You got an idea for an improvement of wxMaxima? Great! Please submit your idea at https://github.com/wxMaxima-developers/wxmaxima/issues. "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3402 ../../src/wxMaxima.cpp:3456
+#: ../../src/wxMaxima.cpp:3404 ../../src/wxMaxima.cpp:3458
 #, c-format
 msgid ""
 "You have version %s. The newest wxMaxima release is %s.\n"
@@ -11481,11 +11493,11 @@ msgid ""
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3506
+#: ../../src/wxMaxima.cpp:3508
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3410 ../../src/wxMaxima.cpp:3464
+#: ../../src/wxMaxima.cpp:3412 ../../src/wxMaxima.cpp:3466
 msgid "Your version of wxMaxima is up to date."
 msgstr ""
 
@@ -11509,11 +11521,11 @@ msgstr ""
 msgid "Zoom out 10%"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3202 ../../src/wxMaximaFrame.cpp:201
+#: ../../src/wxMaxima.cpp:3204 ../../src/wxMaximaFrame.cpp:201
 msgid "[ unsaved ]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3204
+#: ../../src/wxMaxima.cpp:3206
 msgid "[ unsaved* ]"
 msgstr ""
 
@@ -11631,7 +11643,7 @@ msgstr ""
 msgid "exists"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3942
+#: ../../src/MaximaCommandMenus.cpp:4002
 msgid "expression:"
 msgstr ""
 
@@ -11646,7 +11658,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4016 ../../src/MaximaCommandMenus.cpp:4021
+#: ../../src/MaximaCommandMenus.cpp:4076 ../../src/MaximaCommandMenus.cpp:4081
 msgid "filename:"
 msgstr ""
 
@@ -11762,7 +11774,7 @@ msgid "m×n Matrix A:"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:1538 ../../src/MaximaCommandMenus.cpp:1544
-#: ../../src/MaximaCommandMenus.cpp:4190
+#: ../../src/MaximaCommandMenus.cpp:4250
 msgid "n:"
 msgstr ""
 
@@ -11834,8 +11846,8 @@ msgstr ""
 msgid "part() or the [] operator was used in order to extract the nth element of something that was less than n elements long."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4252 ../../src/MaximaCommandMenus.cpp:4257
-#: ../../src/MaximaCommandMenus.cpp:4267
+#: ../../src/MaximaCommandMenus.cpp:4312 ../../src/MaximaCommandMenus.cpp:4317
+#: ../../src/MaximaCommandMenus.cpp:4327
 msgid "part:"
 msgstr ""
 
@@ -11868,7 +11880,7 @@ msgstr ""
 msgid "printOut: Setting the page size to (%li,%li)"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4067
+#: ../../src/MaximaCommandMenus.cpp:4127
 msgid "printf"
 msgstr ""
 
@@ -11936,7 +11948,7 @@ msgstr ""
 msgid "sigma"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:3447
+#: ../../src/MaximaCommandMenus.cpp:3507
 msgid ""
 "solve() will solve a list of equations only if for n independent equations there are n variables to solve to.\n"
 "If only one result variable is of interest the other result variables can be used to to tell solve() which variables to eliminate from the solution\n"
@@ -12017,7 +12029,7 @@ msgstr ""
 msgid "unnamed function (lambda)..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3494
+#: ../../src/wxMaxima.cpp:3496
 msgid "unsaved"
 msgstr ""
 
@@ -12055,7 +12067,7 @@ msgstr ""
 msgid "wxMaxima %ld"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3191 ../../src/wxMaximaFrame.cpp:199
+#: ../../src/wxMaxima.cpp:3193 ../../src/wxMaximaFrame.cpp:199
 #, c-format
 msgid "wxMaxima %s (%s) "
 msgstr ""
@@ -12077,7 +12089,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:209
+#: ../../src/MaximaProcessManager.cpp:211
 msgid ""
 "wxMaxima could not start a server.\n"
 "\n"
@@ -12089,7 +12101,7 @@ msgstr ""
 msgid "wxMaxima dialogs set default values for inputs entries, one of which is '%'. If you have made a selection in your document, the selection will be used instead of '%'."
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:4544
+#: ../../src/MaximaCommandMenus.cpp:4604
 msgid "wxMaxima document"
 msgstr ""
 
@@ -12110,7 +12122,7 @@ msgstr ""
 msgid "wxMaxima is a cross-platform graphical user interface for the computer algebra system Maxima based on wxWidgets.\n"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2852
+#: ../../src/wxMaxima.cpp:2854
 #, c-format
 msgid ""
 "wxMaxima is now the .wxmx diff tool for:%s\n"
@@ -12172,7 +12184,7 @@ msgstr ""
 msgid "wxMaxima version %s"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:6154
+#: ../../src/worksheet/Worksheet.cpp:6164
 msgid "wxMaxima worksheet"
 msgstr ""
 
@@ -12200,17 +12212,17 @@ msgstr ""
 msgid "wxworksheettohtml/totex: no target file name was given."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2202
+#: ../../src/wxMaxima.cpp:2204
 #, c-format
 msgid "wxworksheettohtml: could not write \"%s\"."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2176
+#: ../../src/wxMaxima.cpp:2178
 #, c-format
 msgid "wxworksheettohtml: unknown flavor \"%s\"; using native MathML. Known flavors: mathml, mathjax, svg, bitmap."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2244
+#: ../../src/wxMaxima.cpp:2246
 #, c-format
 msgid "wxworksheettotex: could not write \"%s\"."
 msgstr ""

--- a/src/EventIDs.cpp
+++ b/src/EventIDs.cpp
@@ -581,6 +581,7 @@ const wxWindowIDRef EventIDs::gentran_to_file(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::socket_client_id(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::socket_server_id(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::gnuplot_query_terminals_id(wxWindow::NewControlId());
+const wxWindowIDRef EventIDs::gnuplot_popout_check_id(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_additionalSymbols(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::enable_unicodePane(wxWindow::NewControlId());
 const wxWindowIDRef EventIDs::menu_showLatinGreekLookalikes(wxWindow::NewControlId());

--- a/src/EventIDs.h
+++ b/src/EventIDs.h
@@ -652,6 +652,7 @@ public:
   static const wxWindowIDRef socket_client_id;
   static const wxWindowIDRef socket_server_id;
   static const wxWindowIDRef gnuplot_query_terminals_id;
+  static const wxWindowIDRef gnuplot_popout_check_id;
   static const wxWindowIDRef menu_additionalSymbols;
   static const wxWindowIDRef enable_unicodePane;
   static const wxWindowIDRef menu_showLatinGreekLookalikes;

--- a/src/MaximaCommandMenus.cpp
+++ b/src/MaximaCommandMenus.cpp
@@ -2749,23 +2749,33 @@ void MaximaCommandMenus::EditMenu(wxCommandEvent &event) {
       return;
     wxTextInputStream textIn(input, wxS('\t'),
                              wxConvAuto(wxFONTENCODING_UTF8));
-    wxString gnuplot_popout_tempfilename = wxFileName::CreateTempFileName("wxmaxima_gnuplot_popout_");
-    wxFileOutputStream output(gnuplot_popout_tempfilename);
-    if (!output.IsOk())
-      return;
-    wxTextOutputStream textOut(output);
-#ifdef __WXMSW__
-    textOut << "set term windows\n";
-#endif
     textIn.ReadLine();
     textIn.ReadLine();
 
-    wxString line;
-    while (!input.Eof()) {
-      line = textIn.ReadLine();
-      textOut << line + wxS("\n");
+    // The body both the interactive popout below and the headless warnings
+    // check further down execute: everything but the original terminal/output
+    // directives skipped above.
+    wxString body;
+    {
+      wxString line;
+      while (!input.Eof()) {
+        line = textIn.ReadLine();
+        body += line + wxS("\n");
+      }
     }
-    textOut.Flush();
+
+    wxString gnuplot_popout_tempfilename = wxFileName::CreateTempFileName("wxmaxima_gnuplot_popout_");
+    {
+      wxFileOutputStream output(gnuplot_popout_tempfilename);
+      if (!output.IsOk())
+        return;
+      wxTextOutputStream textOut(output);
+#ifdef __WXMSW__
+      textOut << "set term windows\n";
+#endif
+      textOut << body;
+      textOut.Flush();
+    }
 
     // Execute gnuplot
     std::vector<char *> argv;
@@ -2783,6 +2793,56 @@ void MaximaCommandMenus::EditMenu(wxCommandEvent &event) {
                   wxEXEC_ASYNC | wxEXEC_SHOW_CONSOLE | wxEXEC_MAKE_GROUP_LEADER,
                   m_wxMaxima.m_gnuplotProcess) < 0)
       wxLogMessage(_("Cannot start gnuplot"));
+
+    /* Also run the same script headlessly, with `set term unknown` instead
+       of a real terminal, purely to catch warnings/errors gnuplot prints
+       while preparing the plot (GH #1973: users were left staring at an
+       unexplained empty plot window when e.g. a "set font" their preamble
+       used wasn't understood by their gnuplot version, with no indication
+       anything had gone wrong).
+
+       This is a second, independent process rather than reading
+       m_gnuplotProcess's own stdout/stderr, because m_gnuplotProcess must
+       stay un-redirected: Redirect()ing it would replace its console's real
+       stdin/stdout with pipes we own, silently breaking the "type further
+       gnuplot commands into the popped-out console" feature the manual
+       documents (a plain `set term unknown` run needs no console at all, so
+       redirecting *this* one is harmless). See OnGnuplotPopoutCheckClose(). */
+    wxString gnuplot_popout_checkfilename =
+      wxFileName::CreateTempFileName("wxmaxima_gnuplot_popoutcheck_");
+    {
+      wxFileOutputStream checkOutput(gnuplot_popout_checkfilename);
+      if (checkOutput.IsOk()) {
+        wxTextOutputStream checkTextOut(checkOutput);
+        checkTextOut << "set term unknown\n";
+        checkTextOut << body;
+        checkTextOut.Flush();
+      }
+    }
+    if (wxFileExists(gnuplot_popout_checkfilename)) {
+      // A previous check that is somehow still running (rapid repeated
+      // clicks) is detached rather than overwritten: its termination event
+      // must not be read against a newer process's streams, and Detach()
+      // makes it delete itself once its own child exits - the same pattern
+      // MaximaResponseReader::VariableActionGnuplotCommand uses for
+      // m_gnuplotTerminalQueryProcess.
+      if (m_wxMaxima.m_gnuplotPopoutCheckProcess)
+        m_wxMaxima.m_gnuplotPopoutCheckProcess->Detach();
+      m_wxMaxima.m_gnuplotPopoutCheckFile = gnuplot_popout_checkfilename;
+      m_wxMaxima.m_gnuplotPopoutCheckProcess =
+        new wxProcess(&m_wxMaxima, EventIDs::gnuplot_popout_check_id);
+      m_wxMaxima.m_gnuplotPopoutCheckProcess->Redirect();
+      std::vector<char *> checkArgv;
+      wxCharBuffer checkCommandnamebuffer = m_wxMaxima.m_gnuplotcommand.mb_str();
+      checkArgv.push_back(checkCommandnamebuffer.data());
+      wxCharBuffer checkUrlbuffer = wxString(gnuplot_popout_checkfilename).mb_str();
+      checkArgv.push_back(checkUrlbuffer.data());
+      checkArgv.push_back(NULL);
+      if (wxExecute(checkArgv.data(),
+                    wxEXEC_ASYNC | wxEXEC_HIDE_CONSOLE | wxEXEC_MAKE_GROUP_LEADER,
+                    m_wxMaxima.m_gnuplotPopoutCheckProcess) < 0)
+        wxLogMessage(_("Cannot start the headless gnuplot warnings check"));
+    }
   }
   else if(event.GetId() == wxID_PREFERENCES) {
     // wxGTK uses wxFileConf. ...and wxFileConf loads the config file only once

--- a/src/MaximaProcessManager.cpp
+++ b/src/MaximaProcessManager.cpp
@@ -29,7 +29,9 @@
 #include "Maxima.h"
 #include "EventIDs.h"
 #include "dialogs/MaximaNotStartingDialog.h"
+#include "dialogs/LoggingMessageDialog.h"
 #include <wx/sstream.h>
+#include <wx/tokenzr.h>
 
 #ifndef __WXMSW__
 #include <csignal>
@@ -991,6 +993,115 @@ void MaximaProcessManager::OnGnuplotClose(wxProcessEvent &event) {
   m_wxMaxima.m_gnuplotProcess = NULL;
   wxLogMessage(_("Gnuplot has closed."));
   event.Skip();
+}
+
+void MaximaProcessManager::OnGnuplotPopoutCheckClose(wxProcessEvent &event) {
+  // Same lifetime contract as OnGnuplotQueryTerminals above: always Skip(),
+  // never delete the process ourselves - wxProcess::OnTerminate does that
+  // for us as long as the event is left unprocessed.
+  event.Skip();
+  if (!m_wxMaxima.m_gnuplotPopoutCheckProcess)
+    return;
+  // A new "Pop out interactively" click while an older check is still
+  // running detaches the old one (see MaximaCommandMenus.cpp) rather than
+  // overwriting the pointer, so a stale event here never reads the wrong
+  // process's streams.
+  if (event.GetPid() != m_wxMaxima.m_gnuplotPopoutCheckProcess->GetPid())
+    return;
+
+  wxString gnuplotMessage;
+  // Both streams exist because the check process was created with
+  // Redirect(), but guard anyway. The IsOk() term matters: Eof() only
+  // reports wxSTREAM_EOF, so a pipe stuck in a read-ERROR state would
+  // otherwise keep the loop spinning (and the string growing) forever.
+  {
+    wxInputStream *istream = m_wxMaxima.m_gnuplotPopoutCheckProcess->GetInputStream();
+    wxASSERT(istream);
+    if (istream) {
+      wxTextInputStream textin(*istream);
+      while (istream->IsOk() && !istream->Eof())
+        gnuplotMessage += textin.ReadLine() + "\n";
+    }
+  }
+  {
+    wxInputStream *istream = m_wxMaxima.m_gnuplotPopoutCheckProcess->GetErrorStream();
+    wxASSERT(istream);
+    if (istream) {
+      wxTextInputStream textin(*istream);
+      while (istream->IsOk() && !istream->Eof())
+        gnuplotMessage += textin.ReadLine() + "\n";
+    }
+  }
+  // `set term unknown` is what makes this check headless in the first
+  // place, but it also makes gnuplot print this exact two-line notice on
+  // stderr for every single plot/replot statement in the script - that is
+  // a side effect of our own diagnostic setup, not gnuplot finding
+  // anything wrong with the user's script, so it must never count towards
+  // "there is something to tell the user about" (confirmed against a real
+  // gnuplot 6.0: a script with nothing else wrong with it still prints this
+  // on every `plot`).
+  wxString filtered;
+  wxStringTokenizer lines(gnuplotMessage, wxS("\n"), wxTOKEN_RET_EMPTY_ALL);
+  while (lines.HasMoreTokens()) {
+    wxString line = lines.GetNextToken();
+    wxString trimmed = line;
+    trimmed.Trim(true);
+    trimmed.Trim(false);
+    if (trimmed.IsEmpty())
+      continue;
+    if (trimmed.Contains(wxS("Plotting with 'unknown' terminal")) ||
+        trimmed.Contains(wxS("No output will be generated")))
+      continue;
+    filtered += line + wxS("\n");
+  }
+  gnuplotMessage = filtered;
+  gnuplotMessage.Trim(true);
+  gnuplotMessage.Trim(false);
+
+  if (!m_wxMaxima.m_gnuplotPopoutCheckFile.IsEmpty() &&
+      wxFileExists(m_wxMaxima.m_gnuplotPopoutCheckFile))
+    wxRemoveFile(m_wxMaxima.m_gnuplotPopoutCheckFile);
+  m_wxMaxima.m_gnuplotPopoutCheckFile.Clear();
+  m_wxMaxima.m_gnuplotPopoutCheckProcess = NULL;
+
+  // A script that prepares a plot without errors normally produces no
+  // (remaining, after the filtering above) output at all in gnuplot's
+  // non-interactive, `set term unknown` batch mode, so any output at all
+  // here is worth showing (GH #1973: users were otherwise left staring at
+  // an unexplained empty plot window with no clue that e.g. an
+  // "unrecognized option" in their own preamble had aborted the script
+  // partway through).
+  //
+  // A LoggingMessageBox, not wxLogWarning: this app's own wxLogWindow is
+  // constructed with passToOld=false (see main.cpp) and stays hidden by
+  // default outside debug builds, so a plain wxLogWarning here would be
+  // exactly as invisible to a normal user as the empty plot window this is
+  // meant to explain - confirmed live, not assumed (a real run showed the
+  // warning reaching the log window's backing store but the window itself
+  // never mapped on screen). LoggingMessageBox both logs the message *and*
+  // reliably shows it - the same mechanism this codebase already uses for
+  // every other "make sure the user actually sees this" case - and honors
+  // LoggingMessageDialog's non-interactive flag, so batch/test runs are not
+  // blocked by it. Deferred via CallAfter with the same coalescing-flag
+  // pattern MathParser.cpp uses for its own async warning box: this handler
+  // runs off a wxEVT_END_PROCESS, and a burst of popouts (or one popout
+  // whose check happens to race the interactive window's own close) must
+  // not stack multiple modal boxes on top of each other.
+  if (!gnuplotMessage.IsEmpty()) {
+    static bool warningPending = false;
+    if (wxTheApp && !warningPending) {
+      warningPending = true;
+      wxTheApp->CallAfter([gnuplotMessage] {
+        LoggingMessageBox(
+          wxString::Format(
+            _("Gnuplot reported the following while preparing the "
+              "popped-out plot:\n%s"),
+            gnuplotMessage),
+          _("Warning"), wxOK | wxICON_WARNING);
+        warningPending = false;
+      });
+    }
+  }
 }
 
 void MaximaProcessManager::GnuplotCommandName(wxString gnuplot) {

--- a/src/MaximaProcessManager.h
+++ b/src/MaximaProcessManager.h
@@ -134,6 +134,16 @@ public:
   //! wxEVT_END_PROCESS handler for the gnuplot subprocess: notes it has closed.
   void OnGnuplotClose(wxProcessEvent &event);
 
+  /*! wxEVT_END_PROCESS handler for the hidden, headless gnuplot check that
+    runs alongside "Pop out interactively".
+
+    Reads back whatever gnuplot wrote to stdout/stderr while preparing the
+    plot and, if it looks like it contains a warning or an error, shows it
+    to the user - instead of leaving them looking at an unexplained empty
+    plot window (GH #1973).
+  */
+  void OnGnuplotPopoutCheckClose(wxProcessEvent &event);
+
 private:
   //! The wxMaxima frame whose services the lifecycle handlers drive. Not owned;
   //! the frame owns this object.

--- a/src/worksheet/Worksheet.cpp
+++ b/src/worksheet/Worksheet.cpp
@@ -900,9 +900,19 @@ void Worksheet::ScrollToError() {
   if (!errorCell)
     return;
 
-  if (errorCell->RevealHidden()) {
-    FoldOccurred();
-    RequestRecalculation();
+  // If the cell that errored is folded away, don't force it open just to
+  // point at it (GH #1952): folding a time-consuming calculation down to
+  // one line so the worksheet stays readable is defeated if a single error
+  // deep inside unconditionally unfurls the whole thing. Land on the
+  // outermost fold header that is actually part of the visible tree
+  // instead, leaving the fold itself untouched.
+  GroupCell *target = errorCell;
+  while (GroupCell *parent = target->GetHiddenTreeParent())
+    target = parent;
+  if (target != errorCell) {
+    SetHCaret(target);
+    ScrollToCaret();
+    return;
   }
 
   // Try to scroll to a place from which the full error message is visible

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -896,6 +896,7 @@ wxMaxima::wxMaxima(wxWindow *parent, int id,
   Bind(wxEVT_END_PROCESS, &MaximaProcessManager::OnMaximaClose, &m_processManager, m_maxima_process_id);
   Bind(wxEVT_END_PROCESS, &MaximaProcessManager::OnGnuplotQueryTerminals, &m_processManager, EventIDs::gnuplot_query_terminals_id);
   Bind(wxEVT_END_PROCESS, &MaximaProcessManager::OnGnuplotClose, &m_processManager, m_gnuplot_process_id);
+  Bind(wxEVT_END_PROCESS, &MaximaProcessManager::OnGnuplotPopoutCheckClose, &m_processManager, EventIDs::gnuplot_popout_check_id);
   Bind(wxEVT_MENU, &MaximaCommandMenus::EditInputMenu, &m_menuCommands, EventIDs::popid_edit);
   Bind(wxEVT_MENU, &MaximaEvaluator::EvaluateEvent, &m_evaluator, EventIDs::menu_evaluate);
   Bind(wxEVT_MENU, &wxMaxima::VarReadEvent, this, EventIDs::popid_var_newVar);
@@ -1231,6 +1232,7 @@ wxMaxima::~wxMaxima() {
   // are still running (and sever the bond so a late event is not delivered to
   // the destroyed wxMaxima). See KillAndDetachProcess above.
   KillAndDetachProcess(m_gnuplotTerminalQueryProcess);
+  KillAndDetachProcess(m_gnuplotPopoutCheckProcess);
   KillAndDetachProcess(m_gnuplotProcess);
 
   // Kill maxima

--- a/src/wxMaxima.h
+++ b/src/wxMaxima.h
@@ -292,6 +292,21 @@ protected:
   wxProcess *m_gnuplotProcess = NULL;
   //! Info about the gnuplot process we start for querying the terminals it supports
   wxProcess *m_gnuplotTerminalQueryProcess = NULL;
+  /*! A second, hidden, headless gnuplot invocation of the same "Pop out
+    interactively" script, started alongside m_gnuplotProcess purely to
+    capture warnings/errors gnuplot prints while preparing the plot.
+
+    m_gnuplotProcess itself is never redirected: doing so would replace its
+    console's real stdin/stdout with pipes we own, silently breaking the
+    "type further gnuplot commands into the popped-out console" feature the
+    manual documents. This second process runs with `set term unknown` (no
+    display needed) and Redirect()ed streams instead, so it never shows a
+    window of its own - see OnGnuplotPopoutCheckClose().
+  */
+  wxProcess *m_gnuplotPopoutCheckProcess = NULL;
+  //! The temp file m_gnuplotPopoutCheckProcess reads its script from; removed
+  //! once OnGnuplotPopoutCheckClose() has read back its output.
+  wxString m_gnuplotPopoutCheckFile;
   /*! The gnuplot command whose terminal support we already probed.
 
     Set when a terminal query completes. A Maxima restart re-sends

--- a/test/unit_tests/test_TreeUndo.cpp
+++ b/test/unit_tests/test_TreeUndo.cpp
@@ -455,6 +455,36 @@ SCENARIO("Fold All folds every foldable cell as one atomic undo step (GH #266)")
   }
 }
 
+SCENARIO("An error inside a folded section does not unfold it (GH #1952)") {
+  GIVEN("a worksheet [section, code] with the section folded and the code cell "
+        "flagged as containing an error") {
+    g_ws->ClearDocument();
+    GroupCell *section = AppendCell(GC_TYPE_SECTION, wxS("A section"));
+    GroupCell *child = AppendCell(GC_TYPE_CODE, wxS("bad_command;"));
+    g_ws->TreeUndo_ClearBuffers();
+
+    REQUIRE(g_ws->ToggleFold(section) == section);
+    REQUIRE(section->GetHiddenTree() == child);
+    // Simulates what MaximaEvaluator does when a cell's evaluation produces
+    // an error: register it, then (if AbortOnError, the default) jump to it.
+    g_ws->GetErrorList().Add(child);
+
+    WHEN("ScrollToError() runs, as it does when evaluation aborts on an error") {
+      g_ws->ScrollToError();
+
+      THEN("the section stays folded - only the visible header is targeted") {
+        // Folding a time-consuming calculation down to one line to keep the
+        // worksheet readable (the whole point of folding, see GH #1952) is
+        // defeated if a single error deep inside unconditionally unfurls it.
+        CHECK(section->GetHiddenTree() == child);
+        CHECK(child->GetHiddenTreeParent() == section);
+        CHECK(g_ws->GetHCaret() == section);
+      }
+    }
+  }
+  g_ws->GetErrorList().Clear();
+}
+
 class TestApp : public wxApp {
 public:
   bool OnInit() override { return true; }


### PR DESCRIPTION
## Summary

This PR now bundles two independent fixes on the same branch (per this session's branch policy):

### 1. Warn when gnuplot has trouble preparing a popped-out plot (closes the last open point on #1973)

"Pop out interactively" (the plot image's right-click menu) could leave users staring at an empty or broken gnuplot window with no indication anything had gone wrong, e.g. a `set` option their preamble used not being understood by their gnuplot version.

- A second, hidden gnuplot process now runs the identical script headlessly (`set term unknown`, so it needs no display) alongside the real interactive popout, purely to catch anything gnuplot prints while preparing the plot.
- `MaximaProcessManager::OnGnuplotPopoutCheckClose` reads that process's stdout/stderr once it exits, filters out the two-line "unknown terminal" notice `set term unknown` itself always causes (confirmed against a real gnuplot 6.0 that this happens on every `plot`, even for an otherwise-clean script), and shows anything left via `LoggingMessageBox` (a real, modal dialog — not `wxLogWarning`, since this app's own log window is hidden by default outside debug builds and wouldn't reliably reach the user).
- The real interactive gnuplot process is **never** `Redirect()`ed, so typing further gnuplot commands into its console (the feature the manual documents for `wgnuplot.exe` on Windows) keeps working exactly as before — only the new, purely diagnostic process's streams are captured.

**Verification:** live Xvfb session with real Maxima + gnuplot. A plot with a bad `user_preamble` (reproducing the original bug report's y2-axis warning) raises a "Warning" dialog quoting gnuplot's actual message; the same plot without it raises nothing; the interactive popout window works identically in both cases.

### 2. Don't unfold a folded section just because it errored (closes #1952)

`Worksheet::ScrollToError()` — called automatically whenever evaluation aborts on an error, which is the default — used to call `errorCell->RevealHidden()` unconditionally. If the errored cell was folded away, that silently unfolded the *entire* enclosing section just to point at it, defeating the reason many users fold a calculation down to one line in the first place: keeping the worksheet readable while it evaluates, errors included.

Fixed by walking `GroupCell::GetHiddenTreeParent()` up to the outermost cell that is actually part of the visible tree, and targeting that instead of unfolding when the error cell itself is hidden. The ordinary (not-folded) case is unchanged. `OpenQuestionCaret()`'s own `RevealHidden()` call is left alone since an interactive Maxima question genuinely blocks the evaluation queue until answered, unlike an error.

**Verification:** reproduced live in Xvfb on unmodified `main` (a folded section containing `a:1$ error("...")$ a+1$`, evaluated via "Evaluate All Cells", sprang open the instant the error ran), then confirmed the fix keeps it folded. Added `test/unit_tests/test_TreeUndo.cpp`'s `SCENARIO("An error inside a folded section does not unfold it (GH #1952)")`, confirmed to actually catch the regression by reverting the fix and watching the new assertions fail before restoring it.

## Test plan

- [x] Full `ninja` build succeeds with no new warnings
- [x] Full `ctest` suite passes (224+ tests)
- [x] New unit test (`TreeUndo`) added and confirmed to catch the #1952 regression
- [x] Live Xvfb verification for both fixes, described above
- [ ] CI
