### PR TITLE
Warn if Maxima starts but never connects, hinting at macOS quarantine (GH #1182)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -987,6 +987,51 @@ tried without rebuilding.
     `SCENARIO`s failed with the exact old symptoms, then passed again once
     the fixes were restored.
 
+- **"Maxima started but never connects" watchdog (GH #1182, open since
+  2019).** Before this, if the Maxima process launched successfully but
+  its socket connection back to wxMaxima's `wxSocketServer` never arrived
+  -- wxMaxima is the TCP *server* here; the spawned `maxima` binary is the
+  *client* that has to connect back, see `MaximaProcessManager::
+  StartServer()`/`OnMaximaConnect()` -- nothing timed this out or told the
+  user: the worksheet just sat at "Maxima started. Waiting for
+  connection..." forever, with no error, no retry, no explanation. This is
+  distinct from the *other* code path that already existed
+  (`OnMaximaConnect()`'s `m_unsuccessfulConnectionAttempts < 12` retry
+  loop): that one only fires once a connection attempt reaches wxMaxima and
+  then fails -- it does nothing if no attempt ever arrives at all, which is
+  exactly what happens when the child process never gets far enough to open
+  the socket. Confirmed live in this sandbox (Linux, can't reproduce the
+  actual macOS Gatekeeper trigger, but the missing-timeout mechanism itself
+  is platform-independent): pointed wxMaxima's `-m` flag at a throwaway
+  shell script that just `sleep`s forever instead of a real `maxima`
+  binary -- unmodified `main` sits at "Waiting for connection..." with zero
+  further log output, indefinitely.
+  Fixed with a new one-shot `wxTimer` (`MAXIMA_CONNECT_WATCHDOG_ID`,
+  `wxMaxima::m_maximaConnectWatchdogTimer`) armed for 5 seconds (matching
+  the issue title's own number) every time `StartMaxima()` successfully
+  spawns a process, and stopped both on a real successful connection
+  (`OnMaximaConnect()`) and on `KillMaxima()` (covers deliberate shutdown
+  and the top of every restart, since `StartMaxima(force=true)` always
+  calls `KillMaxima()` before re-arming). If it fires while the process is
+  still alive (`wxProcess::Exists()`) and still not connected, it shows a
+  `LoggingMessageBox` once per run (`m_maximaConnectWatchdogWarningShown`
+  latches so the automatic restart loop -- which re-arms this same timer on
+  every retry -- doesn't reshow the dialog up to 12 times in a row). The
+  message branches on `__WXOSX__`: on macOS it names the quarantine
+  possibility specifically (a background process wxMaxima spawns can never
+  answer the interactive security prompt Gatekeeper would otherwise show,
+  so it just silently never finishes starting) and suggests both re-running
+  the shown command from a Terminal once and `xattr -d
+  com.apple.quarantine`; elsewhere it's a generic "still waiting, check the
+  debug sidebar or your firewall" message, since quarantine isn't the
+  relevant cause there. Verified end-to-end in a live Xvfb session with the
+  same fake-hung-process technique: the log line appears at exactly +5s and
+  only once, and a screenshot confirms the dialog renders correctly with
+  the non-macOS wording (the `__WXOSX__` branch itself is untestable here
+  for the same reason #2229-#2232 were -- no macOS hardware in this
+  sandbox -- but it's the same string-formatting/branching mechanism,
+  already exercised by the generic path).
+
 ## Layout & Compatibility
 
 - **Mathematical Cell Padding:** Use `MC_TEXT_PADDING` (in `Configuration.h`) for text-based cells. **Exception:** `DigitCell` does not include padding to ensure visual consistency in broken-up numbers.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # Current development version
 
+- wxMaxima now warns if Maxima's process has started but hasn't connected
+  back within 5 seconds, instead of leaving the worksheet stuck at "Maxima
+  started. Waiting for connection..." forever with no explanation (GH
+  #1182). On macOS this reproducibly happens when Gatekeeper has
+  quarantined the Maxima binary -- common for a Maxima installed via
+  Homebrew rather than a signed installer -- since a background process
+  wxMaxima spawns can never answer the security prompt macOS would
+  otherwise show; the warning explains this and suggests a fix. wxMaxima
+  keeps waiting and retrying in the background regardless.
 - Fixed two bugs in RTF/Word export (previously untested code, now with
   regression coverage):
   - A hidden multiplication sign (e.g. the implicit "*" in scientific

--- a/locales/wxMaxima/wxMaxima.pot
+++ b/locales/wxMaxima/wxMaxima.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-10 03:42+0000\n"
+"POT-Creation-Date: 2026-08-10 11:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,7 +33,7 @@ msgid ""
 "Operating System: %s\n"
 msgstr ""
 
-#: ../../src/Image.cpp:773
+#: ../../src/Image.cpp:782
 msgid ""
 "\n"
 "Image was loaded from a .wxmx file"
@@ -51,7 +51,7 @@ msgid ""
 "Now reads: "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1981
+#: ../../src/wxMaxima.cpp:1982
 msgid ""
 "\n"
 "Use the menu \"View->Toggle log window\" to show/hide a log window with all debug messages."
@@ -193,7 +193,7 @@ msgstr ""
 msgid " Returns the unique elements of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1596
+#: ../../src/wxMaximaFrame.cpp:1600
 msgid " Wrong, if a is complex"
 msgstr ""
 
@@ -244,7 +244,7 @@ msgstr ""
 msgid "%d differences"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1831
+#: ../../src/wxMaxima.cpp:1832
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
@@ -264,62 +264,62 @@ msgstr ""
 msgid "%s: Can't interpret line: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2859
+#: ../../src/wxMaxima.cpp:2920
 #, c-format
 msgid ""
 "%sCould not write the setting for:%s\n"
 "(Is the client installed?)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1692
+#: ../../src/wxMaximaFrame.cpp:1696
 msgid "&Algebraic Mode"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1921
+#: ../../src/wxMaximaFrame.cpp:1925
 msgid "&Apropos..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:646
+#: ../../src/wxMaximaFrame.cpp:650
 msgid "&Batch File...\tCtrl+B"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1312
+#: ../../src/wxMaximaFrame.cpp:1316
 msgid "&Boundary Value Problem..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1987
+#: ../../src/wxMaximaFrame.cpp:1991
 msgid "&Bug Report"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1542
+#: ../../src/wxMaximaFrame.cpp:1546
 msgid "&Calculus"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1638
+#: ../../src/wxMaximaFrame.cpp:1642
 msgid "&Canonical Form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1392
+#: ../../src/wxMaximaFrame.cpp:1396
 msgid "&Characteristic Polynomial..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1024
+#: ../../src/wxMaximaFrame.cpp:1028
 msgid "&Clear Memory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1620
+#: ../../src/wxMaximaFrame.cpp:1624
 msgid "&Combine Factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1665
+#: ../../src/wxMaximaFrame.cpp:1669
 msgid "&Complex Simplification"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1539
+#: ../../src/wxMaximaFrame.cpp:1543
 msgid "&Continued Fraction"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:675
+#: ../../src/wxMaximaFrame.cpp:679
 msgid "&Copy\tCtrl+C"
 msgstr ""
 
@@ -327,115 +327,115 @@ msgstr ""
 msgid "&Definite integration"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1658
+#: ../../src/wxMaximaFrame.cpp:1662
 msgid "&Demoivre"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1396
+#: ../../src/wxMaximaFrame.cpp:1400
 msgid "&Determinant"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1503
+#: ../../src/wxMaximaFrame.cpp:1507
 msgid "&Differentiate..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:726
+#: ../../src/wxMaximaFrame.cpp:730
 msgid "&Edit"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1280
+#: ../../src/wxMaximaFrame.cpp:1284
 msgid "&Eliminate Variable..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1352
+#: ../../src/wxMaximaFrame.cpp:1356
 msgid "&Enter Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1920
+#: ../../src/wxMaximaFrame.cpp:1924
 msgid "&Example..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1561
+#: ../../src/wxMaximaFrame.cpp:1565
 msgid "&Expand Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1634
+#: ../../src/wxMaximaFrame.cpp:1638
 msgid "&Expand Trigonometric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1663
+#: ../../src/wxMaximaFrame.cpp:1667
 msgid "&Exponentialize"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:651
+#: ../../src/wxMaximaFrame.cpp:655
 msgid "&Export..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1553
+#: ../../src/wxMaximaFrame.cpp:1557
 msgid "&Factor Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:663
+#: ../../src/wxMaximaFrame.cpp:667
 msgid "&File"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1053
+#: ../../src/wxMaximaFrame.cpp:1057
 msgid "&Functions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1527
+#: ../../src/wxMaximaFrame.cpp:1531
 msgid "&Greatest Common Divisor..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2021
+#: ../../src/wxMaximaFrame.cpp:2025
 msgid "&Help"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1490
+#: ../../src/wxMaximaFrame.cpp:1494
 msgid "&Integrate..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:998
+#: ../../src/wxMaximaFrame.cpp:1002
 msgid "&Interrupt\tCtrl+G"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1389
+#: ../../src/wxMaximaFrame.cpp:1393
 msgid "&Invert Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1995
+#: ../../src/wxMaximaFrame.cpp:1999
 msgid "&License"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1800
+#: ../../src/wxMaximaFrame.cpp:1804
 msgid "&List"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:641
+#: ../../src/wxMaximaFrame.cpp:645
 msgid "&Load Package...\tCtrl+L"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1266
+#: ../../src/wxMaximaFrame.cpp:1270
 msgid "&Maxima"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1919
+#: ../../src/wxMaximaFrame.cpp:1923
 msgid "&Maxima help"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1697
+#: ../../src/wxMaximaFrame.cpp:1701
 msgid "&Modulus Computation..."
 msgstr ""
 
-#: ../../src/main.cpp:674
+#: ../../src/main.cpp:699
 msgid "&New\tCtrl+N"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1907
+#: ../../src/wxMaximaFrame.cpp:1911
 msgid "&Numeric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1822
+#: ../../src/wxMaximaFrame.cpp:1826
 msgid "&Numeric Output"
 msgstr ""
 
@@ -447,15 +447,15 @@ msgstr ""
 msgid "&Nusum"
 msgstr ""
 
-#: ../../src/main.cpp:675
+#: ../../src/main.cpp:700
 msgid "&Open\tCtrl+O"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:629
+#: ../../src/wxMaximaFrame.cpp:633
 msgid "&Open...\tCtrl+O"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1817
+#: ../../src/wxMaximaFrame.cpp:1821
 msgid "&Plot"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgstr ""
 msgid "&Power series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:655
+#: ../../src/wxMaximaFrame.cpp:659
 msgid "&Print...\tCtrl+P"
 msgstr ""
 
@@ -471,31 +471,31 @@ msgstr ""
 msgid "&Rational"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1631
+#: ../../src/wxMaximaFrame.cpp:1635
 msgid "&Reduce Trigonometric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1008
+#: ../../src/wxMaximaFrame.cpp:1012
 msgid "&Restart Maxima\tCtrl+Alt+R"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:639
+#: ../../src/wxMaximaFrame.cpp:643
 msgid "&Save\tCtrl+S"
 msgstr ""
 
-#: ../../src/wizards/SumWiz.cpp:43 ../../src/wxMaximaFrame.cpp:1699
+#: ../../src/wizards/SumWiz.cpp:43 ../../src/wxMaximaFrame.cpp:1703
 msgid "&Simplify"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1618
+#: ../../src/wxMaximaFrame.cpp:1622
 msgid "&Simplify Factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1628
+#: ../../src/wxMaximaFrame.cpp:1632
 msgid "&Simplify Trigonometric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1272
+#: ../../src/wxMaximaFrame.cpp:1276
 msgid "&Solve..."
 msgstr ""
 
@@ -507,19 +507,19 @@ msgstr ""
 msgid "&Taylor series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1069
+#: ../../src/wxMaximaFrame.cpp:1073
 msgid "&Time Display"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1409
+#: ../../src/wxMaximaFrame.cpp:1413
 msgid "&Transpose Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1642
+#: ../../src/wxMaximaFrame.cpp:1646
 msgid "&Trigonometric Simplification"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1055
+#: ../../src/wxMaximaFrame.cpp:1059
 msgid "&Variables"
 msgstr ""
 
@@ -531,7 +531,7 @@ msgstr ""
 msgid "(Animation)"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:771
+#: ../../src/MaximaProcessManager.cpp:776
 msgid "(Config tells to suppress the output of long cells)"
 msgstr ""
 
@@ -575,19 +575,19 @@ msgstr ""
 msgid "(f(x),x,a,b), (semi-) infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1878
+#: ../../src/wxMaximaFrame.cpp:1882
 msgid "(f(x),x,a,b), Epsilon algorithm"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1880
+#: ../../src/wxMaximaFrame.cpp:1884
 msgid "(f(x),x,a,b), infinite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1876
+#: ../../src/wxMaximaFrame.cpp:1880
 msgid "(f(x),x,a,b), strategy of Aind"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:596 ../../src/wxMaximaFrame.cpp:1904
+#: ../../src/MaximaCommandMenus.cpp:596 ../../src/wxMaximaFrame.cpp:1908
 msgid "(f(x),x,y) with singularities+discontinuities"
 msgstr ""
 
@@ -625,15 +625,15 @@ msgstr ""
 msgid "2D"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1346
+#: ../../src/wxMaximaFrame.cpp:1350
 msgid "2D Array to Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:780
+#: ../../src/wxMaximaFrame.cpp:784
 msgid "2D equations using ASCII Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:783
+#: ../../src/wxMaximaFrame.cpp:787
 msgid "2D equations using ASCII Art with unicode characters, if available"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "3D"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1835
+#: ../../src/wxMaxima.cpp:1836
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
@@ -680,7 +680,7 @@ msgid ""
 "Most probable cause: A missing comma between two list items."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2642
+#: ../../src/wxMaxima.cpp:2703
 #, c-format
 msgid "A find event, %s"
 msgstr ""
@@ -745,7 +745,7 @@ msgstr ""
 msgid "A scale factor for the printout. Helpful for printing big equations on small pdf pages."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1671
+#: ../../src/wxMaximaFrame.cpp:1675
 msgid "A search-and-replace for equations"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "A subsection heading"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1673
+#: ../../src/wxMaximaFrame.cpp:1677
 msgid "A subst with basic maths knowledge"
 msgstr ""
 
@@ -803,11 +803,11 @@ msgstr ""
 msgid "A worksheet cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1479
+#: ../../src/wxMaximaFrame.cpp:1483
 msgid "A&pply function to each Matrix element..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1325
+#: ../../src/wxMaximaFrame.cpp:1329
 msgid "A&t Value..."
 msgstr ""
 
@@ -824,11 +824,11 @@ msgstr ""
 msgid "Aborting due to --exit-on-error (exit code 1). Cell: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2016
+#: ../../src/wxMaximaFrame.cpp:2020
 msgid "About"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2016 ../../src/wxMaximaFrame.cpp:2018
+#: ../../src/wxMaximaFrame.cpp:2020 ../../src/wxMaximaFrame.cpp:2022
 msgid "About wxMaxima"
 msgstr ""
 
@@ -852,19 +852,19 @@ msgstr ""
 msgid "Accuracy"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1405
+#: ../../src/wxMaximaFrame.cpp:1409
 msgid "Ad&joint Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1694
+#: ../../src/wxMaximaFrame.cpp:1698
 msgid "Add Algebraic E&quality..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1049
+#: ../../src/wxMaximaFrame.cpp:1053
 msgid "Add a directory to search path"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1789
+#: ../../src/wxMaximaFrame.cpp:1793
 msgid "Add a new item to the beginning of the list. Useful for creating stacks."
 msgstr ""
 
@@ -884,7 +884,7 @@ msgstr ""
 msgid "Add dir to path:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1695
+#: ../../src/wxMaximaFrame.cpp:1699
 msgid "Add equality to the rational simplifier"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgstr ""
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1049
+#: ../../src/wxMaximaFrame.cpp:1053
 msgid "Add to &Path..."
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "Additional symbols for the \"symbols\" sidebar:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1599
+#: ../../src/wxMaximaFrame.cpp:1603
 msgid "Additionally: log(a*b)=log(a)+log(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1603
+#: ../../src/wxMaximaFrame.cpp:1607
 msgid "Additionally: log(a/b)=log(a)-log(b), a and b positive integers"
 msgstr ""
 
@@ -951,15 +951,15 @@ msgstr ""
 msgid "Additive function: f(a+b)=f(a)+f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1948
+#: ../../src/wxMaximaFrame.cpp:1952
 msgid "Advanced 2d plotting"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1846
+#: ../../src/wxMaximaFrame.cpp:1850
 msgid "Advanced guess (PSLQ algorithm)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1957
+#: ../../src/wxMaximaFrame.cpp:1961
 msgid "Advanced variable names"
 msgstr ""
 
@@ -975,7 +975,7 @@ msgstr ""
 msgid "Albanian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1062
+#: ../../src/wxMaximaFrame.cpp:1066
 msgid "Aliases"
 msgstr ""
 
@@ -983,15 +983,15 @@ msgstr ""
 msgid "All Levels"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1751
+#: ../../src/wxMaximaFrame.cpp:1755
 msgid "All but the 1st n elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1753
+#: ../../src/wxMaximaFrame.cpp:1757
 msgid "All but the last n elements"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:2198 ../../src/main.cpp:883
+#: ../../src/MaximaCommandMenus.cpp:2198 ../../src/main.cpp:908
 msgid "All openable types (*.wxm, *.wxmx, *.mac, *.out, *.xml)|*.wxm;*.wxmx;*.mac;*.out;*.xml|wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx|Maxima session (*.mac)|*.mac|Xmaxima session (*.out)|*.out|xml from broken .wxmx (*.xml)|*.xml"
 msgstr ""
 
@@ -999,7 +999,7 @@ msgstr ""
 msgid "All variable names"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:770
+#: ../../src/wxMaximaFrame.cpp:774
 msgid "All visible sidebars"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Allow access to an online manual?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1687
+#: ../../src/wxMaximaFrame.cpp:1691
 msgid "Allow substituting operators"
 msgstr ""
 
@@ -1027,15 +1027,15 @@ msgstr ""
 msgid "All|*"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:800
+#: ../../src/wxMaximaFrame.cpp:804
 msgid "Always after underscores"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:801
+#: ../../src/wxMaximaFrame.cpp:805
 msgid "Always autosubscript after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:811
+#: ../../src/wxMaximaFrame.cpp:815
 msgid "Always display this variable with subscript"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgstr ""
 msgid "Anchors file has no top node."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:828
+#: ../../src/wxMaximaFrame.cpp:832
 msgid "Angles"
 msgstr ""
 
@@ -1072,11 +1072,11 @@ msgstr ""
 msgid "Animated Diagram"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1812
+#: ../../src/wxMaximaFrame.cpp:1816
 msgid "Animation autoplay"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1815
+#: ../../src/wxMaximaFrame.cpp:1819
 msgid "Animation framerate..."
 msgstr ""
 
@@ -1084,7 +1084,7 @@ msgstr ""
 msgid "Announce Maxima's output as MathML"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:5467 ../../src/wxMaximaFrame.cpp:1989
+#: ../../src/worksheet/Worksheet.cpp:5467 ../../src/wxMaximaFrame.cpp:1993
 msgid "Anonymize Code for Bug Report"
 msgstr ""
 
@@ -1096,15 +1096,15 @@ msgstr ""
 msgid "Appearance:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1776
+#: ../../src/wxMaximaFrame.cpp:1780
 msgid "Append"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1772
+#: ../../src/wxMaximaFrame.cpp:1776
 msgid "Append a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1773
+#: ../../src/wxMaximaFrame.cpp:1777
 msgid "Append a list to an existing list"
 msgstr ""
 
@@ -1112,15 +1112,15 @@ msgstr ""
 msgid "Append a list to another list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1766
+#: ../../src/wxMaximaFrame.cpp:1770
 msgid "Append an element"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1771
+#: ../../src/wxMaximaFrame.cpp:1775
 msgid "Append an element to the beginning an existing list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1767
+#: ../../src/wxMaximaFrame.cpp:1771
 msgid "Append an element to the end of an existing list"
 msgstr ""
 
@@ -1128,12 +1128,12 @@ msgstr ""
 msgid "Apply a function to each list element"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1847
+#: ../../src/wxMaximaFrame.cpp:1851
 #, c-format
 msgid "Approximate by a fraction using log(), sqrt() and %pi, when needed. Only available in maxima > 5.46.0"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1843
+#: ../../src/wxMaximaFrame.cpp:1847
 msgid "Approximate by nice fraction"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgstr ""
 msgid "Array"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1057
+#: ../../src/wxMaximaFrame.cpp:1061
 msgid "Arrays"
 msgstr ""
 
@@ -1198,7 +1198,7 @@ msgstr ""
 msgid "Ascii code to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1172
+#: ../../src/wxMaximaFrame.cpp:1176
 msgid "Ascii code to char..."
 msgstr ""
 
@@ -1253,11 +1253,11 @@ msgstr ""
 msgid "Automatic labels (%i1, %o1,...)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:986
+#: ../../src/wxMaximaFrame.cpp:990
 msgid "Automatically answer questions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:987
+#: ../../src/wxMaximaFrame.cpp:991
 msgid "Automatically fill in answers known from the last run"
 msgstr ""
 
@@ -1280,15 +1280,15 @@ msgstr ""
 msgid "Autosaving the .wxmx file as %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:818
+#: ../../src/wxMaximaFrame.cpp:822
 msgid "Autosubscript"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:819
+#: ../../src/wxMaximaFrame.cpp:823
 msgid "Autosubscript chars after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:804
+#: ../../src/wxMaximaFrame.cpp:808
 msgid "Autosubscript numbers and text following single letters"
 msgstr ""
 
@@ -1316,7 +1316,7 @@ msgstr ""
 msgid "Barsplot..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1384
+#: ../../src/wxMaximaFrame.cpp:1388
 msgid "Basic matrix operations"
 msgstr ""
 
@@ -1332,12 +1332,12 @@ msgstr ""
 msgid "Batch File"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2079
+#: ../../src/wxMaxima.cpp:2080
 #, c-format
 msgid "Batch mode: %d image(s) could not be loaded at all."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2084
+#: ../../src/wxMaxima.cpp:2085
 #, c-format
 msgid "Batch mode: %d image(s) failed to decode/render (--debug)."
 msgstr ""
@@ -1375,7 +1375,7 @@ msgstr ""
 msgid "Bold"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2261
+#: ../../src/wxMaxima.cpp:2262
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Bug: y position of cell is unknown!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1985
+#: ../../src/wxMaximaFrame.cpp:1989
 msgid "Build &Info"
 msgstr ""
 
@@ -1550,11 +1550,11 @@ msgstr ""
 msgid "Byte:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1495
+#: ../../src/wxMaximaFrame.cpp:1499
 msgid "C&hange Variable in Integrate..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:724
+#: ../../src/wxMaximaFrame.cpp:728
 msgid "C&onfigure"
 msgstr ""
 
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Caching font variant: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1519
+#: ../../src/wxMaximaFrame.cpp:1523
 msgid "Calculate &Product..."
 msgstr ""
 
@@ -1583,15 +1583,15 @@ msgstr ""
 msgid "Calculate Singular Value Decomposition, left and right singular vectors numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1517
+#: ../../src/wxMaximaFrame.cpp:1521
 msgid "Calculate Su&m..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1832
+#: ../../src/wxMaximaFrame.cpp:1836
 msgid "Calculate bigfloat value of the last result"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1829
+#: ../../src/wxMaximaFrame.cpp:1833
 msgid "Calculate float value of the last result"
 msgstr ""
 
@@ -1607,11 +1607,11 @@ msgstr ""
 msgid "Calculate modulus:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1835
+#: ../../src/wxMaximaFrame.cpp:1839
 msgid "Calculate numeric value of the last result"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1520
+#: ../../src/wxMaximaFrame.cpp:1524
 msgid "Calculate products"
 msgstr ""
 
@@ -1619,7 +1619,7 @@ msgstr ""
 msgid "Calculate standard deviation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1517
+#: ../../src/wxMaximaFrame.cpp:1521
 msgid "Calculate sums"
 msgstr ""
 
@@ -1651,16 +1651,16 @@ msgstr ""
 msgid "Can be specified as flag in ev(exp, flag)"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3438
+#: ../../src/wxMaxima.cpp:3499
 msgid "Can not connect to the web server."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3384 ../../src/wxMaxima.cpp:3420
-#: ../../src/wxMaxima.cpp:3472
+#: ../../src/wxMaxima.cpp:3445 ../../src/wxMaxima.cpp:3481
+#: ../../src/wxMaxima.cpp:3533
 msgid "Can not download version info."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:577 ../../src/wxMaxima.cpp:1581
+#: ../../src/MaximaProcessManager.cpp:582 ../../src/wxMaxima.cpp:1582
 msgid "Can not start Maxima. The most probable cause is that Maxima isn't installed (it can be downloaded from https://maxima.sourceforge.io) or in wxMaxima's config dialogue the setting for Maxima's location is wrong."
 msgstr ""
 
@@ -1698,7 +1698,7 @@ msgstr ""
 #: ../../src/wizards/SeriesWiz.cpp:52 ../../src/wizards/SubstituteWiz.cpp:42
 #: ../../src/wizards/SubstituteWiz.cpp:44 ../../src/wizards/SumWiz.cpp:48
 #: ../../src/wizards/SumWiz.cpp:50 ../../src/wizards/SystemWiz.cpp:39
-#: ../../src/wizards/SystemWiz.cpp:41 ../../src/wxMaxima.cpp:3509
+#: ../../src/wizards/SystemWiz.cpp:41 ../../src/wxMaxima.cpp:3570
 msgid "Cancel"
 msgstr ""
 
@@ -1706,7 +1706,7 @@ msgstr ""
 msgid "Cannot authenticate Maxima!"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1283
+#: ../../src/wxMaxima.cpp:1284
 #, c-format
 msgid "Cannot cache the list of known symbols to %s"
 msgstr ""
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "Cannot create a font based on %s. Falling back to a default font."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:370
+#: ../../src/MaximaProcessManager.cpp:374
 msgid "Cannot find a maxima binary and no binary chosen in the config dialogue."
 msgstr ""
 
@@ -1730,8 +1730,8 @@ msgstr ""
 msgid "Cannot interpret the numeric value of pid %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3347 ../../src/wxMaxima.cpp:3354
-#: ../../src/wxMaxima.cpp:3361
+#: ../../src/wxMaxima.cpp:3408 ../../src/wxMaxima.cpp:3415
+#: ../../src/wxMaxima.cpp:3422
 #, c-format
 msgid "Cannot interpret version number component %s"
 msgstr ""
@@ -1763,11 +1763,11 @@ msgstr ""
 msgid "Cannot save the list of subjects manual contains to the file %s."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:191
+#: ../../src/MaximaProcessManager.cpp:192
 msgid "Cannot set the communication address to localhost."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:193
+#: ../../src/MaximaProcessManager.cpp:194
 #, c-format
 msgid "Cannot set the communication port to %i."
 msgstr ""
@@ -1780,7 +1780,7 @@ msgstr ""
 msgid "Cannot start the headless gnuplot warnings check"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:341 ../../src/StatusBar.cpp:254
+#: ../../src/MaximaProcessManager.cpp:342 ../../src/StatusBar.cpp:254
 msgid "Cannot start the maxima binary"
 msgstr ""
 
@@ -1796,11 +1796,11 @@ msgstr ""
 msgid "Cauchy principal value of f(x)/(x-c), finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1882
+#: ../../src/wxMaximaFrame.cpp:1886
 msgid "Cauchy principal value, finite interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:989
+#: ../../src/wxMaximaFrame.cpp:993
 msgid "Ce&ll"
 msgstr ""
 
@@ -1812,7 +1812,7 @@ msgstr ""
 msgid "Cell bracket fill, Inactive"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3082
+#: ../../src/wxMaxima.cpp:3143
 msgid "Cell ends in a backslash"
 msgstr ""
 
@@ -1821,7 +1821,7 @@ msgstr ""
 msgid "Cell with UUID %s not found!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1072
+#: ../../src/wxMaximaFrame.cpp:1076
 msgid "Change &2d Display"
 msgstr ""
 
@@ -1833,7 +1833,7 @@ msgstr ""
 msgid "Change Image..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1997
+#: ../../src/wxMaximaFrame.cpp:2001
 msgid "Change Log"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Change directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1236
+#: ../../src/wxMaximaFrame.cpp:1240
 msgid "Change directory..."
 msgstr ""
 
@@ -1849,7 +1849,7 @@ msgstr ""
 msgid "Change names of greek letters to greek letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1073
+#: ../../src/wxMaximaFrame.cpp:1077
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
 
@@ -1865,11 +1865,11 @@ msgstr ""
 msgid "Change variable and evaluate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1496
+#: ../../src/wxMaximaFrame.cpp:1500
 msgid "Change variable in integral or sum"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1500
+#: ../../src/wxMaximaFrame.cpp:1504
 msgid "Change variable in integral or sum and evaluate the result"
 msgstr ""
 
@@ -1877,7 +1877,7 @@ msgstr ""
 msgid "ChangeLog"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1060
+#: ../../src/wxMaximaFrame.cpp:1064
 msgid "Changed option variables"
 msgstr ""
 
@@ -1898,7 +1898,7 @@ msgstr ""
 msgid "Char #2:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1174
+#: ../../src/wxMaximaFrame.cpp:1178
 msgid "Char to Unicode code point..."
 msgstr ""
 
@@ -1914,7 +1914,7 @@ msgstr ""
 msgid "Char:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1165
+#: ../../src/wxMaximaFrame.cpp:1169
 msgid "Character Tests"
 msgstr ""
 
@@ -1926,11 +1926,11 @@ msgstr ""
 msgid "Chars are strings that are one character long"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2000
+#: ../../src/wxMaximaFrame.cpp:2004
 msgid "Check for Updates"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2001
+#: ../../src/wxMaximaFrame.cpp:2005
 msgid "Check if a newer version of wxMaxima is available."
 msgstr ""
 
@@ -1979,7 +1979,7 @@ msgstr ""
 msgid "Choose the %s Font"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:837
+#: ../../src/wxMaximaFrame.cpp:841
 msgid "Choose the parenthesis type for Matrices"
 msgstr ""
 
@@ -1987,27 +1987,27 @@ msgstr ""
 msgid "Classes:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1412
+#: ../../src/wxMaximaFrame.cpp:1416
 msgid "Classic matrix operations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1032
+#: ../../src/wxMaximaFrame.cpp:1036
 msgid "Clear all aliases"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1029
+#: ../../src/wxMaximaFrame.cpp:1033
 msgid "Clear all arrays"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1026
+#: ../../src/wxMaximaFrame.cpp:1030
 msgid "Clear all dependencies"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1028
+#: ../../src/wxMaximaFrame.cpp:1032
 msgid "Clear all functions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1035
+#: ../../src/wxMaximaFrame.cpp:1039
 msgid "Clear all gradefs"
 msgstr ""
 
@@ -2015,31 +2015,31 @@ msgstr ""
 msgid "Clear all history"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1034
+#: ../../src/wxMaximaFrame.cpp:1038
 msgid "Clear all labels"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1038
+#: ../../src/wxMaximaFrame.cpp:1042
 msgid "Clear all let rule packages"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1037
+#: ../../src/wxMaximaFrame.cpp:1041
 msgid "Clear all macros"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1036
+#: ../../src/wxMaximaFrame.cpp:1040
 msgid "Clear all props"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1031
+#: ../../src/wxMaximaFrame.cpp:1035
 msgid "Clear all rules"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1033
+#: ../../src/wxMaximaFrame.cpp:1037
 msgid "Clear all structures"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1027
+#: ../../src/wxMaximaFrame.cpp:1031
 msgid "Clear all variables"
 msgstr ""
 
@@ -2056,7 +2056,7 @@ msgstr ""
 msgid "Clipboard format parameters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:637
+#: ../../src/wxMaximaFrame.cpp:641
 msgid "Close\tCtrl+W"
 msgstr ""
 
@@ -2064,11 +2064,11 @@ msgstr ""
 msgid "Close Stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:637
+#: ../../src/wxMaximaFrame.cpp:641
 msgid "Close window"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1139
+#: ../../src/wxMaximaFrame.cpp:1143
 msgid "Close..."
 msgstr ""
 
@@ -2148,7 +2148,7 @@ msgstr ""
 msgid "Columns:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1621
+#: ../../src/wxMaximaFrame.cpp:1625
 msgid "Combine factorials in an expression"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Comma"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3141
+#: ../../src/wxMaxima.cpp:3202
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -2262,11 +2262,11 @@ msgstr ""
 msgid "Comment Selection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:718
+#: ../../src/wxMaximaFrame.cpp:722
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:717
+#: ../../src/wxMaximaFrame.cpp:721
 msgid "Comment selection\tCtrl+/"
 msgstr ""
 
@@ -2274,15 +2274,15 @@ msgstr ""
 msgid "Commutative function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:649
+#: ../../src/wxMaximaFrame.cpp:653
 msgid "Compare files..."
 msgstr ""
 
-#: ../../src/main.cpp:723
+#: ../../src/main.cpp:748
 msgid "Comparing worksheets (the --diff option or the wxmxdiff command) needs 2 or 3 files to compare."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1430
+#: ../../src/wxMaximaFrame.cpp:1434
 msgid "Compile a QR decomposition using dgeqrf"
 msgstr ""
 
@@ -2290,27 +2290,27 @@ msgstr ""
 msgid "Compile a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1222
+#: ../../src/wxMaximaFrame.cpp:1226
 msgid "Compile a regular expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1419
+#: ../../src/wxMaximaFrame.cpp:1423
 msgid "Compile eigenvalues using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1422
+#: ../../src/wxMaximaFrame.cpp:1426
 msgid "Compile eigenvalues using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1425
+#: ../../src/wxMaximaFrame.cpp:1429
 msgid "Compile eigenvalues+eigenvectors using dgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1428
+#: ../../src/wxMaximaFrame.cpp:1432
 msgid "Compile eigenvalues+eigenvectors using zgeev"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1110
+#: ../../src/wxMaximaFrame.cpp:1114
 msgid "Compile function..."
 msgstr ""
 
@@ -2331,11 +2331,11 @@ msgstr ""
 msgid "Compiling a function can generate a considerable speed boost if the types of the function parameters are made known to the function before it is compiled. Else the generated code has to be hideously generic."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:926
+#: ../../src/wxMaximaFrame.cpp:930
 msgid "Complete Word\tCtrl+Space"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:927
+#: ../../src/wxMaximaFrame.cpp:931
 msgid "Complete word"
 msgstr ""
 
@@ -2351,35 +2351,35 @@ msgstr ""
 msgid "Composing a list of the line starts we can use as page starts"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1540
+#: ../../src/wxMaximaFrame.cpp:1544
 msgid "Compute continued fraction of a value"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1406
+#: ../../src/wxMaximaFrame.cpp:1410
 msgid "Compute the adjoint matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1393
+#: ../../src/wxMaximaFrame.cpp:1397
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1397
+#: ../../src/wxMaximaFrame.cpp:1401
 msgid "Compute the determinant of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1528
+#: ../../src/wxMaximaFrame.cpp:1532
 msgid "Compute the greatest common divisor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1390
+#: ../../src/wxMaximaFrame.cpp:1394
 msgid "Compute the inverse of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1531
+#: ../../src/wxMaximaFrame.cpp:1535
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1408
+#: ../../src/wxMaximaFrame.cpp:1412
 msgid "Compute the rank of a matrix"
 msgstr ""
 
@@ -2404,7 +2404,7 @@ msgid "Configuration warning"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:367 ../../src/ToolBar.cpp:369
-#: ../../src/wxMaximaFrame.cpp:722 ../../src/wxMaximaFrame.cpp:724
+#: ../../src/wxMaximaFrame.cpp:726 ../../src/wxMaximaFrame.cpp:728
 msgid "Configure wxMaxima"
 msgstr ""
 
@@ -2412,11 +2412,11 @@ msgstr ""
 msgid "Connect the dots"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:165
+#: ../../src/MaximaProcessManager.cpp:166
 msgid "Connection attempt, but connection failed."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:792
+#: ../../src/MaximaProcessManager.cpp:797
 msgid "Connection to Maxima lost."
 msgstr ""
 
@@ -2430,7 +2430,7 @@ msgstr ""
 msgid "Construct a fraction"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1339
+#: ../../src/wxMaximaFrame.cpp:1343
 msgid "Construct fraction..."
 msgstr ""
 
@@ -2442,11 +2442,11 @@ msgstr ""
 msgid "Contents:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1914
+#: ../../src/wxMaximaFrame.cpp:1918
 msgid "Context-sensitive &Help\tCtrl+?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1916
+#: ../../src/wxMaximaFrame.cpp:1920
 msgid "Context-sensitive &Help\tF1"
 msgstr ""
 
@@ -2474,55 +2474,55 @@ msgstr ""
 msgid "Contour lines settings for the following 3d plots"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1579
+#: ../../src/wxMaximaFrame.cpp:1583
 msgid "Contract Logarithms"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1195
+#: ../../src/wxMaximaFrame.cpp:1199
 msgid "Conversions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1263
+#: ../../src/wxMaximaFrame.cpp:1267
 msgid "Convert"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1264
+#: ../../src/wxMaximaFrame.cpp:1268
 msgid "Convert + Write to file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1471
+#: ../../src/wxMaximaFrame.cpp:1475
 msgid "Convert Column to list..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1467
+#: ../../src/wxMaximaFrame.cpp:1471
 msgid "Convert Row to list..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1078
+#: ../../src/wxMaximaFrame.cpp:1082
 msgid "Convert a command to maxima code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1355
+#: ../../src/wxMaximaFrame.cpp:1359
 msgid "Convert a list of lists to a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1611
+#: ../../src/wxMaximaFrame.cpp:1615
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1615
+#: ../../src/wxMaximaFrame.cpp:1619
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1650
+#: ../../src/wxMaximaFrame.cpp:1654
 msgid "Convert complex expression to polar form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1647
+#: ../../src/wxMaximaFrame.cpp:1651
 msgid "Convert complex expression to rect form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1659
+#: ../../src/wxMaximaFrame.cpp:1663
 msgid "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 
@@ -2534,23 +2534,23 @@ msgstr ""
 msgid "Convert string to matching regex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1580
+#: ../../src/wxMaximaFrame.cpp:1584
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1610
+#: ../../src/wxMaximaFrame.cpp:1614
 msgid "Convert to &Factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1614
+#: ../../src/wxMaximaFrame.cpp:1618
 msgid "Convert to &Gamma"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1649
+#: ../../src/wxMaximaFrame.cpp:1653
 msgid "Convert to &Polarform"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1646
+#: ../../src/wxMaximaFrame.cpp:1650
 msgid "Convert to &Rectform"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Convert to Title"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1200
+#: ../../src/wxMaximaFrame.cpp:1204
 msgid "Convert to downcase..."
 msgstr ""
 
@@ -2594,11 +2594,11 @@ msgstr ""
 msgid "Convert to programming language file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1639
+#: ../../src/wxMaximaFrame.cpp:1643
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1664
+#: ../../src/wxMaximaFrame.cpp:1668
 msgid "Convert trigonometric functions to exponential form"
 msgstr ""
 
@@ -2610,11 +2610,11 @@ msgstr ""
 msgid "Converted to linear:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1799
+#: ../../src/wxMaximaFrame.cpp:1803
 msgid "Converts a matrix to a list of lists"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1797
+#: ../../src/wxMaximaFrame.cpp:1801
 msgid "Converts a nested list like [[1,2],[3,4]] to a matrix"
 msgstr ""
 
@@ -2633,11 +2633,11 @@ msgstr ""
 msgid "Copy Animation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:921
+#: ../../src/wxMaximaFrame.cpp:925
 msgid "Copy Previous Input\tCtrl+I"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:924
+#: ../../src/wxMaximaFrame.cpp:928
 msgid "Copy Previous Output\tCtrl+U"
 msgstr ""
 
@@ -2647,23 +2647,23 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:145
 #: ../../src/worksheet/WorksheetContextMenu.cpp:292
-#: ../../src/wxMaximaFrame.cpp:700
+#: ../../src/wxMaximaFrame.cpp:704
 msgid "Copy as EMF"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:135
 #: ../../src/worksheet/WorksheetContextMenu.cpp:282
-#: ../../src/wxMaximaFrame.cpp:689
+#: ../../src/wxMaximaFrame.cpp:693
 msgid "Copy as Image"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:126
 #: ../../src/worksheet/WorksheetContextMenu.cpp:273
-#: ../../src/wxMaximaFrame.cpp:682
+#: ../../src/wxMaximaFrame.cpp:686
 msgid "Copy as LaTeX"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:685
+#: ../../src/wxMaximaFrame.cpp:689
 msgid "Copy as MathML"
 msgstr ""
 
@@ -2674,17 +2674,17 @@ msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:148
 #: ../../src/worksheet/WorksheetContextMenu.cpp:295
-#: ../../src/wxMaximaFrame.cpp:695
+#: ../../src/wxMaximaFrame.cpp:699
 msgid "Copy as RTF"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:142
 #: ../../src/worksheet/WorksheetContextMenu.cpp:289
-#: ../../src/wxMaximaFrame.cpp:692
+#: ../../src/wxMaximaFrame.cpp:696
 msgid "Copy as SVG"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:677
+#: ../../src/wxMaximaFrame.cpp:681
 msgid "Copy as Text\tCtrl+Shift+C"
 msgstr ""
 
@@ -2697,13 +2697,13 @@ msgstr ""
 msgid "Copy file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1248
+#: ../../src/wxMaximaFrame.cpp:1252
 msgid "Copy file..."
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:124
 #: ../../src/worksheet/WorksheetContextMenu.cpp:271
-#: ../../src/wxMaximaFrame.cpp:680
+#: ../../src/wxMaximaFrame.cpp:684
 msgid "Copy for Octave/Matlab"
 msgstr ""
 
@@ -2715,39 +2715,39 @@ msgid "Copy position (UUID)"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:380 ../../src/ToolBar.cpp:384
-#: ../../src/wxMaximaFrame.cpp:675
+#: ../../src/wxMaximaFrame.cpp:679
 msgid "Copy selection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:701
+#: ../../src/wxMaximaFrame.cpp:705
 msgid "Copy selection from document as an Enhanced Metafile"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:693
+#: ../../src/wxMaximaFrame.cpp:697
 msgid "Copy selection from document as an SVG image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:690
+#: ../../src/wxMaximaFrame.cpp:694
 msgid "Copy selection from document as an image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:696
+#: ../../src/wxMaximaFrame.cpp:700
 msgid "Copy selection from document as rtf that a word processor might understand"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:678
+#: ../../src/wxMaximaFrame.cpp:682
 msgid "Copy selection from document as text"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:683
+#: ../../src/wxMaximaFrame.cpp:687
 msgid "Copy selection from document in LaTeX format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:681
+#: ../../src/wxMaximaFrame.cpp:685
 msgid "Copy selection from document in Matlab format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:686
+#: ../../src/wxMaximaFrame.cpp:690
 msgid "Copy selection from document in a MathML format many word processors can display as 2d equation"
 msgstr ""
 
@@ -2755,7 +2755,7 @@ msgstr ""
 msgid "Copy string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1199
+#: ../../src/wxMaximaFrame.cpp:1203
 msgid "Copy string..."
 msgstr ""
 
@@ -2795,16 +2795,16 @@ msgstr ""
 msgid "Could not make sure that we talk to the maxima we started => discarding all data it sends."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:893
+#: ../../src/MaximaProcessManager.cpp:898
 msgid "Could not map view of the file needed in order to send an interrupt signal to maxima."
 msgstr ""
 
-#: ../../src/Image.cpp:1000
+#: ../../src/Image.cpp:1009
 msgid "Could not parse the SVG image data."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:873
-#: ../../src/MaximaProcessManager.cpp:916
+#: ../../src/MaximaProcessManager.cpp:878
+#: ../../src/MaximaProcessManager.cpp:921
 msgid "Could not send an interrupt signal to maxima."
 msgstr ""
 
@@ -2812,11 +2812,11 @@ msgstr ""
 msgid "Could not write the file's contents during saving => aborting."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1359
+#: ../../src/wxMaximaFrame.cpp:1363
 msgid "Create Matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1725
+#: ../../src/wxMaximaFrame.cpp:1729
 msgid "Create a list"
 msgstr ""
 
@@ -2832,19 +2832,19 @@ msgstr ""
 msgid "Create a list from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1707
+#: ../../src/wxMaximaFrame.cpp:1711
 msgid "Create a list from comma-separated elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:922
+#: ../../src/wxMaximaFrame.cpp:926
 msgid "Create a new cell with previous input"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:925
+#: ../../src/wxMaximaFrame.cpp:929
 msgid "Create a new cell with previous output"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1382
+#: ../../src/wxMaximaFrame.cpp:1386
 msgid "Create copy, not clone..."
 msgstr ""
 
@@ -2852,7 +2852,7 @@ msgstr ""
 msgid "Create directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1237
+#: ../../src/wxMaximaFrame.cpp:1241
 msgid "Create directory..."
 msgstr ""
 
@@ -2860,11 +2860,11 @@ msgstr ""
 msgid "Create empty string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1202
+#: ../../src/wxMaximaFrame.cpp:1206
 msgid "Create empty string..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1724
+#: ../../src/wxMaximaFrame.cpp:1728
 msgid "Create list"
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Create scalable plots."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1116
+#: ../../src/wxMaximaFrame.cpp:1120
 msgid "Create struct..."
 msgstr ""
 
@@ -2884,7 +2884,7 @@ msgstr ""
 msgid "Created a .zip archive (the .wxmx file technically is a .zip file)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1383
+#: ../../src/wxMaximaFrame.cpp:1387
 msgid "Creates an independent matrix with the same contents"
 msgstr ""
 
@@ -2909,12 +2909,12 @@ msgstr ""
 msgid "Cut"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:673
+#: ../../src/wxMaximaFrame.cpp:677
 msgid "Cut\tCtrl+X"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:379 ../../src/ToolBar.cpp:383
-#: ../../src/wxMaximaFrame.cpp:673
+#: ../../src/wxMaximaFrame.cpp:677
 msgid "Cut selection"
 msgstr ""
 
@@ -2951,11 +2951,11 @@ msgstr ""
 msgid "Data:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1091
+#: ../../src/wxMaximaFrame.cpp:1095
 msgid "Debugger trigger"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:816
+#: ../../src/wxMaximaFrame.cpp:820
 msgid "Declare Text to always be displayed as subscript"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Declare these chars as ordinary letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1537 ../../src/wxMaximaFrame.cpp:1573
+#: ../../src/wxMaximaFrame.cpp:1541 ../../src/wxMaximaFrame.cpp:1577
 msgid "Decompose rational function to partial fractions"
 msgstr ""
 
@@ -3024,19 +3024,19 @@ msgstr ""
 msgid "Define a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1106
+#: ../../src/wxMaximaFrame.cpp:1110
 msgid "Define function..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1113
+#: ../../src/wxMaximaFrame.cpp:1117
 msgid "Define macro..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1111
+#: ../../src/wxMaximaFrame.cpp:1115
 msgid "Define parameter type..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1115
+#: ../../src/wxMaximaFrame.cpp:1119
 msgid "Define struct..."
 msgstr ""
 
@@ -3044,11 +3044,11 @@ msgstr ""
 msgid "Define the default speed (in frames per second) animations are played back with."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1114
+#: ../../src/wxMaximaFrame.cpp:1118
 msgid "Define variable..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1813
+#: ../../src/wxMaximaFrame.cpp:1817
 msgid "Defines if an animation is automatically started or only by clicking on it."
 msgstr ""
 
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "Degree:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1019
+#: ../../src/wxMaximaFrame.cpp:1023
 msgid "Delete F&unction..."
 msgstr ""
 
@@ -3065,23 +3065,23 @@ msgstr ""
 msgid "Delete Selection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1021
+#: ../../src/wxMaximaFrame.cpp:1025
 msgid "Delete V&ariable..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1020
+#: ../../src/wxMaximaFrame.cpp:1024
 msgid "Delete a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1022
+#: ../../src/wxMaximaFrame.cpp:1026
 msgid "Delete a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1016
+#: ../../src/wxMaximaFrame.cpp:1020
 msgid "Delete all objects with a given name"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1025
+#: ../../src/wxMaximaFrame.cpp:1029
 msgid "Delete all values from memory"
 msgstr ""
 
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Delete file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1250
+#: ../../src/wxMaximaFrame.cpp:1254
 msgid "Delete file..."
 msgstr ""
 
@@ -3101,7 +3101,7 @@ msgstr ""
 msgid "Delete named object(s)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1015
+#: ../../src/wxMaximaFrame.cpp:1019
 msgid "Delete named object..."
 msgstr ""
 
@@ -3123,7 +3123,7 @@ msgstr ""
 msgid "Demo for \"%s\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1967
+#: ../../src/wxMaximaFrame.cpp:1971
 msgid "Demos"
 msgstr ""
 
@@ -3135,7 +3135,7 @@ msgstr ""
 msgid "Denominator:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1064
+#: ../../src/wxMaximaFrame.cpp:1068
 msgid "Dependencies"
 msgstr ""
 
@@ -3178,7 +3178,7 @@ msgstr ""
 msgid "Deviation..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1534
+#: ../../src/wxMaximaFrame.cpp:1538
 msgid "Di&vide Polynomials..."
 msgstr ""
 
@@ -3198,7 +3198,7 @@ msgstr ""
 msgid "Didn't find the maxima HTML manual."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1685
+#: ../../src/wxMaxima.cpp:1686
 msgid "Didn't get a help browser launch program command line, but can request the system's default help browser."
 msgstr ""
 
@@ -3219,7 +3219,7 @@ msgstr ""
 msgid "Differentiate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1504
+#: ../../src/wxMaximaFrame.cpp:1508
 msgid "Differentiate expression"
 msgstr ""
 
@@ -3239,7 +3239,7 @@ msgstr ""
 msgid "Direction:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1246
+#: ../../src/wxMaximaFrame.cpp:1250
 msgid "Directory operations"
 msgstr ""
 
@@ -3255,7 +3255,7 @@ msgstr ""
 msgid "Display"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1075
+#: ../../src/wxMaximaFrame.cpp:1079
 msgid "Display Te&X Form"
 msgstr ""
 
@@ -3271,15 +3271,15 @@ msgstr ""
 msgid "Display all digits"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:788
+#: ../../src/wxMaximaFrame.cpp:792
 msgid "Display an expression as maxima's internal lisp representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:791
+#: ../../src/wxMaximaFrame.cpp:795
 msgid "Display an expression as wxMaxima's internal XML representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:795
+#: ../../src/wxMaximaFrame.cpp:799
 msgid "Display equations"
 msgstr ""
 
@@ -3291,7 +3291,7 @@ msgstr ""
 msgid "Display expression in wxMaxima's internal representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1076
+#: ../../src/wxMaximaFrame.cpp:1080
 msgid "Display last result in TeX form"
 msgstr ""
 
@@ -3304,11 +3304,11 @@ msgstr ""
 msgid "Display resolution according to wxWidgets: %li x %li ppi"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:839
+#: ../../src/wxMaximaFrame.cpp:843
 msgid "Display string quotation marks"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1070
+#: ../../src/wxMaximaFrame.cpp:1074
 msgid "Display time used for evaluation"
 msgstr ""
 
@@ -3316,32 +3316,32 @@ msgstr ""
 msgid "Displayed Precision"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1950
+#: ../../src/wxMaximaFrame.cpp:1954
 msgid "Displaying 3d curves"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1499
+#: ../../src/wxMaximaFrame.cpp:1503
 msgid "Dito, and evaluate the result..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1482
+#: ../../src/wxMaximaFrame.cpp:1486
 msgid "Dito, but affect all clones of the Matrix..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1289
+#: ../../src/wxMaximaFrame.cpp:1293
 msgid "Dito, but as fraction (real only)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1569
+#: ../../src/wxMaximaFrame.cpp:1573
 msgid "Dito, including denominator"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:488
-#: ../../src/wxMaximaFrame.cpp:978
+#: ../../src/wxMaximaFrame.cpp:982
 msgid "Divide Cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1535
+#: ../../src/wxMaximaFrame.cpp:1539
 msgid "Divide numbers or polynomials"
 msgstr ""
 
@@ -3353,12 +3353,12 @@ msgstr ""
 msgid "Do for each list element"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3503
+#: ../../src/wxMaxima.cpp:3564
 #, c-format
 msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:761
+#: ../../src/wxMaximaFrame.cpp:765
 msgid "Dock all Sidebars"
 msgstr ""
 
@@ -3382,11 +3382,11 @@ msgstr ""
 msgid "Documentclass options:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:807
+#: ../../src/wxMaximaFrame.cpp:811
 msgid "Don't autosubscript after an underscore"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1120
+#: ../../src/wxMaximaFrame.cpp:1124
 msgid "Don't evaluate Expression..."
 msgstr ""
 
@@ -3408,7 +3408,7 @@ msgstr ""
 msgid "Don't mark this message text in yellow"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3509
+#: ../../src/wxMaxima.cpp:3570
 msgid "Don't save"
 msgstr ""
 
@@ -3420,7 +3420,7 @@ msgstr ""
 msgid "Don't use if unassigned"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:834
+#: ../../src/wxMaximaFrame.cpp:838
 msgid "Don't use parenthesis for matrices"
 msgstr ""
 
@@ -3452,35 +3452,35 @@ msgstr ""
 msgid "Dutch"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1340
+#: ../../src/wxMaximaFrame.cpp:1344
 msgid "E&quations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:658
+#: ../../src/wxMaximaFrame.cpp:662
 msgid "E&xit\tCtrl+Q"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1402
+#: ../../src/wxMaximaFrame.cpp:1406
 msgid "Eige&nvectors"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1399
+#: ../../src/wxMaximaFrame.cpp:1403
 msgid "Eigen&values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1421
+#: ../../src/wxMaximaFrame.cpp:1425
 msgid "Eigenvalues (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1418
+#: ../../src/wxMaximaFrame.cpp:1422
 msgid "Eigenvalues (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1427
+#: ../../src/wxMaximaFrame.cpp:1431
 msgid "Eigenvalues, left+right eigenvectors (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1424
+#: ../../src/wxMaximaFrame.cpp:1428
 msgid "Eigenvalues, left+right eigenvectors (real)"
 msgstr ""
 
@@ -3522,7 +3522,7 @@ msgstr ""
 msgid "Element-by-element exponentiation of two matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1376
+#: ../../src/wxMaximaFrame.cpp:1380
 msgid "Element-by-element multiplication"
 msgstr ""
 
@@ -3538,7 +3538,7 @@ msgstr ""
 msgid "Eliminate a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1281
+#: ../../src/wxMaximaFrame.cpp:1285
 msgid "Eliminate a variable from a system of equations"
 msgstr ""
 
@@ -3588,7 +3588,7 @@ msgstr ""
 msgid "Ended lisp mode after receiving a maxima prompt!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1865
+#: ../../src/wxMaximaFrame.cpp:1869
 msgid "Engineering format (12.1e6 etc.)"
 msgstr ""
 
@@ -3612,7 +3612,7 @@ msgstr ""
 msgid "Enter UUID to jump to:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1353
+#: ../../src/wxMaximaFrame.cpp:1357
 msgid "Enter a matrix"
 msgstr ""
 
@@ -3652,7 +3652,7 @@ msgstr ""
 msgid "Enumerator:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1254
+#: ../../src/wxMaximaFrame.cpp:1258
 msgid "Environment variables"
 msgstr ""
 
@@ -3668,11 +3668,11 @@ msgstr ""
 msgid "Epsilon:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1158 ../../src/wxMaximaFrame.cpp:1169
+#: ../../src/wxMaximaFrame.cpp:1162 ../../src/wxMaximaFrame.cpp:1173
 msgid "Equal, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1167
+#: ../../src/wxMaximaFrame.cpp:1171
 msgid "Equal?..."
 msgstr ""
 
@@ -3707,17 +3707,17 @@ msgstr ""
 #: ../../src/MaximaFileIO.cpp:130 ../../src/MaximaFileIO.cpp:399
 #: ../../src/MaximaFileIO.cpp:410 ../../src/MaximaFileIO.cpp:528
 #: ../../src/MaximaFileIO.cpp:557 ../../src/MaximaFileIO.cpp:568
-#: ../../src/MaximaProcessManager.cpp:581 ../../src/WXMXformat.cpp:260
+#: ../../src/MaximaProcessManager.cpp:586 ../../src/WXMXformat.cpp:260
 #: ../../src/WXMXformat.cpp:290 ../../src/WXMXformat.cpp:298
 #: ../../src/WXMXformat.cpp:313 ../../src/WXMXformat.cpp:334
 #: ../../src/WXMXformat.cpp:364 ../../src/dialogs/BinaryNameCtrl.cpp:78
-#: ../../src/main.cpp:725 ../../src/wxMaxima.cpp:3384
-#: ../../src/wxMaxima.cpp:3420 ../../src/wxMaxima.cpp:3438
-#: ../../src/wxMaxima.cpp:3472
+#: ../../src/main.cpp:750 ../../src/wxMaxima.cpp:3445
+#: ../../src/wxMaxima.cpp:3481 ../../src/wxMaxima.cpp:3499
+#: ../../src/wxMaxima.cpp:3533
 msgid "Error"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:789
+#: ../../src/MaximaProcessManager.cpp:794
 msgid "Error writing to Maxima"
 msgstr ""
 
@@ -3728,23 +3728,23 @@ msgstr ""
 msgid "Error!"
 msgstr ""
 
-#: ../../src/Image.cpp:779
+#: ../../src/Image.cpp:788
 #, c-format
 msgid "Error: Cannot render %s."
 msgstr ""
 
-#: ../../src/Image.cpp:782
+#: ../../src/Image.cpp:791
 #, c-format
 msgid ""
 "Error: Cannot render %s:\n"
 "%s"
 msgstr ""
 
-#: ../../src/Image.cpp:787
+#: ../../src/Image.cpp:796
 msgid "Error: Cannot render the image."
 msgstr ""
 
-#: ../../src/Image.cpp:789
+#: ../../src/Image.cpp:798
 #, c-format
 msgid ""
 "Error: Cannot render the image:\n"
@@ -3763,15 +3763,15 @@ msgstr ""
 msgid "Evaluate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1689
+#: ../../src/wxMaximaFrame.cpp:1693
 msgid "Evaluate &Noun Forms..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:890
+#: ../../src/wxMaximaFrame.cpp:894
 msgid "Evaluate All Cells\tCtrl+Shift+R"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:885
+#: ../../src/wxMaximaFrame.cpp:889
 msgid "Evaluate All Visible Cells\tCtrl+R"
 msgstr ""
 
@@ -3780,7 +3780,7 @@ msgid "Evaluate Cell"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:169
-#: ../../src/wxMaximaFrame.cpp:878
+#: ../../src/wxMaximaFrame.cpp:882
 msgid "Evaluate Cell(s)"
 msgstr ""
 
@@ -3789,13 +3789,13 @@ msgstr ""
 msgid "Evaluate Cells Above"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:900
+#: ../../src/wxMaximaFrame.cpp:904
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:173
 #: ../../src/worksheet/WorksheetContextMenu.cpp:449
-#: ../../src/wxMaximaFrame.cpp:910
+#: ../../src/wxMaximaFrame.cpp:914
 msgid "Evaluate Cells Below"
 msgstr ""
 
@@ -3837,7 +3837,7 @@ msgstr ""
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:879
+#: ../../src/wxMaximaFrame.cpp:883
 msgid "Evaluate active or selected cell(s)"
 msgstr ""
 
@@ -3845,15 +3845,15 @@ msgstr ""
 msgid "Evaluate all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:891
+#: ../../src/wxMaximaFrame.cpp:895
 msgid "Evaluate all cells in the document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1690
+#: ../../src/wxMaximaFrame.cpp:1694
 msgid "Evaluate all noun forms in expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:886
+#: ../../src/wxMaximaFrame.cpp:890
 msgid "Evaluate all visible cells in the document"
 msgstr ""
 
@@ -3865,7 +3865,7 @@ msgstr ""
 msgid "Evaluate string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1185
+#: ../../src/wxMaximaFrame.cpp:1189
 msgid "Evaluate string..."
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Examples:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1740
+#: ../../src/wxMaximaFrame.cpp:1744
 msgid "Execute a command for each element of the list"
 msgstr ""
 
-#: ../../src/main.cpp:677
+#: ../../src/main.cpp:702
 msgid "Exit"
 msgstr ""
 
@@ -3921,11 +3921,11 @@ msgstr ""
 msgid "Expand Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1562
+#: ../../src/wxMaximaFrame.cpp:1566
 msgid "Expand an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1568
+#: ../../src/wxMaximaFrame.cpp:1572
 msgid "Expand for given variables"
 msgstr ""
 
@@ -3937,19 +3937,19 @@ msgstr ""
 msgid "Expand for variable(s):"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1582
+#: ../../src/wxMaximaFrame.cpp:1586
 msgid "Expand log in previous expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1635
+#: ../../src/wxMaximaFrame.cpp:1639
 msgid "Expand trigonometric expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1825
+#: ../../src/wxMaximaFrame.cpp:1829
 msgid "Expect numbers harder to be complex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1826
+#: ../../src/wxMaximaFrame.cpp:1830
 msgid "Expect variables to contain complex numbers"
 msgstr ""
 
@@ -3962,15 +3962,15 @@ msgstr ""
 msgid "Export As"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1742
+#: ../../src/wxMaximaFrame.cpp:1746
 msgid "Export List to csv file..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1743
+#: ../../src/wxMaximaFrame.cpp:1747
 msgid "Export a list to a csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1366
+#: ../../src/wxMaximaFrame.cpp:1370
 msgid "Export a matrix to a csv file"
 msgstr ""
 
@@ -3986,7 +3986,7 @@ msgstr ""
 msgid "Export commands from the current maxima session to a .mac file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:652
+#: ../../src/wxMaximaFrame.cpp:656
 msgid "Export document to a HTML or LaTeX file"
 msgstr ""
 
@@ -3994,7 +3994,7 @@ msgstr ""
 msgid "Export equations to HTML as:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:600
+#: ../../src/wxMaximaFrame.cpp:604
 msgid "Export failed."
 msgstr ""
 
@@ -4010,7 +4010,7 @@ msgstr ""
 msgid "Export selected commands to a .mac file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:588
+#: ../../src/wxMaximaFrame.cpp:592
 msgid "Export successful."
 msgstr ""
 
@@ -4031,7 +4031,7 @@ msgstr ""
 msgid "Exported %d output image(s) to %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2200 ../../src/wxMaxima.cpp:2242
+#: ../../src/wxMaxima.cpp:2201 ../../src/wxMaxima.cpp:2243
 #, c-format
 msgid "Exported the worksheet to %s"
 msgstr ""
@@ -4052,7 +4052,7 @@ msgstr ""
 msgid "Exporting to maxima batch file failed!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:582
+#: ../../src/wxMaximaFrame.cpp:586
 msgid "Exporting..."
 msgstr ""
 
@@ -4088,7 +4088,7 @@ msgstr ""
 msgid "Expression to plot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1122
+#: ../../src/wxMaximaFrame.cpp:1126
 msgid "Expression to string..."
 msgstr ""
 
@@ -4111,23 +4111,23 @@ msgstr ""
 msgid "Expression:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1457
+#: ../../src/wxMaximaFrame.cpp:1461
 msgid "Extract Column..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1763
+#: ../../src/wxMaximaFrame.cpp:1767
 msgid "Extract Elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1455
+#: ../../src/wxMaximaFrame.cpp:1459
 msgid "Extract Row..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1458
+#: ../../src/wxMaximaFrame.cpp:1462
 msgid "Extract a column from the matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1472
+#: ../../src/wxMaximaFrame.cpp:1476
 msgid "Extract a column from the matrix and convert it to a list"
 msgstr ""
 
@@ -4139,7 +4139,7 @@ msgstr ""
 msgid "Extract a matrix column as a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1347
+#: ../../src/wxMaximaFrame.cpp:1351
 msgid "Extract a matrix from a 2-dimensional array"
 msgstr ""
 
@@ -4151,11 +4151,11 @@ msgstr ""
 msgid "Extract a matrix row as a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1456
+#: ../../src/wxMaximaFrame.cpp:1460
 msgid "Extract a row from the matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1468
+#: ../../src/wxMaximaFrame.cpp:1472
 msgid "Extract a row from the matrix and convert it to a list"
 msgstr ""
 
@@ -4163,15 +4163,15 @@ msgstr ""
 msgid "Extract a variable's value from a list of variable values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1760
+#: ../../src/wxMaximaFrame.cpp:1764
 msgid "Extract an actual value for a variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1197
+#: ../../src/wxMaximaFrame.cpp:1201
 msgid "Extract char..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1241
+#: ../../src/wxMaximaFrame.cpp:1245
 msgid "Extract dir from path..."
 msgstr ""
 
@@ -4183,7 +4183,7 @@ msgstr ""
 msgid "Extract file type extension"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1243
+#: ../../src/wxMaximaFrame.cpp:1247
 msgid "Extract filename from path..."
 msgstr ""
 
@@ -4191,7 +4191,7 @@ msgstr ""
 msgid "Extract filename part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1245
+#: ../../src/wxMaximaFrame.cpp:1249
 msgid "Extract filetype from path..."
 msgstr ""
 
@@ -4199,7 +4199,7 @@ msgstr ""
 msgid "Extract function arguments"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1764
+#: ../../src/wxMaximaFrame.cpp:1768
 msgid "Extract list Elements"
 msgstr ""
 
@@ -4207,7 +4207,7 @@ msgstr ""
 msgid "Extract matrix from 2D array"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1723
+#: ../../src/wxMaximaFrame.cpp:1727
 msgid "Extract the argument list from a function call"
 msgstr ""
 
@@ -4227,11 +4227,11 @@ msgstr ""
 msgid "Extract the nth list elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1761
+#: ../../src/wxMaximaFrame.cpp:1765
 msgid "Extract the value for one variable assigned in a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1476
+#: ../../src/wxMaximaFrame.cpp:1480
 msgid "Extract, append or delete rows or columns"
 msgstr ""
 
@@ -4243,7 +4243,7 @@ msgstr ""
 msgid "Factor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1558
+#: ../../src/wxMaximaFrame.cpp:1562
 msgid "Factor Complex"
 msgstr ""
 
@@ -4251,19 +4251,19 @@ msgstr ""
 msgid "Factor Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1556
+#: ../../src/wxMaximaFrame.cpp:1560
 msgid "Factor Expression including subexpressions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1554 ../../src/wxMaximaFrame.cpp:1557
+#: ../../src/wxMaximaFrame.cpp:1558 ../../src/wxMaximaFrame.cpp:1561
 msgid "Factor an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1559
+#: ../../src/wxMaximaFrame.cpp:1563
 msgid "Factor an expression in Gaussian numbers"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1624
+#: ../../src/wxMaximaFrame.cpp:1628
 msgid "Factorials and &Gamma"
 msgstr ""
 
@@ -4277,23 +4277,23 @@ msgstr ""
 msgid "Failed to delete gnuplot file %s"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:352
+#: ../../src/MaximaProcessManager.cpp:353
 msgid "Failed to start Maxima"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:628
+#: ../../src/MaximaProcessManager.cpp:633
 msgid "Failed to write to Maxima's stdin (LDB)."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1452
+#: ../../src/wxMaximaFrame.cpp:1456
 msgid "Fast fortran routines that perform numerical tasks"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1959
+#: ../../src/wxMaximaFrame.cpp:1963
 msgid "Fast list access"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:218
+#: ../../src/MaximaProcessManager.cpp:219
 msgid "Fatal error"
 msgstr ""
 
@@ -4318,11 +4318,11 @@ msgstr ""
 msgid "Figure %d:"
 msgstr ""
 
-#: ../../src/main.cpp:678
+#: ../../src/main.cpp:703
 msgid "File"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1367
+#: ../../src/wxMaximaFrame.cpp:1371
 msgid "File I/O"
 msgstr ""
 
@@ -4338,7 +4338,7 @@ msgstr ""
 msgid "File name:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2995 ../../src/wxMaxima.cpp:3038
+#: ../../src/wxMaxima.cpp:3056 ../../src/wxMaxima.cpp:3099
 msgid "File not found"
 msgstr ""
 
@@ -4346,15 +4346,15 @@ msgstr ""
 msgid "File opened"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1251
+#: ../../src/wxMaximaFrame.cpp:1255
 msgid "File operations"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2994 ../../src/wxMaxima.cpp:3037
+#: ../../src/wxMaxima.cpp:3055 ../../src/wxMaxima.cpp:3098
 msgid "File you tried to open does not exist."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1255
+#: ../../src/wxMaximaFrame.cpp:1259
 msgid "File/directory functions"
 msgstr ""
 
@@ -4374,15 +4374,15 @@ msgstr ""
 msgid "Find"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:707
+#: ../../src/wxMaximaFrame.cpp:711
 msgid "Find\tCtrl+F"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1505
+#: ../../src/wxMaximaFrame.cpp:1509
 msgid "Find &Limit..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1507
+#: ../../src/wxMaximaFrame.cpp:1511
 msgid "Find Minimum..."
 msgstr ""
 
@@ -4390,35 +4390,35 @@ msgstr ""
 msgid "Find Root..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1508
+#: ../../src/wxMaximaFrame.cpp:1512
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1841
+#: ../../src/wxMaximaFrame.cpp:1845
 msgid "Find a fraction that represents this float exactly"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1506
+#: ../../src/wxMaximaFrame.cpp:1510
 msgid "Find a limit of an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1844
+#: ../../src/wxMaximaFrame.cpp:1848
 msgid "Find a nice fraction that is similar to this float"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1317
+#: ../../src/wxMaximaFrame.cpp:1321
 msgid "Find a numerical solution for a first degree ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1286
+#: ../../src/wxMaximaFrame.cpp:1290
 msgid "Find a root of an equation on an interval"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1293
+#: ../../src/wxMaximaFrame.cpp:1297
 msgid "Find all roots of a polynomial"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1296
+#: ../../src/wxMaximaFrame.cpp:1300
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr ""
 
@@ -4427,7 +4427,7 @@ msgid "Find and Replace"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:401 ../../src/ToolBar.cpp:403
-#: ../../src/wxMaximaFrame.cpp:707
+#: ../../src/wxMaximaFrame.cpp:711
 msgid "Find and replace"
 msgstr ""
 
@@ -4435,19 +4435,19 @@ msgstr ""
 msgid "Find char in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1206
+#: ../../src/wxMaximaFrame.cpp:1210
 msgid "Find char in string..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1571
+#: ../../src/wxMaximaFrame.cpp:1575
 msgid "Find common denominator"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1400
+#: ../../src/wxMaximaFrame.cpp:1404
 msgid "Find eigenvalues of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1403
+#: ../../src/wxMaximaFrame.cpp:1407
 msgid "Find eigenvectors of a matrix"
 msgstr ""
 
@@ -4455,11 +4455,11 @@ msgstr ""
 msgid "Find first difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1204
+#: ../../src/wxMaximaFrame.cpp:1208
 msgid "Find first difference..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1290
+#: ../../src/wxMaximaFrame.cpp:1294
 msgid "Find fractions that real roots of a polynomial and "
 msgstr ""
 
@@ -4467,7 +4467,7 @@ msgstr ""
 msgid "Find minimum"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1285
+#: ../../src/wxMaximaFrame.cpp:1289
 msgid "Find numerical solution..."
 msgstr ""
 
@@ -4491,7 +4491,7 @@ msgstr ""
 msgid "Find:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1869
+#: ../../src/wxMaximaFrame.cpp:1873
 msgid "Fine-tune the display of engineering-format numbers"
 msgstr ""
 
@@ -4499,11 +4499,11 @@ msgstr ""
 msgid "Finnish"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1749
+#: ../../src/wxMaximaFrame.cpp:1753
 msgid "First"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1955
+#: ../../src/wxMaximaFrame.cpp:1959
 msgid "Fitting curves to measurement data"
 msgstr ""
 
@@ -4520,15 +4520,15 @@ msgstr ""
 msgid "Flush stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1137
+#: ../../src/wxMaximaFrame.cpp:1141
 msgid "Flush..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:956
+#: ../../src/wxMaximaFrame.cpp:960
 msgid "Fold All\tCtrl+Alt+["
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:957
+#: ../../src/wxMaximaFrame.cpp:961
 msgid "Fold all sections"
 msgstr ""
 
@@ -4582,7 +4582,7 @@ msgstr ""
 msgid "For loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1096
+#: ../../src/wxMaximaFrame.cpp:1100
 msgid "For loop..."
 msgstr ""
 
@@ -4590,11 +4590,11 @@ msgstr ""
 msgid "Format:"
 msgstr ""
 
-#: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3523
+#: ../../src/worksheet/Worksheet.cpp:301 ../../src/wxMaxima.cpp:3584
 msgid "Forwarding the keyboard focus to a text control"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3526
+#: ../../src/wxMaxima.cpp:3587
 msgid "Forwarding the keyboard focus to the worksheet"
 msgstr ""
 
@@ -4622,7 +4622,7 @@ msgstr ""
 msgid "Fourier coefficients"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1513
+#: ../../src/wxMaximaFrame.cpp:1517
 msgid "Fourier coefficients..."
 msgstr ""
 
@@ -4647,7 +4647,7 @@ msgstr ""
 msgid "Frame rate"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1039 ../../src/wxMaximaFrame.cpp:1043
+#: ../../src/wxMaximaFrame.cpp:1043 ../../src/wxMaximaFrame.cpp:1047
 msgid "Free all unused items now"
 msgstr ""
 
@@ -4655,11 +4655,11 @@ msgstr ""
 msgid "French"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1447
+#: ../../src/wxMaximaFrame.cpp:1451
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1445
+#: ../../src/wxMaximaFrame.cpp:1449
 msgid "Frobenius Norm sqrt(sum((A(i,j))^2)) (real)"
 msgstr ""
 
@@ -4670,11 +4670,11 @@ msgstr ""
 msgid "From:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:864
+#: ../../src/wxMaximaFrame.cpp:868
 msgid "Full Screen\tAlt+Enter"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:861
+#: ../../src/wxMaximaFrame.cpp:865
 msgid "Full Screen\tF11"
 msgstr ""
 
@@ -4706,15 +4706,15 @@ msgstr ""
 msgid "Function:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1667
+#: ../../src/wxMaximaFrame.cpp:1671
 msgid "Functions for complex simplification"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1625
+#: ../../src/wxMaximaFrame.cpp:1629
 msgid "Functions for simplifying factorials and gamma function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1643
+#: ../../src/wxMaximaFrame.cpp:1647
 msgid "Functions for simplifying trigonometric expressions"
 msgstr ""
 
@@ -4742,31 +4742,31 @@ msgstr ""
 msgid "Gamma"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:316
+#: ../../src/wxMaximaFrame.cpp:320
 msgid "General Math"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:734
+#: ../../src/wxMaximaFrame.cpp:738
 msgid "General Math\tAlt+Shift+M"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1350
+#: ../../src/wxMaximaFrame.cpp:1354
 msgid "Generate Matrix from Expression..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1351
+#: ../../src/wxMaximaFrame.cpp:1355
 msgid "Generate a matrix from a lambda expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1712
+#: ../../src/wxMaximaFrame.cpp:1716
 msgid "Generate a new list using a lists' elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1718
+#: ../../src/wxMaximaFrame.cpp:1722
 msgid "Generate a storage for variable values that can be introduced into equations at any time"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1709
+#: ../../src/wxMaximaFrame.cpp:1713
 msgid "Generate list elements using a rule"
 msgstr ""
 
@@ -4774,7 +4774,7 @@ msgstr ""
 msgid "Generate matrix from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1128
+#: ../../src/wxMaximaFrame.cpp:1132
 msgid "Generate unused symbol name"
 msgstr ""
 
@@ -4794,23 +4794,23 @@ msgstr ""
 msgid "German"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1656
+#: ../../src/wxMaximaFrame.cpp:1660
 msgid "Get &Imaginary Part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1522
+#: ../../src/wxMaximaFrame.cpp:1526
 msgid "Get Laplace transformation of an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1652
+#: ../../src/wxMaximaFrame.cpp:1656
 msgid "Get Real P&art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1235
+#: ../../src/wxMaximaFrame.cpp:1239
 msgid "Get current directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1526
+#: ../../src/wxMaximaFrame.cpp:1530
 msgid "Get inverse Laplace transformation of an expression"
 msgstr ""
 
@@ -4818,19 +4818,19 @@ msgstr ""
 msgid "Get position in stream"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1136
+#: ../../src/wxMaximaFrame.cpp:1140
 msgid "Get position..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1657
+#: ../../src/wxMaximaFrame.cpp:1661
 msgid "Get the imaginary part of complex expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1653
+#: ../../src/wxMaximaFrame.cpp:1657
 msgid "Get the real part of complex expression"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:1220
+#: ../../src/MaximaProcessManager.cpp:1225
 #, c-format
 msgid "Gnuplot (command line) found at: %s"
 msgstr ""
@@ -4839,29 +4839,29 @@ msgstr ""
 msgid "Gnuplot flavour"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:1218
+#: ../../src/MaximaProcessManager.cpp:1223
 #, c-format
 msgid "Gnuplot found at: %s"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:994
+#: ../../src/MaximaProcessManager.cpp:999
 msgid "Gnuplot has closed."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:1209
 #: ../../src/MaximaProcessManager.cpp:1214
+#: ../../src/MaximaProcessManager.cpp:1219
 #, c-format
 msgid "Gnuplot not found, using the default: %s"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:1097
+#: ../../src/MaximaProcessManager.cpp:1102
 #, c-format
 msgid ""
 "Gnuplot reported the following while preparing the popped-out plot:\n"
 "%s"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:2071 ../../src/wxMaximaFrame.cpp:1924
+#: ../../src/MaximaCommandMenus.cpp:2071 ../../src/wxMaximaFrame.cpp:1928
 msgid "Go to URL"
 msgstr ""
 
@@ -4873,7 +4873,7 @@ msgstr ""
 msgid "Got a request to undo an action that involves a delete which isn't possible at this moment."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1065
+#: ../../src/wxMaximaFrame.cpp:1069
 msgid "Gradefs"
 msgstr ""
 
@@ -4881,7 +4881,7 @@ msgstr ""
 msgid "Greater or less than a value"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1164
+#: ../../src/wxMaximaFrame.cpp:1168
 msgid "Greater, ignoring case?..."
 msgstr ""
 
@@ -4889,11 +4889,11 @@ msgstr ""
 msgid "Greek"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:281
+#: ../../src/wxMaximaFrame.cpp:285
 msgid "Greek Letters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:738
+#: ../../src/wxMaximaFrame.cpp:742
 msgid "Greek Letters\tAlt+Shift+G"
 msgstr ""
 
@@ -4905,7 +4905,7 @@ msgstr ""
 msgid "Grid:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1852
+#: ../../src/wxMaximaFrame.cpp:1856
 msgid "Guess an exact number that could be meant by this float"
 msgstr ""
 
@@ -4917,7 +4917,7 @@ msgstr ""
 msgid "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|LaTeX file (*.tex)|*.tex"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1375
+#: ../../src/wxMaximaFrame.cpp:1379
 msgid "Hadamard (element-by-element) product..."
 msgstr ""
 
@@ -4929,7 +4929,7 @@ msgstr ""
 msgid "Hadamard exponent"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1379
+#: ../../src/wxMaximaFrame.cpp:1383
 msgid "Hadamard exponent..."
 msgstr ""
 
@@ -4953,7 +4953,7 @@ msgid "Hebrew"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
-#: ../../src/wxMaximaFrame.cpp:351
+#: ../../src/wxMaximaFrame.cpp:355
 msgid "Help"
 msgstr ""
 
@@ -4984,7 +4984,7 @@ msgstr ""
 msgid "Hide Code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:764
+#: ../../src/wxMaximaFrame.cpp:768
 msgid "Hide Code Cells\tAlt+Ctrl+H"
 msgstr ""
 
@@ -5012,7 +5012,7 @@ msgstr ""
 msgid "Hide Subsubsection"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:766
+#: ../../src/wxMaximaFrame.cpp:770
 msgid "Hide all Sidebars\tAlt+Shift+-"
 msgstr ""
 
@@ -5020,7 +5020,7 @@ msgstr ""
 msgid "Hide all multiplication signs that aren't really necessary for understanding the equation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:767
+#: ../../src/wxMaximaFrame.cpp:771
 msgid "Hide all panes"
 msgstr ""
 
@@ -5082,11 +5082,11 @@ msgstr ""
 msgid "Histogram..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:246
+#: ../../src/wxMaximaFrame.cpp:250
 msgid "History"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:744
+#: ../../src/wxMaximaFrame.cpp:748
 msgid "History\tAlt+Shift+I"
 msgstr ""
 
@@ -5094,7 +5094,7 @@ msgstr ""
 msgid "Horizontal cursor works like a normal cursor, but it operates on cells: press up or down arrow to move it, holding down Shift while moving will select cells, pressing backspace or delete twice will delete a cell next to it."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1563
+#: ../../src/wxMaximaFrame.cpp:1567
 msgid "Horner's rule"
 msgstr ""
 
@@ -5106,7 +5106,7 @@ msgstr ""
 msgid "How many digits to show:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:796
+#: ../../src/wxMaximaFrame.cpp:800
 msgid "How to display new equations"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Hungarian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1147
+#: ../../src/wxMaximaFrame.cpp:1151
 msgid "I/O"
 msgstr ""
 
@@ -5369,7 +5369,7 @@ msgstr ""
 msgid "Infinity"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1986
+#: ../../src/wxMaximaFrame.cpp:1990
 msgid "Info about Maxima build"
 msgstr ""
 
@@ -5385,11 +5385,11 @@ msgstr ""
 msgid "Initial Condition"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1304
+#: ../../src/wxMaximaFrame.cpp:1308
 msgid "Initial Value Problem (&1)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1308
+#: ../../src/wxMaximaFrame.cpp:1312
 msgid "Initial Value Problem (&2)..."
 msgstr ""
 
@@ -5421,7 +5421,7 @@ msgid ""
 "Right-click for options!"
 msgstr ""
 
-#: ../../src/wizards/GenWizPanel.cpp:103 ../../src/wxMaximaFrame.cpp:335
+#: ../../src/wizards/GenWizPanel.cpp:103 ../../src/wxMaximaFrame.cpp:339
 msgid "Insert"
 msgstr ""
 
@@ -5429,15 +5429,15 @@ msgstr ""
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:939
+#: ../../src/wxMaximaFrame.cpp:943
 msgid "Insert &Section Cell\tCtrl+3"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:935
+#: ../../src/wxMaximaFrame.cpp:939
 msgid "Insert &Text Cell\tCtrl+1"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:748
+#: ../../src/wxMaximaFrame.cpp:752
 msgid "Insert Cell\tAlt+Shift+C"
 msgstr ""
 
@@ -5453,23 +5453,23 @@ msgstr ""
 msgid "Insert Image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:951
+#: ../../src/wxMaximaFrame.cpp:955
 msgid "Insert Image..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:933
+#: ../../src/wxMaximaFrame.cpp:937
 msgid "Insert Input &Cell\tCtrl+0"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:953
+#: ../../src/wxMaximaFrame.cpp:957
 msgid "Insert Page Break"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:941
+#: ../../src/wxMaximaFrame.cpp:945
 msgid "Insert S&ubsection Cell\tCtrl+4"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:944
+#: ../../src/wxMaximaFrame.cpp:948
 msgid "Insert S&ubsubsection Cell\tCtrl+5"
 msgstr ""
 
@@ -5485,7 +5485,7 @@ msgstr ""
 msgid "Insert Subsubsection Cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:937
+#: ../../src/wxMaximaFrame.cpp:941
 msgid "Insert T&itle Cell\tCtrl+2"
 msgstr ""
 
@@ -5497,39 +5497,39 @@ msgstr ""
 msgid "Insert Title Cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:947
+#: ../../src/wxMaximaFrame.cpp:951
 msgid "Insert a new heading5 cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:949
+#: ../../src/wxMaximaFrame.cpp:953
 msgid "Insert a new heading6 cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:934
+#: ../../src/wxMaximaFrame.cpp:938
 msgid "Insert a new input cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:940
+#: ../../src/wxMaximaFrame.cpp:944
 msgid "Insert a new section cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:942
+#: ../../src/wxMaximaFrame.cpp:946
 msgid "Insert a new subsection cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:945
+#: ../../src/wxMaximaFrame.cpp:949
 msgid "Insert a new subsubsection cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:936
+#: ../../src/wxMaximaFrame.cpp:940
 msgid "Insert a new text cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:938
+#: ../../src/wxMaximaFrame.cpp:942
 msgid "Insert a new title cell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:954
+#: ../../src/wxMaximaFrame.cpp:958
 msgid "Insert a page break"
 msgstr ""
 
@@ -5537,23 +5537,23 @@ msgstr ""
 msgid "Insert a string into another"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1198
+#: ../../src/wxMaximaFrame.cpp:1202
 msgid "Insert char..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:946
+#: ../../src/wxMaximaFrame.cpp:950
 msgid "Insert heading5 Cell\tCtrl+6"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:948
+#: ../../src/wxMaximaFrame.cpp:952
 msgid "Insert heading6 Cell\tCtrl+7"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:951
+#: ../../src/wxMaximaFrame.cpp:955
 msgid "Insert image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:950
+#: ../../src/wxMaximaFrame.cpp:954
 msgid "Insert textbased cell"
 msgstr ""
 
@@ -5565,11 +5565,11 @@ msgstr ""
 msgid "Instantiating the HTML manual browser"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:1177
+#: ../../src/MaximaProcessManager.cpp:1182
 msgid "Instructed to prefer gnuplot over wgnuplot"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:1165
+#: ../../src/MaximaProcessManager.cpp:1170
 msgid "Instructed to prefer wgnuplot over gnuplot"
 msgstr ""
 
@@ -5594,15 +5594,15 @@ msgstr ""
 msgid "Integrate (risch)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1491
+#: ../../src/wxMaximaFrame.cpp:1495
 msgid "Integrate expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1493
+#: ../../src/wxMaximaFrame.cpp:1497
 msgid "Integrate expression with Risch algorithm"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1906
+#: ../../src/wxMaximaFrame.cpp:1910
 msgid "Integrate numerically (QUADPACK)"
 msgstr ""
 
@@ -5623,11 +5623,11 @@ msgstr ""
 msgid "Interactive popup memory limit [MB/plot]:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1774
+#: ../../src/wxMaximaFrame.cpp:1778
 msgid "Interleave"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1775
+#: ../../src/wxMaximaFrame.cpp:1779
 msgid "Interleave the values of two lists"
 msgstr ""
 
@@ -5639,7 +5639,7 @@ msgstr ""
 msgid "Internal"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1121
+#: ../../src/wxMaximaFrame.cpp:1125
 msgid "Interpret like input..."
 msgstr ""
 
@@ -5651,7 +5651,7 @@ msgstr ""
 msgid "Interpret string as maxima code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1123
+#: ../../src/wxMaximaFrame.cpp:1127
 msgid "Interpret string..."
 msgstr ""
 
@@ -5659,7 +5659,7 @@ msgstr ""
 msgid "Interrupt"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:999
+#: ../../src/wxMaximaFrame.cpp:1003
 msgid "Interrupt current computation"
 msgstr ""
 
@@ -5667,7 +5667,7 @@ msgstr ""
 msgid "Interrupt current computation. To completely restart maxima press the button left to this one."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:876
+#: ../../src/MaximaProcessManager.cpp:881
 #, c-format
 msgid "Interrupting maxima: %s"
 msgstr ""
@@ -5676,7 +5676,7 @@ msgstr ""
 msgid "Introduce a list of actual values into an equation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1734
+#: ../../src/wxMaximaFrame.cpp:1738
 msgid "Introduce the actual values for variables stored in the list"
 msgstr ""
 
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Inverse Laplace"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1525
+#: ../../src/wxMaximaFrame.cpp:1529
 msgid "Inverse Laplace T&ransform..."
 msgstr ""
 
@@ -5725,7 +5725,7 @@ msgstr ""
 msgid "Is a char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1149
+#: ../../src/wxMaximaFrame.cpp:1153
 msgid "Is a char?..."
 msgstr ""
 
@@ -5737,7 +5737,7 @@ msgstr ""
 msgid "Is a digit?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1152
+#: ../../src/wxMaximaFrame.cpp:1156
 msgid "Is a digit?..."
 msgstr ""
 
@@ -5757,11 +5757,11 @@ msgstr ""
 msgid "Is a uppercase char?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1150
+#: ../../src/wxMaximaFrame.cpp:1154
 msgid "Is alphabetic?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1151
+#: ../../src/wxMaximaFrame.cpp:1155
 msgid "Is alphanumeric?..."
 msgstr ""
 
@@ -5789,19 +5789,19 @@ msgstr ""
 msgid "Is an odd function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1156
+#: ../../src/wxMaximaFrame.cpp:1160
 msgid "Is equal?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1162
+#: ../../src/wxMaximaFrame.cpp:1166
 msgid "Is greater?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1159
+#: ../../src/wxMaximaFrame.cpp:1163
 msgid "Is lower?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1155
+#: ../../src/wxMaximaFrame.cpp:1159
 msgid "Is lowercase?..."
 msgstr ""
 
@@ -5809,11 +5809,11 @@ msgstr ""
 msgid "Is no integer variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1153
+#: ../../src/wxMaximaFrame.cpp:1157
 msgid "Is printable?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1154
+#: ../../src/wxMaximaFrame.cpp:1158
 msgid "Is uppercase?..."
 msgstr ""
 
@@ -5869,11 +5869,11 @@ msgstr ""
 msgid "Jump to UUID"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:661
+#: ../../src/wxMaximaFrame.cpp:665
 msgid "Jump to UUID..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1082
+#: ../../src/wxMaximaFrame.cpp:1086
 msgid "Jump to last error"
 msgstr ""
 
@@ -5885,7 +5885,7 @@ msgstr ""
 msgid "Jump to previous difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1083
+#: ../../src/wxMaximaFrame.cpp:1087
 msgid "Jump to the last cell Maxima has reported an error in."
 msgstr ""
 
@@ -5910,19 +5910,19 @@ msgstr ""
 msgid "LCM"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1441
+#: ../../src/wxMaximaFrame.cpp:1445
 msgid "L[1] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1440
+#: ../../src/wxMaximaFrame.cpp:1444
 msgid "L[1] Norm (real)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1443
+#: ../../src/wxMaximaFrame.cpp:1447
 msgid "L[inf] Norm (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1442
+#: ../../src/wxMaximaFrame.cpp:1446
 msgid "L[inf] Norm (real)"
 msgstr ""
 
@@ -5942,7 +5942,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1059
+#: ../../src/wxMaximaFrame.cpp:1063
 msgid "Labels"
 msgstr ""
 
@@ -5970,29 +5970,29 @@ msgstr ""
 msgid "Laplace"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1521
+#: ../../src/wxMaximaFrame.cpp:1525
 msgid "Laplace &Transform..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1755
+#: ../../src/wxMaximaFrame.cpp:1759
 msgid "Last"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:557
+#: ../../src/MaximaProcessManager.cpp:562
 #, c-format
 msgid "Last message from maxima's stderr: %s"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:544
+#: ../../src/MaximaProcessManager.cpp:549
 #, c-format
 msgid "Last message from maxima's stdout: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1757
+#: ../../src/wxMaximaFrame.cpp:1761
 msgid "Last n"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3087
+#: ../../src/wxMaxima.cpp:3148
 msgid "Last non-whitespace is a question mark"
 msgstr ""
 
@@ -6000,12 +6000,12 @@ msgstr ""
 msgid "Latvian"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1675
+#: ../../src/wxMaxima.cpp:1676
 #, c-format
 msgid "Launching the system's default help browser as %s."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1666 ../../src/wxMaxima.cpp:1687
+#: ../../src/wxMaxima.cpp:1667 ../../src/wxMaxima.cpp:1688
 msgid "Launching the system's default help browser failed."
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 msgid "Leads to"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1530
+#: ../../src/wxMaximaFrame.cpp:1534
 msgid "Least Common Multiple..."
 msgstr ""
 
@@ -6038,15 +6038,15 @@ msgstr ""
 msgid "Left end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1331
+#: ../../src/wxMaximaFrame.cpp:1335
 msgid "Left side to the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1778
+#: ../../src/wxMaximaFrame.cpp:1782
 msgid "Length"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1138 ../../src/wxMaximaFrame.cpp:1201
+#: ../../src/wxMaximaFrame.cpp:1142 ../../src/wxMaximaFrame.cpp:1205
 msgid "Length..."
 msgstr ""
 
@@ -6054,7 +6054,7 @@ msgstr ""
 msgid "Length:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1066
+#: ../../src/wxMaximaFrame.cpp:1070
 msgid "Letrules"
 msgstr ""
 
@@ -6099,11 +6099,11 @@ msgstr ""
 msgid "Lisp format strings are more powerful than c++ format strings"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1874
+#: ../../src/wxMaxima.cpp:1875
 msgid "Lisp mode."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1044 ../../src/wxMaximaFrame.cpp:1046
+#: ../../src/wxMaximaFrame.cpp:1048 ../../src/wxMaximaFrame.cpp:1050
 msgid "Lisp normally frees memory only when it has time or runs out of space"
 msgstr ""
 
@@ -6127,11 +6127,11 @@ msgstr ""
 msgid "List #2"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1234
+#: ../../src/wxMaximaFrame.cpp:1238
 msgid "List directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1239
+#: ../../src/wxMaximaFrame.cpp:1243
 msgid "List directory..."
 msgstr ""
 
@@ -6151,7 +6151,7 @@ msgstr ""
 msgid "List of char to String"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1184
+#: ../../src/wxMaximaFrame.cpp:1188
 msgid "List of chars to string..."
 msgstr ""
 
@@ -6228,27 +6228,27 @@ msgstr ""
 msgid "Load Package"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:644
+#: ../../src/wxMaximaFrame.cpp:648
 msgid "Load Recent Package"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:647
+#: ../../src/wxMaximaFrame.cpp:651
 msgid "Load a Maxima file using the batch command"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:642
+#: ../../src/wxMaximaFrame.cpp:646
 msgid "Load a Maxima package file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1358 ../../src/wxMaximaFrame.cpp:1364
+#: ../../src/wxMaximaFrame.cpp:1362 ../../src/wxMaximaFrame.cpp:1368
 msgid "Load a matrix from a csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1715
+#: ../../src/wxMaximaFrame.cpp:1719
 msgid "Load a nested list from a csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1415 ../../src/wxMaximaFrame.cpp:1416
+#: ../../src/wxMaximaFrame.cpp:1419 ../../src/wxMaximaFrame.cpp:1420
 msgid "Load lapack"
 msgstr ""
 
@@ -6256,7 +6256,7 @@ msgstr ""
 msgid "Load lisp code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1126
+#: ../../src/wxMaximaFrame.cpp:1130
 msgid "Load lisp..."
 msgstr ""
 
@@ -6264,15 +6264,15 @@ msgstr ""
 msgid "Load style from file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1232
+#: ../../src/wxMaximaFrame.cpp:1236
 msgid "Load the file/dir operations (operatingsystem)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1221
+#: ../../src/wxMaximaFrame.cpp:1225
 msgid "Load the regular expression package (sregex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1258
+#: ../../src/wxMaximaFrame.cpp:1262
 msgid "Load the translation generator (gentran)"
 msgstr ""
 
@@ -6288,11 +6288,11 @@ msgstr ""
 msgid "Lower bound:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1161
+#: ../../src/wxMaximaFrame.cpp:1165
 msgid "Lower, ignoring case?..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1485
+#: ../../src/wxMaximaFrame.cpp:1489
 msgid "M&atrix"
 msgstr ""
 
@@ -6308,11 +6308,11 @@ msgstr ""
 msgid "Macro name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1058
+#: ../../src/wxMaximaFrame.cpp:1062
 msgid "Macros"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:869
+#: ../../src/wxMaximaFrame.cpp:873
 msgid "Main Toolbar\tShift+Alt+B"
 msgstr ""
 
@@ -6324,7 +6324,7 @@ msgstr ""
 msgid "Make an eventual ev() evaluate this"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1104
+#: ../../src/wxMaximaFrame.cpp:1108
 msgid "Make function local..."
 msgstr ""
 
@@ -6352,11 +6352,11 @@ msgstr ""
 msgid "Map an expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1480
+#: ../../src/wxMaximaFrame.cpp:1484
 msgid "Map function to a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1483
+#: ../../src/wxMaximaFrame.cpp:1487
 msgid "Map function to a matrix, affecting all of its clones"
 msgstr ""
 
@@ -6392,7 +6392,7 @@ msgstr ""
 msgid "MathML description"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:307
+#: ../../src/wxMaximaFrame.cpp:311
 msgid "Mathematical Symbols"
 msgstr ""
 
@@ -6416,15 +6416,15 @@ msgstr ""
 msgid "Matrix Exponent"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1373
+#: ../../src/wxMaximaFrame.cpp:1377
 msgid "Matrix exponent..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1363
+#: ../../src/wxMaximaFrame.cpp:1367
 msgid "Matrix from csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1357
+#: ../../src/wxMaximaFrame.cpp:1361
 msgid "Matrix from csv file..."
 msgstr ""
 
@@ -6436,19 +6436,19 @@ msgstr ""
 msgid "Matrix name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:835
+#: ../../src/wxMaximaFrame.cpp:839
 msgid "Matrix parenthesis"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1365
+#: ../../src/wxMaximaFrame.cpp:1369
 msgid "Matrix to csv file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1368
+#: ../../src/wxMaximaFrame.cpp:1372
 msgid "Matrix to file or Matrix from file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1798
+#: ../../src/wxMaximaFrame.cpp:1802
 msgid "Matrix to nested List"
 msgstr ""
 
@@ -6553,6 +6553,34 @@ msgstr ""
 msgid "Maxima has sent a new variable value."
 msgstr ""
 
+#: ../../src/wxMaxima.cpp:2669
+#, c-format
+msgid ""
+"Maxima has started, but hasn't connected to wxMaxima within 5 seconds.\n"
+"\n"
+"wxMaxima will keep waiting and periodically retry. If this doesn't resolve itself, check the debug messages sidebar (View > Show Debug Messages) for more detail, or check if a firewall or security software is blocking local network connections to wxMaxima.\n"
+"\n"
+"Command: %s"
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2643
+#, c-format
+msgid ""
+"Maxima has started, but hasn't connected to wxMaxima yet.\n"
+"\n"
+"On macOS this can happen if Gatekeeper has quarantined the Maxima binary -- common if it wasn't installed via a signed installer (e.g. via Homebrew): the process starts, but macOS silently prevents it from actually running instead of showing a security prompt, since a background process spawned by wxMaxima can never answer one.\n"
+"\n"
+"Try running Maxima once directly from a Terminal:\n"
+"\n"
+"%s\n"
+"\n"
+"If macOS shows a security prompt there, allow it. Otherwise you can remove the quarantine flag directly with:\n"
+"\n"
+"xattr -d com.apple.quarantine %s\n"
+"\n"
+"Then restart wxMaxima. wxMaxima will keep waiting and periodically retry in the meantime."
+msgstr ""
+
 #: ../../src/StatusBar.cpp:349
 msgid ""
 "Maxima has stopped in a debugger and is waiting for a command.\n"
@@ -6568,7 +6596,7 @@ msgstr ""
 msgid "Maxima help file not found!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1077
+#: ../../src/wxMaximaFrame.cpp:1081
 msgid "Maxima input"
 msgstr ""
 
@@ -6576,8 +6604,12 @@ msgstr ""
 msgid "Maxima is calculating"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1876
+#: ../../src/wxMaxima.cpp:1877
 msgid "Maxima is ready for input."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2665 ../../src/wxMaxima.cpp:2680
+msgid "Maxima isn't connecting"
 msgstr ""
 
 #: ../../src/Dirstructure.cpp:153
@@ -6593,7 +6625,7 @@ msgstr ""
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:569
+#: ../../src/MaximaProcessManager.cpp:574
 msgid "Maxima process terminated unexpectedly."
 msgstr ""
 
@@ -6625,15 +6657,15 @@ msgstr ""
 msgid "Maxima session (*.mac)|*.mac"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1518 ../../src/wxMaximaFrame.cpp:1981
+#: ../../src/dialogs/ConfigDialogue.cpp:1518 ../../src/wxMaximaFrame.cpp:1985
 msgid "Maxima shows help in a browser"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1523 ../../src/wxMaximaFrame.cpp:1977
+#: ../../src/dialogs/ConfigDialogue.cpp:1523 ../../src/wxMaximaFrame.cpp:1981
 msgid "Maxima shows help in a sidebar"
 msgstr ""
 
-#: ../../src/dialogs/ConfigDialogue.cpp:1511 ../../src/wxMaximaFrame.cpp:1972
+#: ../../src/dialogs/ConfigDialogue.cpp:1511 ../../src/wxMaximaFrame.cpp:1976
 msgid "Maxima shows help in the console"
 msgstr ""
 
@@ -6661,7 +6693,7 @@ msgstr ""
 msgid "Maxima supports three types of numbers: exact fractions (which can be generated for example by typing 1/10), IEEE floating-point numbers (0.2) and arbitrary precision big floats (1b-1). Note that, owing to their nature as binary (not decimal) numbers, there is for example no way to generate an IEEE floating-point number that exactly equals 0.1. If floating-point numbers are used instead of fractions, Maxima will therefore sometimes have to introduce a (very small) error and use things like 3602879701896397/36028797018963968 for 0.1."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1265
+#: ../../src/wxMaximaFrame.cpp:1269
 msgid "Maxima to other language"
 msgstr ""
 
@@ -6716,7 +6748,7 @@ msgstr ""
 msgid "Maxima version: %s, Anchors cache version"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1962
+#: ../../src/wxMaximaFrame.cpp:1966
 msgid "Maxima vs. Programming languages"
 msgstr ""
 
@@ -6775,6 +6807,10 @@ msgstr ""
 
 #: ../../src/wizards/ActualValuesStorageWiz.cpp:34
 msgid "Maxima's power lies in symbolic operations."
+msgstr ""
+
+#: ../../src/wxMaxima.cpp:2632
+msgid "Maxima's process is running, but hasn't connected back to wxMaxima within 5 seconds."
 msgstr ""
 
 #: ../../src/StatusBar.cpp:365
@@ -6860,16 +6896,16 @@ msgstr ""
 msgid "Median..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1961
+#: ../../src/wxMaximaFrame.cpp:1965
 msgid "Memoizing"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1047
+#: ../../src/wxMaximaFrame.cpp:1051
 msgid "Memory"
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:180
-#: ../../src/wxMaximaFrame.cpp:969
+#: ../../src/wxMaximaFrame.cpp:973
 msgid "Merge Cells"
 msgstr ""
 
@@ -6881,7 +6917,7 @@ msgstr ""
 msgid "Method:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1360
+#: ../../src/wxMaximaFrame.cpp:1364
 msgid "Methods of generating a matrix"
 msgstr ""
 
@@ -6912,7 +6948,7 @@ msgstr ""
 msgid "Misc settings"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3136 ../../src/wxMaxima.cpp:3138
+#: ../../src/wxMaxima.cpp:3197 ../../src/wxMaxima.cpp:3199
 msgid "Mismatched parenthesis"
 msgstr ""
 
@@ -6950,7 +6986,7 @@ msgstr ""
 msgid "Mu"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1386
+#: ../../src/wxMaximaFrame.cpp:1390
 msgid "Multiplication, exponent and similar"
 msgstr ""
 
@@ -6958,7 +6994,7 @@ msgstr ""
 msgid "Multiplicative function: f(a*b)=f(a)*f(b)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1372
+#: ../../src/wxMaximaFrame.cpp:1376
 msgid "Multiply matrices..."
 msgstr ""
 
@@ -6986,7 +7022,7 @@ msgstr ""
 msgid "Nepali"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1354 ../../src/wxMaximaFrame.cpp:1796
+#: ../../src/wxMaximaFrame.cpp:1358 ../../src/wxMaximaFrame.cpp:1800
 msgid "Nested list to Matrix"
 msgstr ""
 
@@ -6995,8 +7031,8 @@ msgid "Nested list to matrix"
 msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:748
-#: ../../src/dialogs/ConfigDialogue.cpp:772 ../../src/wxMaximaFrame.cpp:806
-#: ../../src/wxMaximaFrame.cpp:1087
+#: ../../src/dialogs/ConfigDialogue.cpp:772 ../../src/wxMaximaFrame.cpp:810
+#: ../../src/wxMaximaFrame.cpp:1091
 msgid "Never"
 msgstr ""
 
@@ -7004,7 +7040,7 @@ msgstr ""
 msgid "Never autosubscript this variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:813
+#: ../../src/wxMaximaFrame.cpp:817
 msgid "Never display this variable with subscript"
 msgstr ""
 
@@ -7017,7 +7053,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:628
+#: ../../src/wxMaximaFrame.cpp:632
 msgid "New\tCtrl+N"
 msgstr ""
 
@@ -7063,7 +7099,7 @@ msgstr ""
 msgid "New variable:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:963
+#: ../../src/wxMaximaFrame.cpp:967
 msgid "Next Command\tAlt+Down"
 msgstr ""
 
@@ -7071,12 +7107,12 @@ msgstr ""
 msgid "Next Difference"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:785
+#: ../../src/wxMaximaFrame.cpp:789
 msgid "Nice Graphical Equations"
 msgstr ""
 
 #: ../../src/dialogs/ConfigDialogue.cpp:725
-#: ../../src/dialogs/ConfigDialogue.cpp:737 ../../src/wxMaximaFrame.cpp:1587
+#: ../../src/dialogs/ConfigDialogue.cpp:737 ../../src/wxMaximaFrame.cpp:1591
 msgid "No"
 msgstr ""
 
@@ -7100,7 +7136,7 @@ msgstr ""
 msgid "No differences"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3169
+#: ../../src/wxMaxima.cpp:3230
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
@@ -7124,8 +7160,8 @@ msgstr ""
 msgid "No image to export"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2653 ../../src/wxMaxima.cpp:2661
-#: ../../src/wxMaxima.cpp:2682 ../../src/wxMaxima.cpp:2694
+#: ../../src/wxMaxima.cpp:2714 ../../src/wxMaxima.cpp:2722
+#: ../../src/wxMaxima.cpp:2743 ../../src/wxMaxima.cpp:2755
 msgid "No matches found!"
 msgstr ""
 
@@ -7145,7 +7181,7 @@ msgstr ""
 msgid "No topics found in topic tag"
 msgstr ""
 
-#: ../../src/Image.cpp:1037
+#: ../../src/Image.cpp:1046
 msgid "No usable image data was found."
 msgstr ""
 
@@ -7153,7 +7189,7 @@ msgstr ""
 msgid "Non-builtin symbols"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:834
+#: ../../src/wxMaximaFrame.cpp:838
 msgid "None"
 msgstr ""
 
@@ -7230,11 +7266,11 @@ msgstr ""
 msgid "Number to octets"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1188
+#: ../../src/wxMaximaFrame.cpp:1192
 msgid "Number to octets..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1943
+#: ../../src/wxMaximaFrame.cpp:1947
 msgid "Number types"
 msgstr ""
 
@@ -7242,7 +7278,7 @@ msgstr ""
 msgid "Number:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1823
+#: ../../src/wxMaximaFrame.cpp:1827
 msgid "Numeric output"
 msgstr ""
 
@@ -7250,7 +7286,7 @@ msgstr ""
 msgid "Numerical QR decomposition of a matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1451
+#: ../../src/wxMaximaFrame.cpp:1455
 msgid "Numerical operations (lapack)"
 msgstr ""
 
@@ -7258,15 +7294,15 @@ msgstr ""
 msgid "Numerical solution for 1st degree ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1316
+#: ../../src/wxMaximaFrame.cpp:1320
 msgid "Numerical solution..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1295
+#: ../../src/wxMaximaFrame.cpp:1299
 msgid "Numerical solutions of polynomial (bfloat)..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1292
+#: ../../src/wxMaximaFrame.cpp:1296
 msgid "Numerical solutions of polynomial..."
 msgstr ""
 
@@ -7312,7 +7348,7 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:130
+#: ../../src/wxMaximaFrame.cpp:134
 #, c-format
 msgid "OS: %s Version %li.%li"
 msgstr ""
@@ -7337,11 +7373,11 @@ msgstr ""
 msgid "Octets to String"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1190
+#: ../../src/wxMaximaFrame.cpp:1194
 msgid "Octets to number..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1192
+#: ../../src/wxMaximaFrame.cpp:1196
 msgid "Octets to string..."
 msgstr ""
 
@@ -7378,11 +7414,11 @@ msgstr ""
 msgid "Omicron"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1089
+#: ../../src/wxMaximaFrame.cpp:1093
 msgid "On all errors"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1088
+#: ../../src/wxMaximaFrame.cpp:1092
 msgid "On lisp errors"
 msgstr ""
 
@@ -7390,11 +7426,11 @@ msgstr ""
 msgid "One sample t-test"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1964
+#: ../../src/wxMaximaFrame.cpp:1968
 msgid "Online tutorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:803
+#: ../../src/wxMaximaFrame.cpp:807
 msgid "Only Integers and single letters"
 msgstr ""
 
@@ -7403,7 +7439,7 @@ msgid "Only user-defined labels"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:2197 ../../src/ToolBar.cpp:330
-#: ../../src/ToolBar.cpp:333 ../../src/main.cpp:882
+#: ../../src/ToolBar.cpp:333 ../../src/main.cpp:907
 msgid "Open"
 msgstr ""
 
@@ -7411,11 +7447,11 @@ msgstr ""
 msgid "Open a cell when Maxima expects input"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:629
+#: ../../src/wxMaximaFrame.cpp:633
 msgid "Open a document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:628
+#: ../../src/wxMaximaFrame.cpp:632
 msgid "Open a new window"
 msgstr ""
 
@@ -7431,7 +7467,7 @@ msgstr ""
 msgid "Open for appending"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1133
+#: ../../src/wxMaximaFrame.cpp:1137
 msgid "Open for appending..."
 msgstr ""
 
@@ -7439,7 +7475,7 @@ msgstr ""
 msgid "Open for reading"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1132
+#: ../../src/wxMaximaFrame.cpp:1136
 msgid "Open for reading..."
 msgstr ""
 
@@ -7447,7 +7483,7 @@ msgstr ""
 msgid "Open for writing"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1134
+#: ../../src/wxMaximaFrame.cpp:1138
 msgid "Open for writing..."
 msgstr ""
 
@@ -7455,7 +7491,7 @@ msgstr ""
 msgid "Open matrix"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:631
+#: ../../src/wxMaximaFrame.cpp:635
 msgid "Open recent"
 msgstr ""
 
@@ -7468,16 +7504,16 @@ msgstr ""
 msgid "Opening file"
 msgstr ""
 
-#: ../../src/sidebars/HelpBrowser.cpp:175 ../../src/wxMaxima.cpp:1808
+#: ../../src/sidebars/HelpBrowser.cpp:175 ../../src/wxMaxima.cpp:1809
 #, c-format
 msgid "Opening help file %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1567
+#: ../../src/wxMaximaFrame.cpp:1571
 msgid "Optimize for CPU time"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1566
+#: ../../src/wxMaximaFrame.cpp:1570
 msgid "Optimize for memory"
 msgstr ""
 
@@ -7498,15 +7534,15 @@ msgstr ""
 msgid "Output"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1259
+#: ../../src/wxMaximaFrame.cpp:1263
 msgid "Output C"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1260
+#: ../../src/wxMaximaFrame.cpp:1264
 msgid "Output Fortran"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1262
+#: ../../src/wxMaximaFrame.cpp:1266
 msgid "Output Rational Fortran"
 msgstr ""
 
@@ -7559,7 +7595,7 @@ msgstr ""
 msgid "Pade approximation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1515
+#: ../../src/wxMaximaFrame.cpp:1519
 msgid "Pade approximation of a Taylor series"
 msgstr ""
 
@@ -7567,7 +7603,7 @@ msgstr ""
 msgid "Pagebreak"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1674
+#: ../../src/wxMaximaFrame.cpp:1678
 msgid "Parallel Substitute..."
 msgstr ""
 
@@ -7599,7 +7635,7 @@ msgstr ""
 msgid "Parse string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1186
+#: ../../src/wxMaximaFrame.cpp:1190
 msgid "Parse string only..."
 msgstr ""
 
@@ -7611,7 +7647,7 @@ msgstr ""
 msgid "Part:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1536 ../../src/wxMaximaFrame.cpp:1572
+#: ../../src/wxMaximaFrame.cpp:1540 ../../src/wxMaximaFrame.cpp:1576
 msgid "Partial &Fractions..."
 msgstr ""
 
@@ -7625,7 +7661,7 @@ msgstr ""
 msgid "Paste"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:704
+#: ../../src/wxMaximaFrame.cpp:708
 msgid "Paste\tCtrl+V"
 msgstr ""
 
@@ -7633,11 +7669,11 @@ msgstr ""
 msgid "Paste from clipboard"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:705
+#: ../../src/wxMaximaFrame.cpp:709
 msgid "Paste text from clipboard"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:272 ../../src/wxMaximaFrame.cpp:759
+#: ../../src/wxMaximaFrame.cpp:276 ../../src/wxMaximaFrame.cpp:763
 msgid "Performance Monitor"
 msgstr ""
 
@@ -7665,7 +7701,7 @@ msgstr ""
 msgid "Piechart..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1587
+#: ../../src/wxMaxima.cpp:1588
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr ""
 
@@ -7677,15 +7713,15 @@ msgstr ""
 msgid "Please select exactly 2 or 3 files."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1805
+#: ../../src/wxMaximaFrame.cpp:1809
 msgid "Plot &2d..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1807
+#: ../../src/wxMaximaFrame.cpp:1811
 msgid "Plot &3d..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1809
+#: ../../src/wxMaximaFrame.cpp:1813
 msgid "Plot &Format..."
 msgstr ""
 
@@ -7735,11 +7771,11 @@ msgstr ""
 msgid "Plot format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1805
+#: ../../src/wxMaximaFrame.cpp:1809
 msgid "Plot in 2 dimensions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1807
+#: ../../src/wxMaximaFrame.cpp:1811
 msgid "Plot in 3 dimensions"
 msgstr ""
 
@@ -7751,7 +7787,7 @@ msgstr ""
 msgid "Plot to file:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:341 ../../src/wxMaximaFrame.cpp:749
+#: ../../src/wxMaximaFrame.cpp:345 ../../src/wxMaximaFrame.cpp:753
 msgid "Plot using Draw"
 msgstr ""
 
@@ -7800,7 +7836,7 @@ msgstr ""
 msgid "Polynomial:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1791
+#: ../../src/wxMaximaFrame.cpp:1795
 msgid "Pop"
 msgstr ""
 
@@ -7821,7 +7857,7 @@ msgstr ""
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1223
+#: ../../src/wxMaximaFrame.cpp:1227
 msgid "Position of a match"
 msgstr ""
 
@@ -7841,7 +7877,7 @@ msgstr ""
 msgid "Power series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1512
+#: ../../src/wxMaximaFrame.cpp:1516
 msgid "Power series..."
 msgstr ""
 
@@ -7861,7 +7897,7 @@ msgstr ""
 msgid "Prefer user labels"
 msgstr ""
 
-#: ../../src/main.cpp:676
+#: ../../src/main.cpp:701
 msgid "Preferences"
 msgstr ""
 
@@ -7869,11 +7905,11 @@ msgstr ""
 msgid "Preferences button"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:722
+#: ../../src/wxMaximaFrame.cpp:726
 msgid "Preferences...\tCtrl+,"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1770
+#: ../../src/wxMaximaFrame.cpp:1774
 msgid "Prepend an element"
 msgstr ""
 
@@ -7885,7 +7921,7 @@ msgstr ""
 msgid "Pressing Ctrl+Space or Ctrl+Tab starts an autocomplete function that can not only complete all functions that are integrated into the Maxima core and their parameters: It also knows about parameters from currently loaded packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:961
+#: ../../src/wxMaximaFrame.cpp:965
 msgid "Previous Command\tAlt+Up"
 msgstr ""
 
@@ -7910,11 +7946,11 @@ msgid "Print cell brackets"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:343 ../../src/ToolBar.cpp:345
-#: ../../src/wxMaximaFrame.cpp:655
+#: ../../src/wxMaximaFrame.cpp:659
 msgid "Print document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1866
+#: ../../src/wxMaximaFrame.cpp:1870
 msgid "Print floating-point numbers with exponents dividable by 3"
 msgstr ""
 
@@ -7990,7 +8026,7 @@ msgstr ""
 msgid "Product sign"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1129
+#: ../../src/wxMaximaFrame.cpp:1133
 msgid "Program"
 msgstr ""
 
@@ -8002,11 +8038,11 @@ msgstr ""
 msgid "Program block"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1100
+#: ../../src/wxMaximaFrame.cpp:1104
 msgid "Program block with local variables..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1102
+#: ../../src/wxMaximaFrame.cpp:1106
 msgid "Program block, no local variables..."
 msgstr ""
 
@@ -8014,7 +8050,7 @@ msgstr ""
 msgid "Psi"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1788
+#: ../../src/wxMaximaFrame.cpp:1792
 msgid "Push"
 msgstr ""
 
@@ -8022,7 +8058,7 @@ msgstr ""
 msgid "Push an element to a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1429
+#: ../../src/wxMaximaFrame.cpp:1433
 msgid "QR decomposition"
 msgstr ""
 
@@ -8030,7 +8066,7 @@ msgstr ""
 msgid "Querying gnuplot which graphics drivers it supports."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:658
+#: ../../src/wxMaximaFrame.cpp:662
 msgid "Quit wxMaxima"
 msgstr ""
 
@@ -8042,44 +8078,44 @@ msgstr ""
 msgid "Range radius:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1408
+#: ../../src/wxMaximaFrame.cpp:1412
 msgid "Rank"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:260 ../../src/wxMaximaFrame.cpp:757
+#: ../../src/wxMaximaFrame.cpp:264 ../../src/wxMaximaFrame.cpp:761
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2168
+#: ../../src/wxMaximaFrame.cpp:2195
 #, c-format
 msgid "Re-Reading the config from %s."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2165
+#: ../../src/wxMaximaFrame.cpp:2192
 msgid "Re-Reading the config from the default location."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:901
+#: ../../src/wxMaximaFrame.cpp:905
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:911
+#: ../../src/wxMaximaFrame.cpp:915
 msgid "Re-evaluate all cells below the one the cursor is in"
 msgstr ""
 
-#: ../../src/main.cpp:605
+#: ../../src/main.cpp:630
 msgid "Re-opening STDERR failed."
 msgstr ""
 
-#: ../../src/main.cpp:606
+#: ../../src/main.cpp:631
 msgid "Re-opening STDIN failed."
 msgstr ""
 
-#: ../../src/main.cpp:604
+#: ../../src/main.cpp:629
 msgid "Re-opening STDOUT failed."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2889
+#: ../../src/wxMaxima.cpp:2950
 #, c-format
 msgid "Re-pointed the .wxmx file association at %s"
 msgstr ""
@@ -8120,7 +8156,7 @@ msgstr ""
 msgid "Read environment variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1253
+#: ../../src/wxMaximaFrame.cpp:1257
 msgid "Read environment variable..."
 msgstr ""
 
@@ -8128,7 +8164,7 @@ msgstr ""
 msgid "Read line"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1714
+#: ../../src/wxMaximaFrame.cpp:1718
 msgid "Read nested list from csv file..."
 msgstr ""
 
@@ -8155,12 +8191,12 @@ msgstr ""
 msgid "Reading the Lisp part of wxMaxima from the included header file."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:156
+#: ../../src/wxMaximaFrame.cpp:160
 #, c-format
 msgid "Reading the config from %s."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:159
+#: ../../src/wxMaximaFrame.cpp:163
 msgid "Reading the config from the default location."
 msgstr ""
 
@@ -8207,11 +8243,11 @@ msgstr ""
 msgid "Recalculation hit the end of the worksheet => Updating its size (Visited %d cells, recalculated %d, in %ld ms)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:964
+#: ../../src/wxMaximaFrame.cpp:968
 msgid "Recall next command from history"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:962
+#: ../../src/wxMaximaFrame.cpp:966
 msgid "Recall previous command from history"
 msgstr ""
 
@@ -8229,7 +8265,7 @@ msgstr ""
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:634
+#: ../../src/wxMaximaFrame.cpp:638
 msgid "Recover unsaved"
 msgstr ""
 
@@ -8237,7 +8273,7 @@ msgstr ""
 msgid "Rectform"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1677
+#: ../../src/wxMaximaFrame.cpp:1681
 msgid "Recursive Substitute..."
 msgstr ""
 
@@ -8249,11 +8285,11 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:670
+#: ../../src/wxMaximaFrame.cpp:674
 msgid "Redo\tCtrl+Y"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:670
+#: ../../src/wxMaximaFrame.cpp:674
 msgid "Redo last change"
 msgstr ""
 
@@ -8261,7 +8297,7 @@ msgstr ""
 msgid "Reduce (tr)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1632
+#: ../../src/wxMaximaFrame.cpp:1636
 msgid "Reduce trigonometric expression"
 msgstr ""
 
@@ -8287,15 +8323,15 @@ msgstr ""
 msgid "Regex match position"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2009
+#: ../../src/wxMaximaFrame.cpp:2013
 msgid "Register wxMaxima as the tool that compares .wxmx files in TortoiseSVN and TortoiseGit"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1229
+#: ../../src/wxMaximaFrame.cpp:1233
 msgid "Regular expression that matches a string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1230
+#: ../../src/wxMaximaFrame.cpp:1234
 msgid "Regular expressions"
 msgstr ""
 
@@ -8333,15 +8369,15 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:917
+#: ../../src/wxMaximaFrame.cpp:921
 msgid "Remove All Output"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1463
+#: ../../src/wxMaximaFrame.cpp:1467
 msgid "Remove Columns..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1460
+#: ../../src/wxMaximaFrame.cpp:1464
 msgid "Remove Rows..."
 msgstr ""
 
@@ -8349,11 +8385,11 @@ msgstr ""
 msgid "Remove all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1785
+#: ../../src/wxMaximaFrame.cpp:1789
 msgid "Remove all list elements that appear twice in a row. Normally used in conjunction with sort."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1208
+#: ../../src/wxMaximaFrame.cpp:1212
 msgid "Remove all occurrences of a word..."
 msgstr ""
 
@@ -8369,7 +8405,7 @@ msgstr ""
 msgid "Remove and return the first element of a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1464
+#: ../../src/wxMaximaFrame.cpp:1468
 msgid "Remove columns from a matrix"
 msgstr ""
 
@@ -8377,15 +8413,15 @@ msgstr ""
 msgid "Remove directory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1238
+#: ../../src/wxMaximaFrame.cpp:1242
 msgid "Remove directory..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1784
+#: ../../src/wxMaximaFrame.cpp:1788
 msgid "Remove duplicates"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1210
+#: ../../src/wxMaximaFrame.cpp:1214
 msgid "Remove first occurrence of a word..."
 msgstr ""
 
@@ -8401,11 +8437,11 @@ msgstr ""
 msgid "Remove matrix rows"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:918
+#: ../../src/wxMaximaFrame.cpp:922
 msgid "Remove output from input cells"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1461
+#: ../../src/wxMaximaFrame.cpp:1465
 msgid "Remove rows from the a matrix"
 msgstr ""
 
@@ -8413,15 +8449,15 @@ msgstr ""
 msgid "Rename file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1249
+#: ../../src/wxMaximaFrame.cpp:1253
 msgid "Rename file..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1564
+#: ../../src/wxMaximaFrame.cpp:1568
 msgid "Reorganize an expression using horner's rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1380
+#: ../../src/wxMaximaFrame.cpp:1384
 msgid "Repetitive element-by-element multiplication"
 msgstr ""
 
@@ -8437,7 +8473,7 @@ msgstr ""
 msgid "Replace first regex match"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1990
+#: ../../src/wxMaximaFrame.cpp:1994
 msgid "Replace non-builtin variable and function names in the selected code cells (or the whole document) with random names, so a worksheet can be shared without revealing its original names"
 msgstr ""
 
@@ -8445,11 +8481,11 @@ msgstr ""
 msgid "Replace the first occurrence of Part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1214
+#: ../../src/wxMaximaFrame.cpp:1218
 msgid "Replace..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2720
+#: ../../src/wxMaxima.cpp:2781
 #, c-format
 msgid "Replaced %li occurrences."
 msgstr ""
@@ -8462,7 +8498,7 @@ msgstr ""
 msgid "Replaces the subexpression that part(expr, n_1, n_2, ...) would select by a new value. The part numbers form a path: n_1 selects a part of the expression, n_2 a part of that, and so on."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1987
+#: ../../src/wxMaximaFrame.cpp:1991
 msgid "Report bug"
 msgstr ""
 
@@ -8470,7 +8506,7 @@ msgstr ""
 msgid "Reset all GUI settings"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1030
+#: ../../src/wxMaximaFrame.cpp:1034
 msgid "Reset option variables"
 msgstr ""
 
@@ -8484,7 +8520,7 @@ msgid "Resetting all configuration settings"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:411 ../../src/ToolBar.cpp:417
-#: ../../src/wxMaximaFrame.cpp:1008
+#: ../../src/wxMaximaFrame.cpp:1012
 msgid "Restart Maxima"
 msgstr ""
 
@@ -8501,7 +8537,7 @@ msgstr ""
 msgid "Resulting Matrix name (may be empty):"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1224
+#: ../../src/wxMaximaFrame.cpp:1228
 msgid "Return a match"
 msgstr ""
 
@@ -8509,11 +8545,11 @@ msgstr ""
 msgid "Return from a block or loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1103
+#: ../../src/wxMaximaFrame.cpp:1107
 msgid "Return from current block/loop..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1792
+#: ../../src/wxMaximaFrame.cpp:1796
 msgid "Return the first item of the list and remove it from the list. Useful for creating stacks."
 msgstr ""
 
@@ -8529,7 +8565,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1748
+#: ../../src/wxMaximaFrame.cpp:1752
 msgid "Returns an arbitrary list item"
 msgstr ""
 
@@ -8537,7 +8573,7 @@ msgstr ""
 msgid "Returns the first element of a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1750
+#: ../../src/wxMaximaFrame.cpp:1754
 msgid "Returns the first item of the list"
 msgstr ""
 
@@ -8545,23 +8581,23 @@ msgstr ""
 msgid "Returns the last element of a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1756
+#: ../../src/wxMaximaFrame.cpp:1760
 msgid "Returns the last item of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1758
+#: ../../src/wxMaximaFrame.cpp:1762
 msgid "Returns the last n items of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1779
+#: ../../src/wxMaximaFrame.cpp:1783
 msgid "Returns the length of the list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1752
+#: ../../src/wxMaximaFrame.cpp:1756
 msgid "Returns the list without its first n elements"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1754
+#: ../../src/wxMaximaFrame.cpp:1758
 msgid "Returns the list without its last n elements"
 msgstr ""
 
@@ -8573,11 +8609,11 @@ msgstr ""
 msgid "Reuse last"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1780
+#: ../../src/wxMaximaFrame.cpp:1784
 msgid "Reverse"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1781
+#: ../../src/wxMaximaFrame.cpp:1785
 msgid "Reverse the order of the list items"
 msgstr ""
 
@@ -8614,11 +8650,11 @@ msgstr ""
 msgid "Right end"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1335
+#: ../../src/wxMaximaFrame.cpp:1339
 msgid "Right side to the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1492
+#: ../../src/wxMaximaFrame.cpp:1496
 msgid "Risch Integration..."
 msgstr ""
 
@@ -8626,11 +8662,11 @@ msgstr ""
 msgid "Romanian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:822
+#: ../../src/wxMaximaFrame.cpp:826
 msgid "Rounded"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1474
+#: ../../src/wxMaximaFrame.cpp:1478
 msgid "Row and column operations"
 msgstr ""
 
@@ -8658,11 +8694,11 @@ msgstr ""
 msgid "Rule:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1061
+#: ../../src/wxMaximaFrame.cpp:1065
 msgid "Rules"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1730
+#: ../../src/wxMaximaFrame.cpp:1734
 msgid "Run each element through an expression"
 msgstr ""
 
@@ -8671,32 +8707,32 @@ msgstr ""
 msgid "Running %s on the file %s: "
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:297
+#: ../../src/MaximaProcessManager.cpp:298
 #, c-format
 msgid "Running maxima as: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:138
+#: ../../src/wxMaximaFrame.cpp:142
 msgid "Running on DirectFB"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:122
+#: ../../src/wxMaximaFrame.cpp:126
 msgid "Running on MS Windows"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:124
+#: ../../src/wxMaximaFrame.cpp:128
 msgid "Running on MS Windows using DirectDraw"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:144
+#: ../../src/wxMaximaFrame.cpp:148
 msgid "Running on Mac OS"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:135
+#: ../../src/wxMaximaFrame.cpp:139
 msgid "Running on Motif"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:141
+#: ../../src/wxMaximaFrame.cpp:145
 msgid "Running on the universal wxWidgets port"
 msgstr ""
 
@@ -8708,11 +8744,11 @@ msgstr ""
 msgid "Runs each element of an object (list, matrix, equation,...) through an expression individually"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1728
+#: ../../src/wxMaximaFrame.cpp:1732
 msgid "Runs each element through a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1731
+#: ../../src/wxMaximaFrame.cpp:1735
 msgid "Runs each element through an expression"
 msgstr ""
 
@@ -8765,7 +8801,7 @@ msgid "Samples on a line:"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
-#: ../../src/dialogs/ConfigDialogue.cpp:2163 ../../src/wxMaxima.cpp:3509
+#: ../../src/dialogs/ConfigDialogue.cpp:2163 ../../src/wxMaxima.cpp:3570
 msgid "Save"
 msgstr ""
 
@@ -8777,7 +8813,7 @@ msgstr ""
 msgid "Save As"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:640
+#: ../../src/wxMaximaFrame.cpp:644
 msgid "Save As...\tShift+Ctrl+S"
 msgstr ""
 
@@ -8789,7 +8825,7 @@ msgstr ""
 msgid "Save Selection to Image"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:712
+#: ../../src/wxMaximaFrame.cpp:716
 msgid "Save Selection to Image..."
 msgstr ""
 
@@ -8801,7 +8837,7 @@ msgstr ""
 msgid "Save as lisp code"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1125
+#: ../../src/wxMaximaFrame.cpp:1129
 msgid "Save as lisp..."
 msgstr ""
 
@@ -8810,11 +8846,11 @@ msgid "Save config to file"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:331 ../../src/ToolBar.cpp:334
-#: ../../src/wxMaximaFrame.cpp:639
+#: ../../src/wxMaximaFrame.cpp:643
 msgid "Save document"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:640
+#: ../../src/wxMaximaFrame.cpp:644
 msgid "Save document as"
 msgstr ""
 
@@ -8822,7 +8858,7 @@ msgstr ""
 msgid "Save plot to file"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:713
+#: ../../src/wxMaximaFrame.cpp:717
 msgid "Save selection from document to an image file"
 msgstr ""
 
@@ -8842,7 +8878,7 @@ msgstr ""
 msgid "Saving failed!"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:594
+#: ../../src/wxMaximaFrame.cpp:598
 msgid "Saving failed."
 msgstr ""
 
@@ -8878,7 +8914,7 @@ msgstr ""
 msgid "Screen reader"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:662
+#: ../../src/wxMaximaFrame.cpp:666
 msgid "Scroll to a cell with a certain UUID"
 msgstr ""
 
@@ -8894,7 +8930,7 @@ msgstr ""
 msgid "Search input / UUID"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1212
+#: ../../src/wxMaximaFrame.cpp:1216
 msgid "Search..."
 msgstr ""
 
@@ -8939,7 +8975,7 @@ msgstr ""
 msgid "Select All"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:710
+#: ../../src/wxMaximaFrame.cpp:714
 msgid "Select All\tCtrl+A"
 msgstr ""
 
@@ -8958,7 +8994,7 @@ msgid "Select a constant"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:390 ../../src/ToolBar.cpp:392
-#: ../../src/wxMaximaFrame.cpp:710
+#: ../../src/wxMaximaFrame.cpp:714
 msgid "Select all"
 msgstr ""
 
@@ -8994,7 +9030,7 @@ msgstr ""
 msgid "Send the current cell to maxima"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:921
+#: ../../src/MaximaProcessManager.cpp:926
 msgid "Sending Maxima a SIGINT signal."
 msgstr ""
 
@@ -9006,7 +9042,7 @@ msgstr ""
 msgid "Sending a new command to Maxima."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:902
+#: ../../src/MaximaProcessManager.cpp:907
 msgid "Sending an interrupt signal to Maxima."
 msgstr ""
 
@@ -9018,7 +9054,7 @@ msgstr ""
 msgid "Sending maxima the info how to express 2d maths as XML"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1570
+#: ../../src/wxMaximaFrame.cpp:1574
 msgid "Sequential Comparative Simplification"
 msgstr ""
 
@@ -9030,35 +9066,35 @@ msgstr ""
 msgid "Series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1516
+#: ../../src/wxMaximaFrame.cpp:1520
 msgid "Series approximation"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:227
+#: ../../src/MaximaProcessManager.cpp:228
 msgid "Server started"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1861
+#: ../../src/wxMaximaFrame.cpp:1865
 msgid "Set &displayed Precision..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1600
+#: ../../src/wxMaximaFrame.cpp:1604
 msgid "Set Maxima option variable logexpand:all"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1604
+#: ../../src/wxMaximaFrame.cpp:1608
 msgid "Set Maxima option variable logexpand:super"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1597
+#: ../../src/wxMaximaFrame.cpp:1601
 msgid "Set Maxima option variable logexpand:true"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:859
+#: ../../src/wxMaximaFrame.cpp:863
 msgid "Set Zoom"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1856
+#: ../../src/wxMaximaFrame.cpp:1860
 msgid "Set bigfloat &Precision..."
 msgstr ""
 
@@ -9075,7 +9111,7 @@ msgstr ""
 msgid "Set image resolution [in ppi]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1547
+#: ../../src/wxMaximaFrame.cpp:1551
 msgid "Set main variable..."
 msgstr ""
 
@@ -9083,15 +9119,15 @@ msgstr ""
 msgid "Set maximum image size [in mm]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1810
+#: ../../src/wxMaximaFrame.cpp:1814
 msgid "Set plot format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1135
+#: ../../src/wxMaximaFrame.cpp:1139
 msgid "Set position..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1693
+#: ../../src/wxMaximaFrame.cpp:1697
 msgid "Set the \"algebraic\" flag"
 msgstr ""
 
@@ -9099,7 +9135,7 @@ msgstr ""
 msgid "Set the diagram title"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1816
+#: ../../src/wxMaximaFrame.cpp:1820
 msgid "Set the frame rate for animations."
 msgstr ""
 
@@ -9111,31 +9147,31 @@ msgstr ""
 msgid "Set the next plot's title. Empty = no title."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1857
+#: ../../src/wxMaximaFrame.cpp:1861
 msgid "Set the precision for numbers that are defined as bigfloat. Such numbers can be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:848
+#: ../../src/wxMaximaFrame.cpp:852
 msgid "Set zoom to 100%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:850
+#: ../../src/wxMaximaFrame.cpp:854
 msgid "Set zoom to 120%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:852
+#: ../../src/wxMaximaFrame.cpp:856
 msgid "Set zoom to 150%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:854
+#: ../../src/wxMaximaFrame.cpp:858
 msgid "Set zoom to 200%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:856
+#: ../../src/wxMaximaFrame.cpp:860
 msgid "Set zoom to 300%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:846
+#: ../../src/wxMaximaFrame.cpp:850
 msgid "Set zoom to 80%"
 msgstr ""
 
@@ -9173,11 +9209,11 @@ msgstr ""
 msgid "Setup a 3D plot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1326
+#: ../../src/wxMaximaFrame.cpp:1330
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1698
+#: ../../src/wxMaximaFrame.cpp:1702
 msgid "Setup modulus computation"
 msgstr ""
 
@@ -9193,7 +9229,7 @@ msgstr ""
 msgid "Setup the engineering format"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1868
+#: ../../src/wxMaximaFrame.cpp:1872
 msgid "Setup the engineering format..."
 msgstr ""
 
@@ -9205,7 +9241,7 @@ msgstr ""
 msgid "Show \"%\" in special constants"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1926
+#: ../../src/wxMaximaFrame.cpp:1930
 msgid "Show &Tips..."
 msgstr ""
 
@@ -9213,15 +9249,15 @@ msgstr ""
 msgid "Show * as multiplication dot"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:929
+#: ../../src/wxMaximaFrame.cpp:933
 msgid "Show Template\tCtrl+Shift+Space"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:790
+#: ../../src/wxMaximaFrame.cpp:794
 msgid "Show XML representation"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1926
+#: ../../src/wxMaximaFrame.cpp:1930
 msgid "Show a tip"
 msgstr ""
 
@@ -9241,7 +9277,7 @@ msgstr ""
 msgid "Show an example for the command:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1920
+#: ../../src/wxMaximaFrame.cpp:1924
 msgid "Show an example of usage"
 msgstr ""
 
@@ -9249,31 +9285,31 @@ msgstr ""
 msgid "Show commands from current session only"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1921
+#: ../../src/wxMaximaFrame.cpp:1925
 msgid "Show commands similar to"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1054
+#: ../../src/wxMaximaFrame.cpp:1058
 msgid "Show defined functions"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1056
+#: ../../src/wxMaximaFrame.cpp:1060
 msgid "Show defined variables"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1108
+#: ../../src/wxMaximaFrame.cpp:1112
 msgid "Show definition of a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:777
+#: ../../src/wxMaximaFrame.cpp:781
 msgid "Show equations in their linear form"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1107
+#: ../../src/wxMaximaFrame.cpp:1111
 msgid "Show function &Definition..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:930
+#: ../../src/wxMaximaFrame.cpp:934
 msgid "Show function template"
 msgstr ""
 
@@ -9285,7 +9321,7 @@ msgstr ""
 msgid "Show labels:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:787
+#: ../../src/wxMaximaFrame.cpp:791
 msgid "Show lisp representation"
 msgstr ""
 
@@ -9309,7 +9345,7 @@ msgstr ""
 msgid "Show max. 50 digits"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:868
+#: ../../src/wxMaximaFrame.cpp:872
 msgid "Show or hide the wxMaxima logging window"
 msgstr ""
 
@@ -9333,7 +9369,7 @@ msgstr ""
 msgid "Show the Copy, Cut and the Paste button?"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:650
+#: ../../src/wxMaximaFrame.cpp:654
 msgid "Show the differences between 2 or 3 files"
 msgstr ""
 
@@ -9361,24 +9397,24 @@ msgstr ""
 msgid "Show tips at Startup"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1040 ../../src/wxMaximaFrame.cpp:1045
+#: ../../src/wxMaximaFrame.cpp:1044 ../../src/wxMaximaFrame.cpp:1049
 msgid "Show used + to-be-freed memory"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1067
+#: ../../src/wxMaximaFrame.cpp:1071
 msgid "Show user definitions"
 msgstr ""
 
 #: ../../src/ToolBar.cpp:544 ../../src/ToolBar.cpp:546
-#: ../../src/wxMaximaFrame.cpp:1914 ../../src/wxMaximaFrame.cpp:1916
+#: ../../src/wxMaximaFrame.cpp:1918 ../../src/wxMaximaFrame.cpp:1920
 msgid "Show wxMaxima help"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1862
+#: ../../src/wxMaximaFrame.cpp:1866
 msgid "Shows how many digits of a numbers are displayed"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:769
+#: ../../src/wxMaximaFrame.cpp:773
 msgid "Sidebars"
 msgstr ""
 
@@ -9398,7 +9434,7 @@ msgstr ""
 msgid "Simplify"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1550
+#: ../../src/wxMaximaFrame.cpp:1554
 msgid "Simplify &Radicals..."
 msgstr ""
 
@@ -9414,19 +9450,19 @@ msgstr ""
 msgid "Simplify Expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1605
+#: ../../src/wxMaximaFrame.cpp:1609
 msgid "Simplify Logarithms"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1619
+#: ../../src/wxMaximaFrame.cpp:1623
 msgid "Simplify an expression containing factorials"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1576
+#: ../../src/wxMaximaFrame.cpp:1580
 msgid "Simplify equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1551
+#: ../../src/wxMaximaFrame.cpp:1555
 msgid "Simplify expression containing radicals"
 msgstr ""
 
@@ -9434,11 +9470,11 @@ msgstr ""
 msgid "Simplify radicals"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1549
+#: ../../src/wxMaximaFrame.cpp:1553
 msgid "Simplify rational expression"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1575
+#: ../../src/wxMaximaFrame.cpp:1579
 msgid "Simplify sum() commands..."
 msgstr ""
 
@@ -9450,7 +9486,7 @@ msgstr ""
 msgid "Simplify the sum"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1629
+#: ../../src/wxMaximaFrame.cpp:1633
 msgid "Simplify trigonometric expression"
 msgstr ""
 
@@ -9458,15 +9494,15 @@ msgstr ""
 msgid "Since wxMaxima 0.8.2 you can also insert images into your documents. Use 'Cell->Insert Image...' menu command."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1433
+#: ../../src/wxMaximaFrame.cpp:1437
 msgid "Singular Values"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1434 ../../src/wxMaximaFrame.cpp:1437
+#: ../../src/wxMaximaFrame.cpp:1438 ../../src/wxMaximaFrame.cpp:1441
 msgid "Singular values using dgesvd"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1436
+#: ../../src/wxMaximaFrame.cpp:1440
 msgid "Singular values, left + right vectors"
 msgstr ""
 
@@ -9498,7 +9534,7 @@ msgstr ""
 msgid "Slovenian"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1672
+#: ../../src/wxMaximaFrame.cpp:1676
 msgid "Smart Substitute..."
 msgstr ""
 
@@ -9519,19 +9555,19 @@ msgstr ""
 msgid "Solve"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1278
+#: ../../src/wxMaximaFrame.cpp:1282
 msgid "Solve &Algebraic System..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1276
+#: ../../src/wxMaximaFrame.cpp:1280
 msgid "Solve &Linear System..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1300
+#: ../../src/wxMaximaFrame.cpp:1304
 msgid "Solve &ODE..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1274
+#: ../../src/wxMaximaFrame.cpp:1278
 msgid "Solve (to_poly)..."
 msgstr ""
 
@@ -9539,7 +9575,7 @@ msgstr ""
 msgid "Solve A*x=b numerically"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1431
+#: ../../src/wxMaximaFrame.cpp:1435
 msgid "Solve Ax=b"
 msgstr ""
 
@@ -9547,7 +9583,7 @@ msgstr ""
 msgid "Solve ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1321
+#: ../../src/wxMaximaFrame.cpp:1325
 msgid "Solve ODE with Lapla&ce..."
 msgstr ""
 
@@ -9555,7 +9591,7 @@ msgstr ""
 msgid "Solve ODE..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1432
+#: ../../src/wxMaximaFrame.cpp:1436
 msgid "Solve a linear equation system using dgesv"
 msgstr ""
 
@@ -9563,11 +9599,11 @@ msgstr ""
 msgid "Solve algebraic system"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1279
+#: ../../src/wxMaximaFrame.cpp:1283
 msgid "Solve algebraic system of equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1313
+#: ../../src/wxMaximaFrame.cpp:1317
 msgid "Solve boundary value problem for second degree ODE"
 msgstr ""
 
@@ -9575,11 +9611,11 @@ msgstr ""
 msgid "Solve differential equations using laplace()"
 msgstr ""
 
-#: ../../src/MaximaCommandMenus.cpp:925 ../../src/wxMaximaFrame.cpp:1272
+#: ../../src/MaximaCommandMenus.cpp:925 ../../src/wxMaximaFrame.cpp:1276
 msgid "Solve equation(s)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1275
+#: ../../src/wxMaximaFrame.cpp:1279
 msgid "Solve equation(s) with to_poly_solve"
 msgstr ""
 
@@ -9591,11 +9627,11 @@ msgstr ""
 msgid "Solve equations to polynom"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1305
+#: ../../src/wxMaximaFrame.cpp:1309
 msgid "Solve initial value problem for first degree ODE"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1309
+#: ../../src/wxMaximaFrame.cpp:1313
 msgid "Solve initial value problem for second degree ODE"
 msgstr ""
 
@@ -9603,19 +9639,19 @@ msgstr ""
 msgid "Solve linear system"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1277
+#: ../../src/wxMaximaFrame.cpp:1281
 msgid "Solve linear system of equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1297
+#: ../../src/wxMaximaFrame.cpp:1301
 msgid "Solve numerical, 1 Variable"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1301
+#: ../../src/wxMaximaFrame.cpp:1305
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1322
+#: ../../src/wxMaximaFrame.cpp:1326
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 
@@ -9631,7 +9667,7 @@ msgstr ""
 msgid "Solve polynomials numerically (real roots)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1283
+#: ../../src/wxMaximaFrame.cpp:1287
 msgid "Solve symbolically"
 msgstr ""
 
@@ -9640,11 +9676,11 @@ msgstr ""
 msgid "Solve..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1953
+#: ../../src/wxMaximaFrame.cpp:1957
 msgid "Solving differential equations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1941
+#: ../../src/wxMaximaFrame.cpp:1945
 msgid "Solving equations with Maxima"
 msgstr ""
 
@@ -9655,7 +9691,7 @@ msgid ""
 "In both cases the '' operator will do what is requested."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1783
+#: ../../src/wxMaximaFrame.cpp:1787
 msgid "Sort"
 msgstr ""
 
@@ -9671,7 +9707,7 @@ msgstr ""
 msgid "Sort all characters in string"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1213
+#: ../../src/wxMaximaFrame.cpp:1217
 msgid "Sort the characters..."
 msgstr ""
 
@@ -9696,7 +9732,7 @@ msgstr ""
 msgid "Split"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1225
+#: ../../src/wxMaximaFrame.cpp:1229
 msgid "Split on match"
 msgstr ""
 
@@ -9708,11 +9744,11 @@ msgstr ""
 msgid "Split string into tokens"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1205
+#: ../../src/wxMaximaFrame.cpp:1209
 msgid "Split..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:825
+#: ../../src/wxMaximaFrame.cpp:829
 msgid "Square"
 msgstr ""
 
@@ -9764,19 +9800,19 @@ msgstr ""
 msgid "Start value of the parameter"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:403
+#: ../../src/wxMaxima.cpp:404
 msgid "Starting Maxima process failed"
 msgstr ""
 
-#: ../../src/main.cpp:956
+#: ../../src/main.cpp:981
 msgid "Starting a new wxMaxima process for a new window"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1858 ../../src/wxMaxima.cpp:1884
+#: ../../src/wxMaxima.cpp:1859 ../../src/wxMaxima.cpp:1885
 msgid "Starting evaluation of the document"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:205
+#: ../../src/MaximaProcessManager.cpp:206
 msgid "Starting server failed"
 msgstr ""
 
@@ -9789,11 +9825,11 @@ msgstr ""
 msgid "Startup commands"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:266
+#: ../../src/wxMaximaFrame.cpp:270
 msgid "Statistics"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:736
+#: ../../src/wxMaximaFrame.cpp:740
 msgid "Statistics\tAlt+Shift+S"
 msgstr ""
 
@@ -9805,11 +9841,11 @@ msgstr ""
 msgid "Store filenames in image cells to enable image reloading after re-opening the worksheet"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:831
+#: ../../src/wxMaximaFrame.cpp:835
 msgid "Straight lines"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1140
+#: ../../src/wxMaximaFrame.cpp:1144
 msgid "Stream"
 msgstr ""
 
@@ -9831,7 +9867,7 @@ msgstr ""
 msgid "Strike Through"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1219
+#: ../../src/wxMaximaFrame.cpp:1223
 msgid "String"
 msgstr ""
 
@@ -9845,7 +9881,7 @@ msgstr ""
 msgid "String #2:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1170
+#: ../../src/wxMaximaFrame.cpp:1174
 msgid "String Tests"
 msgstr ""
 
@@ -9857,7 +9893,7 @@ msgstr ""
 msgid "String to list of char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1182
+#: ../../src/wxMaximaFrame.cpp:1186
 msgid "String to list of chars..."
 msgstr ""
 
@@ -9865,7 +9901,7 @@ msgstr ""
 msgid "String to octets"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1194
+#: ../../src/wxMaximaFrame.cpp:1198
 msgid "String to octets..."
 msgstr ""
 
@@ -9891,7 +9927,7 @@ msgstr ""
 msgid "Struct type name:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1063
+#: ../../src/wxMaximaFrame.cpp:1067
 msgid "Structs"
 msgstr ""
 
@@ -9915,7 +9951,7 @@ msgstr ""
 msgid "Subsection cell (Heading 3)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1680
+#: ../../src/wxMaximaFrame.cpp:1684
 msgid "Subst constant t into eq with diff(x,t)..."
 msgstr ""
 
@@ -9929,15 +9965,15 @@ msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:715 ../../src/MaximaCommandMenus.cpp:3550
 #: ../../src/MaximaCommandMenus.cpp:4560 ../../src/wizards/SubstituteWiz.cpp:53
-#: ../../src/wxMaximaFrame.cpp:1688
+#: ../../src/wxMaximaFrame.cpp:1692
 msgid "Substitute"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1227
+#: ../../src/wxMaximaFrame.cpp:1231
 msgid "Substitute all matches"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1226
+#: ../../src/wxMaximaFrame.cpp:1230
 msgid "Substitute first match"
 msgstr ""
 
@@ -9945,20 +9981,20 @@ msgstr ""
 msgid "Substitute only in a specific part"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1683
+#: ../../src/wxMaximaFrame.cpp:1687
 msgid "Substitute only in parts..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1684
+#: ../../src/wxMaximaFrame.cpp:1688
 msgid "Substitute only in the elements n_1, n_2,..."
 msgstr ""
 
 #: ../../src/worksheet/WorksheetContextMenu.cpp:358
-#: ../../src/wxMaximaFrame.cpp:1670
+#: ../../src/wxMaximaFrame.cpp:1674
 msgid "Substitute..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1678 ../../src/wxMaximaFrame.cpp:1681
+#: ../../src/wxMaximaFrame.cpp:1682 ../../src/wxMaximaFrame.cpp:1685
 msgid "Substitutes until the equation no more changes"
 msgstr ""
 
@@ -9975,7 +10011,7 @@ msgstr ""
 msgid "Substitutes, but makes sure that nothing is substituted into the other substituents."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1675
+#: ../../src/wxMaximaFrame.cpp:1679
 msgid "Substitutes, but not in the other substituents"
 msgstr ""
 
@@ -10007,7 +10043,7 @@ msgstr ""
 msgid "Swedish"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1588
+#: ../../src/wxMaximaFrame.cpp:1592
 msgid "Switch off simplifications of log(). Set Maxima option variable logexpand:false"
 msgstr ""
 
@@ -10024,7 +10060,7 @@ msgstr ""
 msgid "Symbolic Constant"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:740
+#: ../../src/wxMaximaFrame.cpp:744
 msgid "Symbols\tAlt+Shift+Y"
 msgstr ""
 
@@ -10048,11 +10084,11 @@ msgstr ""
 msgid "Tab"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:252
+#: ../../src/wxMaximaFrame.cpp:256
 msgid "Table of Contents"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:746
+#: ../../src/wxMaximaFrame.cpp:750
 msgid "Table of Contents\tAlt+Shift+T"
 msgstr ""
 
@@ -10072,7 +10108,7 @@ msgstr ""
 msgid "Taylor series"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1511
+#: ../../src/wxMaximaFrame.cpp:1515
 msgid "Taylor series..."
 msgstr ""
 
@@ -10080,7 +10116,7 @@ msgstr ""
 msgid "Taylor series:"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1488
+#: ../../src/wxMaxima.cpp:1489
 msgid "Telling maxima about the new working directory."
 msgstr ""
 
@@ -10088,15 +10124,15 @@ msgstr ""
 msgid "Tells maxima for an f(x), that f(x=t)=a"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1982
+#: ../../src/wxMaximaFrame.cpp:1986
 msgid "Tells maxima to show the help for ?, ?? and describe() in a separate browser window"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1978
+#: ../../src/wxMaximaFrame.cpp:1982
 msgid "Tells maxima to show the help for ?, ?? and describe() in a wxMaxima sidebar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1973
+#: ../../src/wxMaximaFrame.cpp:1977
 msgid "Tells maxima to show the help for ?, ?? and describe() on the console"
 msgstr ""
 
@@ -10141,7 +10177,7 @@ msgstr ""
 msgid "The .xml file doesn't seem to be valid xml or isn't a content.xml extracted from a .wxmx zip archive"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:844
+#: ../../src/MaximaProcessManager.cpp:849
 msgid "The Maxima process doesn't offer a shared memory segment we can send an interrupt signal to."
 msgstr ""
 
@@ -10173,7 +10209,7 @@ msgstr ""
 msgid "The cache for the subjects the manual contains is from a different Maxima version."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1413
+#: ../../src/wxMaximaFrame.cpp:1417
 msgid "The classic operations one typically uses matrices for"
 msgstr ""
 
@@ -10193,7 +10229,7 @@ msgstr ""
 msgid "The command local() allows telling Maxima which functions to make local to the current program when defined."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:324
+#: ../../src/wxMaximaFrame.cpp:328
 msgid "The current Wizard"
 msgstr ""
 
@@ -10271,11 +10307,11 @@ msgstr ""
 msgid "The grid in the background of the diagram"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1332
+#: ../../src/wxMaximaFrame.cpp:1336
 msgid "The half of the equation that is to the left of the \"=\""
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1336
+#: ../../src/wxMaximaFrame.cpp:1340
 msgid "The half of the equation that is to the right of the \"=\""
 msgstr ""
 
@@ -10283,7 +10319,7 @@ msgstr ""
 msgid "The help dir from the cache differs from the current one."
 msgstr ""
 
-#: ../../src/Image.cpp:1136
+#: ../../src/Image.cpp:1145
 msgid ""
 "The image could not be displayed. It may be broken, in a wrong format or be the result of gnuplot not being able to write the image or not being able to understand what maxima wanted to plot.\n"
 "One example of the latter would be: Gnuplot refuses to plot entirely empty images"
@@ -10294,7 +10330,7 @@ msgstr ""
 msgid "The image file \"%s\" cannot be found."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:753
+#: ../../src/wxMaximaFrame.cpp:757
 msgid "The integrated help browser"
 msgstr ""
 
@@ -10322,15 +10358,15 @@ msgstr ""
 msgid "The load() command of Maxima versions >5.38 is able to load .wxm files as library of Maxima's commands."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:228
+#: ../../src/wxMaximaFrame.cpp:232
 msgid "The main toolbar"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1919
+#: ../../src/wxMaximaFrame.cpp:1923
 msgid "The manual of Maxima"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1918
+#: ../../src/wxMaximaFrame.cpp:1922
 msgid "The manual of wxMaxima"
 msgstr ""
 
@@ -10467,7 +10503,7 @@ msgstr ""
 msgid "The variables to search the optimum solution for"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:207
+#: ../../src/wxMaximaFrame.cpp:211
 msgid "The worksheet"
 msgstr ""
 
@@ -10634,11 +10670,11 @@ msgstr ""
 msgid "Title, section and subsection cells can be folded to hide their contents. To fold or unfold, click in the square next to the cell. If you shift-click, all sublevels of that cell will also fold/unfold."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1831
+#: ../../src/wxMaximaFrame.cpp:1835
 msgid "To &Bigfloat"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1828
+#: ../../src/wxMaximaFrame.cpp:1832
 msgid "To &Float"
 msgstr ""
 
@@ -10646,15 +10682,15 @@ msgstr ""
 msgid "To Float"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1834
+#: ../../src/wxMaximaFrame.cpp:1838
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1840
+#: ../../src/wxMaximaFrame.cpp:1844
 msgid "To exact fraction"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1851
+#: ../../src/wxMaximaFrame.cpp:1855
 msgid "To exact number"
 msgstr ""
 
@@ -10685,7 +10721,7 @@ msgstr ""
 msgid "Toc levels shown here"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:862 ../../src/wxMaximaFrame.cpp:865
+#: ../../src/wxMaximaFrame.cpp:866 ../../src/wxMaximaFrame.cpp:869
 msgid "Toggle full screen editing"
 msgstr ""
 
@@ -10701,11 +10737,11 @@ msgstr ""
 msgid "Toggle vertical scroll synchronization"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1211
+#: ../../src/wxMaximaFrame.cpp:1215
 msgid "Tokenize..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1946
+#: ../../src/wxMaximaFrame.cpp:1950
 msgid "Tolerance calculations with Maxima"
 msgstr ""
 
@@ -10721,11 +10757,11 @@ msgstr ""
 msgid "Top end"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2862
+#: ../../src/wxMaxima.cpp:2923
 msgid "Tortoise diff tool"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1112
+#: ../../src/wxMaximaFrame.cpp:1116
 msgid "Trace a function..."
 msgstr ""
 
@@ -10733,11 +10769,11 @@ msgstr ""
 msgid "Trace function(s)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1218
+#: ../../src/wxMaximaFrame.cpp:1222
 msgid "Transformations"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1410
+#: ../../src/wxMaximaFrame.cpp:1414
 msgid "Transpose a matrix"
 msgstr ""
 
@@ -10781,15 +10817,15 @@ msgid ""
 "See also guess_exact_value()"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1215
+#: ../../src/wxMaximaFrame.cpp:1219
 msgid "Trim both ends..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1216
+#: ../../src/wxMaximaFrame.cpp:1220
 msgid "Trim left..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1217
+#: ../../src/wxMaximaFrame.cpp:1221
 msgid "Trim right..."
 msgstr ""
 
@@ -10805,7 +10841,7 @@ msgstr ""
 msgid "Trim string right"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1548
+#: ../../src/wxMaximaFrame.cpp:1552
 msgid "Try to guess which form is &simple"
 msgstr ""
 
@@ -10848,11 +10884,11 @@ msgstr ""
 msgid "Trying to remove the old temp file %s"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:168
+#: ../../src/MaximaProcessManager.cpp:169
 msgid "Trying to restart maxima."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:184
+#: ../../src/MaximaProcessManager.cpp:185
 #, c-format
 msgid "Trying to start the socket a Maxima on the local machine can connect to on port %i"
 msgstr ""
@@ -10861,7 +10897,7 @@ msgstr ""
 msgid "Turkish"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1965
+#: ../../src/wxMaximaFrame.cpp:1969
 msgid "Tutorials"
 msgstr ""
 
@@ -10889,7 +10925,7 @@ msgstr ""
 msgid "URL MathJaX.js is located at:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1180
+#: ../../src/wxMaximaFrame.cpp:1184
 msgid "UTF8 to Unicode code point..."
 msgstr ""
 
@@ -10897,25 +10933,25 @@ msgstr ""
 msgid "Ukrainian"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3166
+#: ../../src/wxMaxima.cpp:3227
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3154
+#: ../../src/wxMaxima.cpp:3215
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3468
+#: ../../src/wxMaxima.cpp:3529
 #, c-format
 msgid "Unable to interpret the version info I got from %s: %s"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3414
+#: ../../src/wxMaxima.cpp:3475
 #, c-format
 msgid "Unable to interpret the version info I got: %s"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1041
+#: ../../src/wxMaximaFrame.cpp:1045
 msgid "Undefine"
 msgstr ""
 
@@ -10936,7 +10972,7 @@ msgstr ""
 msgid "Undo"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:668
+#: ../../src/wxMaximaFrame.cpp:672
 msgid "Undo\tCtrl+Z"
 msgstr ""
 
@@ -10944,7 +10980,7 @@ msgstr ""
 msgid "Undo and redo button"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:668
+#: ../../src/wxMaximaFrame.cpp:672
 msgid "Undo last change"
 msgstr ""
 
@@ -10953,11 +10989,11 @@ msgstr ""
 msgid "Unexpected text style %li for TextCell"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:958
+#: ../../src/wxMaximaFrame.cpp:962
 msgid "Unfold All\tCtrl+Alt+]"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:959
+#: ../../src/wxMaximaFrame.cpp:963
 msgid "Unfold all folded sections"
 msgstr ""
 
@@ -10993,15 +11029,15 @@ msgstr ""
 msgid "Unhide contents"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:287
+#: ../../src/wxMaximaFrame.cpp:291
 msgid "Unicode characters"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:742
+#: ../../src/wxMaximaFrame.cpp:746
 msgid "Unicode chars\tAlt+Shift+U"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1178
+#: ../../src/wxMaximaFrame.cpp:1182
 msgid "Unicode code point to UTF8..."
 msgstr ""
 
@@ -11009,7 +11045,7 @@ msgstr ""
 msgid "Unicode code point to char"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1176
+#: ../../src/wxMaximaFrame.cpp:1180
 msgid "Unicode code point to char..."
 msgstr ""
 
@@ -11025,11 +11061,11 @@ msgstr ""
 msgid "Unlike in other programming language return() only exits from the current loop or block(), not from the whole function."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3105
+#: ../../src/wxMaxima.cpp:3166
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3148
+#: ../../src/wxMaxima.cpp:3209
 msgid "Unterminated string."
 msgstr ""
 
@@ -11045,9 +11081,9 @@ msgstr ""
 msgid "Updating maxima's configuration"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3407 ../../src/wxMaxima.cpp:3412
-#: ../../src/wxMaxima.cpp:3414 ../../src/wxMaxima.cpp:3461
-#: ../../src/wxMaxima.cpp:3466 ../../src/wxMaxima.cpp:3469
+#: ../../src/wxMaxima.cpp:3468 ../../src/wxMaxima.cpp:3473
+#: ../../src/wxMaxima.cpp:3475 ../../src/wxMaxima.cpp:3522
+#: ../../src/wxMaxima.cpp:3527 ../../src/wxMaxima.cpp:3530
 msgid "Upgrade"
 msgstr ""
 
@@ -11064,7 +11100,7 @@ msgstr ""
 msgid "Upsilon"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:829
+#: ../../src/wxMaximaFrame.cpp:833
 msgid "Use \"<\" and \">\" as parenthesis for matrices"
 msgstr ""
 
@@ -11084,7 +11120,7 @@ msgstr ""
 msgid "Use Text search filtering"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1745 ../../src/wxMaximaFrame.cpp:1776
+#: ../../src/wxMaximaFrame.cpp:1749 ../../src/wxMaximaFrame.cpp:1780
 msgid "Use a list"
 msgstr ""
 
@@ -11092,7 +11128,7 @@ msgstr ""
 msgid "Use a list as parameter list for a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:2008
+#: ../../src/wxMaximaFrame.cpp:2012
 msgid "Use as TortoiseSVN/Git diff tool"
 msgstr ""
 
@@ -11104,23 +11140,23 @@ msgstr ""
 msgid "Use centered dot character for multiplication"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1745
+#: ../../src/wxMaximaFrame.cpp:1749
 msgid "Use list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1738
+#: ../../src/wxMaximaFrame.cpp:1742
 msgid "Use list as the arguments of a function"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:823
+#: ../../src/wxMaximaFrame.cpp:827
 msgid "Use rounded parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:826
+#: ../../src/wxMaximaFrame.cpp:830
 msgid "Use square parenthesis for matrices"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1117
+#: ../../src/wxMaximaFrame.cpp:1121
 msgid "Use struct field..."
 msgstr ""
 
@@ -11132,7 +11168,7 @@ msgstr ""
 msgid "Use unicode Math Symbols, if available"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:832
+#: ../../src/wxMaximaFrame.cpp:836
 msgid "Use vertical lines instead of parenthesis for matrices"
 msgstr ""
 
@@ -11159,19 +11195,19 @@ msgstr ""
 msgid "Using Maxima help file from wxMaxima configuration file (helpFile=...))"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1566
+#: ../../src/wxMaxima.cpp:1567
 msgid "Using Maxima path from command line."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1563
+#: ../../src/wxMaxima.cpp:1564
 msgid "Using configured Maxima path."
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:976
+#: ../../src/MaximaProcessManager.cpp:981
 msgid "Using gnuplot's antialiassing-less png driver for embedded plots as pngcairo could not be found"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:971
+#: ../../src/MaximaProcessManager.cpp:976
 msgid "Using gnuplot's pngcairo driver for embedded plots"
 msgstr ""
 
@@ -11249,7 +11285,7 @@ msgstr ""
 msgid "Variable name"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1119
+#: ../../src/wxMaximaFrame.cpp:1123
 msgid "Variable name, not contents..."
 msgstr ""
 
@@ -11278,7 +11314,7 @@ msgstr ""
 msgid "Variable:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:298 ../../src/wxMaximaFrame.cpp:755
+#: ../../src/wxMaximaFrame.cpp:302 ../../src/wxMaximaFrame.cpp:759
 msgid "Variables"
 msgstr ""
 
@@ -11299,7 +11335,7 @@ msgstr ""
 msgid "Vietnamese"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:870
+#: ../../src/wxMaximaFrame.cpp:874
 msgid "View"
 msgstr ""
 
@@ -11320,12 +11356,12 @@ msgid "Warn if an inactive window is idle"
 msgstr ""
 
 #: ../../src/MathParser.cpp:1343 ../../src/MaximaFileIO.cpp:536
-#: ../../src/MaximaProcessManager.cpp:1100
-#: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1585
+#: ../../src/MaximaProcessManager.cpp:1105
+#: ../../src/MaximaResponseReader.cpp:361 ../../src/wxMaxima.cpp:1586
 msgid "Warning"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1593
+#: ../../src/wxMaximaFrame.cpp:1597
 msgid "Warning:"
 msgstr ""
 
@@ -11340,7 +11376,7 @@ msgstr ""
 msgid "Warning: Lookalike chars: "
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1583
+#: ../../src/wxMaximaFrame.cpp:1587
 msgid "Warning: No test if the argument of the log is complex, positive or negative"
 msgstr ""
 
@@ -11355,7 +11391,7 @@ msgstr ""
 msgid "WebP (*.webp)|*.webp|"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:1871
+#: ../../src/wxMaxima.cpp:1872
 msgid "Welcome to wxMaxima"
 msgstr ""
 
@@ -11367,7 +11403,7 @@ msgstr ""
 msgid "When applying functions with one argument from menus, the default argument is '%'. To apply the function to some other value, select it in the document before executing a menu command."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1092
+#: ../../src/wxMaximaFrame.cpp:1096
 msgid "When to invoke the lisp compiler's debugger"
 msgstr ""
 
@@ -11375,7 +11411,7 @@ msgstr ""
 msgid "While loop"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1097
+#: ../../src/wxMaximaFrame.cpp:1101
 msgid "While loop..."
 msgstr ""
 
@@ -11485,7 +11521,7 @@ msgstr ""
 msgid "You got an idea for an improvement of wxMaxima? Great! Please submit your idea at https://github.com/wxMaxima-developers/wxmaxima/issues. "
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3404 ../../src/wxMaxima.cpp:3458
+#: ../../src/wxMaxima.cpp:3465 ../../src/wxMaxima.cpp:3519
 #, c-format
 msgid ""
 "You have version %s. The newest wxMaxima release is %s.\n"
@@ -11493,11 +11529,11 @@ msgid ""
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3508
+#: ../../src/wxMaxima.cpp:3569
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3412 ../../src/wxMaxima.cpp:3466
+#: ../../src/wxMaxima.cpp:3473 ../../src/wxMaxima.cpp:3527
 msgid "Your version of wxMaxima is up to date."
 msgstr ""
 
@@ -11505,27 +11541,27 @@ msgstr ""
 msgid "Zeta"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:842
+#: ../../src/wxMaximaFrame.cpp:846
 msgid "Zoom &In\tCtrl++"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:843
+#: ../../src/wxMaximaFrame.cpp:847
 msgid "Zoom Ou&t\tCtrl+-"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:842
+#: ../../src/wxMaximaFrame.cpp:846
 msgid "Zoom in 10%"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:843
+#: ../../src/wxMaximaFrame.cpp:847
 msgid "Zoom out 10%"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3204 ../../src/wxMaximaFrame.cpp:201
+#: ../../src/wxMaxima.cpp:3265 ../../src/wxMaximaFrame.cpp:205
 msgid "[ unsaved ]"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3206
+#: ../../src/wxMaxima.cpp:3267
 msgid "[ unsaved* ]"
 msgstr ""
 
@@ -11553,23 +11589,23 @@ msgstr ""
 msgid "antisymmetric"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1727
+#: ../../src/wxMaximaFrame.cpp:1731
 msgid "apply function to each element"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:776
+#: ../../src/wxMaximaFrame.cpp:780
 msgid "as 1D ASCII"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:779
+#: ../../src/wxMaximaFrame.cpp:783
 msgid "as ASCII Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:782
+#: ../../src/wxMaximaFrame.cpp:786
 msgid "as ASCII+Unicode Art"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1717
+#: ../../src/wxMaximaFrame.cpp:1721
 msgid "as storage for actual values for variables"
 msgstr ""
 
@@ -11581,7 +11617,7 @@ msgstr ""
 msgid "both sides"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1173
+#: ../../src/wxMaximaFrame.cpp:1177
 msgid "char to Ascii code..."
 msgstr ""
 
@@ -11615,7 +11651,7 @@ msgstr ""
 msgid "diff(x,t)="
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1098 ../../src/wxMaximaFrame.cpp:1739
+#: ../../src/wxMaximaFrame.cpp:1102 ../../src/wxMaximaFrame.cpp:1743
 msgid "do for each element"
 msgstr ""
 
@@ -11662,19 +11698,19 @@ msgstr ""
 msgid "filename:"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1711
+#: ../../src/wxMaximaFrame.cpp:1715
 msgid "from a list"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1708
+#: ../../src/wxMaximaFrame.cpp:1712
 msgid "from a rule"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1722
+#: ../../src/wxMaximaFrame.cpp:1726
 msgid "from function arguments"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1706
+#: ../../src/wxMaximaFrame.cpp:1710
 msgid "from individual elements"
 msgstr ""
 
@@ -11702,7 +11738,7 @@ msgstr ""
 msgid "in"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:784
+#: ../../src/wxMaximaFrame.cpp:788
 msgid "in 2D"
 msgstr ""
 
@@ -11749,11 +11785,11 @@ msgstr ""
 msgid "matrix([x_1,x_2,...],[y_1,y_2,...])"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1439
+#: ../../src/wxMaximaFrame.cpp:1443
 msgid "max(abs(A(i,j))) (complex)"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1438
+#: ../../src/wxMaximaFrame.cpp:1442
 msgid "max(abs(A(i,j))) (real)"
 msgstr ""
 
@@ -11814,7 +11850,7 @@ msgstr ""
 msgid "noun: Not evaluated by default"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1747
+#: ../../src/wxMaximaFrame.cpp:1751
 msgid "nth"
 msgstr ""
 
@@ -11884,7 +11920,7 @@ msgstr ""
 msgid "printf"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1142
+#: ../../src/wxMaximaFrame.cpp:1146
 msgid "printf..."
 msgstr ""
 
@@ -11904,15 +11940,15 @@ msgstr ""
 msgid "ratsubst works like subst, but it knows some basic maths, if needed."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1145
+#: ../../src/wxMaximaFrame.cpp:1149
 msgid "readbyte..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1144
+#: ../../src/wxMaximaFrame.cpp:1148
 msgid "readchar..."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1143
+#: ../../src/wxMaximaFrame.cpp:1147
 msgid "readline..."
 msgstr ""
 
@@ -12025,16 +12061,16 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1109
+#: ../../src/wxMaximaFrame.cpp:1113
 msgid "unnamed function (lambda)..."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3496
+#: ../../src/wxMaxima.cpp:3557
 msgid "unsaved"
 msgstr ""
 
 #: ../../src/MaximaCommandMenus.cpp:2270 ../../src/MaximaFileIO.cpp:774
-#: ../../src/wxMaximaFrame.cpp:203
+#: ../../src/wxMaximaFrame.cpp:207
 msgid "untitled"
 msgstr ""
 
@@ -12042,11 +12078,11 @@ msgstr ""
 msgid "upsilon"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1737
+#: ../../src/wxMaximaFrame.cpp:1741
 msgid "use as function arguments"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1733
+#: ../../src/wxMaximaFrame.cpp:1737
 msgid "use the actual values stored"
 msgstr ""
 
@@ -12054,20 +12090,20 @@ msgstr ""
 msgid "wgnuplot: Steals the mouse focus during plotting"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1146
+#: ../../src/wxMaximaFrame.cpp:1150
 msgid "writebyte..."
 msgstr ""
 
-#: ../../src/dialogs/AboutDialog.cpp:64 ../../src/main.cpp:796
+#: ../../src/dialogs/AboutDialog.cpp:64 ../../src/main.cpp:821
 msgid "wxMaxima"
 msgstr ""
 
-#: ../../src/main.cpp:805
+#: ../../src/main.cpp:830
 #, c-format
 msgid "wxMaxima %ld"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:3193 ../../src/wxMaximaFrame.cpp:199
+#: ../../src/wxMaxima.cpp:3254 ../../src/wxMaximaFrame.cpp:203
 #, c-format
 msgid "wxMaxima %s (%s) "
 msgstr ""
@@ -12089,7 +12125,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr ""
 
-#: ../../src/MaximaProcessManager.cpp:211
+#: ../../src/MaximaProcessManager.cpp:212
 msgid ""
 "wxMaxima could not start a server.\n"
 "\n"
@@ -12114,7 +12150,7 @@ msgstr ""
 msgid "wxMaxima encountered an error loading "
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1918
+#: ../../src/wxMaximaFrame.cpp:1922
 msgid "wxMaxima help"
 msgstr ""
 
@@ -12122,7 +12158,7 @@ msgstr ""
 msgid "wxMaxima is a cross-platform graphical user interface for the computer algebra system Maxima based on wxWidgets.\n"
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2854
+#: ../../src/wxMaxima.cpp:2915
 #, c-format
 msgid ""
 "wxMaxima is now the .wxmx diff tool for:%s\n"
@@ -12167,11 +12203,11 @@ msgstr ""
 msgid "wxMaxima remembers the answers to maxima's questions. If this checkbox is set it automatically offers to enter the last answer to this question the user has input."
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1933
+#: ../../src/wxMaximaFrame.cpp:1937
 msgid "wxMaxima shows help in a browser"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1931
+#: ../../src/wxMaximaFrame.cpp:1935
 msgid "wxMaxima shows help in the sidebar"
 msgstr ""
 
@@ -12179,7 +12215,7 @@ msgstr ""
 msgid "wxMaxima startup file location: "
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:119
+#: ../../src/wxMaximaFrame.cpp:123
 #, c-format
 msgid "wxMaxima version %s"
 msgstr ""
@@ -12188,19 +12224,19 @@ msgstr ""
 msgid "wxMaxima worksheet"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1997
+#: ../../src/wxMaximaFrame.cpp:2001
 msgid "wxMaxima's ChangeLog"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:1995
+#: ../../src/wxMaximaFrame.cpp:1999
 msgid "wxMaxima's license"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:152
+#: ../../src/wxMaximaFrame.cpp:156
 msgid "wxWidgets is using GTK 2"
 msgstr ""
 
-#: ../../src/wxMaximaFrame.cpp:150
+#: ../../src/wxMaximaFrame.cpp:154
 msgid "wxWidgets is using GTK 3"
 msgstr ""
 
@@ -12212,17 +12248,17 @@ msgstr ""
 msgid "wxworksheettohtml/totex: no target file name was given."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2204
+#: ../../src/wxMaxima.cpp:2205
 #, c-format
 msgid "wxworksheettohtml: could not write \"%s\"."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2178
+#: ../../src/wxMaxima.cpp:2179
 #, c-format
 msgid "wxworksheettohtml: unknown flavor \"%s\"; using native MathML. Known flavors: mathml, mathjax, svg, bitmap."
 msgstr ""
 
-#: ../../src/wxMaxima.cpp:2246
+#: ../../src/wxMaxima.cpp:2247
 #, c-format
 msgid "wxworksheettotex: could not write \"%s\"."
 msgstr ""

--- a/src/MaximaProcessManager.cpp
+++ b/src/MaximaProcessManager.cpp
@@ -159,6 +159,7 @@ void MaximaProcessManager::OnMaximaConnect() {
 
   m_wxMaxima.m_client = std::make_unique<Maxima>(m_wxMaxima.m_server->Accept(false), &m_wxMaxima.m_configuration);
   if (m_wxMaxima.m_client->IsConnected()) {
+    m_wxMaxima.m_maximaConnectWatchdogTimer.Stop();
     m_wxMaxima.m_client->Bind(EVT_MAXIMA, &MaximaProcessManager::MaximaEvent, this);
     m_wxMaxima.m_evaluator.SetupVariables();
   } else {
@@ -365,6 +366,9 @@ bool MaximaProcessManager::StartMaxima(bool force) {
       m_wxMaxima.m_inLDB = false;
       m_wxMaxima.m_lastPrompt = wxS("(%i1) ");
       m_wxMaxima.StatusMaximaBusy(StatusBar::MaximaStatus::wait_for_start);
+      // Warn the user (GH #1182) if the process we just spawned is still
+      // alive but never connects back to us within a few seconds.
+      m_wxMaxima.m_maximaConnectWatchdogTimer.StartOnce(5000);
     } else {
       m_wxMaxima.m_statusBar->NetworkStatus(StatusBar::offline);
       wxLogMessage(_("Cannot find a maxima binary and no binary chosen in the "
@@ -381,6 +385,7 @@ bool MaximaProcessManager::StartMaxima(bool force) {
 }
 
 void MaximaProcessManager::KillMaxima(bool logMessage) {
+  m_wxMaxima.m_maximaConnectWatchdogTimer.Stop();
   if (logMessage && (m_wxMaxima.m_closing || (m_wxMaxima.m_maximaProcess == NULL) || (m_wxMaxima.m_pid > 0))) {
     if (m_wxMaxima.m_maximaPid > 0)
       wxLogMessage("Killing Maxima. Wrapper PID=%ld, Maxima PID=%ld", m_wxMaxima.m_pid,

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -353,6 +353,7 @@ wxMaxima::wxMaxima(wxWindow *parent, int id,
     GetWorksheet()->KeyboardInactiveTimer().SetOwner(this,
                                                      KEYBOARD_INACTIVITY_TIMER_ID);
   m_maximaStdoutPollTimer.SetOwner(this, MAXIMA_STDOUT_POLL_ID);
+  m_maximaConnectWatchdogTimer.SetOwner(this, MAXIMA_CONNECT_WATCHDOG_ID);
 
   m_autoSaveTimer.SetOwner(this, AUTO_SAVE_TIMER_ID);
   // Window size/position persistence is handled by wxPersistenceManager
@@ -2622,6 +2623,66 @@ void wxMaxima::OnTimerEvent(wxTimerEvent &event) {
     }
 
     break;
+  case MAXIMA_CONNECT_WATCHDOG_ID: {
+    bool connected = m_client && m_client->IsConnected();
+    bool processAlive =
+      (m_maximaProcess != NULL) && (m_pid > 0) && wxProcess::Exists(m_pid);
+    if ((!connected) && processAlive && (!m_maximaConnectWatchdogWarningShown)) {
+      m_maximaConnectWatchdogWarningShown = true;
+      wxLogMessage(_("Maxima's process is running, but hasn't connected "
+                     "back to wxMaxima within 5 seconds."));
+      wxString command = GetCommand(false);
+      // Deferred: this timer can fire while a restart triggered from within
+      // another event handler is still in flight; no modal dialogs directly
+      // inside event handlers (see the similar CallAfter()s in
+      // MaximaProcessManager.cpp/StartMaxima()).
+      CallAfter([this, command] {
+#if defined(__WXOSX__)
+        LoggingMessageBox(
+          wxString::Format(
+            _("Maxima has started, but hasn't connected to wxMaxima yet.\n"
+              "\n"
+              "On macOS this can happen if Gatekeeper has quarantined the "
+              "Maxima binary -- common if it wasn't installed via a signed "
+              "installer (e.g. via Homebrew): the process starts, but "
+              "macOS silently prevents it from actually running instead "
+              "of showing a security prompt, since a background process "
+              "spawned by wxMaxima can never answer one.\n"
+              "\n"
+              "Try running Maxima once directly from a Terminal:\n"
+              "\n"
+              "%s\n"
+              "\n"
+              "If macOS shows a security prompt there, allow it. "
+              "Otherwise you can remove the quarantine flag directly "
+              "with:\n"
+              "\n"
+              "xattr -d com.apple.quarantine %s\n"
+              "\n"
+              "Then restart wxMaxima. wxMaxima will keep waiting and "
+              "periodically retry in the meantime."),
+            command, command),
+          _("Maxima isn't connecting"), wxOK | wxICON_INFORMATION);
+#else
+        LoggingMessageBox(
+          wxString::Format(
+            _("Maxima has started, but hasn't connected to wxMaxima "
+              "within 5 seconds.\n"
+              "\n"
+              "wxMaxima will keep waiting and periodically retry. If this "
+              "doesn't resolve itself, check the debug messages sidebar "
+              "(View > Show Debug Messages) for more detail, or check if "
+              "a firewall or security software is blocking local network "
+              "connections to wxMaxima.\n"
+              "\n"
+              "Command: %s"),
+            command),
+          _("Maxima isn't connecting"), wxOK | wxICON_INFORMATION);
+#endif
+      });
+    }
+    break;
+  }
   case KEYBOARD_INACTIVITY_TIMER_ID:
   case AUTO_SAVE_TIMER_ID:
     if ((!GetWorksheet()->KeyboardInactiveTimer().IsRunning()) &&

--- a/src/wxMaxima.h
+++ b/src/wxMaxima.h
@@ -128,7 +128,9 @@ public:
     //! The time between two auto-saves has elapsed.
     AUTO_SAVE_TIMER_ID,
     //! We look if we got new data from maxima's stdout.
-    MAXIMA_STDOUT_POLL_ID
+    MAXIMA_STDOUT_POLL_ID,
+    //! Maxima's process was started; has it connected back to us by now?
+    MAXIMA_CONNECT_WATCHDOG_ID
   };
 
 #ifdef wxHAS_POWER_EVENTS
@@ -140,6 +142,20 @@ public:
 
   //! A timer that polls for output from the maxima process.
   wxTimer m_maximaStdoutPollTimer;
+
+  /*! Fires once, a few seconds after Maxima's process is started.
+
+    If by then the process is still running but has never connected back to
+    us (GH #1182 -- reproducibly hangs at "Maxima started. Waiting for
+    connection..." forever on macOS when the Maxima binary is quarantined by
+    Gatekeeper, since a spawned, non-interactive child process can never
+    answer a security prompt macOS may be silently blocking it on) this
+    warns the user instead of leaving them looking at an unexplained,
+    permanently stuck status message.
+  */
+  wxTimer m_maximaConnectWatchdogTimer;
+  //! Have we already shown the "Maxima hasn't connected" warning this run?
+  bool m_maximaConnectWatchdogWarningShown = false;
 
   void ShowTip(bool force);
   //! Do we want to evaluate the document on startup?


### PR DESCRIPTION
## Summary

GH #1182 has been open since 2019: on macOS, wxMaxima can reproducibly get stuck at "Maxima started. Waiting for connection..." forever, with the `maxima` process itself alive and healthy (it runs fine from a Terminal), but its socket connection back to wxMaxima never arrives. The extensive investigation on the issue never found a definitive root cause in wxMaxima's own communication code, but the reporter's own workaround and later comments consistently point at macOS's Gatekeeper: a spawned, non-interactive child process can't answer the interactive security prompt Gatekeeper would otherwise show for a quarantined (e.g. Homebrew-installed) binary, so it just never gets far enough to open its side of the connection. The issue's actual, actionable ask (per its title) is narrower than root-causing that: *inform the user* when this happens instead of leaving them looking at a permanently stuck status message.

### What was missing

wxMaxima is the TCP **server** here (`MaximaProcessManager::StartServer()`); the spawned `maxima` binary is the **client** that has to connect back. The existing retry logic in `OnMaximaConnect()` (`m_unsuccessfulConnectionAttempts < 12`) only fires once a connection attempt reaches wxMaxima and then fails — it does nothing if no attempt ever arrives at all, which is exactly this failure mode. There was no timeout, no warning, nothing.

### Fix

A new one-shot `wxTimer` (`MAXIMA_CONNECT_WATCHDOG_ID`) is armed for 5 seconds (matching the issue title's own number) every time `StartMaxima()` successfully spawns a process, and stopped both on a real successful connection and on `KillMaxima()` (covering deliberate shutdown and every restart). If it fires while the process is still alive (`wxProcess::Exists()`) but still not connected, it shows a `LoggingMessageBox` **once per run** (a latch prevents the automatic restart loop from reshowing it up to 12 times in a row). The message branches on `__WXOSX__`:
- **macOS**: names the quarantine possibility specifically, suggests running the shown command once from a Terminal (to trigger/clear Gatekeeper's prompt) or clearing the flag directly with `xattr -d com.apple.quarantine`.
- **elsewhere**: a generic "still waiting, check the debug sidebar or your firewall" message, since quarantine isn't the relevant cause there.

wxMaxima keeps waiting and retrying in the background regardless — this is purely about not leaving the user in the dark.

### Verification

This sandbox has no macOS hardware, so the `__WXOSX__`-specific wording itself is untestable here (same limitation as the #2229-#2232 wxWidgets-version-gated issues from earlier in this session) — but the underlying missing-timeout mechanism is platform-independent, and I verified it end-to-end in a live Xvfb session: pointed wxMaxima's `-m` flag at a throwaway shell script that just `sleep`s forever instead of a real `maxima` binary. On unmodified `main` this sits at "Waiting for connection..." indefinitely with no further log output. With this fix, the watchdog fires at exactly +5 seconds, logs once, and a screenshot confirms the dialog renders correctly with the generic (non-macOS) wording.

## Test plan

- [x] `ninja` builds cleanly
- [x] Full `ctest` suite: 225/225 passing
- [x] Live Xvfb repro with a fake hung "Maxima" process: watchdog fires once at +5s, dialog renders correctly (screenshot taken)
- [x] Confirmed the watchdog stops correctly on both a real successful connection and on `KillMaxima()`, so it doesn't fire spuriously after normal shutdown/restart


---
_Generated by [Claude Code](https://claude.ai/code/session_011iszcZR49S3QXrTKUQjiu6)_